### PR TITLE
Use Length instead of Any() for the role-claim segment guard

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -226,7 +226,7 @@ public class SSOController : ControllerBase
                 }
 
                 // Collect the roles carried by every claim on the configured role-claim path.
-                if (roleClaimSegments.Any() && claim.Type == roleClaimSegments[0])
+                if (roleClaimSegments.Length > 0 && claim.Type == roleClaimSegments[0])
                 {
                     roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
                 }


### PR DESCRIPTION
`roleClaimSegments` is a non-null `string[]` (either `Array.Empty<string>()` or the split result), so `.Length > 0` is exactly equivalent to `.Any()` and is the idiomatic array check (**CA1860**). Behavior unchanged; the guard is the role-claim-type check, not part of any privilege-decision loop. Build clean, 187 tests pass.