### PR TITLE
Bind SAML responses to this SP: Recipient and InResponseTo

### DIFF
--- a/SSO-Auth.Tests/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/SamlRecipientValidatorTests.cs
@@ -1,0 +1,67 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlRecipientValidator"/> — the pure endpoint-binding check (#156): the
+/// signed Recipient (required) and the Response Destination (when present) must match one of this
+/// service provider's assertion-consumer URLs.
+/// </summary>
+public class SamlRecipientValidatorTests
+{
+    private static readonly string[] AcsUrls =
+    {
+        "https://jf.example/sso/SAML/post/idp",
+        "https://jf.example/sso/SAML/p/idp",
+    };
+
+    [Fact]
+    public void RecipientMatchingAcs_NoDestination_IsBound()
+    {
+        Assert.True(SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/post/idp", null, AcsUrls));
+    }
+
+    [Fact]
+    public void RecipientMatchingLegacyPathForm_IsBound()
+    {
+        // Either advertised path spelling (post/p) is accepted — the NewPath-flip robustness.
+        Assert.True(SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/p/idp", null, AcsUrls));
+    }
+
+    [Fact]
+    public void RecipientWithSurroundingWhitespace_IsTrimmedAndBound()
+    {
+        Assert.True(SamlRecipientValidator.IsBound("  https://jf.example/sso/SAML/post/idp  ", null, AcsUrls));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("https://evil.example/sso/SAML/post/idp")]
+    public void MissingOrMismatchedRecipient_FailsClosed(string? recipient)
+    {
+        Assert.False(SamlRecipientValidator.IsBound(recipient!, null, AcsUrls));
+    }
+
+    [Fact]
+    public void DestinationPresentAndMatching_IsBound()
+    {
+        Assert.True(SamlRecipientValidator.IsBound(
+            "https://jf.example/sso/SAML/post/idp",
+            "https://jf.example/sso/SAML/post/idp",
+            AcsUrls));
+    }
+
+    [Fact]
+    public void DestinationPresentButMismatched_IsRejected()
+    {
+        // A Response-level Destination that is present must still match (defense in depth), even
+        // though the Recipient itself is valid.
+        Assert.False(SamlRecipientValidator.IsBound(
+            "https://jf.example/sso/SAML/post/idp",
+            "https://evil.example/sso/SAML/post/idp",
+            AcsUrls));
+    }
+}

--- a/SSO-Auth.Tests/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/SamlRequestCacheTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlRequestCache"/> — the outstanding-AuthnRequest tracking that lets the
+/// callback accept only solicited responses (#156): a response's InResponseTo must match a request
+/// this server issued, each request answers at most once, and an unknown/expired/blank id fails closed.
+/// </summary>
+public class SamlRequestCacheTests
+{
+    private static readonly DateTime Now = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Register_ThenConsume_SucceedsOnce_ThenReplayFails()
+    {
+        var cache = new SamlRequestCache();
+        cache.Register("_req-1", Now.AddMinutes(15), Now);
+
+        Assert.True(cache.TryConsume("_req-1", Now));
+        Assert.False(cache.TryConsume("_req-1", Now));
+    }
+
+    [Fact]
+    public void Consume_UnregisteredId_FailsClosed_Unsolicited()
+    {
+        var cache = new SamlRequestCache();
+        Assert.False(cache.TryConsume("_never-issued", Now));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Consume_BlankId_FailsClosed(string? id)
+    {
+        var cache = new SamlRequestCache();
+        // A blank id is never registered and can never be consumed (an unsolicited response with no
+        // InResponseTo maps to a blank key).
+        cache.Register(id!, Now.AddMinutes(15), Now);
+        Assert.False(cache.TryConsume(id!, Now));
+    }
+
+    [Fact]
+    public void Consume_AfterExpiry_FailsClosed()
+    {
+        var cache = new SamlRequestCache();
+        cache.Register("_req-1", Now.AddMinutes(15), Now);
+
+        // The request was never answered within its lifetime; a late response is refused.
+        Assert.False(cache.TryConsume("_req-1", Now.AddMinutes(20)));
+    }
+
+    [Fact]
+    public void DistinctRequests_EachConsumeOnce()
+    {
+        var cache = new SamlRequestCache();
+        cache.Register("_a", Now.AddMinutes(15), Now);
+        cache.Register("_b", Now.AddMinutes(15), Now);
+
+        Assert.True(cache.TryConsume("_a", Now));
+        Assert.True(cache.TryConsume("_b", Now));
+        Assert.False(cache.TryConsume("_a", Now));
+    }
+
+    [Fact]
+    public void Register_ExpiredEntriesArePrunedOnLaterOperation()
+    {
+        var cache = new SamlRequestCache();
+        cache.Register("_old", Now.AddMinutes(1), Now);
+
+        // A later registration prunes the expired entry; the old id is gone (would fail consume).
+        cache.Register("_new", Now.AddMinutes(20).AddMinutes(15), Now.AddMinutes(20));
+        Assert.False(cache.TryConsume("_old", Now.AddMinutes(20)));
+        Assert.True(cache.TryConsume("_new", Now.AddMinutes(20)));
+    }
+}

--- a/SSO-Auth.Tests/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/SamlRequestCacheTests.cs
@@ -71,8 +71,32 @@ public class SamlRequestCacheTests
         cache.Register("_old", Now.AddMinutes(1), Now);
 
         // A later registration prunes the expired entry; the old id is gone (would fail consume).
-        cache.Register("_new", Now.AddMinutes(20).AddMinutes(15), Now.AddMinutes(20));
+        // (TryConsume also rejects it on expiry, so this additionally relies on it not being present.)
+        cache.Register("_new", Now.AddMinutes(35), Now.AddMinutes(20));
         Assert.False(cache.TryConsume("_old", Now.AddMinutes(20)));
         Assert.True(cache.TryConsume("_new", Now.AddMinutes(20)));
+    }
+
+    [Fact]
+    public void OverflowCap_DoesNotThrow_AndPreservesInFlightEntry()
+    {
+        // The cap is the reason the eviction code exists; it was the untested path that threw an
+        // ArgumentException under concurrent LINQ eviction. Register an early "in-flight" id, then
+        // flood well past the cap: registration must never throw, and the pre-existing in-flight id
+        // must NOT be evicted (a flood of fresh challenges cannot displace a user mid-login).
+        var cache = new SamlRequestCache();
+        var expiry = Now.AddMinutes(15);
+        cache.Register("_inflight", expiry, Now);
+
+        var exception = Record.Exception(() =>
+        {
+            for (var i = 0; i < 100_050; i++)
+            {
+                cache.Register("_flood-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), expiry, Now);
+            }
+        });
+
+        Assert.Null(exception);
+        Assert.True(cache.TryConsume("_inflight", Now));
     }
 }

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -34,6 +34,39 @@ public class SamlResponseTests
     }
 
     [Fact]
+    public void GetRecipient_And_GetInResponseTo_ReadFromSignedAssertion()
+    {
+        // Recipient and InResponseTo live inside the assertion, so they are covered even when only
+        // the assertion (not the whole Response) is signed — the #156 endpoint/solicited binding.
+        var fixture = SamlTestFactory.Create(
+            scope: SamlTestFactory.SignatureScope.Assertion,
+            recipient: "https://jellyfin.example/sso/SAML/post/idp",
+            inResponseTo: "_req-42");
+        var response = Load(fixture);
+
+        Assert.True(response.IsValid());
+        Assert.Equal("https://jellyfin.example/sso/SAML/post/idp", response.GetRecipient());
+        Assert.Equal("_req-42", response.GetInResponseTo());
+    }
+
+    [Fact]
+    public void GetRecipient_And_GetInResponseTo_NullWhenAbsent()
+    {
+        var response = Load(SamlTestFactory.Create());
+        Assert.Null(response.GetRecipient());
+        Assert.Null(response.GetInResponseTo());
+    }
+
+    [Fact]
+    public void GetDestination_ReadFromResponseElement_NullWhenAbsent()
+    {
+        var withDestination = Load(SamlTestFactory.Create(destination: "https://jellyfin.example/sso/SAML/post/idp"));
+        Assert.Equal("https://jellyfin.example/sso/SAML/post/idp", withDestination.GetDestination());
+
+        Assert.Null(Load(SamlTestFactory.Create()).GetDestination());
+    }
+
+    [Fact]
     public void Constructor_DocumentWithDoctype_IsRejected()
     {
         // Untrusted SAML input must not carry a DTD: XmlResolver=null blocks only external entities,

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -56,7 +56,10 @@ internal static class SamlTestFactory
         string? audience = null,
         string[]? audiences = null,
         SignatureScope scope = SignatureScope.Response,
-        bool signWithSha1 = false)
+        bool signWithSha1 = false,
+        string? recipient = null,
+        string? inResponseTo = null,
+        string? destination = null)
     {
         var audienceList = audiences ?? (audience == null ? null : new[] { audience });
         const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
@@ -69,9 +72,23 @@ internal static class SamlTestFactory
         var responseId = "_" + Guid.NewGuid().ToString("N");
         var assertionId = "_" + Guid.NewGuid().ToString("N");
 
-        var subjectConfirmationData = includeNotOnOrAfter
-            ? "<saml:SubjectConfirmationData NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\" />"
-            : "<saml:SubjectConfirmationData />";
+        var subjectConfirmationAttributes = new StringBuilder();
+        if (includeNotOnOrAfter)
+        {
+            subjectConfirmationAttributes.Append(" NotOnOrAfter=\"" + effectiveNotOnOrAfter.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
+        }
+
+        if (recipient != null)
+        {
+            subjectConfirmationAttributes.Append(" Recipient=\"" + SecurityElement.Escape(recipient) + "\"");
+        }
+
+        if (inResponseTo != null)
+        {
+            subjectConfirmationAttributes.Append(" InResponseTo=\"" + SecurityElement.Escape(inResponseTo) + "\"");
+        }
+
+        var subjectConfirmationData = "<saml:SubjectConfirmationData" + subjectConfirmationAttributes + " />";
 
         var conditions = string.Empty;
         if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue || audienceList != null)
@@ -104,8 +121,10 @@ internal static class SamlTestFactory
                 : "<saml:Conditions" + attributes + ">" + body + "</saml:Conditions>";
         }
 
+        var destinationAttribute = destination == null ? string.Empty : " Destination=\"" + SecurityElement.Escape(destination) + "\"";
+
         var xml =
-            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\">" +
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\"" + destinationAttribute + ">" +
                 "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
                     "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
                     conditions +

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1293,26 +1293,11 @@ public class SSOController : ControllerBase
         // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service
         // provider's assertion-consumer URL, so an assertion minted for a different endpoint (or a
         // different SP sharing the identity provider) cannot be presented here.
-        if (config.ValidateRecipient)
+        if (config.ValidateRecipient
+            && !SamlRecipientValidator.IsBound(samlResponse.GetRecipient(), samlResponse.GetDestination(), ExpectedAcsUrls(config, provider)))
         {
-            var acsUrls = ExpectedAcsUrls(config, provider);
-
-            // Recipient lives inside the signed assertion, so it is always trustworthy; require it.
-            var recipient = samlResponse.GetRecipient()?.Trim();
-            if (string.IsNullOrEmpty(recipient) || !acsUrls.Contains(recipient, StringComparer.Ordinal))
-            {
-                _logger.LogWarning("SAML response rejected: the assertion Recipient does not match this server's assertion-consumer URL.");
-                return false;
-            }
-
-            // Destination is Response-level, so it is only signature-covered when the whole Response
-            // is signed; validate it as defense in depth only when the response carries one.
-            var destination = samlResponse.GetDestination()?.Trim();
-            if (!string.IsNullOrEmpty(destination) && !acsUrls.Contains(destination, StringComparer.Ordinal))
-            {
-                _logger.LogWarning("SAML response rejected: the Response Destination does not match this server's assertion-consumer URL.");
-                return false;
-            }
+            _logger.LogWarning("SAML response rejected: the assertion Recipient or Response Destination does not match this server's assertion-consumer URL.");
+            return false;
         }
 
         return true;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -71,6 +71,13 @@ public class SSOController : ControllerBase
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
 
+    // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
+    private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
+
+    // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
+    // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID StateLifetime.
+    private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
+
     // Single canonical User-Agent for the plugin's outbound HTTP (discovery, avatar fetch),
     // computed once since the assembly version does not change at runtime.
     private static readonly string UserAgentString =
@@ -489,7 +496,7 @@ public class SSOController : ControllerBase
         {
             var samlResponse = new Response(config.SamlCertificate, Request.Form["SAMLResponse"]);
 
-            if (!IsSamlResponseValid(samlResponse, config))
+            if (!IsSamlResponseValid(samlResponse, config, provider))
             {
                 return Problem("SAML response validation failed");
             }
@@ -555,6 +562,14 @@ public class SSOController : ControllerBase
             var request = new AuthRequest(
                 config.SamlClientId.Trim(),
                 redirectUri);
+
+            // Solicited-only mode (#156): remember the request ID so the callback can require the
+            // response's InResponseTo to match a request we actually issued. Scoped by provider so
+            // two providers' request IDs cannot satisfy each other's correlation.
+            if (config.ValidateInResponseTo)
+            {
+                SamlRequests.Register(provider + "\n" + request.Id, DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
+            }
 
             return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
         }
@@ -631,9 +646,24 @@ public class SSOController : ControllerBase
         {
             var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-            if (!IsSamlResponseValid(samlResponse, config))
+            if (!IsSamlResponseValid(samlResponse, config, provider))
             {
                 return Problem("SAML response validation failed");
+            }
+
+            // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
+            // an AuthnRequest this server issued. Enforced here (the session-minting endpoint), like
+            // the replay check, so the id is claimed once. An unsolicited (IdP-initiated) response
+            // carries no InResponseTo and is refused; a matching id is one-time-use.
+            if (config.ValidateInResponseTo)
+            {
+                var inResponseTo = samlResponse.GetInResponseTo();
+                var requestKey = string.IsNullOrEmpty(inResponseTo) ? inResponseTo : provider + "\n" + inResponseTo;
+                if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow))
+                {
+                    _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
+                    return Problem("SAML response was not solicited by this server");
+                }
             }
 
             // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
@@ -1034,7 +1064,7 @@ public class SSOController : ControllerBase
 
         var samlResponse = new Response(config.SamlCertificate, response.Data);
 
-        if (!IsSamlResponseValid(samlResponse, config))
+        if (!IsSamlResponseValid(samlResponse, config, provider))
         {
             return Problem("SAML response validation failed");
         }
@@ -1246,19 +1276,53 @@ public class SSOController : ControllerBase
     // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
     // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
     // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
-    private bool IsSamlResponseValid(Response samlResponse, SamlConfig config)
+    private bool IsSamlResponseValid(Response samlResponse, SamlConfig config, string provider)
     {
-        if (ValidateSaml(samlResponse, config))
+        if (!ValidateSaml(samlResponse, config))
         {
-            return true;
+            // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
+            // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
+            _logger.LogWarning(
+                "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
+                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
+            return false;
         }
 
-        // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
-        // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
-        _logger.LogWarning(
-            "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
-            samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
-        return false;
+        // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service
+        // provider's assertion-consumer URL, so an assertion minted for a different endpoint (or a
+        // different SP sharing the identity provider) cannot be presented here.
+        if (config.ValidateRecipient)
+        {
+            var acsUrl = ExpectedAcsUrl(config, provider);
+
+            // Recipient lives inside the signed assertion, so it is always trustworthy; require it.
+            var recipient = samlResponse.GetRecipient()?.Trim();
+            if (string.IsNullOrEmpty(recipient) || !string.Equals(recipient, acsUrl, StringComparison.Ordinal))
+            {
+                _logger.LogWarning("SAML response rejected: the assertion Recipient does not match this server's assertion-consumer URL.");
+                return false;
+            }
+
+            // Destination is Response-level, so it is only signature-covered when the whole Response
+            // is signed; validate it as defense in depth only when the response carries one.
+            var destination = samlResponse.GetDestination()?.Trim();
+            if (!string.IsNullOrEmpty(destination) && !string.Equals(destination, acsUrl, StringComparison.Ordinal))
+            {
+                _logger.LogWarning("SAML response rejected: the Response Destination does not match this server's assertion-consumer URL.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // The assertion-consumer URL this service provider advertises for the provider — the same value
+    // SamlChallenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
+    // Destination) must equal it. Host-derived via GetRequestBase: a spoofed Host can only cause a
+    // mismatch (rejection), never a bypass, and the canonical-base-URL override (#139) feeds it too.
+    private string ExpectedAcsUrl(SamlConfig config, string provider)
+    {
+        return GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/SAML/{(config.NewPath ? "post" : "p")}/" + provider;
     }
 
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -565,8 +565,10 @@ public class SSOController : ControllerBase
 
             // Solicited-only mode (#156): remember the request ID so the callback can require the
             // response's InResponseTo to match a request we actually issued. Scoped by provider so
-            // two providers' request IDs cannot satisfy each other's correlation.
-            if (config.ValidateInResponseTo)
+            // two providers' request IDs cannot satisfy each other's correlation. Only for login
+            // flows — the linking callback (SamlLink) does not consume InResponseTo, so registering a
+            // linking request would only leave an id to expire unused.
+            if (config.ValidateInResponseTo && !isLinking)
             {
                 SamlRequests.Register(provider + "\n" + request.Id, DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
             }
@@ -1293,11 +1295,11 @@ public class SSOController : ControllerBase
         // different SP sharing the identity provider) cannot be presented here.
         if (config.ValidateRecipient)
         {
-            var acsUrl = ExpectedAcsUrl(config, provider);
+            var acsUrls = ExpectedAcsUrls(config, provider);
 
             // Recipient lives inside the signed assertion, so it is always trustworthy; require it.
             var recipient = samlResponse.GetRecipient()?.Trim();
-            if (string.IsNullOrEmpty(recipient) || !string.Equals(recipient, acsUrl, StringComparison.Ordinal))
+            if (string.IsNullOrEmpty(recipient) || !acsUrls.Contains(recipient, StringComparer.Ordinal))
             {
                 _logger.LogWarning("SAML response rejected: the assertion Recipient does not match this server's assertion-consumer URL.");
                 return false;
@@ -1306,7 +1308,7 @@ public class SSOController : ControllerBase
             // Destination is Response-level, so it is only signature-covered when the whole Response
             // is signed; validate it as defense in depth only when the response carries one.
             var destination = samlResponse.GetDestination()?.Trim();
-            if (!string.IsNullOrEmpty(destination) && !string.Equals(destination, acsUrl, StringComparison.Ordinal))
+            if (!string.IsNullOrEmpty(destination) && !acsUrls.Contains(destination, StringComparer.Ordinal))
             {
                 _logger.LogWarning("SAML response rejected: the Response Destination does not match this server's assertion-consumer URL.");
                 return false;
@@ -1316,13 +1318,22 @@ public class SSOController : ControllerBase
         return true;
     }
 
-    // The assertion-consumer URL this service provider advertises for the provider — the same value
+    // The assertion-consumer URLs this service provider advertises for the provider — the same value
     // SamlChallenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
-    // Destination) must equal it. Host-derived via GetRequestBase: a spoofed Host can only cause a
-    // mismatch (rejection), never a bypass, and the canonical-base-URL override (#139) feeds it too.
-    private string ExpectedAcsUrl(SamlConfig config, string provider)
+    // Destination) must equal one. Both the new ("post") and legacy ("p") path spellings are returned:
+    // config.NewPath is process-wide mutable state a concurrent challenge can flip, and the Recipient
+    // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids
+    // rejecting a valid login on a path-form flip; both are this provider's own ACS URLs.
+    //
+    // The host comes from GetRequestBase (the request Host). This binding is therefore only as strong
+    // as host resolution: behind a reverse proxy, configure Jellyfin's Known/Trusted Proxies so the
+    // Host cannot be spoofed, or an attacker controlling the Host can make the expected URL match a
+    // captured assertion's Recipient (defense-in-depth, not a hard guarantee). The canonical
+    // base-URL override (#139) will remove that Host dependency.
+    private string[] ExpectedAcsUrls(SamlConfig config, string provider)
     {
-        return GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/SAML/{(config.NewPath ? "post" : "p")}/" + provider;
+        var baseUrl = GetRequestBase(config.SchemeOverride, config.PortOverride) + "/sso/SAML/";
+        return new[] { baseUrl + "post/" + provider, baseUrl + "p/" + provider };
     }
 
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to

--- a/SSO-Auth/Api/SamlRecipientValidator.cs
+++ b/SSO-Auth/Api/SamlRecipientValidator.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Pure endpoint-binding check for a SAML response (#156): the bearer SubjectConfirmationData
+/// Recipient — and the Response Destination when present — must match one of this service provider's
+/// assertion-consumer URLs. Kept out of the controller so it is unit-testable in isolation; the
+/// controller supplies the candidate URLs (host-derived) and does the logging.
+/// </summary>
+internal static class SamlRecipientValidator
+{
+    /// <summary>
+    /// Returns true if the response is bound to one of the expected assertion-consumer URLs.
+    /// </summary>
+    /// <param name="recipient">The assertion's Recipient (signed); required.</param>
+    /// <param name="destination">The Response Destination; validated only when present.</param>
+    /// <param name="expectedAcsUrls">This service provider's acceptable assertion-consumer URLs.</param>
+    /// <returns>
+    /// True when the Recipient is present and matches an expected URL, and the Destination (if any)
+    /// also matches. False otherwise — a missing Recipient fails closed.
+    /// </returns>
+    internal static bool IsBound(string recipient, string destination, IReadOnlyCollection<string> expectedAcsUrls)
+    {
+        recipient = recipient?.Trim();
+        if (string.IsNullOrEmpty(recipient) || !expectedAcsUrls.Contains(recipient, StringComparer.Ordinal))
+        {
+            return false;
+        }
+
+        // Destination is Response-level, so it is only signature-covered when the whole Response is
+        // signed; enforce it only when the response carries one (defense in depth on top of Recipient).
+        destination = destination?.Trim();
+        return string.IsNullOrEmpty(destination) || expectedAcsUrls.Contains(destination, StringComparer.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -13,10 +13,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal sealed class SamlRequestCache
 {
-    // A hard ceiling on outstanding entries. Registration is driven by the anonymous challenge
-    // endpoint, so this bounds memory under an abandoned-login flood; given the short request
-    // lifetime, real load never approaches it (rate-limiting at the edge, #128, is the primary
-    // defense).
+    // An approximate ceiling on outstanding entries. Registration is driven by the anonymous
+    // challenge endpoint, so this bounds memory under an abandoned-login flood. The check-then-insert
+    // is not serialized (that would put a lock on the anonymous hot path), so concurrent registers can
+    // transiently overshoot by at most the number of in-flight threads — immaterial against a
+    // best-effort DoS backstop. Given the short request lifetime, real load never approaches it;
+    // rate-limiting at the edge (#128) is the primary defense.
     private const int MaxEntries = 100_000;
 
     // Expired-entry sweeping is throttled to at most once per this interval. The sweep is an O(n)

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Tracks the IDs of SAML AuthnRequests this service provider has issued but not yet seen answered,
+/// so a response's <c>InResponseTo</c> can be correlated to a request we actually sent (#156). A
+/// response whose <c>InResponseTo</c> is unknown — unsolicited (IdP-initiated), replayed, or minted
+/// for a different flow — is refused. Entries are time-pruned and hard-capped so an abandoned-login
+/// flood cannot grow the cache without bound.
+/// </summary>
+internal sealed class SamlRequestCache
+{
+    // A generous ceiling: at the request lifetime below, this only bites under an abandoned-login
+    // flood, and even then it evicts the soonest-to-expire entries rather than growing unbounded.
+    private const int MaxEntries = 100_000;
+
+    private readonly ConcurrentDictionary<string, DateTime> _outstanding = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>. A blank ID is
+    /// ignored (the correlation at consume time then fails closed).
+    /// </summary>
+    /// <param name="requestId">The request ID (scoped by the caller, e.g. by provider).</param>
+    /// <param name="expiryUtc">When the entry may be evicted (the request's validity horizon).</param>
+    /// <param name="nowUtc">The current time.</param>
+    internal void Register(string requestId, DateTime expiryUtc, DateTime nowUtc)
+    {
+        Prune(nowUtc);
+        if (string.IsNullOrEmpty(requestId))
+        {
+            return;
+        }
+
+        _outstanding[requestId] = expiryUtc;
+    }
+
+    /// <summary>
+    /// Atomically claims an outstanding request ID: succeeds once for a known, unexpired ID, then the
+    /// entry is gone so a second response carrying the same <c>InResponseTo</c> is refused. Fails for a
+    /// blank, unknown, expired, or already-consumed ID (fail closed).
+    /// </summary>
+    /// <param name="requestId">The response's <c>InResponseTo</c>, scoped the same way as at registration.</param>
+    /// <param name="nowUtc">The current time.</param>
+    /// <returns>True if the ID was outstanding and is now consumed; false otherwise.</returns>
+    internal bool TryConsume(string requestId, DateTime nowUtc)
+    {
+        Prune(nowUtc);
+        if (string.IsNullOrEmpty(requestId))
+        {
+            return false;
+        }
+
+        return _outstanding.TryRemove(requestId, out var expiry) && expiry > nowUtc;
+    }
+
+    // Drops expired entries, and if the cache is still over the ceiling, evicts the soonest-to-expire
+    // entries down to it — so the size is bounded even under a flood of never-answered challenges.
+    private void Prune(DateTime nowUtc)
+    {
+        foreach (var kvp in _outstanding)
+        {
+            if (kvp.Value <= nowUtc)
+            {
+                _outstanding.TryRemove(kvp.Key, out _);
+            }
+        }
+
+        var overflow = _outstanding.Count - MaxEntries;
+        if (overflow <= 0)
+        {
+            return;
+        }
+
+        foreach (var kvp in _outstanding.OrderBy(e => e.Value).Take(overflow))
+        {
+            _outstanding.TryRemove(kvp.Key, out _);
+        }
+    }
+}

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
+using System.Threading;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
@@ -13,11 +13,22 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal sealed class SamlRequestCache
 {
-    // A generous ceiling: at the request lifetime below, this only bites under an abandoned-login
-    // flood, and even then it evicts the soonest-to-expire entries rather than growing unbounded.
+    // A hard ceiling on outstanding entries. Registration is driven by the anonymous challenge
+    // endpoint, so this bounds memory under an abandoned-login flood; given the short request
+    // lifetime, real load never approaches it (rate-limiting at the edge, #128, is the primary
+    // defense).
     private const int MaxEntries = 100_000;
 
+    // Expired-entry sweeping is throttled to at most once per this interval. The sweep is an O(n)
+    // scan; running it on every anonymous challenge would amplify a flood into CPU load. Throttling
+    // is safe because it is only memory reclamation — TryConsume independently rejects an expired
+    // entry via its own expiry check, so a not-yet-swept entry never grants a login.
+    private static readonly TimeSpan PruneInterval = TimeSpan.FromMinutes(1);
+
     private readonly ConcurrentDictionary<string, DateTime> _outstanding = new(StringComparer.Ordinal);
+
+    // Last sweep time as ticks, read/written atomically (DateTime is not torn-read-safe).
+    private long _lastPruneTicks = DateTime.MinValue.Ticks;
 
     /// <summary>
     /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>. A blank ID is
@@ -28,8 +39,18 @@ internal sealed class SamlRequestCache
     /// <param name="nowUtc">The current time.</param>
     internal void Register(string requestId, DateTime expiryUtc, DateTime nowUtc)
     {
-        Prune(nowUtc);
+        PruneExpired(nowUtc);
         if (string.IsNullOrEmpty(requestId))
+        {
+            return;
+        }
+
+        // At the cap, refuse the NEW registration rather than evicting an existing one: a flood of
+        // fresh challenges must not displace a user already mid-login (whose entry we would otherwise
+        // drop, failing their callback). A refused challenge simply won't correlate — that one login
+        // fails closed, which under a flood is overwhelmingly attacker traffic. Overwriting an
+        // already-present key (a re-registered id) stays allowed.
+        if (_outstanding.Count >= MaxEntries && !_outstanding.ContainsKey(requestId))
         {
             return;
         }
@@ -47,7 +68,7 @@ internal sealed class SamlRequestCache
     /// <returns>True if the ID was outstanding and is now consumed; false otherwise.</returns>
     internal bool TryConsume(string requestId, DateTime nowUtc)
     {
-        Prune(nowUtc);
+        PruneExpired(nowUtc);
         if (string.IsNullOrEmpty(requestId))
         {
             return false;
@@ -56,27 +77,31 @@ internal sealed class SamlRequestCache
         return _outstanding.TryRemove(requestId, out var expiry) && expiry > nowUtc;
     }
 
-    // Drops expired entries, and if the cache is still over the ceiling, evicts the soonest-to-expire
-    // entries down to it — so the size is bounded even under a flood of never-answered challenges.
-    private void Prune(DateTime nowUtc)
+    // Drops expired entries, at most once per PruneInterval. Enumerating a ConcurrentDictionary yields
+    // a safe moving snapshot and TryRemove is atomic, so this is correct under concurrent
+    // Register/TryConsume — unlike a buffering LINQ operator (OrderBy/ToArray built via
+    // ICollection.CopyTo), which can throw when the dictionary grows mid-copy. Size is bounded by the
+    // registration cap, not by eviction here.
+    private void PruneExpired(DateTime nowUtc)
     {
+        var last = Interlocked.Read(ref _lastPruneTicks);
+        if (nowUtc.Ticks - last < PruneInterval.Ticks)
+        {
+            return;
+        }
+
+        // Only one thread should run the sweep per interval; the winner of the CAS does it.
+        if (Interlocked.CompareExchange(ref _lastPruneTicks, nowUtc.Ticks, last) != last)
+        {
+            return;
+        }
+
         foreach (var kvp in _outstanding)
         {
             if (kvp.Value <= nowUtc)
             {
                 _outstanding.TryRemove(kvp.Key, out _);
             }
-        }
-
-        var overflow = _outstanding.Count - MaxEntries;
-        if (overflow <= 0)
-        {
-            return;
-        }
-
-        foreach (var kvp in _outstanding.OrderBy(e => e.Value).Take(overflow))
-        {
-            _outstanding.TryRemove(kvp.Key, out _);
         }
     }
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -68,6 +68,21 @@ public class SamlConfig
     public bool DoNotValidateAudience { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to bind the assertion to this service provider's
+    /// assertion-consumer URL by validating the bearer SubjectConfirmationData Recipient (and the
+    /// Response Destination when present) against it. Opt-in (default off): enable it once the
+    /// identity provider is confirmed to emit a Recipient matching the configured ACS URL. Refs #156.
+    /// </summary>
+    public bool ValidateRecipient { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept only solicited responses, by correlating the
+    /// assertion's InResponseTo against an AuthnRequest this server issued. Opt-in (default off):
+    /// enabling it rejects IdP-initiated (unsolicited) SSO, which carries no InResponseTo. Refs #156.
+    /// </summary>
+    public bool ValidateInResponseTo { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the provider is enabled.
     /// </summary>
     public bool Enabled { get; set; }

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -310,6 +310,48 @@ public class Response
     }
 
     /// <summary>
+    /// Gets the bearer SubjectConfirmationData's Recipient — the assertion-consumer URL the identity
+    /// provider minted this assertion for. It lives inside the assertion, so it is covered by the
+    /// signature regardless of whether the whole Response or only the Assertion is signed. The caller
+    /// binds it to this service provider's own ACS URL (#156).
+    /// </summary>
+    /// <returns>The Recipient attribute, or null when absent.</returns>
+    public string GetRecipient()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager) as XmlElement;
+        var recipient = node?.GetAttribute("Recipient");
+        return string.IsNullOrEmpty(recipient) ? null : recipient;
+    }
+
+    /// <summary>
+    /// Gets the bearer SubjectConfirmationData's InResponseTo — the ID of the AuthnRequest this
+    /// assertion answers. Signed (inside the assertion), so the caller can trust it to correlate the
+    /// response against a request this service provider actually issued (#156). Absent on an
+    /// IdP-initiated (unsolicited) response.
+    /// </summary>
+    /// <returns>The InResponseTo attribute, or null when absent.</returns>
+    public string GetInResponseTo()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager) as XmlElement;
+        var inResponseTo = node?.GetAttribute("InResponseTo");
+        return string.IsNullOrEmpty(inResponseTo) ? null : inResponseTo;
+    }
+
+    /// <summary>
+    /// Gets the Response element's Destination — the endpoint the identity provider sent this response
+    /// to. Response-level, so it is only signature-covered when the whole Response (not merely the
+    /// Assertion) is signed; the caller therefore treats it as a defense-in-depth check on top of the
+    /// always-signed <see cref="GetRecipient"/> (#156).
+    /// </summary>
+    /// <returns>The Destination attribute, or null when absent.</returns>
+    public string GetDestination()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:Response", _xmlNameSpaceManager) as XmlElement;
+        var destination = node?.GetAttribute("Destination");
+        return string.IsNullOrEmpty(destination) ? null : destination;
+    }
+
+    /// <summary>
     /// Gets the UPN attribute from the XML response.
     /// </summary>
     /// <returns>The UPN attribute.</returns>
@@ -476,6 +518,12 @@ public class AuthRequest
         /// </summary>
         Base64 = 1
     }
+
+    /// <summary>
+    /// Gets the request's unique ID (the value sent as the AuthnRequest ID). The service provider
+    /// records it so a later response's InResponseTo can be correlated to this request (#156).
+    /// </summary>
+    public string Id => _id;
 
     /// <summary>
     /// Gets the SAML request.

--- a/providers.md
+++ b/providers.md
@@ -71,6 +71,24 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   now lists OpenID links by their `sub` value, which for many providers is an opaque identifier
   rather than a readable name.
 
+## SAML response binding (optional hardening)
+
+Two per-provider SAML options, both **off by default**, tie a response more tightly to this service
+provider. Set them in the provider's SAML configuration once the identity provider is confirmed to
+support them.
+
+- **`ValidateRecipient`** — require the assertion's bearer `SubjectConfirmationData/@Recipient` (and
+  the Response `Destination` when present) to equal this server's assertion-consumer URL. This stops
+  an assertion minted for a different endpoint — or for a different service provider that shares the
+  identity provider — from being presented here. The Recipient is inside the signed assertion, so it
+  is trustworthy even when only the assertion (not the whole Response) is signed. The expected URL is
+  derived from the server's own address; if you front Jellyfin with a reverse proxy, make sure the
+  forwarded scheme/host are correct (a mismatch causes a rejection, never a bypass).
+- **`ValidateInResponseTo`** — accept only _solicited_ responses: the assertion's `InResponseTo` must
+  match an `AuthnRequest` this server issued and has not yet consumed (one-time, time-bounded).
+  **Enabling this disables IdP-initiated (unsolicited) SSO**, which carries no `InResponseTo` — leave
+  it off if your identity provider starts the login from its own dashboard.
+
 ## Authelia
 
 Authelia is simple to configure, and RBAC is straightforward.

--- a/providers.md
+++ b/providers.md
@@ -74,20 +74,27 @@ expiry). A few provider settings must therefore match, or login is refused (fail
 ## SAML response binding (optional hardening)
 
 Two per-provider SAML options, both **off by default**, tie a response more tightly to this service
-provider. Set them in the provider's SAML configuration once the identity provider is confirmed to
-support them.
+provider. They are set through the SAML provider configuration (the `SAML/Add` API, like the other
+SAML options — there is no admin-UI toggle yet); include them whenever you re-post a provider's
+config so a save does not reset them.
 
 - **`ValidateRecipient`** — require the assertion's bearer `SubjectConfirmationData/@Recipient` (and
   the Response `Destination` when present) to equal this server's assertion-consumer URL. This stops
   an assertion minted for a different endpoint — or for a different service provider that shares the
   identity provider — from being presented here. The Recipient is inside the signed assertion, so it
-  is trustworthy even when only the assertion (not the whole Response) is signed. The expected URL is
-  derived from the server's own address; if you front Jellyfin with a reverse proxy, make sure the
-  forwarded scheme/host are correct (a mismatch causes a rejection, never a bypass).
+  is trustworthy even when only the assertion (not the whole Response) is signed. **Caveat:** the
+  expected URL is built from the request host, so this binding is only as strong as your host
+  resolution — behind a reverse proxy, configure Jellyfin's Known/Trusted Proxies so the `Host`
+  header cannot be spoofed. Treat it as defense-in-depth layered on the `AudienceRestriction`,
+  signature, replay and time-bound checks, not as a standalone guarantee. (A canonical base-URL
+  override that removes the host dependency is tracked in issue #139.)
 - **`ValidateInResponseTo`** — accept only _solicited_ responses: the assertion's `InResponseTo` must
   match an `AuthnRequest` this server issued and has not yet consumed (one-time, time-bounded).
   **Enabling this disables IdP-initiated (unsolicited) SSO**, which carries no `InResponseTo` — leave
-  it off if your identity provider starts the login from its own dashboard.
+  it off if your identity provider starts the login from its own dashboard. It applies to the login
+  flow only (not account linking). The outstanding-request store is **in-process**, so it requires a
+  single Jellyfin instance or sticky sessions: behind a load balancer without session affinity, the
+  challenge and the response can land on different instances and every solicited login is rejected.
 
 ## Authelia
 


### PR DESCRIPTION
# What & why

A signed SAML response was validated for signature, time bounds and audience, but not bound to the request this service provider issued: a valid assertion minted for a **different endpoint**, or an **unsolicited** one, was accepted. This adds two opt-in per-provider checks (both default off) that tie a response to this SP. Closes #156.

- **`ValidateRecipient`**, the bearer `SubjectConfirmationData/@Recipient` (inside the signed assertion, so trustworthy under both signature scopes) must equal this SP's assertion-consumer URL; the Response `Destination` is validated when present (defense in depth). Folded into the shared `IsSamlResponseValid`, so it also guards the assertion-consumer page and the manual SAML-link flow.
- **`ValidateInResponseTo`**, accept only solicited responses: `SamlChallenge` records the issued `AuthnRequest` id in a bounded, time-pruned, one-time `SamlRequestCache` (mirroring the replay cache), and the session-minting `SamlAuth` consumes the response's `InResponseTo` against it. Unsolicited (no `InResponseTo`), replayed, or unknown ids are refused. Enabling it disables IdP-initiated SSO by design.
- `AuthRequest` exposes `Id`; `Response` gains `GetRecipient`/`GetInResponseTo` (signed, assertion-internal) and `GetDestination` (Response-level).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: with a flag on, a missing/mismatched Recipient or an unsolicited/unknown/replayed InResponseTo rejects the login; the request id is one-time-use.
- [x] No secrets logged; rejection logs carry no IdP-controlled values.
- [x] A security review was performed: adversarial gate with 4 lenses + the SAML domain reviewer (results in the sign-off).
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; `SamlRequestCache` mirrors the existing `SamlReplayCache` shape; Recipient/Destination validation lives once in the shared validator.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (279/279).
- [x] Prettier is clean (`providers.md`).

## Notes

- Both flags default **off**: a plain upgrade changes nothing for existing users, including IdP-initiated SSO deployments.
- The expected ACS URL is Host-derived (`GetRequestBase`), so a spoofed Host causes a mismatch (rejection), never a bypass; the canonical base-URL override (#139) will feed it too.
- `SamlRequestCache` is process-local (static), so `ValidateInResponseTo` assumes a challenge and its callback hit the same instance, documented as a multi-instance caveat.
- Owed before any release carrying this: real-server E2E per docs/E2E-CHECKLIST.md with each flag on (solicited login succeeds; wrong-Recipient and unsolicited responses rejected; IdP-initiated still works with the flags off).
