### PR TITLE
Prohibit DTD processing when parsing the SAML response (XXE / DoS)

### DIFF
--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -34,6 +34,74 @@ public class SamlResponseTests
     }
 
     [Fact]
+    public void Constructor_DocumentWithDoctype_IsRejected()
+    {
+        // Untrusted SAML input must not carry a DTD: XmlResolver=null blocks only external entities,
+        // but an internal DTD still expands entities (a billion-laughs style DoS). DtdProcessing is
+        // prohibited, so a DOCTYPE is rejected outright at parse time (fail-closed). A well-formed
+        // SAML assertion never has one.
+        var withDoctype =
+            "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE samlp:Response [ <!ENTITY x \"expanded\"> ]>" +
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
+                "<saml:Assertion><saml:Subject><saml:NameID>&x;</saml:NameID></saml:Subject></saml:Assertion>" +
+            "</samlp:Response>";
+        Assert.Throws<XmlException>(() =>
+            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(withDoctype)));
+    }
+
+    [Fact]
+    public void Constructor_BillionLaughsEntityExpansion_IsRejected()
+    {
+        // The classic nested-entity amplification: it must be rejected at parse time (DTD prohibited)
+        // rather than expanded into a memory blow-up.
+        var billionLaughs =
+            "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE lolz [" +
+            "<!ENTITY lol \"lol\">" +
+            "<!ENTITY lol2 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">" +
+            "<!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">" +
+            "]>" +
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
+                "<saml:Assertion><saml:Subject><saml:NameID>&lol3;</saml:NameID></saml:Subject></saml:Assertion>" +
+            "</samlp:Response>";
+        Assert.Throws<XmlException>(() =>
+            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(billionLaughs)));
+    }
+
+    [Fact]
+    public void Constructor_ExternalEntityDoctype_IsRejected()
+    {
+        // The classic XXE/SSRF shape (an external SYSTEM entity). XmlResolver=null already blocks the
+        // fetch, but DtdProcessing.Prohibit rejects the DOCTYPE outright — belt and suspenders.
+        var xxe =
+            "<?xml version=\"1.0\"?>" +
+            "<!DOCTYPE samlp:Response [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>" +
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
+                "<saml:Assertion><saml:Subject><saml:NameID>&xxe;</saml:NameID></saml:Subject></saml:Assertion>" +
+            "</samlp:Response>";
+        Assert.Throws<XmlException>(() =>
+            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xxe)));
+    }
+
+    [Fact]
+    public void Constructor_DoctypePrependedToSignedResponse_IsRejectedBeforeSignatureCheck()
+    {
+        // A DOCTYPE smuggled in front of an otherwise-valid, correctly-signed response must be
+        // rejected at parse time — DTD rejection pre-empts signature acceptance, so an attacker
+        // cannot pair a valid signature with a malicious DTD.
+        var fixture = SamlTestFactory.Create();
+        var signedXml = fixture.Document.OuterXml;
+        var declarationEnd = signedXml.IndexOf("?>", System.StringComparison.Ordinal);
+        var withDoctype = declarationEnd >= 0
+            ? signedXml.Insert(declarationEnd + 2, "<!DOCTYPE samlp:Response [ <!ENTITY x \"y\"> ]>")
+            : "<!DOCTYPE samlp:Response [ <!ENTITY x \"y\"> ]>" + signedXml;
+
+        Assert.Throws<XmlException>(() =>
+            new Response(fixture.CertificateBase64, SamlFixture.Encode(withDoctype)));
+    }
+
+    [Fact]
     public void IsValid_NoSignature_ReturnsFalse()
     {
         // A well-formed but entirely unsigned response must never validate.

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -77,9 +77,27 @@ public class Response
     public void LoadXml(string xml)
     {
         _xmlDoc = new XmlDocument();
+
+        // PreserveWhitespace is load-bearing for XML signature validation (canonicalization depends
+        // on the exact whitespace), so it must stay true.
         _xmlDoc.PreserveWhitespace = true;
         _xmlDoc.XmlResolver = null;
-        _xmlDoc.LoadXml(xml);
+
+        // The SAML response is untrusted input. Reject any DTD/DOCTYPE outright: XmlResolver=null
+        // alone blocks only EXTERNAL entities (XXE/SSRF), while an internal DTD still expands
+        // entities (a billion-laughs style denial of service). DtdProcessing.Prohibit makes the
+        // reader throw on a DOCTYPE, which is the fail-closed posture; a well-formed SAML assertion
+        // never carries one.
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+        };
+        using (var stringReader = new StringReader(xml))
+        using (var reader = XmlReader.Create(stringReader, settings))
+        {
+            _xmlDoc.Load(reader);
+        }
 
         _xmlNameSpaceManager = GetNamespaceManager(); // lets construct a "manager" for XPath queries
     }


### PR DESCRIPTION
Closes #119 (P2#9). Refs #120.

`Response.LoadXml` parsed the untrusted SAML response with `XmlResolver=null` but plain `XmlDocument.LoadXml`, which (confirmed by a probe against the current code) **allowed an internal DTD and expanded its entities**. `XmlResolver=null` blocks only *external* entities (XXE/SSRF); the internal-entity billion-laughs amplification DoS was open.

## Fix

Load via `XmlReader` with `DtdProcessing.Prohibit` + `XmlResolver=null`, so any `<!DOCTYPE>` is rejected at parse (fail-closed). `PreserveWhitespace=true` is retained, load-bearing for XML signature canonicalization.

Two properties the reviews established beyond the DoS fix:
- The `XmlReader` applies XML 1.0 EOL/attribute normalization, which is the infoset form conformant IdP signing stacks digest against, so signature interop is **preserved and slightly improved**, not regressed (the old non-normalizing `LoadXml` could actually fail a conformant signature over CRLF-pretty content).
- Prohibiting DTDs closes a DTD-declared-ID parser-differential that could otherwise influence signed-element resolution (`SignedXml.GetIdElement`). The anti-XSW `ValidateSignatureReference` binding is untouched.

## Verification

- Tests-first (the probe proved the old parser expanded entities); 234/234 green, build clean (`--warnaserror`). Four new characterization tests: DOCTYPE rejected, billion-laughs rejected, external-entity XXE rejected, and a DOCTYPE smuggled in front of an otherwise-valid **signed** response rejected before the signature check.
- Full adversarial gate, **five** reviews all PASS: bypass, availability, integration, correctness-via-SAML-domain reviewer, each with independent empirical probes. Availability and bypass independently signed CRLF/pretty/declaration/comment document shapes and confirmed old-and-new both validate (no canonicalization regression); the SAML-domain reviewer confirmed the change is spec-conformant (SAML 2.0 core forbids DTDs) and net-positive for interop.
- The one behavioral change (a DOCTYPE-bearing response now throws `XmlException` → 500) joins the pre-existing uncaught-parse-error class at all three call sites; fail-closed, no new session/client surface.

The follow-up interop regression test (a CRLF-signed response validating through the new reader, empirically proven by three probes but needing a carefully-built raw-wire fixture to avoid an `OuterXml`-escaping false pass) is tracked in #120. A local E2E-checklist note covers the same property on a real server.

Closes #119