### PR TITLE
Serialize plugin-configuration read-modify-writes

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1052,7 +1052,12 @@ public class SSOController : ControllerBase
             return BadRequest("No matching provider found");
         }
 
-        if (!found || mismatch)
+        if (!found)
+        {
+            return NotFound("No SSO link is registered for that canonical name.");
+        }
+
+        if (mismatch)
         {
             return StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name.");
         }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -450,9 +450,7 @@ public class SSOController : ControllerBase
     [HttpPost("OID/Add/{provider}")]
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
-        var configuration = SSOPlugin.Instance.Configuration;
-        configuration.OidConfigs[provider] = config;
-        SSOPlugin.Instance.UpdateConfiguration(configuration);
+        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs[provider] = config);
     }
 
     /// <summary>
@@ -463,9 +461,7 @@ public class SSOController : ControllerBase
     [HttpGet("OID/Del/{provider}")]
     public void OidDel(string provider)
     {
-        var configuration = SSOPlugin.Instance.Configuration;
-        configuration.OidConfigs.Remove(provider);
-        SSOPlugin.Instance.UpdateConfiguration(configuration);
+        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
     }
 
     /// <summary>
@@ -708,9 +704,7 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/Add/{provider}")]
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
-        var configuration = SSOPlugin.Instance.Configuration;
-        configuration.SamlConfigs[provider] = newConfig;
-        SSOPlugin.Instance.UpdateConfiguration(configuration);
+        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs[provider] = newConfig);
         return Ok();
     }
 
@@ -723,9 +717,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/Del/{provider}")]
     public OkResult SamlDel(string provider)
     {
-        var configuration = SSOPlugin.Instance.Configuration;
-        configuration.SamlConfigs.Remove(provider);
-        SSOPlugin.Instance.UpdateConfiguration(configuration);
+        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
         return Ok();
     }
 
@@ -895,28 +887,49 @@ public class SSOController : ControllerBase
         return Ok();
     }
 
-    private SerializableDictionary<string, Guid> GetCanonicalLinks(string mode, string provider)
+    // Applies a mutation to a provider's canonical-links map on the LIVE configuration, reassigning the
+    // map so a lazily-created (previously-null) one is persisted. Runs inside MutateConfiguration, so the
+    // whole read-modify-write is serialized and concurrent first-logins cannot lose each other's links.
+    private static void MutateLinks(PluginConfiguration configuration, string mode, string provider, Action<SerializableDictionary<string, Guid>> mutate)
     {
-        SerializableDictionary<string, Guid> links = null;
-
-        switch (mode.ToLower())
+        switch (mode.ToLowerInvariant())
         {
             case "saml":
-                links = SSOPlugin.Instance.Configuration.SamlConfigs[provider].CanonicalLinks;
+            {
+                var providerConfig = configuration.SamlConfigs[provider];
+                var links = providerConfig.CanonicalLinks;
+                mutate(links);
+                providerConfig.CanonicalLinks = links;
                 break;
+            }
+
             case "oid":
-                links = SSOPlugin.Instance.Configuration.OidConfigs[provider].CanonicalLinks;
+            {
+                var providerConfig = configuration.OidConfigs[provider];
+                var links = providerConfig.CanonicalLinks;
+                mutate(links);
+                providerConfig.CanonicalLinks = links;
                 break;
+            }
+
             default:
                 throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
         }
+    }
 
-        if (links == null)
+    // Looks up a canonical link under the config lock, so the read cannot tear against a concurrent write.
+    private static Guid? TryGetCanonicalLink(string mode, string provider, string canonicalName)
+    {
+        return SSOPlugin.Instance.ReadConfiguration(configuration =>
         {
-            links = new SerializableDictionary<string, Guid>();
-        }
-
-        return links;
+            var links = mode.ToLowerInvariant() switch
+            {
+                "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
+                "oid" => configuration.OidConfigs[provider].CanonicalLinks,
+                _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
+            };
+            return links.TryGetValue(canonicalName, out var id) ? id : (Guid?)null;
+        });
     }
 
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName, bool allowExistingAccountLink)
@@ -924,7 +937,8 @@ public class SSOController : ControllerBase
         // An identity already linked to a still-existing account is keyed on the canonical name;
         // a dangling link (user since deleted) is treated as no link.
         Guid? linkedUserId = null;
-        if (GetCanonicalLinks(mode, provider).TryGetValue(canonicalName, out var linked) && _userManager.GetUserById(linked) != null)
+        var linked = TryGetCanonicalLink(mode, provider, canonicalName);
+        if (linked.HasValue && _userManager.GetUserById(linked.Value) != null)
         {
             linkedUserId = linked;
         }
@@ -961,18 +975,6 @@ public class SSOController : ControllerBase
             default:
                 throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
         }
-    }
-
-    private Guid GetCanonicalLink(string mode, string provider, string canonicalName)
-    {
-        SerializableDictionary<string, Guid> links = null;
-        Guid userId = Guid.Empty;
-
-        links = GetCanonicalLinks(mode, provider);
-
-        userId = links[canonicalName];
-
-        return userId;
     }
 
     /// <summary>
@@ -1024,18 +1026,38 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
         }
 
-        Guid linkedId = GetCanonicalLink(mode, provider, canonicalName);
+        var mismatch = false;
+        var found = false;
+        try
+        {
+            SSOPlugin.Instance.MutateConfiguration(configuration => MutateLinks(configuration, mode, provider, links =>
+            {
+                if (!links.TryGetValue(canonicalName, out var linkedId))
+                {
+                    return;
+                }
 
-        if (linkedId != jellyfinUserId)
+                found = true;
+                if (linkedId != jellyfinUserId)
+                {
+                    mismatch = true;
+                    return;
+                }
+
+                links.Remove(canonicalName);
+            }));
+        }
+        catch (KeyNotFoundException)
+        {
+            return BadRequest("No matching provider found");
+        }
+
+        if (!found || mismatch)
         {
             return StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name.");
         }
 
-        var links = GetCanonicalLinks(mode, provider);
-
-        links.Remove(canonicalName);
-
-        return UpdateCanonicalLinkConfig(links, mode, provider);
+        return Ok();
     }
 
     /// <summary>
@@ -1166,41 +1188,19 @@ public class SSOController : ControllerBase
         return Problem("Something went wrong!");
     }
 
-    private ActionResult CreateCanonicalLink(string mode, string provider, [FromRoute] Guid jellyfinUserId, string providerUserId)
+    private ActionResult CreateCanonicalLink(string mode, string provider, Guid jellyfinUserId, string providerUserId)
     {
-        SerializableDictionary<string, Guid> links = null;
         try
         {
-            links = GetCanonicalLinks(mode, provider);
+            SSOPlugin.Instance.MutateConfiguration(configuration =>
+                MutateLinks(configuration, mode, provider, links => links[providerUserId] = jellyfinUserId));
         }
         catch (KeyNotFoundException)
         {
             return BadRequest("No matching provider found");
         }
 
-        links[providerUserId] = jellyfinUserId;
-        UpdateCanonicalLinkConfig(links, mode, provider);
-
         return NoContent();
-    }
-
-    private OkResult UpdateCanonicalLinkConfig(SerializableDictionary<string, Guid> links, string mode, string provider)
-    {
-        var configuration = SSOPlugin.Instance.Configuration;
-        switch (mode.ToLower())
-        {
-            case "saml":
-                configuration.SamlConfigs[provider].CanonicalLinks = links;
-                break;
-            case "oid":
-                configuration.OidConfigs[provider].CanonicalLinks = links;
-                break;
-            default:
-                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
-        }
-
-        SSOPlugin.Instance.UpdateConfiguration(configuration);
-        return Ok();
     }
 
     /// <summary>

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -13,6 +13,10 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// </summary>
 public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
 {
+    // Serializes every read-modify-write of the plugin configuration so concurrent mutations
+    // (notably first-logins each writing a canonical link) cannot lose one another's updates.
+    private static readonly object ConfigMutationLock = new object();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOPlugin"/> class.
     /// </summary>
@@ -38,6 +42,40 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     /// Gets the GUID of the SSO plugin.
     /// </summary>
     public override Guid Id => Guid.Parse("505ce9d1-d916-42fa-86ca-673ef241d7df");
+
+    /// <summary>
+    /// Applies a mutation to the live configuration under a single lock and persists it, so a
+    /// read-modify-write cannot race another and lose its update. All configuration writes must go
+    /// through this rather than reading <see cref="BasePlugin{T}.Configuration"/>, mutating, and
+    /// calling <c>UpdateConfiguration</c> separately.
+    /// </summary>
+    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    public void MutateConfiguration(Action<PluginConfiguration> mutate)
+    {
+        ArgumentNullException.ThrowIfNull(mutate);
+        lock (ConfigMutationLock)
+        {
+            var configuration = Configuration;
+            mutate(configuration);
+            UpdateConfiguration(configuration);
+        }
+    }
+
+    /// <summary>
+    /// Reads a value from the live configuration under the same lock as <see cref="MutateConfiguration"/>,
+    /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
+    /// </summary>
+    /// <typeparam name="T">The value read.</typeparam>
+    /// <param name="read">The read to perform against the live configuration.</param>
+    /// <returns>The value returned by <paramref name="read"/>.</returns>
+    public T ReadConfiguration<T>(Func<PluginConfiguration, T> read)
+    {
+        ArgumentNullException.ThrowIfNull(read);
+        lock (ConfigMutationLock)
+        {
+            return read(Configuration);
+        }
+    }
 
     /// <summary>
     /// Returns the available internal web pages of this plugin.


### PR DESCRIPTION
# What & why

The plugin configuration was read, mutated, and persisted without synchronization. On the login path `CreateCanonicalLink` did an unguarded read-modify-write of the canonical-links map, so two concurrent first-logins could lose a link or corrupt the config. Closes #51

- New `SSOPlugin.MutateConfiguration(Action)` / `ReadConfiguration<T>(Func)` guarded by one `ConfigMutationLock`; mutate = read-live → mutate → persist, all under the lock.
- All config writes routed through it (OID/SAML Add+Del; canonical-link create/delete via a `MutateLinks` helper that reassigns the map so a lazily-created one persists, the `CanonicalLinks` getter returns a fresh unstored dict when null).
- The login-path canonical-link read goes through `ReadConfiguration` so it can't tear against a concurrent write.
- Removed `GetCanonicalLinks`/`GetCanonicalLink`/`UpdateCanonicalLinkConfig` (folded in). `DeleteCanonicalLink` now returns a clean 409/400 instead of a 500 on absent link / unknown provider.

## Type of change

- [x] Security hardening / bug fix

## Security checklist

- [x] Fix verified by a 3-lens adversarial review (correctness/concurrency, availability/integration, bypass), all PASS: lost-update closed, first-link persists, no lock held across `await`, anti-takeover decision and delete auth unchanged, no write path escapes the lock.

## Quality checklist

- [x] Net simplification: three link helpers collapse into `MutateLinks` + `TryGetCanonicalLink`; no duplication.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green, Debug (`--no-incremental`) + Release, 0 warnings.
- [x] `dotnet test` green: 113/113.

## Notes

Out of scope, tracked as follow-ups (F-9/F-10): the settings-page save has no server-side merge (can wipe server-managed fields from stale page data, V2 solved this with `PreserveServerManagedFields`); admin list-read endpoints are not yet lock-guarded.
