### PR TITLE
Make Unregister actually revoke SSO access, persist, and null-guard

### DIFF
--- a/SSO-Auth.Tests/CanonicalLinkRevokerTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkRevokerTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="CanonicalLinkRevoker"/> — removing a user's canonical links so an admin's SSO
+/// unregister actually stops SSO login from resolving to the account (#213).
+/// </summary>
+public class CanonicalLinkRevokerTests
+{
+    private static readonly Guid Target = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void RemovesOnlyTheTargetUsersEntries()
+    {
+        var links = new Dictionary<string, Guid>
+        {
+            ["sub-a"] = Target,
+            ["sub-b"] = Other,
+            ["legacy-alice"] = Target,
+        };
+
+        var removed = CanonicalLinkRevoker.RemoveUser(links, Target);
+
+        Assert.Equal(2, removed);
+        Assert.Equal(new[] { "sub-b" }, links.Keys);
+        Assert.Equal(Other, links["sub-b"]);
+    }
+
+    [Fact]
+    public void NoMatchingEntries_RemovesNothing()
+    {
+        var links = new Dictionary<string, Guid> { ["sub-b"] = Other };
+
+        Assert.Equal(0, CanonicalLinkRevoker.RemoveUser(links, Target));
+        Assert.Single(links);
+    }
+
+    [Fact]
+    public void NullMap_IsNoOp()
+    {
+        Assert.Equal(0, CanonicalLinkRevoker.RemoveUser(null, Target));
+    }
+}

--- a/SSO-Auth/Api/CanonicalLinkRevoker.cs
+++ b/SSO-Auth/Api/CanonicalLinkRevoker.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Removes canonical-link entries that point at a given Jellyfin user. An admin revoking a user's SSO
+/// access must clear these links, because SSO login resolves through the per-provider CanonicalLinks
+/// maps (key -> user id), not <c>AuthenticationProviderId</c>. Pure so the remove-by-value contract is
+/// unit-testable independent of the controller and the config lock.
+/// </summary>
+internal static class CanonicalLinkRevoker
+{
+    /// <summary>
+    /// Removes every entry whose value is <paramref name="userId"/> from the links map.
+    /// </summary>
+    /// <param name="links">The provider's canonical-links map (key -> user id); a null map is a no-op.</param>
+    /// <param name="userId">The Jellyfin user id whose links to remove.</param>
+    /// <returns>The number of entries removed.</returns>
+    internal static int RemoveUser(IDictionary<string, Guid> links, Guid userId)
+    {
+        if (links is null)
+        {
+            return 0;
+        }
+
+        // Materialize the matching keys before removing so the map is not mutated during enumeration.
+        var keys = links.Where(pair => pair.Value == userId).Select(pair => pair.Key).ToList();
+        foreach (var key in keys)
+        {
+            links.Remove(key);
+        }
+
+        return keys.Count;
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -862,12 +862,52 @@ public class SSOController : ControllerBase
     /// <returns>Whether this API endpoint succeeded.</returns>
     [Authorize(Policy = Policies.RequiresElevation)]
     [HttpPost("Unregister/{username}")]
-    public ActionResult Unregister(string username, [FromBody] string provider)
+    public async Task<ActionResult> Unregister(string username, [FromBody] string provider)
     {
-        User user = _userManager.GetUserByName(username);
+        var user = _userManager.GetUserByName(username);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        // SSO login resolves through the per-provider CanonicalLinks maps, not AuthenticationProviderId,
+        // so revoking SSO means removing this user's canonical links from every provider — otherwise the
+        // account would still sign in via SSO (#213). Done under the config lock. NOTE: with a provider's
+        // AllowExistingAccountLink enabled, the same-named account can be re-adopted on the next SSO login,
+        // so a hard revoke there also needs the local account disabled or renamed; with the fail-closed
+        // default (adoption off) the revoke is durable.
+        var revoked = RemoveCanonicalLinksForUser(user.Id);
+
+        // Switch the account back to the requested auth provider and PERSIST it — the previous version set
+        // this in memory only and never called UpdateUserAsync, so the switch was silently discarded.
         user.AuthenticationProviderId = provider;
+        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+
+        _logger.LogInformation("Unregistered SSO for user {UserId}: removed {Count} canonical link(s).", user.Id, revoked);
 
         return Ok();
+    }
+
+    // Removes every canonical link pointing at the given user across all SAML and OpenID providers, so an
+    // SSO login no longer resolves to the account. Runs under the config lock and returns the number of
+    // links removed.
+    private static int RemoveCanonicalLinksForUser(Guid userId)
+    {
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            int removed = 0;
+            foreach (var config in configuration.SamlConfigs.Values)
+            {
+                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+            }
+
+            foreach (var config in configuration.OidConfigs.Values)
+            {
+                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+            }
+
+            return removed;
+        });
     }
 
     // Applies a mutation to a provider's canonical-links map on the LIVE configuration, reassigning the


### PR DESCRIPTION
# What & why

The admin control `POST /sso/Unregister/{username}` (RequiresElevation) was documented as removing a user from SSO, but it did none of it: it set `AuthenticationProviderId` in memory only (never persisted), had no null guard (an unknown username 500'd on the NRE), and, most importantly, did not revoke SSO at all, because SSO login resolves through the per-provider `CanonicalLinks` maps, not `AuthenticationProviderId`. Closes #213.

- `Unregister` is now `async`; a null user returns **404** instead of 500.
- New pure helper `CanonicalLinkRevoker.RemoveUser(IDictionary<string,Guid>, Guid)` removes every entry whose value is the user id (materializes keys first, exact-Guid match, null map no-op; returns the count), unit-tested.
- `RemoveCanonicalLinksForUser` runs under the config lock (`MutateConfiguration`, which persists) and clears the user's links across every SAML/OpenID provider, so SSO login no longer resolves to the account.
- Then it switches `AuthenticationProviderId` and persists via `UpdateUserAsync`, and logs the user id + removed-link count.

Closes #213

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, removal runs before the persist, under the config lock; if `UpdateUserAsync` throws, the links are already gone. Exact-Guid match means only the named user's links are removed. Endpoint stays `RequiresElevation`.
- [x] No secrets logged; secrets redacted on export, the log line carries only the user id (Guid) and a count; the admin-supplied `provider` is not logged.
- [x] A security review was performed, 4-lens adversarial gate (bypass / correctness / integration / availability) all PASS; empirically confirmed the `CanonicalLinks` maps are the sole SSO-resolution path, the `MutateConfiguration<int>` overload locks + persists (and skips `PreserveServerManagedFields` for the live object), and no cross-user removal.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A (no IdP input logged).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, `CanonicalLinkRevoker` is a pure helper with its own tests.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 450 tests (3 new `CanonicalLinkRevoker` cases: removes only the target's entries, no-match removes nothing, null map no-op).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

Documented caveat (both lenses): with a provider's `AllowExistingAccountLink` enabled, the still-existing same-named Jellyfin account can be re-adopted on the next SSO login, a hard revoke there also needs the local account disabled or renamed. Under the fail-closed default (adoption off) the revoke is durable. `Unregister` is a controller method, so an E2E-checklist item was added (unknown user → 404; a linked user's SSO login is refused after unregister; the switch persists across restart). V2 persists the switch but does not remove the `CanonicalLinks` (SSO would still resolve there), this closes the deeper gap in both.
