### PR TITLE
Consume the SAML replay cache in the account-linking callback

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -801,14 +801,7 @@ public class SSOController : ControllerBase
             // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
             // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
             // renders the intermediate page, so the two-step post-then-auth flow consumes the id once.
-            var samlNow = DateTime.UtcNow;
-            var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
-
-            // Scope the replay key by provider so two IdPs that happen to emit the same assertion ID
-            // cannot block each other; a missing ID stays empty so TryConsume still fails closed.
-            var assertionId = samlResponse.GetAssertionId();
-            var replayKey = string.IsNullOrEmpty(assertionId) ? assertionId : provider + "\n" + assertionId;
-            if (!SamlReplays.TryConsume(replayKey, replayRetention, samlNow))
+            if (!TryConsumeSamlReplay(samlResponse, provider))
             {
                 return Problem("SAML assertion has already been used");
             }
@@ -1249,6 +1242,14 @@ public class SSOController : ControllerBase
             return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
         }
 
+        // Enforce one-time use here too (#219): without it, a captured, still-valid assertion could be
+        // replayed to bind its NameID to the caller's account. The linking flow issues no AuthnRequest,
+        // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use control.
+        if (!TryConsumeSamlReplay(samlResponse, provider))
+        {
+            return Problem("SAML assertion has already been used");
+        }
+
         string providerUserId = samlResponse.GetNameID();
 
         return CreateCanonicalLink("saml", provider, jellyfinUserId, providerUserId);
@@ -1511,6 +1512,19 @@ public class SSOController : ControllerBase
     private static void Invalidate()
     {
         AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
+    }
+
+    // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.
+    // Returns false when the assertion was already used (or carries no ID — a missing ID stays empty,
+    // so TryConsume fails closed). The key is scoped by provider so two IdPs emitting the same assertion
+    // ID cannot block each other. Shared by SamlAuth (session mint) and SamlLink (account linking, #219).
+    private bool TryConsumeSamlReplay(Response samlResponse, string provider)
+    {
+        var samlNow = DateTime.UtcNow;
+        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
+        var assertionId = samlResponse.GetAssertionId();
+        var replayKey = string.IsNullOrEmpty(assertionId) ? assertionId : provider + "\n" + assertionId;
+        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
     }
 
     // Validates the SAML response and, on failure, logs the declared signature algorithm plus the


### PR DESCRIPTION
# What & why

`SamlLink` (the SAML account-linking callback) validated the assertion (signature/time/audience via `IsSamlResponseValid`) but never enforced one-time use, so a captured, still-valid assertion could be replayed to bind its NameID to the caller's account. `SamlAuth` (session mint) already consumes the replay cache; `SamlLink` did not. Closes #219.

- Extracted `SamlAuth`'s inline replay-consume block into a shared private helper `TryConsumeSamlReplay(Response, string provider)` (provider-scoped assertion-ID key, `ComputeRetention` from the assertion's `NotOnOrAfter`, fails closed on a missing ID), removing the duplication the fix would otherwise introduce.
- `SamlLink` now calls it after validation and before creating the link, returning `Problem("SAML assertion has already been used")` on a replay.
- Deliberately **not** adding `InResponseTo` consumption to `SamlLink`: the linking flow issues no `AuthnRequest` (`SamlPost` skips `SamlRequests.Register` when `isLinking`), so there is nothing to correlate, the replay cache is the applicable one-time-use control.

Closes #219

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, the linking assertion is now one-time-use; a missing/empty assertion ID fails the consume closed, and the extraction keeps `SamlAuth`'s consume order (allow-list → replay → identity) intact.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, 5-lens adversarial gate (bypass / correctness / integration / availability / saml-domain) all PASS; the extraction verified byte-equivalent, the shared cache can only fail closed (never bypass), and the `InResponseTo` omission was confirmed correct.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A (no new logging).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, the replay-consume is now one shared helper used by both `SamlAuth` and `SamlLink`.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 447 tests (`SamlReplayCache.TryConsume` is already unit-tested; `SamlLink` is controller-level).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

`SamlLink` is a controller method (not unit-testable without a host), so an E2E-checklist item was added (a replayed link assertion is refused the second time). A consumed replay returns `Problem()` (HTTP 500), matching the existing `SamlAuth` behavior, kept for consistency, out of scope here. V2 shares this gap; the same hardening should land there.
