### PR TITLE
Cover the OpenID challenge PKCE-discovery fail-closed gate (#141)

### DIFF
--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -30,6 +31,7 @@ public class SSOControllerOidChallengeTests
     [Fact]
     public async Task OidChallenge_RequirePkceButProviderDoesNotAdvertiseS256_Returns400()
     {
+        var requested = new List<string>();
         var harness = new SsoControllerHarness(
             c => c.OidConfigs["kc"] = new OidConfig
             {
@@ -39,11 +41,18 @@ public class SSOControllerOidChallengeTests
                 RequirePkce = true,
             },
             // Discovery is served but omits code_challenge_methods_supported, so S256 is not advertised.
-            httpResponder: _ => Json("{\"issuer\":\"https://idp-no-s256.example.com\"}"));
+            httpResponder: request =>
+            {
+                requested.Add(request.RequestUri!.AbsoluteUri);
+                return Json("{\"issuer\":\"https://idp-no-s256.example.com\"}");
+            });
 
         var result = await harness.Controller.OidChallenge("kc");
 
         Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+        // The 400 must come from the PKCE gate, which only fires after the discovery document is fetched
+        // and found to lack S256 — so the discovery endpoint must actually have been contacted.
+        Assert.Contains("https://idp-no-s256.example.com/.well-known/openid-configuration", requested);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the OpenID challenge's PKCE-discovery gate (#141, RFC 9700 §2.1.1) via
+/// <see cref="SsoControllerHarness"/>. When a provider is marked <c>RequirePkce</c>, the challenge must
+/// fail closed unless the authorization server's discovery document advertises PKCE (S256): a document
+/// without S256, or one that cannot be read at all, is refused with a 400. The discovery document is
+/// served in-process through the harness's stub HTTP responder.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerOidChallengeTests
+{
+    [Fact]
+    public async Task OidChallenge_DisabledProvider_Throws()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => harness.Controller.OidChallenge("kc"));
+    }
+
+    [Fact]
+    public async Task OidChallenge_RequirePkceButProviderDoesNotAdvertiseS256_Returns400()
+    {
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = "https://idp-no-s256.example.com",
+                OidClientId = "jf",
+                RequirePkce = true,
+            },
+            // Discovery is served but omits code_challenge_methods_supported, so S256 is not advertised.
+            httpResponder: _ => Json("{\"issuer\":\"https://idp-no-s256.example.com\"}"));
+
+        var result = await harness.Controller.OidChallenge("kc");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidChallenge_RequirePkceButDiscoveryUnreadable_Returns400()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp-unreachable.example.com",
+            OidClientId = "jf",
+            RequirePkce = true,
+        });
+        // No httpResponder: the discovery fetch fails, so PKCE (S256) support cannot be confirmed.
+
+        var result = await harness.Controller.OidChallenge("kc");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+}

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -40,7 +40,10 @@ internal sealed class SsoControllerHarness
 
     public PluginConfiguration Configuration { get; }
 
-    public SsoControllerHarness(Action<PluginConfiguration>? configure = null, IPAddress? clientIp = null)
+    public SsoControllerHarness(
+        Action<PluginConfiguration>? configure = null,
+        IPAddress? clientIp = null,
+        Func<HttpRequestMessage, HttpResponseMessage>? httpResponder = null)
     {
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);
@@ -56,6 +59,15 @@ internal sealed class SsoControllerHarness
         SessionManager = Substitute.For<ISessionManager>();
         AuthContext = Substitute.For<IAuthorizationContext>();
 
+        // With no responder the factory returns null (an unreachable network — the controller's discovery
+        // fetch fails closed). With one, every CreateClient() hands back a client backed by the stub, so
+        // OpenID discovery/JWKS can be served in-process.
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        if (httpResponder is not null)
+        {
+            httpClientFactory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new StubHttpMessageHandler(httpResponder)));
+        }
+
         Controller = new SSOController(
             Substitute.For<ILogger<SSOController>>(),
             Substitute.For<ILoggerFactory>(),
@@ -64,7 +76,7 @@ internal sealed class SsoControllerHarness
             AuthContext,
             Substitute.For<ICryptoProvider>(),
             Substitute.For<IProviderManager>(),
-            Substitute.For<IHttpClientFactory>(),
+            httpClientFactory,
             Substitute.For<IServerConfigurationManager>())
         {
             ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },

--- a/SSO-Auth.Tests/StubHttpMessageHandler.cs
+++ b/SSO-Auth.Tests/StubHttpMessageHandler.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A test <see cref="HttpMessageHandler"/> that answers every request from a supplied responder
+/// delegate, so the controller's outbound HTTP (OpenID discovery, JWKS) can be served in-process
+/// without a network. The responder receives the request and returns the canned response.
+/// </summary>
+internal sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+    public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+    {
+        _responder = responder;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_responder(request));
+    }
+}


### PR DESCRIPTION
# What & why

Extends the controller-test coverage to the OpenID challenge's PKCE-discovery gate (#141, RFC 9700 §2.1.1), the security-critical fail-closed path that refuses a login when a `RequirePkce` provider's authorization server does not (verifiably) advertise PKCE (S256).

To reach it, the harness gains an in-process discovery mock: a stub `HttpMessageHandler` and an optional `httpResponder` on `SsoControllerHarness`, so the controller's outbound discovery fetch is served without a network. With no responder the client is unreachable (models a failed fetch).

Covered branches of `OidChallenge`:
- a **disabled** provider throws (`ArgumentException`);
- with `RequirePkce` set, a discovery document that **does not advertise S256** is refused with 400;
- with `RequirePkce` set, a discovery document that **cannot be read** is refused with 400 ("support could not be verified").

The full challenge happy path and the `OidAuth`/`SamlAuth` callbacks are deferred to #289: the authorize-state store is a private static field, so a happy-path test pollutes sibling tests; it needs a test-reset hook first.

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Test-only change; no production code is touched. The tests pin the existing PKCE fail-closed behaviour (#141) rather than change it.

- [x] Fail-closed preserved, the tests assert the 400 refusals when PKCE (S256) is not advertised or not verifiable; the posture is unchanged.
- [x] No secrets logged; secrets are redacted on config export. (unchanged; no logging touched)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed; tests only.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (the stub handler and a `Json` helper are the only new surface; the discovery mock is reusable for future callback coverage)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (537 tests).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- The discovery-mock harness is the enabler for the deferred full-flow coverage tracked in #289.