### PR TITLE
Escape media-folder Name/Id in the config-page folder list

### DIFF
--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -58,17 +58,23 @@ const ssoConfigurationPage = {
       .forEach((e) => e.remove());
 
     const checkboxes = folders.Items.map((folder) => {
+      // The library folder Name/Id come from the Jellyfin core API; build the row with
+      // createElement/textContent (never innerHTML) so a folder named e.g. `<img onerror=...>`
+      // stays inert on the config page (#221). Mirrors linking.js populateExistingLinks.
       const out = document.createElement("label");
 
-      out.innerHTML = `
-        <input
-          is="emby-checkbox"
-          class="folder-checkbox chkFolder"
-          data-id="${folder.Id}"
-          type="checkbox"
-        />
-        <span>${folder.Name}</span>
-      `;
+      // createElement's `is` option upgrades the customized built-in; the attribute is set as well
+      // so CSS attribute selectors and the web-components polyfill see it.
+      const checkbox = document.createElement("input", { is: "emby-checkbox" });
+      checkbox.setAttribute("is", "emby-checkbox");
+      checkbox.classList.add("folder-checkbox", "chkFolder");
+      checkbox.type = "checkbox";
+      checkbox.dataset.id = folder.Id;
+
+      const label = document.createElement("span");
+      label.textContent = folder.Name;
+
+      out.append(checkbox, label);
 
       return out;
     });

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -62,6 +62,10 @@ const ssoConfigurationPage = {
       // createElement/textContent (never innerHTML) so a folder named e.g. `<img onerror=...>`
       // stays inert on the config page (#221). Mirrors linking.js populateExistingLinks.
       const out = document.createElement("label");
+      // Tag the row with the class the re-render cleanup (querySelectorAll above) removes, so a
+      // second populate deterministically clears the old rows instead of relying on the
+      // emby-checkbox upgrade to add it — otherwise folder IDs could be duplicated on re-populate.
+      out.classList.add("emby-checkbox-label");
 
       // createElement's `is` option upgrades the customized built-in; the attribute is set as well
       // so CSS attribute selectors and the web-components polyfill see it.


### PR DESCRIPTION
# What & why

`_populateFolders` built each "Enabled folders" row with `out.innerHTML` interpolating the Jellyfin library folder `Name` and `Id` (admin/core-API controlled) into an HTML string, a DOM-injection sink (admin self-XSS: a folder named `<img onerror=…>` executes on the SSO config page). This was the last remaining unescaped `innerHTML` sink in the admin UI (linking.js was already hardened in A-4).

The row is now built with `document.createElement`: `folder.Id` via `checkbox.dataset.id`, `folder.Name` via `span.textContent`, and the emby-checkbox customized built-in via `createElement("input", { is: "emby-checkbox" })` + `setAttribute("is", …)`, the same inert pattern as `linking.js` `populateExistingLinks`. The `.folder-checkbox` + `data-id` contract that `populateEnabledFolders` / `serializeEnabledFolders` read is preserved.

Closes #221

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, the injection sink is removed; both `Name` and `Id` are assigned via inert DOM APIs (`textContent` / `dataset`), no `innerHTML`/template interpolation remains.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, browser JS (CI cannot exercise the DOM), so the review is the primary verification: 3-lens adversarial gate (bypass / correctness / integration) all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, mirrors the existing `linking.js` pattern.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, N/A, no C# change.
- [x] `dotnet test` is green, N/A, no C# change.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, `prettier --check SSO-Auth/Config/config.js` passes.

## Notes

DOM behavior (emby-checkbox upgrade, `.emby-checkbox-label` re-render cleanup) rests on the linking.js precedent and cannot be unit-tested; an E2E-checklist item was added (folder rows render/toggle, a markup-named library shows inert, enabled-folder set round-trips on save/reload).
