### PR TITLE
Bump setup-java and cache actions in the SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 17
           distribution: zulu
@@ -30,13 +30,13 @@ jobs:
           # A full clone lets SonarCloud attribute issues to the right commits/authors.
           fetch-depth: 0
       - name: Cache SonarCloud packages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache SonarCloud scanner
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ./.sonar/scanner
           key: ${{ runner.os }}-sonar-scanner


### PR DESCRIPTION
Applies the two Dependabot-proposed bumps (`actions/setup-java` 4.8.0 → 5.5.0, `actions/cache` 4.3.0 → 6.1.0, same commit SHAs) in a PR of my own, superseding #105 and #106: Dependabot-triggered workflow runs do not receive the Actions secrets, so the required SonarCloud check can never pass on them. The structural fix, mirroring `SONAR_TOKEN` into the Dependabot secrets store, is a setting I control; until then, Dependabot action bumps get re-raised this way.