### PR TITLE
Make the CanonicalLinks getter self-healing

### DIFF
--- a/SSO-Auth.Tests/CanonicalLinksSelfHealingTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinksSelfHealingTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the self-healing <c>CanonicalLinks</c> getter (#239): a direct
+/// <c>CanonicalLinks[key] = id</c> must persist into the stored map, not a throwaway. Before the fix
+/// the getter returned a fresh empty map while the backing field was null, so the write was silently
+/// lost — login-critical account-link state.
+/// </summary>
+public class CanonicalLinksSelfHealingTests
+{
+    private static readonly Guid User = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public void OidConfig_DirectWrite_Persists()
+    {
+        var config = new OidConfig();
+
+        config.CanonicalLinks["sub-1"] = User;
+
+        Assert.True(config.CanonicalLinks.ContainsKey("sub-1"));
+        Assert.Equal(User, config.CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public void SamlConfig_DirectWrite_Persists()
+    {
+        var config = new SamlConfig();
+
+        config.CanonicalLinks["nameid-1"] = User;
+
+        Assert.True(config.CanonicalLinks.ContainsKey("nameid-1"));
+        Assert.Equal(User, config.CanonicalLinks["nameid-1"]);
+    }
+
+    [Fact]
+    public void CanonicalLinks_ReturnsTheSameInstanceAcrossReads()
+    {
+        var config = new OidConfig();
+
+        // Two reads return the one stored map, not a fresh throwaway each time.
+        Assert.Same(config.CanonicalLinks, config.CanonicalLinks);
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1028,14 +1028,13 @@ public class SSOController : ControllerBase
         });
     }
 
-    // Applies a mutation to a provider's canonical-links map on the LIVE configuration, reassigning the
-    // map so a lazily-created (previously-null) one is persisted. Runs inside MutateConfiguration, so the
-    // whole read-modify-write is serialized and concurrent first-logins cannot lose each other's links.
+    // Applies a mutation to a provider's canonical-links map on the LIVE configuration. The map is
+    // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
+    // directly. Runs inside MutateConfiguration, so the read-modify-write is serialized and concurrent
+    // first-logins cannot lose each other's links.
     private static void MutateLinks(PluginConfiguration configuration, string mode, string provider, Action<SerializableDictionary<string, Guid>> mutate)
     {
-        var links = GetLinks(configuration, mode, provider);
-        mutate(links);
-        SetLinks(configuration, mode, provider, links);
+        mutate(GetLinks(configuration, mode, provider));
     }
 
     // The provider's canonical-links map; callers must hold the config lock (ReadConfiguration /
@@ -1048,23 +1047,6 @@ public class SSOController : ControllerBase
             "oid" => configuration.OidConfigs[provider].CanonicalLinks,
             _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
         };
-    }
-
-    // Reassigns a provider's canonical-links map, so a lazily-created (previously-null) map is
-    // persisted. Pairs with GetLinks; both must run under the config lock.
-    private static void SetLinks(PluginConfiguration configuration, string mode, string provider, SerializableDictionary<string, Guid> links)
-    {
-        switch (mode.ToLowerInvariant())
-        {
-            case "saml":
-                configuration.SamlConfigs[provider].CanonicalLinks = links;
-                break;
-            case "oid":
-                configuration.OidConfigs[provider].CanonicalLinks = links;
-                break;
-            default:
-                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
-        }
     }
 
     private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
@@ -1178,7 +1160,6 @@ public class SSOController : ControllerBase
             if (wroteLink)
             {
                 links[canonicalKey] = effectiveUserId;
-                SetLinks(configuration, mode, provider, links);
             }
 
             return (effectiveUserId, wroteLink);

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -227,15 +227,11 @@ public class SamlConfig : ProviderConfigBase
     [System.Text.Json.Serialization.JsonIgnore]
     public SerializableDictionary<string, Guid> CanonicalLinks
     {
-        get
-        {
-            if (_canonicalLinks == null)
-            {
-                return new SerializableDictionary<string, Guid>();
-            }
-
-            return _canonicalLinks;
-        }
+        // Self-healing lazy init: the backing map is created and stored on first access, so a direct
+        // `CanonicalLinks[key] = id` persists into the stored map instead of a discarded throwaway.
+        // Every access runs under the config lock (ReadConfiguration/MutateConfiguration), so the
+        // assignment cannot race; an empty map serializes the same as the old throwaway did.
+        get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();
         set => _canonicalLinks = value;
     }
 }
@@ -386,15 +382,11 @@ public class OidConfig : ProviderConfigBase
     [System.Text.Json.Serialization.JsonIgnore]
     public SerializableDictionary<string, Guid> CanonicalLinks
     {
-        get
-        {
-            if (_canonicalLinks == null)
-            {
-                return new SerializableDictionary<string, Guid>();
-            }
-
-            return _canonicalLinks;
-        }
+        // Self-healing lazy init: the backing map is created and stored on first access, so a direct
+        // `CanonicalLinks[key] = id` persists into the stored map instead of a discarded throwaway.
+        // Every access runs under the config lock (ReadConfiguration/MutateConfiguration), so the
+        // assignment cannot race; an empty map serializes the same as the old throwaway did.
+        get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();
         set => _canonicalLinks = value;
     }
 


### PR DESCRIPTION
## What & why

`SamlConfig.CanonicalLinks` and `OidConfig.CanonicalLinks` returned a **fresh empty map on every read** while the backing field was null, so the natural `config.CanonicalLinks[key] = id` wrote into a **discarded throwaway** and was silently lost. Canonical links are login-critical account-link state (SSO login resolves a user through these per-provider maps), and nothing errored when a write vanished. The code was only correct through compensating plumbing that re-assigned the map after every mutation (`SetLinks`), so any future caller that skipped the detour hit the trap.

Fix: make the getter **self-healing**, `get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();`, so first access creates *and stores* the map and every direct access persists into it. The compensators are removed with it:

- `SetLinks` helper deleted entirely (0 remaining callers).
- `MutateLinks` simplified to `mutate(GetLinks(...))` (no re-assign).
- the `SetLinks` call in `LinkCanonicalIfAbsent` dropped.

Net **~27 lines of fragile plumbing removed** from the controller; the semantics fix lives in the property. (Distinct from the #204 property-dedup; both `SamlConfig`/`OidConfig` copies are fixed identically here.)

## Type of change
- [x] Bug fix (config persistence, login path)
- [x] Quality (dead-plumbing removal)
- [ ] Breaking

## Security
- [x] Config-persistence on the login path → adversarial-review gate run (see Notes).
- [x] No semantic change to link resolution/adoption/revocation; self-healing only ever allocates *empty* maps, never plants a link.

## Quality
- [x] Removes duplicated compensating plumbing; the invariant now lives once in the property.

## Verification
- [x] `dotnet build` (Debug, `--warnaserror`) clean; `dotnet test` 476 passing (+3 self-healing tests: direct-write-persists for both configs, same-instance-across-reads).

## Notes

**Adversarial-review gate, 4 lenses (config persistence, login path), all PASS:**
- **correctness**: the getter genuinely persists direct writes; every `SetLinks` removal is safe because all mutations already land on the stored map via `GetLinks`; no caller relied on re-assigning a different instance (full-map replacement uses the setter directly, retained); XML byte-identical.
- **availability/mass-lockout**: `ConfigMutationLock` is an exclusive Monitor, `ReadConfiguration` and `MutateConfiguration` take the *same* lock, so there are no concurrent readers and the `??=` cannot race; no first-login link-loss window; lazy-init-on-read only ever stores a benign empty map.
- **bypass**: resolution/adoption (#155)/revocation (#213)/`[JsonIgnore]` withholding (#157) semantics untouched; only empty maps allocated.
- **integration**: empty stored map serializes identically to the prior throwaway; the setter and its remaining callers (re-injection at ~507/820, `PreserveServerManagedFields`) intact.

One documented forward-looking caveat (non-blocking): the getter now has a write-on-read side effect, so the config-lock invariant is load-bearing for the getter itself, any *future* off-lock read of `.CanonicalLinks` would be a lock-free read-modify-write. No such caller exists today; noted in the getter comment.

Closes #239
