### PR TITLE
Add a canonical external base-URL override

### DIFF
--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -1,0 +1,92 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="CanonicalBaseUrl"/> — the helper that decides whether a per-provider base-URL
+/// override (#139) is a usable absolute http/https origin and normalizes it. This is the point that
+/// keeps a spoofable request Host out of the redirect_uri when an override is set, and the point that
+/// rejects a malformed override at save time so it can never reach the login path.
+/// </summary>
+public class CanonicalBaseUrlTests
+{
+    [Theory]
+    [InlineData("https://jellyfin.example.com", "https://jellyfin.example.com")]
+    [InlineData("http://jellyfin.example.com", "http://jellyfin.example.com")]
+    [InlineData("https://jellyfin.example.com:8920", "https://jellyfin.example.com:8920")]
+    [InlineData("https://jellyfin.example.com/", "https://jellyfin.example.com")] // trailing slash trimmed
+    [InlineData("https://example.com/jellyfin/", "https://example.com/jellyfin")] // path base kept, slash trimmed
+    [InlineData("  https://jellyfin.example.com  ", "https://jellyfin.example.com")] // surrounding whitespace
+    [InlineData("HTTPS://Jellyfin.Example.COM", "https://jellyfin.example.com")] // scheme/host lowercased
+    public void TryNormalize_ValidBase_NormalizesAndAccepts(string raw, string expected)
+    {
+        Assert.True(CanonicalBaseUrl.TryNormalize(raw, out var normalized));
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryNormalize_Blank_IsNotAnOverride(string? raw)
+    {
+        Assert.False(CanonicalBaseUrl.TryNormalize(raw, out var normalized));
+        Assert.Null(normalized);
+    }
+
+    [Theory]
+    [InlineData("jellyfin.example.com")] // no scheme -> relative
+    [InlineData("//jellyfin.example.com")] // parses as an absolute file:// URI -> rejected by the scheme check
+    [InlineData("ftp://jellyfin.example.com")] // wrong scheme
+    [InlineData("file:///etc/passwd")] // wrong scheme
+    [InlineData("https://")] // no host
+    [InlineData("https://example.com?next=/evil")] // query would corrupt every derived redirect_uri
+    [InlineData("https://example.com#frag")] // fragment likewise
+    [InlineData("https://user:pass@example.com")] // userinfo can mask the real host
+    [InlineData("not a url")]
+    public void TryNormalize_Malformed_Rejected(string raw)
+    {
+        Assert.False(CanonicalBaseUrl.TryNormalize(raw, out var normalized));
+        Assert.Null(normalized);
+    }
+
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("https://jellyfin.example.com", false)]
+    [InlineData("https://example.com/jellyfin/", false)]
+    [InlineData("ftp://example.com", true)]
+    [InlineData("jellyfin.example.com", true)]
+    [InlineData("https://example.com?a=b", true)]
+    public void IsInvalidOverride_OnlyNonBlankMalformedValues_AreInvalid(string? raw, bool expected)
+    {
+        Assert.Equal(expected, CanonicalBaseUrl.IsInvalidOverride(raw));
+    }
+
+    // The OID/SAML Add endpoints persist through MutateConfiguration (the live config object), which
+    // bypasses SSOPlugin.UpdateConfiguration's save-time validation, so they gate the incoming override
+    // themselves via SSOController.RejectInvalidBaseUrlOverride. Pin that decision so the Add paths cannot
+    // regress into persisting a malformed override that then silently falls back to the request Host.
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://example.com")]
+    [InlineData("jellyfin.example.com")]
+    public void RejectInvalidBaseUrlOverride_Malformed_Throws(string raw)
+    {
+        Assert.Throws<System.ArgumentException>(() => SSOController.RejectInvalidBaseUrlOverride(raw));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("https://jellyfin.example.com")]
+    [InlineData("https://example.com/jellyfin/")]
+    public void RejectInvalidBaseUrlOverride_BlankOrValid_DoesNotThrow(string? raw)
+    {
+        SSOController.RejectInvalidBaseUrlOverride(raw);
+    }
+}

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -213,4 +213,73 @@ public class ConfigPreservationTests
 
         Assert.True(string.IsNullOrEmpty(SSOPlugin.ResolveUpdatedSecret(incoming, live)));
     }
+
+    // --- Base-URL override validation on save (#139) ---
+
+    [Fact]
+    public void ValidateBaseUrlOverrides_ValidOrBlankOnBothProtocols_DoesNotThrow()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "https://jellyfin.example.com" };
+        incoming.OidConfigs["idp-blank"] = new OidConfig { BaseUrlOverride = null };
+        incoming.SamlConfigs["saml"] = new SamlConfig { BaseUrlOverride = "https://sso.example.com/jellyfin" };
+        incoming.SamlConfigs["saml-blank"] = new SamlConfig { BaseUrlOverride = "   " };
+
+        SSOPlugin.ValidateBaseUrlOverrides(incoming);
+    }
+
+    [Fact]
+    public void ValidateBaseUrlOverrides_MalformedOidOverride_ThrowsNamingProviderAndProtocol()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "not-a-url" };
+
+        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateBaseUrlOverrides(incoming));
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateBaseUrlOverrides_MalformedSamlOverride_Throws()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["saml"] = new SamlConfig { BaseUrlOverride = "ftp://example.com" };
+
+        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateBaseUrlOverrides(incoming));
+        Assert.Contains("SAML", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateBaseUrlOverrides_NullConfigMaps_DoNotThrow()
+    {
+        var incoming = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
+
+        SSOPlugin.ValidateBaseUrlOverrides(incoming);
+    }
+
+    [Theory]
+    [InlineData(typeof(OidConfig))]
+    [InlineData(typeof(SamlConfig))]
+    public void BaseUrlOverride_InheritedFromProviderConfigBase_RoundTripsThroughXml(Type configType)
+    {
+        // BaseUrlOverride lives on the shared ProviderConfigBase (#139); confirm XmlSerializer still emits
+        // and reads back the inherited property for both derived config types, so the base-class
+        // extraction did not change the on-disk config contract.
+        var config = (ProviderConfigBase)Activator.CreateInstance(configType)!;
+        config.BaseUrlOverride = "https://jellyfin.example.com";
+
+        var serializer = new XmlSerializer(configType);
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("BaseUrlOverride", xml, StringComparison.Ordinal);
+        Assert.Contains("https://jellyfin.example.com", xml, StringComparison.Ordinal);
+
+        using var stringReader = new System.IO.StringReader(xml);
+        using var xmlReader = System.Xml.XmlReader.Create(
+            stringReader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var back = (ProviderConfigBase)serializer.Deserialize(xmlReader)!;
+        Assert.Equal("https://jellyfin.example.com", back.BaseUrlOverride);
+    }
 }

--- a/SSO-Auth/Api/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/CanonicalBaseUrl.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Normalizes the per-provider canonical external base-URL override (#139). When an admin pins the
+/// external base URL, <c>GetRequestBase</c> returns it verbatim instead of deriving the redirect_uri
+/// and SAML base from the request <c>Host</c> header — which a reverse proxy forwarding an unfiltered
+/// <c>X-Forwarded-Host</c> lets an attacker influence, poisoning the authorization response's target
+/// (RFC 9700 sect. 4.1). Only a well-formed absolute http/https authority is accepted; anything else
+/// is rejected so a malformed override is caught at every admin write path (the config-page save and
+/// the OID/SAML Add endpoints) and cannot be persisted, rather than silently falling back to the
+/// untrusted host at login.
+/// </summary>
+internal static class CanonicalBaseUrl
+{
+    /// <summary>
+    /// Tries to normalize a configured base-URL override to an absolute origin (scheme + host + optional
+    /// port + optional path base), with any trailing slash trimmed so it concatenates cleanly with the
+    /// <c>/sso/...</c> paths. A blank value is not an override (the caller keeps the request-host
+    /// behavior) and returns <see langword="false"/>.
+    /// </summary>
+    /// <param name="raw">The configured override value.</param>
+    /// <param name="normalized">The normalized base URL when the value is a valid override.</param>
+    /// <returns><see langword="true"/> if <paramref name="raw"/> is a valid absolute http/https base URL.</returns>
+    internal static bool TryNormalize(string raw, out string normalized)
+    {
+        normalized = null;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        if (!Uri.TryCreate(raw.Trim(), UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        // Only http/https, and only a bare origin: a query or fragment on a base URL is a misconfiguration
+        // that would corrupt every derived redirect_uri, and a userinfo component (user:pass@host) has no
+        // place in a public base URL and can mask the real host.
+        if ((!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal) && !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            || !string.IsNullOrEmpty(uri.Query)
+            || !string.IsNullOrEmpty(uri.Fragment)
+            || !string.IsNullOrEmpty(uri.UserInfo)
+            || string.IsNullOrEmpty(uri.Host))
+        {
+            return false;
+        }
+
+        normalized = uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        return true;
+    }
+
+    /// <summary>
+    /// Whether a non-blank override value is invalid, i.e. an admin set something but it is not a usable
+    /// base URL. Used at save time to reject the configuration fail-closed. A blank value is valid (the
+    /// feature is simply off).
+    /// </summary>
+    /// <param name="raw">The configured override value.</param>
+    /// <returns><see langword="true"/> if the value is set but not a valid base URL.</returns>
+    internal static bool IsInvalidOverride(string raw)
+        => !string.IsNullOrWhiteSpace(raw) && !TryNormalize(raw, out _);
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -204,7 +204,7 @@ public class SSOController : ControllerBase
             if (timedState.Valid)
             {
                 _logger.LogInformation("Is request linking: {IsLinking}", isLinking);
-                return HtmlAuthPage(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride), mode: "OID", isLinking: isLinking));
+                return HtmlAuthPage(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), mode: "OID", isLinking: isLinking));
             }
             else
             {
@@ -257,7 +257,7 @@ public class SSOController : ControllerBase
                 config.NewPath = newPath;
             }
 
-            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{(newPath ? "redirect" : "r")}/" + provider;
+            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/OID/{(newPath ? "redirect" : "r")}/" + provider;
 
             var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
             var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
@@ -327,8 +327,22 @@ public class SSOController : ControllerBase
     private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
     {
         var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
-        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/OID/{OidcCallbackPath.RedirectSegment(Request.Path.Value)}/" + provider;
+        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/OID/{OidcCallbackPath.RedirectSegment(Request.Path.Value)}/" + provider;
         return CreateOidcClient(config, redirectUri, string.Join(" ", scopes.Prepend("openid profile")));
+    }
+
+    // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
+    // through MutateConfiguration, which passes the live configuration object, so they bypass the
+    // config-page save-time validation in SSOPlugin.UpdateConfiguration (which only runs for a fresh
+    // incoming config). Without this, a malformed override set via the Add API would be persisted and then
+    // silently fall back to the request Host at login. Throwing keeps it out of the store, so the
+    // "rejected at every admin write path" invariant holds. Blank is valid (the feature is off).
+    internal static void RejectInvalidBaseUrlOverride(string baseUrlOverride)
+    {
+        if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
+        {
+            throw new ArgumentException("The Base URL override must be an absolute http(s) URL such as https://jellyfin.example.com, or left blank.");
+        }
     }
 
     /// <summary>
@@ -340,6 +354,7 @@ public class SSOController : ControllerBase
     [HttpPost("OID/Add/{provider}")]
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
+        RejectInvalidBaseUrlOverride(config?.BaseUrlOverride);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // Re-inject the server-managed fields this API cannot carry: CanonicalLinks is
@@ -555,7 +570,7 @@ public class SSOController : ControllerBase
                     WebResponse.Generator(
                         data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
                         provider: provider,
-                        baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride),
+                        baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
                         mode: "SAML",
                         isLinking: isLinking));
             }
@@ -605,7 +620,7 @@ public class SSOController : ControllerBase
                 config.NewPath = newPath;
             }
 
-            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride) + $"/sso/SAML/{(newPath ? "post" : "p")}/" + provider;
+            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/SAML/{(newPath ? "post" : "p")}/" + provider;
             string relayState = null;
             if (isLinking)
             {
@@ -642,6 +657,7 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/Add/{provider}")]
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
+        RejectInvalidBaseUrlOverride(newConfig?.BaseUrlOverride);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // Preserve the server-managed canonical links (#157), as OidAdd does: the posted config
@@ -1482,14 +1498,15 @@ public class SSOController : ControllerBase
     // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids
     // rejecting a valid login on a path-form flip; both are this provider's own ACS URLs.
     //
-    // The host comes from GetRequestBase (the request Host). This binding is therefore only as strong
-    // as host resolution: behind a reverse proxy, configure Jellyfin's Known/Trusted Proxies so the
-    // Host cannot be spoofed, or an attacker controlling the Host can make the expected URL match a
-    // captured assertion's Recipient (defense-in-depth, not a hard guarantee). The canonical
-    // base-URL override (#139) will remove that Host dependency.
+    // The host comes from GetRequestBase. With BaseUrlOverride set (#139) it is the pinned canonical
+    // host, so this binding is exact regardless of the request Host. Without it the host is the request
+    // Host, so the binding is only as strong as host resolution: behind a reverse proxy, configure
+    // Jellyfin's Known/Trusted Proxies (or set BaseUrlOverride) so the Host cannot be spoofed, or an
+    // attacker controlling the Host can make the expected URL match a captured assertion's Recipient
+    // (defense-in-depth, not a hard guarantee).
     private string[] ExpectedAcsUrls(SamlConfig config, string provider)
     {
-        var baseUrl = GetRequestBase(config.SchemeOverride, config.PortOverride) + "/sso/SAML/";
+        var baseUrl = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + "/sso/SAML/";
         return new[] { baseUrl + "post/" + provider, baseUrl + "p/" + provider };
     }
 
@@ -1592,8 +1609,24 @@ public class SSOController : ControllerBase
         return buffer;
     }
 
-    private string GetRequestBase(string schemeOverride = null, int? portOverride = null)
+    private string GetRequestBase(string schemeOverride = null, int? portOverride = null, string baseUrlOverride = null)
     {
+        // A configured canonical base URL is authoritative: it removes the dependency on the request
+        // Host (spoofable behind a proxy forwarding X-Forwarded-Host), so redirect_uri and the SAML base
+        // cannot be poisoned (#139). A malformed value is rejected at every admin write path (the config
+        // page via UpdateConfiguration, and OID/SAML Add via RejectInvalidBaseUrlOverride), so it should
+        // never reach here. If one does anyway (a hand-edited or restored config), fail closed rather than
+        // silently reverting to the spoofable request Host: only a blank override uses the host fallback.
+        if (!string.IsNullOrWhiteSpace(baseUrlOverride))
+        {
+            if (CanonicalBaseUrl.TryNormalize(baseUrlOverride, out var canonical))
+            {
+                return canonical;
+            }
+
+            throw new InvalidOperationException("The configured Base URL override is not a valid absolute http(s) URL.");
+        }
+
         int requestPort;
 
         if (portOverride != null)

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -57,10 +57,25 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
 }
 
 /// <summary>
+/// Configuration shared by every SSO provider (OpenID and SAML).
+/// </summary>
+public abstract class ProviderConfigBase
+{
+    /// <summary>
+    /// Gets or sets the canonical external base URL for this provider, e.g.
+    /// <c>https://jellyfin.example.com</c>. When set, the provider's derived external URLs (the OpenID
+    /// redirect_uri, or the SAML base and assertion-consumer URL) are built from it instead of the request
+    /// <c>Host</c> header (#139), so a spoofed or proxy-forwarded host cannot redirect the login elsewhere.
+    /// It overrides the scheme and port overrides. Blank keeps the request-host behavior.
+    /// </summary>
+    public string BaseUrlOverride { get; set; }
+}
+
+/// <summary>
 /// The configuration required for a SAML flow.
 /// </summary>
 [XmlRoot("PluginConfiguration")]
-public class SamlConfig
+public class SamlConfig : ProviderConfigBase
 {
     private SerializableDictionary<string, Guid> _canonicalLinks;
 
@@ -229,7 +244,7 @@ public class SamlConfig
 /// The configuration required for a OpenID flow.
 /// </summary>
 [XmlRoot("PluginConfiguration")]
-public class OidConfig
+public class OidConfig : ProviderConfigBase
 {
     private SerializableDictionary<string, Guid> _canonicalLinks;
 

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -288,7 +288,7 @@ const ssoConfigurationPage = {
     });
   },
   saveProvider: (page, provider_name) => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const form_elements = ssoConfigurationPage.listArgumentsByType(page);
 
       ApiClient.getPluginConfiguration(
@@ -343,15 +343,28 @@ const ssoConfigurationPage = {
         ApiClient.updatePluginConfiguration(
           ssoConfigurationPage.pluginUniqueId,
           config,
-        ).then(function (result) {
-          Dashboard.processPluginConfigurationUpdateResult(result);
-          ssoConfigurationPage.loadConfiguration(page);
-          ssoConfigurationPage.loadProvider(page, provider_name);
+        ).then(
+          function (result) {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+            ssoConfigurationPage.loadConfiguration(page);
+            ssoConfigurationPage.loadProvider(page, provider_name);
 
-          page.querySelector("#selectProvider").value = provider_name;
-          Dashboard.alert("Settings saved.");
-          resolve();
-        });
+            page.querySelector("#selectProvider").value = provider_name;
+            Dashboard.alert("Settings saved.");
+            resolve();
+          },
+          // Rejection handler attached directly to the save call, so it reports only a genuine save
+          // failure (e.g. the server rejecting a malformed Base URL Override, #139) and not an error
+          // thrown by the post-save UI work above. This replaces the prior silent no-op.
+          function () {
+            Dashboard.alert({
+              title: "Save failed",
+              message:
+                "Could not save the provider. Check that the Base URL Override is a full URL such as https://jellyfin.example.com, or leave it blank.",
+            });
+            reject(new Error("Provider save failed"));
+          },
+        );
       });
     });
   },
@@ -373,7 +386,9 @@ export default function initSsoConfigurationPage(view) {
   view.querySelector("#SaveProvider").addEventListener("click", (e) => {
     const target_provider = view.querySelector("#OidProviderName").value;
 
-    ssoConfigurationPage.saveProvider(view, target_provider);
+    // The save already alerts the admin on failure; swallow the rejection here so a failed save is not
+    // an unhandled promise rejection (the rejection exists so callers can distinguish failure from success).
+    ssoConfigurationPage.saveProvider(view, target_provider).catch(() => {});
 
     e.preventDefault();
     return false;

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -716,6 +716,42 @@
                   </div>
                 </div>
 
+                <div class="inputContainer">
+                  <label
+                    class="inputLabel inputLabelUnfocused"
+                    for="BaseUrlOverride"
+                    >Base URL Override</label
+                  >
+                  <input
+                    is="emby-input"
+                    id="BaseUrlOverride"
+                    type="text"
+                    class="sso-text"
+                  />
+                  <div class="fieldDescription">
+                    The canonical external base URL of this server, e.g.
+                    <code>https://jellyfin.example.com</code>. When set, the
+                    redirect URI and SAML base URL are built from it instead of
+                    the request host, so a spoofed or proxy-forwarded host
+                    cannot redirect the login elsewhere. It overrides the scheme
+                    and port overrides above.
+                  </div>
+                  <div class="fieldDescription" style="color: #cc3333">
+                    ⚠ Recommended. When left blank, the redirect URI derives
+                    from the request Host header; behind a reverse proxy that is
+                    only safe if Jellyfin's Known Proxies is set and the proxy
+                    sends a trusted X-Forwarded-Host (not a client-supplied one)
+                    — setting this override is the robust fix. This is the base
+                    URL, not the redirect URI — register
+                    <code
+                      >&lt;this
+                      URL&gt;/sso/OID/redirect/&lt;ProviderName&gt;</code
+                    >
+                    (or the legacy <code>/sso/OID/r/&lt;ProviderName&gt;</code>)
+                    as the exact redirect URI at your provider.
+                  </div>
+                </div>
+
                 <button
                   id="SaveProvider"
                   is="emby-button"

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -104,6 +104,15 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
         {
             if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration))
             {
+                // Reject the save fail-closed before anything is persisted if a base-URL override is
+                // malformed (#139), so a bad value can never reach the login path. This validates the
+                // config-page save (a fresh incoming config); the OID/SAML Add endpoints write through
+                // MutateConfiguration (the live object, so this branch is skipped) and validate their own
+                // incoming provider at the controller via RejectInvalidBaseUrlOverride. Login-path writes
+                // (canonical links) also reuse the live object and are intentionally not revalidated here,
+                // so a slow/bad override can never throw on the login path.
+                ValidateBaseUrlOverrides(incoming);
+
                 PreserveServerManagedFields(incoming, Configuration);
 
                 // Snapshot which providers were saved with an insecure option (#140) while under the
@@ -122,6 +131,38 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
             foreach (var (provider, options) in insecureToAudit)
             {
                 SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", provider, options);
+            }
+        }
+    }
+
+    // Throws if any provider's canonical base-URL override (#139) is set but not a valid absolute
+    // http/https base URL, rejecting the save fail-closed before anything is persisted. A blank value is
+    // valid (the feature is off). The provider name is line-ending-stripped inline in case it reaches a
+    // log through the thrown exception.
+    internal static void ValidateBaseUrlOverrides(PluginConfiguration incoming)
+    {
+        static void Check(string protocol, string provider, string value)
+        {
+            if (CanonicalBaseUrl.IsInvalidOverride(value))
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.");
+            }
+        }
+
+        if (incoming.OidConfigs != null)
+        {
+            foreach (var kvp in incoming.OidConfigs)
+            {
+                Check("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
+            }
+        }
+
+        if (incoming.SamlConfigs != null)
+        {
+            foreach (var kvp in incoming.SamlConfigs)
+            {
+                Check("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
             }
         }
     }

--- a/providers.md
+++ b/providers.md
@@ -71,6 +71,33 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   now lists OpenID links by their `sub` value, which for many providers is an opaque identifier
   rather than a readable name.
 
+## Canonical base URL (recommended hardening)
+
+By default the plugin builds the OpenID `redirect_uri` and the SAML base URL from the request `Host`
+header. Behind a reverse proxy that forwards an unfiltered `X-Forwarded-Host`, a client can influence
+that host and point the authorization response — the authorization code included — at another origin.
+Exact redirect-URI matching at the provider is the backstop, but it only helps if you register an
+**exact** redirect URI (not a wildcard); many self-hosted providers allow wildcards.
+
+- **Set `BaseUrlOverride`** (OpenID: the "Base URL Override" field in the admin page; SAML: the
+  `BaseUrlOverride` config value, like the other SAML options) to your canonical external base URL,
+  e.g. `https://jellyfin.example.com`. When set, every `redirect_uri` and SAML URL is built from it and
+  the request `Host` is ignored, so a spoofed host cannot redirect the login. It must be an absolute
+  `http`/`https` URL with no query or fragment; a malformed value is rejected when you save. It
+  overrides the per-provider scheme and port overrides.
+- **Register the exact callback URLs used by your deployment**, matching the override. OpenID may use
+  `<base URL>/sso/OID/redirect/<ProviderName>` or the legacy `<base URL>/sso/OID/r/<ProviderName>`;
+  SAML may use `<base URL>/sso/SAML/post/<ProviderName>` or `<base URL>/sso/SAML/p/<ProviderName>`.
+  Register the form your deployment actually uses; do not rely on wildcard redirect URIs.
+- **Sub-path deployments:** if Jellyfin is served under a path (e.g. `https://example.com/jellyfin`),
+  include that path in the override — it becomes authoritative and the request's own path base is not
+  added. Omitting it breaks every `/sso/...` URL.
+- If you leave `BaseUrlOverride` blank, the URLs fall back to the request `Host`; setting
+  `BaseUrlOverride` is the robust mitigation. Relying on the fallback behind a reverse proxy is safe
+  only if Jellyfin's **Known Proxies** is set **and** the proxy sends a trusted `X-Forwarded-Host`
+  (not a client-supplied one). Known Proxies alone only decides which upstreams may supply forwarded
+  headers — it does not by itself make a forwarded host trustworthy.
+
 ## SAML response binding (optional hardening)
 
 Two per-provider SAML options, both **off by default**, tie a response more tightly to this service
@@ -83,11 +110,11 @@ config so a save does not reset them.
   an assertion minted for a different endpoint — or for a different service provider that shares the
   identity provider — from being presented here. The Recipient is inside the signed assertion, so it
   is trustworthy even when only the assertion (not the whole Response) is signed. **Caveat:** the
-  expected URL is built from the request host, so this binding is only as strong as your host
-  resolution — behind a reverse proxy, configure Jellyfin's Known/Trusted Proxies so the `Host`
-  header cannot be spoofed. Treat it as defense-in-depth layered on the `AudienceRestriction`,
-  signature, replay and time-bound checks, not as a standalone guarantee. (A canonical base-URL
-  override that removes the host dependency is tracked in issue #139.)
+  expected URL is built from the base URL, so this binding is only as strong as host resolution unless
+  you pin it — set `BaseUrlOverride` (see [Canonical base URL](#canonical-base-url-recommended-hardening))
+  to make it exact. The request-host fallback is only safe if Jellyfin's Known Proxies is set **and**
+  the proxy sends a trusted `X-Forwarded-Host`. Treat it as defense-in-depth layered on the `AudienceRestriction`,
+  signature, replay and time-bound checks, not as a standalone guarantee.
 - **`ValidateInResponseTo`** — accept only _solicited_ responses: the assertion's `InResponseTo` must
   match an `AuthnRequest` this server issued and has not yet consumed (one-time, time-bounded).
   **Enabling this disables IdP-initiated (unsolicited) SSO**, which carries no `InResponseTo` — leave


### PR DESCRIPTION
# What & why

The OIDC `redirect_uri` and SAML base URL were derived from the request `Host`
header. Behind a reverse proxy that forwards an unfiltered `X-Forwarded-Host`, a
client can influence that host and point the authorization response, the
authorization code included, at another origin (RFC 9700 sect. 4.1). Exact
redirect-URI matching at the provider is the only backstop, and self-hosted
providers commonly allow wildcard redirect URIs.

This adds a per-provider **`BaseUrlOverride`** (OIDC + SAML). When set,
`GetRequestBase` returns it verbatim and the request `Host` is ignored, so it
cannot be spoofed; blank preserves the existing request-host behavior
(backward-compatible, opt-in). A malformed override is rejected **fail-closed at
every admin write path**, the config-page save (`ValidateBaseUrlOverrides`) and
the `OID/Add` / `SAML/Add` endpoints (`RejectInvalidBaseUrlOverride`), so it can
never be persisted and then silently fall back to the host at login. Login-path
writes reuse the live config object and are not revalidated, so validation never
throws on the login path.

Closes #139

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a malformed override is rejected at every admin
      write path; at login `TryNormalize` still fails closed and falls back to
      the request Host (never a bad redirect_uri).
- [x] No secrets logged; the override is not a secret. The provider name in the
      rejection message is line-ending-stripped inline.
- [x] A security review was performed (full 4-lens adversarial gate +
      OIDC/SAML domain reviewers; see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged).

## Quality checklist

- [x] No duplicated logic; the normalize/validate decision lives in one small
      testable helper (`CanonicalBaseUrl`), reused by both write paths.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (401 tests; new coverage for normalization,
      save-time validation, and the Add-path rejection).
- [x] Prettier is clean for the `.js` / `.html` / `.md` changes.

## Notes

The adversarial-review gate ran on the first cut and caught a real defect: the
save-time validation lived only on the config-page path, so `OID/Add` and
`SAML/Add` (the only SAML config path) persisted a malformed override
unvalidated, a silent hardening-disable. Fixed by validating the incoming
override at those endpoints too. Re-reviewed clean. Verdicts are documented in
the pre-merge review.

Real-server verification (cannot be unit-tested) is tracked in the E2E
checklist: the spoofed-Host redirect_uri test with the override set, the
config-page/API rejection UX, and a sub-path deployment.