### PR TITLE
Take the config lock for login-path provider-dictionary reads

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -170,7 +170,7 @@ public class SSOController : ControllerBase
         OidConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.OidConfigs[provider];
+            config = GetOidConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -279,7 +279,7 @@ public class SSOController : ControllerBase
         OidConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.OidConfigs[provider];
+            config = GetOidConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -351,6 +351,18 @@ public class SSOController : ControllerBase
 
         throw new ArgumentException(ProviderDoesNotExistMessage);
     }
+
+    // Reads a provider's config under the config lock, so an anonymous login-path index does not race an
+    // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
+    // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
+    // Throws KeyNotFoundException for an unknown provider, exactly as the direct index did, so the existing
+    // catch at each call site is unchanged. An uncontended lock is nanoseconds; it is only held long during
+    // a first-login/admin persist, which is exactly when a consistent read matters.
+    private static OidConfig GetOidConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs[provider]);
+
+    private static SamlConfig GetSamlConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs[provider]);
 
     // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
@@ -603,7 +615,7 @@ public class SSOController : ControllerBase
         OidConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.OidConfigs[provider];
+            config = GetOidConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -674,7 +686,7 @@ public class SSOController : ControllerBase
         SamlConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.SamlConfigs[provider];
+            config = GetSamlConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -743,7 +755,7 @@ public class SSOController : ControllerBase
         SamlConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.SamlConfigs[provider];
+            config = GetSamlConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -862,7 +874,7 @@ public class SSOController : ControllerBase
         SamlConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.SamlConfigs[provider];
+            config = GetSamlConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -1374,7 +1386,7 @@ public class SSOController : ControllerBase
         SamlConfig config;
         try
         {
-            config = SSOPlugin.Instance.Configuration.SamlConfigs[provider];
+            config = GetSamlConfig(provider);
         }
         catch (KeyNotFoundException)
         {
@@ -1423,7 +1435,7 @@ public class SSOController : ControllerBase
         try
         {
             // Touch the indexer only to verify the provider exists; it throws if it does not.
-            _ = SSOPlugin.Instance.Configuration.OidConfigs[provider];
+            _ = GetOidConfig(provider);
         }
         catch (KeyNotFoundException)
         {


### PR DESCRIPTION
# What & why

Eight anonymous login-path sites indexed the **live** `OidConfigs` / `SamlConfigs` dictionaries lock-free (`SSOPlugin.Instance.Configuration.OidConfigs[provider]`), while the admin `OidAdd`/`SamlAdd`/`Del` paths mutate those same `Dictionary` instances **in place** under `ConfigMutationLock`. A `Dictionary` read-during-write is undefined behaviour in .NET, a login racing a provider add/remove could throw, misread, or spin on a corrupted bucket chain during a resize, wedging a request thread at 100% CPU. Exposure is admin-time only (provider add/remove is rare), but the failure lands on the login path. Closes #252.

Fix: two DRY helpers, `GetOidConfig` / `GetSamlConfig`, route the read through the existing `ReadConfiguration` (the config lock). All eight sites now call the helper, each still inside its existing `try/catch (KeyNotFoundException)`. Writers and the lock are unchanged; a read can no longer race the in-place mutation. Uncontended the lock is nanoseconds; it is only held long during a first-login/admin persist, which is exactly when a consistent read matters.

Closes #252

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, an unknown provider still throws `KeyNotFoundException` into the existing catch (same 400 / not-found handling); the change only moves the dictionary index under the lock, removing undefined behaviour, and alters no auth decision.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, 4-lens gate (correctness / integration / availability / bypass) all PASS: identical exception propagation, all eight reads replaced, single reentrant lock with no cross-lock nesting (no deadlock), and bounded contention that strictly beats the unbounded UB CPU-spin.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, two DRY helpers replace eight inlined lock-free index reads.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 468 tests (the race is not unit-testable; the config-lock plumbing is exercised by the existing suite and the fix reuses the proven `ReadConfiguration` pattern).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

Chose the minimal-first option (route reads through the lock) over copy-and-swap: uncontended the lock is nanoseconds and the read only queues behind a rare admin/first-login persist. The `GetLinks`/`SetLinks` bracket reads are already invoked only inside `Mutate`/`Read` lambdas (under the lock), so they were not lock-free. An E2E-checklist item was added (provider add/remove during logins does not wedge a request). Surfaced by the 2026-07-13 weekly security routine.
