### PR TITLE
Cover the Unregister happy path and the canonical-link endpoints

### DIFF
--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the canonical-link endpoints via <see cref="SsoControllerHarness"/>. They cover
+/// the authorization guard (a non-admin editing another user's links is refused with 403) and, once the
+/// guard passes, the mode dispatch: an invalid mode is rejected and a delete of an unknown canonical
+/// name is a 404. The authorization decision runs through the mocked <see cref="IAuthorizationContext"/>.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerLinkTests
+{
+    private static readonly Guid Target = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly Guid Other = Guid.Parse("66666666-6666-6666-6666-666666666666");
+
+    [Fact]
+    public async Task AddCanonicalLink_NonAdminEditingAnotherUser_Returns403()
+    {
+        var harness = ForCaller(isAdmin: false, callerId: Other);
+
+        var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse());
+
+        Assert.Equal(403, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_NonAdminEditingAnotherUser_Returns403()
+    {
+        var harness = ForCaller(isAdmin: false, callerId: Other);
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.Equal(403, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task GetOidLinksByUser_NonAdminQueryingAnotherUser_Returns403()
+    {
+        var harness = ForCaller(isAdmin: false, callerId: Other);
+
+        var result = await harness.Controller.GetOidLinksByUser(Target);
+
+        Assert.Equal(403, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_AuthorizedButInvalidMode_Throws()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        // The guard passes (admin), so the mode dispatch runs and rejects an unknown mode fail-closed.
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            harness.Controller.AddCanonicalLink("ldap", "keycloak", Target, new AuthResponse()));
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedButUnknownCanonicalName_ReturnsNotFound()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig());
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "does-not-exist");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    // Builds a harness whose mocked IAuthorizationContext resolves the request to the given caller. An
+    // admin (or the target user themselves) passes AssertCanUpdateUser; a non-admin editing another user
+    // is refused.
+    private static SsoControllerHarness ForCaller(bool isAdmin, Guid callerId, Action<PluginConfiguration>? configure = null)
+    {
+        var harness = new SsoControllerHarness(configure);
+
+        var user = new User("caller", "SSO-Auth", "Default") { Id = callerId, EnableUserPreferenceAccess = true };
+        user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
+
+        // AuthorizationInfo.UserId is derived from User.Id, so setting the user fixes the caller identity.
+        var authInfo = new AuthorizationInfo { User = user };
+        harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>()).Returns(Task.FromResult(authInfo));
+        return harness;
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the <c>Unregister</c> endpoint via <see cref="SsoControllerHarness"/>: a known
+/// user's SSO is revoked (its canonical links are dropped and the auth provider is persisted), and the
+/// revoke returns Ok. The unknown-user guard is covered in <see cref="SSOControllerChallengeTests"/>.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerUnregisterTests
+{
+    private static readonly Guid UserId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    [Fact]
+    public async Task Unregister_KnownUser_PersistsProviderSwitch_ReturnsOk()
+    {
+        var harness = new SsoControllerHarness();
+        var user = SeedUser(harness);
+
+        var result = await harness.Controller.Unregister("alice", "Jellyfin");
+
+        Assert.IsType<OkResult>(result);
+        // The switch back to the local auth provider must be PERSISTED (a prior version only set it in memory).
+        Assert.Equal("Jellyfin", user.AuthenticationProviderId);
+        await harness.UserManager.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task Unregister_KnownUser_RemovesTheUsersCanonicalLinks()
+    {
+        var harness = new SsoControllerHarness(c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = UserId },
+            });
+        SeedUser(harness);
+
+        await harness.Controller.Unregister("alice", "Jellyfin");
+
+        // Revoking SSO must drop every canonical link pointing at the user, or the account could still sign in (#213).
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks);
+        Assert.False(links.ContainsKey("sub-alice"));
+    }
+
+    // Registers a user with the harness's mocked IUserManager so GetUserByName resolves it.
+    private static User SeedUser(SsoControllerHarness harness)
+    {
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.GetUserByName("alice").Returns(user);
+        return user;
+    }
+}

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -36,6 +36,8 @@ internal sealed class SsoControllerHarness
 
     public ISessionManager SessionManager { get; }
 
+    public IAuthorizationContext AuthContext { get; }
+
     public PluginConfiguration Configuration { get; }
 
     public SsoControllerHarness(Action<PluginConfiguration>? configure = null, IPAddress? clientIp = null)
@@ -52,13 +54,14 @@ internal sealed class SsoControllerHarness
 
         UserManager = Substitute.For<IUserManager>();
         SessionManager = Substitute.For<ISessionManager>();
+        AuthContext = Substitute.For<IAuthorizationContext>();
 
         Controller = new SSOController(
             Substitute.For<ILogger<SSOController>>(),
             Substitute.For<ILoggerFactory>(),
             SessionManager,
             UserManager,
-            Substitute.For<IAuthorizationContext>(),
+            AuthContext,
             Substitute.For<ICryptoProvider>(),
             Substitute.For<IProviderManager>(),
             Substitute.For<IHttpClientFactory>(),


### PR DESCRIPTION
# What & why

Extends the in-process `SsoControllerHarness` coverage to two more endpoint areas that were untested, continuing the drive toward the new-code coverage goal.

- **Unregister:** a known user's SSO is revoked, the switch back to the local auth provider is persisted (`UpdateUserAsync` is called, not just set in memory), and the user's canonical links are removed so the account can no longer resolve via SSO (#213).
- **Canonical-link endpoints:** `AddCanonicalLink`, `DeleteCanonicalLink`, and `GetOidLinksByUser` refuse a non-admin editing another user's links with 403; once authorized, an invalid mode is rejected fail-closed and an unknown canonical name returns 404.

The harness now exposes its mocked `IAuthorizationContext` so a test can resolve the request to a chosen caller.

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Test-only change; no production code is touched. The added tests pin existing fail-closed behaviour rather than change it.

- [x] Fail-closed preserved, the tests assert it (unknown mode rejected, unknown canonical name → 404, non-admin cross-user edit → 403); none is weakened.
- [x] No secrets logged; secrets are redacted on config export. (unchanged; no logging touched)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed; tests only.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (shared caller setup factored into a private `ForCaller`/`SeedUser` helper per file)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (525 tests).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Builds on the harness added in #279 and extended through #281–#283; this is the sixth controller-test batch. Further batches will cover the OIDC/SAML challenge-and-callback paths that need a mocked discovery document.