### PR TITLE
Rebuild the OID callback redirect_uri from the callback's own route

### DIFF
--- a/SSO-Auth.Tests/OidcCallbackPathTests.cs
+++ b/SSO-Auth.Tests/OidcCallbackPathTests.cs
@@ -1,0 +1,56 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcCallbackPath.RedirectSegment"/> — the r/redirect choice for rebuilding
+/// the callback's redirect_uri. The token request's redirect_uri must match the authorization
+/// request's, and the IdP calls back on exactly the advertised route, so the segment must mirror
+/// the callback path. The old inline expression tested for "/start/" (never present on callback
+/// routes) and therefore always produced "r", breaking the new-path flow against spec-enforcing
+/// IdPs (#98).
+/// </summary>
+public class OidcCallbackPathTests
+{
+    [Theory]
+    [InlineData("/sso/OID/redirect/keycloak", "redirect")]
+    [InlineData("/sso/OID/r/keycloak", "r")]
+    [InlineData("/SSO/OID/Redirect/keycloak", "redirect")]
+    public void RedirectSegment_MirrorsTheCallbackRoute(string path, string expected)
+    {
+        Assert.Equal(expected, OidcCallbackPath.RedirectSegment(path));
+    }
+
+    [Theory]
+    // A provider NAMED "redirect" must never flip the classic route — including with a trailing
+    // slash, which a substring "/redirect/" test would wrongly match (the N1 corner both reviews
+    // flagged). Segment-exact matching keys only on the element right after "OID".
+    [InlineData("/sso/OID/r/redirect")]
+    [InlineData("/sso/OID/r/redirect/")]
+    [InlineData("/sso/OID/r/my-redirect-provider")]
+    public void RedirectSegment_ProviderNamedRedirect_OnClassicRoute_StaysR(string path)
+    {
+        Assert.Equal("r", OidcCallbackPath.RedirectSegment(path));
+    }
+
+    [Fact]
+    public void RedirectSegment_RedirectRouteWithProviderNamedRedirect_IsRedirect()
+    {
+        // The new-path route with a provider also named "redirect": the route segment (after OID)
+        // decides, so this is correctly "redirect".
+        Assert.Equal("redirect", OidcCallbackPath.RedirectSegment("/sso/OID/redirect/redirect"));
+    }
+
+    [Fact]
+    public void RedirectSegment_EmptyPath_DefaultsToClassic()
+    {
+        Assert.Equal("r", OidcCallbackPath.RedirectSegment(string.Empty));
+    }
+
+    [Fact]
+    public void RedirectSegment_NullPath_DefaultsToClassic()
+    {
+        Assert.Equal("r", OidcCallbackPath.RedirectSegment(null));
+    }
+}

--- a/SSO-Auth/Api/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/OidcCallbackPath.cs
@@ -1,0 +1,41 @@
+using System;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Derives the r/redirect path segment for rebuilding the callback's redirect URI. The token
+/// request's redirect_uri must match the authorization request's (RFC 6749 section 4.1.3), and the
+/// IdP delivers the callback on exactly the route the authorization request advertised — so the
+/// segment is read off the callback's own path. The previous expression tested for "/start/", a
+/// challenge-route segment that never occurs on callback routes, so the new-path flow sent a
+/// mismatched redirect_uri that spec-enforcing IdPs reject (#98).
+/// </summary>
+internal static class OidcCallbackPath
+{
+    /// <summary>
+    /// Returns the redirect-path segment ("redirect" or "r") matching the callback route in the given path.
+    /// </summary>
+    /// <param name="path">The callback request path, e.g. <c>/sso/OID/redirect/{provider}</c>.</param>
+    /// <returns>"redirect" when the route segment (the element after "OID") is "redirect", otherwise "r".</returns>
+    internal static string RedirectSegment(string? path)
+    {
+        // Match the route segment exactly (the element after "OID"), not by substring: a provider
+        // literally named "redirect" must never flip the classic route, regardless of trailing
+        // slashes or where "redirect" appears in the provider name.
+        var segments = path?.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments is not null)
+        {
+            for (var i = 0; i + 1 < segments.Length; i++)
+            {
+                if (string.Equals(segments[i], "OID", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Equals(segments[i + 1], "redirect", StringComparison.OrdinalIgnoreCase) ? "redirect" : "r";
+                }
+            }
+        }
+
+        return "r";
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -277,15 +277,15 @@ public class SSOController : ControllerBase
         return new OidcClient(options);
     }
 
-    // Callback-side client: the redirect URI is rebuilt with the same expression the callback always
-    // used — a "/start/" test against the callback path, which never contains it, so the segment is
-    // always "r" (pre-existing quirk, deliberately preserved; strict IdPs fail closed on a mismatch).
-    // A null scopes array is tolerated here but not on the challenge side — also a pre-existing
-    // asymmetry deliberately preserved.
+    // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls
+    // back on exactly the route the authorization request advertised), so the token request's
+    // redirect_uri matches the authorization request's as RFC 6749 requires (#98). A null scopes
+    // array is tolerated here but not on the challenge side — a pre-existing asymmetry deliberately
+    // preserved.
     private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
     {
         var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
-        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{(Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase) ? "redirect" : "r")}/" + provider;
+        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{OidcCallbackPath.RedirectSegment(Request.Path.Value)}/" + provider;
         return CreateOidcClient(config, redirectUri, string.Join(" ", scopes.Prepend("openid profile")));
     }
 


### PR DESCRIPTION
Fixes #98. The OID callback rebuilt the token-request `redirect_uri` segment with a `/start/` test that never matches a callback route (`OID/r` or `OID/redirect`), so it always emitted `r`. A login started on the new-path route (`OID/start`, which advertises `OID/redirect`) then sent `redirect_uri=.../r/...` to the token endpoint while the authorization request used `.../redirect/...`, RFC 6749 §4.1.3 mismatch, rejected by spec-enforcing IdPs. The classic `/p/` flow (both sides `r`) was unaffected, which is why it went unnoticed.

## Fix

A pure, tested helper `OidcCallbackPath.RedirectSegment` derives the segment from the callback's own route. The IdP delivers the callback on exactly the route the authorization request advertised, so mirroring the callback path makes both `redirect_uri`s match for every flow (including linking, which reuses `config.NewPath`, now no longer read at callback time). The match is **segment-exact** (the element after `OID`), not a substring, so a provider literally named `redirect` cannot flip the classic route even with a trailing slash.

## Verification

- Tests first; 230/230 green, build clean (`--warnaserror`). Nine helper tests pin both routes, case-insensitivity, the provider-named-`redirect` corner (classic and new-path), and null/empty paths.
- Two independent adversarial reviews (bypass + correctness) PASS on the base fix: both traced the full mint chain (nothing mints before a successful token exchange; `redirect_uri` is an IdP-side verification value, so any wrong segment fails closed at the exchange, never a bypass) and empirically probed `%2F`, trailing-slash, query-injection, and null-path manipulation on Kestrel. Both flagged one non-blocking, fail-closed corner (substring match + provider named `redirect` + trailing slash); this PR closes it outright with segment-exact matching and a pinning test.

Closes #98