### PR TITLE
Add CodeRabbit review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,48 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+#
+# Review output is limited to inline findings posted under the bot's own
+# identity; the summary/decoration features that would edit maintainer-authored
+# PR bodies are disabled. Path instructions encode the repo's standing security
+# invariants so the review checks against them explicitly.
+language: en-US
+reviews:
+  profile: assertive
+  high_level_summary: false
+  poem: false
+  review_status: false
+  sequence_diagrams: false
+  changed_files_summary: false
+  estimate_code_review_effort: false
+  in_progress_fortune: false
+  auto_review:
+    enabled: true
+  path_instructions:
+    - path: "SSO-Auth/Saml.cs"
+      instructions: |
+        Hand-rolled SAML 2.0 validation core on a login path. Fail-closed is the
+        invariant: a missing signature, time bound, audience, recipient, replay
+        check, or algorithm-allowlist match must reject, never default-accept.
+        Flag any change that weakens validation order, widens an algorithm
+        allowlist, softens a rejection into a pass, or touches XML parsing in a
+        way that could enable XXE or signature wrapping.
+    - path: "SSO-Auth/Api/**"
+      instructions: |
+        Login-path controllers and pure helpers. Privileges (admin, folder
+        access, Live TV) must only ever be granted monotonically from verified
+        claims/roles; login validity must never default to true. Secrets
+        (OidSecret, signing keys) must never be logged. Log-forging sanitizers
+        (ReplaceLineEndings) must appear inline at the log call site, not
+        behind a helper. Behavior-preserving refactors must preserve exception
+        types and evaluation order exactly.
+    - path: "SSO-Auth/Config/**"
+      instructions: |
+        Admin-only configuration persisted by Jellyfin. Flag config-save paths
+        that could wipe server-managed values, and new properties whose default
+        weakens the security posture (fail-open defaults are bugs).
+    - path: ".github/workflows/**"
+      instructions: |
+        Release pipeline and CI. Actions must be pinned to commit SHAs and
+        workflow permissions kept least-privilege. The MD5 .md5 sidecar in the
+        publish pipeline is load-bearing (the Jellyfin plugin manifest checksum
+        is read from it) — flag any change that drops it. Publishing must only
+        ever be triggered by a tag push.


### PR DESCRIPTION
Part of closing the review gap (`Refs #101`) after the Copilot review removal (#99).

Adds `.coderabbit.yaml` ahead of installing the CodeRabbit GitHub App (free Pro tier for public repositories):

- **Output discipline:** `high_level_summary`, `poem`, `review_status`, `sequence_diagrams`, `changed_files_summary`, `estimate_code_review_effort`, and `in_progress_fortune` are disabled, review output is limited to inline findings posted under the bot's own identity; nothing edits my own PR bodies.
- **Assertive profile** with auto-review on.
- **Path instructions** encode the repo's standing security invariants for `Saml.cs`, `SSO-Auth/Api/**`, `SSO-Auth/Config/**`, and `.github/workflows/**` (fail-closed validation, monotonic privilege grants, no secret logging, inline log sanitizers, SHA-pinned least-privilege CI, the load-bearing MD5 sidecar).

Config-only; takes effect once the app is installed on the repo.

Refs #101