### PR TITLE
Clarify the ExtractRoles fail-closed comment for mixed role arrays

### DIFF
--- a/SSO-Auth/Api/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/OidcRoleExtractor.cs
@@ -38,9 +38,10 @@ internal static class OidcRoleExtractor
         }
 
         // A multi-segment path parses the claim value as a JSON object and walks it. The claim value is
-        // attacker-influenced, so any malformed or unexpected shape (non-object root, non-object node,
-        // non-array terminal, or a terminal array of non-strings) must fail CLOSED to an empty role set
-        // rather than throw an unhandled 500 on the public callback (#216).
+        // attacker-influenced, so it must never throw an unhandled 500 on the public callback (#216): any
+        // malformed or non-resolving shape (non-object root, non-object node, non-array terminal) fails
+        // closed to an empty role set, and the terminal array is filtered to its string elements — a mixed
+        // array keeps its strings, an array with no strings yields none.
         try
         {
             var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);


### PR DESCRIPTION
# What & why

Comment-only clarification in `OidcRoleExtractor.ExtractRoles`, following a CodeRabbit note on the merged #224. The multi-segment block comment implied that a terminal array of non-strings "fails closed to an empty role set"; in fact the array is filtered to its string elements, so a mixed array keeps its strings and only an array with no string elements (or a malformed value) yields none. Reworded to match the implementation. No behavior change.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, comment-only; the fail-closed behavior is unchanged, the comment now describes it accurately.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, N/A, no logic change (comment only), so no adversarial-lens gate.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, N/A, no logic change.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, unchanged (no logic change).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only a `.cs` comment.

## Notes

Documents the disposition of the CodeRabbit comment on #224 (the earlier `<returns>` doc was already fixed in commit 12cc9d7; this addresses the accompanying block-comment accuracy note).
