### PR TITLE
Cover the enabled SAML challenge, the Unregister guard, and the provider lists

### DIFF
--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the enabled-provider SAML challenge, the Unregister guard, and the admin
+/// provider-list endpoints via <see cref="SsoControllerHarness"/>.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerChallengeTests
+{
+    [Fact]
+    public void SamlChallenge_EnabledProvider_RedirectsToTheIdentityProvider()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlEndpoint = "https://idp.example.com/sso",
+            SamlClientId = "jellyfin-sp",
+        });
+
+        var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.StartsWith("https://idp.example.com/sso", result.Url);
+    }
+
+    [Fact]
+    public async Task Unregister_UnknownUser_ReturnsNotFound()
+    {
+        // The mocked IUserManager returns null for any name, so the guard short-circuits.
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.Unregister("nobody", "Jellyfin");
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public void OidProviders_ReturnsOkSnapshot()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig());
+
+        Assert.IsType<OkObjectResult>(harness.Controller.OidProviders());
+    }
+
+    [Fact]
+    public void SamlProviders_ReturnsOkSnapshot()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
+
+        Assert.IsType<OkObjectResult>(harness.Controller.SamlProviders());
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -25,6 +26,8 @@ public class SSOControllerChallengeTests
         var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
 
         Assert.StartsWith("https://idp.example.com/sso", result.Url);
+        // The redirect carries the deflated+encoded AuthnRequest, so it must be a real SAML redirect.
+        Assert.Contains("SAMLRequest=", result.Url);
     }
 
     [Fact]
@@ -39,18 +42,22 @@ public class SSOControllerChallengeTests
     }
 
     [Fact]
-    public void OidProviders_ReturnsOkSnapshot()
+    public void OidProviders_ReturnsOkSnapshotContainingTheProvider()
     {
         var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig());
 
-        Assert.IsType<OkObjectResult>(harness.Controller.OidProviders());
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidProviders());
+        var snapshot = Assert.IsType<SerializableDictionary<string, OidConfig>>(ok.Value);
+        Assert.True(snapshot.ContainsKey("keycloak"));
     }
 
     [Fact]
-    public void SamlProviders_ReturnsOkSnapshot()
+    public void SamlProviders_ReturnsOkSnapshotContainingTheProvider()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
 
-        Assert.IsType<OkObjectResult>(harness.Controller.SamlProviders());
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviders());
+        var snapshot = Assert.IsType<SerializableDictionary<string, SamlConfig>>(ok.Value);
+        Assert.True(snapshot.ContainsKey("adfs"));
     }
 }


### PR DESCRIPTION
## What & why

Fifth batch of `SSOController` tests on the harness:

- **Enabled SAML challenge**: a configured, enabled SAML provider redirects the challenge to its identity-provider endpoint (`RedirectResult` to `SamlEndpoint`).
- **Unregister guard**: an unknown username returns `NotFound` (the mocked `IUserManager` resolves no user, so the guard short-circuits before touching links).
- **Provider lists**: `OID/Get` and `SAML/Get` return the config snapshot.

+4 tests (518 total).

## Type of change

- [x] Test coverage (no production code changed)
- [ ] Bug fix / feature / breaking

## Security

- [x] N/A for the running product, test-only, no production code changes. The tests pin fail-closed/expected behavior on the OIDC/SAML/config paths (the Unregister guard, the SAML challenge target) rather than change them.

## Quality

- [x] Reuses the `SsoControllerHarness`; the tests share the static `SSOPlugin.Instance`, so they run in the non-parallel `SSOController` collection.

## Verification

- [x] `dotnet build --no-restore --warnaserror` clean (test project).
- [x] `dotnet test` 518 passing.
- [x] Prettier N/A (no `.js`/`.html`/`.md`/`.css` change).

## Notes

Part of the coverage program (#192): `SSOController` line coverage has climbed from 3.3% to ~19.4% across these batches, toward the `new_coverage >= 80` goal; the interim coverage policy is unchanged.

Refs #192
