### PR TITLE
Point config page help links at this repo's wiki

### DIFF
--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -18,7 +18,7 @@
               is="emby-button"
               class="raised button-alt headerHelpButton"
               target="_blank"
-              href="https://github.com/9p4/jellyfin-plugin-sso"
+              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               >${Help}</a
             >
           </div>
@@ -34,7 +34,7 @@
             See the
             <a
               is="emby-linkbutton"
-              href="https://github.com/9p4/jellyfin-plugin-sso"
+              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               class="button-link"
               >help page</a
             >


### PR DESCRIPTION
# What & why

The plugin config page (`SSO-Auth/Config/configPage.html`) still opened the
archived upstream `9p4/jellyfin-plugin-sso` from its two help/documentation
links, the header `${Help}` button and the inline "help page" link. That repo
no longer receives updates, so the config UI pointed users at stale docs.

Both links now target this repository's wiki
(`https://github.com/iderex/jellyfin-plugin-sso/wiki`), matching the earlier
migration of the README and `build.yaml` off `9p4` (#150).

Closes #291

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this change touches only two static `href` values on help
anchors. It does not touch the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline; there is no data flow or behavioral
change.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0 warnings).
- [x] `dotnet test` is green (537 passed, 0 failed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Scoped to the two stale help/documentation links only. Deliberately left
untouched:

- the roadmap link (line 44) points at a project board and needs a different
  destination, tracked separately, not this change;
- the historical issue-comment reference (line 516) is an intentional pointer
  to a specific archived-upstream discussion.

Out-of-scope observation (not changed here): the `${Help}` header button uses
`target="_blank"` without `rel="noopener"`, pre-existing, unrelated to the
link-target migration.

E2E: worth a one-time visual check that both help links open the wiki in a
running Jellyfin (config page render is otherwise unchanged).
