### PR TITLE
Verify Jellyfin compatibility in CI (ABI consistency + packaging)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,8 @@ jobs:
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 9.0.x
+    - name: Jellyfin compatibility metadata check
+      run: bash scripts/check-jellyfin-compat.sh
     - name: Restore dependencies
       run: dotnet restore
     - name: Vulnerable dependency scan
@@ -34,3 +36,11 @@ jobs:
       run: dotnet build --no-restore --warnaserror
     - name: Test
       run: dotnet test --no-build --verbosity normal
+
+  # Verify the plugin actually packages as a loadable Jellyfin plugin (JPRM builds it against the
+  # targeted ABI and produces the manifest) on every PR, not only at release time.
+  package:
+    uses: ./.github/workflows/build.yml
+    with:
+      dotnet-version: "9.0.x"
+      dotnet-target: "net9.0"

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.11" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />

--- a/scripts/check-jellyfin-compat.sh
+++ b/scripts/check-jellyfin-compat.sh
@@ -5,8 +5,8 @@
 # Compile-time API compatibility is already enforced by building against the pinned Jellyfin.*
 # packages with --warnaserror; this catches the metadata/ABI drift that a build cannot.
 #
-# Runtime SSO behavior against a live Jellyfin + identity provider is verified separately by the
-# manual end-to-end checklist (docs/E2E-CHECKLIST.md) — it cannot be exercised headlessly.
+# Runtime SSO behavior against a live Jellyfin + identity provider is verified separately by a
+# manual end-to-end check on a real server — it cannot be exercised headlessly.
 set -euo pipefail
 
 csproj="SSO-Auth/SSO-Auth.csproj"
@@ -20,15 +20,17 @@ check() { # description actual expected
   if [ "$2" != "$3" ]; then echo "::error::$1 mismatch: '$2' vs '$3'"; fail=1; else echo "ok: $1 = $2"; fi
 }
 
-tfm=$(grep -oP '(?<=<TargetFramework>)[^<]+' "$csproj" | head -1); need "$tfm" "csproj TargetFramework"
-asmver=$(grep -oP '(?<=<AssemblyVersion>)[^<]+' "$csproj" | head -1); need "$asmver" "csproj AssemblyVersion"
-filever=$(grep -oP '(?<=<FileVersion>)[^<]+' "$csproj" | head -1); need "$filever" "csproj FileVersion"
-controller=$(grep -oP 'Jellyfin\.Controller"\s+Version="\K[^"]+' "$csproj" | head -1); need "$controller" "Jellyfin.Controller version"
-model=$(grep -oP 'Jellyfin\.Model"\s+Version="\K[^"]+' "$csproj" | head -1); need "$model" "Jellyfin.Model version"
+# `|| true` so a missing match yields an empty value handled by need()/fail below, rather than
+# aborting the whole script via `set -e`/`pipefail` before a clear error can be printed.
+tfm=$(grep -oP '(?<=<TargetFramework>)[^<]+' "$csproj" | head -1 || true); need "$tfm" "csproj TargetFramework"
+asmver=$(grep -oP '(?<=<AssemblyVersion>)[^<]+' "$csproj" | head -1 || true); need "$asmver" "csproj AssemblyVersion"
+filever=$(grep -oP '(?<=<FileVersion>)[^<]+' "$csproj" | head -1 || true); need "$filever" "csproj FileVersion"
+controller=$(grep -oP 'Jellyfin\.Controller"\s+Version="\K[^"]+' "$csproj" | head -1 || true); need "$controller" "Jellyfin.Controller version"
+model=$(grep -oP 'Jellyfin\.Model"\s+Version="\K[^"]+' "$csproj" | head -1 || true); need "$model" "Jellyfin.Model version"
 
-byframework=$(grep -oP 'framework:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$byframework" "build.yaml framework"
-byversion=$(grep -oP '^version:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$byversion" "build.yaml version"
-abi=$(grep -oP 'targetAbi:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$abi" "build.yaml targetAbi"
+byframework=$(grep -oP 'framework:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$byframework" "build.yaml framework"
+byversion=$(grep -oP '^version:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$byversion" "build.yaml version"
+abi=$(grep -oP 'targetAbi:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$abi" "build.yaml targetAbi"
 
 [ "$fail" -eq 0 ] || { echo "aborting: could not read all metadata"; exit 1; }
 

--- a/scripts/check-jellyfin-compat.sh
+++ b/scripts/check-jellyfin-compat.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Jellyfin compatibility gate: verify the plugin metadata is internally consistent and correctly
+# targets its Jellyfin ABI, so a packaged plugin actually loads on the intended server generation.
+# Compile-time API compatibility is already enforced by building against the pinned Jellyfin.*
+# packages with --warnaserror; this catches the metadata/ABI drift that a build cannot.
+#
+# Runtime SSO behavior against a live Jellyfin + identity provider is verified separately by the
+# manual end-to-end checklist (docs/E2E-CHECKLIST.md) — it cannot be exercised headlessly.
+set -euo pipefail
+
+csproj="SSO-Auth/SSO-Auth.csproj"
+buildyaml="build.yaml"
+fail=0
+
+need() { # value description
+  if [ -z "$1" ]; then echo "::error::could not read $2"; fail=1; fi
+}
+check() { # description actual expected
+  if [ "$2" != "$3" ]; then echo "::error::$1 mismatch: '$2' vs '$3'"; fail=1; else echo "ok: $1 = $2"; fi
+}
+
+tfm=$(grep -oP '(?<=<TargetFramework>)[^<]+' "$csproj" | head -1); need "$tfm" "csproj TargetFramework"
+asmver=$(grep -oP '(?<=<AssemblyVersion>)[^<]+' "$csproj" | head -1); need "$asmver" "csproj AssemblyVersion"
+filever=$(grep -oP '(?<=<FileVersion>)[^<]+' "$csproj" | head -1); need "$filever" "csproj FileVersion"
+controller=$(grep -oP 'Jellyfin\.Controller"\s+Version="\K[^"]+' "$csproj" | head -1); need "$controller" "Jellyfin.Controller version"
+model=$(grep -oP 'Jellyfin\.Model"\s+Version="\K[^"]+' "$csproj" | head -1); need "$model" "Jellyfin.Model version"
+
+byframework=$(grep -oP 'framework:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$byframework" "build.yaml framework"
+byversion=$(grep -oP '^version:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$byversion" "build.yaml version"
+abi=$(grep -oP 'targetAbi:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1); need "$abi" "build.yaml targetAbi"
+
+[ "$fail" -eq 0 ] || { echo "aborting: could not read all metadata"; exit 1; }
+
+check "target framework (csproj vs build.yaml)" "$tfm" "$byframework"
+check "plugin version (build.yaml vs AssemblyVersion)" "$byversion" "$asmver"
+check "FileVersion vs AssemblyVersion" "$filever" "$asmver"
+check "Jellyfin Controller vs Model package version" "$controller" "$model"
+# targetAbi is the minimum supported server ABI; its major.minor must match the SDK we build against.
+check "targetAbi major.minor vs Jellyfin.Controller" "$(echo "$abi" | cut -d. -f1-2)" "$(echo "$controller" | cut -d. -f1-2)"
+
+if [ "$fail" -ne 0 ]; then
+  echo "Jellyfin compatibility metadata is inconsistent."
+  exit 1
+fi
+echo "Jellyfin compatibility metadata is consistent."


### PR DESCRIPTION
Adds a Jellyfin compatibility gate to CI. Closes #57

- `scripts/check-jellyfin-compat.sh`: metadata/ABI consistency (TFM, plugin version, Controller==Model, targetAbi major.minor), run in the .NET workflow.
- A `package` job runs JPRM on every PR, proving the plugin still packages as a loadable Jellyfin plugin + manifest (previously only at release).
- Aligns `Jellyfin.Controller` 10.11.0 -> 10.11.11 to match `Jellyfin.Model` (the check surfaced this skew).

Compile-against-pinned-packages already gives API compatibility). Build 0-warning both configs; 129 tests pass; the compat script passes locally.