### PR TITLE
Expand the public AI-and-contributions note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,8 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
+Before opening a pull request, please read the **[note on AI and on contributions](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md#-a-note-on-ai-and-on-contributions)** in the README. This is a security-sensitive login path: every change is issue-driven, adversarially reviewed on the login path, and documented before it merges, and you are expected to understand and own every line you propose — a pull request that is unreviewed AI output will be turned away.
+
 ### Improving The Documentation
 
 <!-- TODO

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 
 > ### 🤖 A note on AI and on contributions
 >
-> The maintainer is a non-native English speaker, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) is used to **translate documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments.
+> The maintainer is a non-native English speaker, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) assists him in two ways: it **translates documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments — and it **helps generate and analyse code** during development.
 >
-> - **A human reviews it.** Every AI-translated text is reviewed and edited by the maintainer before it lands; he holds responsibility for it.
+> - **A human owns and reviews everything.** Claude never produces finished code, a complete pull request, or any other artifact that lands unexamined. Every AI-assisted change — translated text or code — is reviewed, understood, edited, and evaluated by the maintainer before it merges; he holds responsibility for it. The AI proposes; the human decides.
 > - **The AI is not in the product.** It plays **no role at runtime**, in authentication, or in processing your users' data.
+>
+> The review discipline around this is modelled — as far as is practical for a volunteer project — on the change-control expected of **TÜV/BSI-certified software in critical sectors such as healthcare**: every change is issue-driven, adversarially reviewed on the login path, and documented before it merges. It is an approximation of that practice, not a certification.
 >
 > Provided in the spirit of transparent AI use, in line with the EU AI Act's transparency principles (Art. 50).
 >


### PR DESCRIPTION
## What & why

Expands the public AI-disclosure note in the README, and points CONTRIBUTING at it.

The note previously framed Claude's role as documentation/comment translation only. It now also discloses, transparently, that Claude **assists with generating and analysing code** during development, while stating clearly that:

- Claude **never** produces finished code, a complete pull request, or any artifact that lands unexamined;
- **everything** Claude produces (text or code) is reviewed, understood, edited, and evaluated by hand before it merges, and I hold responsibility for it, the AI proposes, I decide;
- the AI plays **no role in the product** (runtime/auth/user data).

It also frames the review discipline as modelled, as far as is practical for a volunteer project, on the change-control expected of **TÜV/BSI-certified software in critical sectors such as healthcare** (an approximation, explicitly not a certification claim), and keeps the EU AI Act Art. 50 transparency line and the "don't vibe-code / own every line" contribution note.

## Changes (every item)

- `README.md`, "A note on AI and on contributions": added the code generation+analysis disclosure and the "human owns/reviews/evaluates everything, AI never lands unexamined" bullet; added the TÜV/BSI critical-sector framing paragraph.
- `CONTRIBUTING.md`, "Your First Code Contribution": added a pointer to the README note and the review rigor before opening a PR.



## Type of change
- [x] Documentation
- [ ] Bug fix / feature / breaking

## Verification
- [x] Prettier clean (`README.md`, `CONTRIBUTING.md`).
- [x] Docs-only; no code or behavior change.

## Notes
Transparent AI-use disclosure per EU AI Act Art. 50. No runtime/product impact.

Closes #267