### PR TITLE
Document the mandatory two-reviewer PR process in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,13 +4,14 @@
 # security-critical paths (the SSO login path, crypto, config persistence, and
 # the release pipeline).
 #
-# Note: this only requests review; it is not a hard merge gate. GitHub cannot
-# require an approving review on a self-authored PR (a required-approval count
-# would deadlock the solo maintainer), so "require review from Code Owners" is
-# intentionally left off in the ruleset. The maintainer sign-off is instead a
-# process gate: every PR gets both a Copilot review and a mandatory `iderex`
-# review that confirms or rejects Copilot's findings before merge (submitted as
-# a Comment-event review on iderex-authored PRs, an approval on others).
+# Note: this only requests review; it is not a hard merge gate. GitHub can
+# require approvals, but a PR author cannot approve their own PR, so with a solo
+# maintainer as the only Code Owner a required-approval count (or "require
+# review from Code Owners") would deadlock every maintainer-authored PR — it is
+# therefore intentionally left off in the ruleset. The maintainer sign-off is
+# instead a process gate: every PR gets both a Copilot review and a mandatory
+# `iderex` review that confirms or rejects Copilot's findings before merge
+# (a Comment-event review on iderex-authored PRs, an approval on others).
 
 # Default owner for everything in the repo.
 *                        @iderex

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,13 @@
 # security-critical paths (the SSO login path, crypto, config persistence, and
 # the release pipeline).
 #
-# Note: this only requests review; it is not a hard merge gate unless a ruleset
-# turns on "require review from Code Owners". With a solo maintainer that would
-# be self-blocking, so it is intentionally left off.
+# Note: this only requests review; it is not a hard merge gate. GitHub cannot
+# require an approving review on a self-authored PR (a required-approval count
+# would deadlock the solo maintainer), so "require review from Code Owners" is
+# intentionally left off in the ruleset. The maintainer sign-off is instead a
+# process gate: every PR gets both a Copilot review and a mandatory `iderex`
+# review that confirms or rejects Copilot's findings before merge (submitted as
+# a Comment-event review on iderex-authored PRs, an approval on others).
 
 # Default owner for everything in the repo.
 *                        @iderex


### PR DESCRIPTION
Every PR now has two mandatory reviewers, Copilot and me (`iderex`), and I submit a consolidated sign-off review that confirms or rejects Copilot's findings before merge.

This updates the CODEOWNERS note to describe that gate accurately: it is a **process** gate, not a native GitHub required-review, because GitHub forbids approving a self-authored PR and a required-approval count would deadlock a solo project. The ruleset's `pull_request` rule keeps `required_approving_review_count: 0` for that reason; the sign-off is enforced by the delivery flow instead (a Comment-event review on my own PRs, a real approval on external ones).

Refs #60.