### PR TITLE
Make SSO account adoption atomic

### DIFF
--- a/SSO-Auth.Tests/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/AccountLinkResolverTests.cs
@@ -89,4 +89,24 @@ public class AccountLinkResolverTests
         Assert.Null(linkedUserId);
         Assert.False(migrate);
     }
+
+    // --- ResolveLinkWrite: atomic check-then-link outcome (#133) ---
+
+    [Fact]
+    public void ResolveLinkWrite_NoExistingLink_WritesCandidate()
+    {
+        var (effective, wrote) = AccountLinkResolver.ResolveLinkWrite(existingLiveLinkUserId: null, Subject);
+        Assert.Equal(Subject, effective);
+        Assert.True(wrote);
+    }
+
+    [Fact]
+    public void ResolveLinkWrite_ExistingLiveLink_UsesWinner_WithoutWriting()
+    {
+        // A concurrent first-login already linked this identity: use its account, do NOT overwrite it
+        // and do NOT report a write (so the caller does not re-emit the adoption audit).
+        var (effective, wrote) = AccountLinkResolver.ResolveLinkWrite(existingLiveLinkUserId: Existing, Subject);
+        Assert.Equal(Existing, effective);
+        Assert.False(wrote);
+    }
 }

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -114,6 +114,23 @@ internal static class AccountLinkResolver
 
         return (null, false);
     }
+
+    /// <summary>
+    /// Decides the outcome of the atomic "link this identity unless it is already linked" step (#133):
+    /// if a live link already exists (a concurrent first-login won the race), that winner is used and
+    /// nothing is written; otherwise the candidate is linked. The caller performs this inside a single
+    /// read-modify-write so the check and the write cannot interleave, and audits an adoption only when
+    /// <c>WroteLink</c> is true. Pure so the no-overwrite / wrote-flag contract is unit-testable.
+    /// </summary>
+    /// <param name="existingLiveLinkUserId">The user already linked to this identity (with a still-existing account), or null.</param>
+    /// <param name="candidateUserId">The user to link when no live link exists (the adopted or newly created account).</param>
+    /// <returns>The effective user id, and whether this call should write the link.</returns>
+    internal static (Guid EffectiveUserId, bool WroteLink) ResolveLinkWrite(Guid? existingLiveLinkUserId, Guid candidateUserId)
+    {
+        return existingLiveLinkUserId.HasValue
+            ? (existingLiveLinkUserId.Value, false)
+            : (candidateUserId, true);
+    }
 }
 
 /// <summary>

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -788,29 +788,9 @@ public class SSOController : ControllerBase
     // whole read-modify-write is serialized and concurrent first-logins cannot lose each other's links.
     private static void MutateLinks(PluginConfiguration configuration, string mode, string provider, Action<SerializableDictionary<string, Guid>> mutate)
     {
-        switch (mode.ToLowerInvariant())
-        {
-            case "saml":
-            {
-                var providerConfig = configuration.SamlConfigs[provider];
-                var links = providerConfig.CanonicalLinks;
-                mutate(links);
-                providerConfig.CanonicalLinks = links;
-                break;
-            }
-
-            case "oid":
-            {
-                var providerConfig = configuration.OidConfigs[provider];
-                var links = providerConfig.CanonicalLinks;
-                mutate(links);
-                providerConfig.CanonicalLinks = links;
-                break;
-            }
-
-            default:
-                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
-        }
+        var links = GetLinks(configuration, mode, provider);
+        mutate(links);
+        SetLinks(configuration, mode, provider, links);
     }
 
     // The provider's canonical-links map; callers must hold the config lock (ReadConfiguration /
@@ -823,6 +803,23 @@ public class SSOController : ControllerBase
             "oid" => configuration.OidConfigs[provider].CanonicalLinks,
             _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
         };
+    }
+
+    // Reassigns a provider's canonical-links map, so a lazily-created (previously-null) map is
+    // persisted. Pairs with GetLinks; both must run under the config lock.
+    private static void SetLinks(PluginConfiguration configuration, string mode, string provider, SerializableDictionary<string, Guid> links)
+    {
+        switch (mode.ToLowerInvariant())
+        {
+            case "saml":
+                configuration.SamlConfigs[provider].CanonicalLinks = links;
+                break;
+            case "oid":
+                configuration.OidConfigs[provider].CanonicalLinks = links;
+                break;
+            default:
+                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
+        }
     }
 
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
@@ -877,18 +874,32 @@ public class SSOController : ControllerBase
                 return decision.UserId;
 
             case AccountLinkAction.AdoptExistingAccount:
-                CreateCanonicalLink(mode, provider, decision.UserId, canonicalKey);
-                SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, username);
-                return decision.UserId;
+            {
+                // Atomic check-then-link (#133): if a concurrent first-login already linked this
+                // identity, that winner is used and no second write or duplicate audit occurs.
+                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
+                if (wrote)
+                {
+                    SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, username);
+                }
+
+                return adoptedUserId;
+            }
 
             case AccountLinkAction.CreateNewAccount:
+            {
                 _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
                 var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
                 user.AuthenticationProviderId = GetType().FullName;
                 // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
                 user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
-                CreateCanonicalLink(mode, provider, user.Id, canonicalKey);
-                return user.Id;
+
+                // Atomic check-then-link (#133): if a concurrent first-login for the same identity
+                // linked meanwhile, use its account — this freshly created user is left unlinked rather
+                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login).
+                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id);
+                return effectiveUserId;
+            }
 
             case AccountLinkAction.RejectNameTaken:
                 _logger.LogWarning(
@@ -901,6 +912,32 @@ public class SSOController : ControllerBase
             default:
                 throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
         }
+    }
+
+    // Atomically links canonicalKey to candidateUserId unless a live link already exists for it (#133).
+    // The existence check and the write are ONE MutateConfiguration read-modify-write, so two concurrent
+    // first-logins for the same identity cannot both write or both adopt: the loser observes the
+    // winner's link and reports WroteLink=false (so the caller does not re-emit the adoption audit).
+    // The link write goes straight into the config (no discarded ActionResult), so a failure to persist
+    // propagates rather than falling through as a successful adoption.
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(string mode, string provider, string canonicalKey, Guid candidateUserId)
+    {
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            var links = GetLinks(configuration, mode, provider);
+            Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null
+                ? current
+                : (Guid?)null;
+
+            var (effectiveUserId, wroteLink) = AccountLinkResolver.ResolveLinkWrite(existing, candidateUserId);
+            if (wroteLink)
+            {
+                links[canonicalKey] = effectiveUserId;
+                SetLinks(configuration, mode, provider, links);
+            }
+
+            return (effectiveUserId, wroteLink);
+        });
     }
 
     // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).


### PR DESCRIPTION
# What & why

The account adoption/creation path checked the existing link and then wrote a new one in **separate** lock acquisitions, so two concurrent first-logins for the same identity could both resolve to "adopt", both write (one link overwriting the other), and both emit the `[SSO Audit] AccountAdopted` line. The adoption case also discarded `CreateCanonicalLink`'s `ActionResult`, so a failed link write could fall through as a successful adoption. Closes #133.

- **`LinkCanonicalIfAbsent`** folds the existence check and the link write into one `MutateConfiguration` read-modify-write: under the lock it re-checks whether a live link exists for the key and, only if not, writes the candidate. A concurrent first-login that linked meanwhile is observed as the winner, its account is returned and no second write happens.
- **Audit once:** `AccountAdopted` is emitted only when this call actually wrote the link.
- **Error contract:** the write goes straight into the config (no discarded `ActionResult`), so a persistence failure propagates instead of being reported as a successful adoption.
- **Create-race:** a lost race leaves the freshly created user unlinked (a rare, benign orphan) rather than overwriting the winner's link, no duplicate logged-in account.
- The no-overwrite / wrote-flag decision is the pure, unit-tested `AccountLinkResolver.ResolveLinkWrite`; `MutateLinks` is refactored onto shared `GetLinks`/`SetLinks`.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the atomic step only ever links the already-decided candidate (adopt target or freshly created user); the adoption gate (`AllowExistingAccountLink`) still runs before it; a persistence failure propagates rather than falling through as success.
- [x] No secrets logged; the audit line is unchanged except that it now fires once.
- [x] A security review was performed: adversarial gate with 4 lenses (results in the sign-off).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged).

## Quality checklist

- [x] No duplicated logic; the atomic decision is one pure `ResolveLinkWrite`, the map access is the shared `GetLinks`/`SetLinks`.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (296/296).
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed.

## Notes

- Atomicity is provided by the `ConfigMutationLock` (established in #51); the bug-prone no-overwrite / wrote-flag decision is unit-tested via `ResolveLinkWrite`. A true multi-threaded controller test is not feasible without a plugin/user-manager harness, consistent with prior deliveries; the review verifies the wiring.
- Owed before any release: real-server E2E, two near-simultaneous first logins of the same new identity resolve to a single account and a single audit line.
