### PR TITLE
Restrict avatar content types to a raster allow-list

### DIFF
--- a/SSO-Auth.Tests/AvatarContentTypeTests.cs
+++ b/SSO-Auth.Tests/AvatarContentTypeTests.cs
@@ -1,0 +1,38 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AvatarContentType"/> — the raster-only allow-list that decides which avatar
+/// content types are stored and rejects vector types such as <c>image/svg+xml</c> (#217).
+/// </summary>
+public class AvatarContentTypeTests
+{
+    [Theory]
+    [InlineData("image/png", "png")]
+    [InlineData("image/jpeg", "jpeg")]
+    [InlineData("image/jpg", "jpeg")]
+    [InlineData("image/gif", "gif")]
+    [InlineData("image/webp", "webp")]
+    [InlineData("IMAGE/PNG", "png")]
+    public void AllowedRasterTypes_Resolve(string mediaType, string expected)
+    {
+        Assert.True(AvatarContentType.TryResolveExtension(mediaType, out var extension));
+        Assert.Equal(expected, extension);
+    }
+
+    [Theory]
+    [InlineData("image/svg+xml")]
+    [InlineData("image/bmp")]
+    [InlineData("image/tiff")]
+    [InlineData("text/html")]
+    [InlineData("application/octet-stream")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void VectorOrDisallowedTypes_AreRejected(string? mediaType)
+    {
+        Assert.False(AvatarContentType.TryResolveExtension(mediaType, out var extension));
+        Assert.Null(extension);
+    }
+}

--- a/SSO-Auth/Api/AvatarContentType.cs
+++ b/SSO-Auth/Api/AvatarContentType.cs
@@ -1,0 +1,31 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Resolves the stored file extension for an avatar HTTP content type, restricted to an allow-list of
+/// raster image types. Vector types — notably <c>image/svg+xml</c> — are rejected: an SVG can carry
+/// inline script, so a stored SVG avatar could become a stored-XSS vector if the host later serves it
+/// executably. The extension is taken from the allow-list, never from the raw content-type subtype (#217).
+/// </summary>
+internal static class AvatarContentType
+{
+    /// <summary>
+    /// Tries to map an avatar content type to a safe stored file extension.
+    /// </summary>
+    /// <param name="mediaType">The response media type (case-insensitive), with parameters already stripped.</param>
+    /// <param name="extension">The bare file extension (no leading dot) when allowed; otherwise null.</param>
+    /// <returns><c>true</c> when the media type is an allowed raster image; otherwise <c>false</c>.</returns>
+    internal static bool TryResolveExtension(string mediaType, out string extension)
+    {
+        extension = (mediaType ?? string.Empty).ToLowerInvariant() switch
+        {
+            "image/png" => "png",
+            "image/jpeg" => "jpeg",
+            "image/jpg" => "jpeg",
+            "image/gif" => "gif",
+            "image/webp" => "webp",
+            _ => null,
+        };
+
+        return extension is not null;
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1437,7 +1437,11 @@ public class SSOController : ControllerBase
             // from the raw subtype — image/svg+xml is rejected because a stored SVG can carry script (#217).
             if (!AvatarContentType.TryResolveExtension(mediaType, out var extension))
             {
-                throw new InvalidOperationException("Avatar content type is not an allowed raster image, got: " + (mediaType ?? "(none)"));
+                // Log the rejected type sanitized inline at the log call (mediaType is server-controlled),
+                // and keep the thrown/caught exception message generic so no untrusted text reaches the
+                // logged exception — mirrors the disallowed-URL warning above.
+                _logger.LogWarning("Refusing avatar with disallowed content type: {MediaType}", (mediaType ?? "(none)").ReplaceLineEndings(string.Empty));
+                throw new InvalidOperationException("Avatar content type is not an allowed raster image.");
             }
 
             const long MaxAvatarBytes = 10 * 1024 * 1024;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1432,9 +1432,12 @@ public class SSOController : ControllerBase
 
             // Media types are case-insensitive (RFC 7231); use the parsed type with parameters stripped.
             var mediaType = avatarResponse.Content.Headers.ContentType?.MediaType;
-            if (string.IsNullOrEmpty(mediaType) || !mediaType.StartsWith("image/", StringComparison.OrdinalIgnoreCase))
+
+            // Allow only raster image types and derive the stored extension from that allow-list, never
+            // from the raw subtype — image/svg+xml is rejected because a stored SVG can carry script (#217).
+            if (!AvatarContentType.TryResolveExtension(mediaType, out var extension))
             {
-                throw new InvalidOperationException("Content type of avatar URL is not an image, got: " + (mediaType ?? "(none)"));
+                throw new InvalidOperationException("Avatar content type is not an allowed raster image, got: " + (mediaType ?? "(none)"));
             }
 
             const long MaxAvatarBytes = 10 * 1024 * 1024;
@@ -1443,7 +1446,6 @@ public class SSOController : ControllerBase
                 throw new InvalidOperationException("Avatar exceeds the maximum allowed size.");
             }
 
-            var extension = mediaType.Split('/')[^1];
             using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes, timeout.Token).ConfigureAwait(false);
 
             var userDataPath =


### PR DESCRIPTION
# What & why

The avatar fetch accepted any content type matching `mediaType.StartsWith("image/")` and derived the stored file extension from the raw subtype, so `image/svg+xml` was accepted and stored as an SVG, a potential stored-XSS vector (SVG can carry inline script) if the host later serves it executably. Closes #217.

A new pure helper `AvatarContentType.TryResolveExtension` restricts avatars to a raster allow-list (`image/png`, `image/jpeg`, `image/jpg`, `image/gif`, `image/webp`) and returns the safe extension from that list; the controller rejects anything else and takes the extension from the helper. The stored filename is byte-identical for the allowed raster types (they map to the same bare subtype the old `Split('/')` produced); only non-raster/vector types are newly refused. The avatar is best-effort, so a refused type just means the login proceeds without an avatar.

Closes #217

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, a non-allow-listed content type is refused (throws inside the best-effort try → login proceeds without an avatar); no SVG/vector type reaches storage.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, 3-lens adversarial gate (bypass / correctness / integration) all PASS; the bypass lens empirically confirmed `MediaTypeHeaderValue` strips parameters (so `image/svg+xml; charset=…` still resolves to `image/svg+xml` and is rejected) and casing/null handling.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, `AvatarContentType` is a pure helper with its own unit tests.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 447 tests (13 new `AvatarContentType` cases: allowed types incl. casing, and svg/bmp/tiff/text/empty/null rejected).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

Trust model: the gate keys on the *declared* content type, which is also what is passed to `_providerManager.SaveImage` and governs how Jellyfin serves the stored file, so a raster-declared file is served as a raster type, never as executable SVG. V2 shares this gap (its gate also uses `StartsWith("image/")`); the same hardening should land there. E2E-checklist item added (svg avatar refused, raster stored).
