### PR TITLE
Extract the OID role-to-privilege mapping into a tested pure helper

### DIFF
--- a/SSO-Auth.Tests/OidcRolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/OidcRolePrivilegeMapperTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="OidcRolePrivilegeMapper.Evaluate"/> — the role→privilege
+/// mapping extracted from the OID callback. These pin the exact behavior (including its quirks) so
+/// the extraction is a proven no-op and the mapping can be reasoned about in isolation.
+/// </summary>
+public class OidcRolePrivilegeMapperTests
+{
+    private static OidConfig Config(Action<OidConfig> configure)
+    {
+        var config = new OidConfig();
+        configure(config);
+        return config;
+    }
+
+    [Fact]
+    public void NoConfiguredRoles_GrantsNothing()
+    {
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "anything" }, Config(_ => { }));
+
+        Assert.False(grants.Valid);
+        Assert.False(grants.Admin);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+        Assert.Empty(grants.Folders);
+    }
+
+    [Fact]
+    public void EmptyRoles_GrantsNothing()
+    {
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin" };
+            c.AdminRoles = new[] { "admins" };
+        });
+
+        var grants = OidcRolePrivilegeMapper.Evaluate(Array.Empty<string>(), config);
+
+        Assert.False(grants.Valid);
+        Assert.False(grants.Admin);
+    }
+
+    [Fact]
+    public void RoleOnAllowList_GrantsValid()
+    {
+        var config = Config(c => c.Roles = new[] { "users", "jellyfin" });
+
+        Assert.True(OidcRolePrivilegeMapper.Evaluate(new[] { "jellyfin" }, config).Valid);
+        Assert.False(OidcRolePrivilegeMapper.Evaluate(new[] { "other" }, config).Valid);
+    }
+
+    [Fact]
+    public void RoleOnAdminList_GrantsAdmin()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "jellyfin-admins" });
+
+        Assert.True(OidcRolePrivilegeMapper.Evaluate(new[] { "jellyfin-admins" }, config).Admin);
+        Assert.False(OidcRolePrivilegeMapper.Evaluate(new[] { "jellyfin-users" }, config).Admin);
+    }
+
+    [Fact]
+    public void RoleMatchingIsOrdinalCaseSensitive()
+    {
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin" };
+            c.AdminRoles = new[] { "Admins" };
+        });
+
+        Assert.False(OidcRolePrivilegeMapper.Evaluate(new[] { "Jellyfin" }, config).Valid);
+        Assert.False(OidcRolePrivilegeMapper.Evaluate(new[] { "admins" }, config).Admin);
+    }
+
+    [Fact]
+    public void FolderRolesDisabled_GrantsNoFolders()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+        });
+
+        Assert.Empty(OidcRolePrivilegeMapper.Evaluate(new[] { "media" }, config).Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_AddsFoldersForMatchingRole_TrimmingMapRole()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "  media  ", Folders = new List<string> { "movies", "shows" } },
+                new FolderRoleMap { Role = "music", Folders = new List<string> { "songs" } },
+            };
+        });
+
+        // The map Role is trimmed before comparison, so "media" matches "  media  ".
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "media" }, config);
+        Assert.Equal(new List<string> { "movies", "shows" }, grants.Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_AccumulatesAcrossRolesAndMaps_PreservingDuplicates()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies", "shows" } },
+                new FolderRoleMap { Role = "music", Folders = new List<string> { "songs" } },
+            };
+        });
+
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "media", "music" }, config);
+
+        // Order follows role order then mapping order; duplicates are kept (AddRange, no dedup).
+        Assert.Equal(new List<string> { "movies", "movies", "shows", "songs" }, grants.Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_NullMapping_Throws()
+    {
+        // Characterizes a pre-existing latent NullReferenceException: EnableFolderRoles is on but
+        // FolderRoleMapping is null (the OID path, unlike SAML, does not null-check it). Preserved
+        // by the faithful extraction and tracked separately; a hostile IdP cannot trigger it (it is
+        // an admin misconfiguration), and it fails closed (a 500, no session).
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = null;
+        });
+
+        Assert.Throws<NullReferenceException>(() => OidcRolePrivilegeMapper.Evaluate(new[] { "media" }, config));
+    }
+
+    [Fact]
+    public void LiveTvRolesDisabled_GrantsNoLiveTv()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = false;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "tv", "tv-admin" }, config);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void LiveTvRolesEnabled_GrantsLiveTvAndManagement()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        Assert.True(OidcRolePrivilegeMapper.Evaluate(new[] { "tv" }, config).EnableLiveTv);
+        Assert.True(OidcRolePrivilegeMapper.Evaluate(new[] { "tv-admin" }, config).EnableLiveTvManagement);
+        Assert.False(OidcRolePrivilegeMapper.Evaluate(new[] { "tv" }, config).EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void LiveTvRolesEnabled_NullRoleLists_DoNotThrowAndGrantNothing()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = null;
+            c.LiveTvManagementRoles = null;
+        });
+
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "tv" }, config);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void MultipleRoles_AnyMatchGrants()
+    {
+        var config = Config(c => c.Roles = new[] { "jellyfin" });
+
+        Assert.True(OidcRolePrivilegeMapper.Evaluate(new[] { "nope", "jellyfin", "other" }, config).Valid);
+    }
+}

--- a/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Maps the roles carried by an OpenID login to the privileges they grant, according to the
+/// provider configuration. Pure: it derives the grants from (roles, config) and makes no decision
+/// about the session itself — the caller merges the result into the authorize state (OR-ing the
+/// booleans, appending the folders), which is why every grant here is monotonic (only ever granted,
+/// never revoked). This mirrors, one-for-one, the per-role logic that used to live inline in the OID
+/// callback.
+/// </summary>
+internal static class OidcRolePrivilegeMapper
+{
+    /// <summary>
+    /// Evaluates the privileges granted by the given roles under the given configuration.
+    /// </summary>
+    /// <param name="roles">The roles extracted from the login's claims (across all matching claims).</param>
+    /// <param name="config">The OpenID provider configuration.</param>
+    /// <returns>The granted privileges; booleans are false and the folder list empty when nothing matches.</returns>
+    internal static RoleGrants Evaluate(IEnumerable<string> roles, OidConfig config)
+    {
+        var valid = false;
+        var admin = false;
+        var enableLiveTv = false;
+        var enableLiveTvManagement = false;
+        var folders = new List<string>();
+
+        foreach (var role in roles)
+        {
+            if (config.Roles != null && config.Roles.Any(allowed => role.Equals(allowed)))
+            {
+                valid = true;
+            }
+
+            if (config.AdminRoles != null && config.AdminRoles.Any(adminRole => role.Equals(adminRole)))
+            {
+                admin = true;
+            }
+
+            if (config.EnableFolderRoles)
+            {
+                // Deliberately not null-guarded and iterated with foreach (not LINQ Where): this
+                // preserves the OID callback's exact behavior, including throwing NullReferenceException
+                // when FolderRoleMapping is null (an admin misconfiguration; fails closed). Tracked in #89.
+                foreach (var folderRoleMap in config.FolderRoleMapping)
+                {
+                    if (role.Equals(folderRoleMap.Role?.Trim()))
+                    {
+                        folders.AddRange(folderRoleMap.Folders);
+                    }
+                }
+            }
+
+            if (config.EnableLiveTvRoles)
+            {
+                if (config.LiveTvRoles != null && config.LiveTvRoles.Any(liveTvRole => role.Equals(liveTvRole)))
+                {
+                    enableLiveTv = true;
+                }
+
+                if (config.LiveTvManagementRoles != null && config.LiveTvManagementRoles.Any(managementRole => role.Equals(managementRole)))
+                {
+                    enableLiveTvManagement = true;
+                }
+            }
+        }
+
+        return new RoleGrants(valid, admin, enableLiveTv, enableLiveTvManagement, folders);
+    }
+
+    /// <summary>
+    /// The privileges a set of roles grants under a provider configuration.
+    /// </summary>
+    /// <param name="Valid">Whether any role is on the login allow-list (<see cref="OidConfig.Roles"/>).</param>
+    /// <param name="Admin">Whether any role is on the admin list (<see cref="OidConfig.AdminRoles"/>).</param>
+    /// <param name="EnableLiveTv">Whether any role grants Live TV (only when role-based Live TV is enabled).</param>
+    /// <param name="EnableLiveTvManagement">Whether any role grants Live TV management (only when role-based Live TV is enabled).</param>
+    /// <param name="Folders">The folders granted by matching folder-role mappings (only when folder roles are enabled).</param>
+    internal readonly record struct RoleGrants(
+        bool Valid,
+        bool Admin,
+        bool EnableLiveTv,
+        bool EnableLiveTvManagement,
+        List<string> Folders);
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -213,6 +213,7 @@ public class SSOController : ControllerBase
                     .Select(segment => segment.Replace("\\.", "."))
                     .ToArray();
 
+            var roles = new List<string>();
             foreach (var claim in result.User.Claims)
             {
                 if (claim.Type == (config.DefaultUsernameClaim?.Trim() ?? "preferred_username"))
@@ -224,79 +225,23 @@ public class SSOController : ControllerBase
                     }
                 }
 
-                // Role processing
-                if (roleClaimSegments.Any())
+                // Collect the roles carried by every claim on the configured role-claim path.
+                if (roleClaimSegments.Any() && claim.Type == roleClaimSegments[0])
                 {
-                    if (claim.Type == roleClaimSegments[0])
-                    {
-                        foreach (string role in OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value))
-                        {
-                            // Check if allowed to login based on roles
-                            if (config.Roles != null && config.Roles.Any())
-                            {
-                                foreach (string validRoles in config.Roles)
-                                {
-                                    if (role.Equals(validRoles))
-                                    {
-                                        timedState.Valid = true;
-                                    }
-                                }
-                            }
-
-                            // Check if admin based on roles
-                            if (config.AdminRoles != null && config.AdminRoles.Any())
-                            {
-                                foreach (string validAdminRoles in config.AdminRoles)
-                                {
-                                    if (role.Equals(validAdminRoles))
-                                    {
-                                        timedState.Admin = true;
-                                    }
-                                }
-                            }
-
-                            // Get allowed folders from roles
-                            if (config.EnableFolderRoles)
-                            {
-                                foreach (FolderRoleMap folderRoleMap in config.FolderRoleMapping)
-                                {
-                                    if (role.Equals(folderRoleMap.Role?.Trim()))
-                                    {
-                                        timedState.Folders.AddRange(folderRoleMap.Folders);
-                                    }
-                                }
-                            }
-
-                            if (config.EnableLiveTvRoles)
-                            {
-                                // Check if allowed Live TV based on roles
-                                if (config.LiveTvRoles != null && config.LiveTvRoles.Any())
-                                {
-                                    foreach (string validLiveTvRoles in config.LiveTvRoles)
-                                    {
-                                        if (role.Equals(validLiveTvRoles))
-                                        {
-                                            timedState.EnableLiveTv = true;
-                                        }
-                                    }
-                                }
-
-                                // Check if allowed Live TV management based on roles
-                                if (config.LiveTvManagementRoles != null && config.LiveTvManagementRoles.Any())
-                                {
-                                    foreach (string validLiveTvManagementRoles in config.LiveTvManagementRoles)
-                                    {
-                                        if (role.Equals(validLiveTvManagementRoles))
-                                        {
-                                            timedState.EnableLiveTvManagement = true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
                 }
             }
+
+            // Map the collected roles to privileges and merge them into the authorize state. The grants
+            // are monotonic (login validity, admin, Live TV, Live TV management, and folder access are
+            // only ever added), so OR-ing the booleans and appending the folders preserves the prior
+            // config-default values initialized above.
+            var grants = OidcRolePrivilegeMapper.Evaluate(roles, config);
+            timedState.Valid |= grants.Valid;
+            timedState.Admin |= grants.Admin;
+            timedState.EnableLiveTv |= grants.EnableLiveTv;
+            timedState.EnableLiveTvManagement |= grants.EnableLiveTvManagement;
+            timedState.Folders.AddRange(grants.Folders);
 
             // If the provider doesn't support the preferred username claim, then use the sub claim
             if (!timedState.Valid)


### PR DESCRIPTION
First half of the role-mapping decomposition tracked in #89 (the OID path).

`OidPost` inlined, per claim and per role, the logic that turns roles into privileges, login validity, admin, folder access, Live TV, Live TV management. It was the bulk of `OidPost`'s cognitive complexity (**S3776**) and had no unit coverage.

**Change:** collect the roles across all matching claims, then map them with the new pure `OidcRolePrivilegeMapper.Evaluate(roles, config)` (returns a `RoleGrants` record) and merge into the authorize state, OR the booleans, append the folders. The merge is **monotonic**, which preserves the pre-initialized config defaults exactly.

**Faithfulness:** verified by two independent adversarial reviews (bypass + correctness). Identical guards, ordinal `role.Equals`, the `EnableFolderRoles`/`EnableLiveTvRoles` master switches, folder order/duplicates, and, deliberately, via `foreach` not LINQ `Where`, the **pre-existing NullReferenceException** when `EnableFolderRoles` is set but `FolderRoleMapping` is null (admin misconfiguration; fails closed with a 500). 13 new characterization tests pin every branch, including that NRE.

Clears **S3776/S3267/CA1860/S1066** in `OidPost`. Remaining in #89: the SAML path, the folder-loop S3267 (kept as a faithful `foreach`), and the `Authenticate` parameter object (S107).

Build clean (`--warnaserror`), 173 tests pass. SonarCloud will likely be red on new_coverage only (the controller merge lines), the accepted free-plan state.