### PR TITLE
Pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: "${{ inputs.dotnet-version }}"
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Make sure the actual branch is checked out when running on pull requests
           ref: ${{ github.head_ref }}
       - name: Prettify code
-        uses: creyD/prettier_action@v4.6
+        uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:
           dry: True
           prettier_options: '--check **/*.{js,html,md,css,scss}'

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 9.0.x
     - name: Restore dependencies
@@ -26,7 +26,7 @@ jobs:
     - name: Build Dotnet
       run: dotnet build --no-restore --warnaserror
     - name: "Flag as nightly in build.yaml"
-      uses: fjogeleit/yaml-update-action@v0.17.0
+      uses: fjogeleit/yaml-update-action@dffe9a5223d84653c13374032382f6bb5de8e5ef # v0.17.0
       with:
         valueFile: 'build.yaml'
         propertyPath: 'version'


### PR DESCRIPTION
# What & why

Third-party actions were pinned by mutable tag, so a repointed/compromised tag would run attacker code in CI with repository credentials. Pin each to a full commit SHA (with a `# vX` comment); Dependabot keeps them current. Closes #40

Evidence: the March 2025 `tj-actions/changed-files` compromise repointed tags across 23,000+ repos; only SHA-pinned workflows were safe. This was surfaced by an evidence review of current DevSecOps sources and is the highest-leverage supply-chain fix for a login-path plugin whose CI token can write releases.

- `actions/checkout` → `9c091bb` (v7)
- `actions/setup-dotnet` → `26b0ec1` (v5)
- `creyD/prettier_action` → `8c18391` (v4.6)
- `fjogeleit/yaml-update-action` → `dffe9a5` (v0.17.0)

(The other actions, download/upload-artifact, action-gh-release, jellyfin-plugin-repository-manager, jellyfin-plugin-repo-action, were already SHA-pinned.)

## Type of change

- [x] CI / supply-chain hardening

## Verification

- [x] SHAs resolved from each action's published tag (annotated-tag dereferenced to the commit).
- [ ] Workflow runs validate the pinned actions resolve.
