### PR TITLE
Add a 7-day Dependabot cooldown for nuget and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Wait 7 days before proposing a new version so a release compromised between
+    # publish and adoption is caught before it enters a PR (recent supply-chain
+    # attacks were live for hours-to-days). Security updates are exempt — they are
+    # still proposed immediately.
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Same cooldown for action bumps — the tj-actions / Trivy-action incidents were
+    # exactly compromised-tag adoptions a delay would have caught.
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# What & why

Adds a 7-day Dependabot `cooldown` to the `nuget` and `github-actions` update entries, closing #143. Version updates now wait 7 days before Dependabot opens a PR, so a dependency or action compromised in the window between publish and adoption is caught before it reaches the repo, the tj-actions/changed-files (March 2025) and Trivy-action tag-force-push (March 2026) compromises were live for hours to days. Security updates are exempt from the cooldown and are still proposed immediately. Syntax verified against the current GitHub Dependabot options reference.

Closes #143

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, N/A (supply-chain intake config; no runtime code path).
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, supply-chain config only; not on the login/crypto/config-persistence/release-pipeline surface, so no adversarial-lens gate. CodeRabbit reviewed.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, minimal `cooldown` block per ecosystem.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, N/A, no source change.
- [x] `dotnet test` is green, N/A, no source change.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.yml` (dependabot.yml parses cleanly via js-yaml).

## Notes

`cooldown` applies to version updates only (not security updates), so it delays routine bumps without ever holding back a vulnerability fix. Complements the existing SHA-pinning and satisfies zizmor's `dependabot-cooldown` audit; broader supply-chain items stay tracked (#144 zizmor gate, #168 Scorecard, #147 SLSA, #149 Unicode gate, #145 SHA-pin policy).
