### PR TITLE
Extract the SAML role-to-privilege mapping into a tested pure helper

### DIFF
--- a/SSO-Auth.Tests/SamlRolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/SamlRolePrivilegeMapperTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="SamlRolePrivilegeMapper.Evaluate"/> — the role→privilege
+/// mapping extracted from the SAML callback. These pin the exact behavior, including the quirks that
+/// differ from the OpenID path: the folder-role list is null-checked (no throw), the folder role is
+/// matched without trimming, the comparison receiver is the configured value (so a null configured
+/// entry throws), and login validity is NOT decided here.
+/// </summary>
+public class SamlRolePrivilegeMapperTests
+{
+    private static SamlConfig Config(Action<SamlConfig> configure)
+    {
+        var config = new SamlConfig();
+        configure(config);
+        return config;
+    }
+
+    [Fact]
+    public void NoConfiguredRoles_GrantsNothing()
+    {
+        var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "anything" }, Config(_ => { }));
+
+        Assert.False(grants.Admin);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+        Assert.Empty(grants.Folders);
+    }
+
+    [Fact]
+    public void EmptyRoles_GrantsNothing()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "admins" });
+        Assert.False(SamlRolePrivilegeMapper.Evaluate(Array.Empty<string>(), config).Admin);
+    }
+
+    [Fact]
+    public void RoleOnAdminList_GrantsAdmin()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "jellyfin-admins" });
+
+        Assert.True(SamlRolePrivilegeMapper.Evaluate(new[] { "jellyfin-admins" }, config).Admin);
+        Assert.False(SamlRolePrivilegeMapper.Evaluate(new[] { "jellyfin-users" }, config).Admin);
+    }
+
+    [Fact]
+    public void RoleMatchingIsOrdinalCaseSensitive()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "Admins" });
+        Assert.False(SamlRolePrivilegeMapper.Evaluate(new[] { "admins" }, config).Admin);
+    }
+
+    [Fact]
+    public void FolderRolesDisabled_GrantsNoFolders()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+        });
+
+        Assert.Empty(SamlRolePrivilegeMapper.Evaluate(new[] { "media" }, config).Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_NullMapping_DoesNotThrow_GrantsNoFolders()
+    {
+        // Unlike the OpenID path, the SAML callback null-checks FolderRoleMapping, so a null mapping
+        // with EnableFolderRoles on is a safe no-op (no NullReferenceException).
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = null;
+        });
+
+        Assert.Empty(SamlRolePrivilegeMapper.Evaluate(new[] { "media" }, config).Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_MatchesRoleWithoutTrimming()
+    {
+        // Unlike the OpenID path, the SAML mapping is matched WITHOUT trimming, so a padded map role
+        // does not match an unpadded assertion role.
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "  media  ", Folders = new List<string> { "movies" } },
+                new FolderRoleMap { Role = "music", Folders = new List<string> { "songs" } },
+            };
+        });
+
+        Assert.Empty(SamlRolePrivilegeMapper.Evaluate(new[] { "media" }, config).Folders);
+        Assert.Equal(new List<string> { "songs" }, SamlRolePrivilegeMapper.Evaluate(new[] { "music" }, config).Folders);
+    }
+
+    [Fact]
+    public void FolderRolesEnabled_AccumulatesAcrossRolesAndMaps_PreservingDuplicates()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies", "shows" } },
+                new FolderRoleMap { Role = "music", Folders = new List<string> { "songs" } },
+            };
+        });
+
+        var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "media", "music" }, config);
+        Assert.Equal(new List<string> { "movies", "movies", "shows", "songs" }, grants.Folders);
+    }
+
+    [Fact]
+    public void LiveTvRolesDisabled_GrantsNoLiveTv()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = false;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "tv", "tv-admin" }, config);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void LiveTvRolesEnabled_GrantsLiveTvAndManagement()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        Assert.True(SamlRolePrivilegeMapper.Evaluate(new[] { "tv" }, config).EnableLiveTv);
+        Assert.True(SamlRolePrivilegeMapper.Evaluate(new[] { "tv-admin" }, config).EnableLiveTvManagement);
+        Assert.False(SamlRolePrivilegeMapper.Evaluate(new[] { "tv" }, config).EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void LiveTvRolesEnabled_NullRoleLists_DoNotThrowAndGrantNothing()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = null;
+            c.LiveTvManagementRoles = null;
+        });
+
+        var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "tv" }, config);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void NullConfiguredAdminRole_Throws()
+    {
+        // Characterizes the SAML receiver quirk: allowedRole.Equals(role) throws when a configured
+        // role entry is null (the loop does not break on an earlier match either). Preserved by the
+        // faithful extraction; a null entry is an admin misconfiguration and fails closed.
+        var config = Config(c => c.AdminRoles = new string?[] { null });
+
+        Assert.Throws<NullReferenceException>(() => SamlRolePrivilegeMapper.Evaluate(new[] { "x" }, config));
+    }
+
+    [Fact]
+    public void MultipleRoles_AnyMatchGrantsAdmin()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "admins" });
+        Assert.True(SamlRolePrivilegeMapper.Evaluate(new[] { "nope", "admins", "other" }, config).Admin);
+    }
+
+    [Fact]
+    public void NullConfiguredAdminRoleAfterAMatch_StillThrows()
+    {
+        // The matching loop has no early break, so a null configured entry after an earlier match
+        // still throws — this is exactly why the extraction keeps foreach rather than Any(predicate),
+        // which would short-circuit before reaching the null entry. Preserves the original behavior.
+        var config = Config(c => c.AdminRoles = new[] { "admins", null });
+
+        Assert.Throws<NullReferenceException>(() => SamlRolePrivilegeMapper.Evaluate(new[] { "admins" }, config));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -712,58 +712,15 @@ public class SSOController : ControllerBase
                 folders = new List<string>();
             }
 
-            foreach (string role in samlResponse.GetCustomAttributes("Role"))
-            {
-                if (config.AdminRoles != null)
-                {
-                    foreach (string allowedRole in config.AdminRoles)
-                    {
-                        if (allowedRole.Equals(role))
-                        {
-                            isAdmin = true;
-                        }
-                    }
-                }
-
-                if (config.EnableFolderRoles)
-                {
-                    if (config.FolderRoleMapping != null)
-                    {
-                        foreach (FolderRoleMap folderRoleMap in config.FolderRoleMapping)
-                        {
-                            if (folderRoleMap.Role.Equals(role))
-                            {
-                                folders.AddRange(folderRoleMap.Folders);
-                            }
-                        }
-                    }
-                }
-
-                if (config.EnableLiveTvRoles)
-                {
-                    if (config.LiveTvRoles != null)
-                    {
-                        foreach (string allowedLiveTvRole in config.LiveTvRoles)
-                        {
-                            if (allowedLiveTvRole.Equals(role))
-                            {
-                                liveTv = true;
-                            }
-                        }
-                    }
-
-                    if (config.LiveTvManagementRoles != null)
-                    {
-                        foreach (string allowedLiveTvManagementRole in config.LiveTvManagementRoles)
-                        {
-                            if (allowedLiveTvManagementRole.Equals(role))
-                            {
-                                liveTvManagement = true;
-                            }
-                        }
-                    }
-                }
-            }
+            // Map the assertion's roles to privileges and merge into the pre-initialized locals. The
+            // grants are monotonic (admin, Live TV, Live TV management, and folder access are only ever
+            // added), so OR-ing the booleans and appending the folders preserves the config defaults set
+            // above. Login validity is decided separately by SamlLoginPolicy, so it is not mapped here.
+            var samlGrants = SamlRolePrivilegeMapper.Evaluate(samlResponse.GetCustomAttributes("Role"), config);
+            isAdmin |= samlGrants.Admin;
+            liveTv |= samlGrants.EnableLiveTv;
+            liveTvManagement |= samlGrants.EnableLiveTvManagement;
+            folders.AddRange(samlGrants.Folders);
 
             Guid userId;
             try

--- a/SSO-Auth/Api/SamlRolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/SamlRolePrivilegeMapper.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Maps the roles carried by a SAML assertion to the privileges they grant, according to the
+/// provider configuration. Pure: it derives the grants from (roles, config) and makes no decision
+/// about the session (login validity is decided separately by <see cref="SamlLoginPolicy"/>), so
+/// every grant here is monotonic — the caller OR-s the booleans and appends the folders.
+///
+/// This mirrors the SAML callback's per-role logic one-for-one, including its quirks, which differ
+/// from the OpenID path (see <see cref="OidcRolePrivilegeMapper"/>): the comparison receiver is the
+/// configured value (<c>allowedRole.Equals(role)</c>), the folder-role list IS null-checked, and the
+/// folder role is compared without trimming. The matching loops are intentionally kept as
+/// no-break <c>foreach</c> (not LINQ) so the exact iteration and exception behavior — e.g. a
+/// NullReferenceException on a null role entry even after an earlier match — is preserved.
+/// </summary>
+internal static class SamlRolePrivilegeMapper
+{
+    /// <summary>
+    /// Evaluates the privileges granted by the given roles under the given configuration.
+    /// </summary>
+    /// <param name="roles">The role values carried by the (already signature-validated) assertion.</param>
+    /// <param name="config">The SAML provider configuration.</param>
+    /// <returns>The granted privileges; booleans are false and the folder list empty when nothing matches.</returns>
+    internal static RoleGrants Evaluate(IEnumerable<string> roles, SamlConfig config)
+    {
+        var admin = false;
+        var enableLiveTv = false;
+        var enableLiveTvManagement = false;
+        var folders = new List<string>();
+
+        foreach (string role in roles)
+        {
+            if (config.AdminRoles != null)
+            {
+                foreach (string allowedRole in config.AdminRoles)
+                {
+                    if (allowedRole.Equals(role))
+                    {
+                        admin = true;
+                    }
+                }
+            }
+
+            if (config.EnableFolderRoles && config.FolderRoleMapping != null)
+            {
+                foreach (FolderRoleMap folderRoleMap in config.FolderRoleMapping)
+                {
+                    if (folderRoleMap.Role.Equals(role))
+                    {
+                        folders.AddRange(folderRoleMap.Folders);
+                    }
+                }
+            }
+
+            if (config.EnableLiveTvRoles)
+            {
+                if (config.LiveTvRoles != null)
+                {
+                    foreach (string allowedLiveTvRole in config.LiveTvRoles)
+                    {
+                        if (allowedLiveTvRole.Equals(role))
+                        {
+                            enableLiveTv = true;
+                        }
+                    }
+                }
+
+                if (config.LiveTvManagementRoles != null)
+                {
+                    foreach (string allowedLiveTvManagementRole in config.LiveTvManagementRoles)
+                    {
+                        if (allowedLiveTvManagementRole.Equals(role))
+                        {
+                            enableLiveTvManagement = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return new RoleGrants(admin, enableLiveTv, enableLiveTvManagement, folders);
+    }
+
+    /// <summary>
+    /// The privileges a set of SAML roles grants under a provider configuration.
+    /// </summary>
+    /// <param name="Admin">Whether any role is on the admin list.</param>
+    /// <param name="EnableLiveTv">Whether any role grants Live TV (only when role-based Live TV is enabled).</param>
+    /// <param name="EnableLiveTvManagement">Whether any role grants Live TV management (only when role-based Live TV is enabled).</param>
+    /// <param name="Folders">The folders granted by matching folder-role mappings (only when folder roles are enabled).</param>
+    internal readonly record struct RoleGrants(
+        bool Admin,
+        bool EnableLiveTv,
+        bool EnableLiveTvManagement,
+        List<string> Folders);
+}


### PR DESCRIPTION
Second half of the role-mapping decomposition (#89), the SAML path, pairs with the OID extraction in #90.

`SamlAuth` inlined, per role, the logic that grants admin, folder access, and Live TV. Move it verbatim into the pure `SamlRolePrivilegeMapper.Evaluate(roles, config)` and merge into the pre-initialized locals (OR the booleans, append the folders), the grants are monotonic, so the config defaults are preserved. Login validity stays with `SamlLoginPolicy`.

**Faithful**, verified by two independent adversarial reviews (bypass + correctness). The SAML quirks are preserved exactly and deliberately differ from the OID mapper: the comparison receiver is the configured value (so a null configured entry throws, **even after an earlier match**, kept as a no-break `foreach`, not LINQ `Any` which would short-circuit), `FolderRoleMapping` IS null-checked (no NRE), and the folder role is matched **without** trimming. 14 characterization tests pin every branch and each of those differences.

Clears **S3776** and collapses **S1066** in `SamlAuth`. The matching loops stay as faithful `foreach` (their no-break/receiver exception semantics must be preserved, so they are NOT converted to LINQ, the S3267 there is left deliberately), tracked in #89. Build clean (`--warnaserror`), 187 tests pass.