### PR TITLE
Add least-privilege permissions to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
         description: "The .NET target to set for JPRM"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 
 jobs:
   prettier:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -5,6 +5,11 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# The single build job also creates the GitHub release and updates the
+# manifest branch, so it needs write access to repository contents.
+permissions:
+  contents: write
+
 jobs:
   build:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,11 @@ on:
       - released
   workflow_dispatch:
 
+# Default to read-only; the jobs that create the release and update the
+# manifest branch opt into write access explicitly.
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml
@@ -14,6 +19,8 @@ jobs:
       dotnet-target:  "net9.0"
   upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
     - build
     steps:
@@ -40,6 +47,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   generate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs:
     - upload
     steps:


### PR DESCRIPTION
# What & why

CodeQL (`actions/missing-workflow-permissions`) flagged six workflow jobs running with the default, overly-broad `GITHUB_TOKEN`. This sets least-privilege permissions. Closes #38 (Code Scanning alerts #1–#6)

- `prettier.yml`, `build.yml`: `contents: read`.
- `publish.yml`: default `contents: read`; `contents: write` only on `upload` (creates the release) and `generate` (updates the manifest branch).
- `publish-nightly.yml`: `contents: write` (single job creates the release + manifest).

## Type of change

- [x] CI / security hardening

## Verification

- [x] Release/nightly publish flows unchanged (the jobs that push releases/manifest keep `contents: write`; everything else drops to read).
- [ ] Workflow YAML validated by the PR run itself.

## Notes

Branch protection on `main` is still not enabled (separate GitHub-settings item flagged for later).