### PR TITLE
Point config page roadmap link at this project's board

### DIFF
--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -41,7 +41,7 @@
             and
             <a
               is="emby-linkbutton"
-              href="https://github.com/9p4/jellyfin-plugin-sso/projects/1"
+              href="https://github.com/users/iderex/projects/1"
               class="button-link"
               >roadmap
             </a>


### PR DESCRIPTION
# What & why

The plugin config page's "roadmap" linkbutton (`SSO-Auth/Config/configPage.html`, line 44) still pointed at the archived upstream board `github.com/9p4/jellyfin-plugin-sso/projects/1`, which no longer tracks this project. This retargets it to the live public **SSO Roadmap** board (Projects v2 #1) at `github.com/users/iderex/projects/1`, now the single source of truth for the roadmap (the old `ROADMAP.md` was deleted and its content migrated to the board).

Follow-up to #291/#293, which retargeted the two help links to the wiki but deliberately left the roadmap link out because it needs a different destination (a project board, not a wiki page).

Closes #294

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, the change is a single static documentation hyperlink `href` on the admin-only config page. No login path, crypto, config persistence, or release-pipeline code is touched; no user input, interpolation, or new external resource load. The retargeted URL is the verified public GitHub project board over HTTPS.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release).
- [x] `dotnet test` is green (537 passed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Scoped to the single roadmap link only. The `${Help}` header button (line 20) uses `target="_blank"` without `rel="noopener"`, a pre-existing reverse-tabnabbing nit noticed while touching this file; left out here to keep the PR single-purpose, to be flagged as its own follow-up. The historical issue-comment reference further down the file is unrelated and untouched.
