### PR TITLE
Reject an unloadable SAML certificate instead of 500-ing every callback

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -282,4 +282,32 @@ public class ConfigPreservationTests
         var back = (ProviderConfigBase)serializer.Deserialize(xmlReader)!;
         Assert.Equal("https://jellyfin.example.com", back.BaseUrlOverride);
     }
+
+    // --- SAML certificate validation on save (#206) ---
+
+    [Fact]
+    public void ValidateSamlCertificates_ValidOrBlank_DoesNotThrow()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["ok"] = new SamlConfig { SamlCertificate = SamlTestFactory.Create().CertificateBase64 };
+        incoming.SamlConfigs["blank"] = new SamlConfig { SamlCertificate = null };
+
+        SSOPlugin.ValidateSamlCertificates(incoming);
+    }
+
+    [Fact]
+    public void ValidateSamlCertificates_GarbageCertificate_ThrowsNamingProvider()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig { SamlCertificate = "QUJD" }; // valid base64, not a cert
+
+        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateSamlCertificates(incoming));
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateSamlCertificates_NullMap_DoesNotThrow()
+    {
+        SSOPlugin.ValidateSamlCertificates(new PluginConfiguration { SamlConfigs = null });
+    }
 }

--- a/SSO-Auth.Tests/SamlCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlCertificateTests.cs
@@ -1,0 +1,49 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlCertificate"/> and the SAML/Add certificate guard (#206): a non-blank but
+/// unloadable SAML signing certificate is rejected at the admin write path, so it cannot make every
+/// callback throw a CryptographicException 500; blank is valid (a half-configured provider).
+/// </summary>
+public class SamlCertificateTests
+{
+    [Fact]
+    public void IsInvalid_ValidCertificate_False()
+    {
+        Assert.False(SamlCertificate.IsInvalid(SamlTestFactory.Create().CertificateBase64));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsInvalid_Blank_False(string? certificateStr)
+    {
+        Assert.False(SamlCertificate.IsInvalid(certificateStr));
+    }
+
+    [Theory]
+    [InlineData("@@ not base64 @@")] // FormatException
+    [InlineData("QUJD")] // valid base64 ("ABC") but not a certificate -> CryptographicException
+    public void IsInvalid_SetButUnloadable_True(string certificateStr)
+    {
+        Assert.True(SamlCertificate.IsInvalid(certificateStr));
+    }
+
+    [Fact]
+    public void RejectInvalidSamlCertificate_ValidOrBlank_DoesNotThrow()
+    {
+        SSOController.RejectInvalidSamlCertificate(SamlTestFactory.Create().CertificateBase64);
+        SSOController.RejectInvalidSamlCertificate(null);
+        SSOController.RejectInvalidSamlCertificate(string.Empty);
+    }
+
+    [Fact]
+    public void RejectInvalidSamlCertificate_Garbage_Throws()
+    {
+        Assert.Throws<System.ArgumentException>(() => SSOController.RejectInvalidSamlCertificate("QUJD"));
+    }
+}

--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -93,4 +93,15 @@ public class SamlResponseParsingTests
         Assert.True(SamlResponseLoader.TryParse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xml), out var response));
         Assert.Null(response.GetSignatureAlgorithm());
     }
+
+    [Fact]
+    public void TryParse_GarbageCertificate_ReturnsFalse()
+    {
+        // A non-loadable configured SamlCertificate (a legacy or hand-edited config) must fail closed to a
+        // clean rejection rather than the unhandled CryptographicException 500 it produced before (#206).
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(SamlResponseLoader.TryParse("QUJD", fixture.EncodeResponse(), out var response));
+        Assert.Null(response);
+    }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -345,6 +345,19 @@ public class SSOController : ControllerBase
         }
     }
 
+    // Rejects a non-loadable SAML signing certificate at the SAML/Add endpoint (#206), which persists
+    // through MutateConfiguration and so bypasses the config-page save-time validation in
+    // SSOPlugin.ValidateSamlCertificates. Without this, a garbage certificate set via the Add API would be
+    // persisted and then throw a CryptographicException on every callback (an unhandled 500). Blank is
+    // valid (a half-configured provider).
+    internal static void RejectInvalidSamlCertificate(string certificateStr)
+    {
+        if (SamlCertificate.IsInvalid(certificateStr))
+        {
+            throw new ArgumentException("The SAML signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.");
+        }
+    }
+
     /// <summary>
     /// Adds an OpenID auth configuration. Requires administrator privileges. If the provider already exists, it will be removed and readded.
     /// </summary>
@@ -667,6 +680,7 @@ public class SSOController : ControllerBase
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
         RejectInvalidBaseUrlOverride(newConfig?.BaseUrlOverride);
+        RejectInvalidSamlCertificate(newConfig?.SamlCertificate);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // Preserve the server-managed canonical links (#157), as OidAdd does: the posted config

--- a/SSO-Auth/Api/SamlCertificate.cs
+++ b/SSO-Auth/Api/SamlCertificate.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Validates the per-provider SAML signing certificate (#206). A non-blank but unloadable
+/// <c>SamlCertificate</c> makes the <see cref="Response"/> constructor throw on every callback
+/// (<see cref="FormatException"/> on non-base64, <see cref="CryptographicException"/> on bytes that are
+/// not a certificate), which escaped as an unhandled HTTP 500. Rejecting an invalid certificate at every
+/// admin write path — and treating it as a parse failure at login — keeps that fail-closed and out of the
+/// 500 path.
+/// </summary>
+internal static class SamlCertificate
+{
+    /// <summary>
+    /// Whether a certificate value is set but is not a loadable X.509 certificate. Blank is valid (a
+    /// half-configured provider; the login then fails closed for lack of a certificate rather than being
+    /// blocked from saving).
+    /// </summary>
+    /// <param name="certificateStr">The Base64-encoded (DER) certificate string.</param>
+    /// <returns><see langword="true"/> if the value is set but not a loadable certificate.</returns>
+    internal static bool IsInvalid(string certificateStr)
+    {
+        if (string.IsNullOrWhiteSpace(certificateStr))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateStr));
+            return false;
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException or ArgumentException)
+        {
+            return true;
+        }
+    }
+}

--- a/SSO-Auth/Api/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/SamlResponseLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Security.Cryptography;
 using System.Xml;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
@@ -37,8 +38,12 @@ internal static class SamlResponseLoader
             response = new Response(certificateStr, responseString);
             return true;
         }
-        catch (Exception ex) when (ex is FormatException or XmlException)
+        catch (Exception ex) when (ex is FormatException or XmlException or CryptographicException or ArgumentException)
         {
+            // FormatException/XmlException: a malformed response body (#199). CryptographicException/
+            // ArgumentException: a null/garbage configured SamlCertificate (#206) — the save-time
+            // validation blocks that, but a legacy or hand-edited config could still carry one, so fail
+            // closed to a clean rejection here rather than an unhandled 500.
             response = null;
             return false;
         }

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -112,6 +112,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
                 // (canonical links) also reuse the live object and are intentionally not revalidated here,
                 // so a slow/bad override can never throw on the login path.
                 ValidateBaseUrlOverrides(incoming);
+                ValidateSamlCertificates(incoming);
 
                 PreserveServerManagedFields(incoming, Configuration);
 
@@ -163,6 +164,28 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
             foreach (var kvp in incoming.SamlConfigs)
             {
                 Check("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
+            }
+        }
+    }
+
+    // Throws if any SAML provider's signing certificate (#206) is set but not a loadable X.509
+    // certificate, rejecting the save fail-closed before it is persisted so a garbage certificate cannot
+    // make every callback throw an unhandled 500. Blank is valid (a half-configured provider). Only this
+    // admin config-page save path validates here; SAML/Add validates its own incoming provider at the
+    // controller (RejectInvalidSamlCertificate), and login-path writes reuse the live object.
+    internal static void ValidateSamlCertificates(PluginConfiguration incoming)
+    {
+        if (incoming.SamlConfigs == null)
+        {
+            return;
+        }
+
+        foreach (var kvp in incoming.SamlConfigs)
+        {
+            if (SamlCertificate.IsInvalid(kvp.Value?.SamlCertificate))
+            {
+                throw new ArgumentException(
+                    $"SAML provider '{kvp.Key?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
             }
         }
     }


### PR DESCRIPTION
# What & why

Closes #206.

A non-blank but unloadable `SamlCertificate` in a provider config made the
`Response` constructor throw on every SAML callback, a null/empty cert threw
`ArgumentNullException` from `Convert.FromBase64String`, and valid-base64-that-
is-not-a-certificate threw `CryptographicException` from
`X509CertificateLoader.LoadCertificate`, surfacing as an unhandled HTTP 500 on
each login attempt for that provider. This is admin-config-controlled input,
not attacker/IdP input, but a misconfigured provider should fail with a clear
error, not a stack-trace 500.

This is the certificate-config half of #206. The non-form-content-type half was
already delivered in #207 (`SamlPost` now binds `SAMLResponse` via `[FromForm]`),
so this PR closes the issue.

The fix mirrors the already-merged #139 base-URL-override validation:

- `SamlCertificate.IsInvalid(certificateStr)`, one pure, testable helper:
  blank is valid (a half-configured provider), a loadable cert is valid,
  a non-blank cert that will not load is invalid. It uses the exact
  `X509CertificateLoader.LoadCertificate(Convert.FromBase64String(...))` call
  the login path uses, so "passes validation" and "loads at login" are the same
  set, no validate/consume differential.
- Reject at both admin write paths: `ValidateSamlCertificates` in
  `SSOPlugin.UpdateConfiguration` (config-page save) and
  `RejectInvalidSamlCertificate` at `SAML/Add`.
- Defense-in-depth at login: `SamlResponseLoader.TryParse`'s catch is broadened
  to include the cert-load exceptions, so a legacy or hand-edited bad cert that
  is already persisted fails closed to a clean 400 instead of a 500.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The signature/XSW/algorithm/audience/recipient/replay/time pipeline in
`Response.IsValid()` is untouched and still runs, unchanged, after a successful
parse, the broadened `TryParse` catch wraps only the constructor (cert load +
XML parse), whose sole `CryptographicException` source is the cert loader, so an
invalid signature can never be accepted. A blank/garbage cert provably throws in
the constructor before any signature check. The thrown `ArgumentException`
contains only the provider key, line-ending-stripped inline; the cert bytes are
never logged and the loaded cert is disposed via `using`.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (once the test project exists).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

`dotnet build --no-incremental --warnaserror`: 0 warnings, 0 errors.
`dotnet test`: 423/423 pass (+12 new: `SamlCertificateTests`, and additions to
`ConfigPreservationTests` and `SamlResponseParsingTests`). No `.js/.html/.md/.css`
touched, so Prettier is N/A.

## Notes

Adversarial-review gate (5 lenses, refute-by-default): availability, bypass,
correctness, integration, saml-reviewer, all PASS.

One availability note surfaced by two lenses (not a blocker, matches the
accepted #139 precedent): validation iterates all SAML providers and does not
check `Enabled`, so a deployment that already carries an unloadable cert on any
provider, including a disabled or abandoned one, will have its first
config-page save rejected until that cert is cleared (blank is accepted) or the
provider is deleted (`SAML/Del`). This is admin-facing and self-inflicted; the
exception names the exact provider, all other providers keep working, and the
offending provider's login was already broken (it 500'd before this change).
