### PR TITLE
Add rel="noopener noreferrer" to the config page Help link

### DIFF
--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -18,6 +18,7 @@
               is="emby-button"
               class="raised button-alt headerHelpButton"
               target="_blank"
+              rel="noopener noreferrer"
               href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               >${Help}</a
             >


### PR DESCRIPTION
# What & why

The `${Help}` header button in `SSO-Auth/Config/configPage.html` opens the
wiki with `target="_blank"` but no `rel` attribute, so the opened page
receives a live `window.opener` reference and can navigate the original tab
elsewhere (reverse-tabnabbing / `window.opener` vector). This adds
`rel="noopener noreferrer"` to sever that reference.

It is the only `target="_blank"` anchor on the page; the inline
`emby-linkbutton` links below open in-place and are unaffected. The link
destination is left untouched (a separate change tracks retargeting the URL).

Closes #298

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

N/A, this is a static HTML attribute add with no logic change and touches
none of the login path, crypto, config persistence, or the release pipeline,
so the adversarial-review gate does not apply. The change is itself a small
anti-tabnabbing hardening: it removes the `window.opener` reference the opened
wiki page would otherwise hold, closing a reverse-tabnabbing vector for older
Jellyfin webviews that do not imply `noopener` for `target="_blank"`.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (561 passed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Scope is strictly the `rel` attribute add. The `href` is deliberately
unchanged, a separate change may be migrating that URL, so this stays
single-purpose. No other `target="_blank"` anchors exist on the page.
