### PR TITLE
Deduplicate the OIDC client construction

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -145,30 +145,7 @@ public class SSOController : ControllerBase
                 return BadRequest("Invalid or expired state");
             }
 
-            var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
-            var options = new OidcClientOptions
-            {
-                Authority = config.OidEndpoint?.Trim(),
-                ClientId = config.OidClientId?.Trim(),
-                ClientSecret = config.OidSecret?.Trim(),
-                RedirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{(Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase) ? "redirect" : "r")}/" + provider,
-                Scope = string.Join(" ", scopes.Prepend("openid profile")),
-                DisablePushedAuthorization = config.DisablePushedAuthorization,
-                LoggerFactory = _loggerFactory,
-                LoadProfile = !config.DoNotLoadProfile,
-                HttpClientFactory = o =>
-                {
-                    var client = _httpClientFactory.CreateClient();
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
-                    return client;
-                }
-            };
-            var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
-            options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
-            options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
-            options.Policy.Discovery.RequireHttps = !config.DisableHttps;
-            options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
-            var oidcClient = new OidcClient(options);
+            var oidcClient = CreateCallbackOidcClient(config, provider);
             var currentState = timedState.State;
             var result = await oidcClient.ProcessResponseAsync(Request.QueryString.Value, currentState).ConfigureAwait(false);
 
@@ -244,29 +221,7 @@ public class SSOController : ControllerBase
 
             string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{(newPath ? "redirect" : "r")}/" + provider;
 
-            var options = new OidcClientOptions
-            {
-                Authority = config.OidEndpoint?.Trim(),
-                ClientId = config.OidClientId?.Trim(),
-                ClientSecret = config.OidSecret?.Trim(),
-                RedirectUri = redirectUri,
-                Scope = string.Join(" ", config.OidScopes.Prepend("openid profile")),
-                DisablePushedAuthorization = config.DisablePushedAuthorization,
-                LoggerFactory = _loggerFactory,
-                LoadProfile = !config.DoNotLoadProfile,
-                HttpClientFactory = o =>
-                {
-                    var client = _httpClientFactory.CreateClient();
-                    client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
-                    return client;
-                }
-            };
-            var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
-            options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
-            options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
-            options.Policy.Discovery.RequireHttps = !config.DisableHttps;
-            options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
-            var oidcClient = new OidcClient(options);
+            var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
             var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
 
             if (state.IsError)
@@ -287,6 +242,49 @@ public class SSOController : ControllerBase
         }
 
         throw new ArgumentException(ProviderDoesNotExistMessage);
+    }
+
+    // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
+    // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
+    // so the caller supplies them. Constructed in the same order as before the extraction, so a null
+    // OidEndpoint still fails at the same point (the Uri constructor, after the options object).
+    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope)
+    {
+        var options = new OidcClientOptions
+        {
+            Authority = config.OidEndpoint?.Trim(),
+            ClientId = config.OidClientId?.Trim(),
+            ClientSecret = config.OidSecret?.Trim(),
+            RedirectUri = redirectUri,
+            Scope = scope,
+            DisablePushedAuthorization = config.DisablePushedAuthorization,
+            LoggerFactory = _loggerFactory,
+            LoadProfile = !config.DoNotLoadProfile,
+            HttpClientFactory = o =>
+            {
+                var client = _httpClientFactory.CreateClient();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
+                return client;
+            }
+        };
+        var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
+        options.Policy.Discovery.RequireHttps = !config.DisableHttps;
+        options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
+        return new OidcClient(options);
+    }
+
+    // Callback-side client: the redirect URI is rebuilt with the same expression the callback always
+    // used — a "/start/" test against the callback path, which never contains it, so the segment is
+    // always "r" (pre-existing quirk, deliberately preserved; strict IdPs fail closed on a mismatch).
+    // A null scopes array is tolerated here but not on the challenge side — also a pre-existing
+    // asymmetry deliberately preserved.
+    private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
+    {
+        var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
+        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{(Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase) ? "redirect" : "r")}/" + provider;
+        return CreateOidcClient(config, redirectUri, string.Join(" ", scopes.Prepend("openid profile")));
     }
 
     /// <summary>


### PR DESCRIPTION
## What

`OidPost` and `OidChallenge` assembled near-identical `OidcClientOptions` inline (~25 lines each; token-identical apart from `RedirectUri` and `Scope`). This extracts a shared `CreateOidcClient(config, redirectUri, scope)` core plus a thin `CreateCallbackOidcClient(config, provider)` wrapper that owns the callback's two former ternaries (the scopes null-guard and the redirect-path segment). Removes the duplication and takes `OidPost` under the cognitive-complexity threshold (S3776, `Refs #89`).

## Why it is behavior-preserving

- The two original inline blocks were verified **token-identical** in every shared field (both trims, `DisablePushedAuthorization`, `LoadProfile`, the `HttpClientFactory` lambda, the endpoint `Uri`, and the three `Policy.Discovery` negations `RequireHttps`/`ValidateIssuerName`/`ValidateEndpoints`), only `RedirectUri`/`Scope` differed, which are exactly the core's two parameters.
- Property-initializer order and failure points are preserved: a null `OidEndpoint` still throws at the `Uri` constructor after options assembly, in both callers.
- The caller asymmetries stay on their original sides: the callback tolerates a null scopes array (yielding the same `"openid profile  "` join artifact, empirically verified), the challenge still throws on it; the challenge's `NewPath`/`isLinking` handling is untouched.
- The callback's redirect-segment expression is kept verbatim, including its pre-existing always-`"r"` quirk (the `/start/` test never matches a callback path), now documented at the wrapper and tracked separately rather than silently changed.

## Verification

- Build clean (`--warnaserror --no-incremental`, Debug); 211/211 tests green.
- Two independent adversarial reviews (bypass-lens + correctness-lens) proved byte-equivalence, including a mechanical diff of both original blocks against the shared core and empirical probes of the null-scopes and exception-ordering behavior.

Refs #89