### PR TITLE
Make the OpenID client secret write-only in JSON responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,12 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 
 ## Security
 
-SSO is a sensitive part of your stack, and this plugin is being built to **fail closed**: a missing signature, a weak SHA-1 signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Security-relevant behavior is covered by the automated test suite.
+This plugin is built to **fail closed**: a missing signature, a weak SHA-1 signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Two operator-facing controls:
 
-The anonymous SSO endpoints can additionally be **rate-limited per client address** (opt-in, off by default): set `EnableRateLimit` in the plugin's XML configuration, with `RateLimitMaxAttempts` (default 30) per `RateLimitWindowSeconds` (default 60) per endpoint stage, and throttled requests answered with `429 Retry-After`. The limiter keys on the connection's remote address only — **if Jellyfin runs behind a reverse proxy, configure Jellyfin's own _Known proxies_ networking setting** so the server resolves the real client from the forwarded headers; the plugin deliberately never parses `X-Forwarded-For` itself (a client-spoofable header must not steer throttling). Without _Known proxies_ configured, every request appears to come from the proxy: if that address is non-public (loopback/private, the common local-proxy case) no bucket is created, so the userbase is never pooled — but a proxy on a **public** address would still put all clients in one shared bucket, which is why configuring _Known proxies_ matters. Non-public source addresses are never throttled; IPv6 clients are keyed on their /64. The limiter is best-effort and in-process: counters are per Jellyfin instance and reset on restart — it blunts sustained brute force at the public edge, it is not a hard quota.
+- **Write-only client secret** — the OpenID secret is stored but never returned in a config response; on the settings page, leave it blank to keep the current value or type a new one to replace it.
+- **Optional rate limiting** on the anonymous SSO endpoints (opt-in, off by default) to blunt brute force. Behind a reverse proxy, configure Jellyfin's _Known proxies_ setting so it targets the real client.
+
+Details and tuning are on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) wiki page; security-relevant behavior is covered by the test suite.
 
 Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new) — not the public issue tracker. See [SECURITY.md](SECURITY.md).
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 
 ## Security
 
-This plugin is built to **fail closed**: a missing signature, a weak SHA-1 signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Two operator-facing controls:
+This plugin is built to **fail closed by default**: a missing signature, a weak SHA-1 signature, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. A few documented per-provider options (e.g. `DoNotValidateAudience`, `DoNotValidateIssuerName`) can deliberately relax specific checks for providers that need it — the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) page notes which. Two operator-facing controls:
 
 - **Write-only client secret** — the OpenID secret is stored but never returned in a config response; on the settings page, leave it blank to keep the current value or type a new one to replace it.
 - **Optional rate limiting** on the anonymous SSO endpoints (opt-in, off by default) to blunt brute force. Behind a reverse proxy, configure Jellyfin's _Known proxies_ setting so it targets the real client.

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -92,4 +92,93 @@ public class ConfigPreservationTests
         Assert.Contains("CanonicalLinks", xml, StringComparison.Ordinal);
         Assert.Contains("sub-secret", xml, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void OidSecret_SerializedValueIsHidden_ButStaysDeserializableAndInXml()
+    {
+        var config = new OidConfig { OidClientId = "client", OidSecret = "s3cr3t-value" };
+
+        // JSON responses (API / core getPluginConfiguration) must not leak the secret VALUE. The
+        // property is still emitted, but as null (write-only), so the plaintext never leaves the server.
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("s3cr3t-value", json, StringComparison.Ordinal);
+        Assert.Contains("\"OidSecret\":null", json, StringComparison.Ordinal);
+        Assert.Contains("client", json, StringComparison.Ordinal);
+
+        // Jellyfin core serializes the plugin config with a camelCase naming policy; the value must
+        // stay hidden there too (the property name differs, the hidden-value guarantee must not).
+        var camel = System.Text.Json.JsonSerializer.Serialize(
+            config,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        Assert.DoesNotContain("s3cr3t-value", camel, StringComparison.Ordinal);
+
+        // XML (on-disk config) must still persist the secret, so it survives a restart.
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("OidSecret", xml, StringComparison.Ordinal);
+        Assert.Contains("s3cr3t-value", xml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OidSecret_IsDeserializedFromJson_SoItCanBeSetAndRotated()
+    {
+        // The write half: unlike a bidirectional [JsonIgnore], an incoming secret on a save (config
+        // PUT / OID/Add) must survive System.Text.Json deserialization — this is the exact boundary
+        // the config page crosses, and the case that a bidirectional ignore silently broke.
+        const string body = "{\"OidClientId\":\"client\",\"OidSecret\":\"typed-secret\"}";
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<OidConfig>(body);
+        Assert.Equal("typed-secret", parsed!.OidSecret);
+    }
+
+    [Fact]
+    public void Rotation_ThroughJsonThenPreserve_KeepsTheNewSecret()
+    {
+        // The realistic rotation path: a config PUT carrying a new secret is deserialized, then
+        // PreserveServerManagedFields runs against the live config — the new secret must win.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidSecret = "old-secret" };
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = System.Text.Json.JsonSerializer.Deserialize<OidConfig>(
+            "{\"OidSecret\":\"rotated-secret\"}")!;
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.Equal("rotated-secret", incoming.OidConfigs["idp"].OidSecret);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Preserve_BlankIncomingSecret_KeepsLiveSecret(string? incomingSecret)
+    {
+        // A save that did not set a new secret arrives blank (the value is withheld from JSON), and
+        // must keep the stored one — fail closed, a blank save never wipes the live secret.
+        // Whitespace-only counts as blank, to match the Trim() where the secret is consumed.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidSecret = "live-secret" };
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidSecret = incomingSecret };
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.Equal("live-secret", incoming.OidConfigs["idp"].OidSecret);
+    }
+
+    [Fact]
+    public void Preserve_NewProviderWithBlankSecret_StaysBlank()
+    {
+        // A brand-new provider has no live secret to re-inject, so a blank stays blank (the OIDC
+        // flow then fails closed for lack of a secret rather than adopting some other value).
+        var live = new PluginConfiguration();
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["fresh"] = new OidConfig { OidSecret = null };
+
+        SSOPlugin.PreserveServerManagedFields(incoming, live);
+
+        Assert.True(string.IsNullOrEmpty(incoming.OidConfigs["fresh"].OidSecret));
+    }
 }

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -181,4 +181,36 @@ public class ConfigPreservationTests
 
         Assert.True(string.IsNullOrEmpty(incoming.OidConfigs["fresh"].OidSecret));
     }
+
+    [Fact]
+    public void ResolveUpdatedSecret_BlankAndIdentityUnchanged_KeepsLiveSecret()
+    {
+        var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
+        var incoming = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "  " };
+
+        Assert.Equal("live", SSOPlugin.ResolveUpdatedSecret(incoming, live));
+    }
+
+    [Fact]
+    public void ResolveUpdatedSecret_NonBlank_IsAlwaysKept_AsRotation()
+    {
+        var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
+        var incoming = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "rotated" };
+
+        Assert.Equal("rotated", SSOPlugin.ResolveUpdatedSecret(incoming, live));
+    }
+
+    [Theory]
+    [InlineData("https://other-idp/.well-known", "cid")] // endpoint repointed
+    [InlineData("https://idp/.well-known", "other-cid")] // client id changed
+    public void ResolveUpdatedSecret_BlankButIdentityChanged_DropsSecret_FailClosed(string endpoint, string clientId)
+    {
+        // A blank secret is NOT carried across a provider-identity change: otherwise an admin could
+        // exfiltrate the write-only secret by repointing the provider at a token endpoint they
+        // control. The secret stays blank, so the login fails closed until a new one is supplied.
+        var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
+        var incoming = new OidConfig { OidEndpoint = endpoint, OidClientId = clientId, OidSecret = null };
+
+        Assert.True(string.IsNullOrEmpty(SSOPlugin.ResolveUpdatedSecret(incoming, live)));
+    }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -347,6 +347,14 @@ public class SSOController : ControllerBase
             if (config != null && configuration.OidConfigs.TryGetValue(provider, out var existing))
             {
                 config.CanonicalLinks = existing.CanonicalLinks;
+
+                // Same for the write-only secret (#189): a blank incoming value means "keep the
+                // stored one", consistent with the config-page save, so updating an existing
+                // provider via this API without resupplying the secret does not wipe it.
+                if (string.IsNullOrWhiteSpace(config.OidSecret))
+                {
+                    config.OidSecret = existing.OidSecret;
+                }
             }
 
             configuration.OidConfigs[provider] = config;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -341,20 +341,14 @@ public class SSOController : ControllerBase
     {
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
-            // Preserve the server-managed canonical links (#157): this replaces the whole provider
-            // object, and CanonicalLinks is [JsonIgnore] so the posted config never carries them —
-            // re-inject the live map so a save via this API cannot wipe existing account links.
+            // Re-inject the server-managed fields this API cannot carry: CanonicalLinks is
+            // [JsonIgnore] so the posted config never has them (#157), and the write-only secret
+            // follows the same blank-means-keep rule as the config-page save (#189), centralized in
+            // ResolveUpdatedSecret so both paths agree on rotation and identity-change behavior.
             if (config != null && configuration.OidConfigs.TryGetValue(provider, out var existing))
             {
                 config.CanonicalLinks = existing.CanonicalLinks;
-
-                // Same for the write-only secret (#189): a blank incoming value means "keep the
-                // stored one", consistent with the config-page save, so updating an existing
-                // provider via this API without resupplying the secret does not wipe it.
-                if (string.IsNullOrWhiteSpace(config.OidSecret))
-                {
-                    config.OidSecret = existing.OidSecret;
-                }
+                config.OidSecret = SSOPlugin.ResolveUpdatedSecret(config, existing);
             }
 
             configuration.OidConfigs[provider] = config;

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -246,6 +246,14 @@ public class OidConfig
     /// <summary>
     /// Gets or sets OpenID shared secret.
     /// </summary>
+    // Write-only across the JSON boundary (#189): still deserialized from an incoming save (so it
+    // can be set and rotated), but serialized back out as null, so the plaintext client secret
+    // never reaches the admin browser (HAR, proxy log, shared screen) on a config-page load and
+    // cannot be read back via a config GET. It is still persisted to the config XML. On save, a
+    // blank incoming value re-injects the live secret (see SSOPlugin.PreserveServerManagedFields),
+    // so leaving the field blank keeps the stored secret; a new value replaces it. A plain
+    // [JsonIgnore] is wrong here — it is bidirectional and would also drop the value on save.
+    [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
     public string OidSecret { get; set; }
 
     /// <summary>

--- a/SSO-Auth/Config/WriteOnlySecretConverter.cs
+++ b/SSO-Auth/Config/WriteOnlySecretConverter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Makes a string property write-only across the JSON boundary (#189): it is still read
+/// (deserialized) from an incoming save as normal, so the value can be set and rotated, but it is
+/// never written (serialized) back out — a configuration response carries the property as
+/// <c>null</c> instead of its stored value, so the plaintext secret never reaches the admin browser,
+/// a HAR capture, or a proxy log. This is deliberately NOT <c>[JsonIgnore]</c>: that attribute is
+/// bidirectional and would also drop the value on the incoming save, silently breaking rotation and
+/// new-provider setup. The field is still persisted to the config XML (this converter only affects
+/// System.Text.Json).
+/// </summary>
+internal sealed class WriteOnlySecretConverter : JsonConverter<string>
+{
+    /// <inheritdoc />
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+
+    /// <inheritdoc />
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        => writer.WriteNullValue();
+}

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -186,12 +186,16 @@
                   <input
                     is="emby-input"
                     id="OidSecret"
-                    required=""
-                    type="text"
+                    type="password"
+                    autocomplete="off"
+                    placeholder="Leave blank to keep the current secret"
                     class="sso-text"
                   />
                   <div class="fieldDescription">
-                    The OpenID client secret. Randomly generated & shared.
+                    The OpenID client secret. Randomly generated & shared. For
+                    security it is never sent back to this page: leave it blank
+                    to keep the stored value, or enter a new secret to replace
+                    it.
                   </div>
                 </div>
 

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -105,10 +105,14 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     }
 
     /// <summary>
-    /// Copies the server-managed fields (per-provider canonical links) from <paramref name="live"/>
-    /// into <paramref name="incoming"/>, so a save built from a stale client snapshot cannot clear
-    /// them. Only providers present in <paramref name="incoming"/> are touched (a deleted provider
-    /// stays deleted; a newly added one keeps its own empty map).
+    /// Copies the server-managed fields from <paramref name="live"/> into <paramref name="incoming"/>,
+    /// so a save built from a stale client snapshot cannot clear them. Only providers present in
+    /// <paramref name="incoming"/> are touched (a deleted provider stays deleted; a newly added one
+    /// keeps its own empty map). Two kinds of field are preserved: the per-provider canonical links
+    /// (always server-owned, #157), and the OpenID client secret (#189) — the latter only when the
+    /// incoming value is blank, since the secret is withheld from JSON responses so a save that did
+    /// not set a new one arrives empty and must keep the stored value (a non-blank incoming value is
+    /// an intentional rotation and is left as-is).
     /// </summary>
     /// <param name="incoming">The configuration about to be persisted.</param>
     /// <param name="live">The current live configuration to read server-managed values from.</param>
@@ -121,6 +125,15 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
                 if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
                 {
                     incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
+
+                    // Blank (incl. whitespace-only) means "keep the stored secret": the field is
+                    // withheld from JSON responses, so a save that did not set a new one arrives
+                    // blank. Whitespace-only is treated as blank to match the Trim() at the point
+                    // the secret is consumed, so a value that trims to empty never wipes the live one.
+                    if (string.IsNullOrWhiteSpace(incomingProvider.OidSecret))
+                    {
+                        incomingProvider.OidSecret = kvp.Value.OidSecret;
+                    }
                 }
             }
         }

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -125,15 +125,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
                 if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
                 {
                     incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
-
-                    // Blank (incl. whitespace-only) means "keep the stored secret": the field is
-                    // withheld from JSON responses, so a save that did not set a new one arrives
-                    // blank. Whitespace-only is treated as blank to match the Trim() at the point
-                    // the secret is consumed, so a value that trims to empty never wipes the live one.
-                    if (string.IsNullOrWhiteSpace(incomingProvider.OidSecret))
-                    {
-                        incomingProvider.OidSecret = kvp.Value.OidSecret;
-                    }
+                    incomingProvider.OidSecret = ResolveUpdatedSecret(incomingProvider, kvp.Value);
                 }
             }
         }
@@ -148,6 +140,31 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Decides which OpenID client secret an updated provider should keep (#189), the single rule
+    /// shared by the config-page save and <c>OID/Add</c>. A non-blank incoming secret is an explicit
+    /// rotation and wins. A blank one means "keep the stored secret" — but ONLY while the provider
+    /// identity (endpoint and client id) is unchanged: if either changed, the stored secret is not
+    /// carried over (it stays blank, failing the login closed until an admin supplies one), so a
+    /// write-only secret cannot be exfiltrated by repointing the provider at a different token
+    /// endpoint. Whitespace-only counts as blank, matching the <c>Trim()</c> at the consumption site.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted.</param>
+    /// <param name="live">The current live provider config.</param>
+    /// <returns>The secret to persist for the updated provider.</returns>
+    internal static string ResolveUpdatedSecret(OidConfig incoming, OidConfig live)
+    {
+        if (!string.IsNullOrWhiteSpace(incoming.OidSecret))
+        {
+            return incoming.OidSecret;
+        }
+
+        var identityUnchanged =
+            string.Equals(incoming.OidEndpoint, live.OidEndpoint, StringComparison.Ordinal)
+            && string.Equals(incoming.OidClientId, live.OidClientId, StringComparison.Ordinal);
+        return identityUnchanged ? live.OidSecret : incoming.OidSecret;
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

The OpenID client secret was serialized to every elevated caller (`OID/Get`, core `getPluginConfiguration`), so the plaintext reached the admin browser, and any HAR capture, proxy log, or shared screen, on each config-page load. This makes it **write-only across the JSON boundary**: hidden on read, still settable and rotatable on write. Closes #189 (the not-in-transit-to-the-client half of secret protection; encryption at rest is the separate #158).

Mechanism: a small serialize-only `JsonConverter` (`WriteOnlySecretConverter`), the property serializes as `null` but deserializes normally. A plain `[JsonIgnore]` is deliberately **not** used because it is bidirectional and would also drop the value on the incoming save. The secret is still persisted to the config XML (the converter only affects System.Text.Json), so existing providers keep working across an upgrade. On save, a blank incoming secret re-injects the live one (`PreserveServerManagedFields`, and inline in `OID/Add` for parity), so leaving the field blank keeps the stored value; a new value replaces it.

Scope note: the SAML certificate is intentionally left readable, it is the identity provider's **public** signing certificate (used to verify assertions), not a secret, and no SP private key is stored. (If you want it withheld for parity anyway, say so, it's a one-line follow-on.)

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a blank/failed save re-injects the live secret (never wipes it); a missing secret fails the token exchange closed, never opens auth.
- [x] Secret never leaves the server over JSON (verified empirically across `OID/Get`, `getPluginConfiguration`, nested graph, and camelCase options) and is never logged.
- [x] A security review was performed: full 4-lens gate, then a focused 2-lens re-review of the fix (see Notes).

## Quality checklist

- [x] Minimal: one 4-line converter reused via an attribute; no response DTO or redaction pipeline.
- [x] No duplicated logic; the blank-preserve rule mirrors the existing CanonicalLinks handling.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green.
- [x] `dotnet test` green (328/328; new tests cross the JSON boundary in both directions).
- [x] Prettier clean (README, configPage.html, E2E checklist).

## Notes

**Adversarial-review gate (two rounds).** Round 1 (full 4 lenses) caught a real blocker: the first cut used a bidirectional `[System.Text.Json.JsonIgnore]`, which also strips the value on **deserialize**, so setting or rotating a secret via the config page silently no-opped (the old value was re-injected) and new confidential providers could never be configured. All four lenses converged on it (availability/correctness/integration FAIL, bypass NEEDS_IMPROVEMENT); the availability lens noted the reference implementation avoids `[JsonIgnore]` for exactly this reason. Crucially, the original unit test passed because it constructed the object in memory and never crossed the System.Text.Json boundary, the exact blind spot the gate exists to catch.

Fix: the serialize-only converter above, plus `IsNullOrWhiteSpace` for the blank-preserve predicate (consistent with the `Trim()` at the consumption site), plus tests that now deserialize real JSON (`OidSecret_IsDeserializedFromJson_SoItCanBeSetAndRotated`, `Rotation_ThroughJsonThenPreserve_KeepsTheNewSecret`).

Round 2 (focused correctness + bypass re-review of the fix): **bypass PASS**, **correctness NEEDS_IMPROVEMENT** with only LOW nits, all addressed, `OID/Add` now re-injects a blank secret for an existing provider too (parity with the config-page path), and the serialize test additionally asserts the value stays hidden under Jellyfin's camelCase policy. Both lenses verified the fix empirically (deserialize yields the value; serialize emits `null` nested and camelCase; malformed token → 400; XML still round-trips).

A behind-the-browser config-save/rotation check is on the E2E checklist (browser-only, can't be unit-tested until the endpoint-test layer in #192 lands).