### PR TITLE
Encode the auth-completion data value as a JS string literal

### DIFF
--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -20,20 +20,21 @@ public class WebResponseTests
 
         var html = WebResponse.Generator(hostileData, "keycloak", "https://jf.example.com", "SAML");
 
-        // Emitted via JSON serialization (double-quoted, fully escaped) rather than a raw
-        // single-quoted concatenation.
+        // Emitted via JSON serialization (double-quoted, encoded) rather than a raw single-quoted
+        // concatenation.
         Assert.Contains("var data = " + JsonSerializer.Serialize(hostileData) + ";", html);
-        // The raw break-out sequence must not survive into the page (the default encoder escapes
-        // "<" to <, so the injected script tags cannot terminate the surrounding script).
+        // Security property: the injected closing </script> tag must not appear literally in the
+        // page, so it cannot terminate the surrounding script and inject markup.
         Assert.DoesNotContain("</script><script>alert(1)", html);
     }
 
     [Fact]
     public void Generator_BenignBase64Data_RoundTripsAsSameString()
     {
-        // A base64 value without '+' (which the encoder would escape to +): it serializes
-        // byte-identically, so the embedded literal is the same string, only re-quoted. Base64 with
-        // '+' still round-trips at runtime (+ parses back to '+') — the wire value is unchanged.
+        // The normal case: the embedded value is the same string, only re-quoted. Whatever encoding
+        // the serializer applies to individual characters, the requirement is that the runtime
+        // value the browser sends back is unchanged; this vector is chosen so the literal is also
+        // textually identical.
         var base64 = "PHNhbWxwOlJlc3BvbnNlLz4=";
 
         var html = WebResponse.Generator(base64, "authelia", "https://jf.example.com", "OID");

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="WebResponse"/> — the auth-completion page returned to the browser. The
+/// server-controlled <c>data</c> value (base64 SAML XML / an OpenID state id) is embedded into the
+/// page's JavaScript; it must be emitted as an encoded string literal so it cannot break out of the
+/// script context, independent of the base64 shape the callers currently pass.
+/// </summary>
+public class WebResponseTests
+{
+    [Fact]
+    public void Generator_EmitsDataAsEncodedJsonStringLiteral()
+    {
+        // A value chosen to break out of a single-quoted literal and inject markup, if unescaped.
+        var hostileData = "abc'; </script><script>alert(1)</script>//";
+
+        var html = WebResponse.Generator(hostileData, "keycloak", "https://jf.example.com", "SAML");
+
+        // Emitted via JSON serialization (double-quoted, fully escaped) rather than a raw
+        // single-quoted concatenation.
+        Assert.Contains("var data = " + JsonSerializer.Serialize(hostileData) + ";", html);
+        // The raw break-out sequence must not survive into the page (the default encoder escapes
+        // "<" to <, so the injected script tags cannot terminate the surrounding script).
+        Assert.DoesNotContain("</script><script>alert(1)", html);
+    }
+
+    [Fact]
+    public void Generator_BenignBase64Data_RoundTripsAsSameString()
+    {
+        // A base64 value without '+' (which the encoder would escape to +): it serializes
+        // byte-identically, so the embedded literal is the same string, only re-quoted. Base64 with
+        // '+' still round-trips at runtime (+ parses back to '+') — the wire value is unchanged.
+        var base64 = "PHNhbWxwOlJlc3BvbnNlLz4=";
+
+        var html = WebResponse.Generator(base64, "authelia", "https://jf.example.com", "OID");
+
+        Assert.Contains("var data = \"" + base64 + "\";", html);
+    }
+}

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 
 namespace Jellyfin.Plugin.SSO_Auth;
 
@@ -463,7 +464,7 @@ async function main() {
     localStorage.removeItem('jellyfin_credentials');
     document.getElementById('iframe-main').src = '" + punycodeBaseUrl + @"/web/index.html';
 
-    var data = '" + data + @"';
+    var data = " + JsonSerializer.Serialize(data) + @";
     while (localStorage.getItem(""_deviceId2"") == null ||
         localStorage.getItem(""jellyfin_credentials"") == null ||
         JSON.parse(localStorage.getItem(""jellyfin_credentials""))['Servers'][0]['Id'] == null) {


### PR DESCRIPTION
Hardens the SSO auth-completion page against script-context injection and addresses SonarCloud **S5131** (BLOCKER taint) for the `data` flow. Refs #61.

## What

`WebResponse.Generator` embedded the server `data` value with raw concatenation into a single-quoted JS literal: `var data = '" + data + @"';`. It now emits `var data = " + JsonSerializer.Serialize(data) + @";`, a fully escaped, double-quoted literal. The default `System.Text.Json` encoder escapes `<`, `>`, `&`, `'`, `"`, `+`, and U+2028/U+2029, so no value of `data` can break out of the string or the surrounding `<script>`.

- **Inert today, defense-in-depth:** `data` is `Convert.ToBase64String(...)` (SAML) or a CSPRNG state id (OIDC), so it could not inject; SonarCloud cannot see through base64. This closes the flow regardless.
- **Behavior-preserving:** the runtime string is identical, base64 with `+` emits `\u002B` and the JS parser decodes it back to `+`, so the payload POSTed to `/sso/{mode}/Auth/{provider}` is byte-identical (the OIDC state dict-key lookup and SAML base64-decode both still match). Verified empirically across benign and `+`-bearing base64.

## Review

Build clean (`--warnaserror`), 149 tests pass (+2 Generator tests: a hostile `</script>` payload is escaped; benign base64 round-trips). 3-lens adversarial review (bypass / correctness / integration), all PASS.

## Follow-up (out of scope, tracked)

The review found the same generated page still raw-interpolates `punycodeBaseUrl` (Host-header-derived, the one genuinely external value; `IdnMapping.GetAscii` does not sanitize ASCII) and `provider` (admin-controlled). Both are pre-existing and not worsened here. Tracked in #79 for a dedicated hardening pass. Note: S5131 may persist on SonarCloud pointing at those values rather than `data`; if so it is handled via #79.