### PR TITLE
Extract OID authorize-state derivation into a pure builder

### DIFF
--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="OidcAuthorizeStateBuilder.Build"/> — the username/validity/
+/// avatar/folder derivation extracted from the OID callback. These pin the exact behavior (including
+/// the last-claim-wins username, the sub-claim fallback, and the fail-closed null-Roles throw) so the
+/// extraction is a proven no-op and the derivation is testable in isolation.
+/// </summary>
+public class OidcAuthorizeStateBuilderTests
+{
+    private static OidConfig Config(Action<OidConfig> configure)
+    {
+        var config = new OidConfig();
+        configure(config);
+        return config;
+    }
+
+    private static List<Claim> Claims(params (string Type, string Value)[] claims)
+    {
+        var list = new List<Claim>();
+        foreach (var (type, value) in claims)
+        {
+            list.Add(new Claim(type, value));
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public void NoClaims_NoRolesConfigured_NotValid()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(Claims(), Config(_ => { }));
+
+        Assert.Null(result.Username);
+        Assert.False(result.Valid);
+        Assert.False(result.Admin);
+        Assert.False(result.EnableLiveTv);
+        Assert.False(result.EnableLiveTvManagement);
+        Assert.Empty(result.Folders);
+        Assert.Null(result.AvatarUrl);
+    }
+
+    [Fact]
+    public void PreferredUsernameClaim_NoRolesConfigured_IsValid()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));
+
+        Assert.Equal("alice", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void CustomUsernameClaim_IsRespected()
+    {
+        var config = Config(c => c.DefaultUsernameClaim = "email");
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("email", "alice@example.com")), config);
+
+        Assert.Equal("alice@example.com", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void LastMatchingUsernameClaimWins()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "first"), ("preferred_username", "second")),
+            Config(_ => { }));
+
+        Assert.Equal("second", result.Username);
+    }
+
+    [Fact]
+    public void AllowListConfigured_MatchingRole_IsValid()
+    {
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "jellyfin-users")),
+            config);
+
+        Assert.Equal("alice", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void AllowListConfigured_NoMatchingRole_NotValid()
+    {
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "outsiders")),
+            config);
+
+        Assert.Equal("alice", result.Username);
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void AdminRole_GrantsAdmin_ViaNestedJsonRoleClaim()
+    {
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.RoleClaim = "realm_access.roles";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("realm_access", "{\"roles\":[\"admins\"]}")),
+            config);
+
+        Assert.True(result.Admin);
+    }
+
+    [Fact]
+    public void SubFallback_WhenNotValidAndRolesEmpty_UsesSubAndIsValid()
+    {
+        // No preferred-username claim, an empty (non-null) allow-list → the sub claim is the username
+        // and, because the allow-list is empty, the login is valid.
+        var config = Config(c => c.Roles = Array.Empty<string>());
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("sub", "subject-123")), config);
+
+        Assert.Equal("subject-123", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void SubFallback_NotReached_WhenAlreadyValid()
+    {
+        // A preferred-username claim with no allow-list makes the login valid, so the sub fallback
+        // (which would overwrite the username) is not entered.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "subject-123")),
+            Config(_ => { }));
+
+        Assert.Equal("alice", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void SubFallback_NullRolesArray_Throws()
+    {
+        // Faithful to the original: the sub fallback does not null-check config.Roles, so when RBAC is
+        // off (Roles == null) and only a sub claim is present, it throws (fails closed). Tracked in #89.
+        var config = Config(c => c.Roles = null);
+
+        Assert.Throws<NullReferenceException>(() => OidcAuthorizeStateBuilder.Build(Claims(("sub", "subject-123")), config));
+    }
+
+    [Fact]
+    public void AvatarUrlFormat_ResolvedFromClaims()
+    {
+        var config = Config(c => c.AvatarUrlFormat = "https://avatars.example.com/@{sub}.png");
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice"), ("sub", "123")), config);
+
+        Assert.Equal("https://avatars.example.com/123.png", result.AvatarUrl);
+    }
+
+    [Fact]
+    public void NoAvatarUrlFormat_YieldsNull()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));
+        Assert.Null(result.AvatarUrl);
+    }
+
+    [Fact]
+    public void FolderRolesOff_CopiesEnabledFolders()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.EnabledFolders = new[] { "movies", "shows" };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), config);
+        Assert.Equal(new List<string> { "movies", "shows" }, result.Folders);
+    }
+
+    [Fact]
+    public void FolderRolesOn_AppendsRoleGrantedFolders()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.RoleClaim = "role";
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "media")),
+            config);
+
+        Assert.Equal(new List<string> { "movies" }, result.Folders);
+    }
+
+    [Fact]
+    public void LiveTv_DefaultsFromConfig_ThenRoleGrantsAdd()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTv = true;
+            c.EnableLiveTvManagement = false;
+            c.EnableLiveTvRoles = true;
+            c.RoleClaim = "role";
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "tv-admin")),
+            config);
+
+        Assert.True(result.EnableLiveTv);            // from config default
+        Assert.True(result.EnableLiveTvManagement);  // granted by the role
+    }
+}

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Derives the per-login authorize-state values (username, login validity, admin, Live TV, folder
+/// access, avatar) from a verified OpenID login's claims and the provider configuration. Pure: it
+/// reads only (claims, config) and returns the derived values, which the OID callback assigns onto
+/// the fresh authorize state. Mirrors, one-for-one, the derivation that used to live inline in the
+/// callback — including its quirks (username is the last matching claim; the "sub" claim is a
+/// fallback only when no allow-list made the login valid; a null <c>Roles</c> array in that fallback
+/// still throws, an admin misconfiguration that fails closed).
+/// </summary>
+internal static class OidcAuthorizeStateBuilder
+{
+    // Splits the role-claim path on dots that are not escaped with a backslash ("a.b\.c" -> "a", "b.c").
+    // Compiled once and reused: it runs for every claim on every login (hot path), so it must not be
+    // recompiled per call. The match timeout is defense-in-depth on the match input: the pattern is
+    // fixed and linear (a fixed-width lookbehind plus a literal dot) so it cannot backtrack into a
+    // timeout, but the cap guarantees role parsing can never block the login path.
+    private static readonly Regex RoleClaimSplitRegex =
+        new Regex(@"(?<!\\)\.", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Derives the authorize-state values from the login's claims and the provider configuration.
+    /// </summary>
+    /// <param name="claims">The claims of the verified OpenID login.</param>
+    /// <param name="config">The OpenID provider configuration.</param>
+    /// <returns>The derived authorize-state values.</returns>
+    internal static OidcAuthorizeState Build(IEnumerable<Claim> claims, OidConfig config)
+    {
+        // Materialize so the claims can be enumerated more than once (avatar format, role claim, sub fallback).
+        var claimList = claims as IReadOnlyList<Claim> ?? claims.ToList();
+
+        // Folders start from the statically-enabled set only when folder roles are off; role-granted
+        // folders are appended below.
+        var folders = !config.EnableFolderRoles && config.EnabledFolders != null
+            ? new List<string>(config.EnabledFolders)
+            : new List<string>();
+
+        var enableLiveTv = config.EnableLiveTv;
+        var enableLiveTvManagement = config.EnableLiveTvManagement;
+
+        string? avatarUrl = null;
+        if (config.AvatarUrlFormat is not null)
+        {
+            avatarUrl = claimList.Aggregate(
+                config.AvatarUrlFormat,
+                (s, claim) => s.Contains($"@{{{claim.Type}}}") ? s.Replace($"@{{{claim.Type}}}", claim.Value) : s);
+        }
+
+        // The role-claim path depends only on config.RoleClaim, so process it once rather than per claim.
+        // The regex splits on dots not escaped with a backslash; escaped "\." are then normalized to ".".
+        string[] roleClaimSegments = string.IsNullOrEmpty(config.RoleClaim)
+            ? Array.Empty<string>()
+            : RoleClaimSplitRegex.Split(config.RoleClaim.Trim())
+                .Select(segment => segment.Replace("\\.", "."))
+                .ToArray();
+
+        string? username = null;
+        var valid = false;
+        var roles = new List<string>();
+        foreach (var claim in claimList)
+        {
+            if (claim.Type == (config.DefaultUsernameClaim?.Trim() ?? "preferred_username"))
+            {
+                username = claim.Value;
+                if (config.Roles == null || config.Roles.Length == 0)
+                {
+                    valid = true;
+                }
+            }
+
+            // Collect the roles carried by every claim on the configured role-claim path.
+            if (roleClaimSegments.Length > 0 && claim.Type == roleClaimSegments[0])
+            {
+                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
+            }
+        }
+
+        // Map the collected roles to privileges and merge (monotonic: only ever grants).
+        var grants = OidcRolePrivilegeMapper.Evaluate(roles, config);
+        valid |= grants.Valid;
+        var admin = grants.Admin;
+        enableLiveTv |= grants.EnableLiveTv;
+        enableLiveTvManagement |= grants.EnableLiveTvManagement;
+        folders.AddRange(grants.Folders);
+
+        // If the provider doesn't supply the preferred-username claim, fall back to the "sub" claim.
+        if (!valid)
+        {
+            foreach (var claim in claimList)
+            {
+                if (claim.Type == "sub")
+                {
+                    username = claim.Value;
+
+                    // Faithful to the original: unlike the preferred-username branch above, this does
+                    // NOT null-check config.Roles, so a null Roles array here throws (an admin
+                    // misconfiguration where RBAC is off and the provider supplies only "sub"). The
+                    // null-forgiving operator keeps that exact fail-closed behavior; tracked in #89.
+                    if (config.Roles!.Length == 0)
+                    {
+                        valid = true;
+                    }
+                }
+            }
+        }
+
+        return new OidcAuthorizeState(username, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+    }
+
+    /// <summary>
+    /// The authorize-state values derived from an OpenID login.
+    /// </summary>
+    /// <param name="Username">The resolved username (last matching preferred-username or sub claim), or null when none is present.</param>
+    /// <param name="Valid">Whether the login is permitted (no allow-list, or a role matched the allow-list).</param>
+    /// <param name="Admin">Whether the login grants administrator rights.</param>
+    /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
+    /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
+    /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
+    /// <param name="AvatarUrl">The resolved avatar URL, or null when no avatar format is configured.</param>
+    internal readonly record struct OidcAuthorizeState(
+        string? Username,
+        bool Valid,
+        bool Admin,
+        bool EnableLiveTv,
+        bool EnableLiveTvManagement,
+        List<string> Folders,
+        string? AvatarUrl);
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -71,14 +71,6 @@ public class SSOController : ControllerBase
     private static readonly string UserAgentString =
         $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
 
-    // Splits the role-claim path on dots that are not escaped with a backslash ("a.b\.c" -> "a", "b.c").
-    // Compiled once and reused: it runs for every claim on every login (hot path), so it must not be
-    // recompiled per call. The match timeout is defense-in-depth on the match input: the pattern is
-    // fixed and linear (a fixed-width lookbehind plus a literal dot) so it cannot backtrack into a
-    // timeout, but the cap guarantees role parsing can never block the login path.
-    private static readonly Regex RoleClaimSplitRegex =
-        new Regex(@"(?<!\\)\.", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -185,79 +177,17 @@ public class SSOController : ControllerBase
                 return ReturnError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
             }
 
-            if (!config.EnableFolderRoles && config.EnabledFolders != null)
-            {
-                timedState.Folders = new List<string>(config.EnabledFolders);
-            }
-            else
-            {
-                timedState.Folders = new List<string>();
-            }
-
-            timedState.EnableLiveTv = config.EnableLiveTv;
-            timedState.EnableLiveTvManagement = config.EnableLiveTvManagement;
-
-            if (config.AvatarUrlFormat is not null)
-            {
-                timedState.AvatarURL = result.User.Claims.Aggregate(
-                    config.AvatarUrlFormat,
-                    (s, claim) => s.Contains($"@{{{claim.Type}}}") ? s.Replace($"@{{{claim.Type}}}", claim.Value) : s);
-            }
-
-            // The role-claim path depends only on config.RoleClaim, so process it once here rather
-            // than per claim. The regex splits on dots not escaped with a backslash ("a.b.c" ->
-            // a, b, c; "a.b\.c" -> a, b.c), then the escaped "\." are normalized back to ".".
-            string[] roleClaimSegments = string.IsNullOrEmpty(config.RoleClaim)
-                ? Array.Empty<string>()
-                : RoleClaimSplitRegex.Split(config.RoleClaim.Trim())
-                    .Select(segment => segment.Replace("\\.", "."))
-                    .ToArray();
-
-            var roles = new List<string>();
-            foreach (var claim in result.User.Claims)
-            {
-                if (claim.Type == (config.DefaultUsernameClaim?.Trim() ?? "preferred_username"))
-                {
-                    timedState.Username = claim.Value;
-                    if (config.Roles == null || config.Roles.Length == 0)
-                    {
-                        timedState.Valid = true;
-                    }
-                }
-
-                // Collect the roles carried by every claim on the configured role-claim path.
-                if (roleClaimSegments.Length > 0 && claim.Type == roleClaimSegments[0])
-                {
-                    roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
-                }
-            }
-
-            // Map the collected roles to privileges and merge them into the authorize state. The grants
-            // are monotonic (login validity, admin, Live TV, Live TV management, and folder access are
-            // only ever added), so OR-ing the booleans and appending the folders preserves the prior
-            // config-default values initialized above.
-            var grants = OidcRolePrivilegeMapper.Evaluate(roles, config);
-            timedState.Valid |= grants.Valid;
-            timedState.Admin |= grants.Admin;
-            timedState.EnableLiveTv |= grants.EnableLiveTv;
-            timedState.EnableLiveTvManagement |= grants.EnableLiveTvManagement;
-            timedState.Folders.AddRange(grants.Folders);
-
-            // If the provider doesn't support the preferred username claim, then use the sub claim
-            if (!timedState.Valid)
-            {
-                foreach (var claim in result.User.Claims)
-                {
-                    if (claim.Type == "sub")
-                    {
-                        timedState.Username = claim.Value;
-                        if (config.Roles.Length == 0)
-                        {
-                            timedState.Valid = true;
-                        }
-                    }
-                }
-            }
+            // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
+            // from the verified login's claims and the provider configuration, then apply them to the
+            // fresh authorize state (its derivation fields are still at their defaults at this point).
+            var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config);
+            timedState.Username = derived.Username;
+            timedState.Valid = derived.Valid;
+            timedState.Admin = derived.Admin;
+            timedState.EnableLiveTv = derived.EnableLiveTv;
+            timedState.EnableLiveTvManagement = derived.EnableLiveTvManagement;
+            timedState.Folders = derived.Folders;
+            timedState.AvatarURL = derived.AvatarUrl;
 
             bool isLinking = timedState.IsLinking;
 


### PR DESCRIPTION
## What

Extracts the per-login authorize-state derivation from the OID callback (`OidPost`) into a pure, testable `OidcAuthorizeStateBuilder.Build(claims, config)`. The callback now assigns the returned values onto the fresh authorize state instead of computing them inline.

This is the next step in decomposing the `OidPost` God method (`Refs #89`), targeting its cognitive-complexity finding (S3776).

## Why it is behavior-preserving

The authorize state is created fresh at `OidChallenge` with only `IsLinking`/`Provider` set, so all seven derived fields (`Username`, `Valid`, `Admin`, `EnableLiveTv`, `EnableLiveTvManagement`, `Folders`, `AvatarURL`) are at their defaults when the callback runs. That makes the mutation-to-assignment change exact.

The builder mirrors the inline logic one-for-one, including its quirks:
- username is the **last** matching claim (last-wins);
- the `sub` claim is a fallback used **only** when no allow-list validated the login;
- a null `Roles` array in that fallback still throws (**fail-closed**), preserved via the null-forgiving operator (compile-time only, same runtime NRE);
- the `RoleClaimSplitRegex` moves verbatim into the builder, its sole consumer.

## Tests

15 characterization tests pin the derivation in isolation: username resolution and last-wins, allow-list match/no-match, nested-JSON admin, sub fallback (including the null-Roles throw), avatar resolution, folder copy/append, and Live TV defaulting.

## Verification

- Build clean (`--warnaserror --no-incremental`, Debug).
- Full suite green: 202/202.
- Two independent adversarial reviews (bypass-lens + correctness-lens) proved exact equivalence: the fresh-defaults invariant holds, every field reproduces the inline logic, the null-Roles throw remains fail-closed, and the only divergence (recompute-vs-sticky under an unreachable state-replay) is strictly more fail-closed.

Refs #89