### PR TITLE
Make the OpenID authorize-state store test-resettable

### DIFF
--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -11,11 +11,13 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// In-process tests of the OpenID challenge's PKCE-discovery gate (#141, RFC 9700 §2.1.1) via
-/// <see cref="SsoControllerHarness"/>. When a provider is marked <c>RequirePkce</c>, the challenge must
-/// fail closed unless the authorization server's discovery document advertises PKCE (S256): a document
-/// without S256, or one that cannot be read at all, is refused with a 400. The discovery document is
-/// served in-process through the harness's stub HTTP responder.
+/// In-process tests of the OpenID challenge via <see cref="SsoControllerHarness"/>. They cover the
+/// PKCE-discovery gate (#141, RFC 9700 §2.1.1) — when a provider is marked <c>RequirePkce</c>, the
+/// challenge must fail closed unless the authorization server's discovery document advertises PKCE
+/// (S256), so a document without S256 or one that cannot be read is refused with a 400 — and the
+/// enabled-provider happy path, where a served discovery document yields a redirect to the authorization
+/// endpoint. The discovery document is served in-process through the harness's stub HTTP responder; the
+/// harness resets the shared authorize-state store between tests (#289).
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerOidChallengeTests
@@ -71,6 +73,43 @@ public class SSOControllerOidChallengeTests
 
         Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
     }
+
+    [Fact]
+    public async Task OidChallenge_EnabledProviderWithDiscovery_RedirectsToAuthorizeEndpoint()
+    {
+        const string authority = "https://idp-full.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri.Contains("jwks", StringComparison.Ordinal)
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+
+        var result = await harness.Controller.OidChallenge("kc");
+
+        // A served discovery document lets OidcClient build the authorization redirect; the harness's
+        // per-test reset of the static state store (#289) keeps the added authorize state from leaking.
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith(authority + "/authorize", redirect.Url);
+    }
+
+    private static string Discovery(string authority) =>
+        $"{{\"issuer\":\"{authority}\","
+        + $"\"authorization_endpoint\":\"{authority}/authorize\","
+        + $"\"token_endpoint\":\"{authority}/token\","
+        + $"\"jwks_uri\":\"{authority}/jwks\","
+        + $"\"userinfo_endpoint\":\"{authority}/userinfo\","
+        + "\"response_types_supported\":[\"code\"],"
+        + "\"subject_types_supported\":[\"public\"],"
+        + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
+        + "\"grant_types_supported\":[\"authorization_code\"],"
+        + "\"code_challenge_methods_supported\":[\"S256\"]}";
 
     private static HttpResponseMessage Json(string body) =>
         new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -90,17 +90,17 @@ public class SSOControllerOidChallengeTests
             httpResponder: request =>
             {
                 var url = request.RequestUri!.AbsoluteUri;
-                if (url.Contains(".well-known/openid-configuration", StringComparison.Ordinal))
+                if (url == authority + "/.well-known/openid-configuration")
                 {
                     return Json(Discovery(authority));
                 }
 
-                if (url.Contains("/jwks", StringComparison.Ordinal))
+                if (url == authority + "/jwks")
                 {
                     return Json("{\"keys\":[]}");
                 }
 
-                // A challenge should only fetch discovery (and its JWKS); anything else is unexpected and
+                // A challenge should only fetch discovery and its JWKS; any other URL is unexpected and
                 // fails the request so a regression that reaches, e.g., the token endpoint is caught.
                 return new HttpResponseMessage(HttpStatusCode.NotFound);
             });

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -87,9 +87,23 @@ public class SSOControllerOidChallengeTests
                 OidScopes = Array.Empty<string>(),
                 DisablePushedAuthorization = true,
             },
-            httpResponder: request => request.RequestUri!.AbsoluteUri.Contains("jwks", StringComparison.Ordinal)
-                ? Json("{\"keys\":[]}")
-                : Json(Discovery(authority)));
+            httpResponder: request =>
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                if (url.Contains(".well-known/openid-configuration", StringComparison.Ordinal))
+                {
+                    return Json(Discovery(authority));
+                }
+
+                if (url.Contains("/jwks", StringComparison.Ordinal))
+                {
+                    return Json("{\"keys\":[]}");
+                }
+
+                // A challenge should only fetch discovery (and its JWKS); anything else is unexpected and
+                // fails the request so a regression that reaches, e.g., the token endpoint is caught.
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
 
         var result = await harness.Controller.OidChallenge("kc");
 

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -45,6 +45,10 @@ internal sealed class SsoControllerHarness
         IPAddress? clientIp = null,
         Func<HttpRequestMessage, HttpResponseMessage>? httpResponder = null)
     {
+        // The controller keeps process-wide OpenID caches as private statics; clear them so a prior test
+        // that exercised the login flow cannot leak in-flight state into this one (#289).
+        SSOController.ResetOidStateForTests();
+
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -339,6 +339,20 @@ public class SSOController : ControllerBase
         throw new ArgumentException(ProviderDoesNotExistMessage);
     }
 
+    // Test-only reset of the process-wide OpenID caches this controller keeps as private statics: the
+    // in-flight authorize-state store and the PKCE-discovery cache. A test that drives the login flow
+    // mutates these, so without a reset the state leaks into a sibling test in the same non-parallel
+    // collection. The other static caches are deliberately not cleared here: the SAML replay/request
+    // caches key on random IDs and the rate limiter is isolated by per-test client IP, so they cannot
+    // bleed between tests. Internal and reachable only through InternalsVisibleTo; it is never wired to
+    // an endpoint or DI, so it adds no runtime or security surface. Callback/challenge coverage relies
+    // on it for isolation (#289).
+    internal static void ResetOidStateForTests()
+    {
+        StateManager.Clear();
+        PkceSupportCache.Clear();
+    }
+
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
     // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).


### PR DESCRIPTION
# What & why

Unblocks isolated unit coverage of the OpenID login flow. The controller keeps its in-flight authorize-state store (`StateManager`) and PKCE-discovery cache (`PkceSupportCache`) as process-wide private statics; a test that drives `OidChallenge` adds an entry to the state store, which then leaks into sibling tests in the same non-parallel collection (it broke `OidStates_NoFlowsInProgress_ReturnsEmpty`).

This adds an `internal`, test-only `ResetOidStateForTests()` that clears those two caches, and calls it at the start of `SsoControllerHarness` so every controller test starts clean. The enabled-provider challenge happy path (redirect to the authorization endpoint, using the harness's served discovery document) is re-enabled here as the first beneficiary.

The method is `internal` (visible only to the test assembly via the pre-existing `InternalsVisibleTo`), carries no HTTP attribute, and is never wired to an endpoint or DI, so it adds no runtime or security surface. The SAML replay/request caches and the rate limiter are deliberately not cleared, they are already isolated by random IDs and per-test client IP, and the method comment says so.

Closes #289
Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches `SSOController.cs` (login-path file), so the adversarial-review gate was run (4 lenses, refute-by-default) even though the only production change is a test-only internal method.

- [x] Fail-closed preserved, the cleared caches are consumed strictly fail-closed on both sides (an empty `StateManager` makes every callback `TryGetValue` fail → re-auth; a `PkceSupportCache` miss forces a fresh discovery fetch). No fail-open path.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] A security review was performed, 4-lens gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call. (unchanged; no logging touched)

**Adversarial-review gate (refute-by-default):**
- **bypass** → PASS: internal, single friend-assembly, no endpoint/DI/public wrapper; cleared collections consumed fail-closed; no existing login-path code altered.
- **availability** → PASS: no production caller/route; worst case under a hypothetical forced call is a transient re-login for in-flight handshakes (self-healing), no persistent state touched; a hostile in-process plugin could already `.Clear()` the private fields by reflection, so the bar is unchanged.
- **integration** → PASS: not a routable action method (internal/static, no verb attribute); the served discovery document faithfully satisfies OidcClient/PKCE-probe validation; no test-only types leak into the shipped assembly.
- **correctness** → NEEDS_IMPROVEMENT, resolved: the initial name (`ResetSharedStateForTests`) was broader than the 2-of-6 statics it clears. Renamed to `ResetOidStateForTests` and documented why the SAML caches / rate limiter are left out (they are isolated by random IDs / per-test client IP). Re-verified: the suite is order-independent (3 consecutive green full runs).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires. (one 4-line method + a harness call)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (538 tests; 3 consecutive full runs to confirm order-independence).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- This is the enabler for the deferred OIDC/SAML callback coverage; further batches (OidAuth/SamlAuth token-exchange branches) can now be isolated. Tracked under #192.