### PR TITLE
Add a structured SSO audit log

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -46,6 +46,10 @@ public class SSOController : ControllerBase
     private const string ProviderDoesNotExistMessage = "Provider does not exist";
     private const string PermissionDeniedMessage = "Error. Check permissions.";
 
+    // Display names for the audit log (the internal link-map mode tokens are the lowercase "oid"/"saml").
+    private const string OpenIdProtocol = "OpenID";
+    private const string SamlProtocol = "SAML";
+
     private readonly IUserManager _userManager;
     private readonly ISessionManager _sessionManager;
     private readonly IAuthorizationContext _authContext;
@@ -298,7 +302,7 @@ public class SSOController : ControllerBase
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs[provider] = config);
-        SsoAudit.ProviderConfigured(_logger, "OpenID", provider);
+        SsoAudit.ProviderConfigured(_logger, OpenIdProtocol, provider);
     }
 
     /// <summary>
@@ -310,7 +314,7 @@ public class SSOController : ControllerBase
     public void OidDel(string provider)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
-        SsoAudit.ProviderRemoved(_logger, "OpenID", provider);
+        SsoAudit.ProviderRemoved(_logger, OpenIdProtocol, provider);
     }
 
     /// <summary>
@@ -422,7 +426,7 @@ public class SSOController : ControllerBase
                 DefaultProvider = config.DefaultProvider?.Trim(),
                 AvatarUrl = timedState.AvatarURL,
             }).ConfigureAwait(false);
-            SsoAudit.LoginSucceeded(_logger, "OpenID", provider, timedState.Username, timedState.Admin);
+            SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, timedState.Username, timedState.Admin);
             return Ok(authenticationResult);
         }
 
@@ -548,7 +552,7 @@ public class SSOController : ControllerBase
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs[provider] = newConfig);
-        SsoAudit.ProviderConfigured(_logger, "SAML", provider);
+        SsoAudit.ProviderConfigured(_logger, SamlProtocol, provider);
         return Ok();
     }
 
@@ -562,7 +566,7 @@ public class SSOController : ControllerBase
     public OkResult SamlDel(string provider)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
-        SsoAudit.ProviderRemoved(_logger, "SAML", provider);
+        SsoAudit.ProviderRemoved(_logger, SamlProtocol, provider);
         return Ok();
     }
 
@@ -672,7 +676,7 @@ public class SSOController : ControllerBase
                 DefaultProvider = config.DefaultProvider?.Trim(),
                 AvatarUrl = null,
             }).ConfigureAwait(false);
-            SsoAudit.LoginSucceeded(_logger, "SAML", provider, nameId, derived.Admin);
+            SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
             return Ok(authenticationResult);
         }
 
@@ -769,7 +773,7 @@ public class SSOController : ControllerBase
 
             case AccountLinkAction.AdoptExistingAccount:
                 CreateCanonicalLink(mode, provider, decision.UserId, canonicalName);
-                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? "OpenID" : "SAML", provider, canonicalName);
+                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, canonicalName);
                 return decision.UserId;
 
             case AccountLinkAction.CreateNewAccount:

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -313,8 +313,12 @@ public class SSOController : ControllerBase
     [HttpGet("OID/Del/{provider}")]
     public void OidDel(string provider)
     {
-        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
-        SsoAudit.ProviderRemoved(_logger, OpenIdProtocol, provider);
+        var removed = false;
+        SSOPlugin.Instance.MutateConfiguration(configuration => removed = configuration.OidConfigs.Remove(provider));
+        if (removed)
+        {
+            SsoAudit.ProviderRemoved(_logger, OpenIdProtocol, provider);
+        }
     }
 
     /// <summary>
@@ -565,8 +569,13 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/Del/{provider}")]
     public OkResult SamlDel(string provider)
     {
-        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
-        SsoAudit.ProviderRemoved(_logger, SamlProtocol, provider);
+        var removed = false;
+        SSOPlugin.Instance.MutateConfiguration(configuration => removed = configuration.SamlConfigs.Remove(provider));
+        if (removed)
+        {
+            SsoAudit.ProviderRemoved(_logger, SamlProtocol, provider);
+        }
+
         return Ok();
     }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -298,6 +298,7 @@ public class SSOController : ControllerBase
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs[provider] = config);
+        SsoAudit.ProviderConfigured(_logger, "OpenID", provider);
     }
 
     /// <summary>
@@ -309,6 +310,7 @@ public class SSOController : ControllerBase
     public void OidDel(string provider)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
+        SsoAudit.ProviderRemoved(_logger, "OpenID", provider);
     }
 
     /// <summary>
@@ -420,6 +422,7 @@ public class SSOController : ControllerBase
                 DefaultProvider = config.DefaultProvider?.Trim(),
                 AvatarUrl = timedState.AvatarURL,
             }).ConfigureAwait(false);
+            SsoAudit.LoginSucceeded(_logger, "OpenID", provider, timedState.Username, timedState.Admin);
             return Ok(authenticationResult);
         }
 
@@ -545,6 +548,7 @@ public class SSOController : ControllerBase
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs[provider] = newConfig);
+        SsoAudit.ProviderConfigured(_logger, "SAML", provider);
         return Ok();
     }
 
@@ -558,6 +562,7 @@ public class SSOController : ControllerBase
     public OkResult SamlDel(string provider)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
+        SsoAudit.ProviderRemoved(_logger, "SAML", provider);
         return Ok();
     }
 
@@ -667,6 +672,7 @@ public class SSOController : ControllerBase
                 DefaultProvider = config.DefaultProvider?.Trim(),
                 AvatarUrl = null,
             }).ConfigureAwait(false);
+            SsoAudit.LoginSucceeded(_logger, "SAML", provider, nameId, derived.Admin);
             return Ok(authenticationResult);
         }
 
@@ -763,6 +769,7 @@ public class SSOController : ControllerBase
 
             case AccountLinkAction.AdoptExistingAccount:
                 CreateCanonicalLink(mode, provider, decision.UserId, canonicalName);
+                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? "OpenID" : "SAML", provider, canonicalName);
                 return decision.UserId;
 
             case AccountLinkAction.CreateNewAccount:

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -313,8 +313,7 @@ public class SSOController : ControllerBase
     [HttpGet("OID/Del/{provider}")]
     public void OidDel(string provider)
     {
-        var removed = false;
-        SSOPlugin.Instance.MutateConfiguration(configuration => removed = configuration.OidConfigs.Remove(provider));
+        var removed = SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs.Remove(provider));
         if (removed)
         {
             SsoAudit.ProviderRemoved(_logger, OpenIdProtocol, provider);
@@ -569,8 +568,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/Del/{provider}")]
     public OkResult SamlDel(string provider)
     {
-        var removed = false;
-        SSOPlugin.Instance.MutateConfiguration(configuration => removed = configuration.SamlConfigs.Remove(provider));
+        var removed = SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs.Remove(provider));
         if (removed)
         {
             SsoAudit.ProviderRemoved(_logger, SamlProtocol, provider);

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Emits consistent, structured audit-log entries for security-relevant SSO events that exist today:
+/// successful logins, adoption of a pre-existing account, and provider configuration changes. Every
+/// entry shares the "[SSO Audit]" prefix so operators can filter the trail, and only non-sensitive
+/// fields are logged (never secrets or certificates). Identity-provider- and admin-supplied values
+/// are stripped of line endings inline before logging so they cannot forge or split an entry.
+/// </summary>
+internal static class SsoAudit
+{
+    /// <summary>Records a successful login (a session was issued).</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="username">The Jellyfin username the session was issued for.</param>
+    /// <param name="isAdmin">Whether the session was granted administrator rights.</param>
+    internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool isAdmin)
+        => logger.LogInformation(
+            "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}).",
+            username?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            isAdmin);
+
+    /// <summary>Records an SSO identity being linked to a pre-existing account (the opt-in adoption path).</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="displayName">The adopted account's name.</param>
+    internal static void AccountAdopted(ILogger logger, string protocol, string provider, string displayName)
+        => logger.LogWarning(
+            "[SSO Audit] SSO identity linked to existing account '{DisplayName}' via {Protocol} provider '{Provider}' (AllowExistingAccountLink).",
+            displayName?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+
+    /// <summary>Records a provider being added or updated.</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    internal static void ProviderConfigured(ILogger logger, string protocol, string provider)
+        => logger.LogInformation(
+            "[SSO Audit] Provider configured: {Protocol} '{Provider}'.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+
+    /// <summary>Records a provider being removed.</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    internal static void ProviderRemoved(ILogger logger, string protocol, string provider)
+        => logger.LogInformation(
+            "[SSO Audit] Provider removed: {Protocol} '{Provider}'.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+}

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -62,6 +62,26 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     }
 
     /// <summary>
+    /// Applies a mutation that returns a result (e.g. whether a removal changed anything) under the
+    /// same single lock and persists it, so the read-modify-write and the result observation are one
+    /// atomic operation.
+    /// </summary>
+    /// <typeparam name="T">The value the mutation returns.</typeparam>
+    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    /// <returns>The value returned by <paramref name="mutate"/>.</returns>
+    public T MutateConfiguration<T>(Func<PluginConfiguration, T> mutate)
+    {
+        ArgumentNullException.ThrowIfNull(mutate);
+        lock (ConfigMutationLock)
+        {
+            var configuration = Configuration;
+            var result = mutate(configuration);
+            UpdateConfiguration(configuration);
+            return result;
+        }
+    }
+
+    /// <summary>
     /// Reads a value from the live configuration under the same lock as <see cref="MutateConfiguration"/>,
     /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
     /// </summary>


### PR DESCRIPTION
Closes #131 (P2#10, second half, the audit-trail complement to the log-forging sanitization already in place).

A new `SsoAudit` static helper emits consistent, filterable `[SSO Audit]` entries at the security-relevant events that exist today:
- **LoginSucceeded** (OID + SAML), after a session is issued.
- **AccountAdopted**, the opt-in `AllowExistingAccountLink` adoption of a pre-existing account.
- **ProviderConfigured / ProviderRemoved**, the admin-only provider add/remove endpoints.

Ported from the V2 reference, **keeping only the events that map to currently-implemented functionality** (the logout and config-import events are omitted until those features are ported, nothing advertises an unimplemented capability).

## Safety

- Only non-sensitive fields are logged (username, provider name, `isAdmin`), never a secret, config object, or certificate.
- IdP/admin-supplied values are stripped of line endings **inline at the log call** inside the helper (co-located sanitizer-at-sink; keeps the CodeQL log-forging barrier).
- Purely additive: no control-flow/behavior change; each event fires only on its genuine decision point (verified unreachable on every denial/error/403/500 path).

## Verification

- Build clean (`--warnaserror`), 240/240 tests.
- Two adversarial reviews (bypass + correctness) PASS: no secret leak, no forging vector, no false audit, matched structured-logging templates, no dead code (all 4 methods wired; unported-feature events correctly absent). The one non-blocking nit they raised, the adoption event logging `oid`/`saml` while login events log `OpenID`/`SAML`, is fixed here (consistent display protocol across the trail).

Follow-up (out of scope): unify the existing detailed denial logs under the same `[SSO Audit]` prefix as a `LoginDenied` event (deferred, the current denial logs carry richer role/claim debug context a terse audit line would lose).

Closes #131