### PR TITLE
Add explicit assertions to the does-not-throw tests

### DIFF
--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -87,7 +87,9 @@ public class CanonicalBaseUrlTests
     [InlineData("https://example.com/jellyfin/")]
     public void RejectInvalidBaseUrlOverride_BlankOrValid_DoesNotThrow(string? raw)
     {
-        SSOController.RejectInvalidBaseUrlOverride(raw);
+        var exception = Record.Exception(() => SSOController.RejectInvalidBaseUrlOverride(raw));
+
+        Assert.Null(exception);
     }
 
     // Resolve (#242): the base-URL decision GetRequestBase used to make inline against the live Request.

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -66,7 +66,9 @@ public class ConfigPreservationTests
         var live = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
 
         // Fail-safe: a malformed config with missing maps must not NRE the save path.
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        var exception = Record.Exception(() => SSOPlugin.PreserveServerManagedFields(incoming, live));
+
+        Assert.Null(exception);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SamlCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlCertificateTests.cs
@@ -36,9 +36,14 @@ public class SamlCertificateTests
     [Fact]
     public void RejectInvalidSamlCertificate_ValidOrBlank_DoesNotThrow()
     {
-        SSOController.RejectInvalidSamlCertificate(SamlTestFactory.Create().CertificateBase64);
-        SSOController.RejectInvalidSamlCertificate(null);
-        SSOController.RejectInvalidSamlCertificate(string.Empty);
+        var exception = Record.Exception(() =>
+        {
+            SSOController.RejectInvalidSamlCertificate(SamlTestFactory.Create().CertificateBase64);
+            SSOController.RejectInvalidSamlCertificate(null);
+            SSOController.RejectInvalidSamlCertificate(string.Empty);
+        });
+
+        Assert.Null(exception);
     }
 
     [Fact]


### PR DESCRIPTION
## What & why

Three tests asserted their contract only by *not throwing*, which SonarCloud flags as **S2699** (BLOCKER, "add at least one assertion"):

- `SamlCertificateTests.RejectInvalidSamlCertificate_ValidOrBlank_DoesNotThrow`
- `CanonicalBaseUrlTests.RejectInvalidBaseUrlOverride_BlankOrValid_DoesNotThrow`
- `ConfigPreservationTests.Preserve_NullConfigMaps_DoNotThrow`

Wrap each call in `Record.Exception(...)` and assert the result is `null`, so the does-not-throw intent is machine-visible. What each test exercises is unchanged.

## Type of change
- [x] Test quality (clears 3 SonarCloud S2699 BLOCKERs)

## Verification
- [x] `dotnet test` 492 passing (unchanged count, the assertions replace the bare calls).

## Notes

Partial pickup of the #196 sweep. Not touched here, with their disposition:
- **S125 ×2** (`SsoRateLimiter.cs`, `SamlRequestCache.cs`), these are **false positives**: both flagged lines are explanatory prose (the heuristic misfires on the punctuation), not commented-out code. They should be marked *Accepted* in SonarCloud rather than have good comments degraded to appease the rule.
- **S3776 ×4** (`SSOController` ×3, `OidcIdTokenValidator`), cognitive-complexity refactors, larger; the `SSOController` ones fold into the monolith decomposition (#160).
- **S6964 ×4 / S6932 ×1** (`PluginConfiguration`, `SSOController`), value-type `[FromBody]` / model-binding on `RequiresElevation` whole-object-replace endpoints; needs the annotate-vs-document decision.

Refs #196
