### PR TITLE
Set defensive response headers on the rendered auth page

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -172,7 +172,7 @@ public class SSOController : ControllerBase
             if (timedState.Valid)
             {
                 _logger.LogInformation("Is request linking: {IsLinking}", isLinking);
-                return Content(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride), mode: "OID", isLinking: isLinking), MediaTypeNames.Text.Html);
+                return HtmlAuthPage(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride), mode: "OID", isLinking: isLinking));
             }
             else
             {
@@ -468,14 +468,13 @@ public class SSOController : ControllerBase
 
             if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
             {
-                return Content(
-                        WebResponse.Generator(
-                            data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
-                            provider: provider,
-                            baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride),
-                            mode: "SAML",
-                            isLinking: isLinking),
-                        MediaTypeNames.Text.Html);
+                return HtmlAuthPage(
+                    WebResponse.Generator(
+                        data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
+                        provider: provider,
+                        baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride),
+                        mode: "SAML",
+                        isLinking: isLinking));
             }
 
             _logger.LogWarning(
@@ -1321,6 +1320,21 @@ public class SSOController : ControllerBase
         errorResult.ContentType = MediaTypeNames.Text.Plain;
         errorResult.StatusCode = code;
         return errorResult;
+    }
+
+    // Returns the rendered auth page as HTML with defensive response headers. The page carries the
+    // one-time state token / signed assertion and completes the login from an inline script, so it
+    // must not be framed (clickjacking), MIME-sniffed, cached, or leak its URL via Referer. A
+    // Content-Security-Policy is intentionally NOT set here: the page relies on an inline script and
+    // style, so a safe CSP needs per-response nonces threaded into WebResponse.Generator — tracked
+    // separately (it needs a real-server check that the login page still runs).
+    private ContentResult HtmlAuthPage(string html)
+    {
+        Response.Headers["X-Frame-Options"] = "DENY";
+        Response.Headers["X-Content-Type-Options"] = "nosniff";
+        Response.Headers["Referrer-Policy"] = "no-referrer";
+        Response.Headers.CacheControl = "no-store";
+        return Content(html, MediaTypeNames.Text.Html);
     }
 }
 


### PR DESCRIPTION
Closes #122 (P2#13).

The plugin renders an HTML auth page (OID and SAML) that carries the one-time state token / signed assertion and completes the login from an inline script. This routes both render sites through a `HtmlAuthPage` helper that sets:

- `X-Frame-Options: DENY`, clickjacking (the page is always top-level, never legitimately framed);
- `X-Content-Type-Options: nosniff`;
- `Referrer-Policy: no-referrer`, the OID callback URL carries `code`/`state`; stops it leaking via Referer;
- `Cache-Control: no-store`, a token-bearing page must not be cached.

Purely additive, adds headers, removes/alters no validation; reached only after the login gates pass.

## Deferred: CSP

No `Content-Security-Policy` here, the page uses an inline `<script>` and `<style>`, so a page-preserving CSP needs per-response nonces threaded into `WebResponse.Generator` plus a real-server check. Tracked in #123. The residual XSS surface without CSP is already narrow (reflected values are `JsonSerializer`-encoded).

## Verification

- Build clean (`--warnaserror`), 234/234. Not unit-testable at the controller level (no controller test host); verification is the E2E checklist.
- Two adversarial reviews (bypass + integration) PASS. Both confirmed the headers only harden the two top-level success responses and cannot gate login: `DENY` stops the page being framed, not the `iframe` it loads; the same-origin `/sso/*/Auth` XHR reads neither `Referer` nor a sniffed type. Integration flagged one E2E-gated caveat, confirm the account-**linking** flow lands top-level (not iframed) on a real jellyfin-web 10.11 server so `DENY` doesn't block link completion; added to the E2E checklist. Not a code defect (primary login is unambiguously top-level).

Closes #122