### PR TITLE
Pin the OpenID state single-use / invalidate-on-consumption invariant

### DIFF
--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
@@ -80,6 +81,57 @@ public class AuthStateStoreTests
     [Fact]
     public void IsRedeemableBy_Expired_False()
         => Assert.False(AuthStateStore.IsRedeemableBy(State("p", "tok", true, Now.AddMinutes(-2)), "tok", "p", Now, Lifetime));
+
+    // --- Single-use / invalidate-immediately (#138: upstream 9p4 v4.0.0.4 fix, PR #343 / 5b3d70d) ---
+    // Upstream v4.0.0.3 invalidated the OpenID authorize state only by expiry (Invalidate()) after a
+    // successful auth, leaving the consumed `state` redeemable again within its ~15-min lifetime — a
+    // replay. The fix removed the consumed state immediately; here OidAuth removes it atomically as the
+    // redemption gate (TryRemove(KeyValuePair), #133), so it is single-use even under concurrent replay.
+    // These pin that invariant so a future refactor cannot silently reintroduce the replay window.
+
+    [Fact]
+    public void ConsumedState_AtomicClaimSucceedsOnce_ThenReplayIsRejected()
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        var state = State("p", "tok", true, Now);
+        store.TryAdd("tok", state);
+
+        var claim = new KeyValuePair<string, TimedAuthorizeState>("tok", state);
+        Assert.True(store.TryRemove(claim)); // the redeeming request wins the atomic claim
+        Assert.False(store.TryRemove(claim)); // a replay of the same state finds it already consumed
+        Assert.False(store.TryGetValue("tok", out _)); // and it is gone from the store
+    }
+
+    [Fact]
+    public void ConsumedState_IsNoLongerRedeemable()
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        var state = State("p", "tok", true, Now);
+        store.TryAdd("tok", state);
+        store.TryRemove(new KeyValuePair<string, TimedAuthorizeState>("tok", state));
+
+        // A replay looks the state up (now absent) and the redemption gate fails closed on the null.
+        store.TryGetValue("tok", out var afterConsume);
+        Assert.Null(afterConsume);
+        Assert.False(AuthStateStore.IsRedeemableBy(afterConsume, "tok", "p", Now, Lifetime));
+    }
+
+    [Fact]
+    public async Task ConcurrentRedemption_OfSameState_ClaimsExactlyOnce()
+    {
+        // Two requests racing to redeem the same state: the atomic TryRemove(KeyValuePair) must let
+        // exactly one win, so a doubled callback cannot mint two sessions from one authorize state.
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        var state = State("p", "tok", true, Now);
+        store.TryAdd("tok", state);
+        var claim = new KeyValuePair<string, TimedAuthorizeState>("tok", state);
+
+        var a = Task.Run(() => store.TryRemove(claim), TestContext.Current.CancellationToken);
+        var b = Task.Run(() => store.TryRemove(claim), TestContext.Current.CancellationToken);
+        var results = await Task.WhenAll(a, b);
+
+        Assert.Single(results, redeemed => redeemed); // exactly one request claimed the state
+    }
 
     [Fact]
     public void InvalidateExpired_RemovesOnlyExpiredEntries()


### PR DESCRIPTION
# What & why

Verification + regression test for the upstream 9p4 **v4.0.0.4** authorize-state fix (our baseline), so a future refactor of the state store or `OidAuth` cannot silently reintroduce it. Closes #138. No production change, the fix is present and hardened here; this locks the invariant and documents the finding trail.

**Exact upstream fix identified** (via `gh api .../compare/v4.0.0.3...v4.0.0.4`): commit `5b3d70d` ("fix: invalidate state immediately after auth", PR #343), plus `547eabf`. **Vulnerable path (v4.0.0.3):** `OidAuth` called `Invalidate()` (expiry-only pruning) after a successful auth but never removed the consumed OpenID `state`, so the same authorization-response `state` stayed **replayable** for its ~15-min lifetime. **Fix:** replaced with `StateManager.Remove(kvp.Key)`.

**Status here:** present and stronger, `OidAuth` claims the state *atomically as the redemption gate* (`StateManager.TryRemove(KeyValuePair)`, #133), so it is single-use *before* the session is minted and exactly one of concurrent replays wins. Cross-provider replay + expiry are gated by `AuthStateStore`.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs (test + documentation only)

## Security checklist

- [x] Fail-closed preserved: no production change; the tests pin the existing single-use / fail-closed-on-consumed invariant.
- [x] A security review was performed: test-only diff → lightweight review pass (per the /deliver tiering); the finding trail is documented in docs/SECURITY-FINDINGS.md.

## Quality checklist

- [x] Characterization/regression tests only; no logic change.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green.
- [x] `dotnet test` green (362/362; 3 new AuthStateStore tests).

## Notes

Scope honesty: the new tests pin the **store-level** invariant (`TryRemove(KeyValuePair)` atomic single-use claim; `IsRedeemableBy` fails closed on a consumed/absent state; concurrent redemption claims exactly once). The **OidAuth call-site** enforcement (that the controller actually consumes the state atomically before minting) is not unit-testable until the endpoint-test layer (#192) lands, so it is on the E2E checklist as a replay-a-consumed-state check. The exact upstream commit, the vulnerable path, and the present-and-hardened status are recorded in docs/SECURITY-FINDINGS.md (local).

Test-only diff, so a proportionate lightweight review rather than the full lens gate; CodeRabbit + the iderex sign-off still apply.
