### PR TITLE
Point the plugin manifest and docs at this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Copy the **full publish output** (`SSO-Auth.dll` and every dependency DLL beside
 
 A packaged release installable from a plugin repository will be published once the hardening pass reaches its first release milestone.
 
+**Client support:** SSO sign-in runs in the Jellyfin **Web UI** and in clients that support **Quick Connect** (the mobile and TV apps drive the login through Quick Connect). A native client that does not support Quick Connect cannot complete the browser redirect flow — use the Web UI or a Quick Connect client there.
+
+**Coming from the old plugin repository?** This project is the maintained continuation of the archived `9p4/jellyfin-plugin-sso`. If your Jellyfin still points at the old `9p4` manifest, it will not receive updates from here. Once packaged releases resume, switch the plugin-repository URL to this repository's manifest; until then, build from source as above. The plugin GUID is unchanged, so an in-place update keeps your existing configuration.
+
 ## Configuration
 
 Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Guides](providers.md) walk through setup for common identity providers.

--- a/build.yaml
+++ b/build.yaml
@@ -1,14 +1,15 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
-imageUrl: "https://raw.githubusercontent.com/9p4/jellyfin-plugin-sso/main/img/logo.png"
+imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
 version: "4.0.0.4"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
-owner: "9p4"
+owner: "iderex"
 overview: "Authenticate users against an SSO provider."
 description: |
   This plugin allows users to sign in through an SSO provider (such as Google, Facebook, or your own provider). This enables one-click signin.
-  Review documentation at https://github.com/9p4/jellyfin-plugin-sso
+  SSO sign-in works in the Jellyfin Web UI and in clients that support Quick Connect.
+  Review documentation at https://github.com/iderex/jellyfin-plugin-sso
 category: "Authentication"
 artifacts:
   - "SSO-Auth.dll"


### PR DESCRIPTION
## What & why

The archived `9p4/jellyfin-plugin-sso` (and `eddymoulton/jellyfin-plugin-oidc`) are no longer maintained; this repository is the continuation. But `build.yaml` still shipped `owner: 9p4`, a logo URL under the `9p4` repo, and a documentation link to the archived repo, so the **published manifest credited and pointed users at a dead upstream**, and anyone whose Jellyfin follows the old manifest never receives the security releases from here. Distribution reach is a security property.

- `build.yaml`: `owner`, `imageUrl`, and the documentation link now point at this repository. The plugin **GUID is unchanged**, so an in-place update keeps the existing configuration. Added a line to the manifest description that SSO works in the Web UI and in Quick Connect clients.
- `README.md`: documents the **client-support constraint** (SSO runs in the Web UI or a client that supports Quick Connect, a recurring point of confusion) and the **plugin-repository migration** for anyone still pointing at the old `9p4` manifest. The continuation status was already stated in the intro and Credits.

## Type of change

- [x] Documentation + release-manifest metadata
- [ ] Bug fix / feature / breaking

## Notes

Declarative metadata and docs only, no version, GUID, checksum, or publish-trigger change, so nothing about how the artifact is built or verified changes. `imageUrl` resolves (the logo exists at `img/logo.png` in this repo). `build.yaml` still parses; no `9p4` reference remains in it.

Closes #150
