### PR TITLE
Require modern signature algorithms in SAML validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 
 ## Security
 
-SSO is a sensitive part of your stack, and this plugin is being built to **fail closed**: a missing signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Security-relevant behavior is covered by the automated test suite.
+SSO is a sensitive part of your stack, and this plugin is being built to **fail closed**: a missing signature, a weak SHA-1 signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Security-relevant behavior is covered by the automated test suite.
 
 Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new) — not the public issue tracker. See [SECURITY.md](SECURITY.md).
 

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -91,6 +91,50 @@ public class SamlResponseTests
         Assert.False(Load(fixture).IsValid());
     }
 
+    // --- Signature/digest algorithm allowlist (A-3: reject SHA-1) ---
+
+    [Fact]
+    public void IsValid_Sha1SignedResponse_ReturnsFalse()
+    {
+        // A response signed with RSA-SHA1 and a SHA-1 digest verifies cryptographically against the
+        // certificate, but SHA-1 is collision-weak — it must be rejected fail-closed before that check.
+        var fixture = SamlTestFactory.Create(signWithSha1: true);
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_Sha1SignedAssertionScope_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion, signWithSha1: true);
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void GetSignatureAlgorithm_Sha256SignedResponse_ReturnsRsaSha256Uri()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.Equal("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", Load(fixture).GetSignatureAlgorithm());
+    }
+
+    [Fact]
+    public void GetSignatureAlgorithm_Sha1SignedResponse_ReturnsRsaSha1Uri()
+    {
+        // Diagnostic getter reports the rejected weak algorithm so an operator can identify the cause.
+        var fixture = SamlTestFactory.Create(signWithSha1: true);
+        Assert.Equal("http://www.w3.org/2000/09/xmldsig#rsa-sha1", Load(fixture).GetSignatureAlgorithm());
+    }
+
+    [Fact]
+    public void GetSignatureAlgorithm_UnsignedResponse_ReturnsNull()
+    {
+        var unsigned =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"_a\" Version=\"2.0\"><saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject></saml:Assertion>" +
+            "</samlp:Response>";
+        var response = new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
+        Assert.Null(response.GetSignatureAlgorithm());
+    }
+
     [Fact]
     public void GetNameID_ValidResponse_ReturnsSignedSubject()
     {

--- a/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SamlSignatureAlgorithms"/> — the XML-DSig algorithm allowlist that
+/// rejects weak/legacy primitives (A-3). Uses the standard XML-DSig algorithm identifier URIs.
+/// </summary>
+public class SamlSignatureAlgorithmsTests
+{
+    private const string RsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    private const string RsaSha512 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+    private const string EcdsaSha384 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384";
+    private const string RsaSha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+
+    private const string DigestSha256 = "http://www.w3.org/2001/04/xmlenc#sha256";
+    private const string DigestSha384 = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+    private const string DigestSha512 = "http://www.w3.org/2001/04/xmlenc#sha512";
+    private const string DigestSha1 = "http://www.w3.org/2000/09/xmldsig#sha1";
+
+    [Fact]
+    public void IsAllowed_RsaSha256WithSha256Digest_ReturnsTrue()
+    {
+        Assert.True(SamlSignatureAlgorithms.IsAllowed(RsaSha256, new[] { DigestSha256 }));
+    }
+
+    [Fact]
+    public void IsAllowed_StrongerVariants_ReturnTrue()
+    {
+        Assert.True(SamlSignatureAlgorithms.IsAllowed(RsaSha512, new[] { DigestSha512 }));
+        Assert.True(SamlSignatureAlgorithms.IsAllowed(EcdsaSha384, new[] { DigestSha384 }));
+    }
+
+    [Fact]
+    public void IsAllowed_RsaSha1Signature_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha1, new[] { DigestSha256 }));
+    }
+
+    [Fact]
+    public void IsAllowed_Sha1Digest_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha256, new[] { DigestSha1 }));
+    }
+
+    [Fact]
+    public void IsAllowed_OneWeakDigestAmongStrong_ReturnsFalse()
+    {
+        // A single weak digest anywhere in the reference set poisons the whole response.
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha256, new[] { DigestSha256, DigestSha1 }));
+    }
+
+    [Fact]
+    public void IsAllowed_NullSignatureMethod_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(null!, new[] { DigestSha256 }));
+    }
+
+    [Fact]
+    public void IsAllowed_NullDigestEnumerable_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha256, null!));
+    }
+
+    [Fact]
+    public void IsAllowed_NoReferences_ReturnsFalse()
+    {
+        // No digest to vouch for anything -> fail closed.
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha256, new List<string>()));
+    }
+
+    [Fact]
+    public void IsAllowed_NullDigestValue_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed(RsaSha256, new string?[] { null }));
+    }
+
+    [Fact]
+    public void IsAllowed_UnknownSignatureMethod_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.IsAllowed("urn:made:up", new[] { DigestSha256 }));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -620,7 +620,7 @@ public class SSOController : ControllerBase
         {
             var samlResponse = new Response(config.SamlCertificate, Request.Form["SAMLResponse"]);
 
-            if (!ValidateSaml(samlResponse, config))
+            if (!IsSamlResponseValid(samlResponse, config))
             {
                 return Problem("SAML response validation failed");
             }
@@ -760,7 +760,7 @@ public class SSOController : ControllerBase
             bool liveTvManagement = config.EnableLiveTvManagement;
             var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-            if (!ValidateSaml(samlResponse, config))
+            if (!IsSamlResponseValid(samlResponse, config))
             {
                 return Problem("SAML response validation failed");
             }
@@ -1158,7 +1158,7 @@ public class SSOController : ControllerBase
 
         var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-        if (!ValidateSaml(samlResponse, config))
+        if (!IsSamlResponseValid(samlResponse, config))
         {
             return Problem("SAML response validation failed");
         }
@@ -1349,6 +1349,25 @@ public class SSOController : ControllerBase
     private void Invalidate()
     {
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
+    }
+
+    // Validates the SAML response and, on failure, logs the declared signature algorithm plus the
+    // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
+    // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
+    // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
+    private bool IsSamlResponseValid(Response samlResponse, SamlConfig config)
+    {
+        if (ValidateSaml(samlResponse, config))
+        {
+            return true;
+        }
+
+        // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
+        // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
+        _logger.LogWarning(
+            "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
+            samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
+        return false;
     }
 
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -108,7 +108,24 @@ public class Response
         }
 
         signedXml.LoadXml((XmlElement)nodeList[0]);
-        return ValidateSignatureReference(signedXml) && signedXml.CheckSignature(_certificate, true) && IsWithinTimeBounds();
+        return ValidateSignatureReference(signedXml)
+            && IsSignatureAlgorithmAllowed(signedXml)
+            && signedXml.CheckSignature(_certificate, true)
+            && IsWithinTimeBounds();
+    }
+
+    // Reject weak/legacy signature and digest algorithms (e.g. RSA-SHA1, SHA-1 digest) before the
+    // cryptographic check, so a misconfigured or downgraded identity provider is not trusted.
+    // Runs after ValidateSignatureReference, which guarantees exactly one reference exists.
+    private bool IsSignatureAlgorithmAllowed(SignedXml signedXml)
+    {
+        var digestMethods = new List<string>();
+        foreach (Reference reference in signedXml.SignedInfo.References)
+        {
+            digestMethods.Add(reference.DigestMethod);
+        }
+
+        return SamlSignatureAlgorithms.IsAllowed(signedXml.SignedInfo.SignatureMethod, digestMethods);
     }
 
     /// <summary>
@@ -142,6 +159,25 @@ public class Response
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Gets the signature-method algorithm URI declared in the response's XML signature, or null when
+    /// the response carries no signature. Diagnostic only (e.g. to explain a rejected weak algorithm in
+    /// a log); it is never a substitute for <see cref="IsValid()"/>.
+    /// </summary>
+    /// <returns>The SignedInfo signature-method URI, or null if unsigned.</returns>
+    public string GetSignatureAlgorithm()
+    {
+        var nodeList = _xmlDoc.SelectNodes("//ds:Signature", _xmlNameSpaceManager);
+        if (nodeList == null || nodeList.Count == 0)
+        {
+            return null;
+        }
+
+        var signedXml = new SignedXml(_xmlDoc);
+        signedXml.LoadXml((XmlElement)nodeList[0]);
+        return signedXml.SignedInfo.SignatureMethod;
     }
 
     private List<string> GetAudiences()

--- a/SSO-Auth/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/SamlSignatureAlgorithms.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth;
+
+/// <summary>
+/// Allowlist of acceptable XML-DSig signature and digest algorithms for a SAML response. .NET's
+/// <c>SignedXml.CheckSignature</c> still accepts SHA-1 (rsa-sha1 / xmldsig#sha1), a collision-weak
+/// primitive, so a misconfigured or downgraded identity provider would otherwise be trusted. This
+/// enforces RSA/ECDSA-SHA-256-or-stronger signatures and SHA-256-or-stronger digests, fail-closed.
+/// </summary>
+internal static class SamlSignatureAlgorithms
+{
+    private static readonly HashSet<string> AllowedSignatureMethods = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",
+        "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512",
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384",
+        "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512",
+    };
+
+    private static readonly HashSet<string> AllowedDigestMethods = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "http://www.w3.org/2001/04/xmlenc#sha256",
+        "http://www.w3.org/2001/04/xmldsig-more#sha384",
+        "http://www.w3.org/2001/04/xmlenc#sha512",
+    };
+
+    /// <summary>
+    /// Whether the signature method and every reference digest method are on the allowlist.
+    /// </summary>
+    /// <param name="signatureMethod">The SignedInfo signature-method URI.</param>
+    /// <param name="digestMethods">The digest-method URI of every reference.</param>
+    /// <returns>True only if the signature method is allowed and there is at least one reference, all of whose digests are allowed.</returns>
+    internal static bool IsAllowed(string signatureMethod, IEnumerable<string> digestMethods)
+    {
+        if (!AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty))
+        {
+            return false;
+        }
+
+        if (digestMethods == null)
+        {
+            return false;
+        }
+
+        var any = false;
+        foreach (var digest in digestMethods)
+        {
+            any = true;
+            if (!AllowedDigestMethods.Contains(digest ?? string.Empty))
+            {
+                return false;
+            }
+        }
+
+        return any;
+    }
+}

--- a/providers.md
+++ b/providers.md
@@ -4,6 +4,8 @@ This plugin has been tested to work against various providers, though not all pr
 
 ❗ Before you proceed, make sure you have another admin account if you are going to link SSO provider to the only admin account on the server, permission might get overwritten (see [#212](https://github.com/9p4/jellyfin-plugin-sso/issues/212)).
 
+❗ **SAML signing algorithm:** SAML responses must be signed with **RSA or ECDSA using SHA-256 or stronger** (SHA-384/SHA-512). Signatures using SHA-1 (`rsa-sha1`) or a SHA-1 digest are rejected, so if your identity provider still signs with SHA-1, reconfigure it to SHA-256 — otherwise every login through that provider fails with a "SAML response validation failed" error. The server log records the offending signature algorithm to help you diagnose this.
+
 ## TOC / Tested Providers:
 
 This section is broken into providers that support Role-Based Access Control (RBAC), and those that do not


### PR DESCRIPTION
## Why

.NET's `SignedXml.CheckSignature` still accepts SHA-1 signatures and digests (verified empirically in the test suite: a cryptographically valid RSA-SHA1 response passes), so an identity provider that signs with a weak or downgraded algorithm was silently trusted. SAML validation now enforces an explicit algorithm allowlist and fails closed on anything not on it.

## What

- New `SamlSignatureAlgorithms` helper: signature method must be RSA or ECDSA with SHA-256/384/512, and every reference digest must be SHA-256/384/512. Fail-closed on null/empty/unknown, no references, or any weak digest in the set.
- Gated in `Response.IsValid()` between the signature-reference check and `CheckSignature`, so the weak algorithm is rejected before any cryptographic verification.
- Operability: all three SAML controller actions route through a wrapper that logs the declared signature algorithm (line-ending-stripped inline) with a remediation hint when validation fails, so a legacy SHA-1 provider lockout after upgrading is diagnosable from the server log. New diagnostic getter `Response.GetSignatureAlgorithm()`.
- Docs: providers.md gains a SHA-256+ signing-requirement callout with the provider-side fix; README security section lists the weak-signature rejection.

## Compatibility

Every mainstream provider (Keycloak, Authelia, authentik, Entra ID, ADFS 2016+, Okta, Google) signs with RSA-SHA256 by default and is unaffected. Providers still signing with SHA-1 are rejected by design; reconfiguring the provider to SHA-256 is the documented, state-free remediation.

## Tests

144 passing (13 new): allowlist unit tests (weak/unknown/null/empty/mixed digest sets) and end-to-end tests proving a cryptographically valid SHA-1-signed response is rejected in both response- and assertion-scope, plus the diagnostic getter.