### PR TITLE
Polish SAML validation and fix relayState log forging

### DIFF
--- a/SSO-Auth.Tests/SamlAssertionTimeTests.cs
+++ b/SSO-Auth.Tests/SamlAssertionTimeTests.cs
@@ -13,7 +13,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class SamlAssertionTimeTests
 {
     private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
-    private static readonly TimeSpan Skew = TimeSpan.FromMinutes(3);
+    // Use the production skew so the tests exercise the real acceptance window.
+    private static readonly TimeSpan Skew = SamlAssertionTime.ClockSkew;
 
     private static string At(int minutesFromNow) =>
         Now.AddMinutes(minutesFromNow).ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -587,8 +587,11 @@ public class SSOController : ControllerBase
 
         bool isLinking = relayState == "linking";
 
+        // relayState is attacker-controllable; strip line endings inline at the log call to prevent
+        // log forging (structured logging alone does not sanitize a newline-bearing value).
         _logger.LogInformation(
-            $"SAML request has relayState of {relayState}");
+            "SAML request has relayState of {RelayState}",
+            relayState?.ReplaceLineEndings(string.Empty));
 
         if (config.Enabled)
         {
@@ -596,7 +599,7 @@ public class SSOController : ControllerBase
 
             if (!ValidateSaml(samlResponse, config))
             {
-                return Problem("Invalid SAML signature");
+                return Problem("SAML response validation failed");
             }
 
             bool valid = false;
@@ -760,7 +763,7 @@ public class SSOController : ControllerBase
 
             if (!ValidateSaml(samlResponse, config))
             {
-                return Problem("Invalid SAML signature");
+                return Problem("SAML response validation failed");
             }
 
             // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
@@ -1109,7 +1112,7 @@ public class SSOController : ControllerBase
 
         if (!ValidateSaml(samlResponse, config))
         {
-            return Problem("Invalid SAML signature");
+            return Problem("SAML response validation failed");
         }
 
         string providerUserId = samlResponse.GetNameID();

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -125,6 +125,9 @@ public class Response
             return false;
         }
 
+        // Trim and fail closed on an empty expected audience, so a caller passing a padded value
+        // (e.g. " https://sp ") still matches the trimmed audiences read from the assertion.
+        expectedAudience = expectedAudience?.Trim();
         if (string.IsNullOrEmpty(expectedAudience))
         {
             return false;
@@ -149,9 +152,13 @@ public class Response
         {
             foreach (XmlNode node in nodes)
             {
-                if (!string.IsNullOrEmpty(node?.InnerText))
+                // Trim so a pretty-printed assertion (indentation/newlines around the value) still
+                // compares equal; skip whitespace-only audiences. The assertion is signed, so
+                // trimming does not weaken the check.
+                var value = node?.InnerText?.Trim();
+                if (!string.IsNullOrEmpty(value))
                 {
-                    output.Add(node.InnerText);
+                    output.Add(value);
                 }
             }
         }

--- a/SSO-Auth/SamlAssertionTime.cs
+++ b/SSO-Auth/SamlAssertionTime.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Globalization;
 
@@ -28,9 +29,9 @@ internal static class SamlAssertionTime
     /// <param name="skew">The clock-skew tolerance applied to each bound.</param>
     /// <returns>True only when a valid upper bound exists and every present bound is satisfied.</returns>
     internal static bool IsWithinValidity(
-        string subjectNotOnOrAfter,
-        string conditionsNotBefore,
-        string conditionsNotOnOrAfter,
+        string? subjectNotOnOrAfter,
+        string? conditionsNotBefore,
+        string? conditionsNotOnOrAfter,
         DateTime nowUtc,
         TimeSpan skew)
     {
@@ -81,7 +82,7 @@ internal static class SamlAssertionTime
         return true;
     }
 
-    internal static bool TryParseUtc(string raw, out DateTime utc)
+    internal static bool TryParseUtc(string? raw, out DateTime utc)
     {
         // SAML timestamps are xsd:dateTime in UTC ('...Z'). Parse culture-invariantly and normalize
         // to UTC, assuming UTC when no offset is present rather than the machine's local zone.


### PR DESCRIPTION
# What & why

Follow-up to #31/#25, resolving the Copilot review and Code Scanning alert #7. Closes #36

- **Fixes cs/log-forging (#7):** the SamlPost `relayState` log interpolated an attacker-controllable query value; now sanitized inline (`ReplaceLineEndings`) with structured logging.
- Generic "SAML response validation failed" at all three validation sites (was "Invalid SAML signature", misleading now that validation covers time + audience).
- Trim the expected audience (fail-closed on empty) and trim/skip-whitespace the audiences read from the signed assertion, pretty-printed assertions still match; no weakening (values are signed).
- `SamlAssertionTime` annotated with nullable reference types to match its null-handling contract.
- Tests reference `SamlAssertionTime.ClockSkew` instead of a hardcoded 3 minutes, so they exercise the real 5-minute window.

## Type of change

- [x] Security hardening / code scanning fix

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (`--no-incremental`) and Release, 0 warnings.
- [x] `dotnet test` green: 113/113.
- [x] Independent verification pass (initially caught that one of three message sites was missed; now fixed and re-verified).

## Notes

Addresses the Copilot comments on #31 (validation error message, expected-audience trim, XML-audience trim) and #25 (nullable annotations, test skew value), and Code Scanning #7. Original comments answered on #31/#25 pointing here.
