### PR TITLE
Package the SAML crypto runtime DLLs (fix packaged SAML login)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -14,6 +14,10 @@ artifacts:
   - "SSO-Auth.dll"
   - "Duende.IdentityModel.OidcClient.dll"
   - "Duende.IdentityModel.dll"
+  # Duende.IdentityModel's own runtime dependency the host does not provide (a latent
+  # omission from the #134 list, surfaced verifying #181 against SSO-Auth.deps.json —
+  # its only parent is Duende.IdentityModel, not the SAML crypto chain below).
+  - "Microsoft.Bcl.Memory.dll"
   # id_token validation (#134): the runtime closure of the JWT validator that the
   # Jellyfin host does not provide. Jellyfin 10.11 ships no Microsoft.IdentityModel.*
   # and no Microsoft.Bcl.Cryptography, so these must travel in the plugin zip or every
@@ -24,6 +28,17 @@ artifacts:
   - "Microsoft.IdentityModel.Logging.dll"
   - "Microsoft.IdentityModel.Abstractions.dll"
   - "Microsoft.Bcl.Cryptography.dll"
+  # SAML XML-signature validation (#181): the runtime closure of the direct
+  # System.Security.Cryptography.Xml reference — Pkcs, then Asn1 (its other dependency,
+  # Microsoft.Bcl.Cryptography, is already listed above for OIDC). None of these are in
+  # the ASP.NET Core shared framework Jellyfin 10.11 (.NET 9) runs on, so without them
+  # the packaged plugin throws FileNotFoundException the moment SignedXml runs — every
+  # packaged SAML login fails, even though local build/dotnet test are green (they run
+  # against the full publish output). Keep in sync with `dotnet publish -c Release` on
+  # every dependency change.
+  - "System.Security.Cryptography.Xml.dll"
+  - "System.Security.Cryptography.Pkcs.dll"
+  - "System.Formats.Asn1.dll"
 changelog: |
   4.0.0.4: Fix security issue in SAML
   4.0.0.0: Jellyfin 10.11


### PR DESCRIPTION
# What & why

The JPRM `artifacts:` allowlist in [build.yaml](build.yaml), the packaging manifest; JPRM copies **only** the listed DLLs into the plugin zip, omitted the runtime closure of the `System.Security.Cryptography.Xml` reference the SAML XML-signature path needs. So the **packaged** plugin throws `FileNotFoundException` the moment `SignedXml` runs, **every packaged SAML login fails on a fresh install**. Local build and `dotnet test` stay green because they run against the full `publish` output, so this was invisible locally and prior packaged builds (incl. 4.0.0.4 and the nightlies) shipped broken SAML. Closes #181.

Fix, add the SAML runtime closure to `artifacts:` (empirically derived from `dotnet publish -c Release` + `SSO-Auth.deps.json`):

- `System.Security.Cryptography.Xml.dll` → `System.Security.Cryptography.Pkcs.dll` → `System.Formats.Asn1.dll`. (Pkcs's other dependency, `Microsoft.Bcl.Cryptography`, is already listed for OIDC/#134.)
- `Microsoft.Bcl.Memory.dll`, a `Duende.IdentityModel` runtime dependency (its only parent per `.deps.json`) that was a **latent omission from the #134 OIDC closure**, surfaced while verifying this; listed under the OIDC block where it belongs.

A completeness pass over the publish output confirmed every other non-plugin DLL (BitFaster, ICU4N, EF Core, Extensions.\*, Polly, etc.) reaches the plugin only transitively via `Jellyfin.Controller`/`Model`, so the host provides them, nothing else is missing. None of the four bundled DLLs are in the .NET 9 ASP.NET Core shared framework, and Jellyfin uses no SAML crypto, so the plugin's ALC-isolated copies cannot shadow a host assembly.

Closes #181

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved, N/A to validation logic; this restores the SAML crypto assemblies so the packaged plugin can run `SignedXml` at all. It only adds DLLs to the packaging manifest.
- [x] No secrets logged; secrets redacted on export, N/A.
- [x] A security review was performed, 2-lens gate (integration + correctness): integration PASS (exact names, complete closure, no host-shadow on .NET 9); correctness NEEDS_IMPROVEMENT on the inline comment misattributing `Microsoft.Bcl.Memory` to the SAML chain, **fixed** (moved to the OIDC block with the correct `.deps.json`-verified attribution; DLL set unchanged).
- [x] Log inputs from the IdP are sanitized inline at the log call, N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit, a packaging-manifest addition with a documented, `deps.json`-verified rationale.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, no source change; `dotnet publish -c Release` confirmed emits all four DLLs (fileversion 10.0.926.x / 10.0.426.x).
- [x] `dotnet test` is green, 468 tests (the SAML tests exercise `SignedXml`, confirming the 10.0.9 assembly loads and works).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, N/A, only `build.yaml`.

## Notes

**This bug class is invisible to CI** (build/test run against the full publish output), so an E2E-checklist item was added: install the **packaged zip** on a real Jellyfin 10.11 (.NET 9) server, on **Linux** too, and confirm a SAML login's `SignedXml` validation does not `FileNotFoundException`. Because prior packaged builds shipped broken SAML, this fix is a strong reason to include in the recommended security/bugfix release. A durable follow-up worth its own issue: a CI check that diffs the publish output's non-host DLLs against the `artifacts:` list so the allowlist cannot rot silently again.
