### PR TITLE
Add OpenSSF Scorecard supply-chain self-audit workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,86 @@
+# OpenSSF Scorecard — supply-chain hygiene self-audit.
+#
+# Scorecard scores the repository against the OpenSSF supply-chain best-practice
+# checks (Branch-Protection, Token-Permissions, Pinned-Dependencies,
+# Dangerous-Workflow, etc.) and uploads the findings as SARIF to the
+# code-scanning tab. The score is treated as a checklist, not a guarantee: each
+# check is triaged (fixed or documented-accept), same as the other security
+# insights.
+#
+# Runs where publishing is valid: on push to the default branch, on a weekly
+# schedule (keeps the Maintained check fresh and re-scores on upstream changes),
+# and on branch_protection_rule changes (the only event that lets the
+# Branch-Protection check see the ruleset). No pull_request trigger — that path
+# is experimental upstream and cannot publish results.
+#
+# Hardened per the repo's workflow policy (see zizmor.yml): every action is
+# SHA-pinned with a version comment, checkout runs with persist-credentials:false,
+# permissions are declared read-only at the top level and the single write scope
+# is granted only on the job that needs it. This is a self-audit only — it does
+# not build, test, or touch the publish/release pipeline.
+name: Scorecard supply-chain security
+
+on:
+  # Branch-Protection check only reads the default branch's ruleset.
+  branch_protection_rule:
+  # Keeps the Maintained check current and re-scores against upstream drift.
+  schedule:
+    - cron: "27 4 * * 1"
+  push:
+    branches: [main]
+
+# Read-only by default; the analysis job adds only the scopes it needs. A
+# read-only top-level declaration is itself one of the Token-Permissions checks
+# Scorecard rewards.
+permissions: read-all
+
+# A newer run on the same ref supersedes an in-flight one; this is an audit, not
+# a publish, so cancelling a superseded run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # publish_results only works from the default branch; guard so a run on any
+    # other ref (e.g. a branch_protection_rule event on a non-default branch)
+    # does not attempt to publish.
+    if: github.event.repository.default_branch == github.ref_name
+    permissions:
+      # Upload the SARIF result to the code-scanning dashboard.
+      security-events: write
+      # Publish results to the OpenSSF API (badge + public score) via OIDC.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Public repo: publish the score to the OpenSSF API so the badge and
+          # the REST API reflect the current result.
+          publish_results: true
+
+      # Keep the raw SARIF as a run artifact for offline inspection/debugging.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Surface the findings in the code-scanning tab, alongside CodeQL and zizmor.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,9 +15,12 @@
 #
 # Hardened per the repo's workflow policy (see zizmor.yml): every action is
 # SHA-pinned with a version comment, checkout runs with persist-credentials:false,
-# permissions are declared read-only at the top level and the single write scope
-# is granted only on the job that needs it. This is a self-audit only — it does
-# not build, test, or touch the publish/release pipeline.
+# permissions are declared read-only at the top level and the write scopes are
+# granted only on the job that needs them. This is a self-audit only — it does
+# not build, test, or touch the publish/release pipeline. Note: publish_results
+# below publishes the OpenSSF supply-chain *score* to the OpenSSF API (the public
+# badge), not any software artifact — it is unrelated to the plugin release
+# pipeline and only works when run from the default branch.
 name: Scorecard supply-chain security
 
 on:
@@ -31,8 +34,10 @@ on:
 
 # Read-only by default; the analysis job adds only the scopes it needs. A
 # read-only top-level declaration is itself one of the Token-Permissions checks
-# Scorecard rewards.
-permissions: read-all
+# Scorecard rewards. Declared as an explicit scope rather than read-all so it is
+# minimal and specific (the job overrides this block with its own scopes).
+permissions:
+  contents: read
 
 # A newer run on the same ref supersedes an in-flight one; this is an audit, not
 # a publish, so cancelling a superseded run is safe.
@@ -50,6 +55,10 @@ jobs:
     # does not attempt to publish.
     if: github.event.repository.default_branch == github.ref_name
     permissions:
+      # Clone the repo (public clone would also work anonymously, but declaring
+      # the scope keeps checkout robust and is what Scorecard's Token-Permissions
+      # check expects at the job level).
+      contents: read
       # Upload the SARIF result to the code-scanning dashboard.
       security-events: write
       # Publish results to the OpenSSF API (badge + public score) via OIDC.


### PR DESCRIPTION
# What & why

Adds `.github/workflows/scorecard.yml`, running the official `ossf/scorecard-action`
as a supply-chain hygiene self-audit. Scorecard scores the repo against the OpenSSF
best-practice checks (Branch-Protection, Token-Permissions, Pinned-Dependencies,
Dangerous-Workflow, Maintained, …) and uploads the findings as SARIF to the
code-scanning tab, next to CodeQL and zizmor. The score is treated as a checklist,
not a guarantee, each check gets triaged (fixed or documented-accept) like the
other security insights.

Design, matched to the existing workflow-hardening policy (`zizmor.yml`):

- Triggers: `push` to `main`, a weekly `schedule` (keeps the Maintained check fresh
  and re-scores on drift), and `branch_protection_rule` (the only event the
  Branch-Protection check can read). No `pull_request` trigger, that path is
  experimental upstream and cannot publish results.
- Least privilege: `permissions: read-all` at the top level, with only
  `security-events: write` and `id-token: write` granted on the analysis job.
  `publish_results: true` so the badge and the OpenSSF API reflect the current score.
- Every action SHA-pinned with a version comment; `checkout` runs with
  `persist-credentials: false`. `checkout`/`upload-sarif` reuse the SHAs already
  pinned elsewhere in the repo; `scorecard-action` is pinned to v2.4.3 and
  `upload-artifact` to v7.0.1 (current latest).

New workflow file only. No existing workflow is changed; the publish/release
pipeline is untouched. Baseline score and per-check triage will be recorded from
the first `main` run once this lands (issue acceptance item).

Closes #168. Refs #144, #145, #146, #147.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — N/A (no login/crypto code).
- [ ] No secrets logged; secrets are redacted on config export., N/A.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — This is supply-chain
      hardening: a new read-only CI workflow, SHA-pinned and least-privilege,
      reasoned against the zizmor gate (unpinned-uses, excessive-permissions,
      template-injection, dangerous-triggers all clear). It does not touch the
      login path, crypto, config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call., N/A.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green. - Unaffected by a workflow-only change; build
      confirmed green after restore.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. - N/A
      (YAML only; not in the Prettier glob).

## Notes

- The `publish_results: true` step needs `id-token: write` and a run from the
  default branch; the job `if:` guards that publishing only happens on `main`.
- Out of scope: recording the baseline score and triaging each check, that
  happens from the first `main` run after merge, tracked on this issue's
  acceptance criteria.
