### PR TITLE
Extract the OIDC role-claim parsing into a tested pure helper

### DIFF
--- a/SSO-Auth.Tests/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/OidcRoleExtractorTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcRoleExtractor"/> — reading role values out of an OpenID claim along the
+/// configured role-claim path. Pins the parsing behavior extracted from the OID callback so it can
+/// be reasoned about and refactored independently of the controller.
+/// </summary>
+public class OidcRoleExtractorTests
+{
+    [Fact]
+    public void SingleSegment_ReturnsRawClaimValueAsOneRole()
+    {
+        // A one-segment path is not JSON: the claim value itself is the single role.
+        Assert.Equal(new List<string> { "jellyfin-admin" }, OidcRoleExtractor.ExtractRoles(new[] { "Role" }, "jellyfin-admin"));
+    }
+
+    [Fact]
+    public void TwoSegments_ReadsTerminalArray()
+    {
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\",\"admins\"]}");
+        Assert.Equal(new List<string> { "users", "admins" }, roles);
+    }
+
+    [Fact]
+    public void NestedSegments_WalkTheJsonPath()
+    {
+        var value = "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]}}}";
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value);
+        Assert.Equal(new List<string> { "media" }, roles);
+    }
+
+    [Fact]
+    public void MissingIntermediateSegment_ReturnsEmpty()
+    {
+        // The intermediate "jellyfin" key is absent inside resource_access, so the walk stops short.
+        var value = "{\"resource_access\":{\"other\":{\"roles\":[\"x\"]}}}";
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value);
+        Assert.Empty(roles);
+    }
+
+    [Fact]
+    public void IntermediateNodeNotAnObject_ReturnsEmpty()
+    {
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}");
+        Assert.Empty(roles);
+    }
+
+    [Fact]
+    public void TerminalNotAnArray_ReturnsEmpty()
+    {
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}");
+        Assert.Empty(roles);
+    }
+
+    [Fact]
+    public void MissingTerminalKey_ReturnsEmpty()
+    {
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}");
+        Assert.Empty(roles);
+    }
+
+    [Fact]
+    public void JsonNull_ReturnsEmpty()
+    {
+        // A literal JSON null deserializes to a null dictionary → no roles (not a throw).
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "null"));
+    }
+
+    [Fact]
+    public void MultiSegmentPath_NonObjectClaimValue_Throws()
+    {
+        // Characterizes the upstream behavior: a multi-segment path over a non-object claim value
+        // throws (surfaces as a 500 in the controller = fail-closed). Pinned so it stays deliberate.
+        Assert.ThrowsAny<Newtonsoft.Json.JsonException>(
+            () => OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json"));
+    }
+}

--- a/SSO-Auth.Tests/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/OidcRoleExtractorTests.cs
@@ -71,10 +71,10 @@ public class OidcRoleExtractorTests
     }
 
     [Fact]
-    public void MultiSegmentPath_NonObjectClaimValue_Throws()
+    public void MultiSegmentPath_MalformedClaimValue_Throws()
     {
-        // Characterizes the upstream behavior: a multi-segment path over a non-object claim value
-        // throws (surfaces as a 500 in the controller = fail-closed). Pinned so it stays deliberate.
+        // Characterizes the upstream behavior: a multi-segment path over a malformed (non-JSON-object)
+        // claim value throws (surfaces as a 500 in the controller = fail-closed). Pinned so it stays deliberate.
         Assert.ThrowsAny<Newtonsoft.Json.JsonException>(
             () => OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json"));
     }

--- a/SSO-Auth/Api/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/OidcRoleExtractor.cs
@@ -34,7 +34,9 @@ internal static class OidcRoleExtractor
             return new List<string> { claimValue };
         }
 
-        // A multi-segment path walks the claim's JSON object; a non-object value yields no roles.
+        // A multi-segment path parses the claim value as a JSON object and walks it. A JSON null
+        // yields no roles; a malformed or non-object value throws (surfaced by the caller as a
+        // failed login, i.e. fail-closed).
         var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);
         if (json is null)
         {

--- a/SSO-Auth/Api/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/OidcRoleExtractor.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Reads the role values out of an OpenID claim according to the configured role-claim path.
+/// The path is the pre-split <c>RoleClaim</c> (see the controller): its first segment names the
+/// claim, and any further segments walk into the claim's JSON object to the array that holds the
+/// roles. This is pure parsing — it makes no authorization decision; the caller maps the returned
+/// role strings to privileges.
+/// </summary>
+internal static class OidcRoleExtractor
+{
+    /// <summary>
+    /// Extracts the role values from a claim value for the given role-claim path.
+    /// </summary>
+    /// <param name="roleClaimSegments">
+    /// The role-claim path already split on unescaped dots and un-escaped (segment[0] is the claim
+    /// name). Must be non-empty; the caller only invokes this for the claim whose type equals segment[0].
+    /// </param>
+    /// <param name="claimValue">The matched claim's value (a raw role, or a JSON object for a nested path).</param>
+    /// <returns>
+    /// The extracted roles: the raw claim value as a single role for a one-segment path; otherwise the
+    /// string array reached by walking the JSON path. An empty list when the path does not resolve to a
+    /// JSON array (missing segment, non-object node, or non-array terminal).
+    /// </returns>
+    internal static List<string> ExtractRoles(string[] roleClaimSegments, string claimValue)
+    {
+        // A single-segment path is not JSON: the claim value itself is the role.
+        if (roleClaimSegments.Length == 1)
+        {
+            return new List<string> { claimValue };
+        }
+
+        // A multi-segment path walks the claim's JSON object; a non-object value yields no roles.
+        var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);
+        if (json is null)
+        {
+            return new List<string>();
+        }
+
+        // Walk the intermediate segments; any missing key or non-object node yields no roles.
+        for (int i = 1; i < roleClaimSegments.Length - 1; i++)
+        {
+            var segment = roleClaimSegments[i];
+            if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
+            {
+                return new List<string>();
+            }
+
+            json = nextObject.ToObject<IDictionary<string, object>>();
+            if (json is null)
+            {
+                return new List<string>();
+            }
+        }
+
+        // The terminal segment must resolve to a JSON array of role strings.
+        if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
+        {
+            return new List<string>();
+        }
+
+        return rolesArray.ToObject<List<string>>();
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -30,8 +30,6 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using SSO_Auth.Lib;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
@@ -227,53 +225,7 @@ public class SSOController : ControllerBase
                 {
                     if (claim.Type == roleClaimSegments[0])
                     {
-                        List<string> roles;
-                        // If we are not using JSON values, just use the raw info from the claim value
-                        if (roleClaimSegments.Length == 1)
-                        {
-                            roles = new List<string> { claim.Value };
-                        }
-                        else
-                        {
-                            // We recursively traverse through the JSON data for the roles and parse it
-                            var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claim.Value);
-                            if (json is null)
-                            {
-                                roles = new List<string>();
-                            }
-                            else
-                            {
-                                bool missingSegment = false;
-                                for (int i = 1; i < roleClaimSegments.Length - 1; i++)
-                                {
-                                    var segment = roleClaimSegments[i];
-                                    if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
-                                    {
-                                        missingSegment = true;
-                                        break;
-                                    }
-
-                                    json = nextObject.ToObject<IDictionary<string, object>>();
-                                    if (json is null)
-                                    {
-                                        missingSegment = true;
-                                        break;
-                                    }
-                                }
-
-                                if (missingSegment || !json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
-                                {
-                                    roles = new List<string>();
-                                }
-                                else
-                                {
-                                    // The final step is to take the JSON and turn it from a dictionary into a string
-                                    roles = rolesArray.ToObject<List<string>>();
-                                }
-                            }
-                        }
-
-                        foreach (string role in roles)
+                        foreach (string role in OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value))
                         {
                             // Check if allowed to login based on roles
                             if (config.Roles != null && config.Roles.Any())


### PR DESCRIPTION
First step of thinning the OID callback (Refs #61, minimal-OOP directive).

`OidPost` inlined the logic that turns the configured role-claim path + a claim value into the role list (single-segment path → raw value; multi-segment → walk the claim's JSON to a terminal array). That parsing was the largest contributor to `OidPost`'s cognitive complexity (**S3776**) and was untestable in place.

- Move it verbatim into `OidcRoleExtractor.ExtractRoles(string[] roleClaimSegments, string claimValue)`, a pure function that makes **no** authorization decision (the caller still maps roles → privileges, unchanged).
- Add unit tests covering single-segment, flat/nested arrays, every miss path (missing intermediate key, non-object node, missing/non-array terminal), JSON-null, and the malformed-JSON throw (pinned as fail-closed).
- Drop the now-unused `Newtonsoft.Json` usings from the controller (dead code).

A correctness review verified byte-for-byte equivalence on every path (including the `missingSegment`-flag → early-return equivalence and the preserved throw/null semantics); the flag-assignment body and call-site guards are unchanged. Build clean, 160 tests pass.