### PR TITLE
Build auth-page URLs from JSON-encoded constants, not raw interpolation

### DIFF
--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -41,4 +41,31 @@ public class WebResponseTests
 
         Assert.Contains("var data = \"" + base64 + "\";", html);
     }
+
+    [Fact]
+    public void Generator_EmitsProviderAsEncodedConstant_NotRawInUrl()
+    {
+        // A provider name that would break out of a single-quoted JS/URL literal if interpolated raw.
+        var hostileProvider = "p';alert(1);//";
+
+        var html = WebResponse.Generator("ZGF0YQ==", hostileProvider, "https://jf.example.com", "SAML");
+
+        // The provider is emitted once as a JSON-encoded constant and used through
+        // encodeURIComponent in the URLs, never concatenated raw.
+        Assert.Contains("const ssoProvider = " + JsonSerializer.Serialize(hostileProvider) + ";", html);
+        Assert.Contains("encodeURIComponent(ssoProvider)", html);
+        Assert.DoesNotContain("';alert(1);//", html);
+    }
+
+    [Fact]
+    public void Generator_EmitsBaseUrlAsEncodedConstant()
+    {
+        // The base URL derives from the request host, so it is treated as untrusted and emitted as
+        // a JSON-encoded constant rather than interpolated into the script.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML");
+
+        Assert.Contains("const ssoBaseUrl = \"https://jf.example.com\";", html);
+        // URLs are built from the constant, not a raw host string.
+        Assert.Contains("ssoBaseUrl + '/web/index.html'", html);
+    }
 }

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -424,7 +424,14 @@ const sleep = (milliseconds) => {
         var punycodeDomain = idnMapping.GetAscii(domain);
         var punycodeBaseUrl = protocol + punycodeDomain;
 
+        // Emit the server-derived values as JSON-encoded JS constants so they cannot break out of
+        // the script context, then build every URL from these constants rather than interpolating
+        // raw. punycodeBaseUrl derives from the request host, and provider from the route, so both
+        // are treated as untrusted here (defense-in-depth); mode is a fixed literal.
         return Base + @"
+const ssoBaseUrl = " + JsonSerializer.Serialize(punycodeBaseUrl) + @";
+const ssoProvider = " + JsonSerializer.Serialize(provider) + @";
+const ssoMode = " + JsonSerializer.Serialize(mode) + @";
 async function link(request) {
     const jfCredentialsString = localStorage.getItem(""jellyfin_credentials"");
 
@@ -437,7 +444,7 @@ async function link(request) {
     if (jfUser == null) return;
     if (jfToken == null) return;
 
-    const url = '" + $"{punycodeBaseUrl}/sso/{mode}/Link/{provider}/" + @"' + jfUser;
+    const url = ssoBaseUrl + '/sso/' + ssoMode + '/Link/' + encodeURIComponent(ssoProvider) + '/' + jfUser;
 
     return new Promise(resolve => {
        var xhr = new XMLHttpRequest();
@@ -462,7 +469,7 @@ async function link(request) {
 
 async function main() {
     localStorage.removeItem('jellyfin_credentials');
-    document.getElementById('iframe-main').src = '" + punycodeBaseUrl + @"/web/index.html';
+    document.getElementById('iframe-main').src = ssoBaseUrl + '/web/index.html';
 
     var data = " + JsonSerializer.Serialize(data) + @";
     while (localStorage.getItem(""_deviceId2"") == null ||
@@ -480,7 +487,7 @@ async function main() {
 
     if (" + $"{isLinking}".ToLower() + @") await link(request);
 
-    var url = '" + punycodeBaseUrl + "/sso/" + mode + "/Auth/" + provider + @"';
+    var url = ssoBaseUrl + '/sso/' + ssoMode + '/Auth/' + encodeURIComponent(ssoProvider);
 
     let response = await new Promise(resolve => {
        var xhr = new XMLHttpRequest();
@@ -504,7 +511,7 @@ async function main() {
     jfCreds['Servers'][0]['UserId'] = responseJson['User']['Id'];
     localStorage.setItem('jellyfin_credentials', JSON.stringify(jfCreds));
     localStorage.setItem('enableAutoLogin', 'true');
-    window.location.replace('" + punycodeBaseUrl + @"/web/index.html');
+    window.location.replace(ssoBaseUrl + '/web/index.html');
 }
 
 document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Closes the last reflected-XSS surface on the SSO auth-completion page, **SonarCloud S5131 (BLOCKER)**. Closes #79.

## Why

After the `data` value was JSON-encoded (PR #80), `WebResponse.Generator` still interpolated two server values raw into single-quoted JS/URL literals:

- **`punycodeBaseUrl`**, derived from the request `Host` header; `IdnMapping.GetAscii` does **not** sanitize ASCII, so a `'` in the Host header could break out of the JS string (the one genuinely external vector; the earlier review could not rule it out from code alone).
- **`provider`**, the route segment (admin-controlled config key).

## What

Emit the three server values once as JSON-encoded JS constants (`ssoBaseUrl`, `ssoProvider`, `ssoMode`) and build every URL from them, with `encodeURIComponent(ssoProvider)` on the path segment. The default `System.Text.Json` encoder escapes `'`, `"`, `<`, `>`, `&`, `\`, and U+2028/U+2029, so no value can break out of the string or the surrounding `<script>`. No raw interpolation of untrusted values remains (only the `isLinking` bool literal).

## Behavior

Byte-identical URLs for normal providers/hosts (`encodeURIComponent` is identity for unreserved names; JSON does not escape `/` or `:`). Special provider names round-trip via ASP.NET route decoding (encode-once / decode-once), matching the linking.js A-4 approach. No lockout, no wire-contract change.

## Review

Build clean (`--warnaserror`), 151 tests pass (+2). **4-lens adversarial review (bypass / correctness / integration / availability), all PASS**, empirically confirming: no residual raw interpolation, hostile Host/provider cannot break out, normal URLs byte-identical, no const TDZ/clash, routes still resolve. E2E note logged: confirm a percent-encoded provider segment round-trips on a real server.
