### PR TITLE
Harden the SAML test factory and OpenID state add (Copilot review)

### DIFF
--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
@@ -67,7 +68,7 @@ internal static class SamlTestFactory
         var assertionId = "_" + Guid.NewGuid().ToString("N");
 
         var subjectConfirmationData = includeNotOnOrAfter
-            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\" />"
+            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\" />"
             : "<saml:SubjectConfirmationData />";
 
         var conditions = string.Empty;
@@ -76,12 +77,12 @@ internal static class SamlTestFactory
             var attributes = new StringBuilder();
             if (conditionsNotBefore.HasValue)
             {
-                attributes.Append(" NotBefore=\"" + conditionsNotBefore.Value.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
+                attributes.Append(" NotBefore=\"" + conditionsNotBefore.Value.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
             }
 
             if (conditionsNotOnOrAfter.HasValue)
             {
-                attributes.Append(" NotOnOrAfter=\"" + conditionsNotOnOrAfter.Value.ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
+                attributes.Append(" NotOnOrAfter=\"" + conditionsNotOnOrAfter.Value.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
             }
 
             var body = string.Empty;
@@ -107,13 +108,13 @@ internal static class SamlTestFactory
                     "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
                     conditions +
                     "<saml:Subject>" +
-                        "<saml:NameID>" + nameId + "</saml:NameID>" +
+                        "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" +
                         "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
                             subjectConfirmationData +
                         "</saml:SubjectConfirmation>" +
                     "</saml:Subject>" +
                     "<saml:AttributeStatement>" +
-                        "<saml:Attribute Name=\"Role\"><saml:AttributeValue>" + role + "</saml:AttributeValue></saml:Attribute>" +
+                        "<saml:Attribute Name=\"Role\"><saml:AttributeValue>" + SecurityElement.Escape(role) + "</saml:AttributeValue></saml:Attribute>" +
                     "</saml:AttributeStatement>" +
                 "</saml:Assertion>" +
             "</samlp:Response>";

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -426,8 +426,15 @@ public class SSOController : ControllerBase
                 return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
             }
 
-            // IsLinking tracks whether this is a linking request rather than a login.
-            StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking });
+            // IsLinking tracks whether this is a linking request rather than a login. The state value
+            // is a fresh CSPRNG token, so a collision is effectively impossible; log if it ever occurs
+            // instead of silently proceeding to a callback that would then fail with "invalid state".
+            if (!StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking }))
+            {
+                _logger.LogWarning("OpenID authorize-state collision for provider {Provider}; login not started.", provider?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login due to a state collision; please retry.");
+            }
+
             return Redirect(state.StartUrl);
         }
 


### PR DESCRIPTION
# What & why

Follow-up to #18/#21, resolving the remaining Copilot review points. Closes #44

- `SamlTestFactory`: normalize timestamps to UTC before formatting with a trailing `Z`, and XML-escape `nameId`/`role` before concatenation, robust against a non-UTC caller or XML metacharacters.
- `OidChallenge`: check the `TryAdd` result; on the (CSPRNG-collision, effectively impossible) failure, log a warning and return 500 rather than proceeding to a callback that would fail with "invalid state".

## Type of change

- [x] Refactor / test hardening

## Verification

- [x] `dotnet build --warnaserror` green, Debug (`--no-incremental`) + Release, 0 warnings.
- [x] `dotnet test` green: 113/113.

## Notes

Answers the Copilot comments on #18 (timestamp UTC, nameId/role escaping) and #21 (TryAdd result). Deliberately **not** adopting Copilot's per-entry-time suggestion for `AuthStateStore.InvalidateExpired` (#21): the single-`now`-per-sweep is intentional and benign, an entry crossing the boundary mid-sweep is caught on the next prune, and is simpler/deterministic. Original comments answered on #18/#21 pointing here.
