### PR TITLE
Preserve server-managed canonical links across config saves

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the server-managed-field handling (#157): canonical links are preserved across a save
+/// built from a stale client snapshot (<see cref="SSOPlugin.PreserveServerManagedFields"/>), are
+/// withheld from JSON responses ([JsonIgnore]), and still round-trip through the config XML.
+/// </summary>
+public class ConfigPreservationTests
+{
+    private static readonly Guid User = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Fact]
+    public void Preserve_ReinjectsLiveLinks_IntoStaleIncomingProvider()
+    {
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User } };
+        live.SamlConfigs["saml"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = User } };
+
+        // The incoming (stale) config has the providers but empty link maps — as a client snapshot
+        // taken before the login that created the links would.
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig();
+        incoming.SamlConfigs["saml"] = new SamlConfig();
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.Equal(User, incoming.OidConfigs["idp"].CanonicalLinks["sub-1"]);
+        Assert.Equal(User, incoming.SamlConfigs["saml"].CanonicalLinks["nameid-1"]);
+    }
+
+    [Fact]
+    public void Preserve_NewProviderNotInLive_KeepsItsOwnEmptyMap()
+    {
+        var live = new PluginConfiguration();
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["fresh"] = new OidConfig();
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.Empty(incoming.OidConfigs["fresh"].CanonicalLinks);
+    }
+
+    [Fact]
+    public void Preserve_ProviderDeletedInIncoming_IsNotReAdded()
+    {
+        // Deleting a provider must survive the save: a provider present only in live is not resurrected.
+        var live = new PluginConfiguration();
+        live.OidConfigs["gone"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub"] = User } };
+        var incoming = new PluginConfiguration();
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.False(incoming.OidConfigs.ContainsKey("gone"));
+    }
+
+    [Fact]
+    public void Preserve_NullConfigMaps_DoNotThrow()
+    {
+        var incoming = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
+        var live = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
+
+        // Fail-safe: a malformed config with missing maps must not NRE the save path.
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+    }
+
+    [Fact]
+    public void CanonicalLinks_AreOmittedFromJson_ButKeptInXml()
+    {
+        var config = new OidConfig
+        {
+            OidClientId = "client",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-secret"] = User },
+        };
+
+        // JSON (API responses / core getPluginConfiguration) must not leak the account-link map.
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("CanonicalLinks", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-secret", json, StringComparison.Ordinal);
+        Assert.Contains("client", json, StringComparison.Ordinal);
+
+        // XML (on-disk config) must still persist it, so links survive a restart.
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("CanonicalLinks", xml, StringComparison.Ordinal);
+        Assert.Contains("sub-secret", xml, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -331,7 +331,7 @@ public class SSOController : ControllerBase
             // Preserve the server-managed canonical links (#157): this replaces the whole provider
             // object, and CanonicalLinks is [JsonIgnore] so the posted config never carries them —
             // re-inject the live map so a save via this API cannot wipe existing account links.
-            if (configuration.OidConfigs.TryGetValue(provider, out var existing))
+            if (config != null && configuration.OidConfigs.TryGetValue(provider, out var existing))
             {
                 config.CanonicalLinks = existing.CanonicalLinks;
             }
@@ -374,7 +374,9 @@ public class SSOController : ControllerBase
     [HttpGet("OID/GetNames")]
     public ActionResult OidProviderNames()
     {
-        return Ok(SSOPlugin.Instance.Configuration.OidConfigs.Keys);
+        // Materialize the keys under the lock (#157/F-10): returning the live KeyCollection lets the
+        // JSON formatter enumerate it outside the lock, tearing against a concurrent provider add/remove.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.Keys.ToList()));
     }
 
     /// <summary>
@@ -384,7 +386,8 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/GetNames")]
     public ActionResult SamlProviderNames()
     {
-        return Ok(SSOPlugin.Instance.Configuration.SamlConfigs.Keys);
+        // Materialize under the lock (#157/F-10), as OID/GetNames does.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.Keys.ToList()));
     }
 
     /// <summary>
@@ -605,7 +608,7 @@ public class SSOController : ControllerBase
             // Preserve the server-managed canonical links (#157), as OidAdd does: the posted config
             // never carries them ([JsonIgnore]), so re-inject the live map before the wholesale
             // replace so an API save cannot wipe existing account links.
-            if (configuration.SamlConfigs.TryGetValue(provider, out var existing))
+            if (newConfig != null && configuration.SamlConfigs.TryGetValue(provider, out var existing))
             {
                 newConfig.CanonicalLinks = existing.CanonicalLinks;
             }
@@ -1070,8 +1073,9 @@ public class SSOController : ControllerBase
     // A shallow copy of a provider map, taken under the config lock so the admin list endpoints
     // serialize a detached snapshot rather than the live dictionary (#157/F-10): a concurrent
     // provider add/remove cannot then modify the collection mid-serialization. The provider objects
-    // are shared, but their CanonicalLinks are [JsonIgnore] (never serialized) and their remaining
-    // fields only change on an admin save, which swaps the whole configuration object.
+    // are shared, but their CanonicalLinks are [JsonIgnore] (never serialized), and the only other
+    // in-place write on the hot path is the NewPath bool flipped by a challenge — a scalar write that
+    // cannot tear a JSON serialization or throw "collection modified".
     private static SerializableDictionary<string, TValue> SnapshotConfigs<TValue>(SerializableDictionary<string, TValue> source)
     {
         var copy = new SerializableDictionary<string, TValue>();

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -326,7 +326,18 @@ public class SSOController : ControllerBase
     [HttpPost("OID/Add/{provider}")]
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
-        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.OidConfigs[provider] = config);
+        SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            // Preserve the server-managed canonical links (#157): this replaces the whole provider
+            // object, and CanonicalLinks is [JsonIgnore] so the posted config never carries them —
+            // re-inject the live map so a save via this API cannot wipe existing account links.
+            if (configuration.OidConfigs.TryGetValue(provider, out var existing))
+            {
+                config.CanonicalLinks = existing.CanonicalLinks;
+            }
+
+            configuration.OidConfigs[provider] = config;
+        });
         SsoAudit.ProviderConfigured(_logger, OpenIdProtocol, provider);
     }
 
@@ -353,7 +364,7 @@ public class SSOController : ControllerBase
     [HttpGet("OID/Get")]
     public ActionResult OidProviders()
     {
-        return Ok(SSOPlugin.Instance.Configuration.OidConfigs);
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => SnapshotConfigs(c.OidConfigs)));
     }
 
     /// <summary>
@@ -589,7 +600,18 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/Add/{provider}")]
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
-        SSOPlugin.Instance.MutateConfiguration(configuration => configuration.SamlConfigs[provider] = newConfig);
+        SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            // Preserve the server-managed canonical links (#157), as OidAdd does: the posted config
+            // never carries them ([JsonIgnore]), so re-inject the live map before the wholesale
+            // replace so an API save cannot wipe existing account links.
+            if (configuration.SamlConfigs.TryGetValue(provider, out var existing))
+            {
+                newConfig.CanonicalLinks = existing.CanonicalLinks;
+            }
+
+            configuration.SamlConfigs[provider] = newConfig;
+        });
         SsoAudit.ProviderConfigured(_logger, SamlProtocol, provider);
         return Ok();
     }
@@ -620,7 +642,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/Get")]
     public ActionResult SamlProviders()
     {
-        return Ok(SSOPlugin.Instance.Configuration.SamlConfigs);
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => SnapshotConfigs(c.SamlConfigs)));
     }
 
     /// <summary>
@@ -999,17 +1021,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        var mappings = new SerializableDictionary<string, IEnumerable<string>>();
-        var providerList = SSOPlugin.Instance.Configuration.SamlConfigs;
-
-        foreach (var providerName in providerList.Keys)
-        {
-            var canonLinks = providerList[providerName].CanonicalLinks;
-            var canonKeys = from link in canonLinks where link.Value == jellyfinUserId select link.Key;
-            mappings[providerName] = canonKeys;
-        }
-
-        return mappings;
+        return BuildLinksByUser("saml", jellyfinUserId);
     }
 
     /// <summary>
@@ -1027,17 +1039,48 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        var mappings = new SerializableDictionary<string, IEnumerable<string>>();
-        var providerList = SSOPlugin.Instance.Configuration.OidConfigs;
+        return BuildLinksByUser("oid", jellyfinUserId);
+    }
 
-        foreach (var providerName in providerList.Keys)
+    // Builds the provider -> [link keys for this user] map under the config lock, materializing each
+    // provider's matches with ToList (#157/F-10). The previous version assigned a deferred LINQ query
+    // that enumerated the live CanonicalLinks during JSON serialization — outside any lock — which
+    // could tear against a concurrent login writing a link ("collection modified during enumeration").
+    private static SerializableDictionary<string, IEnumerable<string>> BuildLinksByUser(string mode, Guid jellyfinUserId)
+    {
+        return SSOPlugin.Instance.ReadConfiguration(configuration =>
         {
-            var canonLinks = providerList[providerName].CanonicalLinks;
-            var canonKeys = from link in canonLinks where link.Value == jellyfinUserId select link.Key;
-            mappings[providerName] = canonKeys;
+            var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
+                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
+                : configuration.OidConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
+
+            var mappings = new SerializableDictionary<string, IEnumerable<string>>();
+            foreach (var provider in providerList)
+            {
+                mappings[provider.Key] = provider.Value
+                    .Where(link => link.Value == jellyfinUserId)
+                    .Select(link => link.Key)
+                    .ToList();
+            }
+
+            return mappings;
+        });
+    }
+
+    // A shallow copy of a provider map, taken under the config lock so the admin list endpoints
+    // serialize a detached snapshot rather than the live dictionary (#157/F-10): a concurrent
+    // provider add/remove cannot then modify the collection mid-serialization. The provider objects
+    // are shared, but their CanonicalLinks are [JsonIgnore] (never serialized) and their remaining
+    // fields only change on an admin save, which swaps the whole configuration object.
+    private static SerializableDictionary<string, TValue> SnapshotConfigs<TValue>(SerializableDictionary<string, TValue> source)
+    {
+        var copy = new SerializableDictionary<string, TValue>();
+        foreach (var kvp in source)
+        {
+            copy[kvp.Key] = kvp.Value;
         }
 
-        return mappings;
+        return copy;
     }
 
     /// <summary>

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -179,7 +179,12 @@ public class SamlConfig
     /// <summary>
     /// Gets or sets a mapping of canonical names from the provider to jellyfin user ids.
     /// </summary>
+    // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
+    // from every JSON response (#157). This stops the account-link map leaking off the server, closes
+    // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
+    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
     [XmlElement("CanonicalLinks")]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SerializableDictionary<string, Guid> CanonicalLinks
     {
         get
@@ -325,7 +330,12 @@ public class OidConfig
     /// <summary>
     /// Gets or sets a mapping of canonical names from the provider to jellyfin user ids.
     /// </summary>
+    // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
+    // from every JSON response (#157). This stops the account-link map leaking off the server, closes
+    // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
+    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
     [XmlElement("CanonicalLinks")]
+    [System.Text.Json.Serialization.JsonIgnore]
     public SerializableDictionary<string, Guid> CanonicalLinks
     {
         get

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -82,6 +82,62 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     }
 
     /// <summary>
+    /// Persists a replacement configuration, re-injecting server-managed fields from the live
+    /// configuration first (#157). The admin settings page saves through this path (Jellyfin core's
+    /// UpdatePluginConfiguration) with a snapshot taken at page load, so a canonical link created by a
+    /// login since then would be absent from the posted config; re-injecting the live links stops the
+    /// save from wiping them. Takes the same lock as <see cref="MutateConfiguration"/> (reentrant, so
+    /// calls from there are safe) and skips the copy when the incoming object is the live one.
+    /// </summary>
+    /// <param name="configuration">The configuration to persist.</param>
+    public override void UpdateConfiguration(BasePluginConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        lock (ConfigMutationLock)
+        {
+            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration))
+            {
+                PreserveServerManagedFields(incoming, Configuration);
+            }
+
+            base.UpdateConfiguration(configuration);
+        }
+    }
+
+    /// <summary>
+    /// Copies the server-managed fields (per-provider canonical links) from <paramref name="live"/>
+    /// into <paramref name="incoming"/>, so a save built from a stale client snapshot cannot clear
+    /// them. Only providers present in <paramref name="incoming"/> are touched (a deleted provider
+    /// stays deleted; a newly added one keeps its own empty map).
+    /// </summary>
+    /// <param name="incoming">The configuration about to be persisted.</param>
+    /// <param name="live">The current live configuration to read server-managed values from.</param>
+    internal static void PreserveServerManagedFields(PluginConfiguration incoming, PluginConfiguration live)
+    {
+        if (incoming?.OidConfigs != null && live?.OidConfigs != null)
+        {
+            foreach (var kvp in live.OidConfigs)
+            {
+                if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
+                {
+                    incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
+                }
+            }
+        }
+
+        if (incoming?.SamlConfigs != null && live?.SamlConfigs != null)
+        {
+            foreach (var kvp in live.SamlConfigs)
+            {
+                if (incoming.SamlConfigs.TryGetValue(kvp.Key, out var incomingProvider))
+                {
+                    incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Reads a value from the live configuration under the same lock as <see cref="MutateConfiguration"/>,
     /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
     /// </summary>


### PR DESCRIPTION
# What & why

The admin settings page saves the whole plugin configuration through Jellyfin core's `updatePluginConfiguration` from a snapshot taken at page load. A canonical link created by a login since then is absent from the posted config, so the save wiped it (F-9). Account links are also server-managed state that should neither leave the server nor be settable by a config POST. This treats `CanonicalLinks` as a server-managed field and closes the unguarded admin reads (F-10). Closes #157.

- **`[JsonIgnore]` on both `CanonicalLinks` properties**, still persisted in the config XML, withheld from every JSON response. Stops the account-link map leaking off the server, removes the tear from serializing it while a login writes it, and blocks setting links via a config PUT (deserialization ignores them).
- **Re-inject the live links on every save**, a `SSOPlugin.UpdateConfiguration` override copies each provider's live `CanonicalLinks` into the incoming config before persisting (catches the admin-UI core path); `OidAdd`/`SamlAdd` do the same explicitly (the API path, where the override sees the live object and skips). Fail closed: a save missing the links preserves the live values.
- **F-10 locked reads**, the links-by-user endpoints build their result under `ReadConfiguration` and materialize with `ToList` (fixing a deferred-LINQ tear that enumerated the live map during JSON serialization outside any lock); `OID/Get` and `SAML/Get` return a snapshot taken under the lock.

Export/import redaction (part 2 of the issue) is tracked on #161, there is no export endpoint in this repo yet to redact.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a save that omits server-managed links preserves the live values; links cannot be injected or overwritten via a config POST.
- [x] No secrets logged; `CanonicalLinks` is now withheld from JSON responses (`OidSecret`/`SamlCertificate` remain in admin-only responses as before, the admin edit UI needs them; true export redaction is #161).
- [x] A security review was performed: adversarial gate with 4 lenses (results in the sign-off).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged).

## Quality checklist

- [x] No duplicated logic; preservation is one shared `PreserveServerManagedFields`, the links-by-user projection is one shared `BuildLinksByUser`.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (294/294).
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed.

## Notes

- The `UpdateConfiguration` override takes `ConfigMutationLock`, which is reentrant, so calls from within `MutateConfiguration` do not deadlock; the `ReferenceEquals` guard skips the self-copy on that path.
- Behavior note (pre-existing): renaming a provider in the settings UI does not carry its links to the new name, the links key on the old provider name. Out of scope here.
- Owed before any release: real-server E2E, edit a provider in the admin UI while a login has just created a link, save, and confirm the link survives; confirm `OID/Get` no longer returns `CanonicalLinks`.
