### PR TITLE
Add a Login Flow wiki page and link it from the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,8 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
+**Getting oriented.** Before diving into `SSOController.cs` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) wiki page — it walks an OpenID and a SAML sign-in from challenge to session, so you can map a change onto the flow instead of reverse-engineering it.
+
 **Building and testing.** CI runs these on every pull request and they must pass:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Configure your providers on the plugin's settings page (**Dashboard → Plugins 
 
 Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-plugin-sso/wiki)**:
 
-- [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
+- [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Per-identity-provider setup: [Provider Guides](providers.md)
 
 ## Security


### PR DESCRIPTION
# What & why

Closes #245.

There was no public artifact explaining how a login actually flows through the plugin: the README lists features, the wiki covers the security model, and `SSOController.cs` is a ~1,900-line file whose only entry point for a new reader is reverse-engineering the monolith. This adds a **Login Flow** wiki page that walks both sign-in protocols end to end, challenge → identity provider → callback validation → session mint, so users and reviewers can follow what happens without reading the code.

The page:

- describes the four shared stages, then the OpenID Connect and SAML 2.0 flows step by step, each with an accurate Mermaid sequence sketch;
- covers the pieces asked for in the issue, the PKCE-S256 discovery gate (#141) and authorize-state creation, `id_token` validation and the RFC 9207 issuer check, stable-`sub` resolution (#155), SAML AuthnRequest / solicited-only `InResponseTo` (#156), signature/time-bound/audience/recipient validation and the replay cache (#219), canonical-link resolution, role/permission mapping, edge rate limiting (#128), self-service linking, and Quick Connect for non-web clients;
- stays accurate to what is implemented today, and cross-links each validation step to the Security Model page rather than restating it.

The page content is pushed to the wiki repo separately (the wiki is its own repository). This PR is the repo-side half: it links the new page from the README **Documentation** section and from the **Your First Code Contribution** section of `CONTRIBUTING.md` (the orientation link #245 asks for). The wiki Home **Pages** list is updated in the same wiki push.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

N/A, documentation only. This change adds no code and does not touch the login path, crypto, config persistence, or the release pipeline; it only edits Markdown link lists in the README and CONTRIBUTING.md. The wiki page it points to describes existing, already-shipped behavior and introduces no runtime change.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., N/A, no code changed; not run for a docs-only change.
- [x] `dotnet test` is green., N/A, no code changed; not run for a docs-only change.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

- The Login Flow page itself is delivered to the wiki repository (`jellyfin-plugin-sso.wiki`), not to this repo, so it does not appear in this diff. The wiki push also adds the page to the Home **Pages** list.
- The CodeRabbit Linked-Issues pre-merge check flagged that #245 also asks for a `CONTRIBUTING.md` link; that link is now added (second commit).
- The page describes behavior faithfully and defers the "why" to the Security Model page to avoid duplicating (and drifting from) it.
- Out of scope: no source, test, or configuration changes, README and CONTRIBUTING.md documentation links only.
