### PR TITLE
Make string comparisons explicitly ordinal on the auth path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -39,12 +39,12 @@ dotnet_diagnostic.SA1649.severity = none
 # is worked through deliberately in follow-ups (several are behavior-relevant
 # on the login path — string-comparison semantics must not change in a config
 # PR).
-dotnet_diagnostic.CA1309.severity = suggestion
+dotnet_diagnostic.CA1309.severity = error
 dotnet_diagnostic.CA1311.severity = suggestion
 dotnet_diagnostic.CA1848.severity = suggestion
 dotnet_diagnostic.RCS1194.severity = suggestion
 dotnet_diagnostic.MA0002.severity = suggestion
-dotnet_diagnostic.MA0006.severity = suggestion
+dotnet_diagnostic.MA0006.severity = error
 dotnet_diagnostic.MA0011.severity = suggestion
 dotnet_diagnostic.MA0015.severity = suggestion
 dotnet_diagnostic.MA0016.severity = suggestion

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -26,7 +26,7 @@ internal static class AvatarUrlValidator
             return false;
         }
 
-        if (parsed.Scheme != Uri.UriSchemeHttp && parsed.Scheme != Uri.UriSchemeHttps)
+        if (!string.Equals(parsed.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal) && !string.Equals(parsed.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
         {
             return false;
         }

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -110,7 +110,7 @@ internal static class OidcAuthorizeStateBuilder
         var roles = new List<string>();
         foreach (var claim in claims)
         {
-            if (claim.Type == (config.DefaultUsernameClaim?.Trim() ?? "preferred_username"))
+            if (string.Equals(claim.Type, config.DefaultUsernameClaim?.Trim() ?? "preferred_username", StringComparison.Ordinal))
             {
                 username = claim.Value;
                 if (config.Roles == null || config.Roles.Length == 0)
@@ -119,7 +119,7 @@ internal static class OidcAuthorizeStateBuilder
                 }
             }
 
-            if (roleClaimSegments.Length > 0 && claim.Type == roleClaimSegments[0])
+            if (roleClaimSegments.Length > 0 && string.Equals(claim.Type, roleClaimSegments[0], StringComparison.Ordinal))
             {
                 roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
             }
@@ -135,7 +135,7 @@ internal static class OidcAuthorizeStateBuilder
         var valid = false;
         foreach (var claim in claims)
         {
-            if (claim.Type == "sub")
+            if (string.Equals(claim.Type, "sub", StringComparison.Ordinal))
             {
                 username = claim.Value;
 

--- a/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -30,12 +31,12 @@ internal static class OidcRolePrivilegeMapper
 
         foreach (var role in roles)
         {
-            if (config.Roles != null && config.Roles.Any(allowed => role.Equals(allowed)))
+            if (config.Roles != null && config.Roles.Any(allowed => role.Equals(allowed, StringComparison.Ordinal)))
             {
                 valid = true;
             }
 
-            if (config.AdminRoles != null && config.AdminRoles.Any(adminRole => role.Equals(adminRole)))
+            if (config.AdminRoles != null && config.AdminRoles.Any(adminRole => role.Equals(adminRole, StringComparison.Ordinal)))
             {
                 admin = true;
             }
@@ -47,7 +48,7 @@ internal static class OidcRolePrivilegeMapper
                 // when FolderRoleMapping is null (an admin misconfiguration; fails closed). Tracked in #89.
                 foreach (var folderRoleMap in config.FolderRoleMapping)
                 {
-                    if (role.Equals(folderRoleMap.Role?.Trim()))
+                    if (role.Equals(folderRoleMap.Role?.Trim(), StringComparison.Ordinal))
                     {
                         folders.AddRange(folderRoleMap.Folders);
                     }
@@ -56,12 +57,12 @@ internal static class OidcRolePrivilegeMapper
 
             if (config.EnableLiveTvRoles)
             {
-                if (config.LiveTvRoles != null && config.LiveTvRoles.Any(liveTvRole => role.Equals(liveTvRole)))
+                if (config.LiveTvRoles != null && config.LiveTvRoles.Any(liveTvRole => role.Equals(liveTvRole, StringComparison.Ordinal)))
                 {
                     enableLiveTv = true;
                 }
 
-                if (config.LiveTvManagementRoles != null && config.LiveTvManagementRoles.Any(managementRole => role.Equals(managementRole)))
+                if (config.LiveTvManagementRoles != null && config.LiveTvManagementRoles.Any(managementRole => role.Equals(managementRole, StringComparison.Ordinal)))
                 {
                     enableLiveTvManagement = true;
                 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -449,7 +449,7 @@ public class SSOController : ControllerBase
             return BadRequest(NoMatchingProviderMessage);
         }
 
-        bool isLinking = relayState == "linking";
+        bool isLinking = string.Equals(relayState, "linking", StringComparison.Ordinal);
 
         // relayState is attacker-controllable; strip line endings inline at the log call to prevent
         // log forging (structured logging alone does not sanitize a newline-bearing value).
@@ -1299,7 +1299,7 @@ public class SSOController : ControllerBase
             requestPort = -1;
         }
 
-        if (schemeOverride != "http" && schemeOverride != "https")
+        if (!string.Equals(schemeOverride, "http", StringComparison.Ordinal) && !string.Equals(schemeOverride, "https", StringComparison.Ordinal))
         {
             schemeOverride = null;
         }

--- a/SSO-Auth/Api/SamlRolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/SamlRolePrivilegeMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
@@ -37,7 +38,7 @@ internal static class SamlRolePrivilegeMapper
             {
                 foreach (string allowedRole in config.AdminRoles)
                 {
-                    if (allowedRole.Equals(role))
+                    if (allowedRole.Equals(role, StringComparison.Ordinal))
                     {
                         admin = true;
                     }
@@ -48,7 +49,7 @@ internal static class SamlRolePrivilegeMapper
             {
                 foreach (FolderRoleMap folderRoleMap in config.FolderRoleMapping)
                 {
-                    if (folderRoleMap.Role.Equals(role))
+                    if (folderRoleMap.Role.Equals(role, StringComparison.Ordinal))
                     {
                         folders.AddRange(folderRoleMap.Folders);
                     }
@@ -61,7 +62,7 @@ internal static class SamlRolePrivilegeMapper
                 {
                     foreach (string allowedLiveTvRole in config.LiveTvRoles)
                     {
-                        if (allowedLiveTvRole.Equals(role))
+                        if (allowedLiveTvRole.Equals(role, StringComparison.Ordinal))
                         {
                             enableLiveTv = true;
                         }
@@ -72,7 +73,7 @@ internal static class SamlRolePrivilegeMapper
                 {
                     foreach (string allowedLiveTvManagementRole in config.LiveTvManagementRoles)
                     {
-                        if (allowedLiveTvManagementRole.Equals(role))
+                        if (allowedLiveTvManagementRole.Equals(role, StringComparison.Ordinal))
                         {
                             enableLiveTvManagement = true;
                         }

--- a/SSO-Auth/Views/SSOViewsController.cs
+++ b/SSO-Auth/Views/SSOViewsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -51,7 +52,7 @@ public class SSOViewsController : ControllerBase
             return NotFound("Pages is null or empty");
         }
 
-        var view = pages.FirstOrDefault(pageInfo => pageInfo.Name == viewName, null);
+        var view = pages.FirstOrDefault(pageInfo => string.Equals(pageInfo.Name, viewName, StringComparison.Ordinal), null);
 
         if (view == null)
         {


### PR DESCRIPTION
Closes #129 (first analyzer-backlog family from #104, chosen because it is security-adjacent and behavior-preserving).

Converts 18 comparison sites to explicit `StringComparison.Ordinal` and promotes `CA1309` + `MA0006` from suggestion to error. C# `string ==`/`!=` and instance `string.Equals(string)` are already ordinal, so no match outcome changes, but making it explicit on the security-critical comparisons (role allow-list, admin/Live-TV matching, claim-type matching, the avatar SSRF scheme allowlist) prevents a future refactor from silently introducing a culture-sensitive comparison, and it clears the family so it stays enforced.

## Behavior-preserving, carefully

- The role mappers keep the **instance** `.Equals(x, Ordinal)` overload (receiver unchanged), preserving the SAML mapper's documented NRE on a null configured role (pinned by `NullConfiguredAdminRole_Throws`), a switch to static `string.Equals` would have made it null-safe and turned that misconfiguration fail-open. Only the `==`/`!=` operator sites became the null-safe static form.
- The genuinely case-**insensitive** sites (localhost SSRF host check, scheme/port normalization, media-type prefix, OID `r`/`redirect` path segment) are deliberately left `OrdinalIgnoreCase`, converting them would be a real regression (e.g. a `LocalHost` host bypassing the SSRF guard).

## Verification

- Build clean (`--warnaserror` with the two rules at error → proves all sites addressed, none missed), 240/240 tests including the null-quirk facts and the FsCheck monotonicity properties.
- Two adversarial reviews (bypass + correctness) PASS: per-site equivalence proven, instance-vs-static null semantics verified per site, negations logically identical, and the intentional case-insensitive sites confirmed untouched.

Refs #104
Closes #129