### PR TITLE
Introduce the In-Development → Full Release maturity ladder in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 > [!WARNING]
 >
-> ## ⛔ Pre-alpha software — do NOT install this on a production system
+> ## ⛔ In-Development — do NOT install this on a production system
 >
-> This plugin is in **pre-alpha**. It exists **exclusively for developers to test** — nothing else. Under **no circumstances** should it be installed on a production system or put in front of a real Jellyfin instance with real user accounts: it is a login path under active reconstruction, and you must expect **breaking changes, incomplete features, and security gaps that are still being closed**. Wait for a stable release before using it anywhere that matters.
+> This plugin is at the **In-Development** stage — the first rung of its maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). It exists **exclusively for developers to test** — nothing else. Under **no circumstances** should it be installed on a production system or put in front of a real Jellyfin instance with real user accounts: it is a login path under active reconstruction, and you must expect **breaking changes, incomplete features, and security gaps that are still being closed**. Wait for a **Full Release** before using it anywhere that matters.
 
 <h1 align="center">Jellyfin SSO Plugin</h1>
 
@@ -33,13 +33,13 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 >
 > Its hardened sibling project, **`jellyfin-plugin-sso-V2`** (private), is the reference this repository draws on — a good deal still remains to be ported across from there, deliberately, one reviewed change at a time.
 >
-> **Status:** early and under active development. See [Installing](#installing) — for now the reliable path is building from source; a packaged release will follow once the security-hardening pass reaches its first milestone.
+> **Status:** **In-Development** — the first stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — for now the reliable path is building from source; a packaged release will follow as the security-hardening pass advances the maturity stages.
 
 > ### 🤖 A note on AI and on contributions
 >
-> The maintainer is a non-native English speaker, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) assists him in two ways: it **translates documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments — and it **helps generate and analyse code** during development.
+> I am a non-native English speaker, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) assists me in two ways: it **translates documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments — and it **helps generate and analyse code** during development.
 >
-> - **A human owns and reviews everything.** Claude never produces finished code, a complete pull request, or any other artifact that lands unexamined. Every AI-assisted change — translated text or code — is reviewed, understood, edited, and evaluated by the maintainer before it merges; he holds responsibility for it. The AI proposes; the human decides.
+> - **A human owns and reviews everything.** Claude never produces finished code, a complete pull request, or any other artifact that lands unexamined. Every AI-assisted change — translated text or code — is reviewed, understood, edited, and evaluated by me before it merges; I hold responsibility for it. The AI proposes; the human decides.
 > - **The AI is not in the product.** It plays **no role at runtime**, in authentication, or in processing your users' data.
 >
 > The review discipline around this is modelled — as far as is practical for a volunteer project — on the change-control expected of **TÜV/BSI-certified software in critical sectors such as healthcare**: every change is issue-driven, adversarially reviewed on the login path, and documented before it merges. It is an approximation of that practice, not a certification.

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -26,9 +26,10 @@
             <i>Note:</i>
             Making changes to this configuration requires a restart of Jellyfin.
             <br />
-            This plug-in is in early development, not all configuration options
-            have been implented in the UI, for example, SAML provider
-            configuration has not been implemented.
+            This plug-in is at the In-Development stage of its maturity ladder
+            (In-Development &rarr; Alpha &rarr; Beta &rarr; Release Candidate
+            &rarr; Full Release); not all configuration options are exposed in
+            the UI yet.
             <br />
             See the
             <a


### PR DESCRIPTION
# What & why

The project signalled its readiness with an ad-hoc label, "pre-alpha" in the README and Home wiki, "early development" in the config page, with no defined ladder, no criteria for advancing, and no single page a reader could consult.

This introduces an explicit five-stage maturity ladder and documents it once, in the wiki, linked from the README:

**In-Development → Alpha → Beta → Release Candidate → Full Release**

The current stage is **In-Development**, the rung the "pre-alpha" label occupied. "Release Candidate" is the deliberate name for the stage between Beta and Full Release (rather than a "release beta"): a frozen, production-ready candidate awaiting field confirmation.

Changes:
- **README:** the warning block and the Status line name the In-Development stage and link the Roadmap. The AI-and-contributions note is rephrased in the first person.
- **Config page (`configPage.html`):** the admin note names the In-Development stage and drops the stale claim that SAML provider configuration is unimplemented (it is supported); a typo is fixed.
- **Wiki (pushed separately to the wiki repo):** a new [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) page defines each stage, its audience, and the explicit gates between stages, and maps them to the P2–P6 phase milestones; the Home page's status is synced and links the Roadmap.

Closes #284

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Docs-only change. `configPage.html` is edited, but only its static admin note (a `<p>` paragraph), no login path, crypto, config-persistence, or release-pipeline logic is touched, so the adversarial-review gate does not apply. The editor hook flags the file by name; the disposition is recorded here.

- [x] N/A, display text only; no fail-closed logic changed.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline change.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (the ladder is documented in one place, the wiki Roadmap, and referenced, not copied)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (525 tests).
- [x] Prettier is clean for the `.md` / `.html` changes.

## Notes

- The Roadmap and Home edits land in the separate wiki repository, so they are not part of this PR's diff; they are already pushed and live.
- The config page's help links still point at the archived `9p4` upstream; retargeting them to this repository is out of scope here and tracked separately.