### PR TITLE
Add a pre-alpha production-use warning to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+>
+> ## ⛔ Pre-alpha software — do NOT install this on a production system
+>
+> This plugin is in **pre-alpha**. It exists **exclusively for developers to test** — nothing else. Under **no circumstances** should it be installed on a production system or put in front of a real Jellyfin instance with real user accounts: it is a login path under active reconstruction, and you must expect **breaking changes, incomplete features, and security gaps that are still being closed**. Wait for a stable release before using it anywhere that matters.
+
 <h1 align="center">Jellyfin SSO Plugin</h1>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+
 > [!WARNING]
 >
 > ## ⛔ Pre-alpha software — do NOT install this on a production system


### PR DESCRIPTION
# What & why

The README described early, security-first development but never said plainly that the plugin must not guard a real instance yet. A GitHub warning alert now opens the README: pre-alpha software, developer testing only, under no circumstances to be installed on a production system. The wiki Home page received the same warning in a separate wiki edit (wikis take no PRs). Closes #179.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, docs-only change; no login-path, crypto, config-persistence, or release-pipeline surface touched.

- [x] Fail-closed preserved (nothing weakened).
- [x] No secrets logged.
- [ ] A security review was performed, not required for a docs-only change.
- [x] Log inputs sanitized, no log calls touched.

## Quality checklist

- [x] No duplicated logic; the warning text is shared verbatim between README and wiki.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean (README.md).

## Notes

MD041 (first-line-heading) suppressed file-wide per CodeRabbit's suggestion, the warning banner deliberately precedes the heading.
