### PR TITLE
Cap the SAML response size before base64 decode and DOM parse

### DIFF
--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -67,6 +67,18 @@ public class SamlResponseParsingTests
     }
 
     [Fact]
+    public void TryParse_OversizedResponse_ReturnsFalse()
+    {
+        // A body over the length cap is rejected before any base64 decode / DOM parse (#249) — fail
+        // closed, with no crypto or bulk allocation spent on an untrusted multi-MB body.
+        var fixture = SamlTestFactory.Create();
+        var oversized = new string('A', SamlResponseLoader.MaxEncodedResponseLength + 1);
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, oversized, out var response));
+        Assert.Null(response);
+    }
+
+    [Fact]
     public void GetSignatureAlgorithm_ValidResponse_ReturnsTheSignatureMethod()
     {
         var fixture = SamlTestFactory.Create();

--- a/SSO-Auth/Api/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/SamlResponseLoader.cs
@@ -14,6 +14,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal static class SamlResponseLoader
 {
+    // Maximum accepted length of the Base64 SAMLResponse. Real responses are single-digit KB; 256 KB is
+    // generous headroom for role-heavy assertions and bounds the base64 decode + whitespace-preserving DOM
+    // parse on the unauthenticated callback path (#249), where a multi-MB body would otherwise cost ~100 MB
+    // of transient allocations before any signature is checked. The DTD prohibition stops entity expansion
+    // but not raw bulk, and the rate limiter is opt-in — this is the always-on cap.
+    internal const int MaxEncodedResponseLength = 256 * 1024;
+
     /// <summary>
     /// Tries to parse a SAML response, returning <see langword="false"/> (rather than throwing) on the
     /// malformed-input exceptions the <see cref="Response"/> constructor raises.
@@ -28,6 +35,14 @@ internal static class SamlResponseLoader
         // yields a null string on the unauthenticated ACS endpoint); reject it here rather than let
         // Convert.FromBase64String(null) raise ArgumentNullException and escape as an unhandled 500.
         if (string.IsNullOrEmpty(responseString))
+        {
+            response = null;
+            return false;
+        }
+
+        // Reject an oversized body before decoding/parsing it (#249) — fail closed, same clean rejection
+        // as any other malformed response, with no crypto or allocation spent on the untrusted bulk.
+        if (responseString.Length > MaxEncodedResponseLength)
         {
             response = null;
             return false;


### PR DESCRIPTION
# What & why

The unauthenticated SAML callbacks decoded and DOM-parsed a `SAMLResponse` of arbitrary size before any signature check. `SamlPost`, `SamlAuth` and `SamlLink` feed the raw body through `SamlResponseLoader.TryParse` → base64 decode → UTF-8 string → whitespace-preserving `XmlDocument` load, with no plugin-side length bound (only the ~30 MB Kestrel cap). A multi-MB base64 body costs ~100 MB of transient allocations per request with no crypto required from the sender; the DTD prohibition stops entity expansion but not raw bulk, and the rate limiter is opt-in (off by default). Closes #249.

Fix: a fail-closed length check at the top of `SamlResponseLoader.TryParse` (after the null/empty guard, before the decode/parse) rejects a body over `MaxEncodedResponseLength` (256 KB), the same clean rejection as any malformed response. Real responses are single-digit KB, so 256 KB is 30–60x headroom (Azure AD caps a SAML assertion at 150 groups; a body large enough to breach the cap already breaks HTTP transport limits).

Closes #249

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, an oversized body is rejected (response = null; return false) before any decode/parse, identical to the malformed/empty paths; no crypto or bulk allocation is spent.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, 3-lens gate (bypass / availability / correctness) all PASS: the guard sits before the decode/DOM and all three SAML entries route through it; 256 KB gives 30–60x headroom over realistic responses (no legitimate lockout); correct strictly-greater boundary and encoded-length measure.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A (no new logging).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, one guard + one named constant in the existing loader.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 464 tests (new `TryParse_OversizedResponse_ReturnsFalse` rejects a `cap + 1` body by length).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

The cap is an `internal const`, tunable by recompile if a deployment ever needs more, a config knob would be over-engineering for a case no realistic IdP hits. The incoming string is still allocated once by model binding (bounded by the Kestrel cap) before `TryParse`; this fix eliminates the decode/DOM amplification that #249 targeted. Surfaced by the 2026-07-13 weekly performance/security routine. An E2E-checklist item was added.
