### PR TITLE
Elide the default port against the effective scheme, not the request scheme

### DIFF
--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -122,15 +122,28 @@ public class CanonicalBaseUrlTests
     }
 
     [Theory]
-    [InlineData("http", "http://host.example.com")] // literal http honored
-    [InlineData("https", "https://host.example.com")] // literal https honored
-    [InlineData("ftp", "https://host.example.com")] // anything else falls back to the request scheme
-    [InlineData("HTTP", "https://host.example.com")] // case-sensitive: not honored
-    [InlineData("", "https://host.example.com")]
+    [InlineData("http", "http://host.example.com:8096")] // literal http honored
+    [InlineData("https", "https://host.example.com:8096")] // literal https honored
+    [InlineData("ftp", "https://host.example.com:8096")] // anything else falls back to the request scheme
+    [InlineData("HTTP", "https://host.example.com:8096")] // case-sensitive: not honored
+    [InlineData("", "https://host.example.com:8096")]
     public void Resolve_SchemeOverride_OnlyLiteralHttpOrHttpsHonored(string schemeOverride, string expected)
     {
-        // Request scheme is https, port 443 (elided) so only the scheme decision shows.
-        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 443, string.Empty, schemeOverride, null);
+        // Non-default port so port elision does not mask the scheme decision.
+        var result = CanonicalBaseUrl.Resolve(null, "https", "host.example.com", 8096, string.Empty, schemeOverride, null);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("http", "https", 443, "https://host.example.com")] // TLS-terminating proxy: http request, https override, 443 elided
+    [InlineData("https", "http", 80, "http://host.example.com")] // symmetric: https request, http override, 80 elided
+    public void Resolve_ElidesDefaultPortForTheEffectiveScheme(string requestScheme, string schemeOverride, int port, string expected)
+    {
+        // The default-port elision must decide against the scheme that actually appears in the URL
+        // (schemeOverride), not the request scheme — otherwise the canonical URL keeps an explicit
+        // :443 / :80 (#272).
+        var result = CanonicalBaseUrl.Resolve(null, requestScheme, "host.example.com", port, string.Empty, schemeOverride, null);
 
         Assert.Equal(expected, result);
     }

--- a/SSO-Auth/Api/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/CanonicalBaseUrl.cs
@@ -93,22 +93,28 @@ internal static class CanonicalBaseUrl
             throw new InvalidOperationException("The configured Base URL override is not a valid absolute http(s) URL.");
         }
 
-        var requestPort = portOverride ?? port ?? -1;
-
-        if ((requestPort == 80 && string.Equals(scheme, "http", StringComparison.OrdinalIgnoreCase))
-            || (requestPort == 443 && string.Equals(scheme, "https", StringComparison.OrdinalIgnoreCase)))
-        {
-            requestPort = -1;
-        }
-
+        // Only a literal http/https scheme override is honored; anything else falls back to the request
+        // scheme. Resolve the effective scheme FIRST so the default-port elision below decides against the
+        // scheme that will actually appear in the URL (#272).
         if (!string.Equals(schemeOverride, "http", StringComparison.Ordinal) && !string.Equals(schemeOverride, "https", StringComparison.Ordinal))
         {
             schemeOverride = null;
         }
 
+        var effectiveScheme = schemeOverride ?? scheme;
+        var requestPort = portOverride ?? port ?? -1;
+
+        // Elide the default port for the EFFECTIVE scheme, so a TLS-terminating proxy (http request +
+        // schemeOverride=https + port 443) yields the canonical https://host, not https://host:443.
+        if ((requestPort == 80 && string.Equals(effectiveScheme, "http", StringComparison.OrdinalIgnoreCase))
+            || (requestPort == 443 && string.Equals(effectiveScheme, "https", StringComparison.OrdinalIgnoreCase)))
+        {
+            requestPort = -1;
+        }
+
         return new UriBuilder
         {
-            Scheme = schemeOverride ?? scheme,
+            Scheme = effectiveScheme,
             Host = host,
             Port = requestPort,
             Path = pathBase,

--- a/providers.md
+++ b/providers.md
@@ -108,6 +108,13 @@ Exact redirect-URI matching at the provider is the backstop, but it only helps i
   only if Jellyfin's **Known Proxies** is set **and** the proxy sends a trusted `X-Forwarded-Host`
   (not a client-supplied one). Known Proxies alone only decides which upstreams may supply forwarded
   headers — it does not by itself make a forwarded host trustworthy.
+- **Scheme override behind a TLS-terminating proxy (fallback path only):** when `SchemeOverride` sets a
+  scheme that differs from the one Jellyfin sees — a proxy terminates TLS, so Jellyfin receives `http`
+  while the public site is `https` — the derived `redirect_uri` and SAML base use the **canonical** form,
+  without the default port: `https://host`, not `https://host:443` (and, symmetrically, `http://host`,
+  not `http://host:80`). Register that canonical no-port form at your provider. If you previously pinned
+  an explicit `:443`/`:80` `redirect_uri` to work around the old port-in-URL behavior, switch it to the
+  no-port form.
 
 ## SAML response binding (optional hardening)
 


### PR DESCRIPTION
## What & why

The request-derived base URL (used only when there is no `BaseUrlOverride`) elided the default port by checking the **request** scheme, but applied the `SchemeOverride` allowlist afterwards and built the URL from `schemeOverride ?? scheme`. So when the effective scheme differed from the request scheme, the elision decided against the wrong one:

- a TLS-terminating proxy, request `http` + `SchemeOverride = https` + port `443`, produced `https://host:443` instead of the canonical `https://host`;
- symmetrically, request `https` + `SchemeOverride = http` + port `80` → `http://host:80`.

That base URL feeds the OpenID `redirect_uri` and the SAML base (the exact strings the callback comparisons validate against), so a non-canonical URL with an explicit port can mismatch what a provider is configured with.

Fix: resolve the effective scheme first (`schemeOverride` allowlist → `effective = schemeOverride ?? scheme`), then elide port 80 for `http` / 443 for `https` **against that effective scheme**.

## Type of change

- [x] Bug fix (login path)
- [x] Behavior change, see the migration note below

## Behavior change & migration

Only one path changes: the request-fallback (no `BaseUrlOverride`) **with** a `SchemeOverride` that differs from the request scheme **and** a resolved port that is the default of the override scheme. Everything else, no override, override equal to the request scheme, a non-default port, or a set `BaseUrlOverride`, is byte-identical to before.

For that one slice the emitted `redirect_uri`/SAML base changes from `https://host:443` (or `http://host:80`) to the canonical no-port form. A provider that normalizes default ports is unaffected; a deployment that pinned the explicit `:443`/`:80` form to work around the old behavior must switch its registered `redirect_uri` to the no-port form. `providers.md` documents this.

This still needs a short migration note in the release notes before it ships, because that narrow slice is a hard callback mismatch with no graceful fallback, affected setups should be told to re-register the canonical URL rather than discover a silent lockout on upgrade.

## Verification

- [x] `dotnet build` (Debug, `--warnaserror`) clean; `dotnet test` 492 passing (+2).
- [x] Prettier clean (`providers.md`).

## Notes

Adversarial-review gate, 4 lenses (login path). correctness / bypass / tests **PASS**: the common path is unchanged, the differing-scheme cases now elide against the scheme that actually appears in the URL, the authoritative fail-closed override branch and the admin-only scheme allowlist are untouched (no scheme/host/origin change, only the port), and the new tests recompute correctly (port-8096 isolation + both elision directions). availability **NEEDS_IMPROVEMENT**, not a code defect: the code is correct and net-positive, but the narrow slice is a hard-lockout risk that must be surfaced. Addressed by the `providers.md` migration note and the release-note callout flagged above.

Follow-up to #242 (which made this logic testable). Closes #272
