### PR TITLE
Use optional chaining in the server-response filter

### DIFF
--- a/SSO-Auth/Views/apiClient.js
+++ b/SSO-Auth/Views/apiClient.js
@@ -66,7 +66,7 @@ export async function serverAddress({ basePath = "/web" }) {
 
   return Promise.all(promises)
     .then((responses) => {
-      responses = responses.filter((obj) => obj && obj.response.ok);
+      responses = responses.filter((obj) => obj?.response.ok);
       return Promise.all(
         responses.map(async (obj) => {
           return {


### PR DESCRIPTION
Follow-up to #61: the reshaped filter in `apiClient.js` tripped S6582 on the fresh analysis of `main`. `obj?.response.ok` has the same truthiness as `obj && obj.response.ok` in the filter predicate, so behavior is unchanged. This brings the open SonarCloud findings down to the four documented acceptances (three deliberate-design contrast findings and the linking.html module-conversion decline). Refs #61