### PR TITLE
Add xUnit test foundation with SAML validation regression tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/SSO-Auth.Tests/SSO-Auth.Tests.csproj
+++ b/SSO-Auth.Tests/SSO-Auth.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RollForward>Major</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SSO-Auth\SSO-Auth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Xml;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Trust-boundary tests for <see cref="Response"/> — the SAML signature/validation core.
+/// These pin the CURRENT behavior of the upstream implementation so the P2 hardening
+/// changes (see docs/ROADMAP.md) are deliberate, reviewed flips rather than surprises.
+///
+/// Tests named "..._KnownFailOpen" / "..._Characterization" document behavior that is
+/// insecure by today's standard and is tracked in docs/SECURITY-FINDINGS.md; they will
+/// be inverted by the PR that fixes the corresponding finding.
+/// </summary>
+public class SamlResponseTests
+{
+    private static Response Load(SamlFixture fixture, string? certificateBase64 = null)
+        => new Response(certificateBase64 ?? fixture.CertificateBase64, fixture.EncodeResponse());
+
+    [Fact]
+    public void IsValid_ResponseScopeSignature_ReturnsTrue()
+    {
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Response);
+        Assert.True(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_AssertionScopeSignature_ReturnsTrue()
+    {
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
+        Assert.True(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_NoSignature_ReturnsFalse()
+    {
+        // A well-formed but entirely unsigned response must never validate.
+        var unsigned =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"_a\" Version=\"2.0\">" +
+                    "<saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject>" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+        var response = new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
+        Assert.False(response.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_ForeignCertificate_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64()).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_TamperedNameIdAfterSigning_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var nameId = fixture.Document.GetElementsByTagName("NameID", "urn:oasis:names:tc:SAML:2.0:assertion")[0]!;
+        nameId.InnerText = "attacker";
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_ExpiredNotOnOrAfter_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create(notOnOrAfter: System.DateTime.UtcNow.AddMinutes(-5));
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_SignatureWrappingSecondAssertion_ReturnsFalse()
+    {
+        // XSW: keep the validly-signed assertion, but inject an unsigned attacker assertion as the
+        // FIRST assertion. Attribute/NameID extraction reads Assertion[1] (the evil one); the
+        // signature reference resolves to the second (signed) node. The two must not agree.
+        var fixture = SamlTestFactory.Create(nameId: "alice", scope: SamlTestFactory.SignatureScope.Assertion);
+        var doc = fixture.Document;
+        var evil = doc.CreateElement("saml", "Assertion", "urn:oasis:names:tc:SAML:2.0:assertion");
+        evil.SetAttribute("ID", "_evil");
+        evil.SetAttribute("Version", "2.0");
+        var subject = doc.CreateElement("saml", "Subject", "urn:oasis:names:tc:SAML:2.0:assertion");
+        var nameId = doc.CreateElement("saml", "NameID", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nameId.InnerText = "attacker";
+        subject.AppendChild(nameId);
+        evil.AppendChild(subject);
+        doc.DocumentElement!.PrependChild(evil);
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void GetNameID_ValidResponse_ReturnsSignedSubject()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice@example.com");
+        Assert.Equal("alice@example.com", Load(fixture).GetNameID());
+    }
+
+    [Fact]
+    public void GetCustomAttribute_ValidResponse_ReturnsRole()
+    {
+        var fixture = SamlTestFactory.Create(role: "jellyfin-admins");
+        Assert.Equal("jellyfin-admins", Load(fixture).GetCustomAttribute("Role"));
+    }
+
+    [Fact]
+    public void GetCustomAttributes_KnownAttribute_ReturnsValues()
+    {
+        var fixture = SamlTestFactory.Create(role: "jellyfin-users");
+        Assert.Equal(new List<string> { "jellyfin-users" }, Load(fixture).GetCustomAttributes("Role"));
+    }
+
+    [Fact]
+    public void GetCustomAttribute_UnknownAttribute_ReturnsNull()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.Null(Load(fixture).GetCustomAttribute("NonExistent"));
+    }
+
+    // --- Characterization of known-insecure current behavior (docs/SECURITY-FINDINGS.md) ---
+
+    [Fact]
+    public void IsValid_MissingNotOnOrAfter_ReturnsTrue_KnownFailOpen()
+    {
+        // FINDING F-2: with no NotOnOrAfter bound, IsExpired() defaults the expiry to
+        // DateTime.MaxValue and the assertion is accepted forever. The P2 fix flips this to
+        // fail-closed (a missing time bound must be rejected); this assertion inverts then.
+        var fixture = SamlTestFactory.Create(includeNotOnOrAfter: false);
+        Assert.True(Load(fixture).IsValid());
+    }
+}

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Builds real, cryptographically-signed SAML 2.0 responses (and deliberately broken variants)
+/// against a throw-away self-signed certificate, so tests exercise the actual signature-validation
+/// path in <see cref="Jellyfin.Plugin.SSO_Auth.Response"/> rather than mocks.
+///
+/// Scoped to what the current <see cref="Jellyfin.Plugin.SSO_Auth.Response"/> validates
+/// (signature, signature scope, SubjectConfirmationData/@NotOnOrAfter). It grows as the
+/// validation surface is hardened (audience, recipient, InResponseTo, ... — see docs/ROADMAP.md).
+/// </summary>
+internal static class SamlTestFactory
+{
+    /// <summary>Which element the enveloped signature covers.</summary>
+    internal enum SignatureScope
+    {
+        /// <summary>Sign the root samlp:Response element.</summary>
+        Response,
+
+        /// <summary>Sign only the saml:Assertion element.</summary>
+        Assertion,
+    }
+
+    /// <summary>
+    /// Produces a self-signed certificate plus a signed SAML response for the given subject/role.
+    /// </summary>
+    /// <param name="nameId">The value placed in saml:NameID.</param>
+    /// <param name="role">The value of the "Role" attribute.</param>
+    /// <param name="notOnOrAfter">SubjectConfirmationData/@NotOnOrAfter; defaults to five minutes in the future.</param>
+    /// <param name="includeNotOnOrAfter">When false, the NotOnOrAfter attribute is omitted entirely.</param>
+    /// <param name="scope">Which element to sign.</param>
+    /// <param name="signWithSha1">When true, sign with RSA-SHA1/SHA1 digest (for weak-algorithm tests).</param>
+    /// <returns>A fixture exposing the certificate and the signed document.</returns>
+    internal static SamlFixture Create(
+        string nameId = "alice",
+        string role = "jellyfin-users",
+        DateTime? notOnOrAfter = null,
+        bool includeNotOnOrAfter = true,
+        SignatureScope scope = SignatureScope.Response,
+        bool signWithSha1 = false)
+    {
+        var effectiveNotOnOrAfter = notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5);
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test SAML IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var responseId = "_" + Guid.NewGuid().ToString("N");
+        var assertionId = "_" + Guid.NewGuid().ToString("N");
+
+        var subjectConfirmationData = includeNotOnOrAfter
+            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture) + "\" />"
+            : "<saml:SubjectConfirmationData />";
+
+        var xml =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
+                    "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
+                    "<saml:Subject>" +
+                        "<saml:NameID>" + nameId + "</saml:NameID>" +
+                        "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
+                            subjectConfirmationData +
+                        "</saml:SubjectConfirmation>" +
+                    "</saml:Subject>" +
+                    "<saml:AttributeStatement>" +
+                        "<saml:Attribute Name=\"Role\"><saml:AttributeValue>" + role + "</saml:AttributeValue></saml:Attribute>" +
+                    "</saml:AttributeStatement>" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(xml);
+
+        var referenceId = scope == SignatureScope.Response ? responseId : assertionId;
+        SignElement(document, referenceId, rsa, certificate, signWithSha1);
+
+        return new SamlFixture(certificate, document, responseId, assertionId);
+    }
+
+    private static void SignElement(XmlDocument document, string referenceId, RSA signingKey, X509Certificate2 certificate, bool useSha1)
+    {
+        var signedXml = new SignedXml(document) { SigningKey = signingKey };
+
+        var reference = new Reference("#" + referenceId) { DigestMethod = useSha1 ? SignedXml.XmlDsigSHA1Url : SignedXml.XmlDsigSHA256Url };
+        reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+        reference.AddTransform(new XmlDsigExcC14NTransform());
+        signedXml.AddReference(reference);
+
+        signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+        signedXml.SignedInfo.SignatureMethod = useSha1 ? SignedXml.XmlDsigRSASHA1Url : SignedXml.XmlDsigRSASHA256Url;
+
+        var keyInfo = new KeyInfo();
+        keyInfo.AddClause(new KeyInfoX509Data(certificate));
+        signedXml.KeyInfo = keyInfo;
+
+        signedXml.ComputeSignature();
+
+        var signatureElement = signedXml.GetXml();
+        var target = (XmlElement)signedXml.GetIdElement(document, referenceId)!;
+        target.AppendChild(document.ImportNode(signatureElement, true));
+    }
+}
+
+/// <summary>
+/// A signed SAML response together with the certificate that signed it.
+/// </summary>
+internal sealed class SamlFixture
+{
+    private readonly X509Certificate2 _certificate;
+
+    internal SamlFixture(X509Certificate2 certificate, XmlDocument document, string responseId, string assertionId)
+    {
+        _certificate = certificate;
+        Document = document;
+        ResponseId = responseId;
+        AssertionId = assertionId;
+    }
+
+    /// <summary>Gets the signed document (mutable, so tests can inject wrapping attacks).</summary>
+    internal XmlDocument Document { get; }
+
+    /// <summary>Gets the ID attribute of the root Response element.</summary>
+    internal string ResponseId { get; }
+
+    /// <summary>Gets the ID attribute of the Assertion element.</summary>
+    internal string AssertionId { get; }
+
+    /// <summary>Gets the signing certificate exported as a Base64 DER string (the public part only).</summary>
+    internal string CertificateBase64 => Convert.ToBase64String(_certificate.Export(X509ContentType.Cert));
+
+    /// <summary>Gets a Base64 DER string of an unrelated certificate (for negative signature tests).</summary>
+    internal static string ForeignCertificateBase64()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Someone Else", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+        return Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+    }
+
+    /// <summary>Encodes the current document as the Base64 SAMLResponse string the plugin expects.</summary>
+    internal string EncodeResponse() => Encode(Document.OuterXml);
+
+    /// <summary>Encodes an arbitrary XML string as a Base64 SAMLResponse.</summary>
+    internal static string Encode(string xml) => Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
+}

--- a/SSO-Auth.sln
+++ b/SSO-Auth.sln
@@ -5,18 +5,44 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SSO-Auth", "SSO-Auth\SSO-Auth.csproj", "{C30A5CFB-B27E-4E83-9E96-1E0362B36748}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SSO-Auth.Tests", "SSO-Auth.Tests\SSO-Auth.Tests.csproj", "{CF29D43B-A90C-4E7E-B305-37AF655F48F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|x64.Build.0 = Debug|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Debug|x86.Build.0 = Debug|Any CPU
 		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|x64.ActiveCfg = Release|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|x64.Build.0 = Release|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|x86.ActiveCfg = Release|Any CPU
+		{C30A5CFB-B27E-4E83-9E96-1E0362B36748}.Release|x86.Build.0 = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|x64.Build.0 = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Debug|x86.Build.0 = Debug|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|x64.ActiveCfg = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|x64.Build.0 = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|x86.ActiveCfg = Release|Any CPU
+		{CF29D43B-A90C-4E7E-B305-37AF655F48F0}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Establish the automated test net before any code hardening (secure-SDL order): the test project comes first so subsequent security fixes are guarded by regression tests.

- Add the SSO-Auth.Tests project (xUnit v3 on Microsoft Testing Platform, net9.0, RollForward=Major so it runs on the installed .NET 10 runtime).
- Add SamlTestFactory, which builds real cryptographically-signed SAML 2.0 responses (and broken variants) against a throwaway self-signed certificate, so tests exercise the production signature-validation path rather than mocks.
- Add 12 trust-boundary tests for the Response validator: valid response-scope and assertion-scope signatures, unsigned response, foreign certificate, post-signing tampering, expired assertion, XML signature-wrapping (second-assertion injection), and NameID/attribute extraction. One characterization test pins a known fail-open in time validation (missing NotOnOrAfter), to be inverted by the hardening fix.
- Register the test project in the solution.
- Run the test suite under a least-privilege token (contents: read) in CI.

Closes #17 

## What & why

Adds the automated test net (secure-SDL: tests before hardening). New
SSO-Auth.Tests project with SamlTestFactory and 12 trust-boundary tests for
the SAML Response validator, registered in the solution and run in CI under
a least-privilege token. Closes #4

## Type of change
- [x] Refactor / code quality / docs

## Verification
- [x] `dotnet build --warnaserror` green (Debug + Release, 0 warnings).
- [x] `dotnet test` green: 12/12.