### PR TITLE
Skip zizmor SARIF upload on fork and Dependabot PRs

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -59,9 +59,11 @@ jobs:
         # Only upload where the GITHUB_TOKEN can write security events: pushes to main
         # and same-repo human PRs. Fork and Dependabot pull requests run with a
         # read-only token, so the upload is skipped there — the gate step below still
-        # runs and blocks on findings. (This runs before the gate, so no always() is
-        # needed; the gate's pass/fail is independent of the upload.)
+        # runs and blocks on findings. continue-on-error keeps the security gate
+        # independent of the upload: a transient code-scanning upload failure must not
+        # skip the "Fail on actionable findings" step below.
         if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -35,7 +35,6 @@ jobs:
     permissions:
       security-events: write # upload the SARIF into the code-scanning tab
       contents: read
-      actions: read
     env:
       ZIZMOR_VERSION: "1.26.1"
     steps:
@@ -57,7 +56,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload SARIF
-        if: always() # publish findings even when the gate below fails the build
+        # Only upload where the GITHUB_TOKEN can write security events: pushes to main
+        # and same-repo human PRs. Fork and Dependabot pull requests run with a
+        # read-only token, so the upload is skipped there — the gate step below still
+        # runs and blocks on findings. (This runs before the gate, so no always() is
+        # needed; the gate's pass/fail is independent of the upload.)
+        if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -62,7 +62,7 @@ jobs:
         # runs and blocks on findings. continue-on-error keeps the security gate
         # independent of the upload: a transient code-scanning upload failure must not
         # skip the "Fail on actionable findings" step below.
-        if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -61,7 +61,7 @@ jobs:
         # read-only token, so the upload is skipped there — the gate step below still
         # runs and blocks on findings. (This runs before the gate, so no always() is
         # needed; the gate's pass/fail is independent of the upload.)
-        if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+        if: github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What & why

Follow-up to #144. The zizmor workflow runs on `pull_request: [**]`, but the **Upload SARIF** step needs `security-events: write`, and **fork and Dependabot pull requests run with a read-only `GITHUB_TOKEN`**. So on every such PR the upload step failed and reddened the whole `zizmor` check before the gate even ran, most visibly, every Dependabot PR would show a failing zizmor check.

Fix, implementing three CodeRabbit review-body findings on #262 that surfaced after that PR merged:

- **Restrict the SARIF upload to contexts whose token can write security events**, pushes to `main` and same-repo human PRs. Fork and Dependabot PRs skip the upload; the **Fail on actionable findings** gate still runs and blocks on real findings everywhere.
- **Drop `always()`**, the upload runs before the gate, so `always()` never helped that failure path; it only forced an upload of a possibly-broken SARIF when the audit step itself errored.
- **Drop `actions: read`**, not required for `upload-sarif` on a public repo (least privilege).

## Type of change
- [x] Security hardening / supply-chain (CI)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Security
- [x] Fail-closed preserved: the gate step (`--strict-collection --min-severity=low`) runs on all triggers and blocks on findings; only the non-gating SARIF upload is conditioned.
- [x] Least privilege: removes an unused token scope.

## Quality
- [x] Minimal: one `if:` condition + two removals.

## Verification
- [x] The zizmor check on this PR is the empirical verification (same-repo PR → the upload path still runs and must stay green).

## Notes

The upload condition is `github.event_name == 'push' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')`, true for pushes and same-repo non-Dependabot PRs, false for forks and Dependabot. GitHub expressions null-chain safely, so `github.event.pull_request.*` on a push event evaluates to empty without error.

Process note: these three findings lived only in CodeRabbit's "outside diff range" review-body blocks on #262 and were missed at merge; captured as a review-enumeration lesson.

Refs #144
