### PR TITLE
Verify the plugin builds against the declared targetAbi floor in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,6 +54,34 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
 
+  # Verify the plugin's used Jellyfin API surface actually exists on the OLDEST server it claims to
+  # support (build.yaml targetAbi), not only in the newer SDK the shipping build compiles against. A
+  # member added after the floor would compile against the SDK but throw MissingMethodException at
+  # login on an older 10.11 server (#142). Builds SSO-Auth against Jellyfin.* pinned to that floor.
+  abi-floor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      with:
+        dotnet-version: 9.0.x
+    - name: Derive the targetAbi floor
+      id: floor
+      run: |
+        floor=$(grep -oP 'targetAbi:\s*"?\K[0-9]+\.[0-9]+\.[0-9]+' build.yaml | head -1)
+        echo "version=$floor" >> "$GITHUB_OUTPUT"
+        echo "Building against Jellyfin $floor (the declared targetAbi floor)."
+    - name: Build against the ABI floor
+      # A deliberately different Jellyfin version than the shipping build, so locked-mode is off here;
+      # --warnaserror turns any missing or changed API on the floor into a hard failure.
+      env:
+        FLOOR: ${{ steps.floor.outputs.version }}
+      run: dotnet build SSO-Auth/SSO-Auth.csproj -c Release --warnaserror -p:JellyfinVersion="$FLOOR" -p:RestoreLockedMode=false
+
   # Verify the plugin actually packages as a loadable Jellyfin plugin (JPRM builds it against the
   # targeted ABI and produces the manifest) on every PR, not only at release time.
   package:

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -21,6 +21,10 @@
     <AnalysisMode>Recommended</AnalysisMode>
     <AnalysisModeSecurity>All</AnalysisModeSecurity>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <!-- The shipping build compiles against this SDK; the abi-floor CI job overrides it to the
+         build.yaml targetAbi floor to prove the used API surface also exists on the oldest claimed
+         server (#142). The committed lockfile pins the default, so a locked-mode restore is unaffected. -->
+    <JellyfinVersion Condition="'$(JellyfinVersion)' == ''">10.11.11</JellyfinVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -44,10 +48,10 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.11" />
+    <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
     <!-- id_token validation (#134): OidcClient 7.x carries no JWT validation stack of its own. -->
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.11" />
+    <PackageReference Include="Jellyfin.Model" Version="$(JellyfinVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
   </ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -2,6 +2,10 @@ name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
 version: "4.0.0.4"
+# The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
+# newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
+# API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at
+# login on an older 10.11 server (#142). Raise this only to a floor that job still builds clean on.
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "iderex"

--- a/scripts/check-jellyfin-compat.sh
+++ b/scripts/check-jellyfin-compat.sh
@@ -33,6 +33,13 @@ filever=$(grep -oP '(?<=<FileVersion>)[^<]+' "$csproj" | head -1 || true); need 
 controller=$(grep -oP 'Jellyfin\.Controller"\s+Version="\K[^"]+' "$csproj" | head -1 || true); need "$controller" "Jellyfin.Controller version"
 model=$(grep -oP 'Jellyfin\.Model"\s+Version="\K[^"]+' "$csproj" | head -1 || true); need "$model" "Jellyfin.Model version"
 
+# The Jellyfin packages take their version from the $(JellyfinVersion) property (#142, so the
+# abi-floor CI job can override it); resolve it to the property's default so the metadata checks below
+# compare real version numbers rather than the literal '$(JellyfinVersion)'.
+jellyfinversion=$(grep -oP '<JellyfinVersion[^>]*>\K[^<]+' "$csproj" | head -1 || true); need "$jellyfinversion" "csproj JellyfinVersion default"
+[[ "$controller" == '$(JellyfinVersion)' ]] && controller="$jellyfinversion"
+[[ "$model" == '$(JellyfinVersion)' ]] && model="$jellyfinversion"
+
 byframework=$(grep -oP 'framework:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$byframework" "build.yaml framework"
 byversion=$(grep -oP '^version:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$byversion" "build.yaml version"
 abi=$(grep -oP 'targetAbi:\s*"?\K[^"[:space:]]+' "$buildyaml" | head -1 || true); need "$abi" "build.yaml targetAbi"


### PR DESCRIPTION
## What & why

`build.yaml` declares `targetAbi: 10.11.0.0` (the oldest server the manifest claims to load on), but the shipping build compiles against `Jellyfin.Controller/Model` **10.11.11**. Jellyfin changed plugin-facing interfaces within the 10.11.x series, so a member added after 10.11.0 would compile against the SDK yet throw **`MissingMethodException` at login** on a 10.11.0–10.11.8 server, an auth-path outage, while nothing catches the drift.

- **Parameterize** the Jellyfin package version behind a `JellyfinVersion` MSBuild property (default `10.11.11`), so the committed lockfile and the locked-mode restore are unchanged for the shipping build.
- **New CI `abi-floor` job** (`dotnet.yml`) derives the floor from `build.yaml` `targetAbi` and builds `SSO-Auth` against it (`-p:JellyfinVersion=<floor>`, `--warnaserror`), so any used API missing on the floor is a hard failure. The floor tracks whatever `targetAbi` claims.
- `build.yaml` documents the floor; `check-jellyfin-compat.sh` resolves the new property so its metadata checks still compare real version numbers.

**Verified empirically:** the plugin compiles clean (0 errors, 0 warnings) against `Jellyfin.Controller/Model 10.11.0`, the used API surface (`IUserManager.GetUserById/GetUserByName/CreateUserAsync/UpdateUserAsync/ClearProfileImageAsync`, `AuthenticateDirect`, `CreatePasswordHash`, `SaveImage`) all exists on the floor, so the current `10.11.0.0` targetAbi is truthful. No change to the shipping artifact.

## Type of change
- [x] Hardening / CI (prevents a future silent ABI-drift auth outage)

## Verification
- [x] Default (locked-mode, 10.11.11) restore + `dotnet build --warnaserror` clean; `dotnet test` 492 passing.
- [x] Floor build (`-p:JellyfinVersion=10.11.0`) clean.
- [x] `check-jellyfin-compat.sh` green; committed `packages.lock.json` unchanged (stays 10.11.11).

Closes #142
