### PR TITLE
Consolidate shared SamlConfig/OidConfig members into ProviderConfigBase

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -285,6 +285,187 @@ public class ConfigPreservationTests
         Assert.Equal("https://jellyfin.example.com", back.BaseUrlOverride);
     }
 
+    // --- Shared-member consolidation into ProviderConfigBase (#204) ---
+
+    [Fact]
+    public void SamlConfig_WithSharedAndSpecificMembers_RoundTripsThroughXml()
+    {
+        // The shared members (Enabled, roles, overrides, NewPath, CanonicalLinks, …) now live on
+        // ProviderConfigBase. Serializing the concrete type must still emit and read back every one of
+        // them, so the on-disk config contract is unchanged by the base-class extraction.
+        var original = new SamlConfig
+        {
+            // Shared (base) members:
+            BaseUrlOverride = "https://jellyfin.example.com",
+            Enabled = true,
+            EnableAuthorization = true,
+            AllowExistingAccountLink = true,
+            EnableAllFolders = true,
+            EnabledFolders = new[] { "folder-a", "folder-b" },
+            AdminRoles = new[] { "admin" },
+            Roles = new[] { "user" },
+            EnableFolderRoles = true,
+            EnableLiveTvRoles = true,
+            EnableLiveTv = true,
+            EnableLiveTvManagement = true,
+            LiveTvRoles = new[] { "tv" },
+            LiveTvManagementRoles = new[] { "tv-admin" },
+            FolderRoleMapping = new System.Collections.Generic.List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "user", Folders = new System.Collections.Generic.List<string> { "folder-a" } },
+            },
+            DefaultProvider = "provider",
+            SchemeOverride = "https",
+            PortOverride = 8443,
+            NewPath = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = User },
+
+            // Provider-specific members:
+            SamlEndpoint = "https://idp/saml",
+            SamlClientId = "sp-entity",
+            SamlAudience = "sp-audience",
+            DoNotValidateAudience = true,
+            ValidateRecipient = true,
+            ValidateInResponseTo = true,
+        };
+
+        var back = RoundTripXml(original);
+
+        Assert.Equal(original.BaseUrlOverride, back.BaseUrlOverride);
+        Assert.True(back.Enabled);
+        Assert.True(back.EnableAuthorization);
+        Assert.True(back.AllowExistingAccountLink);
+        Assert.True(back.EnableAllFolders);
+        Assert.Equal(original.EnabledFolders, back.EnabledFolders);
+        Assert.Equal(original.AdminRoles, back.AdminRoles);
+        Assert.Equal(original.Roles, back.Roles);
+        Assert.True(back.EnableFolderRoles);
+        Assert.True(back.EnableLiveTvRoles);
+        Assert.True(back.EnableLiveTv);
+        Assert.True(back.EnableLiveTvManagement);
+        Assert.Equal(original.LiveTvRoles, back.LiveTvRoles);
+        Assert.Equal(original.LiveTvManagementRoles, back.LiveTvManagementRoles);
+        Assert.Equal("user", back.FolderRoleMapping[0].Role);
+        Assert.Equal("folder-a", back.FolderRoleMapping[0].Folders[0]);
+        Assert.Equal("provider", back.DefaultProvider);
+        Assert.Equal("https", back.SchemeOverride);
+        Assert.Equal(8443, back.PortOverride);
+        Assert.True(back.NewPath);
+        Assert.Equal(User, back.CanonicalLinks["nameid-1"]);
+
+        Assert.Equal("https://idp/saml", back.SamlEndpoint);
+        Assert.Equal("sp-entity", back.SamlClientId);
+        Assert.Equal("sp-audience", back.SamlAudience);
+        Assert.True(back.DoNotValidateAudience);
+        Assert.True(back.ValidateRecipient);
+        Assert.True(back.ValidateInResponseTo);
+    }
+
+    [Fact]
+    public void OidConfig_WithSharedAndSpecificMembers_RoundTripsThroughXml()
+    {
+        var original = new OidConfig
+        {
+            // Shared (base) members:
+            BaseUrlOverride = "https://jellyfin.example.com",
+            Enabled = true,
+            SchemeOverride = "https",
+            PortOverride = 8443,
+            NewPath = true,
+            Roles = new[] { "user" },
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+
+            // Provider-specific members:
+            OidEndpoint = "https://idp/.well-known",
+            OidClientId = "client",
+            OidSecret = "s3cr3t",
+            OidScopes = new[] { "openid", "profile" },
+            RequirePkce = true,
+        };
+
+        var back = RoundTripXml(original);
+
+        Assert.Equal(original.BaseUrlOverride, back.BaseUrlOverride);
+        Assert.True(back.Enabled);
+        Assert.Equal("https", back.SchemeOverride);
+        Assert.Equal(8443, back.PortOverride);
+        Assert.True(back.NewPath);
+        Assert.Equal(original.Roles, back.Roles);
+        Assert.Equal(User, back.CanonicalLinks["sub-1"]);
+
+        Assert.Equal("https://idp/.well-known", back.OidEndpoint);
+        Assert.Equal("client", back.OidClientId);
+        Assert.Equal("s3cr3t", back.OidSecret);
+        Assert.Equal(original.OidScopes, back.OidScopes);
+        Assert.True(back.RequirePkce);
+    }
+
+    [Fact]
+    public void LegacyElementOrder_StillDeserializes_AfterMembersMovedToBase()
+    {
+        // Existing installs wrote the config with the shared members AFTER the provider-specific ones
+        // (their pre-#204 declaration order); the base-class extraction reverses that in newly written
+        // XML. XML deserialization is by element name, not position, so an on-disk config in the old
+        // order must still load every value. Element order here is deliberately the pre-refactor one.
+        const string legacyXml = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<PluginConfiguration xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <SamlEndpoint>https://idp/saml</SamlEndpoint>
+  <SamlClientId>sp-entity</SamlClientId>
+  <DoNotValidateAudience>true</DoNotValidateAudience>
+  <Enabled>true</Enabled>
+  <EnableAuthorization>true</EnableAuthorization>
+  <Roles>
+    <string>user</string>
+  </Roles>
+  <SchemeOverride>https</SchemeOverride>
+  <PortOverride>8443</PortOverride>
+  <NewPath>true</NewPath>
+  <CanonicalLinks>
+    <item>
+      <key>
+        <string>nameid-1</string>
+      </key>
+      <value>
+        <guid>11111111-1111-1111-1111-111111111111</guid>
+      </value>
+    </item>
+  </CanonicalLinks>
+  <BaseUrlOverride>https://jellyfin.example.com</BaseUrlOverride>
+</PluginConfiguration>";
+
+        var serializer = new XmlSerializer(typeof(SamlConfig));
+        using var stringReader = new System.IO.StringReader(legacyXml);
+        using var xmlReader = System.Xml.XmlReader.Create(
+            stringReader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var back = (SamlConfig)serializer.Deserialize(xmlReader)!;
+
+        Assert.Equal("https://idp/saml", back.SamlEndpoint);
+        Assert.Equal("sp-entity", back.SamlClientId);
+        Assert.True(back.DoNotValidateAudience);
+        Assert.True(back.Enabled);
+        Assert.True(back.EnableAuthorization);
+        Assert.Equal(new[] { "user" }, back.Roles);
+        Assert.Equal("https", back.SchemeOverride);
+        Assert.Equal(8443, back.PortOverride);
+        Assert.True(back.NewPath);
+        Assert.Equal(User, back.CanonicalLinks["nameid-1"]);
+        Assert.Equal("https://jellyfin.example.com", back.BaseUrlOverride);
+    }
+
+    private static T RoundTripXml<T>(T value)
+    {
+        var serializer = new XmlSerializer(typeof(T));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, value);
+
+        using var stringReader = new System.IO.StringReader(writer.ToString());
+        using var xmlReader = System.Xml.XmlReader.Create(
+            stringReader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        return (T)serializer.Deserialize(xmlReader)!;
+    }
+
     // --- SAML certificate validation on save (#206) ---
 
     [Fact]

--- a/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/OidcRolePrivilegeMapper.cs
@@ -75,8 +75,8 @@ internal static class OidcRolePrivilegeMapper
     /// <summary>
     /// The privileges a set of roles grants under a provider configuration.
     /// </summary>
-    /// <param name="Valid">Whether any role is on the login allow-list (<see cref="OidConfig.Roles"/>).</param>
-    /// <param name="Admin">Whether any role is on the admin list (<see cref="OidConfig.AdminRoles"/>).</param>
+    /// <param name="Valid">Whether any role is on the login allow-list (<see cref="ProviderConfigBase.Roles"/>).</param>
+    /// <param name="Admin">Whether any role is on the admin list (<see cref="ProviderConfigBase.AdminRoles"/>).</param>
     /// <param name="EnableLiveTv">Whether any role grants Live TV (only when role-based Live TV is enabled).</param>
     /// <param name="EnableLiveTvManagement">Whether any role grants Live TV management (only when role-based Live TV is enabled).</param>
     /// <param name="Folders">The folders granted by matching folder-role mappings (only when folder roles are enabled).</param>

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -57,10 +57,17 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
 }
 
 /// <summary>
-/// Configuration shared by every SSO provider (OpenID and SAML).
+/// Configuration shared by every SSO provider (OpenID and SAML). Both <see cref="SamlConfig"/> and
+/// <see cref="OidConfig"/> inherit these members; the concrete types are what get XML-serialized
+/// (SerializableDictionary serializes each value as its concrete type), so inherited members emit the
+/// same as declared ones and no <c>[XmlInclude]</c>/polymorphism handling is needed (#204). XML
+/// deserialization is by element name, so moving these up — which places them before the
+/// provider-specific elements in newly written XML — does not stop existing configs from loading.
 /// </summary>
 public abstract class ProviderConfigBase
 {
+    private SerializableDictionary<string, Guid> _canonicalLinks;
+
     /// <summary>
     /// Gets or sets the canonical external base URL for this provider, e.g.
     /// <c>https://jellyfin.example.com</c>. When set, the provider's derived external URLs (the OpenID
@@ -69,6 +76,124 @@ public abstract class ProviderConfigBase
     /// It overrides the scheme and port overrides. Blank keeps the request-host behavior.
     /// </summary>
     public string BaseUrlOverride { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the provider is enabled.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether RBAC is enabled.
+    /// </summary>
+    public bool EnableAuthorization { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
+    /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
+    /// login that matches an existing account is rejected rather than taking it over.
+    /// </summary>
+    public bool AllowExistingAccountLink { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether all folders are allowed by default.
+    /// </summary>
+    public bool EnableAllFolders { get; set; }
+
+    /// <summary>
+    /// Gets or sets what folders should users have access to by default.
+    /// </summary>
+    public string[] EnabledFolders { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that are checked to determine whether the user is an administrator.
+    /// </summary>
+    public string[] AdminRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets what roles are checked to determine whether the user is allowed to use Jellyfin.
+    /// </summary>
+    public string[] Roles { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether RBAC is used to manage folder access.
+    /// </summary>
+    public bool EnableFolderRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether RBAC is used to manage Live TV access.
+    /// </summary>
+    public bool EnableLiveTvRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Live TV is enabled by default.
+    /// </summary>
+    public bool EnableLiveTv { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether Live TV is allowed to be managed by default.
+    /// </summary>
+    public bool EnableLiveTvManagement { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that are checked to determine whether the user is allowed to view Live TV.
+    /// </summary>
+    public string[] LiveTvRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that are checked to determine whether the user is allowed to manage Live TV.
+    /// </summary>
+    public string[] LiveTvManagementRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets which folders map to what roles in RBAC.
+    /// </summary>
+    [XmlArray("FolderRoleMappings")]
+    [XmlArrayItem(typeof(FolderRoleMap), ElementName = "FolderRoleMappings")]
+    public List<FolderRoleMap> FolderRoleMapping { get; set; }
+
+    /// <summary>
+    /// Gets or sets the default provider the user after logging in with SSO.
+    /// </summary>
+    public string DefaultProvider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the redirect scheme override.
+    /// </summary>
+    public string SchemeOverride { get; set; }
+
+    /// <summary>
+    /// Gets or sets the redirect port override.
+    /// </summary>
+    public int? PortOverride { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the last non-linking login used the newer redirect path
+    /// spelling (the "/start/" form rather than the legacy short form). This is server-managed runtime
+    /// state, not an admin-facing setting: every non-linking challenge overwrites it from the incoming
+    /// request path so that a later linking flow — which cannot know which redirect path the identity
+    /// provider has registered — reuses the same spelling. It is persisted in the config XML for that
+    /// reason, not because it is user-configurable.
+    /// </summary>
+    public bool NewPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a mapping of canonical names from the provider to jellyfin user ids.
+    /// </summary>
+    // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
+    // from every JSON response (#157). This stops the account-link map leaking off the server, closes
+    // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
+    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
+    [XmlElement("CanonicalLinks")]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SerializableDictionary<string, Guid> CanonicalLinks
+    {
+        // Self-healing lazy init: the backing map is created and stored on first access, so a direct
+        // `CanonicalLinks[key] = id` persists into the stored map instead of a discarded throwaway.
+        // Every access runs under the config lock (ReadConfiguration/MutateConfiguration), so the
+        // assignment cannot race; an empty map serializes the same as the old throwaway did.
+        get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();
+        set => _canonicalLinks = value;
+    }
 }
 
 /// <summary>
@@ -77,8 +202,6 @@ public abstract class ProviderConfigBase
 [XmlRoot("PluginConfiguration")]
 public class SamlConfig : ProviderConfigBase
 {
-    private SerializableDictionary<string, Guid> _canonicalLinks;
-
     /// <summary>
     /// Gets or sets the SAML information endpoint.
     /// </summary>
@@ -121,124 +244,6 @@ public class SamlConfig : ProviderConfigBase
     /// enabling it rejects IdP-initiated (unsolicited) SSO, which carries no InResponseTo. Refs #156.
     /// </summary>
     public bool ValidateInResponseTo { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the provider is enabled.
-    /// </summary>
-    public bool Enabled { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is enabled.
-    /// </summary>
-    public bool EnableAuthorization { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
-    /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
-    /// login that matches an existing account is rejected rather than taking it over.
-    /// </summary>
-    public bool AllowExistingAccountLink { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether all folders are allowed by default.
-    /// </summary>
-    public bool EnableAllFolders { get; set; }
-
-    /// <summary>
-    /// Gets or sets what folders should users have access to by default.
-    /// </summary>
-    public string[] EnabledFolders { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is an administrator.
-    /// </summary>
-    public string[] AdminRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets what roles are checked to determine whether the user is allowed to use Jellyfin.
-    /// </summary>
-    public string[] Roles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is used to manage folder access.
-    /// </summary>
-    public bool EnableFolderRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is used to manage Live TV access.
-    /// </summary>
-    public bool EnableLiveTvRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether Live TV is enabled by default.
-    /// </summary>
-    public bool EnableLiveTv { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether Live TV is allowed to be managed by default.
-    /// </summary>
-    public bool EnableLiveTvManagement { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is allowed to view Live TV.
-    /// </summary>
-    public string[] LiveTvRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is allowed to manage Live TV.
-    /// </summary>
-    public string[] LiveTvManagementRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets which folders map to what roles in RBAC.
-    /// </summary>
-    [XmlArray("FolderRoleMappings")]
-    [XmlArrayItem(typeof(FolderRoleMap), ElementName = "FolderRoleMappings")]
-    public List<FolderRoleMap> FolderRoleMapping { get; set; }
-
-    /// <summary>
-    /// Gets or sets the default provider the user after logging in with SSO.
-    /// </summary>
-    public string DefaultProvider { get; set; }
-
-    /// <summary>
-    /// Gets or sets the redirect scheme override.
-    /// </summary>
-    public string SchemeOverride { get; set; }
-
-    /// <summary>
-    /// Gets or sets the redirect port override.
-    /// </summary>
-    public int? PortOverride { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the last non-linking login used the newer redirect path
-    /// spelling (the "/start/" form rather than the legacy short form). This is server-managed runtime
-    /// state, not an admin-facing setting: every non-linking challenge overwrites it from the incoming
-    /// request path so that a later linking flow — which cannot know which redirect path the identity
-    /// provider has registered — reuses the same spelling. It is persisted in the config XML for that
-    /// reason, not because it is user-configurable.
-    /// </summary>
-    public bool NewPath { get; set; }
-
-    /// <summary>
-    /// Gets or sets a mapping of canonical names from the provider to jellyfin user ids.
-    /// </summary>
-    // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
-    // from every JSON response (#157). This stops the account-link map leaking off the server, closes
-    // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
-    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
-    [XmlElement("CanonicalLinks")]
-    [System.Text.Json.Serialization.JsonIgnore]
-    public SerializableDictionary<string, Guid> CanonicalLinks
-    {
-        // Self-healing lazy init: the backing map is created and stored on first access, so a direct
-        // `CanonicalLinks[key] = id` persists into the stored map instead of a discarded throwaway.
-        // Every access runs under the config lock (ReadConfiguration/MutateConfiguration), so the
-        // assignment cannot race; an empty map serializes the same as the old throwaway did.
-        get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();
-        set => _canonicalLinks = value;
-    }
 }
 
 /// <summary>
@@ -247,8 +252,6 @@ public class SamlConfig : ProviderConfigBase
 [XmlRoot("PluginConfiguration")]
 public class OidConfig : ProviderConfigBase
 {
-    private SerializableDictionary<string, Guid> _canonicalLinks;
-
     /// <summary>
     /// Gets or sets the OpenID well-known information endpoint.
     /// </summary>
@@ -273,80 +276,6 @@ public class OidConfig : ProviderConfigBase
     public string OidSecret { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the provider is enabled.
-    /// </summary>
-    public bool Enabled { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is enabled.
-    /// </summary>
-    public bool EnableAuthorization { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
-    /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
-    /// login that matches an existing account is rejected rather than taking it over.
-    /// </summary>
-    public bool AllowExistingAccountLink { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether all folders are allowed by default.
-    /// </summary>
-    public bool EnableAllFolders { get; set; }
-
-    /// <summary>
-    /// Gets or sets what folders should users have access to by default.
-    /// </summary>
-    public string[] EnabledFolders { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is an administrator.
-    /// </summary>
-    public string[] AdminRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets what roles are checked to determine whether the user is allowed to use Jellyfin.
-    /// </summary>
-    public string[] Roles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is used to manage folder access.
-    /// </summary>
-    public bool EnableFolderRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether RBAC is used to manage Live TV access.
-    /// </summary>
-    public bool EnableLiveTvRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether Live TV is enabled by default.
-    /// </summary>
-    public bool EnableLiveTv { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether Live TV is allowed to be managed by default.
-    /// </summary>
-    public bool EnableLiveTvManagement { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is allowed to view Live TV.
-    /// </summary>
-    public string[] LiveTvRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets the roles that are checked to determine whether the user is allowed to manage Live TV.
-    /// </summary>
-    public string[] LiveTvManagementRoles { get; set; }
-
-    /// <summary>
-    /// Gets or sets which folders map to what roles in RBAC.
-    /// </summary>
-    [XmlArray("FolderRoleMappings")]
-    [XmlArrayItem(typeof(FolderRoleMap), ElementName = "FolderRoleMappings")]
-    public List<FolderRoleMap> FolderRoleMapping { get; set; }
-
-    /// <summary>
     /// Gets or sets the claim to check roles against. Separated by "."s.
     /// </summary>
     public string RoleClaim { get; set; }
@@ -355,50 +284,6 @@ public class OidConfig : ProviderConfigBase
     /// Gets or Sets additional Scopes to request access to in the authorization request.
     /// </summary>
     public string[] OidScopes { get; set; }
-
-    /// <summary>
-    /// Gets or sets the default provider the user after logging in with SSO.
-    /// </summary>
-    public string DefaultProvider { get; set; }
-
-    /// <summary>
-    /// Gets or sets the redirect scheme override.
-    /// </summary>
-    public string SchemeOverride { get; set; }
-
-    /// <summary>
-    /// Gets or sets the redirect port override.
-    /// </summary>
-    public int? PortOverride { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the last non-linking login used the newer redirect path
-    /// spelling (the "/start/" form rather than the legacy short form). This is server-managed runtime
-    /// state, not an admin-facing setting: every non-linking challenge overwrites it from the incoming
-    /// request path so that a later linking flow — which cannot know which redirect path the identity
-    /// provider has registered — reuses the same spelling. It is persisted in the config XML for that
-    /// reason, not because it is user-configurable.
-    /// </summary>
-    public bool NewPath { get; set; }
-
-    /// <summary>
-    /// Gets or sets a mapping of canonical names from the provider to jellyfin user ids.
-    /// </summary>
-    // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
-    // from every JSON response (#157). This stops the account-link map leaking off the server, closes
-    // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
-    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
-    [XmlElement("CanonicalLinks")]
-    [System.Text.Json.Serialization.JsonIgnore]
-    public SerializableDictionary<string, Guid> CanonicalLinks
-    {
-        // Self-healing lazy init: the backing map is created and stored on first access, so a direct
-        // `CanonicalLinks[key] = id` persists into the stored map instead of a discarded throwaway.
-        // Every access runs under the config lock (ReadConfiguration/MutateConfiguration), so the
-        // assignment cannot race; an empty map serializes the same as the old throwaway did.
-        get => _canonicalLinks ??= new SerializableDictionary<string, Guid>();
-        set => _canonicalLinks = value;
-    }
 
     /// <summary>
     /// Gets or sets the default username claim when creating new accounts.


### PR DESCRIPTION
# What & why

`SamlConfig` and `OidConfig` duplicated a ~70-line block of byte-for-byte
identical members (SonarCloud-reported). This pulls the genuinely-shared members
up into the existing `ProviderConfigBase` (which already held `BaseUrlOverride`
from #139), so both provider configs inherit them once instead of each carrying
its own copy.

Pulled up (each kept its exact type, attributes and default):

- `Enabled`, `EnableAuthorization`, `AllowExistingAccountLink`
- `EnableAllFolders`, `EnabledFolders`, `AdminRoles`, `Roles`
- `EnableFolderRoles`, `EnableLiveTvRoles`, `EnableLiveTv`,
  `EnableLiveTvManagement`, `LiveTvRoles`, `LiveTvManagementRoles`,
  `FolderRoleMapping` (with its `[XmlArray]`/`[XmlArrayItem]`)
- `DefaultProvider`, `SchemeOverride`, `PortOverride`, `NewPath`
- `CanonicalLinks` (with the `_canonicalLinks` backing field, its
  `[XmlElement("CanonicalLinks")]` + `[JsonIgnore]` attributes and the
  self-healing lazy getter)

Provider-specific members stay on the derived types (SAML: endpoint / client id
/ certificate / audience / recipient / in-response-to; OID: endpoint / secret /
scopes / PKCE / validation toggles). `OidSecret` stays on `OidConfig` with its
write-only JSON converter (#189). The two doc-comment `cref`s in
`OidcRolePrivilegeMapper` that pointed at `OidConfig.Roles`/`AdminRoles` are
retargeted to `ProviderConfigBase`.

Closes #204

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches the config-persistence surface, so it went through the
adversarial-review gate (4 refute-by-default lenses: availability, security
bypass, correctness, integration, all PASS).

- [x] Fail-closed preserved: no validation logic changed; the escape-hatch and
      validation flags remain on their concrete types with unchanged `false`
      defaults.
- [x] No secrets logged; `OidSecret` keeps its write-only JSON converter and
      stays hidden from JSON responses (verified by the existing tests).
- [x] A security review was performed (config persistence): the on-disk XML
      contract is unchanged. Values serialize per concrete type
      (`SerializableDictionary` serializes each value as `typeof(TValue)`), so
      inherited members emit the same as declared ones and no `[XmlInclude]` is
      needed. The pull-up changes only the element ORDER in newly written XML;
      deserialization is by element name, so existing on-disk configs still load
      every value — proven by a legacy-element-order test.
- [x] Log inputs from the IdP are sanitized inline at the log call (no logging
      code touched).

## Quality checklist

- [x] No duplicated logic; the duplicated block now lives once on the shared
      base.
- [x] The change adds no more code than the problem requires (net removal in the
      config file; the additions are tests).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (0 warnings, 0 errors).
- [x] `dotnet test` is green (554 passed, incl. 3 new #204 tests).
- [x] Prettier is clean (no `.js` / `.html` / `.md` / `.css` changed).

## Notes

Adversarial-review gate (config-persistence surface), all four lenses PASS:

- Availability / mass-lockout: name-based, order-tolerant deserialization of
  legacy-ordered configs confirmed empirically (legacy-order test + full suite
  green); no existing config fails to load, no userbase lockout.
- Security-bypass: `CanonicalLinks` retains both `[JsonIgnore]` and
  `[XmlElement]`; `OidSecret` keeps its write-only converter; JSON leak surface
  unchanged.
- Correctness: exhaustive member enumeration, the 19 shared members were
  verbatim-identical between the two originals; nothing dropped, duplicated, or
  wrongly promoted; the two backing fields correctly collapse into one.
- Integration: no declared-only reflection over the config types;
  `PreserveServerManagedFields` / `ValidateBaseUrlOverrides` /
  `ValidateSamlCertificates` and all `SSOController` sites still resolve the
  members through inheritance.
