### PR TITLE
Retarget linking page help links off archived 9p4 upstream

### DIFF
--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -41,7 +41,7 @@
               is="emby-button"
               class="raised button-alt headerHelpButton"
               target="_blank"
-              href="https://github.com/9p4/jellyfin-plugin-sso"
+              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               >${Help}</a
             >
           </div>
@@ -59,14 +59,14 @@
             See the
             <a
               is="emby-linkbutton"
-              href="https://github.com/9p4/jellyfin-plugin-sso"
+              href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               class="button-link"
               >homepage</a
             >
             and
             <a
               is="emby-linkbutton"
-              href="https://github.com/9p4/jellyfin-plugin-sso/issues"
+              href="https://github.com/iderex/jellyfin-plugin-sso/issues"
               class="button-link"
               >issue tracker
             </a>


### PR DESCRIPTION
# What & why

The self-service linking page (`SSO-Auth/Config/linking.html`) still pointed
its three help/documentation links at the archived upstream
`9p4/jellyfin-plugin-sso`. This retargets them at this repository, mirroring
the earlier README/build.yaml migration off 9p4 (#150) and the config-page fix
(#293):

- the `${Help}` header button and the inline "homepage" link now target this
  repository's wiki (`https://github.com/iderex/jellyfin-plugin-sso/wiki`);
- the inline "issue tracker" link now targets this repository's issues
  (`https://github.com/iderex/jellyfin-plugin-sso/issues`).

Closes #297

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

N/A, this change only rewrites three static `href` values in an embedded HTML
page. No login-path, crypto, config-persistence, or release-pipeline logic is
touched, so the adversarial-review gate does not apply (static link text, no
logic).

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Scoped strictly to the three stale 9p4 links in `linking.html`. `linking.js`
holds no repository URLs, so it needed no change.

The issue flagged an optional extra: the `${Help}` button uses
`target="_blank"` without `rel="noopener"`. I am declining it here to keep the
scope strictly to the link migration and to stay consistent with the config
page's existing pattern; modern browsers imply `noopener` for `target="_blank"`
anyway, so the reverse-tabnabbing risk is negligible. It can be picked up as a
separate defence-in-depth pass across both pages if desired.
