### PR TITLE
Correct misleading config doc-comments for NewPath and FolderRoleMap

### DIFF
--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -212,7 +212,12 @@ public class SamlConfig : ProviderConfigBase
     public int? PortOverride { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the new, more descriptive paths are to be used.
+    /// Gets or sets a value indicating whether the last non-linking login used the newer redirect path
+    /// spelling (the "/start/" form rather than the legacy short form). This is server-managed runtime
+    /// state, not an admin-facing setting: every non-linking challenge overwrites it from the incoming
+    /// request path so that a later linking flow — which cannot know which redirect path the identity
+    /// provider has registered — reuses the same spelling. It is persisted in the config XML for that
+    /// reason, not because it is user-configurable.
     /// </summary>
     public bool NewPath { get; set; }
 
@@ -367,7 +372,12 @@ public class OidConfig : ProviderConfigBase
     public int? PortOverride { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the new, more descriptive paths are to be used.
+    /// Gets or sets a value indicating whether the last non-linking login used the newer redirect path
+    /// spelling (the "/start/" form rather than the legacy short form). This is server-managed runtime
+    /// state, not an admin-facing setting: every non-linking challenge overwrites it from the incoming
+    /// request path so that a later linking flow — which cannot know which redirect path the identity
+    /// provider has registered — reuses the same spelling. It is persisted in the config XML for that
+    /// reason, not because it is user-configurable.
     /// </summary>
     public bool NewPath { get; set; }
 
@@ -443,7 +453,7 @@ public class OidConfig : ProviderConfigBase
 }
 
 /// <summary>
-/// The OpenID client ID.
+/// Maps a single provider role to the library folders granted to users who hold that role (RBAC folder access).
 /// </summary>
 public class FolderRoleMap
 {


### PR DESCRIPTION
# What & why

Two XML `<summary>` doc-comments in the config model (`SSO-Auth/Config/PluginConfiguration.cs`) currently state the opposite of the truth. A contributor reads them first, so they mislead. This corrects them; it is comment text only, with no change to runtime logic, types, or serialization.

- `NewPath` (on both `SamlConfig` and `OidConfig`): the old summary described it as a setting for "whether the new, more descriptive paths are to be used". It is not an admin-facing option. Every non-linking challenge in `SSOController` (`OidChallenge`, `SamlChallenge`) overwrites `config.NewPath` from the incoming request path (whether it used the newer `/start/` spelling versus the legacy short spelling). It is therefore server-managed runtime state recording which redirect path spelling the last login used, persisted in the config XML only so that a subsequent linking flow, which cannot know which redirect path the identity provider has registered, reuses the same spelling. The summary now says this, keeping the StyleCop SA1623 "Gets or sets a value indicating whether" bool-property prefix.
- `FolderRoleMap`: its summary read "The OpenID client ID."; the type maps a single provider role to the library folders granted to users holding that role (RBAC folder access). Corrected.

Refs #243. This PR covers the config-file (`PluginConfiguration.cs`) doc-truthfulness items from that issue. The remaining items in #243, the doc-comment fixes in `SSOController.cs` (`SamlProviderNames`, `DeleteCanonicalLink`'s `canonicalName` param, `TimedAuthorizeState`'s summary) and the two code-level cleanups (removing the no-op default assignments in the `TimedAuthorizeState` constructor and extracting the duplicated `NewPath` challenge block into one helper) touch the login-path source and are out of scope here; they are left for a separate change so the issue stays open until they land. Hence `Refs`, not `Closes`.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

N/A, this is XML doc-comment text only. No runtime logic, types, serialization, or config-persistence behavior changed (the `NewPath`/`FolderRoleMap` members and their attributes are untouched). The security-reminder hook flags `PluginConfiguration.cs` by filename, but the adversarial-review gate does not apply because no executable or persisted behavior changed. The security checkboxes are therefore left unchecked as not applicable.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both `SSO-Auth` and `SSO-Auth.Tests`, Debug).
- [x] `dotnet test` is green (542 passed, 0 failed, 0 skipped).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (N/A, C# only).

## Notes

Intentionally out of scope (deferred to a follow-up on #243): the `SSOController.cs` doc-comment corrections and the two behaviour-preserving code cleanups (no-op ctor assignments; extracting the duplicated six-line `NewPath` block into a helper carrying the why-comment). Those edit login-path executable code and belong in their own change; keeping them out keeps this PR a pure, gate-free documentation fix.
