### PR TITLE
Scope SonarCloud analysis to source, excluding img assets

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+# Keep SonarCloud analysis scoped to source code. The binary assets under img/
+# (screenshots, logo, demo recording) are not text and trip the encoding sensor,
+# producing a "problems with file encoding" scanner warning on every run.
+sonar.exclusions=img/**


### PR DESCRIPTION
SonarCloud's analysis raises a persistent scanner warning on every run:

> There are problems with file encoding in the source code.

A byte-level scan of all tracked files confirms every source/text file is valid UTF-8; the only non-UTF-8 files are the binary assets under `img/` (five JPGs, two PNGs, one MP4), which the text sensor indexes and trips over. This adds a `sonar-project.properties` with `sonar.exclusions=img/**` so the analysis scope matches the actual source. Closes #70.