### PR TITLE
Fix delete-button contrast and drop dead filter-bubble CSS

### DIFF
--- a/SSO-Auth/Views/emby-restyle.css
+++ b/SSO-Auth/Views/emby-restyle.css
@@ -36,9 +36,11 @@
 theme.css
 */
 .button-delete {
-  /* A darker danger red so the white label meets WCAG AA contrast (>=4.5:1);
-     rgb(247, 0, 0) only reached ~3.4:1. Still unmistakably a destructive action. */
-  background: #c62828;
+  /* Material Red 800: against the theme's rgba(255, 255, 255, 0.87) label this clears WCAG AA
+     with margin (~5.3:1) rather than sitting on the 4.5:1 line; the previous rgb(247, 0, 0)
+     reached only ~3.4:1. Text opacity is kept at the theme's 0.87 for visual consistency.
+     Still an unmistakable destructive-action red. */
+  background: #b71c1c;
   color: rgba(255, 255, 255, 0.87);
 }
 

--- a/SSO-Auth/Views/emby-restyle.css
+++ b/SSO-Auth/Views/emby-restyle.css
@@ -36,7 +36,9 @@
 theme.css
 */
 .button-delete {
-  background: rgb(247, 0, 0);
+  /* A darker danger red so the white label meets WCAG AA contrast (>=4.5:1);
+     rgb(247, 0, 0) only reached ~3.4:1. Still unmistakably a destructive action. */
+  background: #c62828;
   color: rgba(255, 255, 255, 0.87);
 }
 
@@ -212,31 +214,6 @@ Emby Button
 .emby-button-foreground {
   position: relative;
   z-index: 1;
-}
-
-.btnFilterWithBubble {
-  position: relative;
-}
-
-.filterButtonBubble {
-  color: #fff;
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 1.6em;
-  height: 1.6em;
-  z-index: 100000000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 82%;
-  border-radius: 100em;
-  box-shadow:
-    0 4px 5px 0 rgba(0, 0, 0, 0.14),
-    0 1px 10px 0 rgba(0, 0, 0, 0.12),
-    0 2px 4px -1px rgba(0, 0, 0, 0.2);
-  background: #03a9f4;
-  font-weight: bold;
 }
 
 /* fonts.scss */


### PR DESCRIPTION
Resolves the accessibility findings from #69 in the linking-page theme (`emby-restyle.css`).

- **`.button-delete`** (rendered on `configPage.html` and `linking.html`): the red `rgb(247, 0, 0)` under the white label only reached ~3.4:1, below WCAG AA (4.5:1). Darkened to **#c62828** (a standard danger red) which clears 4.5:1 while staying an unmistakable destructive-action button. The owner can nudge the shade, it is a one-line change.
- **`.button-delete:disabled`**: left unchanged, disabled/inactive controls are exempt from WCAG 1.4.3, and the muted look is the intended disabled affordance.
- **`.filterButtonBubble` / `.btnFilterWithBubble`**: removed. Neither is referenced by any plugin page (confirmed by grep), so they were dead theme CSS; deleting them is the smaller fix and clears their contrast finding too (per #69's own guidance).

Note on the remaining #69 item, `linking.html` `javascript:S7785` (top-level await): declined. That inline `<script defer>` is a classic script, not a module; converting it to `type="module"` for top-level await would change execution semantics (real deferral, strict mode, module scope), a behavior change beyond the finding's intent.

Since the switch to CI-based SonarCloud analysis (#73), these web-asset findings are no longer scanned by SonarCloud (C# only; JavaScript security stays covered by CodeQL), so this PR resolves them at the source rather than for the scanner.

Closes #69.