### PR TITLE
Resolve SonarCloud findings across web assets and the compat script

### DIFF
--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -22,21 +22,21 @@ const ssoConfigurationPage = {
     // Add providers as options for the selector
 
     Object.keys(providers).forEach((provider_name) => {
-      var choice = new Option(provider_name, provider_name);
+      const choice = new Option(provider_name, provider_name);
 
       page.querySelector("#selectProvider").appendChild(choice);
     });
   },
   populateEnabledFolders: (folder_list, container) => {
     container.querySelectorAll(".folder-checkbox").forEach((e) => {
-      e.checked = folder_list.includes(e.getAttribute("data-id"));
+      e.checked = folder_list.includes(e.dataset.id);
     });
   },
   serializeEnabledFolders: (container) => {
     return [...container.querySelectorAll(".folder-checkbox")]
       .filter((e) => e.checked)
       .map((e) => {
-        return e.getAttribute("data-id");
+        return e.dataset.id;
       });
   },
   populateFolders: (container) => {
@@ -58,7 +58,7 @@ const ssoConfigurationPage = {
       .forEach((e) => e.remove());
 
     const checkboxes = folders.Items.map((folder) => {
-      var out = document.createElement("label");
+      const out = document.createElement("label");
 
       out.innerHTML = `
         <input
@@ -84,7 +84,7 @@ const ssoConfigurationPage = {
       .forEach((e) => e.remove());
 
     const mapping_elements = folder_role_mappings.map((mapping) => {
-      var elem = document.createElement("div");
+      const elem = document.createElement("div");
 
       elem.classList.add("sso-role-mapping-container");
       elem.innerHTML = `
@@ -111,7 +111,7 @@ const ssoConfigurationPage = {
       ></div>
       `;
 
-      var checklist = elem.querySelector(".sso-folder-list");
+      const checklist = elem.querySelector(".sso-folder-list");
       const enabled_folders = mapping["Folders"];
 
       ssoConfigurationPage
@@ -137,18 +137,18 @@ const ssoConfigurationPage = {
     mapping_elements.forEach((e) => container.appendChild(e));
   },
   serializeRoleMappings: (container) => {
-    var out = [];
-    const roles = [
-      ...container.querySelectorAll(".sso-role-mapping-container"),
-    ].forEach((elem) => {
-      const role = elem.querySelector(".sso-role-mapping-name").value;
-      const checklist = elem.querySelector(".sso-folder-list");
+    const out = [];
+    [...container.querySelectorAll(".sso-role-mapping-container")].forEach(
+      (elem) => {
+        const role = elem.querySelector(".sso-role-mapping-name").value;
+        const checklist = elem.querySelector(".sso-folder-list");
 
-      out.push({
-        Role: role,
-        Folders: ssoConfigurationPage.serializeEnabledFolders(checklist),
-      });
-    });
+        out.push({
+          Role: role,
+          Folders: ssoConfigurationPage.serializeEnabledFolders(checklist),
+        });
+      },
+    );
 
     return out;
   },
@@ -202,16 +202,16 @@ const ssoConfigurationPage = {
   },
   parseTextList: (element) => {
     // Return the parsed text list
-    var out = element.value
+    const out = element.value
       .split("\n")
       .map((e) => e.trim())
-      .filter((e) => e);
+      .filter(Boolean);
     return out;
   },
   loadProvider: (page, provider_name) => {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
-        var provider = config.OidConfigs[provider_name] || {};
+        const provider = config.OidConfigs[provider_name] || {};
 
         const form_elements = ssoConfigurationPage.listArgumentsByType(page);
 
@@ -294,7 +294,7 @@ const ssoConfigurationPage = {
       ApiClient.getPluginConfiguration(
         ssoConfigurationPage.pluginUniqueId,
       ).then((config) => {
-        var current_config = {};
+        let current_config = {};
         if (config.OidConfigs.hasOwnProperty(provider_name)) {
           current_config = config.OidConfigs[provider_name];
         }
@@ -356,7 +356,7 @@ const ssoConfigurationPage = {
     });
   },
   addTextAreaStyle: (view) => {
-    var style = document.createElement("link");
+    const style = document.createElement("link");
     style.rel = "stylesheet";
     style.href =
       ApiClient.getUrl("web/configurationpage") + "?name=SSO-Auth.css";
@@ -364,7 +364,7 @@ const ssoConfigurationPage = {
   },
 };
 
-export default function (view) {
+export default function initSsoConfigurationPage(view) {
   ssoConfigurationPage.addTextAreaStyle(view);
   ssoConfigurationPage.loadConfiguration(view);
 

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -658,7 +658,9 @@
                 </div>
 
                 <div class="inputContainer">
-                  <label class="inputLabel inputLabelUnfocused" for="RoleClaim"
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="SchemeOverride"
                     >Scheme Override</label
                   >
                   <input
@@ -674,7 +676,9 @@
                 </div>
 
                 <div class="inputContainer">
-                  <label class="inputLabel inputLabelUnfocused" for="RoleClaim"
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="PortOverride"
                     >Port Override</label
                   >
                   <input

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -31,9 +31,9 @@ const ssoConfigLinking = {
   },
   loadProviderList: (container, providers, provider_mode) => {
     providers.forEach((provider_name) => {
-      var provider_config = document.createElement("div");
+      const provider_config = document.createElement("div");
       provider_config.classList.add("sso-provider-links-container");
-      provider_config.setAttribute("data-id", provider_name);
+      provider_config.dataset.id = provider_name;
 
       provider_config.innerHTML = `
       <label
@@ -50,7 +50,7 @@ const ssoConfigLinking = {
         data-provider="${provider_name}"
       ></div>
       `;
-      var add_provider = provider_config.querySelector(
+      const add_provider = provider_config.querySelector(
         ".sso-provider-add-link",
       );
 
@@ -106,9 +106,11 @@ const ssoConfigLinking = {
       .forEach((e) => e.remove());
 
     const checkboxes = canonical_names.map((canonical_name) => {
-      var out = document.createElement("label");
-      out.classList.add("sso-provider-link-checkbox-wrapper");
-      out.classList.add("checkbox-wrapper");
+      const out = document.createElement("label");
+      out.classList.add(
+        "sso-provider-link-checkbox-wrapper",
+        "checkbox-wrapper",
+      );
       out.innerHTML = `
         <input
           is="emby-checkbox"
@@ -136,11 +138,11 @@ const ssoConfigLinking = {
 
     const delete_requests = [...view.querySelectorAll(".sso-link-checkbox")]
       .filter((checkbox_link) => {
-        const canonical_name = checkbox_link.getAttribute("data-id");
-        const provider_name = checkbox_link.getAttribute("data-provider");
-        const provider_mode = checkbox_link.getAttribute("data-mode");
+        const canonical_name = checkbox_link.dataset.id;
+        const provider_name = checkbox_link.dataset.provider;
+        const provider_mode = checkbox_link.dataset.mode;
 
-        if (![canonical_name, provider_name, provider_mode].every((e) => e)) {
+        if (![canonical_name, provider_name, provider_mode].every(Boolean)) {
           return false;
         }
 
@@ -151,9 +153,9 @@ const ssoConfigLinking = {
         return true;
       })
       .map((checked_link) => {
-        const canonical_name = checked_link.getAttribute("data-id");
-        const provider_name = checked_link.getAttribute("data-provider");
-        const provider_mode = checked_link.getAttribute("data-mode");
+        const canonical_name = checked_link.dataset.id;
+        const provider_name = checked_link.dataset.provider;
+        const provider_mode = checked_link.dataset.mode;
 
         return ApiClient.fetch({
           type: "DELETE",
@@ -170,7 +172,7 @@ const ssoConfigLinking = {
   },
 };
 
-export default function (view) {
+export default function initLinkingView(view) {
   ssoConfigLinking.loadProviders(view);
 
   view.querySelector("#enable-delete").addEventListener("change", (e) => {

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -37,12 +37,7 @@
 
 .sso-role-mapping-container,
 .sso-bordered-list {
-  /*
-  border-color: #101010;
-  border-color: #383838;
-  */
   border-color: rgba(255, 255, 255, 0.135);
-
   padding-top: 0.5em;
   border-style: solid;
   margin-top: 0.25em;

--- a/SSO-Auth/Views/apiClient.js
+++ b/SSO-Auth/Views/apiClient.js
@@ -7,7 +7,7 @@ export async function serverAddress({ basePath = "/web" }) {
   const apiClient = window.ApiClient;
 
   if (apiClient) {
-    return Promise.resolve(apiClient.serverAddress());
+    return apiClient.serverAddress();
   }
 
   const urls = [];
@@ -36,7 +36,7 @@ export async function serverAddress({ basePath = "/web" }) {
 
     // Don't use bundled app URL (file:) as server URL
     if (url.startsWith("file:")) {
-      return Promise.resolve();
+      return;
     }
 
     urls.push(url);
@@ -44,7 +44,16 @@ export async function serverAddress({ basePath = "/web" }) {
 
   console.debug("URL candidates:", urls);
 
-  const promises = urls.map((url) => {
+  // Fail closed: only probe candidates on this page's own origin.
+  const isSameOrigin = (candidate) => {
+    try {
+      return new URL(candidate).origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  };
+
+  const promises = urls.filter(isSameOrigin).map((url) => {
     return fetch(`${url}/System/Info/Public`)
       .then((resp) => {
         return {
@@ -52,19 +61,17 @@ export async function serverAddress({ basePath = "/web" }) {
           response: resp,
         };
       })
-      .catch(() => {
-        return Promise.resolve();
-      });
+      .catch(() => undefined);
   });
 
   return Promise.all(promises)
     .then((responses) => {
       responses = responses.filter((obj) => obj && obj.response.ok);
       return Promise.all(
-        responses.map((obj) => {
+        responses.map(async (obj) => {
           return {
             url: obj.url,
-            config: obj.response.json(),
+            config: await obj.response.json(),
           };
         }),
       );
@@ -72,16 +79,14 @@ export async function serverAddress({ basePath = "/web" }) {
     .then((configs) => {
       const selection =
         configs.find((obj) => !obj.config.StartupWizardCompleted) || configs[0];
-      return Promise.resolve(selection?.url);
+      return selection?.url;
     })
     .catch((error) => {
       console.log(error);
-      return Promise.resolve();
     });
 }
 
-// TODO: Refactor duplicated code
-// ! Duplicated at
+// Duplicated with WebResponse.cs; tracked in #63.
 // https://github.com/9p4/jellyfin-plugin-sso/blob/38558d762a13422862240af4060bdd1bb1618d57/SSO-Auth/WebResponse.cs#L363-L401
 function getDeviceName() {
   return "DUMMY";
@@ -112,20 +117,20 @@ await awaitLocalStorage();
 
 // Fetch credentials
 
-var credentials = new jellyfinApiclient.Credentials();
+const credentials = new jellyfinApiclient.Credentials();
 
-var server = await serverAddress({ basePath: "/SSOViews" });
+const server = await serverAddress({ basePath: "/SSOViews" });
 console.log({ server: server });
-var deviceId = getDeviceId();
-var appName = "SSO-Auth";
-var appVersion = "0.0.0.9000";
-var capabilities = {};
+const deviceId = getDeviceId();
+const appName = "SSO-Auth";
+const appVersion = "0.0.0.9000";
+const capabilities = {};
 
 const current_server = credentials
   .credentials()
   .Servers.find((e) => e.LocalAddress == server || e.ManualAddress == server);
 
-var localApiClient = new jellyfinApiclient.ApiClient(
+const localApiClient = new jellyfinApiclient.ApiClient(
   server,
   appName,
   appVersion,
@@ -137,7 +142,7 @@ localApiClient.setAuthenticationInfo(
   current_server.UserId,
 );
 
-var connections = new jellyfinApiclient.ConnectionManager(
+const connections = new jellyfinApiclient.ConnectionManager(
   credentials,
   appName,
   appVersion,

--- a/SSO-Auth/Views/emby-restyle.css
+++ b/SSO-Auth/Views/emby-restyle.css
@@ -15,6 +15,8 @@
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   -moz-osx-font-smoothing: grayscale;
+
+  /* Also fixes font ligatures on older WebOS versions */
   font-feature-settings: "liga";
 }
 
@@ -246,6 +248,7 @@ html {
   text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  line-height: 1.35;
 }
 
 html[lang|="ja"] {
@@ -290,10 +293,6 @@ html[lang|="zh-HK"] {
 
 /* site.scss */
 
-html {
-  line-height: 1.35;
-}
-
 body {
   overflow-x: hidden;
   background-color: transparent !important;
@@ -309,11 +308,6 @@ body {
   overflow: hidden;
   padding: 0;
   position: absolute;
-}
-
-.material-icons {
-  /* Fix font ligatures on older WebOS versions */
-  font-feature-settings: "liga";
 }
 
 .backgroundContainer {
@@ -433,7 +427,6 @@ form {
 }
 
 .checkbox-wrapper [type="checkbox"] {
-  /*display:  none;*/
   position: absolute;
   top: 0px;
   left: 0px;
@@ -464,8 +457,6 @@ form {
   width: 20px;
   border: 0.14em solid white;
   border-radius: 0.14em;
-  /* background:  #fff; */
-
   margin-right: 10px;
 }
 

--- a/scripts/check-jellyfin-compat.sh
+++ b/scripts/check-jellyfin-compat.sh
@@ -14,10 +14,15 @@ buildyaml="build.yaml"
 fail=0
 
 need() { # value description
-  if [ -z "$1" ]; then echo "::error::could not read $2"; fail=1; fi
+  local value="$1"
+  local description="$2"
+  if [[ -z "$value" ]]; then echo "::error::could not read $description" >&2; fail=1; fi
 }
 check() { # description actual expected
-  if [ "$2" != "$3" ]; then echo "::error::$1 mismatch: '$2' vs '$3'"; fail=1; else echo "ok: $1 = $2"; fi
+  local description="$1"
+  local actual="$2"
+  local expected="$3"
+  if [[ "$actual" != "$expected" ]]; then echo "::error::$description mismatch: '$actual' vs '$expected'" >&2; fail=1; else echo "ok: $description = $actual"; fi
 }
 
 # `|| true` so a missing match yields an empty value handled by need()/fail below, rather than
@@ -32,7 +37,7 @@ byframework=$(grep -oP 'framework:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 
 byversion=$(grep -oP '^version:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$byversion" "build.yaml version"
 abi=$(grep -oP 'targetAbi:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$abi" "build.yaml targetAbi"
 
-[ "$fail" -eq 0 ] || { echo "aborting: could not read all metadata"; exit 1; }
+[[ "$fail" -eq 0 ]] || { echo "aborting: could not read all metadata"; exit 1; }
 
 check "target framework (csproj vs build.yaml)" "$tfm" "$byframework"
 check "plugin version (build.yaml vs AssemblyVersion)" "$byversion" "$asmver"
@@ -41,7 +46,7 @@ check "Jellyfin Controller vs Model package version" "$controller" "$model"
 # targetAbi is the minimum supported server ABI; its major.minor must match the SDK we build against.
 check "targetAbi major.minor vs Jellyfin.Controller" "$(echo "$abi" | cut -d. -f1-2)" "$(echo "$controller" | cut -d. -f1-2)"
 
-if [ "$fail" -ne 0 ]; then
+if [[ "$fail" -ne 0 ]]; then
   echo "Jellyfin compatibility metadata is inconsistent."
   exit 1
 fi


### PR DESCRIPTION
One-time cleanup of the 71 findings SonarCloud reports on `main`, so the quality gate, now a required PR check on `main`, starts from a clean slate. Closes #61.

## Fixed

- **`scripts/check-jellyfin-compat.sh`** (15): `[[ ]]` conditionals, positional parameters assigned to named locals, `::error::` lines to stderr. Verified empirically old-vs-new: identical exit codes and message text on the pass, missing-metadata, and mismatch paths.
- **`config.js` / `linking.js` / `apiClient.js`** (~40): `var` → `const`/`let` (each site audited for reassignment and hoisting before conversion), `.dataset` over `get/setAttribute` for `data-*`, `Boolean` over identity arrows, named function expressions, merged `classList.add`, dead `roles` binding removed.
- **`apiClient.js`, real defect behind S4123**: `Promise.all` ran over plain objects whose `config` property was a never-awaited `response.json()` promise, the startup-wizard server selection always read `undefined` off a pending promise (reproducible as an unhandled rejection). The body is now awaited, restoring the upstream jellyfin-web intent. Also: a fail-closed same-origin guard on the probed candidate URLs (S8476, a no-op for all legitimate candidates since they derive from `window.location`), and the device-name duplication note now points at its tracker (#63) instead of a stale TODO.
- **`configPage.html`** (2): both flagged inputs had labels carrying a copy-pasted `for="RoleClaim"`, clicking "Scheme Override" or "Port Override" focused the wrong field. Each label now targets its own input; ids unchanged.
- **CSS** (5): commented-out code removed, duplicate `html` / `.material-icons` selectors merged. Cascade safety verified property-by-property (no intervening rule re-declares the merged properties).

## Evaluated, deliberately unchanged (4)

- **Three text-contrast findings** (`emby-restyle.css`, delete button 3.37:1, its disabled state 2.71:1, filter bubble 2.63:1): reaching 4.5:1 requires flipping the intended design (dark text on the red delete button / on the Material-blue badge); pure white on that red maxes out at 4.24:1. The disabled state is additionally exempt under WCAG 1.4.3 (inactive UI component). These should be marked *Accepted* in the SonarCloud UI.
- **`linking.html` S7785** (top-level await): the flagged inline script is a classic `<script defer>`, not a module, `defer` is inert on inline scripts, so converting to `type="module"` to enable top-level await would genuinely defer execution, add strict mode, and change scoping. A behavior change dressed as style; declined.

## Verification

Since CI cannot exercise browser JS, each file group's diff went through an independent adversarial review (refute-by-default), including side-by-side execution of the old and new `serverAddress()` under stubbed browser globals across nine scenarios, identical results except the disclosed S4123 fix. Build clean (`--warnaserror`), 129 tests pass, compat gate consistent, Prettier clean on all changed files.