### PR TITLE
Fail closed when a login resolves no identity

### DIFF
--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -152,6 +152,63 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void RoleGrantValid_NoUsernameClaim_IsNotValid()
+    {
+        // Fail closed (#95): a role matching the allow-list makes the login valid, but with no
+        // username claim (and no sub claim) there is no identity to log in — previously this minted
+        // a valid state whose null username failed downstream with a 500.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("role", "jellyfin-users")), config);
+
+        Assert.Null(result.Username);
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void RoleGrantValid_OnlySubClaim_IsNotValid()
+    {
+        // Fail closed (#95): the sub fallback only runs when the login is NOT yet valid, so a
+        // role-grant-valid login with only a sub claim never resolves a username — it is rejected,
+        // and the sub claim is deliberately NOT adopted (that would widen the fallback's semantics).
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("role", "jellyfin-users"), ("sub", "subject-123")),
+            config);
+
+        Assert.Null(result.Username);
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void EmptyUsernameClaimValue_IsNotValid()
+    {
+        // Fail closed (#95): an empty username claim value is no identity either.
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", string.Empty)), Config(_ => { }));
+
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void WhitespaceUsernameClaimValue_IsNotValid()
+    {
+        // Fail closed (#95): whitespace-only is no identity — Jellyfin's own username validation
+        // rejects it, so accepting it here could only ever produce a downstream 500.
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "   ")), Config(_ => { }));
+
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
     public void SubFallback_LastSubClaimWins()
     {
         var config = Config(c => c.Roles = Array.Empty<string>());

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -143,6 +143,15 @@ public class SamlResponseTests
     }
 
     [Fact]
+    public void GetNameID_MissingNameId_ReturnsNull()
+    {
+        // An assertion without a NameID must yield null (the callback rejects it as an invalid
+        // login), not throw — previously this was an unhandled NRE turning into a 500 (#95).
+        var fixture = SamlTestFactory.Create(includeNameId: false);
+        Assert.Null(Load(fixture).GetNameID());
+    }
+
+    [Fact]
     public void GetCustomAttribute_ValidResponse_ReturnsRole()
     {
         var fixture = SamlTestFactory.Create(role: "jellyfin-admins");

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -34,6 +34,7 @@ internal static class SamlTestFactory
     /// Produces a self-signed certificate plus a signed SAML response for the given subject/role.
     /// </summary>
     /// <param name="nameId">The value placed in saml:NameID.</param>
+    /// <param name="includeNameId">When false, the saml:NameID element is omitted entirely.</param>
     /// <param name="role">The value of the "Role" attribute.</param>
     /// <param name="notOnOrAfter">SubjectConfirmationData/@NotOnOrAfter; defaults to five minutes in the future.</param>
     /// <param name="includeNotOnOrAfter">When false, the NotOnOrAfter attribute is omitted entirely.</param>
@@ -46,6 +47,7 @@ internal static class SamlTestFactory
     /// <returns>A fixture exposing the certificate and the signed document.</returns>
     internal static SamlFixture Create(
         string nameId = "alice",
+        bool includeNameId = true,
         string role = "jellyfin-users",
         DateTime? notOnOrAfter = null,
         bool includeNotOnOrAfter = true,
@@ -108,7 +110,7 @@ internal static class SamlTestFactory
                     "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
                     conditions +
                     "<saml:Subject>" +
-                        "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" +
+                        (includeNameId ? "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" : string.Empty) +
                         "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
                             subjectConfirmationData +
                         "</saml:SubjectConfirmation>" +

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -81,10 +81,11 @@ internal static class AccountLinkResolver
 }
 
 /// <summary>
-/// Thrown when an SSO login resolves to a pre-existing, unlinked Jellyfin account and adopting such
-/// accounts is not permitted for the provider. The controller maps this to an HTTP 403. The message
-/// is deliberately generic — the identity-provider-supplied name is not embedded, since exception
-/// messages may be logged or reported elsewhere; the caller logs the sanitized name and context.
+/// Thrown when an SSO login must not create, adopt, or link an account — a pre-existing, unlinked
+/// Jellyfin account whose adoption the provider forbids, or a login without a resolvable identity.
+/// The controller maps this to an HTTP 403. Messages are deliberately generic — the
+/// identity-provider-supplied name is not embedded, since exception messages may be logged or
+/// reported elsewhere; the caller logs the sanitized name and context.
 /// </summary>
 internal sealed class AccountLinkForbiddenException : Exception
 {
@@ -93,6 +94,16 @@ internal sealed class AccountLinkForbiddenException : Exception
     /// </summary>
     internal AccountLinkForbiddenException()
         : base("An unlinked Jellyfin account already exists for this SSO identity, and adopting it is disabled for the provider (AllowExistingAccountLink).")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AccountLinkForbiddenException"/> class with a
+    /// specific message.
+    /// </summary>
+    /// <param name="message">The message; must not embed the provider-supplied name.</param>
+    internal AccountLinkForbiddenException(string message)
+        : base(message)
     {
     }
 }

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -62,6 +62,13 @@ internal static class OidcAuthorizeStateBuilder
             (username, valid) = ResolveSubFallback(claimList, config, username);
         }
 
+        // Fail closed (#95): a valid login must also have resolved an identity. A role matching the
+        // allow-list can make the login valid while no username/sub claim resolved a username; such a
+        // state used to reach account creation with a null name and fail with a 500 — reject it as an
+        // invalid login instead. Whitespace-only counts as unresolved: Jellyfin's own username
+        // validation rejects it anyway, so no legitimate login can carry one.
+        valid = valid && !string.IsNullOrWhiteSpace(username);
+
         return new OidcAuthorizeState(username, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
     }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -176,8 +176,8 @@ public class SSOController : ControllerBase
             else
             {
                 _logger.LogWarning(
-                    "OpenID user {Username} has one or more incorrect role claims: {@Claims}. Expected any one of: {@ExpectedClaims}",
-                    timedState.Username,
+                    "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
+                    timedState.Username?.ReplaceLineEndings(string.Empty),
                     result.User.Claims.Select(o => new { o.Type, o.Value }),
                     config.Roles);
 
@@ -634,10 +634,20 @@ public class SSOController : ControllerBase
             // here.
             var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
 
+            // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
+            // reject it as an invalid login instead of failing downstream on a null canonical name.
+            // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
+            var nameId = samlResponse.GetNameID();
+            if (string.IsNullOrWhiteSpace(nameId))
+            {
+                _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
+                return ReturnError(StatusCodes.Status401Unauthorized, "Error. Check permissions.");
+            }
+
             Guid userId;
             try
             {
-                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, samlResponse.GetNameID(), config.AllowExistingAccountLink).ConfigureAwait(false);
+                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
             }
             catch (AccountLinkForbiddenException)
             {
@@ -726,6 +736,14 @@ public class SSOController : ControllerBase
 
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName, bool allowExistingAccountLink)
     {
+        // Defense in depth (#95): a login without a resolvable identity must never create, adopt, or
+        // look up an account. Both callbacks reject such logins before calling here; this belt keeps
+        // the invariant if a future caller forgets.
+        if (string.IsNullOrWhiteSpace(canonicalName))
+        {
+            throw new AccountLinkForbiddenException("The SSO login did not resolve an identity; refusing to create or link an account.");
+        }
+
         // An identity already linked to a still-existing account is keyed on the canonical name.
         // A dangling link, whose user was since deleted, is treated as if there were no link.
         Guid? linkedUserId = null;
@@ -992,6 +1010,14 @@ public class SSOController : ControllerBase
 
     private ActionResult CreateCanonicalLink(string mode, string provider, Guid jellyfinUserId, string providerUserId)
     {
+        // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
+        // create a link — a null key would throw inside the config mutation (500), and an empty or
+        // whitespace key would persist a dead link no login can ever redeem.
+        if (string.IsNullOrWhiteSpace(providerUserId))
+        {
+            return BadRequest("The SSO login did not resolve an identity.");
+        }
+
         try
         {
             SSOPlugin.Instance.MutateConfiguration(configuration =>

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -178,7 +178,7 @@ public class SSOController : ControllerBase
                 _logger.LogWarning(
                     "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
                     timedState.Username?.ReplaceLineEndings(string.Empty),
-                    result.User.Claims.Select(o => new { o.Type, o.Value }),
+                    result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
                     config.Roles);
 
                 return ReturnError(StatusCodes.Status401Unauthorized, "Error. Check permissions.");
@@ -480,7 +480,7 @@ public class SSOController : ControllerBase
             _logger.LogWarning(
                 "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
                 samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-                samlResponse.GetCustomAttributes("Role"),
+                samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
                 config.Roles);
             return ReturnError(StatusCodes.Status401Unauthorized, "Error. Check permissions.");
         }

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -283,11 +283,12 @@ public class Response
     /// <summary>
     /// Gets the name ID attribute from the XML response.
     /// </summary>
-    /// <returns>The name ID attribute.</returns>
+    /// <returns>The name ID attribute, or null when the assertion carries no NameID (the caller
+    /// rejects such a login; previously this threw and surfaced as a 500).</returns>
     public string GetNameID()
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:NameID", _xmlNameSpaceManager);
-        return node.InnerText;
+        return node?.InnerText;
     }
 
     /// <summary>


### PR DESCRIPTION
## What

An OpenID login could end up **valid with no resolved username** (role allow-list match while the provider sent no username claim; the `sub` fallback only runs when the login is not yet valid), and a SAML assertion could arrive **without a NameID**. Both crashed downstream on the null identity, surfacing as 500s instead of a clean denial, and the SAML linking endpoint could persist a dead empty-string link. `Closes #95`.

## How

- **OIDC**: the builder clamps validity to a resolved identity (`valid && !IsNullOrWhiteSpace(username)`). Every state consumer gates on `Valid` via `IsRedeemableBy`, so session minting and OID linking are both covered at the single producer.
- **SAML**: `Response.GetNameID` returns null instead of throwing on a missing NameID; `SamlAuth` rejects a null/empty/whitespace NameID as an invalid login (401, logged) at the same point in the guard order as the old crash (replay consumption unchanged).
- **Linking choke point**: `CreateCanonicalLink` refuses an unresolved identity (400) before the config mutation, no null-key crash, no dead `""` link persisted.
- **Belt**: `CreateCanonicalLinkAndUserIfNotExist` throws (mapped to the existing generic 403) should a future caller forget the guard.
- The OID denial log names both causes instead of misattributing everything to role claims, with the username sanitized inline.

## Why no working login regresses

Verified against Jellyfin 10.11's `UserManager` semantics: every newly-rejected input class previously produced a 500 (`GetUserByName`/`CreateUserAsync` reject null/empty/whitespace names; null dictionary keys throw). The one removed "working" flow only ever produced empty-keyed links no login could redeem, closing the identity-collapse channel where every empty-identity user mapped onto one account. Whitespace-only counts as unresolved for the same reason.

## Verification

- Tests first: the new negative tests were red on main (verified), 221/221 green now on a clean rebuild; six new tests pin the clamp (no-username / only-sub / empty / whitespace), the null NameID return, and the deliberate non-adoption of `sub` for role-valid logins.
- Full four-lens adversarial gate: bypass, correctness, and availability PASS (including a red-on-main probe and an empirical check of Jellyfin's username validation); integration returned NEEDS_IMPROVEMENT with two findings, the unguarded SAML linking path and the misattributed denial log, both fixed in this PR and confirmed by a focused re-verify (PASS).
- Three new real-server E2E checklist items cover the rejection-path behavior CI cannot exercise.

Closes #95