### PR TITLE
Reject malformed SAML callback input with a clean 400, not a 500

### DIFF
--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -1,0 +1,96 @@
+using System.Security.Cryptography.Xml;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the malformed-input handling on the SAML callback (#199): <see cref="SamlResponseLoader.TryParse"/>
+/// maps the constructor's malformed-input exceptions to a fail-closed <see langword="false"/> (so the
+/// endpoints return a clean 4xx rather than an unhandled HTTP 500), and <see cref="Response.GetSignatureAlgorithm"/>
+/// — a failure-log diagnostic — never throws on a malformed signature element.
+/// </summary>
+public class SamlResponseParsingTests
+{
+    [Fact]
+    public void TryLoad_ValidResponse_ReturnsTrue()
+    {
+        var fixture = SamlTestFactory.Create();
+
+        Assert.True(SamlResponseLoader.TryParse(fixture.CertificateBase64, fixture.EncodeResponse(), out var response));
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public void TryLoad_NonBase64Response_ReturnsFalse()
+    {
+        // Convert.FromBase64String throws FormatException; TryLoad maps it to a rejection, not a 500.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, "@@ not base64 @@", out var response));
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public void TryLoad_MalformedXmlBody_ReturnsFalse()
+    {
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, SamlFixture.Encode("<unterminated>"), out var response));
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public void TryLoad_DoctypeBody_ReturnsFalse()
+    {
+        // DtdProcessing.Prohibit (the P2#9 XXE guard) throws XmlException on a DOCTYPE; TryLoad maps that
+        // intentional throw to a clean rejection rather than a 500.
+        var fixture = SamlTestFactory.Create();
+        var body = SamlFixture.Encode("<!DOCTYPE foo [<!ENTITY x \"y\">]><samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" />");
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, body, out var response));
+        Assert.Null(response);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryParse_NullOrEmptyResponse_ReturnsFalse(string? responseString)
+    {
+        // A missing SAMLResponse (absent form field / omitted JSON data) is the most common malformed
+        // callback; it must reject cleanly, not raise ArgumentNullException from Convert.FromBase64String.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, responseString, out var response));
+        Assert.Null(response);
+    }
+
+    [Fact]
+    public void GetSignatureAlgorithm_ValidResponse_ReturnsTheSignatureMethod()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.True(SamlResponseLoader.TryParse(fixture.CertificateBase64, fixture.EncodeResponse(), out var response));
+
+        Assert.Equal(SignedXml.XmlDsigRSASHA256Url, response.GetSignatureAlgorithm());
+    }
+
+    [Fact]
+    public void GetSignatureAlgorithm_MalformedSignatureElement_ReturnsNullNotThrow()
+    {
+        // A ds:Signature with no SignedInfo makes SignedXml.LoadXml throw CryptographicException. The
+        // diagnostic must swallow it and return null so the caller's clean rejection is not turned into
+        // a 500 (#199). The document itself is well-formed, so TryLoad succeeds and the throw would
+        // otherwise surface only from GetSignatureAlgorithm.
+        const string xml =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+            "xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">" +
+            "<ds:Signature><ds:Garbage /></ds:Signature>" +
+            "<saml:Assertion />" +
+            "</samlp:Response>";
+
+        Assert.True(SamlResponseLoader.TryParse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xml), out var response));
+        Assert.Null(response.GetSignatureAlgorithm());
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -557,11 +557,12 @@ public class SSOController : ControllerBase
 
         if (config.Enabled)
         {
-            var samlResponse = new Response(config.SamlCertificate, Request.Form["SAMLResponse"]);
-
-            if (!IsSamlResponseValid(samlResponse, config, provider))
+            if (!SamlResponseLoader.TryParse(config.SamlCertificate, Request.Form["SAMLResponse"], out var samlResponse)
+                || !IsSamlResponseValid(samlResponse, config, provider))
             {
-                return Problem("SAML response validation failed");
+                // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
+                // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
+                return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
             }
 
             if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
@@ -731,11 +732,11 @@ public class SSOController : ControllerBase
 
         if (config.Enabled)
         {
-            var samlResponse = new Response(config.SamlCertificate, response.Data);
-
-            if (!IsSamlResponseValid(samlResponse, config, provider))
+            if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
+                || !IsSamlResponseValid(samlResponse, config, provider))
             {
-                return Problem("SAML response validation failed");
+                // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+                return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
             }
 
             // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
@@ -1208,11 +1209,11 @@ public class SSOController : ControllerBase
             return BadRequest(NoMatchingProviderMessage);
         }
 
-        var samlResponse = new Response(config.SamlCertificate, response.Data);
-
-        if (!IsSamlResponseValid(samlResponse, config, provider))
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
+            || !IsSamlResponseValid(samlResponse, config, provider))
         {
-            return Problem("SAML response validation failed");
+            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+            return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
         }
 
         string providerUserId = samlResponse.GetNameID();

--- a/SSO-Auth/Api/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/SamlResponseLoader.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Safely constructs a <see cref="Response"/> from an untrusted SAML response string (#199). The
+/// <see cref="Response"/> constructor throws on malformed input — <see cref="FormatException"/> for a
+/// non-base64 body and <see cref="XmlException"/> for malformed XML or a prohibited DOCTYPE (the P2#9
+/// XXE guard). Left unhandled, those surface to an unauthenticated caller as an HTTP 500 with a stack
+/// trace; this maps them to a fail-closed <see langword="false"/> so the callback endpoints reject a
+/// malformed response the same way they reject an invalid one — a clean 4xx.
+/// </summary>
+internal static class SamlResponseLoader
+{
+    /// <summary>
+    /// Tries to parse a SAML response, returning <see langword="false"/> (rather than throwing) on the
+    /// malformed-input exceptions the <see cref="Response"/> constructor raises.
+    /// </summary>
+    /// <param name="certificateStr">The identity provider's signing certificate as a Base64 string.</param>
+    /// <param name="responseString">The untrusted SAML response (Base64).</param>
+    /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
+    internal static bool TryParse(string certificateStr, string responseString, out Response response)
+    {
+        // A null or empty body is the most common malformed callback (an absent SAMLResponse form field
+        // yields a null string on the unauthenticated ACS endpoint); reject it here rather than let
+        // Convert.FromBase64String(null) raise ArgumentNullException and escape as an unhandled 500.
+        if (string.IsNullOrEmpty(responseString))
+        {
+            response = null;
+            return false;
+        }
+
+        try
+        {
+            response = new Response(certificateStr, responseString);
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or XmlException)
+        {
+            response = null;
+            return false;
+        }
+    }
+}

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -242,9 +242,20 @@ public class Response
             return null;
         }
 
-        var signedXml = new SignedXml(_xmlDoc);
-        signedXml.LoadXml((XmlElement)nodeList[0]);
-        return signedXml.SignedInfo.SignatureMethod;
+        // This is a diagnostic used only in the failure-log path, so it must never throw: a malformed
+        // signature element makes SignedXml.LoadXml raise CryptographicException, which would turn the
+        // clean rejection its caller is about to return into an unhandled HTTP 500 (#199). Return null
+        // (unknown algorithm) on any malformed-signature exception instead.
+        try
+        {
+            var signedXml = new SignedXml(_xmlDoc);
+            signedXml.LoadXml((XmlElement)nodeList[0]);
+            return signedXml.SignedInfo.SignatureMethod;
+        }
+        catch (Exception ex) when (ex is CryptographicException or XmlException or ArgumentException or FormatException)
+        {
+            return null;
+        }
     }
 
     private List<string> GetAudiences()


### PR DESCRIPTION
# What & why

The SAML callback endpoints built a `Response` from untrusted input directly, so
malformed input escaped as an unhandled HTTP 500 with a stack trace to an
unauthenticated caller: the constructor throws `FormatException` (non-base64),
`XmlException` (malformed XML / prohibited DOCTYPE) and `ArgumentNullException`
(null/absent body), and the failure-log diagnostic `GetSignatureAlgorithm` throws
`CryptographicException` on a malformed signature element. Not an auth bypass - 
every faulting path denies login, but a robustness / log-hygiene gap an attacker
could drive at will.

`SamlResponseLoader.TryParse` now rejects a null/empty body up front and maps the
constructor's malformed-input exceptions to a fail-closed `false`; the three SAML
callback sites (SamlPost, SamlAuth, SamlLink) reject a malformed response the same
way they reject an invalid one, via `ReturnError(400)` rather than `Problem()`
(which defaults to 500), since a bad client-supplied SAML response is a client
error. `GetSignatureAlgorithm` is made fail-safe (a diagnostic must never turn a
clean rejection into a 500).

Closes #199

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: every malformed/invalid path denies login; a null,
      non-base64, malformed-XML, DOCTYPE, or malformed-signature body is rejected,
      never default-accepted. The success-path validation chain (signature/XSW,
      algorithm allowlist, single-assertion, audience, recipient/InResponseTo,
      replay, time bounds, XXE) is byte-identical.
- [x] No secrets logged; the generic rejection message is unchanged, so it still
      does not leak why a response was rejected. IdP-controlled log values remain
      inline-sanitized.
- [x] A security review was performed (full 4-lens gate + saml-reviewer; see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged).

## Quality checklist

- [x] No duplicated logic; the parse guard lives in one small, testable helper
      (`SamlResponseLoader`) reused by all three call sites.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (411 tests; new coverage for null/empty, non-base64,
      malformed-XML, DOCTYPE, and the malformed-signature diagnostic).
- [x] Prettier not applicable (no `.js`/`.html`/`.md`/`.css` change).

## Notes

The adversarial-review gate found two real issues on the first cut: a null/absent
`SAMLResponse` still 500'd (the `ArgumentNullException` was outside the
`FormatException/XmlException` filter, unauthenticated-reachable at the SAML ACS),
and `SamlLink` still returned `Problem()` (500) beneath a "clean 4xx" comment while
the other two sites used 400. Both fixed (up-front null/empty guard + `response?.Data`;
`SamlLink` → `ReturnError(400)`); re-reviewed clean by all three lenses. Verdicts are
documented in the pre-merge review.

Pre-existing, out-of-scope residuals the lenses noted (admin-config / non-attacker
input, unchanged by this PR, to be filed as a separate low-priority robustness
follow-up): a null/garbage `SamlCertificate` config still 500s, and the SamlPost ACS
reads `Request.Form` directly so a non-form content-type POST still 500s.

Real-server verification is on the E2E checklist: a malformed/absent SAMLResponse to
the ACS/auth/link endpoints returns a clean 400 (no stack trace) and the embedded
auth page surfaces a login failure rather than hanging.