### PR TITLE
Cover the canonical-link add/delete outcomes

### DIFF
--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -16,8 +16,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// In-process tests of the canonical-link endpoints via <see cref="SsoControllerHarness"/>. They cover
 /// the authorization guard (a non-admin editing another user's links is refused with 403) and, once the
-/// guard passes, the mode dispatch: an invalid mode is rejected and a delete of an unknown canonical
-/// name is a 404. The authorization decision runs through the mocked <see cref="IAuthorizationContext"/>.
+/// guard passes, the mode dispatch and its outcomes: an invalid mode is rejected; the add path rejects
+/// missing data and unknown providers fail-closed; and the delete path removes a caller-owned link,
+/// refuses a UID mismatch with 409, and returns 404 for an unknown canonical name. The authorization
+/// decision runs through the mocked <see cref="IAuthorizationContext"/>.
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerLinkTests
@@ -74,6 +76,83 @@ public class SSOControllerLinkTests
         var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "does-not-exist");
 
         Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetSamlLinksByUser_NonAdminQueryingAnotherUser_Returns403()
+    {
+        var harness = ForCaller(isAdmin: false, callerId: Other);
+
+        var result = await harness.Controller.GetSamlLinksByUser(Target);
+
+        Assert.Equal(403, Assert.IsType<ObjectResult>(result.Result).StatusCode);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_OidMissingData_ReturnsBadRequest()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        // The OID link path needs the redeemable state token in the body; an empty body is a clean 400.
+        var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_OidUnknownProvider_ReturnsBadRequest()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        // Data is present, but no such provider is configured, so the lookup fails closed.
+        var result = await harness.Controller.AddCanonicalLink("oid", "does-not-exist", Target, new AuthResponse { Data = "state-token" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_SamlUnknownProvider_ReturnsBadRequest()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        // SamlLink checks the provider before touching the response, so an unknown provider is a clean 400.
+        var result = await harness.Controller.AddCanonicalLink("saml", "does-not-exist", Target, new AuthResponse { Data = "irrelevant" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedOwnLink_RemovesItAndReturnsOk()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target },
+            });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks);
+        Assert.False(links.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedButUidMismatch_Returns409()
+    {
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                // The link points at a different Jellyfin user, so the delete must refuse rather than remove.
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Other },
+            });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.Equal(409, Assert.IsType<ObjectResult>(result).StatusCode);
+        // The mismatched link is left untouched.
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks);
+        Assert.True(links.ContainsKey("sub-1"));
     }
 
     // Builds a harness whose mocked IAuthorizationContext resolves the request to the given caller. An


### PR DESCRIPTION
# What & why

Continues the controller-test coverage program, exercising the outcomes of the canonical-link add/delete paths that batch 6 only reached at the authorization guard.

- **AddCanonicalLink** (authorized): a missing OID state body and an unknown OID or SAML provider are each rejected fail-closed with 400, the SAML path checks the provider before touching the response, and the OID path requires a redeemable state token.
- **DeleteCanonicalLink** (authorized): a caller-owned link is removed and returns Ok; a UID mismatch (the link points at a different Jellyfin user) is refused with 409 and the link is left untouched.
- **GetSamlLinksByUser**: a non-admin querying another user's links is refused with 403 (symmetric to the OID query covered in batch 6).

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Test-only change; no production code is touched. The added tests pin existing fail-closed behaviour rather than change it.

- [x] Fail-closed preserved, the tests assert it (missing data / unknown provider → 400, UID mismatch → 409, non-admin cross-user query → 403); none is weakened.
- [x] No secrets logged; secrets are redacted on config export. (unchanged; no logging touched)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed; tests only.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (reuses the existing `ForCaller` authorization helper)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (531 tests).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Seventh controller-test batch, building on the harness from #279. The remaining large uncovered area is the OIDC/SAML challenge-and-callback flow, which needs a mocked discovery document and user-creation path; that is the next batch.