### PR TITLE
Remove stray comment token breaking the checkbox-wrapper rule

### DIFF
--- a/SSO-Auth/Views/emby-restyle.css
+++ b/SSO-Auth/Views/emby-restyle.css
@@ -422,7 +422,7 @@ form {
 
 /* Fix checkboxes */
 /* Customize the label (the container) */
-*/ .checkbox-wrapper {
+.checkbox-wrapper {
   position: relative;
 }
 


### PR DESCRIPTION
# What & why

`emby-restyle.css` line 425 started with a leftover `*/` (`*/ .checkbox-wrapper {`). The token makes the selector invalid, the parser drops the whole rule, and `.checkbox-wrapper` never gets `position: relative`. The absolutely positioned invisible checkbox inputs inside each wrapper then resolve against the initial containing block: on the linking page, the "Enable Delete" toggle and every provider-link checkbox rendered by `linking.js` stack as 20x20 hit targets in the top-left viewport corner instead of covering their drawn boxes, a click near the corner silently toggles an unrelated link checkbox.

Removing the token restores the intended rule (standard custom-checkbox pattern: the wrapper is the containing block for the input). Verified in a browser against the standalone linking page: before, all three test inputs sat stacked at viewport (4, 3) and a click at (14, 13) toggled a provider-link checkbox rendered ~1200px further down; after, every wrapper computes `position: relative` and each input overlays its own label's drawn box.

Closes #66

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable, CSS-only change on the linking page; no login path, crypto, config persistence, or release pipeline touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (once the test project exists).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Debug and Release both build with `--warnaserror`; 144/144 tests pass. The same stray-token pattern (`*/` before a selector) occurs nowhere else in the repo's web assets. Optional E2E follow-up against a live server: confirm linking-page checkboxes toggle only when their own row is clicked (covered here by a browser check on the standalone page).