### PR TITLE
Add a nonce-based Content-Security-Policy to the auth page

### DIFF
--- a/SSO-Auth.Tests/AuthPageCspTests.cs
+++ b/SSO-Auth.Tests/AuthPageCspTests.cs
@@ -26,6 +26,7 @@ public class AuthPageCspTests
 
         Assert.StartsWith("default-src 'none';", csp);
         Assert.Contains("connect-src 'self'", csp);
+        Assert.Contains("img-src 'self' data:", csp);
         Assert.Contains("frame-src 'self'", csp);
         Assert.Contains("base-uri 'none'", csp);
         Assert.Contains("form-action 'none'", csp);

--- a/SSO-Auth.Tests/AuthPageCspTests.cs
+++ b/SSO-Auth.Tests/AuthPageCspTests.cs
@@ -1,0 +1,44 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AuthPageCsp"/> — the Content-Security-Policy served with the auth page. The
+/// policy must deny everything by default, allow only the nonce'd inline script and style, and keep
+/// fetch/frame same-origin so the login script can reach <c>/sso/*/Auth</c> and the iframe.
+/// </summary>
+public class AuthPageCspTests
+{
+    [Fact]
+    public void Build_BindsScriptAndStyleToTheNonce()
+    {
+        var csp = AuthPageCsp.Build("r4nd0mNonce==");
+
+        Assert.Contains("script-src 'nonce-r4nd0mNonce=='", csp);
+        Assert.Contains("style-src 'nonce-r4nd0mNonce=='", csp);
+    }
+
+    [Fact]
+    public void Build_DeniesByDefaultAndPinsSameOrigin()
+    {
+        var csp = AuthPageCsp.Build("n0nce");
+
+        Assert.StartsWith("default-src 'none';", csp);
+        Assert.Contains("connect-src 'self'", csp);
+        Assert.Contains("frame-src 'self'", csp);
+        Assert.Contains("base-uri 'none'", csp);
+        Assert.Contains("form-action 'none'", csp);
+        Assert.Contains("frame-ancestors 'none'", csp);
+    }
+
+    [Fact]
+    public void Build_DoesNotAllowUnsafeInlineOrEval()
+    {
+        var csp = AuthPageCsp.Build("n0nce");
+
+        // A nonce is the whole point; 'unsafe-inline'/'unsafe-eval' would defeat it.
+        Assert.DoesNotContain("unsafe-inline", csp);
+        Assert.DoesNotContain("unsafe-eval", csp);
+    }
+}

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -18,7 +18,7 @@ public class WebResponseTests
         // A value chosen to break out of a single-quoted literal and inject markup, if unescaped.
         var hostileData = "abc'; </script><script>alert(1)</script>//";
 
-        var html = WebResponse.Generator(hostileData, "keycloak", "https://jf.example.com", "SAML");
+        var html = WebResponse.Generator(hostileData, "keycloak", "https://jf.example.com", "SAML", "n0nce");
 
         // Emitted via JSON serialization (double-quoted, encoded) rather than a raw single-quoted
         // concatenation.
@@ -37,7 +37,7 @@ public class WebResponseTests
         // textually identical.
         var base64 = "PHNhbWxwOlJlc3BvbnNlLz4=";
 
-        var html = WebResponse.Generator(base64, "authelia", "https://jf.example.com", "OID");
+        var html = WebResponse.Generator(base64, "authelia", "https://jf.example.com", "OID", "n0nce");
 
         Assert.Contains("var data = \"" + base64 + "\";", html);
     }
@@ -48,7 +48,7 @@ public class WebResponseTests
         // A provider name that would break out of a single-quoted JS/URL literal if interpolated raw.
         var hostileProvider = "p';alert(1);//";
 
-        var html = WebResponse.Generator("ZGF0YQ==", hostileProvider, "https://jf.example.com", "SAML");
+        var html = WebResponse.Generator("ZGF0YQ==", hostileProvider, "https://jf.example.com", "SAML", "n0nce");
 
         // The provider is emitted once as a JSON-encoded constant and used through
         // encodeURIComponent in the URLs, never concatenated raw.
@@ -62,10 +62,34 @@ public class WebResponseTests
     {
         // The base URL derives from the request host, so it is treated as untrusted and emitted as
         // a JSON-encoded constant rather than interpolated into the script.
-        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML");
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce");
 
         Assert.Contains("const ssoBaseUrl = \"https://jf.example.com\";", html);
         // URLs are built from the constant, not a raw host string.
         Assert.Contains("ssoBaseUrl + '/web/index.html'", html);
+    }
+
+    [Fact]
+    public void Generator_EmitsNonceOnInlineScriptAndStyle()
+    {
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "OID", "r4nd0mNonce==");
+
+        // The per-response nonce authorizes the page's single inline script and style under the CSP.
+        Assert.Contains("<style nonce=\"r4nd0mNonce==\">", html);
+        Assert.Contains("<script nonce=\"r4nd0mNonce==\">", html);
+        // The placeholder must be fully substituted — no literal token may leak into the page.
+        Assert.DoesNotContain("{{NONCE}}", html);
+    }
+
+    [Fact]
+    public void Generator_UsesNoInlineStyleAttribute_SoStyleSrcNonceHolds()
+    {
+        // A nonce covers <style> elements but not inline style="" attributes; the iframe's positioning
+        // therefore lives in the nonce'd <style> block (#iframe-main), leaving no inline style behind.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "OID", "n0nce");
+
+        Assert.DoesNotContain("style='", html);
+        Assert.DoesNotContain("style=\"", html);
+        Assert.Contains("#iframe-main", html);
     }
 }

--- a/SSO-Auth/Api/AuthPageCsp.cs
+++ b/SSO-Auth/Api/AuthPageCsp.cs
@@ -1,0 +1,28 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Builds the Content-Security-Policy for the rendered auth-completion page. The page runs a single
+/// inline script and a single inline style, both authorized by a per-response nonce; everything else
+/// is denied. Its script XHR-POSTs to <c>/sso/*/Auth</c> and loads <c>/web/index.html</c> in an
+/// iframe, both same-origin (the flow shares <c>localStorage</c> between the page and that iframe, so
+/// a cross-origin base URL cannot work regardless of CSP).
+/// </summary>
+public static class AuthPageCsp
+{
+    /// <summary>
+    /// Builds the Content-Security-Policy header value, binding the inline script and style to
+    /// <paramref name="nonce"/>. The same nonce must be emitted on the page's script and style tags.
+    /// </summary>
+    /// <param name="nonce">The per-response base64 nonce.</param>
+    /// <returns>The Content-Security-Policy header value.</returns>
+    public static string Build(string nonce) =>
+        "default-src 'none'; "
+        + $"script-src 'nonce-{nonce}'; "
+        + $"style-src 'nonce-{nonce}'; "
+        + "connect-src 'self'; "
+        + "img-src 'self' data:; "
+        + "frame-src 'self'; "
+        + "base-uri 'none'; "
+        + "form-action 'none'; "
+        + "frame-ancestors 'none'";
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -241,7 +241,7 @@ public class SSOController : ControllerBase
             if (timedState.Valid)
             {
                 _logger.LogInformation("Is request linking: {IsLinking}", isLinking);
-                return HtmlAuthPage(WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), mode: "OID", isLinking: isLinking));
+                return HtmlAuthPage(nonce => WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), mode: "OID", nonce: nonce, isLinking: isLinking));
             }
             else
             {
@@ -716,12 +716,13 @@ public class SSOController : ControllerBase
 
             if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
             {
-                return HtmlAuthPage(
+                return HtmlAuthPage(nonce =>
                     WebResponse.Generator(
                         data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
                         provider: provider,
                         baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
                         mode: "SAML",
+                        nonce: nonce,
                         isLinking: isLinking));
             }
 
@@ -1910,17 +1911,18 @@ public class SSOController : ControllerBase
 
     // Returns the rendered auth page as HTML with defensive response headers. The page carries the
     // one-time state token / signed assertion and completes the login from an inline script, so it
-    // must not be framed (clickjacking), MIME-sniffed, cached, or leak its URL via Referer. A
-    // Content-Security-Policy is intentionally NOT set here: the page relies on an inline script and
-    // style, so a safe CSP needs per-response nonces threaded into WebResponse.Generator — tracked
-    // separately (it needs a real-server check that the login page still runs).
-    private ContentResult HtmlAuthPage(string html)
+    // must not be framed (clickjacking), MIME-sniffed, cached, or leak its URL via Referer. A strict
+    // Content-Security-Policy locks it to a single nonce'd inline script and style and same-origin
+    // fetch/frame; the same per-response nonce is threaded into the rendered page via the delegate.
+    private ContentResult HtmlAuthPage(Func<string, string> render)
     {
+        var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+        Response.Headers["Content-Security-Policy"] = AuthPageCsp.Build(nonce);
         Response.Headers["X-Frame-Options"] = "DENY";
         Response.Headers["X-Content-Type-Options"] = "nosniff";
         Response.Headers["Referrer-Policy"] = "no-referrer";
         Response.Headers.CacheControl = "no-store";
-        return Content(html, MediaTypeNames.Text.Html);
+        return Content(render(nonce), MediaTypeNames.Text.Html);
     }
 }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1917,7 +1917,7 @@ public class SSOController : ControllerBase
     private ContentResult HtmlAuthPage(Func<string, string> render)
     {
         var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
-        Response.Headers["Content-Security-Policy"] = AuthPageCsp.Build(nonce);
+        Response.Headers.ContentSecurityPolicy = AuthPageCsp.Build(nonce);
         Response.Headers["X-Frame-Options"] = "DENY";
         Response.Headers["X-Content-Type-Options"] = "nosniff";
         Response.Headers["Referrer-Policy"] = "no-referrer";

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -14,17 +14,23 @@ public static class WebResponse
     public static readonly string Base = @"<!DOCTYPE html>
 <html><head>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
-<style>
+<style nonce=""{{NONCE}}"">
   body {
     background: #101010;
     color: #d1cfce;
     font-family: Noto Sans, Noto Sans HK, Noto Sans JP, Noto Sans KR, Noto Sans SC, Noto Sans TC, sans-serif;
   }
+  #iframe-main {
+    position: absolute;
+    width: 0;
+    height: 0;
+    border: 0;
+  }
 </style>
 </head><body>
 <p>Logging in...</p>
 <noscript>Please enable Javascript to complete the login</noscript>
-<script>
+<script nonce=""{{NONCE}}"">
 
 function isTv() {
     // This is going to be really difficult to get right
@@ -412,9 +418,10 @@ const sleep = (milliseconds) => {
     /// <param name="provider">The name of the provider to callback to.</param>
     /// <param name="baseUrl">The base URL of the Jellyfin installation.</param>
     /// <param name="mode">The mode of the function; SAML or OID.</param>
+    /// <param name="nonce">The per-response CSP nonce emitted on the inline script and style tags.</param>
     /// <param name="isLinking">Whether or not this request is to link accounts (Rather than authenticate).</param>
     /// <returns>A string with the HTML to serve to the client.</returns>
-    public static string Generator(string data, string provider, string baseUrl, string mode, bool isLinking = false)
+    public static string Generator(string data, string provider, string baseUrl, string mode, string nonce, bool isLinking = false)
     {
         System.ArgumentNullException.ThrowIfNull(baseUrl);
 
@@ -430,7 +437,7 @@ const sleep = (milliseconds) => {
         // the script context, then build every URL from these constants rather than interpolating
         // raw. punycodeBaseUrl derives from the request host, and provider from the route, so both
         // are treated as untrusted here (defense-in-depth); mode is a fixed literal.
-        return Base + @"
+        return Base.Replace("{{NONCE}}", nonce, System.StringComparison.Ordinal) + @"
 const ssoBaseUrl = " + JsonSerializer.Serialize(punycodeBaseUrl) + @";
 const ssoProvider = " + JsonSerializer.Serialize(provider) + @";
 const ssoMode = " + JsonSerializer.Serialize(mode) + @";
@@ -535,6 +542,6 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 // https://stackoverflow.com/a/25435165
-</script><iframe id='iframe-main' class='docs-texteventtarget-iframe' sandbox='allow-same-origin allow-forms allow-scripts' src='' style='position: absolute;width:0;height:0;border:0;'></iframe></body></html>";
+</script><iframe id='iframe-main' sandbox='allow-same-origin allow-forms allow-scripts' src=''></iframe></body></html>";
     }
 }


### PR DESCRIPTION
## What & why

The auth-completion page (`WebResponse.Generator`) completes SSO login in the browser from an inline `<script>` and inline `<style>`, and carried no `Content-Security-Policy` (tracked from #122, which set the other auth-page headers). This adds a strict, nonce-based CSP.

- A **128-bit CSPRNG nonce** is minted per response in `HtmlAuthPage` (`RandomNumberGenerator.GetBytes(16)`), emitted on the `<script>` and `<style>` tags **and** in the header, so only the page's own inline script/style run.
- New pure helper **`AuthPageCsp.Build(nonce)`** builds the policy: `default-src 'none'; script-src 'nonce-…'; style-src 'nonce-…'; connect-src 'self'; img-src 'self' data:; frame-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'`.
- `HtmlAuthPage` now takes a `Func<string,string>` render delegate, so the header nonce and the page nonce are always the same value; both OID and SAML callers go through it.
- The iframe's former inline `style='position:absolute;…'` moved into the nonce'd `<style>` (`#iframe-main`), a nonce covers `<style>`/`<script>` **elements** but not inline `style=""` **attributes**; a dead `docs-texteventtarget-iframe` copy-paste class was dropped.

**Why `connect-src`/`frame-src 'self'` are safe under Scheme/Port/BaseUrl overrides:** the flow shares `localStorage` between the page and the `/web/index.html` iframe (origin-partitioned), so a cross-origin base URL cannot complete login regardless of CSP, every working deployment is already same-origin.

## Type of change
- [x] Security hardening
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Security
- [x] Login-path change → adversarial-review gate run (see Notes).
- [x] Fail-closed: no `unsafe-inline`/`unsafe-eval`/`strict-dynamic`; a missing/blank nonce would block the script, not open it.
- [x] Nonce is per-response, 128-bit CSPRNG, never reused; `Cache-Control: no-store` prevents cross-user reuse.

## Quality
- [x] Pure, single-responsibility helper behind the controller; minimal diff.
- [x] 5 new unit tests (`AuthPageCspTests`, nonce emission + no-inline-style assertions).

## Verification
- [x] `dotnet build` (Debug, `--warnaserror`) clean; `dotnet test` 473 passing (+5).
- [ ] **Real-server E2E required** (browser flow, CI cannot exercise it): confirm OID + SAML login and account-linking still complete with the CSP active. Tracked on the E2E checklist.

## Notes

**Adversarial-review gate, 5 lenses (login path, browser JS), all PASS:** availability/mass-lockout (the same-origin invariant is enforced by localStorage partitioning independent of the CSP; no working user class is locked out; only pre-2015 nonce-blind engines that already can't run Jellyfin 10.11 are affected), bypass (128-bit per-response nonce, base-uri/form-action/frame-ancestors covered, base64 nonce can't break out of the attribute or header, no leakage), correctness (directives match the page's actual behavior, 2 placeholders replaced with the same value in header and both tags, both callers wired), integration (header emitted once, same-origin iframe/XHR handshake and 0×0 hidden iframe preserved), correctness-parity (OID + SAML both render only through `HtmlAuthPage`, one nonce per response, linking XHR same-origin). Browser JS → the gate is the primary verification.

Closes #123
