### PR TITLE
Document the real build, test, and branch flow in CONTRIBUTING

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ persistence, or the release pipeline.
 ## Verification
 
 - [ ] `dotnet build --no-restore --warnaserror` is green.
-- [ ] `dotnet test` is green (once the test project exists).
+- [ ] `dotnet test` is green.
 - [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
 
 ## Notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,9 +147,9 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 
 **Building and testing.** CI runs these on every pull request and they must pass:
 
-```
-dotnet build --no-restore --warnaserror   # warnings are errors, exactly as in CI
-dotnet test                               # the xUnit project SSO-Auth.Tests must stay green
+```sh
+dotnet build --no-restore --warnaserror     # warnings are errors, exactly as in CI
+dotnet test --no-build --verbosity normal   # the xUnit project SSO-Auth.Tests must stay green
 npx prettier --check "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If you then still feel the need to ask a question and need clarification, we rec
 
 - Open an [Issue](https://github.com/iderex/jellyfin-plugin-sso/issues/new).
 - Provide as much context as you can about what you're running into.
-- Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
+- Provide the relevant versions: your .NET SDK version, the Jellyfin server version, and the SSO provider type (OpenID Connect or SAML, and which identity provider).
 
 We will then take care of the issue as soon as possible.
 
@@ -145,6 +145,16 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
+**Building and testing.** CI runs these on every pull request and they must pass:
+
+```
+dotnet build --no-restore --warnaserror   # warnings are errors, exactly as in CI
+dotnet test                               # the xUnit project SSO-Auth.Tests must stay green
+npx prettier --check "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
+```
+
+**Branching and pull requests.** `main` is the released line and is PR-only. Branch every change — even a one-liner — off `main` for fixes and security work, or off the feature branch for features, using a short kebab-case name with a `fix/`, `harden/`, `feature/`, `chore/`, or `refactor/` prefix. Reference the issue your change addresses (`Closes #N`) and fill in the [pull request template](.github/pull_request_template.md).
+
 Before opening a pull request, please read the **[note on AI and on contributions](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md#-a-note-on-ai-and-on-contributions)** in the README. This is a security-sensitive login path: every change is issue-driven, adversarially reviewed on the login path, and documented before it merges, and you are expected to understand and own every line you propose — a pull request that is unreviewed AI output will be turned away.
 
 ### Improving The Documentation
@@ -164,11 +174,11 @@ Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); e
 
 ### C#
 
-We format all C# code according to the .NET formatter. Run `dotnet build .` and fix any warnings that come up.
+We format all C# code according to the .NET formatter. Build with `dotnet build --no-restore --warnaserror` (the same command CI runs, so warnings fail the build) and fix anything it reports, and keep `dotnet test` green.
 
 ### HTML/CSS/JS/Markdown
 
-We use [Prettier](https://prettier.io) to format these files.
+We use [Prettier](https://prettier.io) to format these files. Run `npx prettier --write "**/*.{js,html,md,css,scss}"` before committing, and `npx prettier --check "**/*.{js,html,md,css,scss}"` to confirm — CI enforces the check (only `*.min.js` is exempt).
 
 <!-- TODO
 

--- a/providers.md
+++ b/providers.md
@@ -2,7 +2,7 @@
 
 This plugin has been tested to work against various providers, though not all providers provide support for all of this plugins' features.
 
-❗ Before you proceed, make sure you have another admin account if you are going to link SSO provider to the only admin account on the server, permission might get overwritten (see [#212](https://github.com/9p4/jellyfin-plugin-sso/issues/212)).
+❗ Before you proceed, make sure you have another admin account if you are going to link an SSO provider to the only admin account on the server — permissions might get overwritten.
 
 ❗ **SAML signing algorithm:** SAML responses must be signed with **RSA or ECDSA using SHA-256 or stronger** (SHA-384/SHA-512). Signatures using SHA-1 (`rsa-sha1`) or a SHA-1 digest are rejected, so if your identity provider still signs with SHA-1, reconfigure it to SHA-256 — otherwise every login through that provider fails with a "SAML response validation failed" error. The server log records the offending signature algorithm to help you diagnose this.
 


### PR DESCRIPTION
## What & why

`CONTRIBUTING.md` did not get an outside contributor to a green PR, the build/test commands were missing or advisory, the xUnit project `SSO-Auth.Tests` went unmentioned, and the branching + PR flow was absent.

- **CONTRIBUTING.md**: added a **Building and testing** block with the exact commands CI enforces (`dotnet build --no-restore --warnaserror`, `dotnet test`, `npx prettier --check ...`) and a **Branching and pull requests** block (branch off `main` for fixes/security or the feature branch for features, kebab-case `fix/`/`harden/`/`feature/`/`chore/`/`refactor/` prefixes, reference the issue, fill the template). Fixed the C# styleguide from the advisory `dotnet build .` to the CI command, gave the Prettier invocation, and replaced the leftover `nodejs/npm` bug-report prompt with the .NET SDK / Jellyfin / provider facts.
- **.github/pull_request_template.md**: dropped the `(once the test project exists)` hedge, the xUnit project exists and CI runs it.
- **providers.md**: dropped the archived-upstream (`9p4`) issue link on the only-admin warning, keeping the warning itself.

## Type of change
- [x] Documentation

## Verification
- [x] Prettier clean on all three files; no `9p4` reference left in `providers.md`.

Closes #244
