### PR TITLE
Serve embedded view assets with an ETag for 304 revalidation

### DIFF
--- a/SSO-Auth/Views/SSOViewsController.cs
+++ b/SSO-Auth/Views/SSOViewsController.cs
@@ -6,6 +6,7 @@ using MediaBrowser.Model;
 using MediaBrowser.Model.Plugins;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 
 namespace Jellyfin.Plugin.SSO_Auth.Views;
 
@@ -16,6 +17,16 @@ namespace Jellyfin.Plugin.SSO_Auth.Views;
 [Route("[controller]")]
 public class SSOViewsController : ControllerBase
 {
+    // The embedded view assets only change with the plugin version, so a version-derived ETag lets clients
+    // 304-revalidate instead of re-downloading jellyfin-apiClient.esm.min.js (~79 KB) + emby-restyle.css on
+    // every linking-page load (#253). Derived from the FILE version (set per release by the build), not the
+    // AssemblyVersion (which can stay static across releases and would then serve stale assets after an
+    // update). The same tag across assets is correct: a client sends the ETag it cached for a given URL, and
+    // the server compares it against that URL's current tag.
+    private static readonly EntityTagHeaderValue AssetETag = new EntityTagHeaderValue(
+        "\"" + System.Diagnostics.FileVersionInfo.GetVersionInfo(
+            typeof(SSOViewsController).Assembly.Location).FileVersion + "\"");
+
     private readonly ILogger<SSOViewsController> _logger;
 
     /// <summary>
@@ -67,6 +78,6 @@ public class SSOViewsController : ControllerBase
             return NotFound();
         }
 #nullable disable
-        return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath));
+        return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath), lastModified: null, entityTag: AssetETag);
     }
 }


### PR DESCRIPTION
# What & why

`SSOViewsController` streamed the embedded linking-page assets (`jellyfin-apiClient.esm.min.js` ~79 KB, `emby-restyle.css` ~10 KB) with no caching headers, so a client re-downloads them on every linking-page load. Closes #253.

Fix: pass a version-derived `EntityTag` to the `File(...)` overload so clients get a `304 Not Modified` on revalidation. The tag is derived from the **file** version (set per release by the build), not `AssemblyVersion` (which can stay static across releases and would then serve stale assets after an update), so it changes on every plugin update. The same tag across the two assets is correct, a client sends the ETag it cached for a given URL and the server compares it against that URL's current tag.

Closes #253

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, N/A: this is static-asset caching on the views controller, not the login/crypto/config/release surface, so no adversarial-lens gate. It only adds a response `ETag`; asset content and the not-found/error paths are unchanged.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, N/A (not on the gate surface); the change adds a caching header to a public static asset.
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, one static `EntityTag` + one `File(...)` argument.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, `--no-incremental --warnaserror` 0/0.
- [x] `dotnet test` is green, 468 tests.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `.cs`.

## Notes

304 revalidation is only observable on a real server, so an E2E-checklist item was added (reload returns 304; a version bump re-fetches). Surfaced by the 2026-07-13 weekly performance routine.
