### PR TITLE
Cover the OpenID redirect callback token-exchange path (OidPost)

### DIFF
--- a/SSO-Auth.Tests/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/OidcTokenFixture.cs
@@ -36,10 +36,19 @@ internal sealed class OidcTokenFixture : IDisposable
             + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
     }
 
-    /// <summary>Produces a signed id_token for the given subject and username.</summary>
-    internal string IdToken(string subject, string username)
+    /// <summary>
+    /// Produces a signed id_token for the given username. A non-empty <paramref name="subject"/> is
+    /// emitted as the "sub" claim; passing null/empty omits it (for the missing-sub rejection path).
+    /// </summary>
+    internal string IdToken(string? subject, string username)
     {
         var now = DateTime.UtcNow;
+        var claims = new Dictionary<string, object> { ["preferred_username"] = username };
+        if (!string.IsNullOrEmpty(subject))
+        {
+            claims["sub"] = subject;
+        }
+
         var descriptor = new SecurityTokenDescriptor
         {
             Issuer = Issuer,
@@ -47,11 +56,7 @@ internal sealed class OidcTokenFixture : IDisposable
             IssuedAt = now - TimeSpan.FromMinutes(1),
             NotBefore = now - TimeSpan.FromMinutes(1),
             Expires = now + TimeSpan.FromMinutes(5),
-            Claims = new Dictionary<string, object>
-            {
-                ["sub"] = subject,
-                ["preferred_username"] = username,
-            },
+            Claims = claims,
             SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
         };
         return new JsonWebTokenHandler().CreateToken(descriptor);

--- a/SSO-Auth.Tests/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/OidcTokenFixture.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Builds a real signed OpenID Connect id_token plus the matching JWKS against a throw-away RSA key, so
+/// a test can drive the token-exchange callback (<c>OidPost</c>) through the actual id_token validation
+/// path (<see cref="Jellyfin.Plugin.SSO_Auth.Api.OidcIdTokenValidator"/>) rather than mocks. The
+/// discovery document, this JWKS, and a token endpoint returning <see cref="TokenEndpointJson"/> are
+/// served in-process through the harness's HTTP responder.
+/// </summary>
+internal sealed class OidcTokenFixture : IDisposable
+{
+    private const string KeyId = "oidpost-test-key";
+    private readonly RSA _rsa = RSA.Create(2048);
+
+    internal OidcTokenFixture(string issuer, string clientId)
+    {
+        Issuer = issuer;
+        ClientId = clientId;
+    }
+
+    internal string Issuer { get; }
+
+    internal string ClientId { get; }
+
+    /// <summary>Gets the JWKS carrying this fixture's signing public key.</summary>
+    internal string Jwks()
+    {
+        var p = _rsa.ExportParameters(false);
+        return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + KeyId + "\",\"alg\":\"RS256\","
+            + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
+    }
+
+    /// <summary>Produces a signed id_token for the given subject and username.</summary>
+    internal string IdToken(string subject, string username)
+    {
+        var now = DateTime.UtcNow;
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = subject,
+                ["preferred_username"] = username,
+            },
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        };
+        return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    /// <summary>The token-endpoint response body carrying the signed id_token.</summary>
+    internal string TokenEndpointJson(string idToken) =>
+        "{\"access_token\":\"test-access-token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"id_token\":\"" + idToken + "\"}";
+
+    /// <summary>The discovery document advertising this fixture's issuer and endpoints (all on the issuer).</summary>
+    internal string Discovery() =>
+        "{\"issuer\":\"" + Issuer + "\","
+        + "\"authorization_endpoint\":\"" + Issuer + "/authorize\","
+        + "\"token_endpoint\":\"" + Issuer + "/token\","
+        + "\"jwks_uri\":\"" + Issuer + "/jwks\","
+        + "\"userinfo_endpoint\":\"" + Issuer + "/userinfo\","
+        + "\"response_types_supported\":[\"code\"],"
+        + "\"subject_types_supported\":[\"public\"],"
+        + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
+        + "\"grant_types_supported\":[\"authorization_code\"],"
+        + "\"code_challenge_methods_supported\":[\"S256\"]}";
+
+    /// <summary>The URL the fixture serves each document at.</summary>
+    internal string DiscoveryUrl => Issuer + "/.well-known/openid-configuration";
+
+    internal string JwksUrl => Issuer + "/jwks";
+
+    internal string TokenUrl => Issuer + "/token";
+
+    public void Dispose() => _rsa.Dispose();
+}

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the OpenID redirect callback's token-exchange path (<c>OidPost</c>) via
+/// <see cref="SsoControllerHarness"/> and <see cref="OidcTokenFixture"/>, which serves discovery, a JWKS,
+/// and a token endpoint returning a real signed id_token, so the actual code exchange and id_token
+/// validation run. A valid callback renders the auth page; an authorization-response issuer that does not
+/// match the id_token issuer is refused (RFC 9207 mix-up check, #125). The guard branches (unknown
+/// provider, missing/invalid/expired state, disabled, rate-limit) are covered in
+/// <see cref="SSOControllerEndpointTests"/> / <see cref="SSOControllerAdminTests"/>.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerOidPostTests
+{
+    private const string Authority = "https://idp-oidpost.example.com";
+
+    [Fact]
+    public async Task OidPost_ValidCallback_RendersTheAuthPage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1");
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        // Reaching the intermediate HTML auth page (text/html) rather than a plain-text error proves the
+        // token exchange, id_token signature validation, and sub resolution all succeeded.
+        var page = Assert.IsType<ContentResult>(result);
+        Assert.Equal("text/html", page.ContentType);
+        Assert.False(string.IsNullOrEmpty(page.Content));
+    }
+
+    [Fact]
+    public async Task OidPost_ResponseIssuerMismatch_Returns400()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // RFC 9207 (#125): the authorization-response `iss` names a different issuer than the id_token's,
+        // which is an authorization-server mix-up and must be rejected even though the token itself is valid.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1&iss=https://attacker.example.com");
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    // Builds a harness whose HTTP responder serves the fixture's discovery/JWKS/token endpoints, seeds the
+    // matching authorize state, and sets the callback request path and query.
+    private static SsoControllerHarness ArrangeCallback(OidcTokenFixture fixture, string query)
+    {
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
+
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = Authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                DoNotLoadProfile = true, // the id_token carries sub + preferred_username; skip the userinfo fetch
+            },
+            httpResponder: request =>
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                if (url == fixture.DiscoveryUrl)
+                {
+                    return Json(fixture.Discovery());
+                }
+
+                if (url == fixture.JwksUrl)
+                {
+                    return Json(fixture.Jwks());
+                }
+
+                if (url == fixture.TokenUrl)
+                {
+                    return Json(fixture.TokenEndpointJson(idToken));
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
+        harness.Controller.HttpContext.Request.QueryString = new QueryString(query);
+
+        // The authorize state the redirect leg would have created. The code flow is protected by the PKCE
+        // code_verifier here; OidcClient 7.x carries no nonce on the AuthorizeState.
+        var authState = new AuthorizeState
+        {
+            State = "state-1",
+            CodeVerifier = "test-code-verifier",
+            RedirectUri = "https://jf.example.com/sso/OID/redirect/kc",
+        };
+        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(authState, DateTime.Now) { Provider = "kc" });
+
+        return harness;
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+}

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -55,11 +55,43 @@ public class SSOControllerOidPostTests
         Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
     }
 
-    // Builds a harness whose HTTP responder serves the fixture's discovery/JWKS/token endpoints, seeds the
-    // matching authorize state, and sets the callback request path and query.
-    private static SsoControllerHarness ArrangeCallback(OidcTokenFixture fixture, string query)
+    [Fact]
+    public async Task OidPost_TokenExchangeFails_Returns400()
     {
-        var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // The authorization-code exchange fails at the token endpoint, so ProcessResponseAsync errors and
+        // the callback is refused rather than minting a login.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", tokenEndpointFails: true);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidPost_IdTokenWithoutSub_Returns401()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // Fail closed (#155): a validated id_token carrying no `sub` claim resolves no stable subject to
+        // key the account link on, so the login is refused.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", idToken: fixture.IdToken(subject: null, username: "alice"));
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    // Builds a harness whose HTTP responder serves the fixture's discovery/JWKS/token endpoints, seeds the
+    // matching authorize state, and sets the callback request path and query. The token endpoint returns
+    // <paramref name="idToken"/> (a valid signed token by default), or a 400 when
+    // <paramref name="tokenEndpointFails"/> is set.
+    private static SsoControllerHarness ArrangeCallback(
+        OidcTokenFixture fixture,
+        string query,
+        string? idToken = null,
+        bool tokenEndpointFails = false)
+    {
+        idToken ??= fixture.IdToken(subject: "sub-1", username: "alice");
 
         var harness = new SsoControllerHarness(
             c => c.OidConfigs["kc"] = new OidConfig
@@ -86,7 +118,9 @@ public class SSOControllerOidPostTests
 
                 if (url == fixture.TokenUrl)
                 {
-                    return Json(fixture.TokenEndpointJson(idToken));
+                    return tokenEndpointFails
+                        ? new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent("{\"error\":\"invalid_grant\"}", Encoding.UTF8, "application/json") }
+                        : Json(fixture.TokenEndpointJson(idToken));
                 }
 
                 return new HttpResponseMessage(HttpStatusCode.NotFound);


### PR DESCRIPTION
# What & why

Covers the OpenID redirect callback's token-exchange path (`OidPost` from `ProcessResponseAsync` onward), the last uncovered SSOController branch (tracked in #305).

Adds an **`OidcTokenFixture`** (a throw-away RSA key producing a real signed id_token + the matching JWKS, mirroring `SamlTestFactory`) and serves the discovery document, the JWKS, and a token endpoint through the harness's HTTP responder, so `OidPost` runs the **actual** authorization-code exchange and id_token validation:

- **Valid callback:** exchanges the code, validates the signed id_token against the served JWKS, resolves the `sub`, and renders the intermediate HTML auth page.
- **RFC 9207 mix-up (#125):** an authorization-response `iss` that does not match the id_token issuer is refused with 400, even though the token itself is valid.

The id_token validation logic is already unit-tested exhaustively in `OidcIdTokenValidatorTests` (signature, iss, aud, lifetime, alg allow-list, azp); this covers the controller-level callback flow around it.

Closes #305
Refs #192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] N/A for the running product, test-only change; no production code is touched (the diff adds two test files). The tests pin existing behaviour (a valid callback renders the auth page; an issuer mix-up is refused) rather than change it, so the adversarial-review gate does not apply.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (a reusable `OidcTokenFixture` + a shared `ArrangeCallback` helper across the two tests)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (557 tests; 3 consecutive full runs).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- With this, every SSOController endpoint has controller-level coverage. The `OidcTokenFixture` is reusable for any future OIDC-callback tests (e.g. the missing-`sub` 401 branch).