### PR TITLE
Harden the SSO login-completion path (fail-closed robustness)

### DIFF
--- a/SSO-Auth.Tests/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/OidcRoleExtractorTests.cs
@@ -71,11 +71,21 @@ public class OidcRoleExtractorTests
     }
 
     [Fact]
-    public void MultiSegmentPath_MalformedClaimValue_Throws()
+    public void MultiSegmentPath_MalformedClaimValue_ReturnsEmpty()
     {
-        // Characterizes the upstream behavior: a multi-segment path over a malformed (non-JSON-object)
-        // claim value throws (surfaces as a 500 in the controller = fail-closed). Pinned so it stays deliberate.
-        Assert.ThrowsAny<Newtonsoft.Json.JsonException>(
-            () => OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json"));
+        // #216: a multi-segment path over a malformed (non-JSON) claim value fails CLOSED to no roles
+        // instead of throwing an unhandled 500 on the public callback.
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json"));
+    }
+
+    [Fact]
+    public void TerminalArrayWithNonStringElements_KeepsOnlyStrings()
+    {
+        // #216: a terminal array mixing strings with objects/numbers must not throw; only the string
+        // elements are taken as roles.
+        var roles = OidcRoleExtractor.ExtractRoles(
+            new[] { "realm_access", "roles" },
+            "{\"roles\":[\"users\",1,{\"nested\":true},\"admins\"]}");
+        Assert.Equal(new List<string> { "users", "admins" }, roles);
     }
 }

--- a/SSO-Auth/Api/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/OidcRoleExtractor.cs
@@ -24,8 +24,10 @@ internal static class OidcRoleExtractor
     /// <param name="claimValue">The matched claim's value (a raw role, or a JSON object for a nested path).</param>
     /// <returns>
     /// The extracted roles: the raw claim value as a single role for a one-segment path; otherwise the
-    /// string array reached by walking the JSON path. An empty list when the path does not resolve to a
-    /// JSON array (missing segment, non-object node, or non-array terminal).
+    /// string elements of the array reached by walking the JSON path (non-string elements are ignored).
+    /// Returns an empty list when the path does not resolve to a JSON array (missing segment, non-object
+    /// node, or non-array terminal) and when the claim value is malformed JSON — a multi-segment parse
+    /// fails closed to no roles rather than throwing (#216).
     /// </returns>
     internal static List<string> ExtractRoles(string[] roleClaimSegments, string claimValue)
     {

--- a/SSO-Auth/Api/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/OidcRoleExtractor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -34,37 +35,46 @@ internal static class OidcRoleExtractor
             return new List<string> { claimValue };
         }
 
-        // A multi-segment path parses the claim value as a JSON object and walks it. A JSON null
-        // yields no roles; a malformed or non-object value throws (surfaced by the caller as a
-        // failed login, i.e. fail-closed).
-        var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);
-        if (json is null)
+        // A multi-segment path parses the claim value as a JSON object and walks it. The claim value is
+        // attacker-influenced, so any malformed or unexpected shape (non-object root, non-object node,
+        // non-array terminal, or a terminal array of non-strings) must fail CLOSED to an empty role set
+        // rather than throw an unhandled 500 on the public callback (#216).
+        try
         {
-            return new List<string>();
-        }
-
-        // Walk the intermediate segments; any missing key or non-object node yields no roles.
-        for (int i = 1; i < roleClaimSegments.Length - 1; i++)
-        {
-            var segment = roleClaimSegments[i];
-            if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
-            {
-                return new List<string>();
-            }
-
-            json = nextObject.ToObject<IDictionary<string, object>>();
+            var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);
             if (json is null)
             {
                 return new List<string>();
             }
-        }
 
-        // The terminal segment must resolve to a JSON array of role strings.
-        if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
+            // Walk the intermediate segments; any missing key or non-object node yields no roles.
+            for (int i = 1; i < roleClaimSegments.Length - 1; i++)
+            {
+                var segment = roleClaimSegments[i];
+                if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
+                {
+                    return new List<string>();
+                }
+
+                json = nextObject.ToObject<IDictionary<string, object>>();
+                if (json is null)
+                {
+                    return new List<string>();
+                }
+            }
+
+            // The terminal segment must resolve to a JSON array; take only its string elements so a
+            // terminal array of objects or numbers cannot throw.
+            if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
+            {
+                return new List<string>();
+            }
+
+            return rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()).ToList();
+        }
+        catch (JsonException)
         {
             return new List<string>();
         }
-
-        return rolesArray.ToObject<List<string>>();
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1343,12 +1343,16 @@ public class SSOController : ControllerBase
             {
                 user.SetPreference(PreferenceKind.EnabledFolders, parameters.EnabledFolders);
             }
+
+            // Live TV access/management are role-derived grants too, so they must respect the same
+            // EnableAuthorization master switch. Applied unconditionally they let a provider grant (or
+            // silently toggle) Live TV on every login even when the admin turned SSO permission
+            // management off (#215).
+            user.SetPermission(PermissionKind.EnableLiveTvAccess, parameters.EnableLiveTv);
+            user.SetPermission(PermissionKind.EnableLiveTvManagement, parameters.EnableLiveTvManagement);
         }
 
         await TrySetUserAvatarAsync(user, parameters.AvatarUrl).ConfigureAwait(false);
-
-        user.SetPermission(PermissionKind.EnableLiveTvAccess, parameters.EnableLiveTv);
-        user.SetPermission(PermissionKind.EnableLiveTvManagement, parameters.EnableLiveTvManagement);
 
         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
@@ -1414,9 +1418,16 @@ public class SSOController : ControllerBase
 
             client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
 
+            // One deadline for the whole fetch: with ResponseHeadersRead the client Timeout stops
+            // applying once the headers arrive, so a malicious endpoint could send headers immediately
+            // then trickle the body forever. A single 10s token passed into GetAsync AND every body
+            // ReadAsync bounds the header wait and the streamed read together, while keeping the
+            // streaming size cap (#220).
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
             // ResponseHeadersRead so the body is streamed, not fully buffered, before ReadCappedAsync
             // enforces the size limit; otherwise the cap runs only after the whole download is in memory.
-            using var avatarResponse = await client.GetAsync(avatarUri, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            using var avatarResponse = await client.GetAsync(avatarUri, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
             avatarResponse.EnsureSuccessStatusCode();
 
             // Media types are case-insensitive (RFC 7231); use the parsed type with parameters stripped.
@@ -1433,7 +1444,7 @@ public class SSOController : ControllerBase
             }
 
             var extension = mediaType.Split('/')[^1];
-            using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes).ConfigureAwait(false);
+            using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes, timeout.Token).ConfigureAwait(false);
 
             var userDataPath =
                 Path.Combine(
@@ -1617,16 +1628,16 @@ public class SSOController : ControllerBase
 
     // Copies the response body into memory, aborting if it exceeds the cap, so a hostile endpoint cannot
     // exhaust resources with an unbounded (or Content-Length-lying) download.
-    private static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes)
+    private static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes, CancellationToken cancellationToken)
     {
         var buffer = new MemoryStream();
-        var source = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await using (source.ConfigureAwait(false))
         {
             var chunk = new byte[81920];
             long total = 0;
             int read;
-            while ((read = await source.ReadAsync(chunk).ConfigureAwait(false)) > 0)
+            while ((read = await source.ReadAsync(chunk, cancellationToken).ConfigureAwait(false)) > 0)
             {
                 total += read;
                 if (total > maxBytes)
@@ -1635,7 +1646,7 @@ public class SSOController : ControllerBase
                     throw new InvalidOperationException("Avatar exceeds the maximum allowed size.");
                 }
 
-                await buffer.WriteAsync(chunk.AsMemory(0, read)).ConfigureAwait(false);
+                await buffer.WriteAsync(chunk.AsMemory(0, read), cancellationToken).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
# What & why

Three fail-closed robustness fixes in the SSO login-completion path, from the 2026-07-13 standing audit. Each is a ready V2 port (or, for #220, the stronger of the two V2-suggested options).

- **#215**, the Live TV grants (`EnableLiveTvAccess` / `EnableLiveTvManagement`) were applied on every login **outside** the `EnableAuthorization` master switch, so a provider re-granted or silently toggled Live TV even when the admin turned SSO permission management off. Moved inside the same block as the admin/folder grants.
- **#216**, `OidcRoleExtractor.ExtractRoles` threw on a malformed multi-segment role-claim value (or a terminal array of non-strings), surfacing as an HTTP 500 on the public callback. Now wraps the parse/walk in `try/catch (JsonException)` returning no roles and takes only the string elements of the terminal array, fail-closed to zero roles.
- **#220**, the avatar fetch used `ResponseHeadersRead`, so the 10s client `Timeout` stopped once headers arrived and a slow-trickle body could hold the login open. A single `CancellationTokenSource(10s)` is threaded into `GetAsync` and every body read/write, bounding the whole fetch while keeping the streaming 10 MB cap. (Chosen over V2's drop-`ResponseHeadersRead` because it keeps the streaming size cap and adds the deadline.)

Closes #215
Closes #216
Closes #220

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, all three changes are strictly monotonic toward fail-closed: #215 only withdraws a grant, #216 only reduces roles (empty on malformed → allow-list denies), #220 only aborts a best-effort fetch.
- [x] No secrets logged; secrets redacted on export, N/A, no secret/logging change (avatar failure logs the exception, no IdP value).
- [x] A security review was performed, 5-lens adversarial gate (bypass / correctness / availability / integration / oidc-domain) all PASS; the correctness lens verified the Newtonsoft exception types empirically.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A, unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, `OidcRoleExtractor` stays pure; the avatar deadline reuses the existing `ReadCappedAsync`.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 434 tests pass (updated + added `OidcRoleExtractor` tests: malformed → empty, non-string terminal filtered).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs` changed.

## Notes

Live TV gating (#215) and the avatar transport deadline (#220) are not unit-testable without a controller host, so E2E-checklist items were added. Behavior note (fail-closed, intended): a provider running `EnableAuthorization=false` with `EnableLiveTv=true` stops re-granting Live TV on each login (it no longer touches the permission, existing state is left as the admin set it); and a login whose role claim is malformed now lands with zero SSO roles instead of 500-ing.
