### PR TITLE
Add a dependency-review PR gate

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Dependency review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Fail closed: any known vulnerability in a newly introduced or
+          # upgraded dependency blocks the PR. Relax only with a documented
+          # reason.
+          fail-on-severity: low


### PR DESCRIPTION
Part of closing the review gap (`Refs #101`).

Adds `.github/workflows/dependency-review.yml`: `actions/dependency-review-action` (SHA-pinned to v5.0.0, `permissions: contents: read`) runs on every PR and fails when a newly introduced or upgraded dependency has a known vulnerability (`fail-on-severity: low`, fail closed; to be relaxed only with a documented reason).

After merge, the `dependency-review` check is added to the required checks in the branch ruleset.

Refs #101