### PR TITLE
Reset SSO config toggles when switching providers

### DIFF
--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -254,7 +254,12 @@ const ssoConfigurationPage = {
         });
 
         form_elements.check_fields.forEach((id) => {
-          if (provider[id]) page.querySelector("#" + id).checked = provider[id];
+          // Always set the checkbox from the loaded provider so switching providers
+          // resets stale toggles. Setting it only when truthy left a previous
+          // provider's checked box in place, which a later save could silently
+          // persist as true — a security downgrade for toggles like
+          // DoNotValidateEndpoints / DisableHttps.
+          page.querySelector("#" + id).checked = Boolean(provider[id]);
         });
 
         form_elements.role_map_fields.forEach((id) => {


### PR DESCRIPTION
## What & why

`loadProvider` in `config.js` set a `.sso-toggle` checkbox's `.checked` only when the loaded provider's stored value was truthy, and never reset it. Switching (in the admin UI) from a provider that has a security toggle checked, `DisableHttps`, `DoNotValidateEndpoints`, `DoNotValidateIssuerName`, `DoNotValidateResponseIssuer`, to one without a stored value left the box visually checked; the save path reads `.checked` verbatim, so a subsequent save **silently persisted `true`** for the second provider. That is a silent security downgrade (validation disabled / HTTPS not enforced for a provider the admin never configured that way).

Fix: set `.checked = Boolean(provider[id])` unconditionally in the `check_fields` loop, so every provider switch/add resets each toggle to the loaded provider's actual value (`false` when unset, the secure default). Load and save are now symmetric over the same `.sso-toggle` set.

## Type of change
- [x] Bug fix (config UI)
- [x] Security hardening (prevents silent persistence of a validation-disabling flag)
- [ ] New feature
- [ ] Breaking change

## Security
- [x] Config-persistence surface → adversarial-review gate run (see Notes).
- [x] Fail-closed default: an unset toggle now resolves to `false` (HTTPS enforced, validation on).

## Quality
- [x] Minimal: one line + an explaining comment; the sibling non-toggle loops are deliberately untouched.

## Verification
- [x] Prettier clean (`config.js`).
- [ ] Browser JS → CI cannot exercise the config UI; the gate is the primary verification. Manual check on the E2E checklist: switch providers, confirm toggles reset and a save persists the reset value.

## Notes

**Adversarial-review gate, 3 lenses (config persistence of security toggles), all PASS:** correctness (`Boolean(provider[id])` resets stale→false and preserves stored→true; every `check_fields` element is guaranteed non-null; no truthy mis-mapping), bypass (covers all four security toggles; closes both the visual and the persisted downgrade; introduces no opposite risk of silently disabling a legitimately-true toggle; `false` is the secure default), integration (fits the load/save lifecycle, reflects through the `emby-checkbox` component without a `change` event, no regression to the sibling `json_fields`/`folder_list_fields`/`role_map_fields` loops).

One out-of-scope residual the gate noted: the *add-new-provider* flow doesn't call `loadProvider`, so a brand-new provider inherits on-screen checkbox state, pre-existing, admin-visible, unchanged by this diff, not the reported bug.

Closes #211
