### PR TITLE
Harden SAML signature processing against XML-signature-wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 
 ## Features
 
-- **OpenID Connect and SAML 2.0** — use either or both, with multiple providers side by side. See the [Provider Guides](providers.md) for per-IdP setup.
-- **Role-based access control** — map identity-provider groups/roles to Jellyfin access: login, administrator, library folders, and Live TV.
-- **Hardened, fail-closed login path** — SSO identities bind to the stable `sub` / `NameID`, so a matching username cannot take over an existing account; a first login that collides with an unlinked account is refused unless explicitly allowed. SAML responses are validated fail-closed: single-reference signature (XML-signature-wrapping aware), DTDs rejected outright (no XXE, no entity-expansion DoS), enforced time bounds, `AudienceRestriction`, and one-time-use replay protection. The OpenID login state is bound to its provider and single-use, closing cross-provider state replay, and the returned `id_token` is validated fail-closed — signature against the provider's published JWKS (asymmetric RS/PS/ES algorithms only), issuer, audience, and expiry (see the [id_token requirements](providers.md#openid-connect-id_token-requirements)). Server-side avatar fetches are SSRF-guarded.
-- **Tested** — a growing xUnit test suite covers the security-critical validation paths, and every change runs through CI (build, format, CodeQL) before merge.
-- **Avatar sync, Quick Connect support, and self-service account linking** at `/SSOViews/linking`.
+- **OpenID Connect and SAML 2.0** — either or both, multiple providers side by side. See the [Provider Guides](providers.md).
+- **Role-based access control** — map identity-provider groups/roles to login, administrator, library folders, and Live TV.
+- **Hardened, fail-closed login path** — identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches. Details on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) page.
+- **Avatar sync, Quick Connect, and self-service account linking**.
+- **Tested** — a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
 
-> More of the feature set from the sibling project is being ported here deliberately, one reviewed change at a time; this list reflects what is actually implemented today.
+> The feature set from the sibling project is being ported here one reviewed change at a time; this list reflects what is implemented today.
 
 ## Installing
 

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -192,6 +192,77 @@ public class SamlResponseTests
         Assert.False(Load(fixture).IsValid());
     }
 
+    // --- Signature-wrapping hardening (#137): single-assertion, bound signature, c14n allowlist ---
+
+    [Fact]
+    public void IsValid_TwoAssertions_ReturnsFalse()
+    {
+        // Single-assertion invariant: even a byte-for-byte duplicate of the validly-signed assertion
+        // makes the count two, which is rejected outright — the readers must never face a choice of
+        // assertions to consume.
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
+        var doc = fixture.Document;
+        var assertion = doc.GetElementsByTagName("Assertion", "urn:oasis:names:tc:SAML:2.0:assertion")[0]!;
+        doc.DocumentElement!.AppendChild(assertion.CloneNode(true));
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_SignatureRelocatedOutsideSignedElement_ReturnsFalse()
+    {
+        // Sign the assertion, then move the enveloped signature out of the assertion up to the
+        // Response. The reference still names the assertion ID, but the signature no longer sits
+        // inside the element it covers — a relocation attack, rejected by the envelopment check.
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
+        var doc = fixture.Document;
+        var signature = doc.GetElementsByTagName("Signature", "http://www.w3.org/2000/09/xmldsig#")[0]!;
+        signature.ParentNode!.RemoveChild(signature);
+        doc.DocumentElement!.AppendChild(signature);
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_WithCommentsCanonicalization_ReturnsFalse()
+    {
+        // A cryptographically valid signature that uses comment-preserving canonicalization must be
+        // rejected: "#WithComments" c14n is off the allowlist because it breaks sign-what-is-seen.
+        var fixture = SamlTestFactory.Create(signWithCommentsC14n: true);
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_NestedAdviceAssertion_ReturnsTrue()
+    {
+        // A spec-legal supporting assertion nested in saml:Advice (part of the signed content) is a
+        // descendant, not a second top-level assertion, so the single-assertion invariant — scoped
+        // to the Response's direct-child assertions — must still accept the response.
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion, includeAdviceAssertion: true);
+        Assert.True(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_InclusiveCanonicalization_ReturnsTrue()
+    {
+        // Inclusive (non-exclusive) comment-free C14N is on the allowlist — an IdP using it must
+        // still authenticate. Guards that allowlist entry end-to-end (the default fixture is exclusive).
+        var fixture = SamlTestFactory.Create(signWithInclusiveC14n: true);
+        Assert.True(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_EmptyFragmentReferenceUri_ReturnsFalse_DoesNotThrow()
+    {
+        // A crafted <ds:Reference URI="#"> (empty fragment) must fail closed as invalid, not throw
+        // (which would surface as a 500 on this unauthenticated path).
+        var fixture = SamlTestFactory.Create();
+        var reference = fixture.Document.GetElementsByTagName("Reference", "http://www.w3.org/2000/09/xmldsig#")[0] as System.Xml.XmlElement;
+        reference!.SetAttribute("URI", "#");
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
     // --- Signature/digest algorithm allowlist (A-3: reject SHA-1) ---
 
     [Fact]

--- a/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
@@ -82,4 +82,68 @@ public class SamlSignatureAlgorithmsTests
     {
         Assert.False(SamlSignatureAlgorithms.IsAllowed("urn:made:up", new[] { DigestSha256 }));
     }
+
+    // --- Canonicalization allowlist (#137) ---
+
+    private const string ExcC14n = "http://www.w3.org/2001/10/xml-exc-c14n#";
+    private const string InclusiveC14n = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+    private const string ExcC14nWithComments = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+    private const string InclusiveC14nWithComments = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+    private const string EnvelopedSignature = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+
+    [Theory]
+    [InlineData(ExcC14n)]
+    [InlineData(InclusiveC14n)]
+    public void IsCanonicalizationAllowed_CommentFreeC14n_ReturnsTrue(string method)
+    {
+        Assert.True(SamlSignatureAlgorithms.IsCanonicalizationAllowed(method));
+    }
+
+    [Theory]
+    [InlineData(ExcC14nWithComments)]
+    [InlineData(InclusiveC14nWithComments)]
+    [InlineData("urn:made:up")]
+    [InlineData(null)]
+    public void IsCanonicalizationAllowed_WithCommentsOrUnknown_ReturnsFalse(string? method)
+    {
+        // Comment-preserving c14n breaks "sign what is seen", so it is rejected.
+        Assert.False(SamlSignatureAlgorithms.IsCanonicalizationAllowed(method!));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_EnvelopedThenC14n_ReturnsTrue()
+    {
+        Assert.True(SamlSignatureAlgorithms.AreTransformsAllowed(new[] { EnvelopedSignature, ExcC14n }));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_EnvelopedOnly_ReturnsTrue()
+    {
+        Assert.True(SamlSignatureAlgorithms.AreTransformsAllowed(new[] { EnvelopedSignature }));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_WithCommentsTransform_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.AreTransformsAllowed(new[] { EnvelopedSignature, ExcC14nWithComments }));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_UnknownTransform_ReturnsFalse()
+    {
+        // An XPath/XSLT filter transform is a wrapping lever — reject the whole chain.
+        Assert.False(SamlSignatureAlgorithms.AreTransformsAllowed(new[] { EnvelopedSignature, "http://www.w3.org/TR/1999/REC-xslt-19991116" }));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_Empty_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.AreTransformsAllowed(new List<string>()));
+    }
+
+    [Fact]
+    public void AreTransformsAllowed_Null_ReturnsFalse()
+    {
+        Assert.False(SamlSignatureAlgorithms.AreTransformsAllowed(null!));
+    }
 }

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -57,6 +57,9 @@ internal static class SamlTestFactory
         string[]? audiences = null,
         SignatureScope scope = SignatureScope.Response,
         bool signWithSha1 = false,
+        bool signWithCommentsC14n = false,
+        bool signWithInclusiveC14n = false,
+        bool includeAdviceAssertion = false,
         string? recipient = null,
         string? inResponseTo = null,
         string? destination = null)
@@ -123,11 +126,18 @@ internal static class SamlTestFactory
 
         var destinationAttribute = destination == null ? string.Empty : " Destination=\"" + SecurityElement.Escape(destination) + "\"";
 
+        // A spec-legal supporting assertion nested inside saml:Advice, part of the signed content.
+        // It must NOT be miscounted as a second top-level assertion by the single-assertion check.
+        var advice = includeAdviceAssertion
+            ? "<saml:Advice><saml:Assertion ID=\"_advice\" Version=\"2.0\"><saml:Issuer>https://idp.example.com</saml:Issuer></saml:Assertion></saml:Advice>"
+            : string.Empty;
+
         var xml =
             "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\"" + destinationAttribute + ">" +
                 "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
                     "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
                     conditions +
+                    advice +
                     "<saml:Subject>" +
                         (includeNameId ? "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" : string.Empty) +
                         "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
@@ -144,21 +154,36 @@ internal static class SamlTestFactory
         document.LoadXml(xml);
 
         var referenceId = scope == SignatureScope.Response ? responseId : assertionId;
-        SignElement(document, referenceId, rsa, certificate, signWithSha1);
+        SignElement(document, referenceId, rsa, certificate, signWithSha1, signWithCommentsC14n, signWithInclusiveC14n);
 
         return new SamlFixture(certificate, document, responseId, assertionId);
     }
 
-    private static void SignElement(XmlDocument document, string referenceId, RSA signingKey, X509Certificate2 certificate, bool useSha1)
+    private static void SignElement(XmlDocument document, string referenceId, RSA signingKey, X509Certificate2 certificate, bool useSha1, bool useWithCommentsC14n, bool useInclusiveC14n)
     {
         var signedXml = new SignedXml(document) { SigningKey = signingKey };
 
         var reference = new Reference("#" + referenceId) { DigestMethod = useSha1 ? SignedXml.XmlDsigSHA1Url : SignedXml.XmlDsigSHA256Url };
         reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
-        reference.AddTransform(new XmlDsigExcC14NTransform());
+        if (useWithCommentsC14n)
+        {
+            reference.AddTransform(new XmlDsigExcC14NWithCommentsTransform());
+        }
+        else if (useInclusiveC14n)
+        {
+            reference.AddTransform(new XmlDsigC14NTransform());
+        }
+        else
+        {
+            reference.AddTransform(new XmlDsigExcC14NTransform());
+        }
+
         signedXml.AddReference(reference);
 
-        signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+        signedXml.SignedInfo!.CanonicalizationMethod =
+            useWithCommentsC14n ? SignedXml.XmlDsigExcC14NWithCommentsTransformUrl
+            : useInclusiveC14n ? SignedXml.XmlDsigC14NTransformUrl
+            : SignedXml.XmlDsigExcC14NTransformUrl;
         signedXml.SignedInfo.SignatureMethod = useSha1 ? SignedXml.XmlDsigRSASHA1Url : SignedXml.XmlDsigRSASHA256Url;
 
         var keyInfo = new KeyInfo();

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -25,6 +25,12 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// </summary>
 public class Response
 {
+    // The only positions an enveloped SAML signature may occupy: a direct child of the Response or
+    // of the Assertion. Encodes the security-critical "no relocated signature" invariant, so it is a
+    // single constant shared by the validator and the diagnostic getter (they must never diverge).
+    private const string SignatureXPath =
+        "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature";
+
     private readonly X509Certificate2 _certificate;
     private XmlDocument _xmlDoc;
     private XmlNamespaceManager _xmlNameSpaceManager; // we need this one to run our XPath queries on the SAML XML
@@ -134,9 +140,7 @@ public class Response
         // Select the signature only at a legal, position-bound location: an enveloped SAML signature
         // is a direct child of the Response or of the Assertion. A relative //ds:Signature would also
         // match a signature relocated into a wrapper or a Signature/Object, so the XPath is anchored.
-        var signatureNodes = _xmlDoc.SelectNodes(
-            "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature",
-            _xmlNameSpaceManager);
+        var signatureNodes = _xmlDoc.SelectNodes(SignatureXPath, _xmlNameSpaceManager);
         if (signatureNodes == null || signatureNodes.Count == 0)
         {
             return false;
@@ -232,9 +236,7 @@ public class Response
     {
         // Same position-bound selection as IsValid, so the diagnostic reflects the signature that
         // would actually be validated rather than any signature found anywhere in the document.
-        var nodeList = _xmlDoc.SelectNodes(
-            "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature",
-            _xmlNameSpaceManager);
+        var nodeList = _xmlDoc.SelectNodes(SignatureXPath, _xmlNameSpaceManager);
         if (nodeList == null || nodeList.Count == 0)
         {
             return null;

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography.Xml;
 using System.Text;
@@ -117,30 +118,79 @@ public class Response
     /// <returns>Whether the XML response is valid.</returns>
     public bool IsValid()
     {
-        var nodeList = _xmlDoc.SelectNodes("//ds:Signature", _xmlNameSpaceManager);
-
-        var signedXml = new SignedXml(_xmlDoc);
-
-        if (nodeList.Count == 0)
+        // Exactly one assertion must be present (fail closed). Every claim reader consumes the
+        // Response's direct-child Assertion[1], so a response carrying a second such assertion — the
+        // SAML assertion-injection / XML-signature-wrapping class — is rejected before any reader can
+        // be pointed at attacker-controlled content. The count is scoped to direct children (the
+        // nodes the readers can actually select): a spec-legal supporting assertion nested in
+        // saml:Advice is not miscounted, and wrapping is independently blocked by the position-bound
+        // signature selection, the enveloped-within check, and the reference-covers-{root|assertion}
+        // check below.
+        if (_xmlDoc.SelectNodes("/samlp:Response/saml:Assertion", _xmlNameSpaceManager)?.Count != 1)
         {
             return false;
         }
 
-        signedXml.LoadXml((XmlElement)nodeList[0]);
-        return ValidateSignatureReference(signedXml)
-            && IsSignatureAlgorithmAllowed(signedXml)
-            && signedXml.CheckSignature(_certificate, true)
-            && IsWithinTimeBounds();
+        // Select the signature only at a legal, position-bound location: an enveloped SAML signature
+        // is a direct child of the Response or of the Assertion. A relative //ds:Signature would also
+        // match a signature relocated into a wrapper or a Signature/Object, so the XPath is anchored.
+        var signatureNodes = _xmlDoc.SelectNodes(
+            "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature",
+            _xmlNameSpaceManager);
+        if (signatureNodes == null || signatureNodes.Count == 0)
+        {
+            return false;
+        }
+
+        var signatureElement = (XmlElement)signatureNodes[0];
+
+        try
+        {
+            var signedXml = new SignedXml(_xmlDoc);
+            signedXml.LoadXml(signatureElement);
+
+            return ValidateSignatureReference(signedXml, signatureElement)
+                && IsSignatureAlgorithmAllowed(signedXml)
+                && signedXml.CheckSignature(_certificate, true)
+                && IsWithinTimeBounds();
+        }
+        catch (Exception ex) when (ex is CryptographicException or ArgumentException or FormatException or XmlException)
+        {
+            // A malformed signature on this untrusted-input path is rejected as invalid rather than
+            // surfacing as an unhandled 500 (fail closed). SignedXml.LoadXml / CheckSignature throw
+            // these on, e.g., a duplicate reference ID (CryptographicException) or a "#"-only /
+            // non-NCName reference fragment (ArgumentException); catching them here keeps the whole
+            // signature path fail-closed without swallowing unrelated errors.
+            return false;
+        }
     }
 
-    // Reject weak/legacy signature and digest algorithms (e.g. RSA-SHA1, SHA-1 digest) before the
-    // cryptographic check, so a misconfigured or downgraded identity provider is not trusted.
+    // Reject weak/legacy signature and digest algorithms (e.g. RSA-SHA1, SHA-1 digest) and any
+    // canonicalization/transform outside the comment-free-C14N + enveloped-signature allowlist,
+    // before the cryptographic check, so a misconfigured or downgraded identity provider — or a
+    // wrapping attack leaning on a comment-preserving or filtering transform — is not trusted.
     // Runs after ValidateSignatureReference, which guarantees exactly one reference exists.
     private static bool IsSignatureAlgorithmAllowed(SignedXml signedXml)
     {
+        if (!SamlSignatureAlgorithms.IsCanonicalizationAllowed(signedXml.SignedInfo.CanonicalizationMethod))
+        {
+            return false;
+        }
+
         var digestMethods = new List<string>();
         foreach (Reference reference in signedXml.SignedInfo.References)
         {
+            var transforms = new List<string>();
+            foreach (Transform transform in reference.TransformChain)
+            {
+                transforms.Add(transform.Algorithm);
+            }
+
+            if (!SamlSignatureAlgorithms.AreTransformsAllowed(transforms))
+            {
+                return false;
+            }
+
             digestMethods.Add(reference.DigestMethod);
         }
 
@@ -180,7 +230,11 @@ public class Response
     /// <returns>The SignedInfo signature-method URI, or null if unsigned.</returns>
     public string GetSignatureAlgorithm()
     {
-        var nodeList = _xmlDoc.SelectNodes("//ds:Signature", _xmlNameSpaceManager);
+        // Same position-bound selection as IsValid, so the diagnostic reflects the signature that
+        // would actually be validated rather than any signature found anywhere in the document.
+        var nodeList = _xmlDoc.SelectNodes(
+            "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature",
+            _xmlNameSpaceManager);
         if (nodeList == null || nodeList.Count == 0)
         {
             return null;
@@ -251,35 +305,57 @@ public class Response
         return latest;
     }
 
-    // an XML signature can "cover" not the whole document, but only a part of it
-    // .NET's built in "CheckSignature" does not cover this case, it will validate to true.
-    // We should check the signature reference, so it "references" the id of the root document element! If not - it's a hack
-    private bool ValidateSignatureReference(SignedXml signedXml)
+    // A single same-document reference is required, and it must cover the element whose content is
+    // actually read: the Response root or the (single) Assertion. .NET's CheckSignature validates the
+    // digest but not WHAT is signed, so without this a signature over an unrelated node would pass.
+    // The signature must additionally be enveloped inside the element its reference covers — a
+    // signature relocated outside it (a wrapping/relocation attack) is rejected even if its digest
+    // still matches the copied element elsewhere in the tree.
+    private bool ValidateSignatureReference(SignedXml signedXml, XmlElement signatureElement)
     {
-        if (signedXml.SignedInfo.References.Count != 1) // no ref at all
+        if (signedXml.SignedInfo.References.Count != 1) // exactly one reference, no more, no less
         {
             return false;
         }
 
         var reference = (Reference)signedXml.SignedInfo.References[0];
-        var id = reference.Uri.Substring(1);
 
-        var idElement = signedXml.GetIdElement(_xmlDoc, id);
-
-        if (idElement == _xmlDoc.DocumentElement)
+        // A same-document ID reference only ("#id"); an empty (whole-document "") or external URI is
+        // rejected. A "#"-only or non-NCName fragment never reaches here — SignedXml.LoadXml resolves
+        // the reference eagerly and throws on it, which IsValid catches and turns into a rejection.
+        if (string.IsNullOrEmpty(reference.Uri) || reference.Uri[0] != '#')
         {
-            return true;
+            return false;
         }
-        else // sometimes its not the "root" doc-element that is being signed, but the "assertion" element
+
+        var idElement = signedXml.GetIdElement(_xmlDoc, reference.Uri.Substring(1));
+        if (idElement == null)
         {
-            var assertionNode = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion", _xmlNameSpaceManager) as XmlElement;
-            if (assertionNode != idElement)
+            return false;
+        }
+
+        var assertionNode = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion", _xmlNameSpaceManager) as XmlElement;
+        if (idElement != _xmlDoc.DocumentElement && idElement != assertionNode)
+        {
+            return false;
+        }
+
+        return IsEnvelopedWithin(signatureElement, idElement);
+    }
+
+    // Whether the signature element is a descendant of the element its reference covers (an enveloped
+    // signature sits inside the element it signs). Rejects a signature moved outside that element.
+    private static bool IsEnvelopedWithin(XmlElement signatureElement, XmlElement signedElement)
+    {
+        for (var parent = signatureElement.ParentNode; parent != null; parent = parent.ParentNode)
+        {
+            if (parent == signedElement)
             {
-                return false;
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
     // Fail-closed time-bound validation: an assertion is accepted only if it carries at least one

--- a/SSO-Auth/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/SamlSignatureAlgorithms.cs
@@ -28,6 +28,62 @@ internal static class SamlSignatureAlgorithms
         "http://www.w3.org/2001/04/xmlenc#sha512",
     };
 
+    // Only comment-free canonicalization is accepted, exclusive or inclusive. The "#WithComments"
+    // variants are deliberately excluded: they preserve XML comments through canonicalization, which
+    // breaks "sign what is seen" (content can differ from what was digested) — Microsoft flags them
+    // for exactly this reason. These serve both as the SignedInfo CanonicalizationMethod and as the
+    // canonicalization step allowed inside a reference's transform chain.
+    private static readonly HashSet<string> AllowedCanonicalizationMethods = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "http://www.w3.org/2001/10/xml-exc-c14n#",
+        "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    };
+
+    // A reference transform chain may contain only the enveloped-signature transform and comment-free
+    // canonicalization. Anything else — XPath/XSLT filters, decryption, or comment-preserving c14n —
+    // is rejected: those are the levers XML-signature-wrapping uses to make the digested bytes differ
+    // from the element that is actually read.
+    private static readonly HashSet<string> AllowedTransforms = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+        "http://www.w3.org/2001/10/xml-exc-c14n#",
+        "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
+    };
+
+    /// <summary>
+    /// Whether the SignedInfo canonicalization method is a comment-free exclusive/inclusive C14N.
+    /// </summary>
+    /// <param name="canonicalizationMethod">The SignedInfo canonicalization-method URI.</param>
+    /// <returns>True only if the method is on the allowlist.</returns>
+    internal static bool IsCanonicalizationAllowed(string canonicalizationMethod)
+        => AllowedCanonicalizationMethods.Contains(canonicalizationMethod ?? string.Empty);
+
+    /// <summary>
+    /// Whether every transform in a reference's chain is on the allowlist (enveloped-signature or
+    /// comment-free C14N), and there is at least one.
+    /// </summary>
+    /// <param name="transforms">The transform-algorithm URIs of one reference, in order.</param>
+    /// <returns>True only if there is at least one transform and all are allowed.</returns>
+    internal static bool AreTransformsAllowed(IEnumerable<string> transforms)
+    {
+        if (transforms == null)
+        {
+            return false;
+        }
+
+        var any = false;
+        foreach (var transform in transforms)
+        {
+            any = true;
+            if (!AllowedTransforms.Contains(transform ?? string.Empty))
+            {
+                return false;
+            }
+        }
+
+        return any;
+    }
+
     /// <summary>
     /// Whether the signature method and every reference digest method are on the allowlist.
     /// </summary>


### PR DESCRIPTION
# What & why

Hardens the SAML signature-validation core (`Saml.cs`) against the XML-signature-wrapping / assertion-injection class, defense-in-depth on top of the existing single-reference binding. Closes #137, which cited the authentik Feb-2026 assertion-injection CVE, GHSL-2024-329/330, and OWASP's absolute-XPath guidance. Every check fails closed.

- **Single-assertion invariant**, exactly one direct-child `saml:Assertion` (the node the claim readers consume); a second injected assertion is rejected before any reader runs. Scoped to direct children, so a spec-legal supporting assertion nested in `saml:Advice` is not miscounted.
- **Position-bound signature selection + envelopment**, the `ds:Signature` is selected only as a direct child of the Response or Assertion (was a relative `//ds:Signature`), must be enveloped inside the element its single same-document `#id` reference covers, and that element must be the Response root or the assertion, the same node the readers read.
- **Canonicalization/transform allowlist**, SignedInfo c14n and every reference transform restricted to comment-free exclusive/inclusive C14N + enveloped-signature; `#WithComments` and any XPath/XSLT transform rejected.
- **Fail-closed on malformed input**, a duplicate reference ID or a `#`-only/non-NCName fragment now yields a clean rejection instead of an unhandled 500.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved and extended: unknown algorithm/transform, wrong-scope signature, relocated signature, multi-assertion, and malformed input all reject.
- [x] What is signed is what is read: the reference must cover the same direct-child assertion the readers consume; content is verified against the pinned IdP certificate (KeyInfo not trusted).
- [x] A security review was performed, full 5-agent gate (SAML domain reviewer + 4 lenses) plus a focused re-review of the post-review delta. See Notes.

## Quality checklist

- [x] The c14n/transform allowlist reuses and extends the existing `SamlSignatureAlgorithms` helper; no duplication.
- [x] Minimal surface: the change is contained to `Saml.cs` + the allowlist helper.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green.
- [x] `dotnet test` green (350/350; 18 new tests).
- [x] Prettier clean (README Features section tidied in this PR, see below).

## Notes

**Adversarial-review gate (SAML domain reviewer + availability/bypass/correctness lenses; the crown-jewel crypto path).**

Round 1 verdicts: **saml-reviewer PASS** (the Mainka/Somorovsky XSW taxonomy is fully closed, no auth-bypass residual, no mainstream-IdP interop regression - verified with an adversarial scratch probe), **bypass PASS** (no bypass constructible; comment-truncation refuted by .NET `InnerText` semantics, duplicate-ID refuted by .NET's own throw, relocation refuted by the envelopment check, all empirical), **correctness NEEDS_IMPROVEMENT**, **availability NEEDS_IMPROVEMENT**.

The two improvement findings, both addressed:
- A `//saml:Assertion` (descendant) count wrongly rejected a spec-legal `saml:Advice`-nested supporting assertion (availability + correctness). Fixed by counting direct-child `/samlp:Response/saml:Assertion`, the exact nodes the readers select. A positive regression test now pins that a nested Advice assertion (and inclusive-C14N) still validate.
- A crafted `<ds:Reference URI="#">` and a duplicate-ID signature threw (→ 500) instead of failing closed (correctness + bypass + saml-reviewer, all noting it as fail-closed-but-a-500). Fixed with a reject-only `catch` filter over the malformed-signature exception types.

**Round-2 focused bypass re-review of the delta: PASS**, empirically, against real RSA-SHA256 signatures, three attacks exploiting the count relaxation (evil direct-child + genuine assertion in Advice; same-ID collision; relocated signature) were all rejected, and the exception filter was proven reject-only.

Documented acceptances: RSA-PSS is omitted from the signature allowlist (restrictive posture; no mainstream SAML IdP defaults to it, add if one is ever targeted). A broader pre-existing robustness gap, other untrusted-input paths (non-base64 body, the diagnostic `GetSignatureAlgorithm` log call) can still surface a 500, is filed as a follow-up; it is fail-closed (no bypass) and out of scope here.

Also tidies the README Features list into a scannable summary that points to the Security Model wiki page (the security bullet had grown into a wall of text; the detail lives on the wiki).