### PR TITLE
Cover the SAML assertion-consumer callback (SamlPost)

### DIFF
--- a/SSO-Auth.Tests/SSOControllerSamlPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlPostTests.cs
@@ -1,0 +1,80 @@
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the SAML assertion-consumer callback (<c>SamlPost</c>) via
+/// <see cref="SsoControllerHarness"/>, using <see cref="SamlTestFactory"/> to produce a real, signed
+/// response so the actual signature-validation path runs. They cover the guard branches (disabled
+/// provider, invalid signature, role not allowed) and the happy path, where a valid signed assertion
+/// renders the intermediate auth page (an HTML <see cref="ContentResult"/> that later posts to SamlAuth).
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlPostTests
+{
+    [Fact]
+    public void SamlPost_DisabledProvider_Returns400()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+
+        var result = harness.Controller.SamlPost("adfs", formSamlResponse: "irrelevant");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public void SamlPost_SignedByAnotherCertificate_Returns400()
+    {
+        var fixture = SamlTestFactory.Create();
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            // The provider trusts a different certificate, so the real signature check must reject it.
+            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
+        });
+
+        var result = harness.Controller.SamlPost("adfs", formSamlResponse: fixture.EncodeResponse());
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public void SamlPost_RoleNotAllowed_Returns401()
+    {
+        var fixture = SamlTestFactory.Create(role: "jellyfin-users");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true, // audience validation is covered separately
+            Roles = new[] { "only-admins" },
+        });
+
+        var result = harness.Controller.SamlPost("adfs", formSamlResponse: fixture.EncodeResponse());
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public void SamlPost_ValidSignedResponse_RendersTheAuthPage()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+        });
+
+        var result = harness.Controller.SamlPost("adfs", formSamlResponse: fixture.EncodeResponse());
+
+        // A valid assertion renders the intermediate HTML auth page (which then posts to SamlAuth).
+        var page = Assert.IsType<ContentResult>(result);
+        Assert.Equal("text/html", page.ContentType);
+        Assert.False(string.IsNullOrEmpty(page.Content));
+        // The page is served with the hardened CSP the auth page sets.
+        Assert.True(harness.Controller.Response.Headers.ContainsKey("Content-Security-Policy"));
+    }
+}


### PR DESCRIPTION
# What & why

Covers the SAML assertion-consumer callback (`SamlPost`), the SAML side's redirect callback, completing the callback coverage. It uses a signed `SamlTestFactory` response so the actual signature-validation path runs.

- **Guard branches:** a disabled provider → 400 "No active providers found"; a response signed by a **different** certificate → 400; an assertion whose role is not in the allow-list → 401.
- **Happy path:** a valid signed assertion renders the intermediate **HTML auth page**, a `text/html` `ContentResult` served with the hardened CSP header, which then posts to `SamlAuth`.

The OpenID redirect callback's token-exchange path (`OidPost` from `ProcessResponseAsync` onward) is deliberately out of scope and tracked in **#305**: its guard branches are already covered, and the token-exchange happy path needs a signed-id_token / JWKS / token-endpoint round-trip fixture. The `OidPost` guards (unknown provider, missing/invalid/expired state, disabled, rate-limit) are already covered in `SSOControllerEndpointTests`/`SSOControllerAdminTests`.

Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] N/A for the running product, test-only change; no production code is touched (the diff adds a single test file). The tests pin the existing fail-closed SamlPost behaviour (invalid signature → 400, role denied → 401, disabled → 400) rather than change it.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (reuses `SamlTestFactory` and the harness)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (555 tests; 3 consecutive full runs).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- With this, every SSOController endpoint except the OidPost token-exchange path (#305) has controller-level coverage.