### PR TITLE
Record the enabled repository security controls in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,5 +30,5 @@ The latest released version is the only supported version.
 ## Repository security controls
 
 - **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.
-- **Dependabot** is enabled, and every CI build fails on a known-vulnerable dependency.
-- Every pull request runs CodeQL, a GitHub Actions workflow audit (zizmor), a dependency review, a Trojan-Source/Unicode check, and a build with warnings treated as errors. Changes to the login path additionally go through an adversarial security review before they merge.
+- **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
+- Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) runs on every pull request. Changes to the login path additionally go through an adversarial security review before they merge.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,3 +26,9 @@ reporting.
 ## Supported versions
 
 The latest released version is the only supported version.
+
+## Repository security controls
+
+- **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.
+- **Dependabot** is enabled, and every CI build fails on a known-vulnerable dependency.
+- Every pull request runs CodeQL, a GitHub Actions workflow audit (zizmor), a dependency review, a Trojan-Source/Unicode check, and a build with warnings treated as errors. Changes to the login path additionally go through an adversarial security review before they merge.


### PR DESCRIPTION
## What & why

Secret scanning and push protection are free for public repositories but must be switched on per repo. For a login plugin the realistic risk while iterating on config or test fixtures is accidentally committing an identity-provider client secret or a CI token, a one-click structural control against it.

Verified from the repository security settings: `secret_scanning` = enabled, `secret_scanning_push_protection` = enabled, Dependabot = enabled (and there are 0 open secret-scanning alerts). This records that state in `SECURITY.md`, together with the Dependabot and per-PR CI controls already in place, so the posture is stated where readers look for it.

## Type of change
- [x] Documentation (records a verified control)

## Verification
- [x] Repo settings confirm secret scanning + push protection enabled.
- [x] Prettier clean.

Closes #148
