### PR TITLE
Validate SAML assertion AudienceRestriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,9 @@ These all require authorization. Append an API key to the end of the request: `c
   - `samlEndpoint`: string. The SAML endpoint.
   - `samlClientId`: string. The SAML client ID.
   - `samlCertificate`: string. The base64 encoded SAML certificate.
+  - `samlAudience`: string. The audience the response must be addressed to (the assertion's `AudienceRestriction`). Leave blank to use `samlClientId`.
+  - `doNotValidateAudience`: boolean. If true, skips validating the assertion's `AudienceRestriction`. Off by default (responses must be addressed to this service provider). Only enable for a provider that cannot emit a matching audience.
+  - `allowExistingAccountLink`: boolean. If true, a first SSO login whose name matches an existing, unlinked Jellyfin account adopts that account. Off by default (such a login is refused rather than taking the account over).
   - `enabled`: boolean. Determines if the provider is enabled or not.
   - `enableAuthorization`: boolean: Determines if the plugin sets permissions for the user. If false, the user will start with no permissions and an administrator will add permissions. If disabled, then the permissions of users will not be modified and the Jellyfin defaults will be used instead.
   - `enableAllFolders`: boolean. Determines if the client logging in is allowed access to all folders.

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -148,4 +148,43 @@ public class SamlResponseTests
             conditionsNotBefore: System.DateTime.UtcNow.AddMinutes(30));
         Assert.False(Load(fixture).IsValid());
     }
+
+    // --- Audience binding (IsValid(expectedAudience), fail-closed) ---
+
+    [Fact]
+    public void IsValid_MatchingAudience_ReturnsTrue()
+    {
+        var fixture = SamlTestFactory.Create(audience: "https://jellyfin.example.com/sso");
+        Assert.True(Load(fixture).IsValid("https://jellyfin.example.com/sso"));
+    }
+
+    [Fact]
+    public void IsValid_WrongAudience_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create(audience: "https://other-sp.example.com");
+        Assert.False(Load(fixture).IsValid("https://jellyfin.example.com/sso"));
+    }
+
+    [Fact]
+    public void IsValid_MissingAudienceWhenExpected_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.False(Load(fixture).IsValid("https://jellyfin.example.com/sso"));
+    }
+
+    [Fact]
+    public void IsValid_EmptyExpectedAudience_ReturnsFalse()
+    {
+        // Audience validation requested but nothing to check against -> fail closed.
+        var fixture = SamlTestFactory.Create(audience: "https://jellyfin.example.com/sso");
+        Assert.False(Load(fixture).IsValid(string.Empty));
+    }
+
+    [Fact]
+    public void IsValid_MultipleAudiences_MatchesAny()
+    {
+        var fixture = SamlTestFactory.Create(audiences: new[] { "https://other-sp.example.com", "https://jellyfin.example.com/sso" });
+        Assert.True(Load(fixture).IsValid("https://jellyfin.example.com/sso"));
+        Assert.False(Load(fixture).IsValid("https://not-listed.example.com"));
+    }
 }

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -38,6 +38,8 @@ internal static class SamlTestFactory
     /// <param name="includeNotOnOrAfter">When false, the NotOnOrAfter attribute is omitted entirely.</param>
     /// <param name="conditionsNotBefore">When set, emits a Conditions element carrying this NotBefore.</param>
     /// <param name="conditionsNotOnOrAfter">When set, emits a Conditions element carrying this NotOnOrAfter.</param>
+    /// <param name="audience">When set, emits a Conditions/AudienceRestriction with this single Audience.</param>
+    /// <param name="audiences">When set, emits a Conditions/AudienceRestriction with these Audiences (overrides audience).</param>
     /// <param name="scope">Which element to sign.</param>
     /// <param name="signWithSha1">When true, sign with RSA-SHA1/SHA1 digest (for weak-algorithm tests).</param>
     /// <returns>A fixture exposing the certificate and the signed document.</returns>
@@ -48,9 +50,12 @@ internal static class SamlTestFactory
         bool includeNotOnOrAfter = true,
         DateTime? conditionsNotBefore = null,
         DateTime? conditionsNotOnOrAfter = null,
+        string? audience = null,
+        string[]? audiences = null,
         SignatureScope scope = SignatureScope.Response,
         bool signWithSha1 = false)
     {
+        var audienceList = audiences ?? (audience == null ? null : new[] { audience });
         const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
         var effectiveNotOnOrAfter = notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5);
 
@@ -66,7 +71,7 @@ internal static class SamlTestFactory
             : "<saml:SubjectConfirmationData />";
 
         var conditions = string.Empty;
-        if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue)
+        if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue || audienceList != null)
         {
             var attributes = new StringBuilder();
             if (conditionsNotBefore.HasValue)
@@ -79,7 +84,21 @@ internal static class SamlTestFactory
                 attributes.Append(" NotOnOrAfter=\"" + conditionsNotOnOrAfter.Value.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
             }
 
-            conditions = "<saml:Conditions" + attributes + " />";
+            var body = string.Empty;
+            if (audienceList != null)
+            {
+                var audienceElements = new StringBuilder();
+                foreach (var a in audienceList)
+                {
+                    audienceElements.Append("<saml:Audience>" + a + "</saml:Audience>");
+                }
+
+                body = "<saml:AudienceRestriction>" + audienceElements + "</saml:AudienceRestriction>";
+            }
+
+            conditions = body.Length == 0
+                ? "<saml:Conditions" + attributes + " />"
+                : "<saml:Conditions" + attributes + ">" + body + "</saml:Conditions>";
         }
 
         var xml =

--- a/SSO-Auth.Tests/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/ValidateSamlTests.cs
@@ -1,0 +1,68 @@
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the controller's ValidateSaml helper: how the expected audience is derived
+/// (SamlAudience, falling back to SamlClientId, both trimmed) and the DoNotValidateAudience opt-out.
+/// </summary>
+public class ValidateSamlTests
+{
+    private const string Audience = "https://jellyfin.example.com/sso";
+
+    private static Response SignedResponseFor(string audience)
+    {
+        var fixture = SamlTestFactory.Create(audience: audience);
+        return new Response(fixture.CertificateBase64, fixture.EncodeResponse());
+    }
+
+    [Fact]
+    public void DoNotValidateAudience_SkipsAudienceCheck()
+    {
+        var response = SignedResponseFor("whatever");
+        var config = new SamlConfig { DoNotValidateAudience = true, SamlClientId = "unrelated" };
+        Assert.True(SSOController.ValidateSaml(response, config));
+    }
+
+    [Fact]
+    public void SamlClientId_UsedAsAudienceWhenNoSamlAudience()
+    {
+        var response = SignedResponseFor(Audience);
+        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = Audience }));
+        Assert.False(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = "https://other" }));
+    }
+
+    [Fact]
+    public void SamlAudience_OverridesSamlClientId()
+    {
+        var response = SignedResponseFor(Audience);
+        var config = new SamlConfig { SamlAudience = Audience, SamlClientId = "https://other" };
+        Assert.True(SSOController.ValidateSaml(response, config));
+    }
+
+    [Fact]
+    public void EmptySamlAudience_FallsBackToSamlClientId()
+    {
+        var response = SignedResponseFor(Audience);
+        var config = new SamlConfig { SamlAudience = "", SamlClientId = Audience };
+        Assert.True(SSOController.ValidateSaml(response, config));
+    }
+
+    [Fact]
+    public void ExpectedAudienceIsTrimmed()
+    {
+        var response = SignedResponseFor(Audience);
+        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = "  " + Audience + "  " }));
+        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlAudience = " " + Audience + " ", SamlClientId = "x" }));
+    }
+
+    [Fact]
+    public void NoExpectedAudienceConfigured_FailsClosed()
+    {
+        var response = SignedResponseFor(Audience);
+        Assert.False(SSOController.ValidateSaml(response, new SamlConfig()));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -593,7 +593,7 @@ public class SSOController : ControllerBase
         {
             var samlResponse = new Response(config.SamlCertificate, Request.Form["SAMLResponse"]);
 
-            if (!samlResponse.IsValid())
+            if (!ValidateSaml(samlResponse, config))
             {
                 return Problem("Invalid SAML signature");
             }
@@ -757,7 +757,7 @@ public class SSOController : ControllerBase
             bool liveTvManagement = config.EnableLiveTvManagement;
             var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-            if (!samlResponse.IsValid())
+            if (!ValidateSaml(samlResponse, config))
             {
                 return Problem("Invalid SAML signature");
             }
@@ -1091,7 +1091,7 @@ public class SSOController : ControllerBase
 
         var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-        if (!samlResponse.IsValid())
+        if (!ValidateSaml(samlResponse, config))
         {
             return Problem("Invalid SAML signature");
         }
@@ -1300,6 +1300,26 @@ public class SSOController : ControllerBase
     private void Invalidate()
     {
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
+    }
+
+    // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
+    // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
+    // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
+    // Issuer sent in the AuthnRequest, and an empty SamlAudience falls through to the client id.
+    internal static bool ValidateSaml(Response samlResponse, SamlConfig config)
+    {
+        if (config.DoNotValidateAudience)
+        {
+            return samlResponse.IsValid();
+        }
+
+        var expected = config.SamlAudience?.Trim();
+        if (string.IsNullOrEmpty(expected))
+        {
+            expected = config.SamlClientId?.Trim();
+        }
+
+        return samlResponse.IsValid(expected);
     }
 
     // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -55,6 +55,19 @@ public class SamlConfig
     public string SamlCertificate { get; set; }
 
     /// <summary>
+    /// Gets or sets the audience (SP entity id) that a SAML response must be addressed to. When
+    /// unset, the SamlClientId is used. Ignored when <see cref="DoNotValidateAudience"/> is set.
+    /// </summary>
+    public string SamlAudience { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip validating the assertion's AudienceRestriction.
+    /// Off by default: responses must be addressed to this service provider (fail closed). Only enable
+    /// for a provider that cannot emit a matching AudienceRestriction.
+    /// </summary>
+    public bool DoNotValidateAudience { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the provider is enabled.
     /// </summary>
     public bool Enabled { get; set; }

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -111,6 +111,54 @@ public class Response
         return ValidateSignatureReference(signedXml) && signedXml.CheckSignature(_certificate, true) && IsWithinTimeBounds();
     }
 
+    /// <summary>
+    /// Checks whether the response is valid AND asserts it was issued for this service provider by
+    /// requiring the signed assertion's AudienceRestriction to name <paramref name="expectedAudience"/>.
+    /// Fail-closed: with no expected audience configured, or no matching Audience present, it is invalid.
+    /// </summary>
+    /// <param name="expectedAudience">The audience (SP entity id) this response must be addressed to.</param>
+    /// <returns>Whether the response is valid and bound to this audience.</returns>
+    public bool IsValid(string expectedAudience)
+    {
+        if (!IsValid())
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(expectedAudience))
+        {
+            return false;
+        }
+
+        foreach (var audience in GetAudiences())
+        {
+            if (string.Equals(audience, expectedAudience, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private List<string> GetAudiences()
+    {
+        var output = new List<string>();
+        var nodes = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:Conditions/saml:AudienceRestriction/saml:Audience", _xmlNameSpaceManager);
+        if (nodes != null)
+        {
+            foreach (XmlNode node in nodes)
+            {
+                if (!string.IsNullOrEmpty(node?.InnerText))
+                {
+                    output.Add(node.InnerText);
+                }
+            }
+        }
+
+        return output;
+    }
+
     // an XML signature can "cover" not the whole document, but only a part of it
     // .NET's built in "CheckSignature" does not cover this case, it will validate to true.
     // We should check the signature reference, so it "references" the id of the root document element! If not - it's a hack


### PR DESCRIPTION
# What & why

SAML validation checked the signature and time bounds but not the audience, so an assertion issued for a different service provider could be replayed against this plugin. This binds the response to this SP by requiring the signed assertion's `AudienceRestriction` to name the expected audience. Closes #30

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Breaking (behavior): audience validation is on by default

## Security checklist

- [x] Fail-closed: empty expected audience, missing `AudienceRestriction`, or mismatch is rejected.
- [x] Audience read only from the signed `Assertion[1]` (same node the signature binds), so an unsigned audience cannot satisfy the check, confirmed against the XSW defense.
- [x] Three-lens adversarial review (SAML-domain/bypass, correctness/availability, integration). Core binding PASS, no bypass. The raised lockout edges (trim + empty-string fallback) and doc/test gaps are fixed in this change.

## Quality checklist

- [x] One shared `ValidateSaml` helper for all three SAML validation sites.
- [x] Expected audience trimmed to match the trimmed AuthnRequest issuer; empty `SamlAudience` falls back to `SamlClientId`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (incl. `--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 92/92.
- [x] Prettier clean (README).

## Upgrade note

Providers whose IdP audience differs from the configured `SamlClientId` must set `samlAudience` or `doNotValidateAudience` (both now documented in the README `SAML/Add` key list).
