### PR TITLE
Add a CI gate that rejects Trojan Source Unicode

### DIFF
--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -1,0 +1,56 @@
+name: unicode-guard
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# Cancel a superseded run on the same ref so a new push / PR update does not
+# queue behind an obsolete check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bidi:
+    name: Reject Trojan Source Unicode
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+      - name: Reject bidirectional / invisible Unicode control characters
+        run: |
+          # Trojan Source (CVE-2021-42574): bidirectional overrides/isolates/marks and
+          # zero-width characters can make source render differently from how it executes,
+          # hiding malicious logic from a human reviewer. Reject them in tracked text files.
+          # (*UTF) enables PCRE2 UTF-8 so \x{...} matches codepoints, not raw bytes; -I skips
+          # binary files (the tracked tree is UTF-8; a binary-marked file also shows as binary
+          # in the PR diff, which defeats the visual-deception the attack relies on). Em dashes,
+          # accents, and other benign non-ASCII are not in the set.
+          pattern='(*UTF)[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200E}\x{200F}\x{061C}\x{200B}-\x{200D}]'
+          # git grep: 0 = a match was found, 1 = clean, >=2 = scanner/tooling error. Capture the
+          # code (the `|| rc=$?` keeps `set -e` from aborting on the clean exit-1) and FAIL CLOSED
+          # on any error rather than mistaking a broken scanner for a clean tree.
+          rc=0
+          git grep -nIP "$pattern" -- . || rc=$?
+          case "$rc" in
+            0)
+              echo "::error::Dangerous bidirectional/invisible Unicode found (Trojan Source, CVE-2021-42574). Remove these control characters."
+              exit 1
+              ;;
+            1)
+              echo "No bidirectional or invisible Unicode control characters found."
+              ;;
+            *)
+              echo "::error::unicode-guard scanner error (git grep exit $rc) — failing closed instead of assuming the tree is clean."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -34,8 +34,12 @@ jobs:
           # (*UTF) enables PCRE2 UTF-8 so \x{...} matches codepoints, not raw bytes; -I skips
           # binary files (the tracked tree is UTF-8; a binary-marked file also shows as binary
           # in the PR diff, which defeats the visual-deception the attack relies on). Em dashes,
-          # accents, and other benign non-ASCII are not in the set.
-          pattern='(*UTF)[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200E}\x{200F}\x{061C}\x{200B}-\x{200D}]'
+          # accents, and other benign non-ASCII are not in the set. U+2060 (word joiner) is
+          # included as an invisible control with no legitimate use in source. U+FEFF (BOM) is
+          # deliberately NOT listed: a leading UTF-8 BOM is legitimate (SSO-Auth.sln carries one),
+          # so banning it outright would false-positive, and the bidi reordering attack does not
+          # rely on it.
+          pattern='(*UTF)[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200E}\x{200F}\x{061C}\x{200B}-\x{200D}\x{2060}]'
           # git grep: 0 = a match was found, 1 = clean, >=2 = scanner/tooling error. Capture the
           # code (the `|| rc=$?` keeps `set -e` from aborting on the clean exit-1) and FAIL CLOSED
           # on any error rather than mistaking a broken scanner for a clean tree.


### PR DESCRIPTION
# What & why

A new hardened CI workflow, `unicode-guard`, fails the build if any tracked text file contains dangerous bidirectional or invisible Unicode control characters, the **Trojan Source** attack (CVE-2021-42574), where such characters make source render differently than it executes and hide malicious logic from a human reviewer. Closes #149.

- Scans the tracked tree with `git grep -nIP '(*UTF)[…]'` over the canonical Trojan Source set: bidi embeddings/overrides (U+202A–202E), isolates (U+2066–2069), marks (U+200E/200F, ALM U+061C) and zero-width joiners (U+200B–200D). `(*UTF)` enables PCRE2 UTF-8 so `\x{…}` matches codepoints, not bytes.
- **Fails closed on a scanner error**: `git grep` exit `0` = found → fail, `1` = clean → pass, `>= 2` = tooling error → fail with an error (never mistakes a broken scanner for a clean tree).
- Hardened like the repo's other workflows: SHA-pinned `actions/checkout` (v7), `persist-credentials: false`, `permissions: contents: read`, concurrency + cancel-in-progress, 5-minute timeout. Purely additive, it can only fail a build on detection.

Closes #149

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, the scanner fails the build on a match AND on a tooling error (exit >= 2), rather than defaulting to "clean".
- [x] No secrets logged; secrets redacted on export, N/A; `contents: read`, no token persisted.
- [x] A security review was performed, 2-lens gate (integration + bypass): bypass PASS (codepoint set canonically complete; purely additive); integration flagged a fail-open-on-scanner-error which is now fixed and empirically re-verified (clean → pass, bidi file → fail, invalid pattern → fail-closed).
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, one focused workflow, no external action dependency.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, N/A, no source change.
- [x] `dotnet test` is green, N/A, no source change.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.yml` (validates via js-yaml).

## Notes

Scope: the canonical bidi/zero-width reordering set. Homoglyph confusables (CVE-2021-42694) need a confusables database and are out of scope. Documented limitation: `git grep -I` skips files git treats as binary (e.g. a UTF-16-encoded source), but such a file also renders as "Binary file not shown" in the PR diff, which defeats the visual deception the attack relies on. The whole current tree passes the gate.
