### PR TITLE
Tidy pure helpers: LINQ filters, member order, argument guards

### DIFF
--- a/SSO-Auth/Api/AuthStateStore.cs
+++ b/SSO-Auth/Api/AuthStateStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
@@ -20,12 +21,9 @@ internal static class AuthStateStore
         DateTime now,
         TimeSpan lifetime)
     {
-        foreach (var kvp in states)
+        foreach (var kvp in states.Where(kvp => now.Subtract(kvp.Value.Created) > lifetime))
         {
-            if (now.Subtract(kvp.Value.Created) > lifetime)
-            {
-                states.TryRemove(kvp.Key, out _);
-            }
+            states.TryRemove(kvp.Key, out _);
         }
     }
 

--- a/SSO-Auth/Api/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/SamlLoginPolicy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
@@ -36,12 +37,9 @@ internal static class SamlLoginPolicy
                     continue;
                 }
 
-                foreach (var allowed in allowedRoles)
+                if (allowedRoles.Any(allowed => !string.IsNullOrEmpty(allowed) && string.Equals(allowed, role, StringComparison.Ordinal)))
                 {
-                    if (!string.IsNullOrEmpty(allowed) && string.Equals(allowed, role, StringComparison.Ordinal))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
         }

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -13,6 +13,31 @@ internal sealed class SamlReplayCache
     private readonly ConcurrentDictionary<string, DateTime> _consumed = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
+    /// window it would still be accepted - its NotOnOrAfter plus the validation clock skew - with a
+    /// one-hour floor that covers an assertion carrying no (or a very short) expiry.
+    /// </summary>
+    /// <param name="nowUtc">The current time.</param>
+    /// <param name="assertionExpiryUtc">The assertion's effective NotOnOrAfter, or null when it declares none.</param>
+    /// <returns>The UTC instant until which the assertion ID must be retained.</returns>
+    internal static DateTime ComputeRetention(DateTime nowUtc, DateTime? assertionExpiryUtc)
+    {
+        // The one-hour floor bounds retention when an assertion carries no (or a very short) expiry; the
+        // skew margin matches the clock skew the signature/time validation allows.
+        var floor = nowUtc.AddHours(1);
+        if (assertionExpiryUtc.HasValue)
+        {
+            var expiryWithSkew = assertionExpiryUtc.Value + SamlAssertionTime.ClockSkew;
+            if (expiryWithSkew > floor)
+            {
+                return expiryWithSkew;
+            }
+        }
+
+        return floor;
+    }
+
+    /// <summary>
     /// Records the assertion ID as consumed. Returns false when the assertion has no usable ID or has
     /// already been consumed within its validity window (a replay).
     /// </summary>
@@ -37,30 +62,5 @@ internal sealed class SamlReplayCache
         }
 
         return _consumed.TryAdd(assertionId, expiryUtc);
-    }
-
-    /// <summary>
-    /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
-    /// window it would still be accepted - its NotOnOrAfter plus the validation clock skew - with a
-    /// one-hour floor that covers an assertion carrying no (or a very short) expiry.
-    /// </summary>
-    /// <param name="nowUtc">The current time.</param>
-    /// <param name="assertionExpiryUtc">The assertion's effective NotOnOrAfter, or null when it declares none.</param>
-    /// <returns>The UTC instant until which the assertion ID must be retained.</returns>
-    internal static DateTime ComputeRetention(DateTime nowUtc, DateTime? assertionExpiryUtc)
-    {
-        // The one-hour floor bounds retention when an assertion carries no (or a very short) expiry; the
-        // skew margin matches the clock skew the signature/time validation allows.
-        var floor = nowUtc.AddHours(1);
-        if (assertionExpiryUtc.HasValue)
-        {
-            var expiryWithSkew = assertionExpiryUtc.Value + SamlAssertionTime.ClockSkew;
-            if (expiryWithSkew > floor)
-            {
-                return expiryWithSkew;
-            }
-        }
-
-        return floor;
     }
 }

--- a/SSO-Auth/SerializableDictionary.cs
+++ b/SSO-Auth/SerializableDictionary.cs
@@ -83,6 +83,8 @@ public class SerializableDictionary<TKey, TValue>
     /// <param name="reader">The XML reader to read from.</param>
     public void ReadXml(System.Xml.XmlReader reader)
     {
+        System.ArgumentNullException.ThrowIfNull(reader);
+
         XmlSerializer keySerializer = new XmlSerializer(typeof(TKey));
         XmlSerializer valueSerializer = new XmlSerializer(typeof(TValue));
 
@@ -121,6 +123,8 @@ public class SerializableDictionary<TKey, TValue>
     /// <param name="writer">An instance of the XmlWriter class.</param>
     public void WriteXml(System.Xml.XmlWriter writer)
     {
+        System.ArgumentNullException.ThrowIfNull(writer);
+
         XmlSerializer keySerializer = new XmlSerializer(typeof(TKey));
         XmlSerializer valueSerializer = new XmlSerializer(typeof(TValue));
 


### PR DESCRIPTION
Behavior-preserving SonarCloud maintainability cleanups on the pure helpers (Refs #61).

- **AuthStateStore.InvalidateExpired**, move the expiry test into a `Where` filter (S3267). The `ConcurrentDictionary` enumeration stays lazy over the same modification-tolerant enumerator, so the removed key set and concurrent-prune behavior are identical.
- **SamlLoginPolicy.IsLoginAllowed**, replace the inner allow-list `foreach` with `Any` (S3267); same short-circuit and null/empty/Ordinal handling.
- **SamlReplayCache**, order the static `ComputeRetention` before the instance `TryConsume` (SA1204).
- **SerializableDictionary**, guard the `IXmlSerializable` reader/writer arguments with `ArgumentNullException.ThrowIfNull` (CA1062).

Build clean (`--warnaserror`), 151 tests pass. A correctness review confirmed the two LINQ rewrites are exactly equivalent, empirically, including the concurrent-prune and null/empty/case paths, and the existing AuthStateStore/SamlLoginPolicy tests pin those paths.