### PR TITLE
Replace KeyNotFoundException control flow in the provider lookup with a null check

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -166,12 +166,8 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        OidConfig config;
-        try
-        {
-            config = GetOidConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        var config = FindOidConfig(provider);
+        if (config is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -275,15 +271,7 @@ public class SSOController : ControllerBase
         }
 
         Invalidate();
-        OidConfig config;
-        try
-        {
-            config = GetOidConfig(provider);
-        }
-        catch (KeyNotFoundException)
-        {
-            throw new ArgumentException(ProviderDoesNotExistMessage);
-        }
+        var config = FindOidConfig(provider) ?? throw new ArgumentException(ProviderDoesNotExistMessage);
 
         if (config.Enabled)
         {
@@ -351,17 +339,17 @@ public class SSOController : ControllerBase
         throw new ArgumentException(ProviderDoesNotExistMessage);
     }
 
-    // Reads a provider's config under the config lock, so an anonymous login-path index does not race an
+    // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
     // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
-    // Throws KeyNotFoundException for an unknown provider, exactly as the direct index did, so the existing
-    // catch at each call site is unchanged. An uncontended lock is nanoseconds; it is only held long during
-    // a first-login/admin persist, which is exactly when a consistent read matters.
-    private static OidConfig GetOidConfig(string provider) =>
-        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs[provider]);
+    // Returns null for an unknown provider so call sites branch on a null check instead of catching
+    // KeyNotFoundException as control flow (#241). An uncontended lock is nanoseconds; it is only held long
+    // during a first-login/admin persist, which is exactly when a consistent read matters.
+    private static OidConfig FindOidConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs.TryGetValue(provider, out var config) ? config : null);
 
-    private static SamlConfig GetSamlConfig(string provider) =>
-        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs[provider]);
+    private static SamlConfig FindSamlConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
 
     // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
@@ -611,12 +599,8 @@ public class SSOController : ControllerBase
             return BadRequest("Missing data");
         }
 
-        OidConfig config;
-        try
-        {
-            config = GetOidConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        var config = FindOidConfig(provider);
+        if (config is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -682,12 +666,8 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        SamlConfig config;
-        try
-        {
-            config = GetSamlConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        var config = FindSamlConfig(provider);
+        if (config is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -752,15 +732,7 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        SamlConfig config;
-        try
-        {
-            config = GetSamlConfig(provider);
-        }
-        catch (KeyNotFoundException)
-        {
-            throw new ArgumentException(ProviderDoesNotExistMessage);
-        }
+        var config = FindSamlConfig(provider) ?? throw new ArgumentException(ProviderDoesNotExistMessage);
 
         if (config.Enabled)
         {
@@ -871,12 +843,8 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        SamlConfig config;
-        try
-        {
-            config = GetSamlConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        var config = FindSamlConfig(provider);
+        if (config is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -1364,12 +1332,8 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     private ActionResult SamlLink(string provider, Guid jellyfinUserId, AuthResponse response)
     {
-        SamlConfig config;
-        try
-        {
-            config = GetSamlConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        var config = FindSamlConfig(provider);
+        if (config is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -1413,12 +1377,7 @@ public class SSOController : ControllerBase
             return BadRequest("Missing data");
         }
 
-        try
-        {
-            // Touch the indexer only to verify the provider exists; it throws if it does not.
-            _ = GetOidConfig(provider);
-        }
-        catch (KeyNotFoundException)
+        if (FindOidConfig(provider) is null)
         {
             return BadRequest(NoMatchingProviderMessage);
         }


### PR DESCRIPTION
## What & why

#252 routed the provider-config lookup through the config lock via `GetOidConfig`/`GetSamlConfig`, but those used the **dictionary indexer**, which throws `KeyNotFoundException` for an unknown provider, so **eight call sites** each wrapped the read in `try/catch(KeyNotFoundException)` to map it to an error. This removes that exception-as-control-flow.

- Helpers switched to `TryGetValue` returning `null` (`FindOidConfig`/`FindSamlConfig`); the read still runs inside `ReadConfiguration`.
- The 8 call sites branch on a **null check**, each preserving its **exact prior error shape**:
  - `return BadRequest(NoMatchingProviderMessage)` on the callback/utility endpoints (5 config sites + 1 existence-only `OidLink`),
  - `?? throw new ArgumentException(ProviderDoesNotExistMessage)` on the 2 challenge endpoints.
- The two `catch(KeyNotFoundException)` blocks around `MutateLinks`/`GetLinks` are **deliberately left**, `GetLinks` still indexes the provider dictionary, so that throw stays (out of #241's scope).

Net **−41 lines**, and `KeyNotFoundException` is no longer used as control flow for the routine unknown-provider case.

## Type of change
- [x] Quality / refactor (login path)
- [ ] Bug fix / feature / breaking

## Security
- [x] Login-path change → adversarial-review gate run (see Notes).
- [x] No semantic change: unknown-provider rejection preserved on every site; read stays under the config lock.

## Quality
- [x] Removes duplicated exception-handling; `−41` lines.

## Verification
- [x] `dotnet build` (Debug, `--warnaserror`) clean; `dotnet test` 476 passing (unchanged, behavior-preserving).

## Notes

**Adversarial-review gate, 4 lenses (login path), all PASS:**
- **correctness**: every rewritten site byte-equivalent for unknown and known providers; `?? throw` sites leave `config` non-null; the existence-only site references no missing var; the two out-of-scope catches correctly retained.
- **bypass**: `TryGetValue`-returns-null is semantically identical to indexer-throws under the same lock; every null branch hard-returns/throws (no fall-through); no attacker-controllable differential (same comparer; `null` provider still fails in both).
- **integration**: challenge-site `ArgumentException` propagates identically in the same scope; the untouched catches still catch the intact `GetLinks` indexer throw; no dead const/import (build 0/0 under warnaserror).
- **availability**: six 400s + two `ArgumentException`s preserved; no new throw or lockout path; happy path unchanged.

Closes #241
