### PR TITLE
Validate the OpenID Connect id_token

### DIFF
--- a/SSO-Auth.Tests/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/OidcIdTokenValidatorTests.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Exercises <see cref="OidcIdTokenValidator"/> against a static JWKS: the happy path and every
+/// rejection path of OIDC Core 3.1.3.7 (signature, issuer, audience, azp, lifetime), plus the
+/// algorithm allowlist (HS256 and unsigned tokens rejected regardless of key material) and the
+/// "invalid_signature" key-refresh contract with OidcClient's response processor.
+/// </summary>
+public sealed class OidcIdTokenValidatorTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcIdTokenValidator _validator = new();
+
+    public void Dispose() => _rsa.Dispose();
+
+    [Fact]
+    public async Task ValidRs256Token_Succeeds_WithRawClaimsAndAlgorithm()
+    {
+        var options = Options();
+        var token = CreateToken(claims: new Dictionary<string, object>
+        {
+            ["sub"] = "user-1",
+            ["preferred_username"] = "alice",
+            ["groups"] = new[] { "media", "admin" },
+        });
+
+        var result = await _validator.ValidateAsync(token, options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+        // Raw JWT claim names must survive (the downstream claim scan compares ordinally).
+        Assert.Equal("alice", result.User.Claims.Single(c => c.Type == "preferred_username").Value);
+        Assert.Equal("user-1", result.User.Claims.Single(c => c.Type == "sub").Value);
+        // Array claims expand to one claim per element.
+        Assert.Equal(2, result.User.Claims.Count(c => c.Type == "groups"));
+    }
+
+    [Fact]
+    public async Task WrongIssuer_IsRejected()
+    {
+        var result = await _validator.ValidateAsync(
+            CreateToken(issuer: "https://evil.example.test"), Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Issuer", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WrongIssuer_WithIssuerValidationDisabled_IsAccepted()
+    {
+        // The provider-level DoNotValidateIssuerName escape hatch relaxes ONLY the issuer match.
+        var options = Options();
+        options.Policy.Discovery.ValidateIssuerName = false;
+
+        var result = await _validator.ValidateAsync(
+            CreateToken(issuer: "https://other.example.test"), options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Fact]
+    public async Task WrongAudience_IsRejected()
+    {
+        var result = await _validator.ValidateAsync(
+            CreateToken(audience: "some-other-client"), Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Audience", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExpiredBeyondSkew_IsRejected()
+    {
+        var result = await _validator.ValidateAsync(
+            CreateToken(lifetime: TimeSpan.FromMinutes(-10)), Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Expired", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExpiredWithinSkew_IsAccepted()
+    {
+        // OidcClientOptions.ClockSkew defaults to five minutes; two minutes past exp is inside it.
+        var result = await _validator.ValidateAsync(
+            CreateToken(lifetime: TimeSpan.FromMinutes(-2)), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Fact]
+    public async Task Hs256Token_IsRejected()
+    {
+        // A symmetric signature must never authenticate a login: HS256 is outside the asymmetric-only
+        // allowlist, and no symmetric key is ever placed in the JWKS to resolve it against.
+        var descriptor = Descriptor();
+        descriptor.SigningCredentials = new SigningCredentials(
+            new SymmetricSecurityKey(new byte[32]) { KeyId = KeyId }, SecurityAlgorithms.HmacSha256);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task UnsignedToken_IsRejected()
+    {
+        var descriptor = Descriptor();
+        descriptor.SigningCredentials = null; // alg=none
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task UnknownSigningKey_ReturnsInvalidSignature_ForKeyRefreshRetry()
+    {
+        // The exact "invalid_signature" string is the contract that makes OidcClient refresh the
+        // JWKS and retry once — the path that heals a signing-key rotation.
+        using var otherRsa = RSA.Create(2048);
+        var descriptor = Descriptor();
+        descriptor.SigningCredentials = new SigningCredentials(
+            new RsaSecurityKey(otherRsa) { KeyId = "rotated-away" }, SecurityAlgorithms.RsaSha256);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Equal("invalid_signature", result.Error);
+    }
+
+    [Fact]
+    public async Task AzpMismatch_IsRejected_AndMatchingAzpAccepted()
+    {
+        var mismatch = await _validator.ValidateAsync(
+            CreateToken(claims: new Dictionary<string, object> { ["azp"] = "someone-else" }),
+            Options(),
+            TestContext.Current.CancellationToken);
+        Assert.True(mismatch.IsError);
+        Assert.Contains("azp", mismatch.Error, StringComparison.Ordinal);
+
+        var match = await _validator.ValidateAsync(
+            CreateToken(claims: new Dictionary<string, object> { ["azp"] = ClientId }),
+            Options(),
+            TestContext.Current.CancellationToken);
+        Assert.False(match.IsError, match.Error);
+    }
+
+    [Fact]
+    public async Task MultiAudience_WithoutAzp_IsRejected()
+    {
+        // OIDC Core 3.1.3.7 rules 3-4: our client id is among the audiences, but the token is also
+        // scoped to another party and carries no azp — reject rather than accept a co-audience token.
+        var descriptor = Descriptor();
+        descriptor.Audience = null;
+        descriptor.Audiences.Add(ClientId);
+        descriptor.Audiences.Add("other-api");
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("audiences", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MultiAudience_WithMatchingAzp_IsAccepted()
+    {
+        var descriptor = Descriptor(claims: new Dictionary<string, object> { ["sub"] = "user-1", ["azp"] = ClientId });
+        descriptor.Audience = null;
+        descriptor.Audiences.Add(ClientId);
+        descriptor.Audiences.Add("other-api");
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Fact]
+    public async Task NullEntryInJwks_IsSkipped_GoodKeyStillValidates()
+    {
+        // A JWKS carrying a literal null entry must not 500 the login (skip-on-malformed contract).
+        var p = _rsa.ExportParameters(false);
+        var options = Options(jwks: $$"""
+            {"keys":[null,{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """);
+
+        var result = await _validator.ValidateAsync(CreateToken(), options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("aaa.bbb.ccc.ddd.eee")]
+    [InlineData("...")]
+    public async Task MalformedToken_IsRejected_WithoutThrowing(string token)
+    {
+        // Hostile/garbage tokens must return a clean error result, never throw (which would surface as
+        // a 500 on the OIDC callback instead of a rejected login).
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task Es256Token_Succeeds_ViaEcKeyConversion()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var point = ecdsa.ExportParameters(false).Q;
+        var options = Options(jwks: $$"""
+            {"keys":[{"kty":"EC","use":"sig","kid":"{{KeyId}}","crv":"P-256",
+              "x":"{{Base64UrlEncoder.Encode(point.X)}}","y":"{{Base64UrlEncoder.Encode(point.Y)}}"}]}
+            """);
+        var descriptor = Descriptor();
+        descriptor.SigningCredentials = new SigningCredentials(
+            new ECDsaSecurityKey(ecdsa) { KeyId = KeyId }, SecurityAlgorithms.EcdsaSha256);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("ES256", result.SignatureAlgorithm);
+    }
+
+    [Fact]
+    public async Task EncryptionOnlyKey_IsNotUsedForSignatures()
+    {
+        // The signing key is advertised as use:"enc": it must be excluded from signature validation,
+        // leaving no usable key — the key-not-found path, i.e. "invalid_signature".
+        var p = _rsa.ExportParameters(false);
+        var options = Options(jwks: $$"""
+            {"keys":[{"kty":"RSA","use":"enc","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """);
+
+        var result = await _validator.ValidateAsync(CreateToken(), options, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Equal("invalid_signature", result.Error);
+    }
+
+    [Fact]
+    public async Task MalformedKeyInSet_IsSkipped_GoodKeyStillValidates()
+    {
+        // One broken advertised key must not take down logins signed by the good one.
+        var p = _rsa.ExportParameters(false);
+        var options = Options(jwks: $$"""
+            {"keys":[
+              {"kty":"RSA","use":"sig","kid":"broken","n":"!!not-base64url!!","e":"AQAB"},
+              {"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+               "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """);
+
+        var result = await _validator.ValidateAsync(CreateToken(), options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    // --- helpers ---
+
+    private OidcClientOptions Options(string? jwks = null)
+    {
+        var p = _rsa.ExportParameters(false);
+        jwks ??= $$"""
+            {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """;
+        return new OidcClientOptions
+        {
+            ClientId = ClientId,
+            ProviderInformation = new ProviderInformation
+            {
+                IssuerName = Issuer,
+                KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
+            },
+        };
+    }
+
+    private SecurityTokenDescriptor Descriptor(
+        string issuer = Issuer,
+        string audience = ClientId,
+        TimeSpan? lifetime = null,
+        IDictionary<string, object>? claims = null)
+    {
+        var now = DateTime.UtcNow;
+        var expires = now + (lifetime ?? TimeSpan.FromMinutes(5));
+        return new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            IssuedAt = now - TimeSpan.FromMinutes(15),
+            NotBefore = now - TimeSpan.FromMinutes(15),
+            Expires = expires,
+            Claims = claims ?? new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(
+                new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        };
+    }
+
+    private string CreateToken(
+        string issuer = Issuer,
+        string audience = ClientId,
+        TimeSpan? lifetime = null,
+        IDictionary<string, object>? claims = null)
+    {
+        return new JsonWebTokenHandler().CreateToken(Descriptor(issuer, audience, lifetime, claims));
+    }
+}

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -314,6 +314,37 @@
         "resolved": "9.0.11",
         "contentHash": "rtUNSIhbQTv8iSBTFvtg2b/ZUkoqC9qAH9DdC2hr+xPpoZrxiCITci9UR/ELUGUGnGUrF8Xye+tGVRhCxE+4LA=="
       },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
+        }
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -559,6 +590,7 @@
           "Duende.IdentityModel.OidcClient": "[7.1.0, )",
           "Jellyfin.Controller": "[10.11.11, )",
           "Jellyfin.Model": "[10.11.11, )",
+          "Microsoft.IdentityModel.JsonWebTokens": "[8.19.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "System.Security.Cryptography.Xml": "[10.0.9, )"
         }

--- a/SSO-Auth/Api/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/OidcIdTokenValidator.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Results;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Validates the OpenID Connect id_token per OIDC Core 1.0 section 3.1.3.7. OidcClient 7.x ships no
+/// validator of its own: with <c>IdentityTokenValidator</c> unset it falls back to a decode-only
+/// stub, so signature, issuer, audience and lifetime all went unchecked. This validator restores the
+/// mandatory checks — signature against the discovery JWKS, iss against the discovery issuer,
+/// aud/azp against the client id, exp/nbf with the client's clock skew — under an asymmetric-only
+/// signature-algorithm allowlist (the posture of the SAML side's <see cref="SamlSignatureAlgorithms"/>).
+/// Every failure rejects the login (fail closed).
+/// </summary>
+internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
+{
+    // Asymmetric signature algorithms only (RFC 7518): symmetric HS* would accept a token minted by
+    // anyone holding the shared client secret, and "none" is unauthenticated by definition — both are
+    // rejected regardless of what key material the discovery document advertises.
+    private static readonly string[] AllowedSignatureAlgorithms =
+    {
+        "RS256", "RS384", "RS512",
+        "PS256", "PS384", "PS512",
+        "ES256", "ES384", "ES512",
+    };
+
+    /// <inheritdoc />
+    public async Task<IdentityTokenValidationResult> ValidateAsync(string identityToken, OidcClientOptions options, CancellationToken cancellationToken = default)
+    {
+        // ECDsa instances built from the JWKS are ours to dispose; RSA keys built from RSAParameters
+        // are not disposable. Tracked here so the finally can release the native handles rather than
+        // leaving them for the finalizer to reclaim (this runs on every login).
+        var ephemeralKeys = new List<IDisposable>();
+        try
+        {
+            var parameters = new TokenValidationParameters
+            {
+                ValidIssuer = options.ProviderInformation.IssuerName,
+                ValidAudience = options.ClientId,
+                IssuerSigningKeys = ConvertSigningKeys(options.ProviderInformation.KeySet, ephemeralKeys),
+                ValidAlgorithms = AllowedSignatureAlgorithms,
+                ClockSkew = options.ClockSkew,
+                RequireSignedTokens = true,
+                RequireExpirationTime = true,
+                // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
+                // legitimately differs from the discovery location; it relaxes ONLY the issuer match.
+                // Signature, audience and lifetime validation have no off switch.
+                ValidateIssuer = options.Policy.Discovery.ValidateIssuerName,
+                // The downstream claim scan compares raw JWT claim names ordinally ("preferred_username",
+                // "sub", the configured role-claim path), so the principal must carry the payload names
+                // verbatim — these two only name the identity's Name/Role accessors.
+                NameClaimType = "name",
+                RoleClaimType = "role",
+            };
+
+            // MapInboundClaims=false keeps the raw JWT claim types; the default mapping would rename
+            // "sub" and friends to SOAP-style URIs and break every ordinal claim comparison downstream.
+            var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+            var result = await handler.ValidateTokenAsync(identityToken, parameters).ConfigureAwait(false);
+            if (!result.IsValid)
+            {
+                return new IdentityTokenValidationResult { Error = MapError(result.Exception) };
+            }
+
+            var token = (JsonWebToken)result.SecurityToken;
+            var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
+
+            // azp (OIDC Core 3.1.3.7 rule 5): optional, but when present it MUST equal this client's id —
+            // a token authorized for a different party must not log in here.
+            if (azp != null && !string.Equals(azp, options.ClientId, StringComparison.Ordinal))
+            {
+                return new IdentityTokenValidationResult { Error = "Identity token validation failed: azp mismatch" };
+            }
+
+            // rules 3-4: with more than one audience the token MUST carry an azp (already pinned to this
+            // client above). A multi-audience token WITHOUT azp is rejected — it may have been minted for
+            // a different party that merely lists this client as a co-audience. ValidateAudience only
+            // checks that our id is among the audiences, so this closes the "additional audiences" clause.
+            if (azp == null && token.Audiences.Count() > 1)
+            {
+                return new IdentityTokenValidationResult { Error = "Identity token validation failed: multiple audiences without azp" };
+            }
+
+            return new IdentityTokenValidationResult
+            {
+                User = new ClaimsPrincipal(result.ClaimsIdentity),
+                SignatureAlgorithm = token.Alg,
+            };
+        }
+        finally
+        {
+            foreach (var key in ephemeralKeys)
+            {
+                key.Dispose();
+            }
+        }
+    }
+
+    // The exact string "invalid_signature" is the OidcClient contract: its response processor reacts
+    // to it by refreshing the discovery JWKS and retrying once, which is what heals a signing-key
+    // rotation between discovery and callback. A signature that fails against a KNOWN key maps there
+    // too — after a rotation an IdP may reuse a kid with new material, and the refresh either repairs
+    // the validation or the retry fails closed. Everything else reports only the exception type:
+    // IdentityModel exception messages can embed token claim values, which must not reach the logs.
+    private static string MapError(Exception? exception) => exception switch
+    {
+        SecurityTokenSignatureKeyNotFoundException => "invalid_signature",
+        SecurityTokenInvalidSignatureException => "invalid_signature",
+        null => "Identity token validation failed",
+        _ => $"Identity token validation failed: {exception.GetType().Name}",
+    };
+
+    // Converts the discovery JWKS into Microsoft.IdentityModel signing keys, mirroring the conversion
+    // of Duende's retired validator package: RSA from e/n, EC from crv/x/y, keys marked use!="sig"
+    // excluded. A malformed or unsupported advertised key is skipped rather than thrown on — one
+    // broken key in the set must not take down logins signed by a good one; if NO usable key remains,
+    // validation fails closed with the key-not-found path above.
+    private static List<SecurityKey> ConvertSigningKeys(Duende.IdentityModel.Jwk.JsonWebKeySet? keySet, List<IDisposable> ephemeralKeys)
+    {
+        var keys = new List<SecurityKey>();
+        if (keySet?.Keys == null)
+        {
+            return keys;
+        }
+
+        foreach (var webKey in keySet.Keys)
+        {
+            // A JWKS with a literal null entry (["keys":[null]]) must be skipped, not dereferenced —
+            // otherwise the whole login 500s, contradicting the skip-on-malformed contract below.
+            if (webKey == null)
+            {
+                continue;
+            }
+
+            if (webKey.Use != null && !string.Equals(webKey.Use, "sig", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (!string.IsNullOrEmpty(webKey.E) && !string.IsNullOrEmpty(webKey.N))
+                {
+                    keys.Add(new RsaSecurityKey(new RSAParameters
+                    {
+                        Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
+                        Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
+                    })
+                    { KeyId = webKey.Kid });
+                }
+                else if (!string.IsNullOrEmpty(webKey.X) && !string.IsNullOrEmpty(webKey.Y) && TryGetCurve(webKey.Crv, out var curve))
+                {
+                    var ecdsa = ECDsa.Create(new ECParameters
+                    {
+                        Curve = curve,
+                        Q = new ECPoint
+                        {
+                            X = Base64UrlEncoder.DecodeBytes(webKey.X),
+                            Y = Base64UrlEncoder.DecodeBytes(webKey.Y),
+                        },
+                    });
+                    ephemeralKeys.Add(ecdsa);
+                    keys.Add(new ECDsaSecurityKey(ecdsa) { KeyId = webKey.Kid });
+                }
+            }
+            catch (FormatException)
+            {
+                // Un-decodable key material in one advertised key: skip it, the remaining keys decide.
+            }
+            catch (CryptographicException)
+            {
+                // Invalid EC point/curve combination: likewise skip.
+            }
+        }
+
+        return keys;
+    }
+
+    private static bool TryGetCurve(string? crv, out ECCurve curve)
+    {
+        switch (crv)
+        {
+            case "P-256":
+                curve = ECCurve.NamedCurves.nistP256;
+                return true;
+            case "P-384":
+                curve = ECCurve.NamedCurves.nistP384;
+                return true;
+            case "P-521":
+                curve = ECCurve.NamedCurves.nistP521;
+                return true;
+            default:
+                curve = default;
+                return false;
+        }
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -277,6 +277,12 @@ public class SSOController : ControllerBase
         options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
         options.Policy.Discovery.RequireHttps = !config.DisableHttps;
         options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
+
+        // OidcClient 7.x validates nothing about the id_token unless a validator is supplied (its
+        // fallback only base64-decodes the payload). Signature validation is required and has no
+        // config toggle: an unvalidated id_token is a forgeable login (#134).
+        options.Policy.RequireIdentityTokenSignature = true;
+        options.IdentityTokenValidator = new OidcIdTokenValidator();
         return new OidcClient(options);
     }
 

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -45,6 +45,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageReference Include="Jellyfin.Controller" Version="10.11.11" />
+    <!-- id_token validation (#134): OidcClient 7.x carries no JWT validation stack of its own. -->
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
     <PackageReference Include="Jellyfin.Model" Version="10.11.11" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />

--- a/SSO-Auth/packages.lock.json
+++ b/SSO-Auth/packages.lock.json
@@ -47,6 +47,15 @@
         "resolved": "3.0.122",
         "contentHash": "bmo+TIK9fLG/NzlZ2Qi5lto2jG/N6/zmc7gDVp5uzvVmnDKMV5SmUR7jToSbx/oqTPMV3ajyCmo2kFBdPDlU0A=="
       },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Direct",
+        "requested": "[8.19.1, )",
+        "resolved": "8.19.1",
+        "contentHash": "6eeY+y2QFyjj3XnCz/8gJdoP5smYHTS9ow1bw2nsZzDIPjPhBZlackYTIduSMipVpxnoT/B62LkrXX2jPggOXg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.19.1"
+        }
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[13.0.4, )",
@@ -307,6 +316,29 @@
         "type": "Transitive",
         "resolved": "9.0.11",
         "contentHash": "rtUNSIhbQTv8iSBTFvtg2b/ZUkoqC9qAH9DdC2hr+xPpoZrxiCITci9UR/ELUGUGnGUrF8Xye+tGVRhCxE+4LA=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "gFA8THIk23uNF/vMdOHnjIdXD1LyA2g12cHzMJ+Xag6WpgWLw6E/6uCXxvA0gp9d2yAvkRt3xzFzMUiO/hofnQ=="
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "H+sMrMpdbWnwkQnpb/ESkQovtOgdefmj0ecGCcP40mDKzE5i4dUYkH6599M9mWYFNGNJnTp92l/9wLubYXWimw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.19.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.19.1",
+        "contentHash": "KDiuSLXud2AFVNAOottd8ztVysfPeHyr4r8gofU3/VKUXlI7oytzGTnPsNJ/B3nui17rgz8wAdWNJOtzPjkUxw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "10.0.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.19.1"
+        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",

--- a/build.yaml
+++ b/build.yaml
@@ -14,6 +14,16 @@ artifacts:
   - "SSO-Auth.dll"
   - "Duende.IdentityModel.OidcClient.dll"
   - "Duende.IdentityModel.dll"
+  # id_token validation (#134): the runtime closure of the JWT validator that the
+  # Jellyfin host does not provide. Jellyfin 10.11 ships no Microsoft.IdentityModel.*
+  # and no Microsoft.Bcl.Cryptography, so these must travel in the plugin zip or every
+  # OIDC login fails with FileNotFoundException. (Only non-host-provided deps are listed
+  # here; Newtonsoft.Json, Jellyfin.*, MediaBrowser.* etc. come from the host.)
+  - "Microsoft.IdentityModel.JsonWebTokens.dll"
+  - "Microsoft.IdentityModel.Tokens.dll"
+  - "Microsoft.IdentityModel.Logging.dll"
+  - "Microsoft.IdentityModel.Abstractions.dll"
+  - "Microsoft.Bcl.Cryptography.dll"
 changelog: |
   4.0.0.4: Fix security issue in SAML
   4.0.0.0: Jellyfin 10.11

--- a/providers.md
+++ b/providers.md
@@ -39,6 +39,26 @@ EnableFolderRoles: false
 FolderRoleMapping: []
 ```
 
+## OpenID Connect id_token requirements
+
+The plugin validates the id_token returned by your OpenID provider (signature, issuer, audience and
+expiry). A few provider settings must therefore match, or login is refused (fail-closed):
+
+- **The id_token must be signed with an asymmetric algorithm — RS256/384/512, PS256/384/512, or
+  ES256/384/512.** Tokens signed with a symmetric algorithm (HS256) or left unsigned (`alg: none`)
+  are rejected regardless of configuration. If your IdP client defaults to HS256 (some Auth0 and
+  Keycloak client templates do), switch its id_token signing algorithm to RS256. EdDSA/Ed25519
+  (OKP keys) is not supported.
+- **The provider must publish a JWKS** (its discovery document's `jwks_uri`) so the signature can be
+  verified. A rotated signing key is picked up automatically on the next login.
+- **Clocks must be roughly in sync.** Expiry is checked with a 5-minute skew allowance; if the
+  Jellyfin host or the IdP clock drifts further, every login fails — keep both on NTP.
+- **Issuer** is matched against the discovery issuer. If your IdP legitimately presents a different
+  issuer (some templated or multi-tenant setups), set `DoNotValidateIssuerName: true` for that
+  provider — this relaxes only the issuer check; signature, audience and expiry stay enforced.
+- If your IdP sends an `at_hash` claim it must match the issued access token — a correctly behaving
+  provider always satisfies this.
+
 ## Authelia
 
 Authelia is simple to configure, and RBAC is straightforward.


### PR DESCRIPTION
# What & why

OidcClient 7.x performs **no id_token validation** unless a validator is supplied, with `IdentityTokenValidator` unset it falls back to a decode-only stub, so signature, issuer, audience and expiry all went unchecked and a login was forgeable on-path. This adds a validator restoring the OIDC Core 3.1.3.7 checks under an asymmetric-only algorithm allowlist. Closes #134.

- `OidcIdTokenValidator` (IIdentityTokenValidator on Microsoft.IdentityModel.JsonWebTokens): signature vs discovery JWKS, iss vs discovery issuer (honoring `DoNotValidateIssuerName`, which relaxes only the issuer match), aud vs client id + azp-equals-client-when-present + reject multi-aud without azp, exp/nbf with the client clock skew, allowlist RS/PS/ES only (HS*/none rejected).
- Wired in `CreateOidcClient` with `RequireIdentityTokenSignature=true` (self-defending: removing the validator later makes construction throw, not silently revert to decode-only).
- `build.yaml`: adds the validator's non-host runtime closure (Microsoft.IdentityModel.* + Microsoft.Bcl.Cryptography), without these the packaged plugin 500s every OIDC login while CI stays green.
- `providers.md`: documents the id_token requirements (asymmetric signing, JWKS, clock sync, issuer, at_hash).
- 20 unit tests against a static JWKS (happy RS256/ES256, wrong iss/aud, azp mismatch, multi-aud with/without azp, expired inside/outside skew, HS256, unsigned, unknown kid → invalid_signature, enc-key excluded, malformed/null JWKS entry skipped, garbage tokens rejected without throwing).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: missing/invalid signature, wrong iss/aud/azp, expired exp, disallowed algorithm, or an unusable key set all reject the login; no fallback path accepts an unvalidated token.
- [x] No secrets logged; validation errors report only exception type names, never claim values.
- [x] A security review was performed: adversarial gate with 4 lenses + OIDC domain reviewer, oidc PASS, availability/bypass/correctness NEEDS_IMPROVEMENT and integration FAIL, all findings fixed in this branch (packaging closure in build.yaml; null-JWKS-entry guard; multi-aud-without-azp rejection; ECDsa disposal; docs). Details in the sign-off review.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; the validator is a single-purpose, testable unit mirroring Duende's retired reference implementation.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (261/261).
- [x] Prettier is clean (`providers.md`).

## Notes

- The exact `"invalid_signature"` error string is the OidcClient contract that triggers a JWKS refresh and one retry, the path that heals signing-key rotation.
- The review gate surfaced a pre-existing packaging gap on the SAML side (Cryptography.Xml/Pkcs/Asn1/Bcl.Memory missing from build.yaml), filed separately as #181.
- Residual, tracked: RFC 9207 iss (#125), PKCE-support discovery probe (#141).
- Owed before any release carrying this: real-server OIDC login E2E (docs/E2E-CHECKLIST.md), the DLL-loading fix class is invisible to local build/tests.
