### PR TITLE
Add FsCheck property tests over the pure login-decision helpers

### DIFF
--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -152,6 +152,24 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void RoleClaimValidatesLoginButNoUsername_IsNotValid()
+    {
+        // The exact #95 role path: a role claim matching the allow-list makes the login valid via the
+        // role-grant merge (not the username branch), but with no username/sub claim there is no
+        // identity — the final clamp must reject it. Exercises grants.Valid=true with a null username.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("role", "jellyfin-users")), config);
+
+        Assert.Null(result.Username);
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
     public void RoleGrantValid_NoUsernameClaim_IsNotValid()
     {
         // Fail closed (#95): a role matching the allow-list makes the login valid, but with no

--- a/SSO-Auth.Tests/OidcRolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/OidcRolePrivilegeMapperTests.cs
@@ -21,6 +21,35 @@ public class OidcRolePrivilegeMapperTests
     }
 
     [Fact]
+    public void UnauthorizedRole_WithPopulatedConfig_GrantsNothing()
+    {
+        // Monotonicity alone would be satisfied by a mapper that grants everything; this pins the
+        // complement — a role on NONE of the (populated) configured lists receives no privilege and
+        // is not valid.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "user" };
+            c.AdminRoles = new[] { "admin" };
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tvadmin" };
+        });
+
+        var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "outsider" }, config);
+
+        Assert.False(grants.Valid);
+        Assert.False(grants.Admin);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+        Assert.Empty(grants.Folders);
+    }
+
+    [Fact]
     public void NoConfiguredRoles_GrantsNothing()
     {
         var grants = OidcRolePrivilegeMapper.Evaluate(new[] { "anything" }, Config(_ => { }));

--- a/SSO-Auth.Tests/PropertyTests.cs
+++ b/SSO-Auth.Tests/PropertyTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using FsCheck;
+using FsCheck.Fluent;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Property-based tests over the pure login-decision helpers. Each pins a security invariant that
+/// must hold for ALL inputs, not just the hand-picked characterization cases. Driven by FsCheck core
+/// from ordinary xUnit v3 facts (no FsCheck.Xunit, so no xunit-version coupling).
+///
+/// The generators deliberately bias toward the meaningful tokens (the configured claim types and
+/// role names) mixed with random noise: purely random strings would essentially never match a
+/// configured role or the "preferred_username"/"sub" claim types, so the interesting branches
+/// (Valid==true, a granted privilege) would almost never be exercised and the properties would pass
+/// vacuously. The bias makes the grant/validity paths actually fire.
+/// </summary>
+public class PropertyTests
+{
+    private static readonly string[] KnownClaimTypes = { "preferred_username", "sub", "email", "role", "groups" };
+    private static readonly string[] KnownRoles = { "admin", "user", "tv", "tvadmin", "media", "outsider", "" };
+
+    // A token that is usually one of the meaningful values but sometimes arbitrary noise.
+    private static Gen<string> TokenGen(string[] known) =>
+        Gen.OneOf(new[]
+        {
+            Gen.Elements(known),
+            ArbMap.Default.GeneratorFor<string>().Where(s => s != null),
+        });
+
+    private static Gen<List<string>> RolesGen =>
+        TokenGen(KnownRoles).ListOf().Select(rs => rs.ToList());
+
+    private static Gen<List<Claim>> ClaimsGen =>
+        TokenGen(KnownClaimTypes)
+            .Zip(ArbMap.Default.GeneratorFor<string>())
+            .Select(pair => new Claim(pair.Item1, pair.Item2 ?? string.Empty))
+            .ListOf()
+            .Select(cs => cs.ToList());
+
+    [Fact]
+    public void OidcBuild_ValidLoginAlwaysResolvesAUsername()
+    {
+        // The #95 invariant, universally: a login the OID builder marks Valid must always carry a
+        // non-whitespace username. Roles is a non-null empty allow-list so the sub fallback does not
+        // hit its documented null-Roles throw.
+        Prop.ForAll(ClaimsGen.ToArbitrary(), claims =>
+        {
+            var config = new OidConfig { Roles = Array.Empty<string>() };
+            var result = OidcAuthorizeStateBuilder.Build(claims, config);
+            return !result.Valid || !string.IsNullOrWhiteSpace(result.Username);
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Fact]
+    public void SamlEvaluate_GrantsAreMonotonicInRoles()
+    {
+        // Adding roles can only ever ADD privileges (the mapper OR-s across roles); it can never
+        // revoke a grant. So the grants for a superset of roles dominate those for the subset.
+        Prop.ForAll(RolesGen.ToArbitrary(), RolesGen.ToArbitrary(), (roles, extra) =>
+        {
+            var config = SamlGrantConfig();
+            var superset = roles.Concat(extra).ToList();
+
+            var g1 = SamlRolePrivilegeMapper.Evaluate(roles, config);
+            var g2 = SamlRolePrivilegeMapper.Evaluate(superset, config);
+
+            return (!g1.Admin || g2.Admin)
+                && (!g1.EnableLiveTv || g2.EnableLiveTv)
+                && (!g1.EnableLiveTvManagement || g2.EnableLiveTvManagement)
+                && g1.Folders.All(g2.Folders.Contains);
+        }).QuickCheckThrowOnFailure();
+    }
+
+    [Fact]
+    public void OidcEvaluate_GrantsAreMonotonicInRoles()
+    {
+        // Same monotonicity for the OpenID mapper: more roles never remove a granted privilege.
+        Prop.ForAll(RolesGen.ToArbitrary(), RolesGen.ToArbitrary(), (roles, extra) =>
+        {
+            var config = OidGrantConfig();
+            var superset = roles.Concat(extra).ToList();
+
+            var g1 = OidcRolePrivilegeMapper.Evaluate(roles, config);
+            var g2 = OidcRolePrivilegeMapper.Evaluate(superset, config);
+
+            return (!g1.Valid || g2.Valid)
+                && (!g1.Admin || g2.Admin)
+                && (!g1.EnableLiveTv || g2.EnableLiveTv)
+                && (!g1.EnableLiveTvManagement || g2.EnableLiveTvManagement)
+                && g1.Folders.All(g2.Folders.Contains);
+        }).QuickCheckThrowOnFailure();
+    }
+
+    private static SamlConfig SamlGrantConfig() => new SamlConfig
+    {
+        AdminRoles = new[] { "admin" },
+        EnableFolderRoles = true,
+        FolderRoleMapping = new List<FolderRoleMap>
+        {
+            new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+        },
+        EnableLiveTvRoles = true,
+        LiveTvRoles = new[] { "tv" },
+        LiveTvManagementRoles = new[] { "tvadmin" },
+    };
+
+    private static OidConfig OidGrantConfig() => new OidConfig
+    {
+        Roles = new[] { "user" },
+        AdminRoles = new[] { "admin" },
+        EnableFolderRoles = true,
+        FolderRoleMapping = new List<FolderRoleMap>
+        {
+            new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+        },
+        EnableLiveTvRoles = true,
+        LiveTvRoles = new[] { "tv" },
+        LiveTvManagementRoles = new[] { "tvadmin" },
+    };
+}

--- a/SSO-Auth.Tests/SSO-Auth.Tests.csproj
+++ b/SSO-Auth.Tests/SSO-Auth.Tests.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Property-based testing. FsCheck core only (depends on FSharp.Core, not xunit): properties
+         are driven from ordinary xUnit v3 [Fact]s via Prop.ForAll(...).QuickCheckThrowOnFailure(),
+         avoiding the FsCheck.Xunit ↔ xunit-version coupling. -->
+    <PackageReference Include="FsCheck" Version="3.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/SSO-Auth.Tests/SamlRolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/SamlRolePrivilegeMapperTests.cs
@@ -23,6 +23,32 @@ public class SamlRolePrivilegeMapperTests
     }
 
     [Fact]
+    public void UnauthorizedRole_WithPopulatedConfig_GrantsNothing()
+    {
+        // Complement to monotonicity: a role on none of the (populated) configured lists receives no
+        // privilege. (SAML has no Valid; validity is decided by SamlLoginPolicy.)
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admin" };
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { "tv" };
+            c.LiveTvManagementRoles = new[] { "tvadmin" };
+        });
+
+        var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "outsider" }, config);
+
+        Assert.False(grants.Admin);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+        Assert.Empty(grants.Folders);
+    }
+
+    [Fact]
     public void NoConfiguredRoles_GrantsNothing()
     {
         var grants = SamlRolePrivilegeMapper.Evaluate(new[] { "anything" }, Config(_ => { }));

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net9.0": {
+      "FsCheck": {
+        "type": "Direct",
+        "requested": "[3.3.3, )",
+        "resolved": "3.3.3",
+        "contentHash": "FtJSNzekCwoVTJPLZwK2In1cr9PhIo6WAX/RSM7BL/jQERgnO0111+hdcN14pcog9BByJmqehBrMbjjKpHZULg==",
+        "dependencies": {
+          "FSharp.Core": "5.0.2"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.7.0, )",
@@ -53,6 +62,11 @@
           "Duende.IdentityModel": "8.1.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
         }
+      },
+      "FSharp.Core": {
+        "type": "Transitive",
+        "resolved": "5.0.2",
+        "contentHash": "DpcajqENgb3VXaHw1FKfVS+TWwEzck1PCajqLwBAVrtd1lfxd7T8JISVZBdV1mX9+2g48+tIgpNaVJWObdMrBw=="
       },
       "ICU4N": {
         "type": "Transitive",


### PR DESCRIPTION
Closes #126 (P5b, verification depth).

Property-based tests pinning three security invariants across arbitrary inputs:

- **`OidcAuthorizeStateBuilder.Build`**, a `Valid` login always resolves a non-whitespace username (the #95 invariant, universally).
- **`OidcRolePrivilegeMapper.Evaluate` / `SamlRolePrivilegeMapper.Evaluate`**, grants are monotonic in the role set: adding roles never revokes a privilege.

## Design

- **FsCheck core only** (depends on `FSharp.Core`, not xunit), driven from ordinary xUnit v3 `[Fact]`s via `Prop.ForAll(...).QuickCheckThrowOnFailure()`, avoids the `FsCheck.Xunit` ↔ xunit-version coupling that would fight the xunit.v3 / Microsoft Testing Platform setup. New dependency captured in the committed `packages.lock.json` (restores clean under CI locked-mode).
- **Non-vacuous by construction**: generators bias role/claim-type tokens toward the configured values mixed with random noise, so the Valid/grant branches actually fire (~69% of trials grant a privilege, measured) rather than passing trivially.
- **Total invariants, no flakiness**: each holds for all inputs (clamp postcondition; OR/accumulate structure), so the per-run random seed cannot find a counterexample.

## Verification

- Build clean (`--warnaserror`), 237/237 (each property runs its 100 cases).
- Meaningfulness proven by mutation, twice: breaking the #95 clamp made the username property `Falsifiable after 6 tests`, and rewriting the SAML admin OR into an overwrite made the monotonicity property `Falsifiable after 19 tests`. One correctness-lens adversarial review PASS (empirical non-vacuity, no-throw-in-generation, no seed-dependent flakiness).

Closes #126