### PR TITLE
Enforce one-time use of SAML assertions (replay protection)

### DIFF
--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -1,0 +1,76 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlReplayCache"/> — one-time-use of SAML assertion IDs, and the retention
+/// window that keeps a consumed id long enough that it cannot be replayed while still acceptable.
+/// </summary>
+public class SamlReplayCacheTests
+{
+    private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void TryConsume_FirstUse_Succeeds_SecondUse_IsReplay()
+    {
+        var cache = new SamlReplayCache();
+        var expiry = Now.AddMinutes(10);
+
+        Assert.True(cache.TryConsume("_assertion-1", expiry, Now));
+        Assert.False(cache.TryConsume("_assertion-1", expiry, Now));
+    }
+
+    [Fact]
+    public void TryConsume_DistinctIds_EachSucceedOnce()
+    {
+        var cache = new SamlReplayCache();
+        var expiry = Now.AddMinutes(10);
+
+        Assert.True(cache.TryConsume("_a", expiry, Now));
+        Assert.True(cache.TryConsume("_b", expiry, Now));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryConsume_MissingId_FailsClosed(string? id)
+    {
+        var cache = new SamlReplayCache();
+        Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now));
+    }
+
+    [Fact]
+    public void TryConsume_AfterEntryExpires_IdCanBeUsedAgain()
+    {
+        // Once retention has elapsed the entry is evicted; a fresh assertion reusing the id (a new
+        // login, not a replay of the same still-valid assertion) is accepted again.
+        var cache = new SamlReplayCache();
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now));
+
+        var later = Now.AddMinutes(20);
+        Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later));
+    }
+
+    [Fact]
+    public void ComputeRetention_NoExpiry_UsesOneHourFloor()
+    {
+        Assert.Equal(Now.AddHours(1), SamlReplayCache.ComputeRetention(Now, null));
+    }
+
+    [Fact]
+    public void ComputeRetention_ShortExpiry_UsesFloor()
+    {
+        // A 5-minute assertion expiry (+skew) is below the one-hour floor, so the floor wins.
+        Assert.Equal(Now.AddHours(1), SamlReplayCache.ComputeRetention(Now, Now.AddMinutes(5)));
+    }
+
+    [Fact]
+    public void ComputeRetention_LongExpiry_UsesExpiryPlusSkew()
+    {
+        var expiry = Now.AddHours(3);
+        Assert.Equal(expiry + SamlAssertionTime.ClockSkew, SamlReplayCache.ComputeRetention(Now, expiry));
+    }
+}

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -200,11 +200,10 @@ public class SamlResponseTests
     [Fact]
     public void GetNotOnOrAfter_ReturnsLatestBound()
     {
-        var expiry = System.DateTime.UtcNow.AddMinutes(5);
+        // Fixed whole-second UTC instant so the assertion is exact (the factory formats to whole
+        // seconds), rather than a wall-clock value with a tolerance.
+        var expiry = new System.DateTime(2026, 7, 11, 12, 5, 0, System.DateTimeKind.Utc);
         var fixture = SamlTestFactory.Create(notOnOrAfter: expiry);
-        var actual = Load(fixture).GetNotOnOrAfter();
-        Assert.NotNull(actual);
-        // Factory formats to whole seconds; compare within a second.
-        Assert.True(System.Math.Abs((actual.Value - expiry).TotalSeconds) < 2);
+        Assert.Equal(expiry, Load(fixture).GetNotOnOrAfter());
     }
 }

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -187,4 +187,24 @@ public class SamlResponseTests
         Assert.True(Load(fixture).IsValid("https://jellyfin.example.com/sso"));
         Assert.False(Load(fixture).IsValid("https://not-listed.example.com"));
     }
+
+    // --- Replay-support getters ---
+
+    [Fact]
+    public void GetAssertionId_ReturnsSignedAssertionId()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.Equal(fixture.AssertionId, Load(fixture).GetAssertionId());
+    }
+
+    [Fact]
+    public void GetNotOnOrAfter_ReturnsLatestBound()
+    {
+        var expiry = System.DateTime.UtcNow.AddMinutes(5);
+        var fixture = SamlTestFactory.Create(notOnOrAfter: expiry);
+        var actual = Load(fixture).GetNotOnOrAfter();
+        Assert.NotNull(actual);
+        // Factory formats to whole seconds; compare within a second.
+        Assert.True(System.Math.Abs((actual.Value - expiry).TotalSeconds) < 2);
+    }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -770,7 +770,12 @@ public class SSOController : ControllerBase
             // renders the intermediate page, so the two-step post-then-auth flow consumes the id once.
             var samlNow = DateTime.UtcNow;
             var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
-            if (!SamlReplays.TryConsume(samlResponse.GetAssertionId(), replayRetention, samlNow))
+
+            // Scope the replay key by provider so two IdPs that happen to emit the same assertion ID
+            // cannot block each other; a missing ID stays empty so TryConsume still fails closed.
+            var assertionId = samlResponse.GetAssertionId();
+            var replayKey = string.IsNullOrEmpty(assertionId) ? assertionId : provider + "\n" + assertionId;
+            if (!SamlReplays.TryConsume(replayKey, replayRetention, samlNow))
             {
                 return Problem("SAML assertion has already been used");
             }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -58,6 +58,9 @@ public class SSOController : ControllerBase
 
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(1);
 
+    // One-time-use tracking for consumed SAML assertion IDs (replay protection).
+    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -760,6 +763,16 @@ public class SSOController : ControllerBase
             if (!ValidateSaml(samlResponse, config))
             {
                 return Problem("Invalid SAML signature");
+            }
+
+            // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
+            // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
+            // renders the intermediate page, so the two-step post-then-auth flow consumes the id once.
+            var samlNow = DateTime.UtcNow;
+            var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
+            if (!SamlReplays.TryConsume(samlResponse.GetAssertionId(), replayRetention, samlNow))
+            {
+                return Problem("SAML assertion has already been used");
             }
 
             List<string> folders;

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -40,10 +40,9 @@ internal sealed class SamlReplayCache
     }
 
     /// <summary>
-    /// Computes how long a just-consumed assertion must be retained for replay protection: at least the
-    /// whole window it would still be accepted - its NotOnOrAfter plus the validation clock skew - and
-    /// never less than one hour, so a long-lived assertion cannot be replayed after the entry would
-    /// otherwise have been evicted.
+    /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
+    /// window it would still be accepted - its NotOnOrAfter plus the validation clock skew - with a
+    /// one-hour floor that covers an assertion carrying no (or a very short) expiry.
     /// </summary>
     /// <param name="nowUtc">The current time.</param>
     /// <param name="assertionExpiryUtc">The assertion's effective NotOnOrAfter, or null when it declares none.</param>

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Tracks SAML assertion IDs that have already been used to mint a session, so a captured assertion
+/// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
+/// evicted opportunistically.
+/// </summary>
+internal sealed class SamlReplayCache
+{
+    private readonly ConcurrentDictionary<string, DateTime> _consumed = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records the assertion ID as consumed. Returns false when the assertion has no usable ID or has
+    /// already been consumed within its validity window (a replay).
+    /// </summary>
+    /// <param name="assertionId">The assertion ID.</param>
+    /// <param name="expiryUtc">When the entry may be evicted (typically the assertion's NotOnOrAfter).</param>
+    /// <param name="nowUtc">The current time.</param>
+    /// <returns>True if this is the first use; false on replay or a missing ID.</returns>
+    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc)
+    {
+        foreach (var kvp in _consumed)
+        {
+            if (kvp.Value <= nowUtc)
+            {
+                _consumed.TryRemove(kvp.Key, out _);
+            }
+        }
+
+        // Fail closed: without an ID we cannot enforce one-time use.
+        if (string.IsNullOrEmpty(assertionId))
+        {
+            return false;
+        }
+
+        return _consumed.TryAdd(assertionId, expiryUtc);
+    }
+
+    /// <summary>
+    /// Computes how long a just-consumed assertion must be retained for replay protection: at least the
+    /// whole window it would still be accepted - its NotOnOrAfter plus the validation clock skew - and
+    /// never less than one hour, so a long-lived assertion cannot be replayed after the entry would
+    /// otherwise have been evicted.
+    /// </summary>
+    /// <param name="nowUtc">The current time.</param>
+    /// <param name="assertionExpiryUtc">The assertion's effective NotOnOrAfter, or null when it declares none.</param>
+    /// <returns>The UTC instant until which the assertion ID must be retained.</returns>
+    internal static DateTime ComputeRetention(DateTime nowUtc, DateTime? assertionExpiryUtc)
+    {
+        // The one-hour floor bounds retention when an assertion carries no (or a very short) expiry; the
+        // skew margin matches the clock skew the signature/time validation allows.
+        var floor = nowUtc.AddHours(1);
+        if (assertionExpiryUtc.HasValue)
+        {
+            var expiryWithSkew = assertionExpiryUtc.Value + SamlAssertionTime.ClockSkew;
+            if (expiryWithSkew > floor)
+            {
+                return expiryWithSkew;
+            }
+        }
+
+        return floor;
+    }
+}

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -166,7 +166,8 @@ public class Response
     public string GetAssertionId()
     {
         var assertion = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]", _xmlNameSpaceManager) as XmlElement;
-        return assertion?.GetAttribute("ID");
+        var id = assertion?.GetAttribute("ID");
+        return string.IsNullOrEmpty(id) ? null : id;
     }
 
     /// <summary>

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -159,6 +159,43 @@ public class Response
         return output;
     }
 
+    /// <summary>
+    /// Gets the ID attribute of the assertion, used to enforce one-time use (replay protection).
+    /// </summary>
+    /// <returns>The assertion ID, or null when absent.</returns>
+    public string GetAssertionId()
+    {
+        var assertion = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]", _xmlNameSpaceManager) as XmlElement;
+        return assertion?.GetAttribute("ID");
+    }
+
+    /// <summary>
+    /// Gets the latest NotOnOrAfter across the assertion's Conditions and bearer SubjectConfirmationData,
+    /// in UTC. Callers use it to retain a consumed assertion for replay protection for the whole time it
+    /// would still be accepted.
+    /// </summary>
+    /// <returns>The latest NotOnOrAfter, or null when neither window carries one.</returns>
+    public DateTime? GetNotOnOrAfter()
+    {
+        DateTime? latest = null;
+        var xpaths = new[]
+        {
+            "/samlp:Response/saml:Assertion[1]/saml:Conditions",
+            "/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData",
+        };
+
+        foreach (var xpath in xpaths)
+        {
+            var value = (_xmlDoc.SelectSingleNode(xpath, _xmlNameSpaceManager) as XmlElement)?.GetAttribute("NotOnOrAfter");
+            if (!string.IsNullOrEmpty(value) && SamlAssertionTime.TryParseUtc(value, out var parsed) && (latest == null || parsed > latest.Value))
+            {
+                latest = parsed;
+            }
+        }
+
+        return latest;
+    }
+
     // an XML signature can "cover" not the whole document, but only a part of it
     // .NET's built in "CheckSignature" does not cover this case, it will validate to true.
     // We should check the signature reference, so it "references" the id of the root document element! If not - it's a hack

--- a/SSO-Auth/SamlAssertionTime.cs
+++ b/SSO-Auth/SamlAssertionTime.cs
@@ -81,7 +81,7 @@ internal static class SamlAssertionTime
         return true;
     }
 
-    private static bool TryParseUtc(string raw, out DateTime utc)
+    internal static bool TryParseUtc(string raw, out DateTime utc)
     {
         // SAML timestamps are xsd:dateTime in UTC ('...Z'). Parse culture-invariantly and normalize
         // to UTC, assuming UTC when no offset is present rather than the machine's local zone.


### PR DESCRIPTION
# What & why

A validly-signed SAML assertion could be submitted more than once, nothing recorded that an assertion ID had already minted a session, so a captured assertion could be replayed within its validity window. This enforces one-time use of the assertion ID at the session-minting endpoint. Closes #32

## Type of change

- [x] Security hardening / vulnerability fix

## Security checklist

- [x] Fail-closed: an assertion with no usable ID is rejected; the ID is read from the signed assertion (XSW-safe, consistent with the signature binding).
- [x] Retention covers the whole acceptance window (NotOnOrAfter + skew, floored at 1h), so an assertion cannot be replayed after its entry would be evicted.
- [x] Enforced only at SamlAuth (session mint), not at the SAML/post ACS, so the two-step flow consumes the ID exactly once.
- [x] Three-lens adversarial review (replay-bypass, correctness/availability, integration), all PASS.

## Quality checklist

- [x] Pure, unit-tested `SamlReplayCache`; reuses `SamlAssertionTime` for parsing/skew (no duplication).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (`--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 102/102.

## Notes

Known limitations (out of scope, tracked): the account-linking endpoint (`SAML/Link`) and the in-memory cache (reset on process restart) are not replay-protected; both are bounded by the time-bound validation.
