### PR TITLE
Cover the OpenID auth callback (OidAuth)

### DIFF
--- a/SSO-Auth.Tests/FakeCryptoProvider.cs
+++ b/SSO-Auth.Tests/FakeCryptoProvider.cs
@@ -1,0 +1,24 @@
+using System;
+using MediaBrowser.Model.Cryptography;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A minimal real <see cref="ICryptoProvider"/> for tests. NSubstitute cannot proxy the
+/// <c>ReadOnlySpan&lt;char&gt;</c> overloads (a ref struct cannot cross a dynamic-proxy boundary), so the
+/// account-provisioning path — which hashes a random password — needs a concrete implementation. The
+/// values are inert; no test asserts on the produced hash.
+/// </summary>
+internal sealed class FakeCryptoProvider : ICryptoProvider
+{
+    public string DefaultHashMethod => "PBKDF2-SHA512";
+
+    public PasswordHash CreatePasswordHash(ReadOnlySpan<char> password) =>
+        new PasswordHash(DefaultHashMethod, Array.Empty<byte>());
+
+    public bool Verify(PasswordHash hash, ReadOnlySpan<char> password) => true;
+
+    public byte[] GenerateSalt() => Array.Empty<byte>();
+
+    public byte[] GenerateSalt(int length) => new byte[length];
+}

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the OpenID auth callback (<c>OidAuth</c>) via <see cref="SsoControllerHarness"/>.
+/// The callback consumes an already-validated authorize state (populated by the browser redirect leg in
+/// the real flow), so these tests seed that state directly with the harness's test hook. They cover the
+/// guard branches (missing data, disabled provider, unknown state) and the happy path, where a valid,
+/// single-use state provisions the account and mints a session.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerOidAuthTests
+{
+    private static readonly Guid UserId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+    [Fact]
+    public async Task OidAuth_MissingData_ReturnsBadRequest()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var result = await harness.Controller.OidAuth("kc", new AuthResponse());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task OidAuth_DisabledProvider_ReturnsProblem()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
+
+        // The provider exists but is disabled, so the redeem guard short-circuits to a problem, not a session.
+        var result = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "state-token" });
+
+        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidAuth_UnknownState_ReturnsProblem()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        // No state was seeded, so the token does not resolve and no session is minted.
+        var result = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "no-such-state" });
+
+        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidAuth_ValidState_ProvisionsAccountReturnsOk_AndIsSingleUse()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = false, // skip the permission-application block; not under test here
+            AllowExistingAccountLink = false,
+        });
+        SeedValidState(harness, "state-token");
+
+        var result = await harness.Controller.OidAuth("kc", new AuthResponse
+        {
+            Data = "state-token",
+            DeviceID = "device-1",
+            DeviceName = "Test Device",
+            AppName = "Jellyfin Web",
+            AppVersion = "1.0",
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+
+        // The state is claimed atomically (TryRemove), so a replay of the same token no longer redeems.
+        var replay = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "state-token" });
+        Assert.Equal(500, Assert.IsType<ObjectResult>(replay).StatusCode);
+    }
+
+    // Seeds a valid, redeemable login state for provider "kc" bound to a new user "alice", and mocks the
+    // user provisioning + session lookup the happy path drives.
+    private static void SeedValidState(SsoControllerHarness harness, string token)
+    {
+        var state = new TimedAuthorizeState(new AuthorizeState { State = token }, DateTime.Now)
+        {
+            Provider = "kc",
+            Valid = true,
+            Subject = "sub-1",
+            Username = "alice",
+            Folders = new List<string>(),
+        };
+        SSOController.SeedOidStateForTests(token, state);
+
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+    }
+}

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -78,7 +78,7 @@ internal sealed class SsoControllerHarness
             SessionManager,
             UserManager,
             AuthContext,
-            Substitute.For<ICryptoProvider>(),
+            new FakeCryptoProvider(),
             Substitute.For<IProviderManager>(),
             httpClientFactory,
             Substitute.For<IServerConfigurationManager>())

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -353,6 +353,15 @@ public class SSOController : ControllerBase
         PkceSupportCache.Clear();
     }
 
+    // Test-only seed of a single authorize-state entry so a test can exercise the OidAuth callback
+    // (which consumes an already-validated state that the browser redirect leg normally populates)
+    // without standing up the full token-exchange flow. Same test-only surface as ResetOidStateForTests
+    // (internal, InternalsVisibleTo, no endpoint/DI) — never reachable in production.
+    internal static void SeedOidStateForTests(string token, TimedAuthorizeState state)
+    {
+        StateManager[token] = state;
+    }
+
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
     // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).


### PR DESCRIPTION
# What & why

Covers the OpenID auth callback (`OidAuth`), the last large uncovered login-path branch, now that #289's state-store reset makes such tests isolatable.

- **Guard branches:** missing data → 400; a disabled provider and an unknown state each → a problem response (no session).
- **Happy path:** a valid, seeded authorize state provisions the account (`CreateUserAsync`) and mints a session (`Ok`), and the state is **single-use**, a replay of the same token no longer redeems (the atomic `TryRemove` claim).

To reach the callback without standing up the full browser token-exchange leg, this adds an `internal`, test-only `SeedOidStateForTests(token, state)` beside the existing `ResetOidStateForTests`, same test-only surface (`InternalsVisibleTo`, no HTTP attribute, no endpoint/DI, never reachable in production). It also adds a concrete `FakeCryptoProvider`, because NSubstitute cannot proxy `ICryptoProvider`'s `ReadOnlySpan<char>` overloads (a ref struct cannot cross a dynamic-proxy boundary) and the account-provisioning path hashes a random password.

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches `SSOController.cs` (login-path file), so the adversarial-review gate was run (4 lenses) even though the only production change is a test-only internal method.

- [x] Fail-closed preserved, the tests assert the callback's guards (missing data/unknown state/disabled → no session) and the single-use claim; no posture changed.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] A security review was performed, 4-lens gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call. (unchanged; no logging touched)

**Adversarial-review gate (refute-by-default):**
- **bypass** → PASS: the seed hook is `internal`, single friend assembly (`SSO-Auth.Tests`), one test caller, no HTTP attribute/DI/reflection; it writes a private static that is already reflectable in-process, so it adds no production-reachable or remote surface; purely additive.
- **integration** → PASS: not a routable action method; `FakeCryptoProvider` is a faithful inert stand-in on the exercised path and does not ship; harness ctor arg order matches the 9-arg production ctor. (It also caught that the work had been started on `main` before branching, corrected before any commit.)
- **correctness** → PASS: constructor-time `ResetOidStateForTests` isolates the seed within the serialized collection; the `ConcurrentDictionary` upsert is sound; the crypto swap regresses nothing (no test asserts on crypto); the replay-500 assertion genuinely depends on the atomic removal (it would fail if single-use were broken).
- **availability** → N/A: test-only; seeding one state cannot cause a lockout.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (a 3-line seed helper + a 5-method inert fake)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (542 tests; 3 consecutive full runs to confirm order-independence).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Builds on the #289 reset hook. The SAML callback (`SamlPost`/`SamlAuth`) is the remaining large branch; it needs a signed-SAML fixture rather than a state seed, and is a separate follow-up.