### PR TITLE
Bind OpenID authorize state to its provider and make it single-use

### DIFF
--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -54,6 +54,11 @@ public class AuthStateStoreTests
     public void IsCurrentFor_Null_False()
         => Assert.False(AuthStateStore.IsCurrentFor(null, "p", Now, Lifetime));
 
+    [Fact]
+    public void IsCurrentFor_CreatedInFuture_False()
+        // A backward clock step (Created ahead of now) must not make a state effectively never expire.
+        => Assert.False(AuthStateStore.IsCurrentFor(State("p", "s", false, Now.AddMinutes(5)), "p", Now, Lifetime));
+
     // --- IsRedeemableBy (OidAuth/OidLink): valid + response match + provider + unexpired ---
 
     [Fact]

--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -27,6 +27,55 @@ public class AuthStateStoreTests
         return store;
     }
 
+    private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private static TimedAuthorizeState State(string provider, string stateValue, bool valid, DateTime created)
+        => new TimedAuthorizeState(new Duende.IdentityModel.OidcClient.AuthorizeState { State = stateValue }, created)
+        {
+            Provider = provider,
+            Valid = valid,
+        };
+
+    // --- IsCurrentFor (OidPost precondition): provider-bound + unexpired ---
+
+    [Fact]
+    public void IsCurrentFor_SameProviderWithinLifetime_True()
+        => Assert.True(AuthStateStore.IsCurrentFor(State("p", "s", false, Now), "p", Now, Lifetime));
+
+    [Fact]
+    public void IsCurrentFor_DifferentProvider_False()
+        => Assert.False(AuthStateStore.IsCurrentFor(State("p", "s", false, Now), "other", Now, Lifetime));
+
+    [Fact]
+    public void IsCurrentFor_Expired_False()
+        => Assert.False(AuthStateStore.IsCurrentFor(State("p", "s", false, Now.AddMinutes(-2)), "p", Now, Lifetime));
+
+    [Fact]
+    public void IsCurrentFor_Null_False()
+        => Assert.False(AuthStateStore.IsCurrentFor(null, "p", Now, Lifetime));
+
+    // --- IsRedeemableBy (OidAuth/OidLink): valid + response match + provider + unexpired ---
+
+    [Fact]
+    public void IsRedeemableBy_AllConditionsMet_True()
+        => Assert.True(AuthStateStore.IsRedeemableBy(State("p", "tok", true, Now), "tok", "p", Now, Lifetime));
+
+    [Fact]
+    public void IsRedeemableBy_NotValid_False()
+        => Assert.False(AuthStateStore.IsRedeemableBy(State("p", "tok", false, Now), "tok", "p", Now, Lifetime));
+
+    [Fact]
+    public void IsRedeemableBy_CrossProviderReplay_False()
+        => Assert.False(AuthStateStore.IsRedeemableBy(State("low-trust", "tok", true, Now), "tok", "high-trust", Now, Lifetime));
+
+    [Fact]
+    public void IsRedeemableBy_ResponseMismatch_False()
+        => Assert.False(AuthStateStore.IsRedeemableBy(State("p", "tok", true, Now), "other", "p", Now, Lifetime));
+
+    [Fact]
+    public void IsRedeemableBy_Expired_False()
+        => Assert.False(AuthStateStore.IsRedeemableBy(State("p", "tok", true, Now.AddMinutes(-2)), "tok", "p", Now, Lifetime));
+
     [Fact]
     public void InvalidateExpired_RemovesOnlyExpiredEntries()
     {

--- a/SSO-Auth/Api/AuthStateStore.cs
+++ b/SSO-Auth/Api/AuthStateStore.cs
@@ -28,4 +28,43 @@ internal static class AuthStateStore
             }
         }
     }
+
+    /// <summary>
+    /// Whether a stored state still belongs to the given provider and has not expired. Used at the
+    /// OpenID callback before a state is validated: a state minted for one provider must not be
+    /// accepted on another provider's callback, and a state older than its lifetime is not honored.
+    /// </summary>
+    /// <param name="state">The stored state, or null.</param>
+    /// <param name="provider">The provider named in the consuming request's route.</param>
+    /// <param name="now">The current time.</param>
+    /// <param name="lifetime">How long a state may live.</param>
+    /// <returns>True only when the state exists, belongs to the provider, and is within its lifetime.</returns>
+    internal static bool IsCurrentFor(TimedAuthorizeState state, string provider, DateTime now, TimeSpan lifetime)
+    {
+        return state != null
+            && string.Equals(state.Provider, provider, StringComparison.Ordinal)
+            && now.Subtract(state.Created) <= lifetime;
+    }
+
+    /// <summary>
+    /// Whether a stored state may be redeemed to mint a session or create a link: it must be
+    /// validated, its authorization-response value must match the presented one, and it must still
+    /// belong to the route provider and be unexpired. The provider check is the state-scoping guard:
+    /// without it, a state validated at a low-trust provider could be replayed against a higher-trust
+    /// provider's endpoint, bypassing that provider's login/role gate (cross-provider state replay).
+    /// </summary>
+    /// <param name="state">The stored state, or null.</param>
+    /// <param name="responseData">The authorization-response value the caller presented.</param>
+    /// <param name="provider">The provider named in the consuming request's route.</param>
+    /// <param name="now">The current time.</param>
+    /// <param name="lifetime">How long a state may live.</param>
+    /// <returns>True only when the state is valid, matches the response value, belongs to the provider, and is unexpired.</returns>
+    internal static bool IsRedeemableBy(TimedAuthorizeState state, string responseData, string provider, DateTime now, TimeSpan lifetime)
+    {
+        return state != null
+            && state.Valid
+            && state.State != null
+            && string.Equals(state.State.State, responseData, StringComparison.Ordinal)
+            && IsCurrentFor(state, provider, now, lifetime);
+    }
 }

--- a/SSO-Auth/Api/AuthStateStore.cs
+++ b/SSO-Auth/Api/AuthStateStore.cs
@@ -41,9 +41,15 @@ internal static class AuthStateStore
     /// <returns>True only when the state exists, belongs to the provider, and is within its lifetime.</returns>
     internal static bool IsCurrentFor(TimedAuthorizeState state, string provider, DateTime now, TimeSpan lifetime)
     {
-        return state != null
-            && string.Equals(state.Provider, provider, StringComparison.Ordinal)
-            && now.Subtract(state.Created) <= lifetime;
+        if (state == null || !string.Equals(state.Provider, provider, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Reject a negative age (Created in the future, e.g. a backward clock step) as well as an
+        // over-lifetime one, so a clock anomaly cannot make a state effectively never expire.
+        var age = now.Subtract(state.Created);
+        return age >= TimeSpan.Zero && age <= lifetime;
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -56,7 +56,10 @@ public class SSOController : ControllerBase
     // OidLink / Invalidate); a plain Dictionary corrupts or throws under that interleaving.
     private static readonly ConcurrentDictionary<string, TimedAuthorizeState> StateManager = new ConcurrentDictionary<string, TimedAuthorizeState>();
 
-    private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(1);
+    // How long an in-flight OpenID authorize state may live before it is rejected/pruned. This now
+    // bounds the whole interactive leg (OidChallenge -> IdP login/MFA/consent -> callback -> mint),
+    // so it must accommodate a real user completing MFA, not just a fast round trip.
+    private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(15);
 
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
@@ -131,8 +134,12 @@ public class SSOController : ControllerBase
                 return BadRequest("Missing state");
             }
 
-            if (!StateManager.TryGetValue(state, out var timedState))
+            if (!StateManager.TryGetValue(state, out var timedState)
+                || !AuthStateStore.IsCurrentFor(timedState, provider, DateTime.Now, StateLifetime))
             {
+                // Unknown, expired, or minted for a different provider — reject so a state issued
+                // for one provider cannot be validated on another's callback. (No removal: the value
+                // is an unguessable CSPRNG token, and expiry pruning is handled by the sweep.)
                 return BadRequest("Invalid or expired state");
             }
 
@@ -429,7 +436,7 @@ public class SSOController : ControllerBase
             // IsLinking tracks whether this is a linking request rather than a login. The state value
             // is a fresh CSPRNG token, so a collision is effectively impossible; log if it ever occurs
             // instead of silently proceeding to a callback that would then fail with "invalid state".
-            if (!StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking }))
+            if (!StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking, Provider = provider }))
             {
                 _logger.LogWarning("OpenID authorize-state collision for provider {Provider}; login not started.", provider?.ReplaceLineEndings(string.Empty));
                 return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login due to a state collision; please retry.");
@@ -503,7 +510,16 @@ public class SSOController : ControllerBase
     [HttpGet("OID/States")]
     public ActionResult OidStates()
     {
-        return Ok(StateManager);
+        // Project to a non-secret summary. The raw store holds the authorize-state token and the
+        // PKCE code_verifier / nonce; those must never be serialized out, even to an admin.
+        var summary = StateManager.Values.Select(s => new
+        {
+            s.Provider,
+            s.Created,
+            s.Valid,
+            s.IsLinking,
+        });
+        return Ok(summary);
     }
 
     /// <summary>
@@ -527,39 +543,38 @@ public class SSOController : ControllerBase
             return BadRequest("No matching provider found");
         }
 
-        if (config.Enabled)
+        // The store is keyed by the authorize-state token, which is exactly response.Data, so look it
+        // up directly (O(1), no full-store scan) and atomically claim it with TryRemove(KeyValuePair):
+        // only the request that wins the removal proceeds, so one state mints at most one session even
+        // under concurrent posts.
+        if (config.Enabled
+            && StateManager.TryGetValue(response.Data, out var timedState)
+            && AuthStateStore.IsRedeemableBy(timedState, response.Data, provider, DateTime.Now, StateLifetime)
+            && StateManager.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(response.Data, timedState)))
         {
-            foreach (var kvp in StateManager)
+            Guid userId;
+            try
             {
-                if (kvp.Value.State.State.Equals(response.Data) && kvp.Value.Valid)
-                {
-                    Guid userId;
-                    try
-                    {
-                        userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, kvp.Value.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
-                    }
-                    catch (AccountLinkForbiddenException)
-                    {
-                        StateManager.TryRemove(kvp.Key, out _);
-                        return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
-                    }
-
-                    var authenticationResult = await Authenticate(
-                        userId,
-                        kvp.Value.Admin,
-                        config.EnableAuthorization,
-                        config.EnableAllFolders,
-                        kvp.Value.Folders.ToArray(),
-                        kvp.Value.EnableLiveTv,
-                        kvp.Value.EnableLiveTvManagement,
-                        response,
-                        config.DefaultProvider?.Trim(),
-                        kvp.Value.AvatarURL)
-                        .ConfigureAwait(false);
-                    StateManager.TryRemove(kvp.Key, out _);
-                    return Ok(authenticationResult);
-                }
+                userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, timedState.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
             }
+            catch (AccountLinkForbiddenException)
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
+            }
+
+            var authenticationResult = await Authenticate(
+                userId,
+                timedState.Admin,
+                config.EnableAuthorization,
+                config.EnableAllFolders,
+                timedState.Folders.ToArray(),
+                timedState.EnableLiveTv,
+                timedState.EnableLiveTvManagement,
+                response,
+                config.DefaultProvider?.Trim(),
+                timedState.AvatarURL)
+                .ConfigureAwait(false);
+            return Ok(authenticationResult);
         }
 
         return Problem("Something went wrong");
@@ -1172,13 +1187,13 @@ public class SSOController : ControllerBase
             return BadRequest("No matching provider found");
         }
 
-        foreach (var kvp in StateManager)
+        // Keyed O(1) lookup + atomic claim (see OidAuth): consume the state so one verified identity
+        // cannot be linked repeatedly and cannot then be reused to mint a session.
+        if (StateManager.TryGetValue(response.Data, out var timedState)
+            && AuthStateStore.IsRedeemableBy(timedState, response.Data, provider, DateTime.Now, StateLifetime)
+            && StateManager.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(response.Data, timedState)))
         {
-            if (kvp.Value.State.State.Equals(response.Data) && kvp.Value.Valid)
-            {
-                string providerUserId = kvp.Value.Username;
-                return CreateCanonicalLink("oid", provider, jellyfinUserId, providerUserId);
-            }
+            return CreateCanonicalLink("oid", provider, jellyfinUserId, timedState.Username);
         }
 
         return Problem("Something went wrong!");
@@ -1524,6 +1539,12 @@ public class TimedAuthorizeState
     /// Gets or sets the Authorization State of the client.
     /// </summary>
     public AuthorizeState State { get; set; }
+
+    /// <summary>
+    /// Gets or sets the provider that minted this state. A state may only be consumed on the same
+    /// provider's endpoints, so it cannot be replayed against another provider's login/role gate.
+    /// </summary>
+    public string Provider { get; set; }
 
     /// <summary>
     /// Gets or sets when this object was created to time it out.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -533,6 +533,11 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult> OidAuth(string provider, [FromBody] AuthResponse response)
     {
+        if (string.IsNullOrEmpty(response?.Data))
+        {
+            return BadRequest("Missing data");
+        }
+
         OidConfig config;
         try
         {
@@ -1177,6 +1182,11 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response)
     {
+        if (string.IsNullOrEmpty(response?.Data))
+        {
+            return BadRequest("Missing data");
+        }
+
         OidConfig config;
         try
         {


### PR DESCRIPTION
An OpenID authorize state was matched only by token value + Valid flag, not by the provider that minted it, and its lifetime was never enforced at consumption, so a state validated at one provider could be replayed against another's endpoints, reused, and the OID/States endpoint dumped the token + PKCE verifier/nonce.

- `TimedAuthorizeState.Provider` set at mint; pure `AuthStateStore.IsCurrentFor`/`IsRedeemableBy` enforce provider-binding + expiry + response match at OidPost/OidAuth/OidLink.
- OidAuth/OidLink use an O(1) keyed lookup + atomic `TryRemove(KeyValuePair)` claim (single-use even under concurrency).
- `StateLifetime` widened to 15 min so it bounds the interactive login/MFA leg without rejecting slow logins.
- OID/States returns a non-secret projection.

4-lens adversarial review + a fix-verification pass, all PASS (the review's two NEEDS_IMPROVEMENT points, 1-min lifetime availability regression and non-atomic single-use, are resolved here). Build 0-warning both configs; `dotnet test` 128/128 (9 new).