### PR TITLE
Harden the avatar fetch from Copilot review feedback

### DIFF
--- a/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
+++ b/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
@@ -28,6 +28,8 @@ public class AvatarUrlValidatorTests
     [InlineData("")]
     [InlineData("http://localhost/x")]
     [InlineData("http://service.localhost/x")]
+    [InlineData("http://localhost./x")]
+    [InlineData("http://service.localhost./x")]
     [InlineData("http://127.0.0.1/x")]
     [InlineData("http://169.254.169.254/latest/meta-data/")]
     [InlineData("http://192.0.0.192/")]
@@ -64,6 +66,12 @@ public class AvatarUrlValidatorTests
     [InlineData("2002:c0a8:101::")] // 6to4 embedding 192.168.1.1
     [InlineData("::7f00:1")] // deprecated IPv4-compatible ::127.0.0.1
     [InlineData("192.0.0.192")] // Oracle Cloud metadata (192.0.0.0/24 protocol assignments)
+    [InlineData("192.0.2.10")] // TEST-NET-1
+    [InlineData("198.51.100.10")] // TEST-NET-2
+    [InlineData("203.0.113.10")] // TEST-NET-3
+    [InlineData("198.18.0.1")] // benchmarking 198.18.0.0/15
+    [InlineData("198.19.255.255")] // benchmarking 198.18.0.0/15 (upper half)
+    [InlineData("192.88.99.1")] // 6to4 relay anycast
     [InlineData("fec0::1")] // deprecated IPv6 site-local
     public void IsBlockedAddress_PrivateOrLoopback_ReturnsTrue(string ip)
     {
@@ -76,6 +84,9 @@ public class AvatarUrlValidatorTests
     [InlineData("172.32.0.1")]
     [InlineData("100.63.255.255")]
     [InlineData("223.255.255.255")] // last unicast address just below the 224/4 multicast range
+    [InlineData("198.17.255.255")] // just below the 198.18.0.0/15 benchmarking range
+    [InlineData("198.20.0.1")] // just above the 198.18.0.0/15 benchmarking range
+    [InlineData("192.0.1.1")] // adjacent to 192.0.0.0/24 and 192.0.2.0/24, not reserved
     [InlineData("2606:4700:4700::1111")]
     [InlineData("64:ff9b::808:808")] // NAT64 embedding the public 8.8.8.8
     public void IsBlockedAddress_PublicAddresses_ReturnsFalse(string ip)

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -31,7 +31,9 @@ internal static class AvatarUrlValidator
             return false;
         }
 
-        var host = parsed.DnsSafeHost;
+        // Strip a fully-qualified trailing dot ("localhost." / "host.") before the localhost check,
+        // since it resolves the same but would otherwise slip past the string comparison.
+        var host = parsed.DnsSafeHost.TrimEnd('.');
         if (host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || host.EndsWith(".localhost", StringComparison.OrdinalIgnoreCase))
         {
             return false;
@@ -65,14 +67,21 @@ internal static class AvatarUrlValidator
 
             // 0.0.0.0/8 (this network), 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local),
             // 172.16.0.0/12, 192.0.0.0/24 (IETF protocol assignments incl. the 192.0.0.192 cloud-metadata
-            // address), 192.168.0.0/16, and 224.0.0.0/3 (multicast 224/4, reserved 240/4, broadcast).
+            // address), 192.0.2.0/24 / 198.51.100.0/24 / 203.0.113.0/24 (TEST-NET-1/2/3), 192.88.99.0/24
+            // (6to4 relay anycast), 192.168.0.0/16, 198.18.0.0/15 (benchmarking), and 224.0.0.0/3
+            // (multicast 224/4, reserved 240/4, broadcast).
             return b[0] == 0
                 || b[0] == 10
                 || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
                 || (b[0] == 169 && b[1] == 254)
                 || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
                 || (b[0] == 192 && b[1] == 0 && b[2] == 0)
+                || (b[0] == 192 && b[1] == 0 && b[2] == 2)
+                || (b[0] == 192 && b[1] == 88 && b[2] == 99)
                 || (b[0] == 192 && b[1] == 168)
+                || (b[0] == 198 && (b[1] == 18 || b[1] == 19))
+                || (b[0] == 198 && b[1] == 51 && b[2] == 100)
+                || (b[0] == 203 && b[1] == 0 && b[2] == 113)
                 || b[0] >= 224;
         }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -145,10 +145,7 @@ public class SSOController : ControllerBase
                 HttpClientFactory = o =>
                 {
                     var client = _httpClientFactory.CreateClient();
-                    System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
-                    System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-                    string version = fvi.FileVersion;
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd($"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/9p4/jellyfin-plugin-sso)");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
                     return client;
                 }
             };
@@ -407,11 +404,7 @@ public class SSOController : ControllerBase
                 HttpClientFactory = o =>
                 {
                     var client = _httpClientFactory.CreateClient();
-                    System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
-                    System.Diagnostics.FileVersionInfo fvi = System.Diagnostics.FileVersionInfo.GetVersionInfo(assembly.Location);
-                    string version = fvi.FileVersion;
-
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd($"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/9p4/jellyfin-plugin-sso)");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
                     return client;
                 }
             };
@@ -1244,8 +1237,7 @@ public class SSOController : ControllerBase
                     };
                     using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
 
-                    var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd($"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/iderex/jellyfin-plugin-sso)");
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
 
                     // ResponseHeadersRead so the body is streamed, not fully buffered, before ReadCappedAsync
                     // enforces the size limit; otherwise the cap runs only after the whole download is in memory.
@@ -1320,6 +1312,13 @@ public class SSOController : ControllerBase
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
     }
 
+    // Single canonical User-Agent for the plugin's outbound HTTP (discovery, avatar fetch).
+    private static string UserAgent()
+    {
+        var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+        return $"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/iderex/jellyfin-plugin-sso)";
+    }
+
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
     // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
     // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
@@ -1360,7 +1359,7 @@ public class SSOController : ControllerBase
             }
 
             attempted = true;
-            var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
             var connected = false;
             try
             {

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -61,6 +61,11 @@ public class SSOController : ControllerBase
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
 
+    // Single canonical User-Agent for the plugin's outbound HTTP (discovery, avatar fetch),
+    // computed once since the assembly version does not change at runtime.
+    private static readonly string UserAgentString =
+        $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -145,7 +150,7 @@ public class SSOController : ControllerBase
                 HttpClientFactory = o =>
                 {
                     var client = _httpClientFactory.CreateClient();
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
                     return client;
                 }
             };
@@ -404,7 +409,7 @@ public class SSOController : ControllerBase
                 HttpClientFactory = o =>
                 {
                     var client = _httpClientFactory.CreateClient();
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
                     return client;
                 }
             };
@@ -1237,7 +1242,7 @@ public class SSOController : ControllerBase
                     };
                     using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
 
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent());
+                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
 
                     // ResponseHeadersRead so the body is streamed, not fully buffered, before ReadCappedAsync
                     // enforces the size limit; otherwise the cap runs only after the whole download is in memory.
@@ -1310,13 +1315,6 @@ public class SSOController : ControllerBase
     private void Invalidate()
     {
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
-    }
-
-    // Single canonical User-Agent for the plugin's outbound HTTP (discovery, avatar fetch).
-    private static string UserAgent()
-    {
-        var version = System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
-        return $"Jellyfin-Plugin-SSO-Auth +{version} (https://github.com/iderex/jellyfin-plugin-sso)";
     }
 
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to


### PR DESCRIPTION
# What & why

Follow-up to #29, resolving the Copilot review of the avatar SSRF guard. Closes #34

- **Fixes a real bug:** `AvatarConnectCallback` used the `Socket(SocketType, ProtocolType)` overload, which defaults to IPv4, so a resolved IPv6 avatar host could never be reached. The socket is now created with `address.AddressFamily`.
- Trims a trailing dot before the `localhost` check (`localhost.` / `service.localhost.`).
- Extends the reserved-range blocklist (TEST-NET-1/2/3, benchmarking 198.18.0.0/15, 6to4 relay 192.88.99.0/24) with tests for the ranges and their public neighbours.
- Centralizes the outbound User-Agent (the OpenID discovery clients still used the old upstream URL).

## Type of change

- [x] Security hardening / bug fix

## Security checklist

- [x] Connect still validates every resolved address before connecting; the AddressFamily fix does not weaken the block (verified: socket family matches the validated address per iteration; disposal holds on the cancellation path).
- [x] Byte math for the new ranges is exact; adjacent public addresses (198.17.x, 198.20.x, 192.0.1.x) stay allowed, covered by tests.
- [x] Verified by an independent review pass (PASS).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (`--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 113/113.

## Notes

Addresses the Copilot comments on #29 (IPv6 socket, trailing-dot localhost, reserved ranges + tests, User-Agent consistency). Those original comments are answered on #29 pointing here.
