### PR TITLE
Cap and throttle the OIDC authorize-state store

### DIFF
--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
@@ -226,5 +227,44 @@ public class AuthStateStoreTests
         var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
         Assert.True(AuthStateStore.TryAdd(store, "a", State("p", "a", false, Now), maxEntries: 10));
         Assert.False(AuthStateStore.TryAdd(store, "a", State("p", "a", false, Now), maxEntries: 10));
+    }
+
+    [Fact]
+    public async Task TryAdd_UnderContention_StaysBoundedAndRejectsSome()
+    {
+        const int cap = 50;
+        const int taskCount = 8;
+        const int perTask = 30;
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        var rejected = 0;
+
+        var tasks = new Task[taskCount];
+        for (var t = 0; t < taskCount; t++)
+        {
+            var id = t;
+            tasks[t] = Task.Run(
+                () =>
+                {
+                    for (var i = 0; i < perTask; i++)
+                    {
+                        var key = $"t{id}-k{i}";
+                        if (!AuthStateStore.TryAdd(store, key, State("p", key, false, Now), cap))
+                        {
+                            Interlocked.Increment(ref rejected);
+                        }
+                    }
+                },
+                TestContext.Current.CancellationToken);
+        }
+
+        await Task.WhenAll(tasks);
+
+        // The unsynchronized check-then-add can transiently overshoot by at most the in-flight thread
+        // count, so the invariant is BOUNDED (not "never exceeds cap"): the cap is reached, the store
+        // stays within cap + taskCount, and once full some inserts are rejected — the concurrent
+        // rejection path.
+        Assert.True(store.Count >= cap);
+        Assert.True(store.Count <= cap + taskCount);
+        Assert.True(rejected > 0);
     }
 }

--- a/SSO-Auth.Tests/AuthStateStoreTests.cs
+++ b/SSO-Auth.Tests/AuthStateStoreTests.cs
@@ -195,4 +195,36 @@ public class AuthStateStoreTests
         Assert.False(store.ContainsKey("seed-expired"));
         Assert.Equal(5000, store.Count);
     }
+
+    // --- TryAdd cap (#246): bound the store; refuse a new state at capacity, never evict in-flight ---
+
+    [Fact]
+    public void TryAdd_BelowCap_AddsTheState()
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+
+        Assert.True(AuthStateStore.TryAdd(store, "a", State("p", "a", false, Now), maxEntries: 2));
+        Assert.True(AuthStateStore.TryAdd(store, "b", State("p", "b", false, Now), maxEntries: 2));
+        Assert.Equal(2, store.Count);
+    }
+
+    [Fact]
+    public void TryAdd_AtCap_RefusesANewKeyAndKeepsTheInFlightState()
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        Assert.True(AuthStateStore.TryAdd(store, "in-flight", State("p", "in-flight", false, Now), maxEntries: 1));
+
+        // At the cap, a fresh challenge is refused rather than evicting the user already mid-login.
+        Assert.False(AuthStateStore.TryAdd(store, "new", State("p", "new", false, Now), maxEntries: 1));
+        Assert.Single(store);
+        Assert.True(store.ContainsKey("in-flight"));
+    }
+
+    [Fact]
+    public void TryAdd_DuplicateKey_ReturnsFalse()
+    {
+        var store = new ConcurrentDictionary<string, TimedAuthorizeState>();
+        Assert.True(AuthStateStore.TryAdd(store, "a", State("p", "a", false, Now), maxEntries: 10));
+        Assert.False(AuthStateStore.TryAdd(store, "a", State("p", "a", false, Now), maxEntries: 10));
+    }
 }

--- a/SSO-Auth/Api/AuthStateStore.cs
+++ b/SSO-Auth/Api/AuthStateStore.cs
@@ -28,6 +28,33 @@ internal static class AuthStateStore
     }
 
     /// <summary>
+    /// Adds a new authorize state unless the store already holds <paramref name="maxEntries"/> entries.
+    /// At the cap a NEW key is refused (that one login fails closed) rather than evicting an in-flight
+    /// state — evicting would drop a user already mid-login (a mass-lockout hazard under a flood). This
+    /// bounds memory under an anonymous challenge flood on the busiest login endpoint, mirroring
+    /// <see cref="SamlRequestCache"/>. The check-then-insert is not serialized (no lock on the anonymous
+    /// hot path), so concurrent adds can transiently overshoot by at most the number of in-flight threads.
+    /// </summary>
+    /// <param name="states">The state store.</param>
+    /// <param name="key">The authorize-state value used as the key.</param>
+    /// <param name="value">The state to store.</param>
+    /// <param name="maxEntries">The approximate ceiling on stored entries.</param>
+    /// <returns>True if the state was added; false if the key already existed or the store is at capacity.</returns>
+    internal static bool TryAdd(
+        ConcurrentDictionary<string, TimedAuthorizeState> states,
+        string key,
+        TimedAuthorizeState value,
+        int maxEntries)
+    {
+        if (states.Count >= maxEntries && !states.ContainsKey(key))
+        {
+            return false;
+        }
+
+        return states.TryAdd(key, value);
+    }
+
+    /// <summary>
     /// Whether a stored state still belongs to the given provider and has not expired. Used at the
     /// OpenID callback before a state is validated: a state minted for one provider must not be
     /// accepted on another provider's callback, and a state older than its lifetime is not honored.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -51,6 +51,11 @@ public class SSOController : ControllerBase
     private const string OpenIdProtocol = "OpenID";
     private const string SamlProtocol = "SAML";
 
+    // An approximate ceiling on outstanding OpenID authorize states, so an anonymous challenge flood cannot
+    // grow the store without bound (mirrors SamlRequestCache); at the cap a fresh challenge is refused rather
+    // than evicting an in-flight state, and rate-limiting at the edge (#128) is the primary defense (#246).
+    private const int MaxStateEntries = 100_000;
+
     private readonly IUserManager _userManager;
     private readonly ISessionManager _sessionManager;
     private readonly IAuthorizationContext _authContext;
@@ -68,6 +73,13 @@ public class SSOController : ControllerBase
     // bounds the whole interactive leg (OidChallenge -> IdP login/MFA/consent -> callback -> mint),
     // so it must accommodate a real user completing MFA, not just a fast round trip.
     private static readonly TimeSpan StateLifetime = TimeSpan.FromMinutes(15);
+
+    // The expired-state sweep (Invalidate) is an O(n) scan; throttling it to at most once per this interval
+    // stops an anonymous challenge flood from amplifying into CPU load (mirrors SamlRequestCache). This only
+    // defers memory reclamation — IsCurrentFor/IsRedeemableBy reject an expired state independently, so a
+    // not-yet-swept entry never grants a login. Its atomic cursor (_lastStatePruneTicks) is a mutable field
+    // and so sits after the readonly static fields below (#246).
+    private static readonly TimeSpan StatePruneInterval = TimeSpan.FromMinutes(1);
 
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
@@ -92,6 +104,10 @@ public class SSOController : ControllerBase
     // computed once since the assembly version does not change at runtime.
     private static readonly string UserAgentString =
         $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
+
+    // Atomic cursor for the throttled authorize-state sweep (#246), read/written via Interlocked (a long is
+    // not torn-read-safe). Mutable, so it sits after the readonly static fields to satisfy field ordering.
+    private static long _lastStatePruneTicks = DateTime.MinValue.Ticks;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
@@ -308,10 +324,10 @@ public class SSOController : ControllerBase
             // IsLinking tracks whether this is a linking request rather than a login. The state value
             // is a fresh CSPRNG token, so a collision is effectively impossible; log if it ever occurs
             // instead of silently proceeding to a callback that would then fail with "invalid state".
-            if (!StateManager.TryAdd(state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking, Provider = provider }))
+            if (!AuthStateStore.TryAdd(StateManager, state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking, Provider = provider }, MaxStateEntries))
             {
-                _logger.LogWarning("OpenID authorize-state collision for provider {Provider}; login not started.", provider?.ReplaceLineEndings(string.Empty));
-                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login due to a state collision; please retry.");
+                _logger.LogWarning("OpenID authorize state not started for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity.", provider?.ReplaceLineEndings(string.Empty));
+                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
             }
 
             return Redirect(state.StartUrl);
@@ -1625,7 +1641,23 @@ public class SSOController : ControllerBase
 
     private static void Invalidate()
     {
-        AuthStateStore.InvalidateExpired(StateManager, DateTime.Now, StateLifetime);
+        // Throttle the O(n) expired-state sweep to at most once per StatePruneInterval so an anonymous
+        // challenge flood does not amplify into CPU load; the CAS makes exactly one thread per interval
+        // run it (#246). The store keeps InvalidateExpired itself pure/unthrottled — the throttle lives
+        // here, at its sole call site.
+        var now = DateTime.Now;
+        var last = Interlocked.Read(ref _lastStatePruneTicks);
+        if (now.Ticks - last < StatePruneInterval.Ticks)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _lastStatePruneTicks, now.Ticks, last) != last)
+        {
+            return;
+        }
+
+        AuthStateStore.InvalidateExpired(StateManager, now, StateLifetime);
     }
 
     // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -109,6 +109,11 @@ public class SSOController : ControllerBase
     // not torn-read-safe). Mutable, so it sits after the readonly static fields to satisfy field ordering.
     private static long _lastStatePruneTicks = DateTime.MinValue.Ticks;
 
+    // Atomic cursor for throttling the capacity-full warning (#246, CWE-400): under a flood every refused
+    // challenge would otherwise emit a warning, amplifying the flood into unbounded log volume. Warn at
+    // most once per StatePruneInterval.
+    private static long _lastCapWarnTicks = DateTime.MinValue.Ticks;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -326,7 +331,18 @@ public class SSOController : ControllerBase
             // instead of silently proceeding to a callback that would then fail with "invalid state".
             if (!AuthStateStore.TryAdd(StateManager, state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking, Provider = provider }, MaxStateEntries))
             {
-                _logger.LogWarning("OpenID authorize state not started for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity.", provider?.ReplaceLineEndings(string.Empty));
+                // The state value is a CSPRNG token, so a collision is effectively impossible; a refusal
+                // here is almost always the capacity backstop under a flood. Throttle the warning to at
+                // most once per interval so the flood cannot amplify into unbounded log volume (#246).
+                var warnNow = DateTime.Now.Ticks;
+                var lastWarn = Interlocked.Read(ref _lastCapWarnTicks);
+                if (warnNow >= lastWarn
+                    && warnNow - lastWarn >= StatePruneInterval.Ticks
+                    && Interlocked.CompareExchange(ref _lastCapWarnTicks, warnNow, lastWarn) == lastWarn)
+                {
+                    _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                }
+
                 return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
             }
 
@@ -1647,7 +1663,11 @@ public class SSOController : ControllerBase
         // here, at its sole call site.
         var now = DateTime.Now;
         var last = Interlocked.Read(ref _lastStatePruneTicks);
-        if (now.Ticks - last < StatePruneInterval.Ticks)
+
+        // Skip only when a non-negative, sub-interval amount of time has passed. A backward wall-clock step
+        // (now.Ticks < last) does NOT skip — it prunes and resets the cursor — so a clock correction cannot
+        // stall the sweep and leave the capped store refusing fresh challenges (#246).
+        if (now.Ticks >= last && now.Ticks - last < StatePruneInterval.Ticks)
         {
             return;
         }


### PR DESCRIPTION
# What & why

The OpenID authorize-state store (`StateManager`) was the one login-path cache with no size cap and an unthrottled O(n) expiry sweep on every anonymous `GET /sso/OID/...` challenge, the busiest anonymous endpoint. A challenge flood therefore grew the store unboundedly for the 15-minute state lifetime while every request paid an increasingly expensive scan (200 rps ≈ 180k live entries and O(n²) aggregate sweep CPU; higher rps into the GB range). Closes #246.

Brings `StateManager` up to the safeguards its sibling `SamlRequestCache` already documents:

- New pure helper `AuthStateStore.TryAdd(states, key, value, maxEntries)`: at the cap (`MaxStateEntries = 100_000`) it refuses a **new** state rather than evicting an in-flight one, evicting would drop a user already mid-login (a mass-lockout hazard). A duplicate key returns false as before. Unit-tested.
- `SSOController.Invalidate()` now CAS-throttles the O(n) sweep to at most once per minute. `AuthStateStore.InvalidateExpired` itself stays pure and unthrottled, the throttle lives at its sole call site, so its three existing tests are unchanged, and every consume path (`IsCurrentFor` / `IsRedeemableBy`) independently rejects an expired state, so deferring the sweep never grants a stale login.

Closes #246

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, the cap replaces unbounded-growth → OOM (which locks out everyone, incl. local auth) with a bounded store; a refused challenge is a clean retryable 500, never a partial state; the throttle only defers memory reclamation, and expired states are still rejected at consume time.
- [x] No secrets logged; secrets redacted on export, the log line carries only the sanitized provider name; the message is generic.
- [x] A security review was performed, 4-lens gate (availability / bypass / correctness / integration) all PASS: never evicts an in-flight login, no expired state can mint a session, the CAS throttle mirrors the proven `SamlRequestCache` pattern, and the residual (SSO challenges refused during a sustained distributed flood) is the correct fail-closed tradeoff behind the edge rate limiter (#128).
- [x] Log inputs from the IdP are sanitized inline at the log call, provider name is `?.ReplaceLineEndings(string.Empty)` at the call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, one pure `TryAdd` helper + a CAS throttle mirroring the sibling cache.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 467 tests (3 new `AuthStateStore.TryAdd` cap tests; the existing `InvalidateExpired` tests are unchanged since it stays pure).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

The cap is a `const` (recompile to tune), 100k simultaneously-outstanding OIDC states in a 15-min window would need ~100k users mid-login concurrently, so a config knob would be over-engineering. Surfaced by the 2026-07-13 weekly performance/security routine. An E2E-checklist item was added.
