### PR TITLE
Fix thread-unsafe OpenID state store

### DIFF
--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AuthStateStore"/> — expiry pruning of the in-flight OpenID
+/// authorize-state store, including the concurrency regression that motivated the move to
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> (adds racing enumeration/pruning threw
+/// InvalidOperationException on the previous plain Dictionary).
+/// </summary>
+public class AuthStateStoreTests
+{
+    private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(1);
+
+    private static ConcurrentDictionary<string, TimedAuthorizeState> StoreWith(params (string Key, DateTime Created)[] entries)
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        foreach (var (key, created) in entries)
+        {
+            store.TryAdd(key, new TimedAuthorizeState(new Duende.IdentityModel.OidcClient.AuthorizeState(), created));
+        }
+
+        return store;
+    }
+
+    [Fact]
+    public void InvalidateExpired_RemovesOnlyExpiredEntries()
+    {
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var store = StoreWith(
+            ("expired", now.AddMinutes(-5)),
+            ("fresh", now.AddSeconds(-10)));
+
+        AuthStateStore.InvalidateExpired(store, now, Lifetime);
+
+        Assert.False(store.ContainsKey("expired"));
+        Assert.True(store.ContainsKey("fresh"));
+    }
+
+    [Fact]
+    public void InvalidateExpired_ExactlyAtLifetime_IsKept()
+    {
+        // Pins the strict ">" comparison of the original implementation: an entry aged exactly
+        // one lifetime is still accepted; one tick beyond is not.
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var store = StoreWith(
+            ("at-boundary", now.Subtract(Lifetime)),
+            ("past-boundary", now.Subtract(Lifetime).AddTicks(-1)));
+
+        AuthStateStore.InvalidateExpired(store, now, Lifetime);
+
+        Assert.True(store.ContainsKey("at-boundary"));
+        Assert.False(store.ContainsKey("past-boundary"));
+    }
+
+    [Fact]
+    public async Task InvalidateExpired_ConcurrentWithAdds_DoesNotThrowAndKeepsFreshEntries()
+    {
+        // Regression for the login-path race: one request pruning while others add states.
+        // On the previous plain Dictionary this interleaving threw InvalidOperationException.
+        var now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var store = StoreWith(("seed-expired", now.AddMinutes(-5)));
+
+        var adder = Task.Run(
+            () =>
+            {
+                for (var i = 0; i < 5000; i++)
+                {
+                    store.TryAdd("fresh-" + i, new TimedAuthorizeState(new Duende.IdentityModel.OidcClient.AuthorizeState(), now));
+                }
+            },
+            TestContext.Current.CancellationToken);
+        var pruner = Task.Run(
+            () =>
+            {
+                for (var i = 0; i < 200; i++)
+                {
+                    AuthStateStore.InvalidateExpired(store, now, Lifetime);
+                }
+            },
+            TestContext.Current.CancellationToken);
+
+        await Task.WhenAll(adder, pruner);
+
+        Assert.False(store.ContainsKey("seed-expired"));
+        Assert.Equal(5000, store.Count);
+    }
+}

--- a/SSO-Auth/Api/AuthStateStore.cs
+++ b/SSO-Auth/Api/AuthStateStore.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Helpers for maintaining the in-flight OpenID authorize-state store in a thread-safe manner.
+/// </summary>
+internal static class AuthStateStore
+{
+    /// <summary>
+    /// Removes every authorize state whose lifetime has elapsed. Safe to call concurrently with
+    /// additions and removals because it operates on a <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+    /// </summary>
+    /// <param name="states">The state store to prune.</param>
+    /// <param name="now">The reference time used to evaluate expiry.</param>
+    /// <param name="lifetime">How long a state may live before it is considered expired.</param>
+    internal static void InvalidateExpired(
+        ConcurrentDictionary<string, TimedAuthorizeState> states,
+        DateTime now,
+        TimeSpan lifetime)
+    {
+        foreach (var kvp in states)
+        {
+            if (now.Subtract(kvp.Value.Created) > lifetime)
+            {
+                states.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -48,7 +49,11 @@ public class SSOController : ControllerBase
     private readonly IProviderManager _providerManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly IHttpClientFactory _httpClientFactory;
-    private static readonly IDictionary<string, TimedAuthorizeState> StateManager = new Dictionary<string, TimedAuthorizeState>();
+    // Concurrent requests add to, enumerate, and prune this map (OidChallenge / OidAuth /
+    // OidLink / Invalidate); a plain Dictionary corrupts or throws under that interleaving.
+    private static readonly ConcurrentDictionary<string, TimedAuthorizeState> StateManager = new ConcurrentDictionary<string, TimedAuthorizeState>();
+
+    private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(1);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
@@ -417,10 +422,8 @@ public class SSOController : ControllerBase
                 return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
             }
 
-            StateManager.Add(state.State, new TimedAuthorizeState(state, DateTime.Now));
-
-            // Track whether this is a linking request or not.
-            StateManager[state.State].IsLinking = isLinking;
+            // IsLinking tracks whether this is a linking request rather than a login.
+            StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking });
             return Redirect(state.StartUrl);
         }
 
@@ -537,7 +540,7 @@ public class SSOController : ControllerBase
                         config.DefaultProvider?.Trim(),
                         kvp.Value.AvatarURL)
                         .ConfigureAwait(false);
-                    StateManager.Remove(kvp.Key);
+                    StateManager.TryRemove(kvp.Key, out _);
                     return Ok(authenticationResult);
                 }
             }
@@ -1270,14 +1273,7 @@ public class SSOController : ControllerBase
 
     private void Invalidate()
     {
-        foreach (var kvp in StateManager)
-        {
-            var now = DateTime.Now;
-            if (now.Subtract(kvp.Value.Created).TotalMinutes > 1)
-            {
-                StateManager.Remove(kvp.Key);
-            }
-        }
+        AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
     }
 
     private string GetRequestBase(string schemeOverride = null, int? portOverride = null)

--- a/SSO-Auth/AssemblyInfo.cs
+++ b/SSO-Auth/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SSO-Auth.Tests")]


### PR DESCRIPTION
# What & why

The static OpenID state `Dictionary` is mutated and enumerated by concurrent requests without synchronization, 500s on the login path under load and possible map corruption. Replaced with a `ConcurrentDictionary`, the expiry sweep extracted into a pure time-injected helper (`AuthStateStore`), and entries are now fully populated before publication. Behavior-preserving apart from thread safety. Closes #20

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: expiry boundary and pruning schedule unchanged, pinned by boundary tests.
- [x] No secrets logged; no config or export changes.
- [x] A security review was performed for this change to the login path.
- [x] No IdP-sourced values added to any log call.

## Quality checklist

- [x] Expiry logic now lives in one pure, single-purpose, tested unit.
- [x] The change adds no more code than the problem requires; the controller shrinks.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug and Release, 0 warnings.
- [x] `dotnet test` green: 15/15 (3 new: expiry pruning, exact boundary, concurrency regression).
- [ ] Prettier: no web files touched.

## Notes

Pre-existing state-store weaknesses (atomic single-redemption claim, age check at read time, UTC-based expiry) are deliberately out of scope and tracked for a follow-up hardening round.
