### PR TITLE
Cover the SAML auth callback (SamlAuth)

### DIFF
--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the SAML auth callback (<c>SamlAuth</c>) via <see cref="SsoControllerHarness"/>,
+/// using <see cref="SamlTestFactory"/> to produce a real, cryptographically-signed response so the
+/// actual signature-validation path runs. They cover the guard branches (disabled provider, invalid
+/// signature, role not allowed) and the happy path, where a valid signed assertion provisions the
+/// account and mints a session.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlAuthTests
+{
+    private static readonly Guid UserId = Guid.Parse("88888888-8888-8888-8888-888888888888");
+
+    [Fact]
+    public async Task SamlAuth_DisabledProvider_ReturnsProblem()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = "irrelevant" });
+
+        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task SamlAuth_SignedByAnotherCertificate_Returns400()
+    {
+        var fixture = SamlTestFactory.Create();
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            // The provider trusts a DIFFERENT certificate, so the real signature check must reject it.
+            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
+        });
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task SamlAuth_RoleNotAllowed_Returns401()
+    {
+        var fixture = SamlTestFactory.Create(role: "jellyfin-users");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true, // audience validation is covered separately; exercise the role gate here
+            // A non-empty allow-list the assertion's role is not in, so login is refused after the
+            // signature validates.
+            Roles = new[] { "only-admins" },
+        });
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task SamlAuth_ValidSignedResponse_ProvisionsAccount_ReturnsOk()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true, // audience validation is covered separately; exercise the callback here
+            EnableAuthorization = false, // skip permission application; not under test here
+            AllowExistingAccountLink = false,
+        });
+
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse
+        {
+            Data = fixture.EncodeResponse(),
+            DeviceID = "device-1",
+            DeviceName = "Test Device",
+            AppName = "Jellyfin Web",
+            AppVersion = "1.0",
+        });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+}


### PR DESCRIPTION
# What & why

Covers the SAML auth callback (`SamlAuth`), completing the login-callback coverage alongside the OIDC side (#299). It uses the existing `SamlTestFactory` to build a real, cryptographically-signed SAML response, so the actual signature-validation path runs (not a mock).

- **Guard branches:** a disabled provider → a problem response; a response signed by a **different** certificate → 400 (the real signature check rejects it); an assertion whose role is not in the configured allow-list → 401 (after the signature validates).
- **Happy path:** a valid signed assertion provisions the account (`CreateUserAsync`) and mints a session (`Ok`).

Audience validation is exercised separately (`ValidateSamlTests`), so these callback tests set `DoNotValidateAudience` to focus on the callback flow rather than re-testing audience logic.

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] N/A for the running product, test-only change; no production code is touched (the diff adds a single test file). The tests pin the existing fail-closed SAML callback behaviour (invalid signature → 400, role denied → 401, disabled → problem) rather than change it, so the adversarial-review gate does not apply.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (reuses `SamlTestFactory` and the harness's `FakeCryptoProvider`)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (546 tests; 3 consecutive full runs to confirm order-independence).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Unlike the OIDC callback (#299), SamlAuth needs no state-seed hook: the SAML assertion is self-contained in the request, so this batch adds no production surface.