### PR TITLE
Harden and speed up the CI/CD workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,13 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # JPRM builds the plugin; nothing pushes via git, so drop the persisted token.
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,11 +6,18 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,17 +9,32 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded run on the same ref so a new push / PR update does not
+# queue behind an obsolete build.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        # No step pushes via git, so do not leave the GITHUB_TOKEN persisted in
+        # .git/config (zizmor "artipacked" hardening — shrinks the credential blast radius).
+        persist-credentials: false
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 9.0.x
+        # Cache the NuGet global-packages folder keyed on the committed lockfiles,
+        # so a clean --locked-mode restore is a cache hit.
+        cache: true
+        cache-dependency-path: '**/packages.lock.json'
     - name: Jellyfin compatibility metadata check
       run: bash scripts/check-jellyfin-compat.sh
     - name: Restore dependencies

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -9,14 +9,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         # Default checkout (the PR merge commit) — it is what should be linted,
         # and checking out head_ref made the job an untrusted-checkout finding.
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Prettify code
         uses: creyD/prettier_action@8c18391fdc98ed0d884c6345f03975edac71b8f0 # v4.6
         with:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -14,15 +14,23 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        # The release/manifest steps authenticate with GITHUB_TOKEN via their action
+        # inputs, not the git remote, so the persisted checkout token is unneeded.
+        persist-credentials: false
     - name: Setup .NET
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
       with:
         dotnet-version: 9.0.x
+        cache: true
+        cache-dependency-path: '**/packages.lock.json'
     - name: Restore dependencies
-      run: dotnet restore
+      # Match the CI build: --locked-mode rejects a drifted or tampered dependency graph.
+      run: dotnet restore --locked-mode
     - name: Build Dotnet
       run: dotnet build --no-restore --warnaserror
     - name: "Flag as nightly in build.yaml"
@@ -55,7 +63,10 @@ jobs:
       id: publish-assets
       uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58
       with:
-          prerelease: false
+          # Mark the nightly as a prerelease so the manifest step's ignorePrereleases
+          # filter keeps 0.0.0.9000 out of the production manifest.json every plugin-repo
+          # consumer fetches. Shipping it as a full release polluted that catalog.
+          prerelease: true
           fail_on_unmatched_files: true
           tag_name: nightly
           files: |
@@ -73,4 +84,3 @@ jobs:
         repository: ${{ github.repository }}
         pagesBranch: manifest-release
         pagesFile: manifest.json
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       dotnet-target:  "net9.0"
   upload:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     needs:
@@ -47,6 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   generate:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     needs:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,11 +10,24 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded analysis on the same ref; the next push re-analyzes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Build and analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # A full clone lets SonarCloud attribute issues to the right commits/authors.
+          fetch-depth: 0
+          # The scanner reads git history, not the remote; drop the persisted push token.
+          persist-credentials: false
       - name: Set up JDK 17
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
@@ -24,11 +37,10 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
         with:
           dotnet-version: 9.0.x
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-        with:
-          # A full clone lets SonarCloud attribute issues to the right commits/authors.
-          fetch-depth: 0
+          # Cache the NuGet global-packages folder keyed on the committed lockfiles.
+          # Runs after checkout so the lockfiles exist to be hashed.
+          cache: true
+          cache-dependency-path: '**/packages.lock.json'
       - name: Cache SonarCloud packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:


### PR DESCRIPTION
# What & why

Research-backed hardening + speed pass over the GitHub Actions workflows, closing #222 (CI hardening + speed) and #214 (nightly published as a full release polluted the production manifest). The pipeline was already SHA-pinned with least-privilege permissions and `--locked-mode` restore; this closes the remaining gaps confirmed against 2025-2026 best practice (zizmor "artipacked" / `persist-credentials`) and recent supply-chain incidents (tj-actions/changed-files, Trivy-action tag force-push).

- `persist-credentials: false` on every checkout, no step pushes via the git remote (the nightly release/manifest steps authenticate with `GITHUB_TOKEN` over the API, verified against the action source: `softprops/action-gh-release` via env, `Kevinjil/jellyfin-plugin-repo-action` via its `githubToken` input / Octokit), so the persisted token is pure blast radius.
- NuGet caching via `setup-dotnet` (`cache: true` + `**/packages.lock.json`) on the build/analyze jobs; `setup-dotnet` now runs after checkout so the committed lockfiles hash (sonarcloud.yml reordered).
- `concurrency` + `cancel-in-progress` on the push/PR workflows only, never the publish workflows (a publish must not be cancelled mid-run).
- `timeout-minutes` on every job; the reusable `build.yml` carries its own.
- `publish-nightly`: `prerelease: true` so the manifest step's `ignorePrereleases` filter keeps `0.0.0.9000` out of the production `manifest.json`, plus `restore --locked-mode` for parity.

Closes #222
Closes #214

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, N/A to the login path; the release-pipeline integrity controls are all intact (SHA-pinned actions, least-privilege permissions, MD5 + SHA256 sidecars, `fail_on_unmatched_files`, the vulnerable-dependency scan, `dependency-review` fail-on-low).
- [x] No secrets logged; secrets redacted on export, `SONAR_TOKEN` still sourced via env and masked; `persist-credentials: false` reduces the token blast radius.
- [x] A security review was performed, 4-lens adversarial gate (security-bypass / integration / availability / correctness) all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A, no logging change.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, config-only, applied consistently across the workflows.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, no source change; all 7 workflow YAMLs parse cleanly (js-yaml).
- [x] `dotnet test` is green, no source change (435 tests on `main`).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.yml` changed (outside the Prettier glob).

## Notes

Release-only workflows cannot be exercised by CI, so the adversarial review is the primary verification; an E2E-checklist item was added to confirm, on the next push to `main`, that the nightly is flagged prerelease and excluded from `manifest.json` and that a real release still publishes. Out of scope / follow-ups: the nightly `Publish Plugin Manifest` step is now redundant (it regenerates the same production manifest with the nightly excluded), harmless, removable later; `build.yml` keeps no NuGet cache (JPRM runs its own restore). Remaining CI/supply-chain items stay tracked separately: #144 (zizmor), #143 (Dependabot cooldown), #168 (Scorecard), #147 (SLSA provenance), #149 (Unicode gate), #145 (SHA-pin repo policy).
