### PR TITLE
Split the avatar SSRF range checks and guard Generator's baseUrl

### DIFF
--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -61,58 +61,62 @@ internal static class AvatarUrlValidator
             return true;
         }
 
-        if (address.AddressFamily == AddressFamily.InterNetwork)
+        return address.AddressFamily switch
         {
-            var b = address.GetAddressBytes();
+            AddressFamily.InterNetwork => IsBlockedIPv4(address.GetAddressBytes()),
+            AddressFamily.InterNetworkV6 => IsBlockedIPv6(address),
 
-            // 0.0.0.0/8 (this network), 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local),
-            // 172.16.0.0/12, 192.0.0.0/24 (IETF protocol assignments incl. the 192.0.0.192 cloud-metadata
-            // address), 192.0.2.0/24 / 198.51.100.0/24 / 203.0.113.0/24 (TEST-NET-1/2/3), 192.88.99.0/24
-            // (6to4 relay anycast), 192.168.0.0/16, 198.18.0.0/15 (benchmarking), and 224.0.0.0/3
-            // (multicast 224/4, reserved 240/4, broadcast).
-            return b[0] == 0
-                || b[0] == 10
-                || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
-                || (b[0] == 169 && b[1] == 254)
-                || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
-                || (b[0] == 192 && b[1] == 0 && b[2] == 0)
-                || (b[0] == 192 && b[1] == 0 && b[2] == 2)
-                || (b[0] == 192 && b[1] == 88 && b[2] == 99)
-                || (b[0] == 192 && b[1] == 168)
-                || (b[0] == 198 && (b[1] == 18 || b[1] == 19))
-                || (b[0] == 198 && b[1] == 51 && b[2] == 100)
-                || (b[0] == 203 && b[1] == 0 && b[2] == 113)
-                || b[0] >= 224;
+            // Unknown address family: block by default.
+            _ => true,
+        };
+    }
+
+    private static bool IsBlockedIPv4(byte[] b)
+    {
+        // 0.0.0.0/8 (this network), 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local),
+        // 172.16.0.0/12, 192.0.0.0/24 (IETF protocol assignments incl. the 192.0.0.192 cloud-metadata
+        // address), 192.0.2.0/24 / 198.51.100.0/24 / 203.0.113.0/24 (TEST-NET-1/2/3), 192.88.99.0/24
+        // (6to4 relay anycast), 192.168.0.0/16, 198.18.0.0/15 (benchmarking), and 224.0.0.0/3
+        // (multicast 224/4, reserved 240/4, broadcast).
+        return b[0] == 0
+            || b[0] == 10
+            || (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+            || (b[0] == 169 && b[1] == 254)
+            || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+            || (b[0] == 192 && b[1] == 0 && b[2] == 0)
+            || (b[0] == 192 && b[1] == 0 && b[2] == 2)
+            || (b[0] == 192 && b[1] == 88 && b[2] == 99)
+            || (b[0] == 192 && b[1] == 168)
+            || (b[0] == 198 && (b[1] == 18 || b[1] == 19))
+            || (b[0] == 198 && b[1] == 51 && b[2] == 100)
+            || (b[0] == 203 && b[1] == 0 && b[2] == 113)
+            || b[0] >= 224;
+    }
+
+    private static bool IsBlockedIPv6(IPAddress address)
+    {
+        if (address.IsIPv4MappedToIPv6)
+        {
+            return IsBlockedAddress(address.MapToIPv4());
         }
 
-        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        // IPv4-in-IPv6 transition addresses (6to4, the NAT64 well-known prefix, and the deprecated
+        // IPv4-compatible form) embed an IPv4 address that can target an internal range - unwrap it and
+        // re-check, so e.g. [64:ff9b::7f00:1] cannot smuggle 127.0.0.1 past the filter.
+        if (TryExtractEmbeddedIPv4(address.GetAddressBytes(), out var embedded))
         {
-            if (address.IsIPv4MappedToIPv6)
-            {
-                return IsBlockedAddress(address.MapToIPv4());
-            }
-
-            // IPv4-in-IPv6 transition addresses (6to4, the NAT64 well-known prefix, and the deprecated
-            // IPv4-compatible form) embed an IPv4 address that can target an internal range - unwrap it and
-            // re-check, so e.g. [64:ff9b::7f00:1] cannot smuggle 127.0.0.1 past the filter.
-            if (TryExtractEmbeddedIPv4(address.GetAddressBytes(), out var embedded))
-            {
-                return IsBlockedAddress(embedded);
-            }
-
-            // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth.
-            var v6 = address.GetAddressBytes();
-            var siteLocal = v6[0] == 0xfe && (v6[1] & 0xc0) == 0xc0;
-
-            return address.IsIPv6LinkLocal
-                || address.IsIPv6UniqueLocal
-                || address.IsIPv6Multicast
-                || siteLocal
-                || IPAddress.IPv6Any.Equals(address);
+            return IsBlockedAddress(embedded);
         }
 
-        // Unknown address family: block by default.
-        return true;
+        // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth.
+        var v6 = address.GetAddressBytes();
+        var siteLocal = v6[0] == 0xfe && (v6[1] & 0xc0) == 0xc0;
+
+        return address.IsIPv6LinkLocal
+            || address.IsIPv6UniqueLocal
+            || address.IsIPv6Multicast
+            || siteLocal
+            || IPAddress.IPv6Any.Equals(address);
     }
 
     /// <summary>

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -100,17 +100,18 @@ internal static class AvatarUrlValidator
             return IsBlockedAddress(address.MapToIPv4());
         }
 
+        var bytes = address.GetAddressBytes();
+
         // IPv4-in-IPv6 transition addresses (6to4, the NAT64 well-known prefix, and the deprecated
         // IPv4-compatible form) embed an IPv4 address that can target an internal range - unwrap it and
         // re-check, so e.g. [64:ff9b::7f00:1] cannot smuggle 127.0.0.1 past the filter.
-        if (TryExtractEmbeddedIPv4(address.GetAddressBytes(), out var embedded))
+        if (TryExtractEmbeddedIPv4(bytes, out var embedded))
         {
             return IsBlockedAddress(embedded);
         }
 
         // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth.
-        var v6 = address.GetAddressBytes();
-        var siteLocal = v6[0] == 0xfe && (v6[1] & 0xc0) == 0xc0;
+        var siteLocal = bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0xc0;
 
         return address.IsIPv6LinkLocal
             || address.IsIPv6UniqueLocal

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -416,6 +416,8 @@ const sleep = (milliseconds) => {
     /// <returns>A string with the HTML to serve to the client.</returns>
     public static string Generator(string data, string provider, string baseUrl, string mode, bool isLinking = false)
     {
+        System.ArgumentNullException.ThrowIfNull(baseUrl);
+
         // Strip out the protocol (http:// or https://) and convert the domain to Punycode
         var idnMapping = new IdnMapping();
         var protocolSeparatorIndex = baseUrl.IndexOf("//");


### PR DESCRIPTION
Behavior-preserving SonarCloud maintainability cleanups on the SSRF guard and the login-completion page (Refs #61).

- **AvatarUrlValidator.IsBlockedAddress**, dispatch on address family via a `switch` and move the IPv4 range list and the IPv6 branch into `IsBlockedIPv4`/`IsBlockedIPv6` helpers. Pure extraction: identical conditions and identical recursion for embedded/IPv4-mapped addresses, reducing the method's cognitive complexity (**S3776**). The blocked-range tests (AvatarUrlValidatorTests) cover it.
- **WebResponse.Generator**, guard the `baseUrl` argument with `ArgumentNullException.ThrowIfNull` instead of dereferencing null in `IndexOf` (**CA1062**).

Build clean (`--warnaserror`), 151 tests pass. SSRF-guard extraction is behavior-preserving (verified against the range tests).