### PR TITLE
Constrain server-side avatar fetch to public http(s) targets

### DIFF
--- a/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
+++ b/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Coverage for the avatar-fetch SSRF guard: only public http(s) targets may be fetched.
+/// </summary>
+public class AvatarUrlValidatorTests
+{
+    [Theory]
+    [InlineData("https://cdn.example.com/avatar.png")]
+    [InlineData("http://example.com/a.jpg")]
+    [InlineData("https://8.8.8.8/pic.png")]
+    public void IsAllowedUrl_PublicHttpTargets_ReturnsTrue(string url)
+    {
+        Assert.True(AvatarUrlValidator.IsAllowedUrl(url, out var uri));
+        Assert.NotNull(uri);
+    }
+
+    [Theory]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("ftp://example.com/x")]
+    [InlineData("gopher://example.com/x")]
+    [InlineData("not a url")]
+    [InlineData("/relative/path")]
+    [InlineData("")]
+    [InlineData("http://localhost/x")]
+    [InlineData("http://service.localhost/x")]
+    [InlineData("http://127.0.0.1/x")]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://192.0.0.192/")]
+    [InlineData("http://10.0.0.5/x")]
+    [InlineData("http://192.168.1.1/x")]
+    [InlineData("http://172.16.0.1/x")]
+    [InlineData("http://[::1]/x")]
+    public void IsAllowedUrl_DisallowedTargets_ReturnsFalse(string url)
+    {
+        Assert.False(AvatarUrlValidator.IsAllowedUrl(url, out var uri));
+        Assert.Null(uri);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("10.1.2.3")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.255")]
+    [InlineData("192.168.0.1")]
+    [InlineData("169.254.0.1")]
+    [InlineData("100.64.0.1")]
+    [InlineData("0.0.0.0")]
+    [InlineData("::1")]
+    [InlineData("fe80::1")]
+    [InlineData("fc00::1")]
+    [InlineData("::ffff:127.0.0.1")]
+    [InlineData("224.0.0.1")] // multicast
+    [InlineData("239.255.255.250")] // multicast (SSDP)
+    [InlineData("240.0.0.1")] // reserved
+    [InlineData("255.255.255.255")] // broadcast
+    [InlineData("64:ff9b::7f00:1")] // NAT64 well-known prefix embedding 127.0.0.1
+    [InlineData("64:ff9b::a00:5")] // NAT64 embedding 10.0.0.5
+    [InlineData("2002:7f00:1::")] // 6to4 embedding 127.0.0.1
+    [InlineData("2002:c0a8:101::")] // 6to4 embedding 192.168.1.1
+    [InlineData("::7f00:1")] // deprecated IPv4-compatible ::127.0.0.1
+    [InlineData("192.0.0.192")] // Oracle Cloud metadata (192.0.0.0/24 protocol assignments)
+    [InlineData("fec0::1")] // deprecated IPv6 site-local
+    public void IsBlockedAddress_PrivateOrLoopback_ReturnsTrue(string ip)
+    {
+        Assert.True(AvatarUrlValidator.IsBlockedAddress(IPAddress.Parse(ip)));
+    }
+
+    [Theory]
+    [InlineData("8.8.8.8")]
+    [InlineData("1.1.1.1")]
+    [InlineData("172.32.0.1")]
+    [InlineData("100.63.255.255")]
+    [InlineData("223.255.255.255")] // last unicast address just below the 224/4 multicast range
+    [InlineData("2606:4700:4700::1111")]
+    [InlineData("64:ff9b::808:808")] // NAT64 embedding the public 8.8.8.8
+    public void IsBlockedAddress_PublicAddresses_ReturnsFalse(string ip)
+    {
+        Assert.False(AvatarUrlValidator.IsBlockedAddress(IPAddress.Parse(ip)));
+    }
+}

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Validation helpers that constrain the server-side avatar fetch to public http(s) targets,
+/// mitigating server-side request forgery via IdP-supplied avatar URLs/claims.
+/// </summary>
+internal static class AvatarUrlValidator
+{
+    /// <summary>
+    /// Checks that the URL is an absolute http/https URL that does not obviously target a
+    /// loopback/private/link-local address or localhost. Hostnames are validated again at connect
+    /// time against their resolved address to defend against DNS-based SSRF and rebinding.
+    /// </summary>
+    /// <param name="url">The candidate avatar URL.</param>
+    /// <param name="uri">The parsed URI when allowed; otherwise null.</param>
+    /// <returns>True when the URL is allowed to be fetched.</returns>
+    internal static bool IsAllowedUrl(string url, out Uri uri)
+    {
+        uri = null;
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+        {
+            return false;
+        }
+
+        var host = parsed.DnsSafeHost;
+        if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (IPAddress.TryParse(host, out var literal) && IsBlockedAddress(literal))
+        {
+            return false;
+        }
+
+        uri = parsed;
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether an IP address belongs to a range that must never be reached by the
+    /// avatar fetch (loopback, private, carrier-grade NAT, link-local, unique-local, unspecified).
+    /// </summary>
+    /// <param name="address">The address to classify.</param>
+    /// <returns>True when the address is blocked.</returns>
+    internal static bool IsBlockedAddress(IPAddress address)
+    {
+        if (IPAddress.IsLoopback(address))
+        {
+            return true;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = address.GetAddressBytes();
+
+            // 0.0.0.0/8 (this network), 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local),
+            // 172.16.0.0/12, 192.0.0.0/24 (IETF protocol assignments incl. the 192.0.0.192 cloud-metadata
+            // address), 192.168.0.0/16, and 224.0.0.0/3 (multicast 224/4, reserved 240/4, broadcast).
+            return b[0] == 0
+                || b[0] == 10
+                || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+                || (b[0] == 169 && b[1] == 254)
+                || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+                || (b[0] == 192 && b[1] == 0 && b[2] == 0)
+                || (b[0] == 192 && b[1] == 168)
+                || b[0] >= 224;
+        }
+
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (address.IsIPv4MappedToIPv6)
+            {
+                return IsBlockedAddress(address.MapToIPv4());
+            }
+
+            // IPv4-in-IPv6 transition addresses (6to4, the NAT64 well-known prefix, and the deprecated
+            // IPv4-compatible form) embed an IPv4 address that can target an internal range - unwrap it and
+            // re-check, so e.g. [64:ff9b::7f00:1] cannot smuggle 127.0.0.1 past the filter.
+            if (TryExtractEmbeddedIPv4(address.GetAddressBytes(), out var embedded))
+            {
+                return IsBlockedAddress(embedded);
+            }
+
+            // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth.
+            var v6 = address.GetAddressBytes();
+            var siteLocal = v6[0] == 0xfe && (v6[1] & 0xc0) == 0xc0;
+
+            return address.IsIPv6LinkLocal
+                || address.IsIPv6UniqueLocal
+                || address.IsIPv6Multicast
+                || siteLocal
+                || IPAddress.IPv6Any.Equals(address);
+        }
+
+        // Unknown address family: block by default.
+        return true;
+    }
+
+    /// <summary>
+    /// Extracts the IPv4 address embedded in an IPv4-in-IPv6 transition address (6to4 <c>2002::/16</c>, the
+    /// NAT64 well-known prefix <c>64:ff9b::/96</c>, or the deprecated IPv4-compatible <c>::/96</c> form), so a
+    /// blocked internal IPv4 cannot be reached by wrapping it in one of these formats.
+    /// </summary>
+    /// <param name="bytes">The 16 bytes of the IPv6 address.</param>
+    /// <param name="embedded">The embedded IPv4 address when one is present; otherwise null.</param>
+    /// <returns>True when an embedded IPv4 address was extracted.</returns>
+    private static bool TryExtractEmbeddedIPv4(byte[] bytes, out IPAddress embedded)
+    {
+        embedded = null;
+
+        // 6to4 (2002::/16): the embedded IPv4 is bytes 2-5.
+        if (bytes[0] == 0x20 && bytes[1] == 0x02)
+        {
+            embedded = new IPAddress(new[] { bytes[2], bytes[3], bytes[4], bytes[5] });
+            return true;
+        }
+
+        // NAT64 well-known prefix (64:ff9b::/96): the embedded IPv4 is the last 4 bytes.
+        if (bytes[0] == 0x00 && bytes[1] == 0x64 && bytes[2] == 0xff && bytes[3] == 0x9b
+            && bytes[4] == 0 && bytes[5] == 0 && bytes[6] == 0 && bytes[7] == 0
+            && bytes[8] == 0 && bytes[9] == 0 && bytes[10] == 0 && bytes[11] == 0)
+        {
+            embedded = new IPAddress(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
+            return true;
+        }
+
+        // IPv4-compatible (::/96, deprecated): first 96 bits zero, last 32 bits an IPv4 that is not the
+        // unspecified (::) or loopback (::1) address (both already handled above).
+        for (var i = 0; i < 12; i++)
+        {
+            if (bytes[i] != 0)
+            {
+                return false;
+            }
+        }
+
+        if (!(bytes[12] == 0 && bytes[13] == 0 && bytes[14] == 0 && (bytes[15] == 0 || bytes[15] == 1)))
+        {
+            embedded = new IPAddress(new[] { bytes[12], bytes[13], bytes[14], bytes[15] });
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -3,11 +3,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Mime;
+using System.Net.Sockets;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Data;
@@ -1199,51 +1202,75 @@ public class SSOController : ControllerBase
 
         if (avatarUrl is not null)
         {
-            try
+            if (!AvatarUrlValidator.IsAllowedUrl(avatarUrl, out var avatarUri))
             {
-                using var client = _httpClientFactory.CreateClient();
-
-                System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
-                System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-                string version = fvi.FileVersion;
-                client.DefaultRequestHeaders.UserAgent.ParseAdd($"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/9p4/jellyfin-plugin-sso)");
-
-                var avatarResponse = await client.GetAsync(avatarUrl);
-
-                if (!avatarResponse.Content.Headers.TryGetValues("content-type", out var contentTypeList))
+                _logger.LogWarning("Refusing to fetch avatar from disallowed URL: {AvatarUrl}", avatarUrl?.ReplaceLineEndings(string.Empty));
+            }
+            else
+            {
+                try
                 {
-                    throw new Exception("Cannot get Content-Type of image : " + avatarUrl);
-                }
-
-                var contentType = contentTypeList.First();
-                if (!contentType.StartsWith("image"))
-                {
-                    throw new Exception("Content type of avatar URL is not an image, got :  " + contentType);
-                }
-
-                var extension = contentType.Split("/").Last();
-                var stream = await avatarResponse.Content.ReadAsStreamAsync();
-
-                if (user != null)
-                {
-                    var userDataPath =
-                        Path.Combine(
-                            _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
-                            user.Username);
-                    if (user.ProfileImage is not null)
+                    // Route every connection (including redirect targets) through a callback that rejects
+                    // private/loopback addresses, closing the SSRF and DNS-rebinding vectors. Redirects stay
+                    // enabled (many avatar URLs redirect) but are bounded, each hop is IP-validated, and both
+                    // the request and the download are bounded.
+                    using var handler = new SocketsHttpHandler
                     {
-                        await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+                        AllowAutoRedirect = true,
+                        MaxAutomaticRedirections = 5,
+                        ConnectCallback = AvatarConnectCallback,
+
+                        // A system proxy would be the connection target, so the ConnectCallback would
+                        // validate the proxy's address rather than the avatar host's - bypassing the guard.
+                        UseProxy = false,
+                    };
+                    using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+                    var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd($"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/iderex/jellyfin-plugin-sso)");
+
+                    // ResponseHeadersRead so the body is streamed, not fully buffered, before ReadCappedAsync
+                    // enforces the size limit; otherwise the cap runs only after the whole download is in memory.
+                    using var avatarResponse = await client.GetAsync(avatarUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+                    avatarResponse.EnsureSuccessStatusCode();
+
+                    // Media types are case-insensitive (RFC 7231); use the parsed type with parameters stripped.
+                    var mediaType = avatarResponse.Content.Headers.ContentType?.MediaType;
+                    if (string.IsNullOrEmpty(mediaType) || !mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new Exception("Content type of avatar URL is not an image, got :  " + (mediaType ?? "(none)"));
                     }
 
-                    user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
+                    const long MaxAvatarBytes = 10 * 1024 * 1024;
+                    if (avatarResponse.Content.Headers.ContentLength > MaxAvatarBytes)
+                    {
+                        throw new Exception("Avatar exceeds the maximum allowed size.");
+                    }
 
-                    await _providerManager.SaveImage(stream, contentType, user.ProfileImage.Path)
-                        .ConfigureAwait(false);
+                    var extension = mediaType.Split('/').Last();
+                    using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes).ConfigureAwait(false);
+
+                    if (user != null)
+                    {
+                        var userDataPath =
+                            Path.Combine(
+                                _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
+                                user.Username);
+                        if (user.ProfileImage is not null)
+                        {
+                            await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+                        }
+
+                        user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
+
+                        await _providerManager.SaveImage(stream, mediaType, user.ProfileImage.Path)
+                            .ConfigureAwait(false);
+                    }
                 }
-            }
-            catch (Exception e)
-            {
-                _logger.LogError(e.Message);
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to fetch or save the SSO avatar.");
+                }
             }
         }
 
@@ -1273,6 +1300,85 @@ public class SSOController : ControllerBase
     private void Invalidate()
     {
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
+    }
+
+    // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that
+    // resolves to an internal address - including via DNS rebinding on a redirect hop - cannot be reached.
+    private static async ValueTask<Stream> AvatarConnectCallback(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    {
+        var addresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
+
+        // Try every non-blocked address in turn (a per-address connect fallback for dual-stack /
+        // multi-record hosts, since supplying a ConnectCallback replaces the handler's built-in one),
+        // connecting to the validated IP rather than the hostname so a DNS rebind cannot redirect the
+        // connection to an internal address.
+        Exception lastError = null;
+        var attempted = false;
+        foreach (var address in addresses)
+        {
+            if (AvatarUrlValidator.IsBlockedAddress(address))
+            {
+                continue;
+            }
+
+            attempted = true;
+            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            var connected = false;
+            try
+            {
+                await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
+                connected = true;
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                lastError = ex;
+            }
+            finally
+            {
+                // Dispose unless ownership passed to the returned NetworkStream. Runs on the
+                // cancellation path too, where the catch filter is skipped and the socket would leak.
+                if (!connected)
+                {
+                    socket.Dispose();
+                }
+            }
+        }
+
+        if (attempted)
+        {
+            throw new HttpRequestException("Could not connect to any allowed address for the avatar host.", lastError);
+        }
+
+        throw new HttpRequestException("Avatar host resolves only to blocked addresses.");
+    }
+
+    // Copies the response body into memory, aborting if it exceeds the cap, so a hostile endpoint cannot
+    // exhaust resources with an unbounded (or Content-Length-lying) download.
+    private static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes)
+    {
+        var buffer = new MemoryStream();
+        var source = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        await using (source.ConfigureAwait(false))
+        {
+            var chunk = new byte[81920];
+            long total = 0;
+            int read;
+            while ((read = await source.ReadAsync(chunk).ConfigureAwait(false)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    await buffer.DisposeAsync().ConfigureAwait(false);
+                    throw new Exception("Avatar exceeds the maximum allowed size.");
+                }
+
+                await buffer.WriteAsync(chunk.AsMemory(0, read)).ConfigureAwait(false);
+            }
+        }
+
+        buffer.Position = 0;
+        return buffer;
     }
 
     private string GetRequestBase(string schemeOverride = null, int? portOverride = null)


### PR DESCRIPTION
# What & why

The server-side avatar fetch built its URL from IdP claim values (`AvatarUrlFormat`) and then did `GetAsync` with no target validation, default redirects, no timeout, and no size cap, a server-side request forgery vector (internal services, cloud metadata at `169.254.169.254`) plus an unbounded-download risk.

The fetch is now constrained to public http(s) targets via a pure `AvatarUrlValidator`, connects only to validated resolved addresses through a `ConnectCallback` (each redirect hop revalidated, closing DNS rebinding), with the system proxy disabled, bounded redirects, a timeout, and a streamed size cap. A refused or failed fetch never fails the login. Closes #28

## Type of change

- [x] Security hardening / vulnerability fix

## Security checklist

- [x] Fail-closed: only public http(s) targets fetched; every attempted address (incl. redirect hops) is IP-validated before connect.
- [x] DNS rebinding closed (connect pins the validated IP); proxy disabled so the callback governs the real target.
- [x] Download streamed and capped at 10 MiB (`ResponseHeadersRead`); redirects bounded (5); 10s timeout.
- [x] Avatar failure is non-fatal to login.
- [x] Reviewed by a four-lens adversarial panel plus a fix-verification pass. The panel raised the size-cap/proxy/connect-fallback/blocklist points and a socket-cleanup gap; all are addressed in this change.

## Quality checklist

- [x] SSRF logic is one pure, fully unit-tested helper.
- [x] No secret logged; IdP-supplied URL sanitized inline before logging.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (incl. `--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 81/81 (48 new address/URL classification cases).

## Notes

Behavior change: avatar URLs that resolve to internal/private addresses are now refused (intended). Only affects the opt-in `AvatarUrlFormat` feature.
