### PR TITLE
Tidy the account-link switch and exception (Copilot review)

### DIFF
--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -82,16 +82,17 @@ internal static class AccountLinkResolver
 
 /// <summary>
 /// Thrown when an SSO login resolves to a pre-existing, unlinked Jellyfin account and adopting such
-/// accounts is not permitted for the provider. The controller maps this to an HTTP 403.
+/// accounts is not permitted for the provider. The controller maps this to an HTTP 403. The message
+/// is deliberately generic — the identity-provider-supplied name is not embedded, since exception
+/// messages may be logged or reported elsewhere; the caller logs the sanitized name and context.
 /// </summary>
 internal sealed class AccountLinkForbiddenException : Exception
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="AccountLinkForbiddenException"/> class.
     /// </summary>
-    /// <param name="canonicalName">The SSO name whose adoption was refused.</param>
-    internal AccountLinkForbiddenException(string canonicalName)
-        : base($"An unlinked Jellyfin account already exists for '{canonicalName}'. Enable AllowExistingAccountLink for this provider to adopt it.")
+    internal AccountLinkForbiddenException()
+        : base("An unlinked Jellyfin account already exists for this SSO identity, and adopting it is disabled for the provider (AllowExistingAccountLink).")
     {
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -943,13 +943,16 @@ public class SSOController : ControllerBase
                 CreateCanonicalLink(mode, provider, user.Id, canonicalName);
                 return user.Id;
 
-            default:
+            case AccountLinkAction.RejectNameTaken:
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
                     canonicalName?.ReplaceLineEndings(string.Empty),
                     mode,
                     provider?.ReplaceLineEndings(string.Empty));
-                throw new AccountLinkForbiddenException(canonicalName);
+                throw new AccountLinkForbiddenException();
+
+            default:
+                throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
         }
     }
 


### PR DESCRIPTION
# What & why

Follow-up to #27, resolving the Copilot review of the account-takeover fix. Closes #42

- Handle `AccountLinkAction.RejectNameTaken` in its own switch case; `default:` now throws `InvalidOperationException` for a genuinely unexpected enum value (defensive/unreachable).
- `AccountLinkForbiddenException` is now parameterless with a generic message, the IdP-supplied name is no longer embedded in an exception that could be logged/reported elsewhere. The refusal is still logged with the sanitized name + provider at the call site, and the client still gets a generic 403.

## Type of change

- [x] Refactor / security hardening (info-leak reduction)

## Security checklist

- [x] Fail-closed account-takeover defense unchanged (verified): `RejectNameTaken` still throws → 403; the other three actions are byte-for-byte identical.
- [x] No IdP-controlled value in the exception message; sanitized logging preserved at the call site.
- [x] Independent verification pass: PASS.

## Verification

- [x] `dotnet build --warnaserror` green, Debug (`--no-incremental`) + Release, 0 warnings.
- [x] `dotnet test` green: 113/113.

## Notes

Answers the Copilot comments on #27 (explicit RejectNameTaken case, generic exception message). Those comments are answered on #27 pointing here.
