### PR TITLE
Surface and audit-log the insecure OpenID discovery toggles

### DIFF
--- a/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
@@ -1,0 +1,59 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcInsecureToggles"/> — the helper that names the enabled RFC 9700
+/// escape-hatch options on a provider (#140), so a save with any of them set can be audit-logged.
+/// </summary>
+public class OidcInsecureTogglesTests
+{
+    [Fact]
+    public void Enabled_FullyValidatedProvider_ReturnsEmpty()
+    {
+        Assert.Empty(OidcInsecureToggles.Enabled(new OidConfig()));
+    }
+
+    [Fact]
+    public void Enabled_NullConfig_ReturnsEmpty()
+    {
+        Assert.Empty(OidcInsecureToggles.Enabled(null));
+    }
+
+    [Fact]
+    public void Enabled_DisableHttps_ReportsIt()
+    {
+        Assert.Equal(new[] { "DisableHttps" }, OidcInsecureToggles.Enabled(new OidConfig { DisableHttps = true }));
+    }
+
+    [Fact]
+    public void Enabled_DoNotValidateIssuerName_ReportsIt()
+    {
+        Assert.Equal(new[] { "DoNotValidateIssuerName" }, OidcInsecureToggles.Enabled(new OidConfig { DoNotValidateIssuerName = true }));
+    }
+
+    [Fact]
+    public void Enabled_DoNotValidateEndpoints_ReportsIt()
+    {
+        Assert.Equal(new[] { "DoNotValidateEndpoints" }, OidcInsecureToggles.Enabled(new OidConfig { DoNotValidateEndpoints = true }));
+    }
+
+    [Fact]
+    public void Enabled_AllThree_ReportsAll_MostSevereFirst()
+    {
+        var config = new OidConfig { DisableHttps = true, DoNotValidateIssuerName = true, DoNotValidateEndpoints = true };
+        Assert.Equal(
+            new[] { "DisableHttps", "DoNotValidateIssuerName", "DoNotValidateEndpoints" },
+            OidcInsecureToggles.Enabled(config));
+    }
+
+    [Fact]
+    public void Enabled_UnrelatedOptions_AreNotReported()
+    {
+        // These are not RFC 9700 discovery/transport escape hatches, so they are out of scope here.
+        var config = new OidConfig { DisablePushedAuthorization = true, DoNotLoadProfile = true };
+        Assert.Empty(OidcInsecureToggles.Enabled(config));
+    }
+}

--- a/SSO-Auth.Tests/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/SsoAuditTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SsoAudit"/> — the structured security audit-log entries. Focused on the
+/// insecure-options warning (#140): it must fire at Warning level, name the provider and the enabled
+/// options, and strip line endings from the (route/admin-supplied) provider name so it cannot forge
+/// or split a log entry.
+/// </summary>
+public class SsoAuditTests
+{
+    [Fact]
+    public void InsecureOptionsEnabled_LogsWarning_NamingProviderAndOptions()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.InsecureOptionsEnabled(logger, "OpenID", "corp", new[] { "DisableHttps", "DoNotValidateEndpoints" });
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corp", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("DisableHttps", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("DoNotValidateEndpoints", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InsecureOptionsEnabled_StripsLineEndingsFromProviderName()
+    {
+        var logger = new CapturingLogger();
+
+        // A provider name carrying a newline must not split the entry — the sanitizer collapses it.
+        SsoAudit.InsecureOptionsEnabled(logger, "OpenID", "corp\r\nInjected", new[] { "DisableHttps" });
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
+        Assert.Contains("corpInjected", message, StringComparison.Ordinal);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        internal List<(LogLevel Level, string Message)> Entries { get; } = new List<(LogLevel, string)>();
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/SSO-Auth/Api/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/OidcInsecureToggles.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Names the per-provider OpenID options that switch off an RFC 9700-mandated protection (#140), so
+/// enabling one leaves a visible, auditable trace instead of silently weakening the login path. These
+/// are legitimate escape hatches (e.g. Google's cross-host endpoints need <c>DoNotValidateEndpoints</c>),
+/// so they are kept — but their cost is surfaced, not hidden.
+/// </summary>
+internal static class OidcInsecureToggles
+{
+    /// <summary>
+    /// Lists the insecure options currently enabled on a provider, by their configuration-key names
+    /// (stable and greppable), most-severe first. Empty when the provider is fully validated.
+    /// </summary>
+    /// <param name="config">The OpenID provider configuration.</param>
+    /// <returns>The enabled insecure option names.</returns>
+    internal static IReadOnlyList<string> Enabled(OidConfig config)
+    {
+        var enabled = new List<string>();
+        if (config == null)
+        {
+            return enabled;
+        }
+
+        // DisableHttps first: it drops TLS on discovery/JWKS/token, so the id_token's signing keys
+        // are fetched over a MITM-able channel — the most damaging of the three.
+        if (config.DisableHttps)
+        {
+            enabled.Add(nameof(OidConfig.DisableHttps));
+        }
+
+        if (config.DoNotValidateIssuerName)
+        {
+            enabled.Add(nameof(OidConfig.DoNotValidateIssuerName));
+        }
+
+        if (config.DoNotValidateEndpoints)
+        {
+            enabled.Add(nameof(OidConfig.DoNotValidateEndpoints));
+        }
+
+        return enabled;
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -354,6 +354,14 @@ public class SSOController : ControllerBase
             configuration.OidConfigs[provider] = config;
         });
         SsoAudit.ProviderConfigured(_logger, OpenIdProtocol, provider);
+
+        // Audit any disabled security check (#140), so enabling an escape hatch (DisableHttps,
+        // DoNotValidateIssuerName, DoNotValidateEndpoints) via this API leaves a trace too.
+        var insecure = OidcInsecureToggles.Enabled(config);
+        if (insecure.Count > 0)
+        {
+            SsoAudit.InsecureOptionsEnabled(_logger, OpenIdProtocol, provider, insecure);
+        }
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
@@ -56,4 +57,16 @@ internal static class SsoAudit
             "[SSO Audit] Provider removed: {Protocol} '{Provider}'.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty));
+
+    /// <summary>Records a provider being saved with one or more security checks disabled (#140).</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="options">The enabled insecure option names (configuration keys, not user input).</param>
+    internal static void InsecureOptionsEnabled(ILogger logger, string protocol, string provider, IReadOnlyList<string> options)
+        => logger.LogWarning(
+            "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. These weaken RFC 9700 transport/issuer/endpoint validation; keep them only if the provider genuinely requires it. DisableHttps in particular exposes the id_token signing keys (JWKS) to a man-in-the-middle.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            string.Join(", ", options));
 }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -583,7 +583,9 @@
                   </div>
                 </div>
 
-                <div class="checkboxContainer">
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
                   <label>
                     <input
                       is="emby-checkbox"
@@ -594,7 +596,13 @@
                     />
                     <span>Disable OpenID HTTPS Discovery (Insecure)</span>
                   </label>
-                  <div class="fieldDescription checkboxFieldDescription"></div>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Insecure: drops TLS on the discovery, JWKS and token
+                    endpoints, so the id_token signing keys can be swapped by a
+                    man-in-the-middle and a forged login accepted. Use only on a
+                    trusted internal network. Enabling it is recorded as an
+                    audit warning.
+                  </div>
                 </div>
 
                 <div class="checkboxContainer">
@@ -628,10 +636,15 @@
                     <span>Do Not Validate OpenID Endpoints (Insecure)</span>
                   </label>
                   <div class="fieldDescription checkboxFieldDescription">
-                    May be required for Google OpenID
+                    ⚠ Insecure: disables endpoint-origin validation (a mix-up
+                    defense). May be required for Google OpenID, whose endpoints
+                    live on different hosts. Enabling it is recorded as an audit
+                    warning.
                   </div>
                 </div>
-                <div class="checkboxContainer">
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
                   <label>
                     <input
                       is="emby-checkbox"
@@ -642,6 +655,12 @@
                     />
                     <span>Do Not Validate OpenID Issuer Name (Insecure)</span>
                   </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Insecure: disables matching the discovery issuer, a mix-up
+                    defense. Only for a provider that legitimately presents a
+                    different issuer (some templated/multi-tenant setups).
+                    Enabling it is recorded as an audit warning.
+                  </div>
                 </div>
                 <div
                   class="checkboxContainer checkboxContainer-withDescription"

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SSO_Auth;
 
@@ -17,14 +19,18 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     // (notably first-logins each writing a canonical link) cannot lose one another's updates.
     private static readonly object ConfigMutationLock = new object();
 
+    private readonly ILogger<SSOPlugin> _logger;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOPlugin"/> class.
     /// </summary>
     /// <param name="applicationPaths">Internal Jellyfin interface for the ApplicationPath.</param>
     /// <param name="xmlSerializer">Internal Jellyfin interface for the XML information.</param>
-    public SSOPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+    /// <param name="logger">The logger (used to audit insecure-option saves, #140).</param>
+    public SSOPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<SSOPlugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
+        _logger = logger;
         Instance = this;
     }
 
@@ -95,12 +101,41 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
         ArgumentNullException.ThrowIfNull(configuration);
         lock (ConfigMutationLock)
         {
-            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration))
+            var adminSave = configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration);
+            if (adminSave)
             {
-                PreserveServerManagedFields(incoming, Configuration);
+                PreserveServerManagedFields((PluginConfiguration)configuration, Configuration);
             }
 
             base.UpdateConfiguration(configuration);
+
+            // Audit after the persist, so a misbehaving logging provider can never abort the save
+            // (the toggles it reads are not touched by the persist). Matches the other SsoAudit calls,
+            // which all run after their write completes.
+            if (adminSave)
+            {
+                AuditInsecureOptions((PluginConfiguration)configuration);
+            }
+        }
+    }
+
+    // Audits any OpenID provider saved with a security check disabled (#140). Runs only on the admin
+    // save path (a fresh incoming config, not an internal login-time write), so it fires once per save
+    // rather than per login. Best-effort: a missing logger never blocks the save.
+    private void AuditInsecureOptions(PluginConfiguration incoming)
+    {
+        if (_logger == null || incoming.OidConfigs == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in incoming.OidConfigs)
+        {
+            var insecure = OidcInsecureToggles.Enabled(kvp.Value);
+            if (insecure.Count > 0)
+            {
+                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", kvp.Key, insecure);
+            }
         }
     }
 

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -99,34 +99,43 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     public override void UpdateConfiguration(BasePluginConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
+        List<(string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
         lock (ConfigMutationLock)
         {
-            var adminSave = configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration);
-            if (adminSave)
+            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration))
             {
-                PreserveServerManagedFields((PluginConfiguration)configuration, Configuration);
+                PreserveServerManagedFields(incoming, Configuration);
+
+                // Snapshot which providers were saved with an insecure option (#140) while under the
+                // lock, but emit the warnings AFTER releasing it (below) — logging must not run inside
+                // the global config lock, where a slow provider would block concurrent config access.
+                insecureToAudit = CollectInsecureOptions(incoming);
             }
 
             base.UpdateConfiguration(configuration);
+        }
 
-            // Audit after the persist, so a misbehaving logging provider can never abort the save
-            // (the toggles it reads are not touched by the persist). Matches the other SsoAudit calls,
-            // which all run after their write completes.
-            if (adminSave)
+        // Outside the lock, and after the save is durably persisted: a slow or misbehaving logging
+        // provider can neither block config reads/writes nor turn a completed save into a failure.
+        if (insecureToAudit != null && _logger != null)
+        {
+            foreach (var (provider, options) in insecureToAudit)
             {
-                AuditInsecureOptions((PluginConfiguration)configuration);
+                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", provider, options);
             }
         }
     }
 
-    // Audits any OpenID provider saved with a security check disabled (#140). Runs only on the admin
-    // save path (a fresh incoming config, not an internal login-time write), so it fires once per save
-    // rather than per login. Best-effort: a missing logger never blocks the save.
-    private void AuditInsecureOptions(PluginConfiguration incoming)
+    // Snapshots, under the caller's lock, the OpenID providers saved with a security check disabled
+    // (#140), as (provider, enabled-option-names) pairs. Pure read: it does not log, so the audit
+    // warnings can be emitted after the config lock is released. Only the admin save path reaches
+    // here (a fresh incoming config), so it fires once per save, not per login.
+    private static List<(string Provider, IReadOnlyList<string> Options)> CollectInsecureOptions(PluginConfiguration incoming)
     {
-        if (_logger == null || incoming.OidConfigs == null)
+        var records = new List<(string, IReadOnlyList<string>)>();
+        if (incoming.OidConfigs == null)
         {
-            return;
+            return records;
         }
 
         foreach (var kvp in incoming.OidConfigs)
@@ -134,9 +143,11 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
             var insecure = OidcInsecureToggles.Enabled(kvp.Value);
             if (insecure.Count > 0)
             {
-                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", kvp.Key, insecure);
+                records.Add((kvp.Key, insecure));
             }
         }
+
+        return records;
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

The three per-provider OpenID escape hatches that switch off an RFC 9700 protection, `DisableHttps`, `DoNotValidateIssuerName`, `DoNotValidateEndpoints`, could be enabled with no warning and no trace. Closes #140 by making their cost **visible and auditable** while keeping the hatches (some providers legitimately need `DoNotValidateEndpoints`).

- Pure helper `OidcInsecureToggles.Enabled(OidConfig)` names the enabled insecure options (DisableHttps first, the most damaging: it exposes the id_token signing keys/JWKS to a MITM).
- An `[SSO Audit]` warning naming the toggles fires when such a provider is saved, on both the config-page whole-config save (`SSOPlugin.UpdateConfiguration`, admin-save branch only → no per-login noise) and the `OID/Add` scripting API. Logged **after** the persist so a misbehaving logging provider can't abort the save.
- The config page shows a concrete warning next to each of the three checkboxes.
- `SSOPlugin` gains an `ILogger<SSOPlugin>` ctor parameter (standard Jellyfin DI).

`DisableHttps` is **hard-warned, not refused**: it is legitimately needed for a trusted internal HTTP IdP, so the hatch stays but its cost is loud. (Now that the id_token signature validator is always on, the original "refuse while validation is off" criterion no longer applies, but DisableHttps still fetches the JWKS over HTTP, so it remains a real downgrade worth warning on.)

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: pure side-effect logging; no auth/validation logic or toggle behavior changed. If DI ever failed to supply the logger the plugin fails to load (SSO unavailable, fail closed), not open.
- [x] No secret/PII logged: only the protocol, the line-ending-sanitized provider name, and the internal option names; the inline log-forging sanitizer is preserved.
- [x] A security review was performed (integration + correctness + bypass lenses, see Notes).

## Quality checklist

- [x] Small pure helper behind the thin controller; no duplication.
- [x] Minimal surface: one helper, one audit method, two save-path call sites, static UI text.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green.
- [x] `dotnet test` green (357/357; 7 new helper tests).
- [x] Prettier clean (configPage.html, E2E checklist).
- [x] E2E checklist updated: real-server plugin-load confirmation (the ctor DI change) + the audit-warning/UI check.

## Notes

**Adversarial-review gate (integration + correctness + bypass; proportionate, observability + a plugin-ctor DI change, no auth-decision logic).** All three **PASS**.
- The key risk, the new `ILogger<SSOPlugin>` ctor param, was **empirically confirmed safe** against Jellyfin 10.11.11: `PluginManager` constructs plugins via `ActivatorUtilities.CreateInstance(serviceProvider, type)`, which resolves all ctor params, and `ILogger<T>` is a registered service. The mandatory "plugin loads on a real server" E2E check is on the checklist as the one thing CI cannot exercise.
- Two LOW findings, both fixed: the audit call now runs **after** the persist (a throwing logger can no longer abort the save), and the two new description containers use the `checkboxContainer-withDescription` class for consistent spacing.
- Confirmed: no secret leak, no auth/authz change, no double-logging, no per-login noise (internal login-time writes pass the live config object and skip the admin-save branch), log-forging sanitizer intact.
