### PR TITLE
Run SonarCloud analysis in CI instead of Automatic Analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,14 +36,14 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
-        id: cache-sonar-scanner
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
-      - name: Install SonarCloud scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+      - name: Install or update SonarCloud scanner
+        # Always run: with a cache hit this is a fast no-op when current, but it keeps a cached
+        # scanner from going stale forever (the cache key never changes).
         run: |
           mkdir -p ./.sonar/scanner
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,61 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Build and analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 17
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        with:
+          java-version: 17
+          distribution: zulu
+      - name: Set up .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: 9.0.x
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # A full clone lets SonarCloud attribute issues to the right commits/authors.
+          fetch-depth: 0
+      - name: Cache SonarCloud packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ./.sonar/scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ./.sonar/scanner
+          dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+      - name: Build and analyze
+        env:
+          # The scanner reads SONAR_TOKEN from the environment; sourcing it via env keeps the
+          # token out of the script text and the process command line, and Actions masks it in logs.
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          ./.sonar/scanner/dotnet-sonarscanner begin \
+            /k:"iderex_jellyfin-plugin-sso" \
+            /o:"iderex" \
+            /d:sonar.exclusions="img/**"
+          dotnet build --no-incremental
+          ./.sonar/scanner/dotnet-sonarscanner end

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,0 @@
-# Keep SonarCloud analysis scoped to source code. The binary assets under img/
-# (screenshots, logo, demo recording) are not text and trip the encoding sensor,
-# producing a "problems with file encoding" scanner warning on every run.
-sonar.exclusions=img/**


### PR DESCRIPTION
Switches SonarCloud from Automatic Analysis to CI-based scanning, so the scan config lives in the repo and the `img/` encoding warning can actually be suppressed (Automatic Analysis ignored the in-repo `sonar-project.properties`). Closes #70.

## What

- **New `.github/workflows/sonarcloud.yml`**: runs the dotnet SonarScanner (`begin` / `dotnet build --no-incremental` / `end`) on ubuntu-latest with `setup-dotnet 9.0.x` and JDK 17, on push to `main` and on PRs. Actions are SHA-pinned and aligned with the other workflows (`checkout` v7, `setup-dotnet` v5); `permissions: contents: read`.
- **Secret**: authenticates with the `SONAR_TOKEN` repo secret, read from step `env` only so it never lands in the script text or on the scanner's command line.
- **Exclusion**: `img/**` passed via `/d:sonar.exclusions` and also set as a server-side project setting, so the binary assets stop tripping the encoding sensor.
- **Removes `sonar-project.properties`**: the MSBuild scanner never read it (that file is only for the CLI scanner), so it was inert.

Automatic Analysis is turned off on the SonarCloud side (`sonar.autoscan.enabled=false`). The required `SonarCloud Code Analysis` check keeps its name because it is posted by the same SonarCloud GitHub App regardless of analysis mode, so branch protection is unaffected.

## Verification

Adversarially reviewed (security + integration lenses): no secret leak, no injection, plain `pull_request` trigger (fork PRs get no secret and fail closed without leaking), least-privilege, all actions SHA-pinned; build proven on ubuntu by the existing `dotnet.yml`. Two review fixes applied: aligned the `checkout` SHA and dropped the redundant command-line token. Post-merge I will confirm the check posts green and that the encoding warning is gone.