### PR TITLE
Drop the Copilot review step from the CODEOWNERS process note

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,8 +9,8 @@
 # maintainer as the only Code Owner a required-approval count (or "require
 # review from Code Owners") would deadlock every maintainer-authored PR — it is
 # therefore intentionally left off in the ruleset. The maintainer sign-off is
-# instead a process gate: every PR gets both a Copilot review and a mandatory
-# `iderex` review that confirms or rejects Copilot's findings before merge
+# instead a process gate: every PR gets a mandatory consolidated `iderex`
+# review before merge that documents the review findings and their resolution
 # (a Comment-event review on iderex-authored PRs, an approval on others).
 
 # Default owner for everything in the repo.


### PR DESCRIPTION
The Copilot code-review quota on the free plan is exhausted (first failure on #96), so the Copilot review step is removed from the PR process. The pre-merge review review remains the mandatory per-PR gate. This updates the CODEOWNERS process comment accordingly; `.github/copilot-instructions.md` stays in place and takes effect again if quota returns.

Comment-only change, no behavior.

Closes #99