### PR TITLE
Use structured logging templates in two controller log calls

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -318,7 +318,7 @@ public class SSOController : ControllerBase
 
             if (timedState.Valid)
             {
-                _logger.LogInformation($"Is request linking: {isLinking}");
+                _logger.LogInformation("Is request linking: {IsLinking}", isLinking);
                 return Content(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride), mode: "OID", isLinking: isLinking), MediaTypeNames.Text.Html);
             }
             else
@@ -1310,7 +1310,7 @@ public class SSOController : ControllerBase
         {
             user.AuthenticationProviderId = defaultProvider;
             await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-            _logger.LogInformation("Set default login provider to " + defaultProvider);
+            _logger.LogInformation("Set default login provider to {DefaultProvider}", defaultProvider);
         }
 
         return await _sessionManager.AuthenticateDirect(authRequest).ConfigureAwait(false);


### PR DESCRIPTION
Replace a string-interpolated (`$"Is request linking: {isLinking}"`) and a string-concatenated (`"Set default login provider to " + defaultProvider`) `LogInformation` with message templates (**S2629/CA2254**). Same log output; both values are non-request data (a bool and the admin-configured default provider), so no log-forging sanitization change is needed. Build clean, 160 tests pass.