### PR TITLE
Extract GetRequestBase's URL derivation into CanonicalBaseUrl.Resolve

### DIFF
--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -143,11 +143,13 @@ public class CanonicalBaseUrlTests
         Assert.Equal("https://host.example.com:8443", result);
     }
 
-    [Fact]
-    public void Resolve_PathBase_IsKept_AndTrailingSlashTrimmed()
+    [Theory]
+    [InlineData("/jellyfin", "https://host.example.com/jellyfin")] // path base kept
+    [InlineData("/jellyfin/", "https://host.example.com/jellyfin")] // trailing slash trimmed
+    public void Resolve_PathBase_IsKept_AndTrailingSlashTrimmed(string pathBase, string expected)
     {
-        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, "/jellyfin", null, null);
+        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, pathBase, null, null);
 
-        Assert.Equal("https://host.example.com/jellyfin", result);
+        Assert.Equal(expected, result);
     }
 }

--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -89,4 +89,65 @@ public class CanonicalBaseUrlTests
     {
         SSOController.RejectInvalidBaseUrlOverride(raw);
     }
+
+    // Resolve (#242): the base-URL decision GetRequestBase used to make inline against the live Request.
+    // A valid override is authoritative and returned verbatim; otherwise the request-derived host fallback
+    // applies (default-port elision, scheme-override allowlist, path-base + trailing-slash handling).
+
+    [Fact]
+    public void Resolve_ValidOverride_IsAuthoritative_IgnoresRequestValues()
+    {
+        var result = CanonicalBaseUrl.Resolve("https://canonical.example.com/", "http", "spoofed.host", 8096, "/pathbase", "http", 1234);
+
+        Assert.Equal("https://canonical.example.com", result);
+    }
+
+    [Fact]
+    public void Resolve_MalformedNonBlankOverride_ThrowsFailClosed()
+    {
+        Assert.Throws<System.InvalidOperationException>(
+            () => CanonicalBaseUrl.Resolve("ftp://bad", "https", "host.example.com", 443, "", null, null));
+    }
+
+    [Theory]
+    [InlineData("http", 80, "http://host.example.com")] // default http port elided
+    [InlineData("https", 443, "https://host.example.com")] // default https port elided
+    [InlineData("https", 80, "https://host.example.com:80")] // non-default for the scheme kept
+    [InlineData("http", 8096, "http://host.example.com:8096")] // custom port kept
+    public void Resolve_BlankOverride_ElidesDefaultPortOnly(string scheme, int port, string expected)
+    {
+        var result = CanonicalBaseUrl.Resolve(null, scheme, "host.example.com", port, string.Empty, null, null);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("http", "http://host.example.com")] // literal http honored
+    [InlineData("https", "https://host.example.com")] // literal https honored
+    [InlineData("ftp", "https://host.example.com")] // anything else falls back to the request scheme
+    [InlineData("HTTP", "https://host.example.com")] // case-sensitive: not honored
+    [InlineData("", "https://host.example.com")]
+    public void Resolve_SchemeOverride_OnlyLiteralHttpOrHttpsHonored(string schemeOverride, string expected)
+    {
+        // Request scheme is https, port 443 (elided) so only the scheme decision shows.
+        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, string.Empty, schemeOverride, null);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Resolve_PortOverride_WinsOverRequestPort()
+    {
+        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, string.Empty, null, 8443);
+
+        Assert.Equal("https://host.example.com:8443", result);
+    }
+
+    [Fact]
+    public void Resolve_PathBase_IsKept_AndTrailingSlashTrimmed()
+    {
+        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, "/jellyfin", null, null);
+
+        Assert.Equal("https://host.example.com/jellyfin", result);
+    }
 }

--- a/SSO-Auth/Api/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/CanonicalBaseUrl.cs
@@ -61,4 +61,57 @@ internal static class CanonicalBaseUrl
     /// <returns><see langword="true"/> if the value is set but not a valid base URL.</returns>
     internal static bool IsInvalidOverride(string raw)
         => !string.IsNullOrWhiteSpace(raw) && !TryNormalize(raw, out _);
+
+    /// <summary>
+    /// Resolves the external base URL that every derived <c>redirect_uri</c> and SAML base is built on.
+    /// A configured <paramref name="baseUrlOverride"/> is authoritative (#139) — it removes the
+    /// dependency on the spoofable request <c>Host</c>. A malformed override is rejected at every admin
+    /// write path, so it should never reach here; if one does (a hand-edited or restored config), this
+    /// fails closed rather than silently reverting to the untrusted request host. Only a blank override
+    /// uses the request-derived fallback: the default port (80 on http, 443 on https) is elided, only a
+    /// literal <c>"http"</c>/<c>"https"</c> scheme override is honored (anything else falls back to the
+    /// request scheme), and the trailing slash is trimmed so the result concatenates cleanly with
+    /// <c>/sso/...</c>.
+    /// </summary>
+    /// <param name="baseUrlOverride">The configured canonical base URL, or blank to use the request.</param>
+    /// <param name="scheme">The request scheme.</param>
+    /// <param name="host">The request host (no port).</param>
+    /// <param name="port">The request port, or null.</param>
+    /// <param name="pathBase">The request path base.</param>
+    /// <param name="schemeOverride">The per-provider scheme override, or null.</param>
+    /// <param name="portOverride">The per-provider port override, or null.</param>
+    /// <returns>The external base URL, without a trailing slash.</returns>
+    internal static string Resolve(string baseUrlOverride, string scheme, string host, int? port, string pathBase, string schemeOverride, int? portOverride)
+    {
+        if (!string.IsNullOrWhiteSpace(baseUrlOverride))
+        {
+            if (TryNormalize(baseUrlOverride, out var canonical))
+            {
+                return canonical;
+            }
+
+            throw new InvalidOperationException("The configured Base URL override is not a valid absolute http(s) URL.");
+        }
+
+        var requestPort = portOverride ?? port ?? -1;
+
+        if ((requestPort == 80 && string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase))
+            || (requestPort == 443 && string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase)))
+        {
+            requestPort = -1;
+        }
+
+        if (!string.Equals(schemeOverride, "http", StringComparison.Ordinal) && !string.Equals(schemeOverride, "https", StringComparison.Ordinal))
+        {
+            schemeOverride = null;
+        }
+
+        return new UriBuilder
+        {
+            Scheme = schemeOverride ?? scheme,
+            Host = host,
+            Port = requestPort,
+            Path = pathBase,
+        }.ToString().TrimEnd('/');
+    }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1792,53 +1792,9 @@ public class SSOController : ControllerBase
         return buffer;
     }
 
-    private string GetRequestBase(string schemeOverride = null, int? portOverride = null, string baseUrlOverride = null)
-    {
-        // A configured canonical base URL is authoritative: it removes the dependency on the request
-        // Host (spoofable behind a proxy forwarding X-Forwarded-Host), so redirect_uri and the SAML base
-        // cannot be poisoned (#139). A malformed value is rejected at every admin write path (the config
-        // page via UpdateConfiguration, and OID/SAML Add via RejectInvalidBaseUrlOverride), so it should
-        // never reach here. If one does anyway (a hand-edited or restored config), fail closed rather than
-        // silently reverting to the spoofable request Host: only a blank override uses the host fallback.
-        if (!string.IsNullOrWhiteSpace(baseUrlOverride))
-        {
-            if (CanonicalBaseUrl.TryNormalize(baseUrlOverride, out var canonical))
-            {
-                return canonical;
-            }
-
-            throw new InvalidOperationException("The configured Base URL override is not a valid absolute http(s) URL.");
-        }
-
-        int requestPort;
-
-        if (portOverride != null)
-        {
-            requestPort = portOverride.Value;
-        }
-        else
-        {
-            requestPort = Request.Host.Port ?? -1;
-        }
-
-        if ((requestPort == 80 && string.Equals(Request.Scheme, "http", StringComparison.OrdinalIgnoreCase)) || (requestPort == 443 && string.Equals(Request.Scheme, "https", StringComparison.OrdinalIgnoreCase)))
-        {
-            requestPort = -1;
-        }
-
-        if (!string.Equals(schemeOverride, "http", StringComparison.Ordinal) && !string.Equals(schemeOverride, "https", StringComparison.Ordinal))
-        {
-            schemeOverride = null;
-        }
-
-        return new UriBuilder
-        {
-            Scheme = schemeOverride ?? Request.Scheme,
-            Host = Request.Host.Host,
-            Port = requestPort,
-            Path = Request.PathBase
-        }.ToString().TrimEnd('/');
-    }
+    // Thin wrapper feeding the live request values into the pure CanonicalBaseUrl.Resolve decision (#242).
+    private string GetRequestBase(string schemeOverride = null, int? portOverride = null, string baseUrlOverride = null) =>
+        CanonicalBaseUrl.Resolve(baseUrlOverride, Request.Scheme, Request.Host.Host, Request.Host.Port, Request.PathBase, schemeOverride, portOverride);
 
     private static ContentResult ReturnError(int code, string message)
     {


### PR DESCRIPTION
## What & why

`GetRequestBase` derives the external base URL every OpenID `redirect_uri` and the SAML base (feeding `ExpectedAcsUrls`, the exact strings callback comparisons validate against) is built on. Its **host-fallback decision**, default-port elision, the literal-`http`/`https` scheme-override allowlist, and the path-base + trailing-slash handling, was inline and **untestable** because it read `Request` directly. The configured-override half already lived in the tested `CanonicalBaseUrl.TryNormalize`, so the seam was half-cut.

Move the whole decision into a pure **`CanonicalBaseUrl.Resolve(baseUrlOverride, scheme, host, port, pathBase, schemeOverride, portOverride)`** and leave a one-expression wrapper feeding the live `Request` values. The branch matrix (port elision × scheme-override allowlist × path-base × override-authoritative/fail-closed) is now covered by **13 unit tests**.

## Type of change
- [x] Quality / refactor + test coverage (login path)
- [ ] Bug fix / feature / breaking

## Security
- [x] Login-path change (base URL → `redirect_uri` + SAML ACS) → adversarial-review gate run (see Notes).
- [x] Behavior-preserving: a valid override stays authoritative (request Host ignored), a malformed non-blank override still fails closed (throws), only a blank override uses the request host.

## Quality
- [x] Completes an existing helper; the request-reading is confined to a thin wrapper.

## Verification
- [x] `dotnet build` (Debug, `--warnaserror`) clean; `dotnet test` 489 passing (+13).

## Notes

**Adversarial-review gate, 4 lenses (login path), all PASS:**
- **correctness**: byte-equivalent across every input (port selection `portOverride ?? port ?? -1`, request-scheme-keyed default-port elision, Ordinal scheme allowlist, `UriBuilder`, `PathString`→`string` identical operator).
- **bypass**: override authoritative + fail-closed anti-Host-poisoning invariant preserved; no param path leaks the spoofable Host or injects via scheme/port override; `TryNormalize` remains the sole validator.
- **callers**: signature/return unchanged; the `InvalidOperationException` (identical message) surfaces at the same lazy per-request moment at all six call sites. Only delta: a behaviorally inert eager read of the (discarded) `Request` values in the override branch.
- **tests**: all 13 expectations recomputed byte-faithful (incl. the request-scheme-drives-elision subtlety); no load-bearing branch left uncovered.

Closes #242
