### PR TITLE
Bind SSO logins to existing accounts fail-closed

### DIFF
--- a/SSO-Auth.Tests/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/AccountLinkResolverTests.cs
@@ -1,0 +1,52 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AccountLinkResolver"/> — the fail-closed decision that binds an SSO identity
+/// to a Jellyfin account. The security-critical case is that a pre-existing, unlinked account is
+/// NOT adopted unless the administrator opted in, preventing account takeover by name collision.
+/// </summary>
+public class AccountLinkResolverTests
+{
+    private static readonly Guid Linked = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Existing = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ExistingLink_IsAlwaysUsed_RegardlessOfOptIn(bool allow)
+    {
+        var decision = AccountLinkResolver.Resolve(Linked, Existing, allow);
+        Assert.Equal(AccountLinkAction.UseExistingLink, decision.Action);
+        Assert.Equal(Linked, decision.UserId);
+    }
+
+    [Fact]
+    public void NoLinkButNameTaken_WithoutOptIn_IsRejected()
+    {
+        var decision = AccountLinkResolver.Resolve(null, Existing, allowExistingAccountLink: false);
+        Assert.Equal(AccountLinkAction.RejectNameTaken, decision.Action);
+        Assert.Equal(Guid.Empty, decision.UserId);
+    }
+
+    [Fact]
+    public void NoLinkButNameTaken_WithOptIn_AdoptsExistingAccount()
+    {
+        var decision = AccountLinkResolver.Resolve(null, Existing, allowExistingAccountLink: true);
+        Assert.Equal(AccountLinkAction.AdoptExistingAccount, decision.Action);
+        Assert.Equal(Existing, decision.UserId);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoLinkAndNameFree_CreatesNewAccount_RegardlessOfOptIn(bool allow)
+    {
+        var decision = AccountLinkResolver.Resolve(null, null, allow);
+        Assert.Equal(AccountLinkAction.CreateNewAccount, decision.Action);
+        Assert.Equal(Guid.Empty, decision.UserId);
+    }
+}

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -1,0 +1,97 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The action to take when resolving an SSO identity to a Jellyfin account.
+/// </summary>
+internal enum AccountLinkAction
+{
+    /// <summary>Use the account already linked to this SSO identity.</summary>
+    UseExistingLink,
+
+    /// <summary>Adopt a pre-existing Jellyfin account that happens to share the identity's name.</summary>
+    AdoptExistingAccount,
+
+    /// <summary>Create a brand-new Jellyfin account for this SSO identity.</summary>
+    CreateNewAccount,
+
+    /// <summary>Refuse: the name is taken by an account we are not permitted to adopt.</summary>
+    RejectNameTaken,
+}
+
+/// <summary>
+/// A resolved account-link decision: the action and the Jellyfin user id it applies to.
+/// </summary>
+internal readonly struct AccountLinkDecision
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccountLinkDecision"/> struct.
+    /// </summary>
+    /// <param name="action">The action to take.</param>
+    /// <param name="userId">The Jellyfin user id the action applies to (empty when creating/rejecting).</param>
+    internal AccountLinkDecision(AccountLinkAction action, Guid userId)
+    {
+        Action = action;
+        UserId = userId;
+    }
+
+    /// <summary>Gets the action to take.</summary>
+    internal AccountLinkAction Action { get; }
+
+    /// <summary>Gets the Jellyfin user id the action applies to.</summary>
+    internal Guid UserId { get; }
+}
+
+/// <summary>
+/// Pure decision logic mapping an SSO identity to a Jellyfin account. An identity already linked to
+/// an account always uses that link. Otherwise a pre-existing account that merely shares the SSO
+/// name is adopted ONLY when the administrator has opted in; by default the login fails closed. This
+/// stops an attacker whose identity provider name matches an existing account (e.g. "admin") from
+/// taking that account over on first login.
+/// </summary>
+internal static class AccountLinkResolver
+{
+    /// <summary>
+    /// Decides how to resolve an SSO login to a Jellyfin account.
+    /// </summary>
+    /// <param name="linkedUserId">User id already linked to this SSO identity, if any and still valid.</param>
+    /// <param name="existingAccountUserId">User id of a pre-existing account matching the name, if any.</param>
+    /// <param name="allowExistingAccountLink">Whether adopting a same-named pre-existing account is permitted.</param>
+    /// <returns>The resolved decision.</returns>
+    internal static AccountLinkDecision Resolve(
+        Guid? linkedUserId,
+        Guid? existingAccountUserId,
+        bool allowExistingAccountLink)
+    {
+        if (linkedUserId.HasValue)
+        {
+            return new AccountLinkDecision(AccountLinkAction.UseExistingLink, linkedUserId.Value);
+        }
+
+        if (existingAccountUserId.HasValue)
+        {
+            return allowExistingAccountLink
+                ? new AccountLinkDecision(AccountLinkAction.AdoptExistingAccount, existingAccountUserId.Value)
+                : new AccountLinkDecision(AccountLinkAction.RejectNameTaken, Guid.Empty);
+        }
+
+        return new AccountLinkDecision(AccountLinkAction.CreateNewAccount, Guid.Empty);
+    }
+}
+
+/// <summary>
+/// Thrown when an SSO login resolves to a pre-existing, unlinked Jellyfin account and adopting such
+/// accounts is not permitted for the provider. The controller maps this to an HTTP 403.
+/// </summary>
+internal sealed class AccountLinkForbiddenException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccountLinkForbiddenException"/> class.
+    /// </summary>
+    /// <param name="canonicalName">The SSO name whose adoption was refused.</param>
+    internal AccountLinkForbiddenException(string canonicalName)
+        : base($"An unlinked Jellyfin account already exists for '{canonicalName}'. Enable AllowExistingAccountLink for this provider to adopt it.")
+    {
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -526,7 +526,16 @@ public class SSOController : ControllerBase
             {
                 if (kvp.Value.State.State.Equals(response.Data) && kvp.Value.Valid)
                 {
-                    Guid userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, kvp.Value.Username);
+                    Guid userId;
+                    try
+                    {
+                        userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, kvp.Value.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
+                    }
+                    catch (AccountLinkForbiddenException)
+                    {
+                        StateManager.TryRemove(kvp.Key, out _);
+                        return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
+                    }
 
                     var authenticationResult = await Authenticate(
                         userId,
@@ -813,7 +822,15 @@ public class SSOController : ControllerBase
                 }
             }
 
-            Guid userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, samlResponse.GetNameID());
+            Guid userId;
+            try
+            {
+                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, samlResponse.GetNameID(), config.AllowExistingAccountLink).ConfigureAwait(false);
+            }
+            catch (AccountLinkForbiddenException)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
+            }
 
             var authenticationResult = await Authenticate(
                 userId,
@@ -873,63 +890,45 @@ public class SSOController : ControllerBase
         return links;
     }
 
-    private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName)
+    private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName, bool allowExistingAccountLink)
     {
-        User user = null;
-
-        // First try to get the user by its id in case it was already registered before
-        Guid userId = Guid.Empty;
-        try
+        // An identity already linked to a still-existing account is keyed on the canonical name;
+        // a dangling link (user since deleted) is treated as no link.
+        Guid? linkedUserId = null;
+        if (GetCanonicalLinks(mode, provider).TryGetValue(canonicalName, out var linked) && _userManager.GetUserById(linked) != null)
         {
-            userId = GetCanonicalLink(mode, provider, canonicalName);
-        }
-        catch (KeyNotFoundException)
-        {
-            userId = Guid.Empty;
+            linkedUserId = linked;
         }
 
-        // No userId found? Let's try and find the user by name instead
-        if (userId == Guid.Empty)
-        {
-            user = _userManager.GetUserByName(canonicalName);
-        }
-        else
-        {
-            user = _userManager.GetUserById(userId);
-        }
+        Guid? existingAccountUserId = _userManager.GetUserByName(canonicalName)?.Id;
 
-        if (user == null)
+        var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
+        switch (decision.Action)
         {
-            _logger.LogInformation($"SSO user {canonicalName} doesn't exist, creating...");
-            user = await _userManager.CreateUserAsync(canonicalName).ConfigureAwait(false);
-            user.AuthenticationProviderId = GetType().FullName;
-            // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
-            user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+            case AccountLinkAction.UseExistingLink:
+                return decision.UserId;
 
-            // Make sure there aren't any trailing existing links
-            var links = GetCanonicalLinks(mode, provider);
-            links.Remove(canonicalName);
-            UpdateCanonicalLinkConfig(links, mode, provider);
-        }
+            case AccountLinkAction.AdoptExistingAccount:
+                CreateCanonicalLink(mode, provider, decision.UserId, canonicalName);
+                return decision.UserId;
 
-        userId = Guid.Empty;
-        try
-        {
-            userId = GetCanonicalLink(mode, provider, canonicalName);
-        }
-        catch (KeyNotFoundException)
-        {
-            userId = Guid.Empty;
-        }
+            case AccountLinkAction.CreateNewAccount:
+                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", canonicalName?.ReplaceLineEndings(string.Empty));
+                var user = await _userManager.CreateUserAsync(canonicalName).ConfigureAwait(false);
+                user.AuthenticationProviderId = GetType().FullName;
+                // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
+                user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+                CreateCanonicalLink(mode, provider, user.Id, canonicalName);
+                return user.Id;
 
-        if (userId == Guid.Empty)
-        {
-            _logger.LogInformation("SSO user link doesn't exist, creating...");
-            userId = user.Id;
-            CreateCanonicalLink(mode, provider, userId, canonicalName);
+            default:
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
+                    canonicalName?.ReplaceLineEndings(string.Empty),
+                    mode,
+                    provider?.ReplaceLineEndings(string.Empty));
+                throw new AccountLinkForbiddenException(canonicalName);
         }
-
-        return userId;
     }
 
     private Guid GetCanonicalLink(string mode, string provider, string canonicalName)

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -65,6 +65,13 @@ public class SamlConfig
     public bool EnableAuthorization { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
+    /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
+    /// login that matches an existing account is rejected rather than taking it over.
+    /// </summary>
+    public bool AllowExistingAccountLink { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether all folders are allowed by default.
     /// </summary>
     public bool EnableAllFolders { get; set; }
@@ -192,6 +199,13 @@ public class OidConfig
     /// Gets or sets a value indicating whether RBAC is enabled.
     /// </summary>
     public bool EnableAuthorization { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
+    /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
+    /// login that matches an existing account is rejected rather than taking it over.
+    /// </summary>
+    public bool AllowExistingAccountLink { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether all folders are allowed by default.


### PR DESCRIPTION
# What & why

On first login, an SSO identity whose name matched a pre-existing Jellyfin account was auto-adopted, the binding fell back to `GetUserByName` and linked the identity to that account. Because the name comes from an identity-provider claim (`preferred_username` / `NameID`), a user able to set it to an existing account's username (e.g. `admin`) could take that account over.

Account binding now fails closed via a pure `AccountLinkResolver`: an already-linked identity keeps its link; a same-named pre-existing account is adopted only when the new per-provider `AllowExistingAccountLink` option is enabled; otherwise the login is refused with a generic 403. Closes #26

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Breaking (behavior): same-named accounts are no longer auto-adopted by default

## Security checklist

- [x] Fail-closed: default `AllowExistingAccountLink = false`; existing configs without the element deserialize to false.
- [x] Already-linked users unaffected (link keyed on the same name used for lookup); a link to a deleted user is treated as no link.
- [x] Generic 403 to the client; provider/option detail logged for the admin only (no account-name enumeration in the response).
- [x] Four-lens adversarial review (bypass, availability, correctness, integration), all PASS.

## Quality checklist

- [x] Decision logic is one pure, fully unit-tested helper; the controller method shrank.
- [x] Log inputs sanitized inline; no duplication added.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (incl. `--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 33/33 (5 new resolver cases).

## Upgrade note

Links created by the previous adopt-by-name behavior are still honored. Administrators should audit each provider's `CanonicalLinks` after upgrading and enable `AllowExistingAccountLink` only for providers where adopting same-named local accounts is intended.
