### PR TITLE
Sanitize adoption-audit fields inline at the call site

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -880,7 +880,15 @@ public class SSOController : ControllerBase
                 var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
                 if (wrote)
                 {
-                    SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, username);
+                    // Strip line endings from the route/IdP-controlled values inline at the call, so a
+                    // log-forging sanitizer is visible here and not only inside SsoAudit (CodeQL does
+                    // not track sanitizers across the helper boundary); SsoAudit also strips them at
+                    // the sink, so this is belt-and-suspenders.
+                    SsoAudit.AccountAdopted(
+                        _logger,
+                        string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol,
+                        provider?.ReplaceLineEndings(string.Empty),
+                        username?.ReplaceLineEndings(string.Empty));
                 }
 
                 return adoptedUserId;


### PR DESCRIPTION
# What & why

Strip line endings inline at the `SsoAudit.AccountAdopted` call in the adoption branch, so the route-controlled `provider` and IdP-controlled `username` are sanitized visibly at the call site (CodeQL does not track a sanitizer across the helper boundary). `SsoAudit` already strips them at its `LogWarning` sink, so this is belt-and-suspenders, but it satisfies the log-forging invariant at the call site too. Refs #133.

This applies the CodeRabbit finding on #190 that was previously declined as redundant; 

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no logic/flow change; log-string sanitization only.
- [x] No secrets logged; IdP/route-controlled log inputs now sanitized inline at the call (in addition to SsoAudit's sink-level strip).
- [x] A security review was performed: trivial, behavior-preserving log-hardening → a lightweight review pass plus the CodeRabbit hard gate (not the full lens panel, per the /deliver tiering for trivial diffs).
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; a two-argument inline sanitization on one call.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (296/296).
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed.

## Notes

Follow-up to #133 / PR #190; not a new behavior. The other `SsoAudit` call sites remain sanitized at the sink (SsoAudit) and are safe; only the CodeRabbit-flagged call gained the redundant inline strip.
