### PR TITLE
Key the OpenID account link on the stable sub claim

### DIFF
--- a/SSO-Auth.Tests/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/AccountLinkResolverTests.cs
@@ -49,4 +49,44 @@ public class AccountLinkResolverTests
         Assert.Equal(AccountLinkAction.CreateNewAccount, decision.Action);
         Assert.Equal(Guid.Empty, decision.UserId);
     }
+
+    // --- ResolveCanonicalLink: subject-keyed lookup with one-time legacy-name migration (#155) ---
+
+    private static readonly Guid Subject = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid Legacy = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    [Fact]
+    public void ResolveCanonicalLink_SubjectKeyed_IsUsed_WithoutMigration()
+    {
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, legacyNameKeyedUserId: null);
+        Assert.Equal(Subject, linkedUserId);
+        Assert.False(migrate);
+    }
+
+    [Fact]
+    public void ResolveCanonicalLink_SubjectKeyed_WinsOverLegacy_NoMigration()
+    {
+        // Once a subject-keyed link exists, the legacy name-keyed one is never consulted or migrated.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, Legacy);
+        Assert.Equal(Subject, linkedUserId);
+        Assert.False(migrate);
+    }
+
+    [Fact]
+    public void ResolveCanonicalLink_OnlyLegacy_IsAdopted_AndMigrated()
+    {
+        // No subject-keyed link yet, but a legacy name-keyed one resolves: adopt it and signal the
+        // one-time re-key to the subject.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy);
+        Assert.Equal(Legacy, linkedUserId);
+        Assert.True(migrate);
+    }
+
+    [Fact]
+    public void ResolveCanonicalLink_NeitherLink_ResolvesNothing()
+    {
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(null, null);
+        Assert.Null(linkedUserId);
+        Assert.False(migrate);
+    }
 }

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -306,6 +306,60 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void Subject_ExtractedFromSubClaim_IndependentOfUsername()
+    {
+        // The link key (#155) is the sub claim, derived independently of the username: a valid login
+        // via preferred_username still surfaces the sub so the account can be keyed on it.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "subject-123")),
+            Config(_ => { }));
+
+        Assert.Equal("alice", result.Username);
+        Assert.Equal("subject-123", result.Subject);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void Subject_NullWhenNoSubClaim()
+    {
+        // A provider that sends no sub leaves Subject null; the callback rejects such a valid login
+        // (fail closed) rather than keying on the mutable username.
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));
+
+        Assert.Equal("alice", result.Username);
+        Assert.Null(result.Subject);
+    }
+
+    [Fact]
+    public void Subject_LastSubWins()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "first"), ("sub", "second")),
+            Config(_ => { }));
+
+        Assert.Equal("second", result.Subject);
+    }
+
+    [Fact]
+    public void Subject_SurfacedEvenWhenLoginInvalid()
+    {
+        // Subject extraction does not depend on validity: a role-gated login that fails still carries
+        // its sub (the callback rejects on validity, not on a missing subject here).
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-users" };
+            c.RoleClaim = "role";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "outsiders"), ("sub", "subject-123")),
+            config);
+
+        Assert.False(result.Valid);
+        Assert.Equal("subject-123", result.Subject);
+    }
+
+    [Fact]
     public void AvatarUrlFormat_ResolvedFromClaims()
     {
         var config = Config(c => c.AvatarUrlFormat = "https://avatars.example.com/@{sub}.png");

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -78,6 +78,42 @@ internal static class AccountLinkResolver
 
         return new AccountLinkDecision(AccountLinkAction.CreateNewAccount, Guid.Empty);
     }
+
+    /// <summary>
+    /// Resolves which existing account link (if any) an OpenID login maps to, preferring the stable
+    /// subject-keyed link and falling back to a legacy name-keyed link left over from before #155.
+    /// Pure: the caller resolves the two candidate links (and confirms their target users still exist)
+    /// before calling, and performs the re-key I/O when <c>MigrateLegacy</c> is set.
+    /// </summary>
+    /// <param name="subjectKeyedUserId">
+    /// The user id linked under the stable subject key, if that link exists and its user still exists.
+    /// </param>
+    /// <param name="legacyNameKeyedUserId">
+    /// The user id linked under the legacy username key, if that link exists and its user still exists.
+    /// Pass <c>null</c> when the subject and username are identical (there is nothing to migrate).
+    /// </param>
+    /// <returns>
+    /// The linked user id (or null when neither link resolves), and whether the legacy link must be
+    /// re-keyed to the subject. Migration is requested only when there is no subject-keyed link yet but
+    /// a legacy one resolves — a one-time, idempotent hand-off: once re-keyed, later logins hit the
+    /// subject key directly and never consult the name again.
+    /// </returns>
+    internal static (Guid? LinkedUserId, bool MigrateLegacy) ResolveCanonicalLink(
+        Guid? subjectKeyedUserId,
+        Guid? legacyNameKeyedUserId)
+    {
+        if (subjectKeyedUserId.HasValue)
+        {
+            return (subjectKeyedUserId.Value, false);
+        }
+
+        if (legacyNameKeyedUserId.HasValue)
+        {
+            return (legacyNameKeyedUserId.Value, true);
+        }
+
+        return (null, false);
+    }
 }
 
 /// <summary>

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -48,6 +48,15 @@ internal static class OidcAuthorizeStateBuilder
         var avatarUrl = ResolveAvatarUrl(claimList, config);
         var (username, valid, roles) = ScanClaims(claimList, config);
 
+        // The stable subject identifier used to key the account link (#155): the "sub" claim, which
+        // OIDC Core requires and (post-#134) the id_token validator has verified. Unlike the username
+        // (derived from the mutable preferred_username), it never changes for a given end user at a
+        // given provider, so an IdP-side rename cannot detach or re-link the account. The last "sub"
+        // wins, matching the sub fallback below. Independent of validity — the link key is needed
+        // whenever the login is valid, not only in the fallback path; the callback rejects a valid
+        // login that resolved no subject (fail closed).
+        var subject = ResolveSubject(claimList);
+
         // Map the collected roles to privileges and merge (monotonic: only ever grants).
         var grants = OidcRolePrivilegeMapper.Evaluate(roles, config);
         valid |= grants.Valid;
@@ -69,7 +78,23 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+        return new OidcAuthorizeState(username, subject, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+    }
+
+    // The last "sub" claim value, or null when none is present. Kept separate from the username
+    // derivation: sub is the identity key regardless of how the username was resolved.
+    private static string? ResolveSubject(IReadOnlyList<Claim> claims)
+    {
+        string? subject = null;
+        foreach (var claim in claims)
+        {
+            if (string.Equals(claim.Type, "sub", StringComparison.Ordinal))
+            {
+                subject = claim.Value;
+            }
+        }
+
+        return subject;
     }
 
     // Resolves the avatar URL by substituting @{claimType} tokens in the configured format, or null
@@ -157,6 +182,7 @@ internal static class OidcAuthorizeStateBuilder
     /// The authorize-state values derived from an OpenID login.
     /// </summary>
     /// <param name="Username">The resolved username (last matching preferred-username or sub claim), or null when none is present.</param>
+    /// <param name="Subject">The stable subject identifier (the "sub" claim) used to key the account link, or null when absent.</param>
     /// <param name="Valid">Whether the login is permitted (no allow-list, or a role matched the allow-list).</param>
     /// <param name="Admin">Whether the login grants administrator rights.</param>
     /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
@@ -165,6 +191,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="AvatarUrl">The resolved avatar URL, or null when no avatar format is configured.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
+        string? Subject,
         bool Valid,
         bool Admin,
         bool EnableLiveTv,

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -163,7 +163,19 @@ public class SSOController : ControllerBase
             // from the verified login's claims and the provider configuration, then apply them to the
             // fresh authorize state (its derivation fields are still at their defaults at this point).
             var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config);
+
+            // Fail closed (#155): a valid OpenID login must resolve a stable subject to key the account
+            // link on. sub is an OIDC Core MUST and (post-#134) the id_token validator has verified the
+            // token, so a missing sub means a non-conformant provider — reject rather than fall back to
+            // keying on the mutable username.
+            if (derived.Valid && string.IsNullOrWhiteSpace(derived.Subject))
+            {
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+            }
+
             timedState.Username = derived.Username;
+            timedState.Subject = derived.Subject;
             timedState.Valid = derived.Valid;
             timedState.Admin = derived.Admin;
             timedState.EnableLiveTv = derived.EnableLiveTv;
@@ -415,7 +427,7 @@ public class SSOController : ControllerBase
             Guid userId;
             try
             {
-                userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, timedState.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
+                userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, timedState.Subject, timedState.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
             }
             catch (AccountLinkForbiddenException)
             {
@@ -669,7 +681,9 @@ public class SSOController : ControllerBase
             Guid userId;
             try
             {
-                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
+                // SAML keys the link directly on the NameID, which is already the stable subject
+                // identifier — key and account name are the same value (no migration path needed).
+                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
             }
             catch (AccountLinkForbiddenException)
             {
@@ -757,26 +771,40 @@ public class SSOController : ControllerBase
         });
     }
 
-    private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalName, bool allowExistingAccountLink)
+    private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
     {
-        // Defense in depth (#95): a login without a resolvable identity must never create, adopt, or
-        // look up an account. Both callbacks reject such logins before calling here; this belt keeps
-        // the invariant if a future caller forgets.
-        if (string.IsNullOrWhiteSpace(canonicalName))
+        // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
+        // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
+        // reject such logins before calling here; this belt keeps the invariant if a caller forgets.
+        if (string.IsNullOrWhiteSpace(canonicalKey) || string.IsNullOrWhiteSpace(username))
         {
             throw new AccountLinkForbiddenException("The SSO login did not resolve an identity; refusing to create or link an account.");
         }
 
-        // An identity already linked to a still-existing account is keyed on the canonical name.
-        // A dangling link, whose user was since deleted, is treated as if there were no link.
-        Guid? linkedUserId = null;
-        var linked = TryGetCanonicalLink(mode, provider, canonicalName);
-        if (linked.HasValue && _userManager.GetUserById(linked.Value) != null)
+        // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the
+        // mutable username instead; when no subject-keyed link exists yet but a legacy one resolves,
+        // adopt and re-key it — the one login that migrates reuses the exact decision the old
+        // name-keyed lookup would have made, then locks it to the subject so a later provider-side
+        // rename cannot detach it. Only OpenID differs key from name; SAML passes key == name.
+        var subjectLink = ResolveLiveLink(mode, provider, canonicalKey);
+        Guid? legacyLink = null;
+        if (!string.Equals(canonicalKey, username, StringComparison.Ordinal))
         {
-            linkedUserId = linked;
+            legacyLink = ResolveLiveLink(mode, provider, username);
         }
 
-        Guid? existingAccountUserId = _userManager.GetUserByName(canonicalName)?.Id;
+        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink);
+        if (migrateLegacy)
+        {
+            MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
+            _logger.LogInformation(
+                "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
+                mode,
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
+        // Adoption of a pre-existing unlinked account still matches on the display name.
+        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
 
         var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
         switch (decision.Action)
@@ -785,23 +813,23 @@ public class SSOController : ControllerBase
                 return decision.UserId;
 
             case AccountLinkAction.AdoptExistingAccount:
-                CreateCanonicalLink(mode, provider, decision.UserId, canonicalName);
-                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, canonicalName);
+                CreateCanonicalLink(mode, provider, decision.UserId, canonicalKey);
+                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, username);
                 return decision.UserId;
 
             case AccountLinkAction.CreateNewAccount:
-                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", canonicalName.ReplaceLineEndings(string.Empty));
-                var user = await _userManager.CreateUserAsync(canonicalName).ConfigureAwait(false);
+                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
+                var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
                 user.AuthenticationProviderId = GetType().FullName;
                 // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
                 user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
-                CreateCanonicalLink(mode, provider, user.Id, canonicalName);
+                CreateCanonicalLink(mode, provider, user.Id, canonicalKey);
                 return user.Id;
 
             case AccountLinkAction.RejectNameTaken:
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                    canonicalName.ReplaceLineEndings(string.Empty),
+                    username.ReplaceLineEndings(string.Empty),
                     mode,
                     provider?.ReplaceLineEndings(string.Empty));
                 throw new AccountLinkForbiddenException();
@@ -809,6 +837,30 @@ public class SSOController : ControllerBase
             default:
                 throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
         }
+    }
+
+    // Resolves a canonical link to a still-existing user, or null when the link is absent or dangling
+    // (its user was deleted). Shared by the subject-keyed lookup and the legacy name-keyed migration.
+    private Guid? ResolveLiveLink(string mode, string provider, string key)
+    {
+        var linked = TryGetCanonicalLink(mode, provider, key);
+        return linked.HasValue && _userManager.GetUserById(linked.Value) != null ? linked : null;
+    }
+
+    // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).
+    // Idempotent: if oldKey is already gone (migrated by a concurrent login) the move is a no-op, and
+    // a pre-existing newKey is left as-is rather than overwritten.
+    private static void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
+    {
+        SSOPlugin.Instance.MutateConfiguration(configuration =>
+            MutateLinks(configuration, mode, provider, links =>
+            {
+                if (links.TryGetValue(oldKey, out var userId) && !links.ContainsKey(newKey))
+                {
+                    links.Remove(oldKey);
+                    links[newKey] = userId;
+                }
+            }));
     }
 
     /// <summary>
@@ -1026,7 +1078,9 @@ public class SSOController : ControllerBase
             && AuthStateStore.IsRedeemableBy(timedState, response.Data, provider, DateTime.Now, StateLifetime)
             && StateManager.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(response.Data, timedState)))
         {
-            return CreateCanonicalLink("oid", provider, jellyfinUserId, timedState.Username);
+            // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
+            // later provider-side rename does not orphan the link the user just created.
+            return CreateCanonicalLink("oid", provider, jellyfinUserId, timedState.Subject);
         }
 
         return Problem("Something went wrong!");
@@ -1440,6 +1494,13 @@ public class TimedAuthorizeState
     /// Gets or sets the user tied to the state.
     /// </summary>
     public string Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stable subject identifier (OpenID "sub") that keys the account link (#155).
+    /// Unlike <see cref="Username"/> it does not change when the identity provider renames the user.
+    /// Null for SAML, whose NameID plays the same role directly.
+    /// </summary>
+    public string Subject { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the user is an administrator.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -756,19 +756,16 @@ public class SSOController : ControllerBase
         }
     }
 
-    // Looks up a canonical link under the config lock, so the read cannot tear against a concurrent write.
-    private static Guid? TryGetCanonicalLink(string mode, string provider, string canonicalName)
+    // The provider's canonical-links map; callers must hold the config lock (ReadConfiguration /
+    // MutateConfiguration) while touching it.
+    private static SerializableDictionary<string, Guid> GetLinks(PluginConfiguration configuration, string mode, string provider)
     {
-        return SSOPlugin.Instance.ReadConfiguration(configuration =>
+        return mode.ToLowerInvariant() switch
         {
-            var links = mode.ToLowerInvariant() switch
-            {
-                "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
-                "oid" => configuration.OidConfigs[provider].CanonicalLinks,
-                _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
-            };
-            return links.TryGetValue(canonicalName, out var id) ? id : (Guid?)null;
-        });
+            "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
+            "oid" => configuration.OidConfigs[provider].CanonicalLinks,
+            _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
+        };
     }
 
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
@@ -786,12 +783,22 @@ public class SSOController : ControllerBase
         // adopt and re-key it — the one login that migrates reuses the exact decision the old
         // name-keyed lookup would have made, then locks it to the subject so a later provider-side
         // rename cannot detach it. Only OpenID differs key from name; SAML passes key == name.
-        var subjectLink = ResolveLiveLink(mode, provider, canonicalKey);
-        Guid? legacyLink = null;
-        if (!string.Equals(canonicalKey, username, StringComparison.Ordinal))
+        // Both candidates are read in ONE pass under the config lock: with separate reads, a
+        // concurrent login's migration could commit between them, so this login would see the subject
+        // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
+        // user off the adoption gate with a spurious 403. A link whose target user was deleted counts
+        // as absent (dangling links are dead, not identities).
+        var (subjectLink, legacyLink) = SSOPlugin.Instance.ReadConfiguration(configuration =>
         {
-            legacyLink = ResolveLiveLink(mode, provider, username);
-        }
+            var links = GetLinks(configuration, mode, provider);
+            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
+                ? s : null;
+            Guid? byName = bySubject is null
+                && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
+                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
+                ? n : (Guid?)null;
+            return (bySubject, byName);
+        });
 
         var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink);
         if (migrateLegacy)
@@ -839,23 +846,17 @@ public class SSOController : ControllerBase
         }
     }
 
-    // Resolves a canonical link to a still-existing user, or null when the link is absent or dangling
-    // (its user was deleted). Shared by the subject-keyed lookup and the legacy name-keyed migration.
-    private Guid? ResolveLiveLink(string mode, string provider, string key)
-    {
-        var linked = TryGetCanonicalLink(mode, provider, key);
-        return linked.HasValue && _userManager.GetUserById(linked.Value) != null ? linked : null;
-    }
-
     // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).
-    // Idempotent: if oldKey is already gone (migrated by a concurrent login) the move is a no-op, and
-    // a pre-existing newKey is left as-is rather than overwritten.
-    private static void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
+    // Idempotent under concurrency: if oldKey is already gone (a concurrent login migrated first) the
+    // move is a no-op, and a LIVE newKey entry is never overwritten — only a dangling one (its target
+    // user deleted), which would otherwise block the hand-off on every subsequent login.
+    private void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
     {
         SSOPlugin.Instance.MutateConfiguration(configuration =>
             MutateLinks(configuration, mode, provider, links =>
             {
-                if (links.TryGetValue(oldKey, out var userId) && !links.ContainsKey(newKey))
+                if (links.TryGetValue(oldKey, out var userId)
+                    && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
                 {
                     links.Remove(oldKey);
                     links[newKey] = userId;

--- a/providers.md
+++ b/providers.md
@@ -58,10 +58,18 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   provider — this relaxes only the issuer check; signature, audience and expiry stay enforced.
 - If your IdP sends an `at_hash` claim it must match the issued access token — a correctly behaving
   provider always satisfies this.
-- **A `sub` claim is required.** The account link is keyed on the immutable `sub`, not on the
-  (mutable) username — so renaming a user at the identity provider keeps their Jellyfin account
-  linked, and a recycled username cannot inherit another user's account. Links created by older
-  plugin versions (keyed on the username) migrate to `sub` automatically on the user's next login.
+- **A `sub` claim is required, and it must be stable.** The account link is keyed on the immutable
+  `sub`, not on the (mutable) username — so renaming a user at the identity provider keeps their
+  Jellyfin account linked, and a recycled username cannot inherit another user's account. A provider
+  that mints a _different_ `sub` for the same user on every login (a misconfigured pairwise-subject
+  setup) will work exactly once and then be refused — fix the IdP configuration; there is nothing
+  safe to anchor the identity to otherwise.
+- **Upgrading from a username-keyed version:** links created by older plugin versions migrate to
+  `sub` automatically on each user's next login. The migration matches on the _current_ username, so
+  a user renamed at the IdP before upgrading cannot be matched to their old link (they get a fresh
+  account — the same outcome a rename already had before). Note that the self-service linking page
+  now lists OpenID links by their `sub` value, which for many providers is an opaque identifier
+  rather than a readable name.
 
 ## Authelia
 

--- a/providers.md
+++ b/providers.md
@@ -58,6 +58,10 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   provider — this relaxes only the issuer check; signature, audience and expiry stay enforced.
 - If your IdP sends an `at_hash` claim it must match the issued access token — a correctly behaving
   provider always satisfies this.
+- **A `sub` claim is required.** The account link is keyed on the immutable `sub`, not on the
+  (mutable) username — so renaming a user at the identity provider keeps their Jellyfin account
+  linked, and a recycled username cannot inherit another user's account. Links created by older
+  plugin versions (keyed on the username) migrate to `sub` automatically on the user's next login.
 
 ## Authelia
 


### PR DESCRIPTION
# What & why

The OpenID canonical link was keyed on the **mutable username** (`preferred_username`). An identity-provider admin can rename or reassign it, so a renamed user lost their link and a recycled username could inherit another user's account. This keys the link on the immutable **`sub`** claim instead (per provider), while the Jellyfin display name still comes from `preferred_username`. Closes #155.

- `OidcAuthorizeStateBuilder` surfaces the `sub` as `Subject`, independent of the username/validity derivation.
- **Fail closed:** the OID callback rejects a *valid* login that carries no `sub` (401) rather than falling back to the username; `sub` is an OIDC Core MUST and is verified by the id_token validator (#134).
- Links are keyed by `canonicalKey` (sub for OIDC, NameID for SAML); `username` still drives the Jellyfin account name and pre-existing-account adoption. **SAML unchanged** (key == name == NameID).
- **Migration:** a legacy username-keyed OIDC link migrates to the `sub` key on the next login, both link candidates are read in ONE pass under the config lock, the re-key is idempotent and never overwrites a live target (only a dangling one), and the migrating login reuses the decision the old name-keyed lookup would have made.
- Manual self-service linking (`OidLink`) keys on `sub` too; migration decision extracted as the pure, unit-tested `AccountLinkResolver.ResolveCanonicalLink`.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a valid login without a `sub`, or without a resolvable identity, is rejected, never keyed on a mutable fallback.
- [x] No secrets logged; log inputs sanitized inline at the log call (`ReplaceLineEndings`).
- [x] A security review was performed: adversarial gate with 4 lenses + OIDC domain reviewer, oidc/bypass/correctness/integration PASS, availability NEEDS_IMPROVEMENT with both code findings fixed in this branch (atomic single-pass link resolution; dangling-target re-key unblocked). Details in the sign-off review.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; the migration decision is a pure, single-purpose, tested unit (`ResolveCanonicalLink`); `GetLinks` is the shared accessor.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (269/269).
- [x] Prettier is clean (`providers.md`).

## Notes

- Deliberate fail-closed trade-offs, documented in providers.md: a provider minting a rotating per-login `sub` works once and is then refused (IdP misconfiguration, keeping a username fallback would reopen the recycled-username takeover this closes); users renamed at the IdP before upgrading get a fresh account (same outcome as before); the linking page now lists OpenID links by their opaque `sub`.
- Follow-up #186: bind links to the discovered issuer (cross-issuer `sub` collision on provider repoint).
- SonarCloud gate red on `new_coverage` only (36.7 < 80, all other conditions OK), accepted per the free-plan policy, merged via admin bypass; the uncovered lines are controller wiring without a controller harness.
- Owed before any release: real-server E2E (legacy-link re-key on first login, rename keeps the account, no-sub provider denied, linking page lists/deletes sub keys).
