### PR TITLE
Extract SAML authorize-state derivation into a pure builder

### DIFF
--- a/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests for <see cref="SamlAuthorizeStateBuilder.Build"/> — the admin/Live TV/
+/// folder privilege derivation extracted from the SAML callback. These pin the exact behavior (folder
+/// defaulting, the config-default-then-role-grant merge for Live TV, and the admin/folder grants) so
+/// the extraction is a proven no-op. Login validity and the username are decided elsewhere, so they
+/// are not part of the derivation and not tested here.
+/// </summary>
+public class SamlAuthorizeStateBuilderTests
+{
+    private static SamlConfig Config(System.Action<SamlConfig> configure)
+    {
+        var config = new SamlConfig();
+        configure(config);
+        return config;
+    }
+
+    [Fact]
+    public void NoRoles_NoConfigDefaults_YieldsNoPrivileges()
+    {
+        var result = SamlAuthorizeStateBuilder.Build(new List<string>(), Config(_ => { }));
+
+        Assert.False(result.Admin);
+        Assert.False(result.EnableLiveTv);
+        Assert.False(result.EnableLiveTvManagement);
+        Assert.Empty(result.Folders);
+    }
+
+    [Fact]
+    public void LiveTv_DefaultsFromConfig_EvenWithoutRoles()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTv = true;
+            c.EnableLiveTvManagement = true;
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string>(), config);
+
+        Assert.True(result.EnableLiveTv);
+        Assert.True(result.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void FolderRolesOff_CopiesEnabledFolders()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.EnabledFolders = new[] { "movies", "shows" };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string>(), config);
+
+        Assert.Equal(new List<string> { "movies", "shows" }, result.Folders);
+    }
+
+    [Fact]
+    public void FolderRolesOn_IgnoresStaticFolders_AppendsRoleGranted()
+    {
+        var config = Config(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.EnabledFolders = new[] { "static" };
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "media" }, config);
+
+        // Folder roles on → the statically-enabled set is NOT copied; only role-granted folders apply.
+        Assert.Equal(new List<string> { "movies" }, result.Folders);
+    }
+
+    [Fact]
+    public void AdminRole_GrantsAdmin()
+    {
+        var config = Config(c => c.AdminRoles = new[] { "admins" });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "admins" }, config);
+
+        Assert.True(result.Admin);
+    }
+
+    [Fact]
+    public void NonMatchingRole_GrantsNothing()
+    {
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "outsiders" }, config);
+
+        Assert.False(result.Admin);
+        Assert.False(result.EnableLiveTv);
+    }
+
+    [Fact]
+    public void LiveTv_GrantedByRole_WhenConfigDefaultOff()
+    {
+        // Pins the role-grant OR for the plain Live TV flag: the config default is off, so a true
+        // result can only come from the role grant being merged in.
+        var config = Config(c =>
+        {
+            c.EnableLiveTv = false;
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "tv" }, config);
+
+        Assert.True(result.EnableLiveTv);
+    }
+
+    [Fact]
+    public void LiveTvManagement_GrantedByRole()
+    {
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = true;
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "tv-admin" }, config);
+
+        Assert.True(result.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void LiveTvRolesDisabled_RoleDoesNotGrantLiveTv()
+    {
+        // EnableLiveTvRoles is off, so a matching Live TV role is ignored (faithful to the mapper).
+        var config = Config(c =>
+        {
+            c.EnableLiveTvRoles = false;
+            c.LiveTvRoles = new[] { "tv" };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "tv" }, config);
+
+        Assert.False(result.EnableLiveTv);
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -597,9 +597,6 @@ public class SSOController : ControllerBase
 
         if (config.Enabled)
         {
-            bool isAdmin = false;
-            bool liveTv = config.EnableLiveTv;
-            bool liveTvManagement = config.EnableLiveTvManagement;
             var samlResponse = new Response(config.SamlCertificate, response.Data);
 
             if (!IsSamlResponseValid(samlResponse, config))
@@ -633,25 +630,11 @@ public class SSOController : ControllerBase
                 return Problem("SAML assertion has already been used");
             }
 
-            List<string> folders;
-            if (!config.EnableFolderRoles && config.EnabledFolders != null)
-            {
-                folders = new List<string>(config.EnabledFolders);
-            }
-            else
-            {
-                folders = new List<string>();
-            }
-
-            // Map the assertion's roles to privileges and merge into the pre-initialized locals. The
-            // grants are monotonic (admin, Live TV, Live TV management, and folder access are only ever
-            // added), so OR-ing the booleans and appending the folders preserves the config defaults set
-            // above. Login validity is decided separately by SamlLoginPolicy, so it is not mapped here.
-            var samlGrants = SamlRolePrivilegeMapper.Evaluate(samlResponse.GetCustomAttributes("Role"), config);
-            isAdmin |= samlGrants.Admin;
-            liveTv |= samlGrants.EnableLiveTv;
-            liveTvManagement |= samlGrants.EnableLiveTvManagement;
-            folders.AddRange(samlGrants.Folders);
+            // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
+            // the assertion's roles and the provider configuration. Login validity was already decided
+            // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
+            // here.
+            var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
 
             Guid userId;
             try
@@ -666,12 +649,12 @@ public class SSOController : ControllerBase
             var authenticationResult = await Authenticate(new SessionParameters
             {
                 UserId = userId,
-                IsAdmin = isAdmin,
+                IsAdmin = derived.Admin,
                 EnableAuthorization = config.EnableAuthorization,
                 EnableAllFolders = config.EnableAllFolders,
-                EnabledFolders = folders.ToArray(),
-                EnableLiveTv = liveTv,
-                EnableLiveTvManagement = liveTvManagement,
+                EnabledFolders = derived.Folders.ToArray(),
+                EnableLiveTv = derived.EnableLiveTv,
+                EnableLiveTvManagement = derived.EnableLiveTvManagement,
                 AuthResponse = response,
                 DefaultProvider = config.DefaultProvider?.Trim(),
                 AvatarUrl = null,

--- a/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Derives the per-login authorize-state privileges (admin, Live TV, Live TV management, folder
+/// access) from a validated SAML assertion's roles and the provider configuration. Pure: it reads
+/// only (roles, config) and returns the derived values, which the SAML callback applies to the
+/// session parameters. Login validity is decided separately by <see cref="SamlLoginPolicy"/> and the
+/// username is the assertion's NameID, so — unlike the OpenID builder
+/// (<see cref="OidcAuthorizeStateBuilder"/>) — neither is derived here. Mirrors, one-for-one, the
+/// privilege derivation that used to live inline in the callback.
+/// </summary>
+internal static class SamlAuthorizeStateBuilder
+{
+    /// <summary>
+    /// Derives the authorize-state privileges from the assertion's roles and the provider configuration.
+    /// </summary>
+    /// <param name="roles">The role values carried by the (already signature-validated) assertion.</param>
+    /// <param name="config">The SAML provider configuration.</param>
+    /// <returns>The derived authorize-state privileges.</returns>
+    internal static SamlAuthorizeState Build(IEnumerable<string> roles, SamlConfig config)
+    {
+        // Folders start from the statically-enabled set only when folder roles are off; role-granted
+        // folders are appended below.
+        var folders = !config.EnableFolderRoles && config.EnabledFolders != null
+            ? new List<string>(config.EnabledFolders)
+            : new List<string>();
+
+        // Map the roles to privileges and merge (monotonic: only ever grants). Login validity is
+        // decided separately by SamlLoginPolicy, so it is not mapped here. Admin starts false, so its
+        // OR-merge is a plain assignment; Live TV starts from the config default and is OR-ed.
+        var grants = SamlRolePrivilegeMapper.Evaluate(roles, config);
+        var admin = grants.Admin;
+        var enableLiveTv = config.EnableLiveTv | grants.EnableLiveTv;
+        var enableLiveTvManagement = config.EnableLiveTvManagement | grants.EnableLiveTvManagement;
+        folders.AddRange(grants.Folders);
+
+        return new SamlAuthorizeState(admin, enableLiveTv, enableLiveTvManagement, folders);
+    }
+
+    /// <summary>
+    /// The authorize-state privileges derived from a SAML login.
+    /// </summary>
+    /// <param name="Admin">Whether the login grants administrator rights.</param>
+    /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
+    /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
+    /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
+    internal readonly record struct SamlAuthorizeState(
+        bool Admin,
+        bool EnableLiveTv,
+        bool EnableLiveTvManagement,
+        List<string> Folders);
+}


### PR DESCRIPTION
## What

Extracts the per-login privilege derivation from the SAML callback (`SamlAuth`) into a pure, testable `SamlAuthorizeStateBuilder.Build(roles, config)`. The callback now reads the returned values into the session parameters instead of computing them inline. This mirrors the OpenID extraction (#94) on the SAML side and clears `SamlAuth`'s cognitive-complexity finding (S3776, `Refs #89`).

## Why it is behavior-preserving

The derived values were plain locals flowing by value into a fresh `SessionParameters` object initializer, no pre-existing mutable state, so moving their computation is a pure value move. The builder reproduces the inline block one-for-one:

- the folder pre-init ternary (`!EnableFolderRoles && EnabledFolders != null` → copy, else empty), then the same `AddRange(grants.Folders)`;
- the boolean seeds (`false` for admin, the config defaults for Live TV) OR-merged with the role grants (`x |= y` on an already-materialized value is exactly `x | y`);
- the same single `SamlRolePrivilegeMapper.Evaluate` call on the same roles (`GetCustomAttributes("Role")` is still invoked exactly twice, at the same program points).

Login validity (`SamlLoginPolicy`) and the username (NameID) are decided elsewhere and stay untouched; the guard ordering (SAML validity → login allow-list → replay consume → derivation → user creation) is unchanged.

## Tests

9 characterization tests pin the derivation in isolation: folder defaulting on/off, admin grant, non-matching role, Live TV config-default pass-through, a positive role-grant test for **each** Live TV flag (so a dropped OR-merge cannot slip through), and the `EnableLiveTvRoles`-off gating.

## Verification

- Build clean (`--warnaserror --no-incremental`, Debug).
- Full suite green: 211/211.
- Two independent adversarial reviews (bypass-lens + correctness-lens) proved exact equivalence: identical folder branches, verbatim boolean seeds, unchanged call counts and guard ordering, `SamlRolePrivilegeMapper` untouched. The one review finding (a missing positive Live TV role-grant test) is fixed in this PR.

Refs #89