### PR TITLE
Fail closed on a missing user and namespace SerializableDictionary

### DIFF
--- a/SSO-Auth.Tests/SerializableDictionarySerializationTests.cs
+++ b/SSO-Auth.Tests/SerializableDictionarySerializationTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Serialization round-trip tests for <see cref="SerializableDictionary{TKey,TValue}"/>. This type
+/// backs the persisted plugin configuration (SamlConfigs / OidConfigs / CanonicalLinks), so its XML
+/// format must stay stable — in particular, moving the type into a named namespace must not change
+/// the on-disk XML, or existing installations' saved configuration would fail to load.
+/// </summary>
+public class SerializableDictionarySerializationTests
+{
+    [Fact]
+    public void RoundTrip_StringToGuid_PreservesEntries()
+    {
+        var original = new SerializableDictionary<string, Guid>
+        {
+            ["alice@example.com"] = Guid.NewGuid(),
+            ["bob"] = Guid.NewGuid(),
+        };
+
+        var restored = RoundTrip(original);
+
+        Assert.Equal(original.Count, restored.Count);
+        foreach (var pair in original)
+        {
+            Assert.Equal(pair.Value, restored[pair.Key]);
+        }
+    }
+
+    [Fact]
+    public void Serialize_DoesNotLeakClrNamespaceIntoXml()
+    {
+        // The CLR namespace must not appear in the XML: the format is defined entirely by
+        // IXmlSerializable (item/key/value), so it is independent of where the type lives.
+        // This is what lets the namespace move stay backward-compatible with saved config.
+        var dict = new SerializableDictionary<string, Guid> { ["provider"] = Guid.NewGuid() };
+
+        var xml = Serialize(dict);
+
+        Assert.DoesNotContain("Jellyfin.Plugin", xml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_FromLegacyFormatXml_StillLoads()
+    {
+        // A document in the exact shape the type has always written (as produced before the type
+        // was moved into a namespace) must still deserialize unchanged.
+        var id = Guid.NewGuid();
+        var legacy =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<dictionary><item><key><string>keycloak</string></key>" +
+            "<value><guid>" + id + "</guid></value></item></dictionary>";
+
+        var serializer = new XmlSerializer(typeof(SerializableDictionary<string, Guid>));
+        using var reader = new StringReader(legacy);
+        var restored = (SerializableDictionary<string, Guid>)serializer.Deserialize(reader)!;
+
+        Assert.Equal(id, restored["keycloak"]);
+    }
+
+    private static string Serialize<TKey, TValue>(SerializableDictionary<TKey, TValue> value)
+    {
+        var serializer = new XmlSerializer(typeof(SerializableDictionary<TKey, TValue>));
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, value);
+        return writer.ToString();
+    }
+
+    private static SerializableDictionary<TKey, TValue> RoundTrip<TKey, TValue>(SerializableDictionary<TKey, TValue> value)
+    {
+        var serializer = new XmlSerializer(typeof(SerializableDictionary<TKey, TValue>));
+        using var reader = new StringReader(Serialize(value));
+        return (SerializableDictionary<TKey, TValue>)serializer.Deserialize(reader)!;
+    }
+}

--- a/SSO-Auth.Tests/SerializableDictionarySerializationTests.cs
+++ b/SSO-Auth.Tests/SerializableDictionarySerializationTests.cs
@@ -35,14 +35,17 @@ public class SerializableDictionarySerializationTests
     [Fact]
     public void Serialize_DoesNotLeakClrNamespaceIntoXml()
     {
-        // The CLR namespace must not appear in the XML: the format is defined entirely by
-        // IXmlSerializable (item/key/value), so it is independent of where the type lives.
-        // This is what lets the namespace move stay backward-compatible with saved config.
+        // The type's CLR namespace must not appear in the XML: the format is defined entirely by
+        // IXmlSerializable (item/key/value), so it is independent of where the type lives. This is
+        // what lets the namespace move stay backward-compatible with saved config. Assert against
+        // the type's actual namespace so the test stays correct if the namespace is ever renamed.
         var dict = new SerializableDictionary<string, Guid> { ["provider"] = Guid.NewGuid() };
+        var clrNamespace = typeof(SerializableDictionary<string, Guid>).Namespace;
 
         var xml = Serialize(dict);
 
-        Assert.DoesNotContain("Jellyfin.Plugin", xml, StringComparison.Ordinal);
+        Assert.False(string.IsNullOrEmpty(clrNamespace));
+        Assert.DoesNotContain(clrNamespace, xml, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1240,6 +1240,13 @@ public class SSOController : ControllerBase
     private async Task<AuthenticationResult> Authenticate(Guid userId, bool isAdmin, bool enableAuthorization, bool enableAllFolders, string[] enabledFolders, bool enableLiveTv, bool enableLiveTvAdmin, AuthResponse authResponse, string defaultProvider, string avatarUrl)
     {
         User user = _userManager.GetUserById(userId);
+        if (user is null)
+        {
+            // Fail closed: the account resolved for this SSO login no longer exists (e.g. it was
+            // deleted between resolution and this call), so no session may be minted for it.
+            throw new AuthenticationException("SSO authentication aborted: the target user does not exist.");
+        }
+
         if (enableAuthorization)
         {
             user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
@@ -1299,22 +1306,19 @@ public class SSOController : ControllerBase
                     var extension = mediaType.Split('/').Last();
                     using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes).ConfigureAwait(false);
 
-                    if (user != null)
+                    var userDataPath =
+                        Path.Combine(
+                            _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
+                            user.Username);
+                    if (user.ProfileImage is not null)
                     {
-                        var userDataPath =
-                            Path.Combine(
-                                _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
-                                user.Username);
-                        if (user.ProfileImage is not null)
-                        {
-                            await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
-                        }
-
-                        user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
-
-                        await _providerManager.SaveImage(stream, mediaType, user.ProfileImage.Path)
-                            .ConfigureAwait(false);
+                        await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
                     }
+
+                    user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
+
+                    await _providerManager.SaveImage(stream, mediaType, user.ProfileImage.Path)
+                        .ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/SSO-Auth/SerializableDictionary.cs
+++ b/SSO-Auth/SerializableDictionary.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
+namespace Jellyfin.Plugin.SSO_Auth;
+
 /// <summary>
 /// For some reason, the generic Dictionary in .net 2.0 is not XML serializable. The following code snippet is a xml serializable generic dictionary. The dictionary is serializable by implementing the IXmlSerializable interface.
 /// Also see https://weblogs.asp.net/pwelter34/444961 for additional information.


### PR DESCRIPTION
Fixes the two reliability bugs the CI-based SonarCloud scan surfaced (they drove `new_reliability_rating` to C). Closes #76.

## 1. `Authenticate` fails closed on a missing user (S2259)

`SSOController.Authenticate` dereferenced the `user` from `GetUserById(userId)` unconditionally, so an account deleted in the window between link resolution (`CreateCanonicalLinkAndUserIfNotExist`) and this call produced a `NullReferenceException`. Now it guards: `if (user is null) throw new AuthenticationException(...)` **before any session-minting**, no session for a non-existent account. The now-redundant `if (user != null)` wrapper in the avatar block is removed (user is provably non-null past the guard). Not a regression: that path already threw (NRE) before; this converts a latent crash into an explicit, clean fail-closed rejection.

## 2. `SerializableDictionary` moved into the plugin namespace (S3903 / CA1050)

Out of the global namespace into `Jellyfin.Plugin.SSO_Auth`. It backs the persisted config (SamlConfigs / OidConfigs / CanonicalLinks), so the on-disk XML must not change, and it doesn't: the format is defined entirely by `IXmlSerializable` (item/key/value) and is independent of the CLR namespace. New tests round-trip the type **and** deserialize the exact historical on-disk format, proving existing installs' config still loads. Consumers compile without new usings (child namespaces resolve the parent).

## Verification

- Build clean (`--warnaserror`), 147 tests pass (+3 serialization tests).
- 4-lens adversarial review (bypass / correctness / integration / availability), all PASS. Confirmed: the throw is fail-closed on both call sites (outside their `AccountLinkForbiddenException` catches, not swallowed), the avatar de-indent is behavior-equivalent, and the namespace move is XML-format-invariant.

## E2E follow-ups (real server, logged in docs/E2E-CHECKLIST.md)

- Confirm `OID/Auth` / `SAML/Auth` return a clean 401 (no token) when the account is gone.
- Confirm a pre-move config file loads unchanged after upgrade.