### PR TITLE
Harden SAML assertion time validation (fail-closed)

### DIFF
--- a/SSO-Auth.Tests/SamlAssertionTimeTests.cs
+++ b/SSO-Auth.Tests/SamlAssertionTimeTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Globalization;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlAssertionTime"/> — the fail-closed time-window check. The upper
+/// bound (NotOnOrAfter) is required and absent/unparseable bounds are rejections, closing the
+/// F-2 fail-open (a missing time bound previously meant "valid forever").
+/// </summary>
+public class SamlAssertionTimeTests
+{
+    private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly TimeSpan Skew = TimeSpan.FromMinutes(3);
+
+    private static string At(int minutesFromNow) =>
+        Now.AddMinutes(minutesFromNow).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+    private static bool Valid(string? subjectNotOnOrAfter, string? condNotBefore, string? condNotOnOrAfter) =>
+        SamlAssertionTime.IsWithinValidity(subjectNotOnOrAfter, condNotBefore, condNotOnOrAfter, Now, Skew);
+
+    [Fact]
+    public void NoUpperBoundAtAll_IsRejected()
+    {
+        Assert.False(Valid(null, null, null));
+    }
+
+    [Fact]
+    public void SubjectUpperBoundInFuture_IsAccepted()
+    {
+        Assert.True(Valid(At(5), null, null));
+    }
+
+    [Fact]
+    public void SubjectUpperBoundInPastBeyondSkew_IsRejected()
+    {
+        Assert.False(Valid(At(-10), null, null));
+    }
+
+    [Fact]
+    public void SubjectUpperBoundJustPastButWithinSkew_IsAccepted()
+    {
+        // Expired by two minutes, tolerated by the five-minute skew.
+        Assert.True(Valid(At(-2), null, null));
+    }
+
+    [Fact]
+    public void UnparseableUpperBound_IsRejected()
+    {
+        Assert.False(Valid("not-a-date", null, null));
+    }
+
+    [Fact]
+    public void ConditionsUpperBoundOnly_IsEnforced()
+    {
+        Assert.True(Valid(null, null, At(5)));
+        Assert.False(Valid(null, null, At(-10)));
+    }
+
+    [Fact]
+    public void ConditionsNotBeforeInFutureBeyondSkew_IsRejected()
+    {
+        Assert.False(Valid(At(5), At(30), null));
+    }
+
+    [Fact]
+    public void ConditionsNotBeforeJustAheadWithinSkew_IsAccepted()
+    {
+        Assert.True(Valid(At(5), At(1), null));
+    }
+
+    [Fact]
+    public void PresentButUnparseableNotBefore_IsRejected()
+    {
+        Assert.False(Valid(At(5), "garbage", null));
+    }
+
+    [Fact]
+    public void BothBoundsPresentAndNowInside_IsAccepted()
+    {
+        Assert.True(Valid(At(5), At(-5), At(5)));
+    }
+}

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -66,7 +66,7 @@ public class SamlResponseTests
     [Fact]
     public void IsValid_ExpiredNotOnOrAfter_ReturnsFalse()
     {
-        var fixture = SamlTestFactory.Create(notOnOrAfter: System.DateTime.UtcNow.AddMinutes(-5));
+        var fixture = SamlTestFactory.Create(notOnOrAfter: System.DateTime.UtcNow.AddMinutes(-10));
         Assert.False(Load(fixture).IsValid());
     }
 
@@ -119,15 +119,33 @@ public class SamlResponseTests
         Assert.Null(Load(fixture).GetCustomAttribute("NonExistent"));
     }
 
-    // --- Characterization of known-insecure current behavior (docs/SECURITY-FINDINGS.md) ---
+    // --- Time-bound validation (fail-closed; F-2 fixed) ---
 
     [Fact]
-    public void IsValid_MissingNotOnOrAfter_ReturnsTrue_KnownFailOpen()
+    public void IsValid_MissingAnyTimeBound_ReturnsFalse()
     {
-        // FINDING F-2: with no NotOnOrAfter bound, IsExpired() defaults the expiry to
-        // DateTime.MaxValue and the assertion is accepted forever. The P2 fix flips this to
-        // fail-closed (a missing time bound must be rejected); this assertion inverts then.
+        // F-2 fix: an assertion with no NotOnOrAfter anywhere must be rejected, not accepted
+        // forever (the previous DateTime.MaxValue fail-open default).
         var fixture = SamlTestFactory.Create(includeNotOnOrAfter: false);
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_OnlyConditionsUpperBound_ReturnsTrue()
+    {
+        // An IdP that carries the upper bound only in Conditions (not SubjectConfirmationData)
+        // must still authenticate — we require at least one upper bound, not that specific one.
+        var fixture = SamlTestFactory.Create(
+            includeNotOnOrAfter: false,
+            conditionsNotOnOrAfter: System.DateTime.UtcNow.AddMinutes(5));
         Assert.True(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_ConditionsNotBeforeInFuture_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create(
+            conditionsNotBefore: System.DateTime.UtcNow.AddMinutes(30));
+        Assert.False(Load(fixture).IsValid());
     }
 }

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -36,6 +36,8 @@ internal static class SamlTestFactory
     /// <param name="role">The value of the "Role" attribute.</param>
     /// <param name="notOnOrAfter">SubjectConfirmationData/@NotOnOrAfter; defaults to five minutes in the future.</param>
     /// <param name="includeNotOnOrAfter">When false, the NotOnOrAfter attribute is omitted entirely.</param>
+    /// <param name="conditionsNotBefore">When set, emits a Conditions element carrying this NotBefore.</param>
+    /// <param name="conditionsNotOnOrAfter">When set, emits a Conditions element carrying this NotOnOrAfter.</param>
     /// <param name="scope">Which element to sign.</param>
     /// <param name="signWithSha1">When true, sign with RSA-SHA1/SHA1 digest (for weak-algorithm tests).</param>
     /// <returns>A fixture exposing the certificate and the signed document.</returns>
@@ -44,9 +46,12 @@ internal static class SamlTestFactory
         string role = "jellyfin-users",
         DateTime? notOnOrAfter = null,
         bool includeNotOnOrAfter = true,
+        DateTime? conditionsNotBefore = null,
+        DateTime? conditionsNotOnOrAfter = null,
         SignatureScope scope = SignatureScope.Response,
         bool signWithSha1 = false)
     {
+        const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
         var effectiveNotOnOrAfter = notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5);
 
         using var rsa = RSA.Create(2048);
@@ -57,13 +62,31 @@ internal static class SamlTestFactory
         var assertionId = "_" + Guid.NewGuid().ToString("N");
 
         var subjectConfirmationData = includeNotOnOrAfter
-            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture) + "\" />"
+            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\" />"
             : "<saml:SubjectConfirmationData />";
+
+        var conditions = string.Empty;
+        if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue)
+        {
+            var attributes = new StringBuilder();
+            if (conditionsNotBefore.HasValue)
+            {
+                attributes.Append(" NotBefore=\"" + conditionsNotBefore.Value.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
+            }
+
+            if (conditionsNotOnOrAfter.HasValue)
+            {
+                attributes.Append(" NotOnOrAfter=\"" + conditionsNotOnOrAfter.Value.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
+            }
+
+            conditions = "<saml:Conditions" + attributes + " />";
+        }
 
         var xml =
             "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\">" +
                 "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
                     "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
+                    conditions +
                     "<saml:Subject>" +
                         "<saml:NameID>" + nameId + "</saml:NameID>" +
                         "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -108,7 +108,7 @@ public class Response
         }
 
         signedXml.LoadXml((XmlElement)nodeList[0]);
-        return ValidateSignatureReference(signedXml) && signedXml.CheckSignature(_certificate, true) && !IsExpired();
+        return ValidateSignatureReference(signedXml) && signedXml.CheckSignature(_certificate, true) && IsWithinTimeBounds();
     }
 
     // an XML signature can "cover" not the whole document, but only a part of it
@@ -142,16 +142,20 @@ public class Response
         return true;
     }
 
-    private bool IsExpired()
+    // Fail-closed time-bound validation: an assertion is accepted only if it carries at least one
+    // parseable upper bound (NotOnOrAfter) and every present bound holds, within a small clock skew.
+    // A missing or unparseable upper bound is a rejection, not an accept-forever (the old behavior).
+    private bool IsWithinTimeBounds()
     {
-        var expirationDate = DateTime.MaxValue;
-        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager);
-        if (node != null && node.Attributes["NotOnOrAfter"] != null)
-        {
-            DateTime.TryParse(node.Attributes["NotOnOrAfter"].Value, out expirationDate);
-        }
+        var subjectConfirmationData = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager);
+        var conditions = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Conditions", _xmlNameSpaceManager);
 
-        return DateTime.UtcNow > expirationDate.ToUniversalTime();
+        return SamlAssertionTime.IsWithinValidity(
+            subjectConfirmationData?.Attributes?["NotOnOrAfter"]?.Value,
+            conditions?.Attributes?["NotBefore"]?.Value,
+            conditions?.Attributes?["NotOnOrAfter"]?.Value,
+            DateTime.UtcNow,
+            SamlAssertionTime.ClockSkew);
     }
 
     /// <summary>

--- a/SSO-Auth/SamlAssertionTime.cs
+++ b/SSO-Auth/SamlAssertionTime.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.SSO_Auth;
+
+/// <summary>
+/// Pure, fail-closed validation of a SAML assertion's time bounds.
+/// </summary>
+internal static class SamlAssertionTime
+{
+    /// <summary>
+    /// The clock-skew tolerance applied to both bounds, so a small clock difference between the
+    /// identity provider and this server does not reject an otherwise-valid assertion. Five minutes
+    /// matches the common IdP default (e.g. ADFS).
+    /// </summary>
+    internal static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Determines whether an assertion is currently within its validity window. Fail-closed:
+    /// at least one upper bound (NotOnOrAfter) MUST be present and parseable, or the assertion is
+    /// rejected; a bound that is present but unparseable is likewise a rejection. Bounds are
+    /// evaluated in UTC with <see cref="ClockSkew"/> tolerance.
+    /// </summary>
+    /// <param name="subjectNotOnOrAfter">SubjectConfirmationData/@NotOnOrAfter, or null if absent.</param>
+    /// <param name="conditionsNotBefore">Conditions/@NotBefore, or null if absent.</param>
+    /// <param name="conditionsNotOnOrAfter">Conditions/@NotOnOrAfter, or null if absent.</param>
+    /// <param name="nowUtc">The current time, in UTC.</param>
+    /// <param name="skew">The clock-skew tolerance applied to each bound.</param>
+    /// <returns>True only when a valid upper bound exists and every present bound is satisfied.</returns>
+    internal static bool IsWithinValidity(
+        string subjectNotOnOrAfter,
+        string conditionsNotBefore,
+        string conditionsNotOnOrAfter,
+        DateTime nowUtc,
+        TimeSpan skew)
+    {
+        // Apply the skew to "now" rather than to the parsed bounds: nowUtc is always a present-day
+        // value, so nowUtc +/- skew cannot overflow, whereas a pathological IdP-supplied bound near
+        // DateTime.MaxValue/MinValue would throw if skew were added to it.
+        var lowerReference = nowUtc + skew; // must be >= NotBefore
+        var upperReference = nowUtc - skew; // must be < NotOnOrAfter
+        var haveUpperBound = false;
+
+        foreach (var raw in new[] { subjectNotOnOrAfter, conditionsNotOnOrAfter })
+        {
+            if (raw == null)
+            {
+                continue;
+            }
+
+            if (!TryParseUtc(raw, out var notOnOrAfter))
+            {
+                return false; // present but unparseable -> fail closed
+            }
+
+            haveUpperBound = true;
+            if (upperReference >= notOnOrAfter) // NotOnOrAfter is an exclusive upper bound
+            {
+                return false;
+            }
+        }
+
+        if (!haveUpperBound)
+        {
+            return false; // no time bound at all -> never accept
+        }
+
+        if (conditionsNotBefore != null)
+        {
+            if (!TryParseUtc(conditionsNotBefore, out var notBefore))
+            {
+                return false;
+            }
+
+            if (lowerReference < notBefore)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseUtc(string raw, out DateTime utc)
+    {
+        // SAML timestamps are xsd:dateTime in UTC ('...Z'). Parse culture-invariantly and normalize
+        // to UTC, assuming UTC when no offset is present rather than the machine's local zone.
+        return DateTime.TryParse(
+            raw,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal,
+            out utc);
+    }
+}


### PR DESCRIPTION
# What & why

SAML response validation defaulted a missing expiry to `DateTime.MaxValue`, so an assertion with no `NotOnOrAfter` (or an unparseable one) was accepted as valid forever. There was no `NotBefore` check and timestamps were parsed in the machine's local culture.

This makes the time-bound check fail-closed: at least one parseable upper bound is required, every present bound must hold, `Conditions/@NotBefore` is enforced when present, timestamps are parsed as UTC culture-invariantly, and a five-minute clock skew is applied to the current time (not to the parsed bound, which avoids an overflow edge). The logic lives in a pure, unit-tested helper. Closes #24

## Type of change

- [x] Security hardening / vulnerability fix

## Security checklist

- [x] Fail-closed: missing, unparseable, or expired bounds are rejected; a `NotBefore` in the future is rejected.
- [x] No secrets logged; no config or export changes.
- [x] A five-lens adversarial review (bypass, availability, correctness, integration, SAML domain) was run, all PASS. The two non-blocking notes (skew value, overflow edge) are addressed in this change.
- [x] No IdP-sourced values added to any log call.

## Quality checklist

- [x] Time logic is one pure, single-purpose, fully tested helper.
- [x] Skew applied to `now` rather than the parsed bound, no arithmetic overflow on pathological timestamps.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug and Release, 0 warnings.
- [x] `dotnet test` green: 27/27 (12 new/changed across the helper and Response suites).

## Notes

Assertion replay cache, audience/recipient binding, and `InResponseTo` correlation remain out of scope and are tracked as follow-ups.
