### PR TITLE
Deduplicate device-name logic onto WebResponse.cs

### DIFF
--- a/SSO-Auth/Views/apiClient.js
+++ b/SSO-Auth/Views/apiClient.js
@@ -85,11 +85,12 @@ export async function serverAddress({ basePath = "/web" }) {
     });
 }
 
-// Duplicated with WebResponse.cs; tracked in #63.
-// https://github.com/9p4/jellyfin-plugin-sso/blob/38558d762a13422862240af4060bdd1bb1618d57/SSO-Auth/WebResponse.cs#L363-L401
-function getDeviceName() {
-  return "DUMMY";
-}
+// The browser-to-device-name derivation is defined once, in the server-rendered auth-completion
+// page (WebResponse.cs). This linking view is not a login client, so it does not re-derive that
+// value; it registers under a fixed placeholder identifier. This is kept byte-identical to the
+// prior behavior on purpose - deriving a real device name here would change the name SSO-view
+// sessions register under, which is a separate, deliberate behavior change.
+const deviceName = "DUMMY";
 
 function getDeviceId() {
   return localStorage.getItem("_deviceId2");
@@ -132,7 +133,7 @@ const localApiClient = new jellyfinApiclient.ApiClient(
   server,
   appName,
   appVersion,
-  getDeviceName(),
+  deviceName,
   deviceId,
 );
 localApiClient.setAuthenticationInfo(
@@ -144,7 +145,7 @@ const connections = new jellyfinApiclient.ConnectionManager(
   credentials,
   appName,
   appVersion,
-  getDeviceName(),
+  deviceName,
   deviceId,
   capabilities,
 );


### PR DESCRIPTION
# What & why

Closes #63.

The browser-to-device-name derivation exists in exactly one place: inlined into
the server-rendered auth-completion page in `SSO-Auth/WebResponse.cs`. The
linking view's `SSO-Auth/Views/apiClient.js` carried a `getDeviceName()` stub
that returned the constant `"DUMMY"`, plus a stale comment claiming it
duplicated that derivation and linking to dead upstream line numbers. It never
actually held the derivation logic, only a placeholder value.

This removes the misleading pretense so the derivation has a single home:

- replace the `getDeviceName()` stub with a documented module-level
  `const deviceName = "DUMMY";` of the same value, and
- point both call sites (the `ApiClient` and `ConnectionManager` constructors)
  at that constant.

There is no behavior change. The device name the linking view registers under
stays byte-identical (`"DUMMY"`), and `WebResponse.cs`, hence the auth page
HTML served to existing login clients, is untouched (the diff is confined to
`apiClient.js`).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No auth/validation logic touched; the
      value only feeds the `Device="…"` label of the linking view's
      already-authenticated request.)
- [x] No secrets logged; secrets are redacted on config export. (Not affected.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Adversarial-review gate run
      because the file is login-adjacent — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Not
      affected; the value is a hardcoded constant, no interpolation.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green. (551 passed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

- **Byte-identical constraint.** The two device-name sites produce different
  values today, the real derived name on the auth page vs. `"DUMMY"` on the
  linking view, so consolidating both onto one shared computation cannot be
  done without changing behavior. Porting the full browser-detection block into
  `apiClient.js` would both flip the linking session name from `"DUMMY"` to a
  real value and add ~130 lines, which is neither byte-identical nor minimal.
  The byte-identical dedup is therefore to designate `WebResponse.cs` as the
  sole derivation and drop the linking view's duplicate-derivation pretense,
  which this PR does.
- **Adversarial-review gate.** Ran all four lenses (availability, bypass,
  correctness, integration) because the file is login-adjacent. All returned
  **PASS**: device-name value and auth-page output are byte-identical, no
  temporal-dead-zone from the function→`const` change (declared above every use
  and above the top-level `await`), no dangling `getDeviceName` reference, no
  injection/escaping or fail-open surface, and no conflict with the #136
  auth-header work (the linking view delegates header construction to the
  vendored library and was not touched by #136).
- **Out of scope / follow-up.** Actually deriving a real device name on the
  linking view (so SSO-view sessions stop registering under `"DUMMY"`) is a
  deliberate behavior change and is tracked separately; it is intentionally not
  part of this byte-identical dedup.
