### PR TITLE
Enforce the SAML login role allow-list at the session-minting endpoint

### DIFF
--- a/SSO-Auth.Tests/SamlLoginPolicyTests.cs
+++ b/SSO-Auth.Tests/SamlLoginPolicyTests.cs
@@ -42,4 +42,12 @@ public class SamlLoginPolicyTests
         Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "Jellyfin" }, new[] { "jellyfin" }));
         Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "jellyfin" }, new string?[] { null }));
     }
+
+    [Fact]
+    public void NullOrEmptyRolesNeverAuthorize()
+    {
+        // A null/empty on both sides must not satisfy the allow-list.
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new string?[] { null }, new string?[] { null }));
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "" }, new[] { "" }));
+    }
 }

--- a/SSO-Auth.Tests/SamlLoginPolicyTests.cs
+++ b/SSO-Auth.Tests/SamlLoginPolicyTests.cs
@@ -1,0 +1,45 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlLoginPolicy"/> — the login allow-list gate that must hold at both the
+/// assertion-consumer page and the session-minting endpoint (enforcing it only at the page is
+/// fail-open). Fail-closed: an assertion whose roles are not on a non-empty allow-list is denied.
+/// </summary>
+public class SamlLoginPolicyTests
+{
+    [Fact]
+    public void NoAllowList_IsAllowed()
+    {
+        Assert.True(SamlLoginPolicy.IsLoginAllowed(new[] { "anything" }, null));
+        Assert.True(SamlLoginPolicy.IsLoginAllowed(new[] { "anything" }, new string[0]));
+    }
+
+    [Fact]
+    public void MatchingRole_IsAllowed()
+    {
+        Assert.True(SamlLoginPolicy.IsLoginAllowed(new[] { "users", "jellyfin" }, new[] { "jellyfin" }));
+    }
+
+    [Fact]
+    public void NoMatchingRole_IsDenied()
+    {
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "users", "other" }, new[] { "jellyfin" }));
+    }
+
+    [Fact]
+    public void EmptyOrNoAssertionRoles_WithAllowList_IsDenied()
+    {
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new string[0], new[] { "jellyfin" }));
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(null, new[] { "jellyfin" }));
+    }
+
+    [Fact]
+    public void ComparisonIsCaseSensitiveAndNullSafe()
+    {
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "Jellyfin" }, new[] { "jellyfin" }));
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "jellyfin" }, new string?[] { null }));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -605,27 +605,7 @@ public class SSOController : ControllerBase
                 return Problem("SAML response validation failed");
             }
 
-            bool valid = false;
-
-            // If no roles are configured, don't use RBAC
-            if (config.Roles.Length == 0)
-            {
-                valid = true;
-            }
-
-            // Check if user is allowed to log in based on roles
-            foreach (string role in samlResponse.GetCustomAttributes("Role"))
-            {
-                foreach (string allowedRole in config.Roles)
-                {
-                    if (allowedRole.Equals(role))
-                    {
-                        valid = true;
-                    }
-                }
-            }
-
-            if (valid)
+            if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
             {
                 return Content(
                         WebResponse.Generator(
@@ -639,7 +619,7 @@ public class SSOController : ControllerBase
 
             _logger.LogWarning(
                 "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-                samlResponse.GetNameID(),
+                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
                 samlResponse.GetCustomAttributes("Role"),
                 config.Roles);
             return ReturnError(StatusCodes.Status401Unauthorized, "Error. Check permissions.");
@@ -763,6 +743,17 @@ public class SSOController : ControllerBase
             if (!ValidateSaml(samlResponse, config))
             {
                 return Problem("SAML response validation failed");
+            }
+
+            // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
+            // can POST an assertion straight to this session-minting endpoint and skip the page, so
+            // checking it only there would be fail-open.
+            if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
+            {
+                _logger.LogWarning(
+                    "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
+                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status401Unauthorized, "Error. Check permissions.");
             }
 
             // Enforce one-time use so a captured assertion cannot be replayed to mint another session.

--- a/SSO-Auth/Api/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/SamlLoginPolicy.cs
@@ -29,10 +29,16 @@ internal static class SamlLoginPolicy
         {
             foreach (var role in assertionRoles)
             {
+                // Skip empty/null role values so a missing role can never satisfy the allow-list
+                // (a null/empty on both sides must not authorize).
+                if (string.IsNullOrEmpty(role))
+                {
+                    continue;
+                }
+
                 foreach (var allowed in allowedRoles)
                 {
-                    // Static Equals is null-safe (a null allowed entry returns false rather than throwing).
-                    if (string.Equals(allowed, role, StringComparison.Ordinal))
+                    if (!string.IsNullOrEmpty(allowed) && string.Equals(allowed, role, StringComparison.Ordinal))
                     {
                         return true;
                     }

--- a/SSO-Auth/Api/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/SamlLoginPolicy.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Pure login-authorization gate for SAML: decides whether an assertion's roles satisfy the
+/// provider's configured login allow-list. Must be enforced at BOTH the assertion-consumer page and
+/// the session-minting endpoint — enforcing it only at the page is fail-open, because a caller can
+/// POST an assertion straight to the minting endpoint and skip the page.
+/// </summary>
+internal static class SamlLoginPolicy
+{
+    /// <summary>
+    /// Determines whether a login is permitted.
+    /// </summary>
+    /// <param name="assertionRoles">The role values carried by the (already signature-validated) assertion.</param>
+    /// <param name="allowedRoles">The provider's configured login allow-list.</param>
+    /// <returns>True when no allow-list is configured (RBAC off) or the assertion carries at least one allowed role.</returns>
+    internal static bool IsLoginAllowed(IEnumerable<string> assertionRoles, string[] allowedRoles)
+    {
+        // No allow-list configured => role-based login is disabled, everyone authenticated is allowed.
+        if (allowedRoles == null || allowedRoles.Length == 0)
+        {
+            return true;
+        }
+
+        if (assertionRoles != null)
+        {
+            foreach (var role in assertionRoles)
+            {
+                foreach (var allowed in allowedRoles)
+                {
+                    // Static Equals is null-safe (a null allowed entry returns false rather than throwing).
+                    if (string.Equals(allowed, role, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
The login allow-list (`SamlConfig.Roles`) was enforced only on the assertion-consumer page, not on the session-minting endpoint, so it could be skipped. Extracted a pure `SamlLoginPolicy.IsLoginAllowed` (RBAC-off when unset; ordinal, null-safe), enforced it in SamlAuth after validation and before consume/mint (401 on denial), and reused it in SamlPost (dropping the duplicated loop). Fail-closed; RBAC-off unchanged.

4-lens adversarial review (bypass/correctness/integration/SAML domain) all PASS. Build 0-warning both configs; `dotnet test` 118/118 (5 new).