### PR TITLE
Dedupe the challenge NewPath logic and correct misleading doc-comments

### DIFF
--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -125,6 +125,31 @@ public class SSOControllerOidChallengeTests
         + "\"grant_types_supported\":[\"authorization_code\"],"
         + "\"code_challenge_methods_supported\":[\"S256\"]}";
 
+    [Fact]
+    public async Task OidChallenge_StartPath_RecordsNewPathAsServerState()
+    {
+        const string authority = "https://idp-newpath.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri == authority + "/jwks"
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+        // A login that arrives on the descriptive `.../start/...` route must record NewPath as
+        // server-managed runtime state, so a later linking flow reuses the same redirect-path spelling.
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        await harness.Controller.OidChallenge("kc");
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+    }
+
     private static HttpResponseMessage Json(string body) =>
         new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -296,12 +296,7 @@ public class SSOController : ControllerBase
                 return ReturnError(StatusCodes.Status400BadRequest, "The identity provider's PKCE (S256) support could not be verified.");
             }
 
-            bool newPath = config.NewPath;
-            if (!isLinking)
-            {
-                newPath = Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase);
-                config.NewPath = newPath;
-            }
+            bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
 
             string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/OID/{(newPath ? "redirect" : "r")}/" + provider;
 
@@ -373,6 +368,25 @@ public class SSOController : ControllerBase
 
     private static SamlConfig FindSamlConfig(string provider) =>
         SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
+
+    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that
+    // as server-managed runtime state on the provider config. A non-linking challenge derives the
+    // spelling from the request path (a `.../start/...` route means the new path) and stores it through
+    // `record`, so a later linking flow — which cannot know which redirect path the identity provider
+    // has registered — reuses the last login's spelling. A linking challenge only reads the stored
+    // value and records nothing. `record` is passed because OidConfig and SamlConfig do not share a
+    // base type. (See ExpectedAcsUrls for the same reason this value is remembered across requests.)
+    private bool ResolveChallengeNewPath(bool currentNewPath, bool isLinking, Action<bool> record)
+    {
+        if (isLinking)
+        {
+            return currentNewPath;
+        }
+
+        var newPath = Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase);
+        record(newPath);
+        return newPath;
+    }
 
     // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
@@ -573,7 +587,7 @@ public class SSOController : ControllerBase
     /// <summary>
     /// Lists the SAML providers names only.
     /// </summary>
-    /// <returns>The list of OpenID configurations.</returns>
+    /// <returns>The list of SAML provider names.</returns>
     [HttpGet("SAML/GetNames")]
     public ActionResult SamlProviderNames()
     {
@@ -759,12 +773,7 @@ public class SSOController : ControllerBase
 
         if (config.Enabled)
         {
-            bool newPath = config.NewPath;
-            if (!isLinking)
-            {
-                newPath = Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase);
-                config.NewPath = newPath;
-            }
+            bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
 
             string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/SAML/{(newPath ? "post" : "p")}/" + provider;
             string relayState = null;
@@ -1211,7 +1220,7 @@ public class SSOController : ControllerBase
     /// <param name="mode">The mode of the function; SAML or OID.</param>
     /// <param name="provider">The name of the provider from which the link should be removed.</param>
     /// <param name="jellyfinUserId">The user ID within jellyfin to unlink from the provider.</param>
-    /// <param name="canonicalName">The user ID within jellyfin to unlink.</param>
+    /// <param name="canonicalName">The provider-side canonical name (the identity's stable subject for OpenID, or the SAML NameID) whose link to the Jellyfin user should be removed.</param>
     /// <returns>Whether this API endpoint succeeded.</returns>
     [Authorize]
     [HttpDelete("{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}")]
@@ -1877,7 +1886,9 @@ public class AuthResponse
 }
 
 /// <summary>
-/// A manager for OpenID to manage the state of the clients.
+/// A time-stamped record of an in-flight OpenID authorize state: it ties the authorize-state token to
+/// the provider, the resolved identity (subject/username), and the login privileges, and is held until
+/// the callback redeems it or it expires.
 /// </summary>
 public class TimedAuthorizeState
 {


### PR DESCRIPTION
# What & why

Completes the login-path remainder of #243 (the config-file doc corrections, `FolderRoleMap`, the `NewPath` property docs, already landed in #300).

- **Dedupe the challenge `NewPath` logic:** the identical 5-line block in `OidChallenge` and `SamlChallenge` is extracted into one `ResolveChallengeNewPath` helper that finally carries the *why* comment in one place: `NewPath` is **server-managed runtime state** recording which redirect-path spelling the last non-linking login arrived on, kept so a later linking flow (which cannot know the IdP-registered redirect path) reuses it. Behaviour is preserved byte-for-byte, the write stays gated on `!isLinking`, and a new test (`OidChallenge_StartPath_RecordsNewPathAsServerState`) pins the `.../start/...` branch recording `NewPath`.
- **Fix three misleading XML doc-comments:** `SamlProviderNames`' return (was "OpenID configurations"), `DeleteCanonicalLink`'s `canonicalName` parameter (was "the user ID within jellyfin to unlink", it is the provider-side canonical name), and `TimedAuthorizeState`'s summary (was "a manager for OpenID").

The no-op `TimedAuthorizeState` constructor assignments named in the issue were already removed in an earlier change; the constructor now sets only `State` and `Created`.

Closes #243

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches `SSOController.cs` (login-path file), so the adversarial-review gate was run (3 lenses; integration N/A, no new integration surface).

- [x] Fail-closed preserved, the `!isLinking` write-gate on `config.NewPath` is preserved exactly; no fail-open introduced.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] A security review was performed, gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call. (unchanged; no logging touched)

**Adversarial-review gate (refute-by-default):**
- **correctness** → PASS: byte-for-byte behavioural equivalence for both `isLinking` branches, same return value, same single read/write of `config.NewPath`, same write-before-`redirectUri` ordering, same `Request.Path`/`StringComparison` semantics; the three doc fixes are accurate.
- **bypass** → PASS: `newPath` is cosmetic (selects only the redirect-path spelling; both spellings route to the same callback and gate no auth/crypto/state decision, the callback even re-derives its own `redirect_uri` from `Request.Path`, not `config.NewPath`); the `!isLinking` write-gate is preserved; no attacker influence, downgrade, SSRF, or fail-open.
- **availability** → PASS: same unsynchronized atomic-`bool` write on the same request thread, no new lock/contention/exception path/lockout; the only new artifact is a negligible, non-leaking per-challenge delegate allocation on a rate-limited, human-initiated path.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (removes the duplication and centralizes the subtle NewPath rationale in one helper)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (547 tests; 3 consecutive full runs).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- The deeper fix the issue mentions (dropping the config write entirely and threading the path spelling through the flow state) would change IdP-facing redirect URIs and is deliberately out of scope, it would need its own E2E-verified issue.