### PR TITLE
Lint the PR merge commit instead of checking out head_ref

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # Default checkout (the PR merge commit) — it is what should be linted,
+        # and checking out head_ref made the job an untrusted-checkout finding.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
       - name: Prettify code
         uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:


### PR DESCRIPTION
Fixes the first finding of the extended CodeQL suite (`actions/untrusted-checkout`, medium, code-scanning alert 8): the Prettier job checked out `github.head_ref` on pull requests. The override is unnecessary, the default checkout (the PR merge commit) is what should be linted, and removing it closes the alert. The job stays a dry-run `--check` with `contents: read`.