### PR TITLE
Import test coverage into the SonarCloud analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,12 +41,15 @@ jobs:
           path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner
           restore-keys: ${{ runner.os }}-sonar-scanner
-      - name: Install or update SonarCloud scanner
-        # Always run: with a cache hit this is a fast no-op when current, but it keeps a cached
-        # scanner from going stale forever (the cache key never changes).
+      - name: Install or update SonarCloud scanner and coverage tool
+        # Always run: with a cache hit this is a fast no-op when current, but it keeps the cached
+        # tools from going stale forever (the cache key never changes). dotnet-coverage collects
+        # coverage at the process level, which is what works for the xUnit v3 / Microsoft Testing
+        # Platform test project (the VSTest --collect data collector does not apply under MTP).
         run: |
           mkdir -p ./.sonar/scanner
           dotnet tool update dotnet-sonarscanner --tool-path ./.sonar/scanner
+          dotnet tool update dotnet-coverage --tool-path ./.sonar/scanner
       - name: Build and analyze
         env:
           # The scanner reads SONAR_TOKEN from the environment; sourcing it via env keeps the
@@ -56,6 +59,8 @@ jobs:
           ./.sonar/scanner/dotnet-sonarscanner begin \
             /k:"iderex_jellyfin-plugin-sso" \
             /o:"iderex" \
-            /d:sonar.exclusions="img/**"
+            /d:sonar.exclusions="img/**" \
+            /d:sonar.cs.vscoveragexml.reportsPaths="coverage.xml"
           dotnet build --no-incremental
+          ./.sonar/scanner/dotnet-coverage collect "dotnet test --no-build" -f xml -o coverage.xml
           ./.sonar/scanner/dotnet-sonarscanner end

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -62,5 +62,5 @@ jobs:
             /d:sonar.exclusions="img/**" \
             /d:sonar.cs.vscoveragexml.reportsPaths="coverage.xml"
           dotnet build --no-incremental
-          ./.sonar/scanner/dotnet-coverage collect "dotnet test --no-build" -f xml -o coverage.xml
+          ./.sonar/scanner/dotnet-coverage collect -f xml -o coverage.xml -- dotnet test --no-build
           ./.sonar/scanner/dotnet-sonarscanner end


### PR DESCRIPTION
The CI scan only ran `dotnet build`, so SonarCloud measured **0% coverage**. This collects coverage while the tests run and hands the report to the scanner, so coverage is measured, shown, and trended per PR.

## How

- Collect with `dotnet-coverage` at the process level. This is the approach that works for the xUnit v3 / **Microsoft Testing Platform** test project, the VSTest `--collect` data collector does not apply under MTP. Verified locally: 144 tests, a valid VS coverage XML with the production types.
- Import via `/d:sonar.cs.vscoveragexml.reportsPaths` (the format SonarCloud reads natively for C#).
- `dotnet-coverage` is installed/updated alongside the scanner into the cached tool path.

## Coverage is imported for visibility, not gated (yet)

Production coverage is currently low (~18%) because the monolithic `SSOController` is not yet decomposed into testable units. Per the project's evidence-based stance, a raw line-coverage % is **not** used as a hard merge gate here, the merge gate stays the reliability/security/hotspot conditions plus the "every security branch has a negative test" rule. Raising coverage toward **80%** is the documented standing goal as the controller is split into pure helpers.

The hard `new_coverage < 80` condition is being removed from the project's quality gate separately (a custom gate is prepared; 

Refs #70.