### PR TITLE
Validate the RFC 9207 authorization-response issuer

### DIFF
--- a/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
@@ -41,11 +41,23 @@ public class OidcInsecureTogglesTests
     }
 
     [Fact]
-    public void Enabled_AllThree_ReportsAll_MostSevereFirst()
+    public void Enabled_DoNotValidateResponseIssuer_ReportsIt()
     {
-        var config = new OidConfig { DisableHttps = true, DoNotValidateIssuerName = true, DoNotValidateEndpoints = true };
+        Assert.Equal(new[] { "DoNotValidateResponseIssuer" }, OidcInsecureToggles.Enabled(new OidConfig { DoNotValidateResponseIssuer = true }));
+    }
+
+    [Fact]
+    public void Enabled_AllFour_ReportsAll_MostSevereFirst()
+    {
+        var config = new OidConfig
+        {
+            DisableHttps = true,
+            DoNotValidateIssuerName = true,
+            DoNotValidateEndpoints = true,
+            DoNotValidateResponseIssuer = true,
+        };
         Assert.Equal(
-            new[] { "DisableHttps", "DoNotValidateIssuerName", "DoNotValidateEndpoints" },
+            new[] { "DisableHttps", "DoNotValidateIssuerName", "DoNotValidateEndpoints", "DoNotValidateResponseIssuer" },
             OidcInsecureToggles.Enabled(config));
     }
 

--- a/SSO-Auth.Tests/OidcResponseIssuerTests.cs
+++ b/SSO-Auth.Tests/OidcResponseIssuerTests.cs
@@ -1,0 +1,70 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcResponseIssuer"/> — the RFC 9207 authorization-response issuer check (#125).
+/// A present response <c>iss</c> must equal the id_token issuer; absence is tolerated; anything that
+/// cannot be shown to agree is a mismatch (fail closed).
+/// </summary>
+public class OidcResponseIssuerTests
+{
+    private const string Issuer = "https://idp.example.com";
+
+    // Builds a parseable (unsigned) id_token carrying the given iss. The check never verifies the
+    // signature — it only reads the issuer — so a JWS with a throwaway signature segment is enough.
+    private static string IdToken(string? issuer)
+    {
+        var payload = issuer == null ? "{}" : $"{{\"iss\":\"{issuer}\"}}";
+        return Base64UrlEncoder.Encode("{\"alg\":\"none\",\"typ\":\"JWT\"}")
+            + "." + Base64UrlEncoder.Encode(payload)
+            + ".c2ln";
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsMismatch_AbsentResponseIssuer_False(string? responseIssuer)
+    {
+        // Many IdPs do not emit iss; requiring it would lock them out, so absence is tolerated.
+        Assert.False(OidcResponseIssuer.IsMismatch(responseIssuer, IdToken(Issuer)));
+    }
+
+    [Fact]
+    public void IsMismatch_ResponseIssuerMatchesToken_False()
+    {
+        Assert.False(OidcResponseIssuer.IsMismatch(Issuer, IdToken(Issuer)));
+    }
+
+    [Fact]
+    public void IsMismatch_ResponseIssuerDiffersFromToken_True()
+    {
+        Assert.True(OidcResponseIssuer.IsMismatch("https://attacker.example", IdToken(Issuer)));
+    }
+
+    [Fact]
+    public void IsMismatch_CaseDifferenceOnly_True()
+    {
+        // Issuer comparison is ordinal (RFC 9207 / OIDC simple string comparison): a case flip is a mismatch.
+        Assert.True(OidcResponseIssuer.IsMismatch(Issuer.ToUpperInvariant(), IdToken(Issuer)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    public void IsMismatch_PresentResponseIssuerButUnreadableToken_True(string? identityToken)
+    {
+        // A response issuer that cannot be shown to match (no/garbage token, or a token with no iss)
+        // fails closed rather than being waved through.
+        Assert.True(OidcResponseIssuer.IsMismatch(Issuer, identityToken));
+    }
+
+    [Fact]
+    public void IsMismatch_TokenWithoutIssuerClaim_True()
+    {
+        Assert.True(OidcResponseIssuer.IsMismatch(Issuer, IdToken(null)));
+    }
+}

--- a/SSO-Auth/Api/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/OidcInsecureToggles.cs
@@ -42,6 +42,13 @@ internal static class OidcInsecureToggles
             enabled.Add(nameof(OidConfig.DoNotValidateEndpoints));
         }
 
+        // RFC 9207 response-iss check (#125): last because it is defence-in-depth on top of the
+        // per-provider callback binding, which already resists the classic mix-up on its own.
+        if (config.DoNotValidateResponseIssuer)
+        {
+            enabled.Add(nameof(OidConfig.DoNotValidateResponseIssuer));
+        }
+
         return enabled;
     }
 }

--- a/SSO-Auth/Api/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/OidcResponseIssuer.cs
@@ -1,0 +1,63 @@
+using System;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// RFC 9207 authorization-response issuer check (OpenID Connect mix-up defense, #125). The library the
+/// plugin uses (Duende.IdentityModel.OidcClient 7.1.0) parses the response <c>iss</c> parameter but never
+/// validates it, and strips it from the resulting claims, so the check has to live here. The expected
+/// issuer is the <c>iss</c> of the id_token the code redeemed to: that token has already been
+/// signature-validated and issuer-matched against the discovery document by <see cref="OidcIdTokenValidator"/>,
+/// so it is a trusted stand-in for "the provider this callback is bound to". When the authorization
+/// response advertises a different issuer, the response came from a different authorization server than
+/// the one whose token we hold — a mix-up signal — and the caller rejects the login (fail closed).
+/// </summary>
+internal static class OidcResponseIssuer
+{
+    /// <summary>
+    /// Determines whether a present authorization-response <c>iss</c> disagrees with the id_token issuer.
+    /// Absence of <paramref name="responseIssuer"/> is tolerated (many IdPs do not yet emit it, and
+    /// requiring it would lock them out); a present value that does not match the token issuer is a
+    /// mismatch. If the token issuer cannot be read while a response issuer is present, that also counts
+    /// as a mismatch — the safe default when the two cannot be shown to agree.
+    /// </summary>
+    /// <param name="responseIssuer">The <c>iss</c> query parameter from the authorization response, if any.</param>
+    /// <param name="identityToken">The redeemed id_token (already validated upstream).</param>
+    /// <returns><see langword="true"/> when a present response issuer does not match the token issuer.</returns>
+    internal static bool IsMismatch(string? responseIssuer, string? identityToken)
+    {
+        if (string.IsNullOrEmpty(responseIssuer))
+        {
+            return false;
+        }
+
+        return !string.Equals(responseIssuer, TokenIssuer(identityToken), StringComparison.Ordinal);
+    }
+
+    // The id_token was validated by OidcIdTokenValidator before this runs, so it parses; the guard and
+    // catch are defensive so a degenerate token can never turn the mix-up check itself into a 500.
+    private static string? TokenIssuer(string? identityToken)
+    {
+        if (string.IsNullOrEmpty(identityToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            return new JsonWebToken(identityToken).Issuer;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (SecurityTokenException)
+        {
+            return null;
+        }
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -175,6 +175,17 @@ public class SSOController : ControllerBase
                 return ReturnError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
             }
 
+            // RFC 9207 (#125): the library parses the authorization-response `iss` but never checks it.
+            // When present it must name the same issuer as the redeemed id_token (which OidcIdTokenValidator
+            // already validated against the discovery issuer); a mismatch means the response came from a
+            // different authorization server than the one we hold a token for — a mix-up — so reject.
+            if (!config.DoNotValidateResponseIssuer
+                && OidcResponseIssuer.IsMismatch(Request.Query["iss"], result.IdentityToken))
+            {
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer did not match the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status400BadRequest, "SSO response validation failed");
+            }
+
             // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
             // from the verified login's claims and the provider configuration, then apply them to the
             // fresh authorize state (its derivation fields are still at their defaults at this point).

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -429,6 +429,13 @@ public class OidConfig : ProviderConfigBase
     public bool DoNotValidateIssuerName { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the RFC 9207 authorization-response <c>iss</c> parameter
+    /// is validated against the id_token issuer (an OpenID Connect mix-up defense). Off by default;
+    /// enabling it disables the check for a provider whose response <c>iss</c> legitimately differs.
+    /// </summary>
+    public bool DoNotValidateResponseIssuer { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the UserInfo endpoint is used to get profile data.
     /// </summary>
     public bool DoNotLoadProfile { get; set; }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -668,6 +668,29 @@
                   <label>
                     <input
                       is="emby-checkbox"
+                      id="DoNotValidateResponseIssuer"
+                      name="DoNotValidateResponseIssuer"
+                      type="checkbox"
+                      class="sso-toggle"
+                    />
+                    <span
+                      >Do Not Validate Authorization-Response Issuer
+                      (Insecure)</span
+                    >
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Insecure: disables the RFC 9207 <code>iss</code> check, an
+                    OpenID Connect mix-up defense. Only for a provider whose
+                    authorization response legitimately carries a different
+                    issuer. Enabling it is recorded as an audit warning.
+                  </div>
+                </div>
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
                       id="DoNotLoadProfile"
                       name="DoNotLoadProfile"
                       type="checkbox"

--- a/providers.md
+++ b/providers.md
@@ -56,6 +56,11 @@ expiry). A few provider settings must therefore match, or login is refused (fail
 - **Issuer** is matched against the discovery issuer. If your IdP legitimately presents a different
   issuer (some templated or multi-tenant setups), set `DoNotValidateIssuerName: true` for that
   provider — this relaxes only the issuer check; signature, audience and expiry stay enforced.
+- **Authorization-response issuer (RFC 9207).** When the provider adds an `iss` parameter to the
+  authorization response (a mix-up defense), it is checked against the id_token issuer and a mismatch
+  is rejected. Providers that do not send `iss` are unaffected. If a provider legitimately sends a
+  different `iss` there, set `DoNotValidateResponseIssuer: true` for that provider to relax only this
+  check.
 - If your IdP sends an `at_hash` claim it must match the issued access token — a correctly behaving
   provider always satisfies this.
 - **A `sub` claim is required, and it must be stable.** The account link is keyed on the immutable


### PR DESCRIPTION
# What & why

Closes #125.

RFC 9207 adds an `iss` parameter to the OpenID Connect authorization response so
the client can detect an IdP mix-up: the response must name the same
authorization server the request was sent to. Duende.IdentityModel.OidcClient
7.1.0 (confirmed by decompiling the pinned DLL, notes on #125) parses that `iss`
but never validates it, and strips it from the resulting claims, so the defense
was unimplemented.

This adds the check where the library omits it:

- `OidcResponseIssuer.IsMismatch`, a pure, testable helper. When the
  authorization response carries an `iss`, it must equal the issuer of the
  redeemed id_token (which `OidcIdTokenValidator` already signature-validated and
  matched against the discovery issuer, so it is a trusted stand-in for "the
  provider this callback is bound to"). A present-but-different `iss` means the
  response came from a different authorization server than the one we hold a
  token for, a mix-up, and the login is rejected. Absence is tolerated (many
  IdPs do not yet emit `iss`; requiring it would lock them out).
- Guard in the OID callback, after the token is redeemed and before the login is
  derived. Opt-out via a new per-provider `DoNotValidateResponseIssuer` flag
  (default off = validation on), audited by `OidcInsecureToggles` like the other
  escape hatches and surfaced in the config UI and `providers.md`.

This is defense-in-depth: the per-provider callback route + provider-bound state
+ fixed per-provider token endpoint already resist the classic mix-up; the `iss`
check confirms the authorization server's identity on top of that.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Fail-closed on every degenerate input: a present-but-mismatched `iss`, a
duplicate `iss` (comma-joins → mismatch), and a present `iss` with an
unreadable/absent id_token issuer all reject with a 400 before the state's
`Valid` flag is set, so the callback can never be redeemed. The helper catches
the id_token parse exceptions, so the check itself cannot 500. Only the provider
name is logged (line-ending-stripped inline); the `iss` value and secrets are
never logged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (once the test project exists).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

`dotnet build --no-incremental --warnaserror`: 0 warnings, 0 errors.
`dotnet test`: 433/433 (+10 new: `OidcResponseIssuerTests` and an
`OidcInsecureToggles` case). Prettier clean for `configPage.html` +
`providers.md`.

## Notes

Adversarial-review gate (5 lenses, refute-by-default): oidc-reviewer, bypass,
correctness, availability, integration, all PASS. bypass and correctness
verified the fail-closed behavior empirically (garbage/null/duplicate `iss`,
`JsonWebToken` exception coverage across 7.x/8.x, `Valid` never set on reject).

Non-blocking follow-ups (a low-priority issue will be filed): (1) tolerate-absence
does not yet require `iss` when the AS advertises
`authorization_response_iss_parameter_supported`; (2) the check compares to the
id_token issuer rather than the discovery issuer directly, which degrades
gracefully under `DoNotValidateIssuerName`; (3) a pre-existing config-UI
stale-checkbox pattern affects all `sso-toggle`s equally.

Upgrade note: the check is on by default, so a provider that already emits an
`iss` that does not match its id_token issuer (non-conformant) will start being
rejected after upgrade; the per-provider `DoNotValidateResponseIssuer` opt-out is
the recourse. Conformant providers (no `iss`, or a matching `iss`) are
unaffected.

Real-server E2E (CI cannot exercise the browser flow): the new checkbox
persists/round-trips through the dashboard; a live provider with a matching `iss`
still logs in and one with a mismatched `iss` is rejected; the opt-out disables
the check.
