### PR TITLE
Hoist and time-box the role-claim split regex

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -202,6 +202,15 @@ public class SSOController : ControllerBase
                     (s, claim) => s.Contains($"@{{{claim.Type}}}") ? s.Replace($"@{{{claim.Type}}}", claim.Value) : s);
             }
 
+            // The role-claim path depends only on config.RoleClaim, so process it once here rather
+            // than per claim. The regex splits on dots not escaped with a backslash ("a.b.c" ->
+            // a, b, c; "a.b\.c" -> a, b.c), then the escaped "\." are normalized back to ".".
+            string[] roleClaimSegments = string.IsNullOrEmpty(config.RoleClaim)
+                ? Array.Empty<string>()
+                : RoleClaimSplitRegex.Split(config.RoleClaim.Trim())
+                    .Select(segment => segment.Replace("\\.", "."))
+                    .ToArray();
+
             foreach (var claim in result.User.Claims)
             {
                 if (claim.Type == (config.DefaultUsernameClaim?.Trim() ?? "preferred_username"))
@@ -214,20 +223,13 @@ public class SSOController : ControllerBase
                 }
 
                 // Role processing
-                // The regex matches any "." not preceded by a "\": a.b.c will be split into a, b, and c, but a.b\.c will be split into a, b.c (after processing the escaped dots)
-                // We have to first process the RoleClaim string
-                string[] segments = string.IsNullOrEmpty(config.RoleClaim) ? Array.Empty<string>() : RoleClaimSplitRegex.Split(config.RoleClaim.Trim());
-
-                if (segments.Any())
+                if (roleClaimSegments.Any())
                 {
-                    // Now we make sure that any escaped "."s ("\.") are replaced with "."
-                    segments = segments.Select(i => i.Replace("\\.", ".")).ToArray();
-
-                    if (claim.Type == segments[0])
+                    if (claim.Type == roleClaimSegments[0])
                     {
                         List<string> roles;
                         // If we are not using JSON values, just use the raw info from the claim value
-                        if (segments.Length == 1)
+                        if (roleClaimSegments.Length == 1)
                         {
                             roles = new List<string> { claim.Value };
                         }
@@ -242,9 +244,9 @@ public class SSOController : ControllerBase
                             else
                             {
                                 bool missingSegment = false;
-                                for (int i = 1; i < segments.Length - 1; i++)
+                                for (int i = 1; i < roleClaimSegments.Length - 1; i++)
                                 {
-                                    var segment = segments[i];
+                                    var segment = roleClaimSegments[i];
                                     if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
                                     {
                                         missingSegment = true;
@@ -259,7 +261,7 @@ public class SSOController : ControllerBase
                                     }
                                 }
 
-                                if (missingSegment || !json.TryGetValue(segments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
+                                if (missingSegment || !json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
                                 {
                                     roles = new List<string>();
                                 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -69,6 +69,14 @@ public class SSOController : ControllerBase
     private static readonly string UserAgentString =
         $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
 
+    // Splits the role-claim path on dots that are not escaped with a backslash ("a.b\.c" -> "a", "b.c").
+    // Compiled once and reused: it runs for every claim on every login (hot path), so it must not be
+    // recompiled per call. The match timeout is defense-in-depth on the match input: the pattern is
+    // fixed and linear (a fixed-width lookbehind plus a literal dot) so it cannot backtrack into a
+    // timeout, but the cap guarantees role parsing can never block the login path.
+    private static readonly Regex RoleClaimSplitRegex =
+        new Regex(@"(?<!\\)\.", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -208,7 +216,7 @@ public class SSOController : ControllerBase
                 // Role processing
                 // The regex matches any "." not preceded by a "\": a.b.c will be split into a, b, and c, but a.b\.c will be split into a, b.c (after processing the escaped dots)
                 // We have to first process the RoleClaim string
-                string[] segments = string.IsNullOrEmpty(config.RoleClaim) ? Array.Empty<string>() : Regex.Split(config.RoleClaim.Trim(), "(?<!\\\\)\\.");
+                string[] segments = string.IsNullOrEmpty(config.RoleClaim) ? Array.Empty<string>() : RoleClaimSplitRegex.Split(config.RoleClaim.Trim());
 
                 if (segments.Any())
                 {


### PR DESCRIPTION
Resolves the ReDoS-timeout finding (SonarCloud `S6444`) and the per-claim regex recompile on the OIDC role-mapping hot path. Refs #61.

## What

The role-claim path was split with an inline `Regex.Split(config.RoleClaim.Trim(), "(?<!\\)\.")` **inside the `foreach (claim ...)` loop**, recompiling the pattern on every claim of every login. Now it is a compiled static `Regex` reused across requests, with a 1-second match timeout.

- **Same behavior:** the runtime pattern is byte-for-byte identical (verified: the old non-verbatim `"(?<!\\)\."` and the new verbatim `@"(?<!\)\."` decode to the same regex `(?<!\)\.`), and `Regex.Split` semantics are unchanged (no capture-group injection, the lookbehind is zero-width). Role→privilege mapping is unaffected.
- **Timeout:** defense-in-depth on the match input. The pattern is fixed and linear so it cannot backtrack into a timeout; the cap guarantees role parsing can never block the login path. If it ever threw, it propagates to a 500, fail-closed, no session, no roles.
- **Perf:** compiled once at type load instead of per-claim.

## Review

Build clean (`--warnaserror`), 147 tests pass. 2-lens adversarial review (correctness + bypass), both PASS: pattern/split empirically identical across leading/trailing/empty/escaped segments, static `Regex` is thread-safe for concurrent logins, timeout is admin-input-only and fails closed, no escalation path. The `config.RoleClaim` input is admin-configured, not IdP/attacker-controlled.