### PR TITLE
Cover the provider-add endpoints and canonical-link preservation

### DIFF
--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -22,18 +22,21 @@ public class SSOControllerAddTests
     {
         var harness = new SsoControllerHarness();
 
-        harness.Controller.OidAdd("keycloak", new OidConfig());
+        harness.Controller.OidAdd("keycloak", new OidConfig { OidClientId = "client-1" });
 
-        var names = Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames()).Value);
-        Assert.Contains("keycloak", names);
+        var stored = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidClientId);
+        Assert.Equal("client-1", stored);
     }
 
     [Fact]
-    public void OidAdd_MalformedBaseUrlOverride_Throws()
+    public void OidAdd_MalformedBaseUrlOverride_Throws_AndDoesNotPersist()
     {
         var harness = new SsoControllerHarness();
 
         Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("keycloak", new OidConfig { BaseUrlOverride = "not-a-url" }));
+
+        // Fail-closed: the reject runs before the write, so nothing was persisted.
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("keycloak")));
     }
 
     [Fact]
@@ -54,18 +57,20 @@ public class SSOControllerAddTests
     {
         var harness = new SsoControllerHarness();
 
-        Assert.IsType<OkResult>(harness.Controller.SamlAdd("adfs", new SamlConfig()));
+        Assert.IsType<OkResult>(harness.Controller.SamlAdd("adfs", new SamlConfig { SamlClientId = "client-1" }));
 
-        var names = Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames()).Value);
-        Assert.Contains("adfs", names);
+        var stored = SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].SamlClientId);
+        Assert.Equal("client-1", stored);
     }
 
     [Fact]
-    public void SamlAdd_MalformedBaseUrlOverride_Throws()
+    public void SamlAdd_MalformedBaseUrlOverride_Throws_AndDoesNotPersist()
     {
         var harness = new SsoControllerHarness();
 
         Assert.Throws<ArgumentException>(() => harness.Controller.SamlAdd("adfs", new SamlConfig { BaseUrlOverride = "not-a-url" }));
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("adfs")));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the provider-add endpoints via <see cref="SsoControllerHarness"/>: a valid
+/// config is stored, a malformed base-URL override is rejected fail-closed, and a re-save preserves
+/// the server-managed canonical links (#157) that the API body never carries.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerAddTests
+{
+    private static readonly Guid User = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    [Fact]
+    public void OidAdd_ValidConfig_StoresTheProvider()
+    {
+        var harness = new SsoControllerHarness();
+
+        harness.Controller.OidAdd("keycloak", new OidConfig());
+
+        var names = Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames()).Value);
+        Assert.Contains("keycloak", names);
+    }
+
+    [Fact]
+    public void OidAdd_MalformedBaseUrlOverride_Throws()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("keycloak", new OidConfig { BaseUrlOverride = "not-a-url" }));
+    }
+
+    [Fact]
+    public void OidAdd_ReSaveOfExisting_PreservesCanonicalLinks()
+    {
+        var harness = new SsoControllerHarness(c =>
+            c.OidConfigs["keycloak"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User } });
+
+        // Re-add the same provider with a fresh config carrying no links, as the [JsonIgnore] API body would.
+        harness.Controller.OidAdd("keycloak", new OidConfig());
+
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks);
+        Assert.Equal(User, links["sub-1"]);
+    }
+
+    [Fact]
+    public void SamlAdd_ValidConfig_StoresTheProvider_ReturnsOk()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.IsType<OkResult>(harness.Controller.SamlAdd("adfs", new SamlConfig()));
+
+        var names = Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames()).Value);
+        Assert.Contains("adfs", names);
+    }
+
+    [Fact]
+    public void SamlAdd_MalformedBaseUrlOverride_Throws()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.Throws<ArgumentException>(() => harness.Controller.SamlAdd("adfs", new SamlConfig { BaseUrlOverride = "not-a-url" }));
+    }
+
+    [Fact]
+    public void SamlAdd_ReSaveOfExisting_PreservesCanonicalLinks()
+    {
+        var harness = new SsoControllerHarness(c =>
+            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = User } });
+
+        harness.Controller.SamlAdd("adfs", new SamlConfig());
+
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].CanonicalLinks);
+        Assert.Equal(User, links["nameid-1"]);
+    }
+}


### PR DESCRIPTION
## What & why

Fourth batch of `SSOController` tests on the harness, covering the provider-add endpoints:

- **`OidAdd` / `SamlAdd`** store a valid posted config (verified through the name endpoints; `SamlAdd` returns `Ok`).
- A **malformed `BaseUrlOverride`** is rejected fail-closed with an `ArgumentException` before anything is persisted.
- **Re-saving an existing provider** with a body that carries no canonical links (as the `[JsonIgnore]` API body always does) **preserves the server-managed canonical links** (#157), so an admin API save cannot silently wipe existing account links.

+6 tests (514 total).

## Type of change
- [x] Test coverage (no production code changed)

## Verification
- [x] `dotnet build --warnaserror` clean (test project); `dotnet test` 514 passing.

Refs #192
## Security

- [x] N/A for the running product, test-only, no production code changes. The added tests do pin fail-closed behaviors on the OIDC/SAML/config-persistence paths (unknown/disabled provider rejection, base-URL-override rejection before any write, and canonical-link preservation on an admin save), so they guard those invariants rather than change them.

## Quality

- [x] Reusable `SsoControllerHarness`; the controller tests share the static `SSOPlugin.Instance`, so they run in one non-parallel collection. Assertions strengthened per review (exact result bodies / stored config / no-persist-on-reject).

## Notes

Part of the coverage program (#192): across these harness batches, `SSOController` line coverage climbed from 3.3% to ~19.4% and overall from 46.5% to ~53.1%, toward the `new_coverage >= 80` goal, with the interim policy unchanged.