### PR TITLE
Check PKCE (S256) support at OpenID discovery

### DIFF
--- a/SSO-Auth.Tests/PkceDiscoveryTests.cs
+++ b/SSO-Auth.Tests/PkceDiscoveryTests.cs
@@ -1,0 +1,43 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="PkceDiscovery"/> — reading <c>code_challenge_methods_supported</c> from an
+/// OpenID discovery document and failing closed on anything that does not clearly advertise S256 (#141).
+/// </summary>
+public class PkceDiscoveryTests
+{
+    [Theory]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"]}")]
+    [InlineData("{\"code_challenge_methods_supported\":[\"plain\",\"S256\"]}")]
+    [InlineData("{\"issuer\":\"https://idp\",\"code_challenge_methods_supported\":[\"S256\"]}")]
+    public void S256Advertised_ReturnsTrue(string json)
+    {
+        Assert.True(PkceDiscovery.SupportsS256(json));
+    }
+
+    [Theory]
+    [InlineData("{\"code_challenge_methods_supported\":[\"plain\"]}")]
+    [InlineData("{\"code_challenge_methods_supported\":[]}")]
+    [InlineData("{\"issuer\":\"https://idp\"}")]
+    [InlineData("{\"code_challenge_methods_supported\":\"S256\"}")]
+    [InlineData("{\"code_challenge_methods_supported\":[256]}")]
+    [InlineData("{\"code_challenge_methods_supported\":null}")]
+    [InlineData("not-json")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void MissingOrMalformedOrNonS256_ReturnsFalse(string? json)
+    {
+        Assert.False(PkceDiscovery.SupportsS256(json));
+    }
+
+    [Fact]
+    public void S256MatchIsCaseSensitive_LowercaseDoesNotCount()
+    {
+        // The registered value is exactly "S256"; a lowercase "s256" is not RFC-conformant and must not
+        // be treated as PKCE support.
+        Assert.False(PkceDiscovery.SupportsS256("{\"code_challenge_methods_supported\":[\"s256\"]}"));
+    }
+}

--- a/SSO-Auth/Api/PkceDiscovery.cs
+++ b/SSO-Auth/Api/PkceDiscovery.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Decides whether an OpenID provider's discovery document advertises PKCE with SHA-256 (<c>S256</c>).
+/// RFC 9700 §2.1.1 requires a client to confirm the authorization server supports PKCE before relying
+/// on it. The OidcClient library sends <c>code_challenge</c> (S256) unconditionally but never checks
+/// the discovery document's <c>code_challenge_methods_supported</c>, so a server that ignores PKCE would
+/// silently downgrade authorization-code-injection protection (#141). Pure: the caller fetches the raw
+/// discovery JSON; this only interprets it, and fails closed (<c>false</c>) on anything unexpected.
+/// </summary>
+internal static class PkceDiscovery
+{
+    /// <summary>
+    /// Returns whether the discovery document lists <c>S256</c> in <c>code_challenge_methods_supported</c>.
+    /// </summary>
+    /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
+    /// <returns>
+    /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
+    /// a non-array value, non-string elements, or malformed/blank JSON.
+    /// </returns>
+    internal static bool SupportsS256(string discoveryJson)
+    {
+        if (string.IsNullOrWhiteSpace(discoveryJson))
+        {
+            return false;
+        }
+
+        try
+        {
+            var methods = JObject.Parse(discoveryJson)["code_challenge_methods_supported"] as JArray;
+            return methods is not null
+                && methods.Any(method =>
+                    method.Type == JTokenType.String
+                    && string.Equals(method.Value<string>(), "S256", StringComparison.Ordinal));
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -75,6 +75,12 @@ public class SSOController : ControllerBase
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
+    // Cache of per-discovery-URL PKCE-S256 support (#141), so a login does not fetch discovery every time
+    // (the document changes rarely). Only definitive results are cached; a fetch failure is not cached, so
+    // it retries on the next login. The short TTL bounds how long a provider's changed support is stale.
+    private static readonly ConcurrentDictionary<string, (bool Supported, DateTime FetchedAt)> PkceSupportCache = new();
+    private static readonly TimeSpan PkceSupportCacheTtl = TimeSpan.FromMinutes(15);
+
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
     // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID StateLifetime.
     private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
@@ -261,6 +267,27 @@ public class SSOController : ControllerBase
 
         if (config.Enabled)
         {
+            // RFC 9700 §2.1.1: confirm the authorization server advertises PKCE (S256) before relying on
+            // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
+            // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
+            // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
+            var pkceSupported = await ProviderAdvertisesPkceS256Async(config, provider).ConfigureAwait(false);
+            if (pkceSupported == false)
+            {
+                if (config.RequirePkce)
+                {
+                    _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                    return ReturnError(StatusCodes.Status400BadRequest, "The identity provider does not advertise the required PKCE (S256) support.");
+                }
+
+                SsoAudit.PkceNotAdvertised(_logger, provider);
+            }
+            else if (pkceSupported is null && config.RequirePkce)
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status400BadRequest, "The identity provider's PKCE (S256) support could not be verified.");
+            }
+
             bool newPath = config.NewPath;
             if (!isLinking)
             {
@@ -328,6 +355,53 @@ public class SSOController : ControllerBase
         options.Policy.RequireIdentityTokenSignature = true;
         options.IdentityTokenValidator = new OidcIdTokenValidator();
         return new OidcClient(options);
+    }
+
+    // Fetches the provider's OpenID discovery document and reports whether it advertises PKCE S256 (#141):
+    // true when advertised, false when the document was read but does not advertise it, null when it could
+    // not be fetched/read. The discovery URL is the admin-configured authority + the well-known path (the
+    // same document OidcClient uses); the fetch is bounded by a timeout and never throws — a transient
+    // failure returns null so the caller decides (fail closed only under RequirePkce). Best-effort: this
+    // does not replace OidcClient's own discovery, which fails the login if the provider is truly down.
+    private async Task<bool?> ProviderAdvertisesPkceS256Async(OidConfig config, string provider)
+    {
+        var authority = config.OidEndpoint?.Trim();
+        if (string.IsNullOrEmpty(authority) || !Uri.TryCreate(authority, UriKind.Absolute, out _))
+        {
+            return null;
+        }
+
+        // OidEndpoint is usually the issuer/authority, but some providers (e.g. PocketID) configure the
+        // full .well-known URL; append the discovery path only when it is not already present, matching how
+        // OidcClient resolves the same document.
+        var trimmed = authority.TrimEnd('/');
+        var discoveryUrl = trimmed.EndsWith("/.well-known/openid-configuration", StringComparison.OrdinalIgnoreCase)
+            ? trimmed
+            : trimmed + "/.well-known/openid-configuration";
+
+        if (PkceSupportCache.TryGetValue(discoveryUrl, out var cached) && DateTime.UtcNow - cached.FetchedAt < PkceSupportCacheTtl)
+        {
+            return cached.Supported;
+        }
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
+            var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
+            var supported = PkceDiscovery.SupportsS256(json);
+            PkceSupportCache[discoveryUrl] = (supported, DateTime.UtcNow);
+            return supported;
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(
+                e,
+                "Could not fetch the OpenID discovery document for provider {Provider} to verify PKCE support; proceeding unless RequirePkce is set.",
+                provider?.ReplaceLineEndings(string.Empty));
+            return null;
+        }
     }
 
     // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -58,6 +58,14 @@ internal static class SsoAudit
             protocol,
             provider?.ReplaceLineEndings(string.Empty));
 
+    /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="provider">The provider name.</param>
+    internal static void PkceNotAdvertised(ILogger logger, string provider)
+        => logger.LogWarning(
+            "[SSO Audit] OpenID provider '{Provider}' does not advertise PKCE (S256) in its discovery document (code_challenge_methods_supported). PKCE is still sent, but a server that ignores it leaves cross-session authorization-code injection undetectable (RFC 9700 §2.1.1). Set RequirePkce to fail closed once the provider supports it.",
+            provider?.ReplaceLineEndings(string.Empty));
+
     /// <summary>Records a provider being saved with one or more security checks disabled (#140).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -439,6 +439,15 @@ public class OidConfig : ProviderConfigBase
     /// Gets or sets a value indicating whether the UserInfo endpoint is used to get profile data.
     /// </summary>
     public bool DoNotLoadProfile { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the authorization server must advertise PKCE with S256
+    /// (in the discovery document's <c>code_challenge_methods_supported</c>) before a login proceeds.
+    /// When true, a login is refused if the server does not advertise S256 — fail closed, RFC 9700
+    /// §2.1.1. When false (the default), an unsupported server only logs an <c>[SSO Audit]</c> warning
+    /// and the login proceeds (PKCE is still sent, but the server may ignore it).
+    /// </summary>
+    public bool RequirePkce { get; set; }
 }
 
 /// <summary>

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -702,6 +702,26 @@
                     May be required for Cloudflare OpenID
                   </div>
                 </div>
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="RequirePkce"
+                      name="RequirePkce"
+                      type="checkbox"
+                      class="sso-toggle"
+                    />
+                    <span>Require PKCE (S256)</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    Refuse login unless the provider's discovery document
+                    advertises PKCE (S256) in code_challenge_methods_supported
+                    (RFC 9700 §2.1.1). When off, an unsupported provider only
+                    logs an audit warning and the login proceeds.
+                  </div>
+                </div>
 
                 <div class="inputContainer">
                   <label

--- a/providers.md
+++ b/providers.md
@@ -61,6 +61,12 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   is rejected. Providers that do not send `iss` are unaffected. If a provider legitimately sends a
   different `iss` there, set `DoNotValidateResponseIssuer: true` for that provider to relax only this
   check.
+- **PKCE (RFC 9700 §2.1.1).** The plugin always sends a PKCE `code_challenge` (S256), but a server that
+  ignores PKCE would silently downgrade cross-session authorization-code-injection protection. On login
+  the provider's discovery document is checked for `S256` in `code_challenge_methods_supported`; if it is
+  absent, an `[SSO Audit]` warning is logged and the login still proceeds. Set `RequirePkce: true` for a
+  provider to fail the login closed instead when `S256` is not advertised (or the discovery document
+  cannot be read).
 - If your IdP sends an `at_hash` claim it must match the issued access token — a correctly behaving
   provider always satisfies this.
 - **A `sub` claim is required, and it must be stable.** The account link is keyed on the immutable


### PR DESCRIPTION
# What & why

RFC 9700 §2.1.1 requires a client to confirm the authorization server supports PKCE before relying on it. OidcClient sends `code_challenge` (S256) unconditionally but never checks the discovery document's `code_challenge_methods_supported`, and `ProviderInformation` does not expose it, so a server that ignores PKCE silently downgrades cross-session authorization-code-injection protection. Closes #141.

- New pure helper `PkceDiscovery.SupportsS256(json)` reads `S256` from `code_challenge_methods_supported`, failing closed on absence / empty / non-array / non-string / malformed / lowercase (13 unit tests).
- `OidChallenge` (login prep) fetches the provider's discovery document itself and, when S256 is absent, logs an `[SSO Audit]` warning; the new per-provider **`RequirePkce`** flag fails the login closed (clean 400) instead. Both a definite "not advertised" and an unreadable discovery fail closed under `RequirePkce`.
- The discovery fetch is cached per URL for 15 minutes (one fetch per provider per 15 min, not per login), and the well-known path is appended only when the authority does not already end with it (so a full-URL `OidEndpoint` like PocketID resolves correctly), matching how OidcClient resolves the same document.
- Config-page **Require PKCE (S256)** toggle (driven by the existing class-based load/save, no `config.js` change); `providers.md` documents it.

Closes #141

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, under `RequirePkce`, both a definite "not advertised" and an unreadable discovery return a clean 400 before the login flow starts; the pure helper fails closed on every unexpected shape; a fetch failure is never cached.
- [x] No secrets logged; secrets redacted on export, the audit warning logs only the provider name (sanitized inline); no discovery contents or secrets logged.
- [x] A security review was performed, 5-lens adversarial gate (bypass / correctness / integration / availability / oidc-domain) all PASS after two review-driven fixes (full-URL `OidEndpoint` handling; per-login latency removed via the cache).
- [x] Log inputs from the IdP are sanitized inline at the log call, the provider name is `?.ReplaceLineEndings(string.Empty)` at each log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, `PkceDiscovery` is a pure helper; the fetch/cache is one controller method.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 463 tests (13 new `PkceDiscovery` cases).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, `configPage.html` and `providers.md` pass (`config.js` unchanged).

## Notes

Documented tradeoff (gate-reviewed): the 15-minute cache means a provider that silently *drops* S256 support would still pass a `RequirePkce` login for up to the TTL, a bounded, not-attacker-triggerable defense-in-depth window (PKCE is still sent, and the one-time state store still blocks the actual injection). Login-time was chosen over save-time so a provider that changes is caught. An E2E-checklist item was added (S256 present / absent → audit warning / `RequirePkce` → 400). SAML is unaffected (PKCE is OIDC-only).
