### PR TITLE
Add Opengrep gate for greppable repo invariants

### DIFF
--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           set -euo pipefail
           url="https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
-          curl -fSL --retry 3 --retry-delay 2 -o opengrep "$url"
+          # --proto '=https' --tlsv1.2: refuse any non-HTTPS transport, including
+          # on a redirect, so the download cannot be downgraded to plaintext.
+          curl -fSL --proto '=https' --tlsv1.2 --retry 3 --retry-delay 2 -o opengrep "$url"
           echo "${OPENGREP_SHA256}  opengrep" | sha256sum -c -
           chmod +x opengrep
 

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -1,0 +1,60 @@
+# Opengrep (open-source Semgrep fork) gate that enforces this repo's greppable
+# security invariants as lint rules (tools/opengrep/rules.yml) — one rule per
+# invariant, added as each is discovered. The rules are `generic`-mode token
+# patterns, so this gate does not depend on a language parser and is
+# deterministic; every rule is verified to produce zero findings on the current
+# tree and to fire on a regression.
+#
+# Supply chain: Opengrep ships no official Action and no published container
+# image, so this pins the exact self-contained release binary by version AND by
+# SHA-256 (no `curl | bash`, no floating "latest"). Bump both together when the
+# version moves. Keep the only `uses:` (checkout) SHA-pinned and
+# persist-credentials:false so this workflow itself passes the zizmor gate.
+name: Repo Invariant Lint (Opengrep)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+# Cancel a superseded run on the same ref so a new push / PR update does not
+# queue behind an obsolete check.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  opengrep:
+    name: Enforce greppable invariants
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    env:
+      # Pinned Opengrep release (opengrep/opengrep). Bump VERSION and SHA256
+      # together — the SHA is the sha256sum of the opengrep_manylinux_x86 asset
+      # for this exact tag and makes the download tamper-evident.
+      OPENGREP_VERSION: "v1.25.0"
+      OPENGREP_SHA256: "9ac4aebb47ba3f7b0d8fc641ac8749cb6c2f253f616131a67d9631e00d4bea33"
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
+
+      - name: Install Opengrep (pinned binary, checksum-verified)
+        run: |
+          set -euo pipefail
+          url="https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86"
+          curl -fSL --retry 3 --retry-delay 2 -o opengrep "$url"
+          echo "${OPENGREP_SHA256}  opengrep" | sha256sum -c -
+          chmod +x opengrep
+
+      - name: Enforce repo invariants
+        # --error makes a finding exit non-zero (the gate). The ruleset is a
+        # local file, so the scan runs fully offline.
+        run: ./opengrep scan --config tools/opengrep/rules.yml --error .

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -1,0 +1,61 @@
+# Opengrep (open-source Semgrep fork) rules that enforce this repo's greppable
+# security invariants as lint rules — one rule per invariant, added as each is
+# discovered (rule-per-regression). Deliberately narrow and low-false-positive:
+# these are `generic`-mode token patterns, NOT semantic C# analysis, so they do
+# not depend on the C# language parser (whose modern-C#/.NET 9 support is still
+# maturing) and cannot silently mis-parse a file into a false negative. Every
+# rule is verified to produce zero findings on the current clean tree; a rule
+# fires only when an invariant regresses.
+#
+# Run locally exactly as CI does:
+#   docker run --rm -v "$PWD:/src" opengrep/opengrep@sha256:<digest> \
+#     opengrep scan --config tools/opengrep/rules.yml --error /src
+rules:
+  # Invariant (release pipeline): publishing is triggered by a tag push only.
+  # Releases are immutable on GitHub — a manual `gh release` mutation permanently
+  # burns a tag and bypasses the /release-prep gate. The publish workflows must
+  # never create/edit/delete a release or its assets. Read-only verbs
+  # (view/list/download) are intentionally allowed.
+  - id: no-gh-release-mutation
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not mutate GitHub releases with `gh release`
+      (create/edit/delete/upload/delete-asset). Publishing is triggered by a tag
+      push only; releases are immutable and a manual mutation burns the tag and
+      bypasses the release gate.
+    patterns:
+      - pattern-either:
+          - pattern: gh release create
+          - pattern: gh release edit
+          - pattern: gh release delete
+          - pattern: gh release upload
+          - pattern: gh release delete-asset
+    paths:
+      include:
+        - ".github/workflows/**"
+        - "**/*.sh"
+        - "**/*.ps1"
+        - "tools/**"
+      exclude:
+        # This rule file necessarily contains the banned strings as its own
+        # patterns — do not scan it (or its siblings) against itself.
+        - "tools/opengrep/**"
+
+  # Invariant (crypto / fail-closed): every security value (OAuth state, nonces,
+  # generated passwords, tokens) must come from a CSPRNG (RandomNumberGenerator).
+  # System.Random is a non-cryptographic PRNG and must never back a security
+  # value. The plugin creates randomness only via RandomNumberGenerator today;
+  # this rule blocks a regression to `new Random(...)`.
+  - id: no-insecure-random
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not use System.Random for security values. Use
+      RandomNumberGenerator (a CSPRNG) for any token, nonce, state, or generated
+      secret.
+    patterns:
+      - pattern: new Random(...)
+    paths:
+      include:
+        - "SSO-Auth/**/*.cs"


### PR DESCRIPTION
# What & why

Closes #173.

Add an Opengrep (open-source Semgrep fork) CI gate that enforces the repo's
greppable security invariants as lint rules, cheap, deterministic, and
complementary to the analyzer, CodeQL, and the review lenses. It starts small,
with a couple of high-value, low-false-positive rules, and grows
rule-per-regression as new invariants are discovered.

- `tools/opengrep/rules.yml` - two `generic`-mode (parser-independent) rules,
  each verified to produce zero findings on the current tree and to fire on a
  regression:
  - `no-gh-release-mutation`: publishing is tag-triggered only; block mutating
    `gh release` verbs (create/edit/delete/upload/delete-asset). Read-only
    verbs (view/list/download) stay allowed.
  - `no-insecure-random`: security values must come from a CSPRNG
    (`RandomNumberGenerator`); block a regression to `new Random(...)` in the
    plugin source.
- `.github/workflows/opengrep.yml`, run Opengrep on push/PR. No official
  Action or published container image exists, so the self-contained release
  binary is pinned by version **and** SHA-256 (no `curl | bash`, no floating
  "latest"); the only action (checkout) stays SHA-pinned with
  `persist-credentials: false`; least-privilege permissions; the scan runs
  offline against the local ruleset.

Design note: `generic`-mode rules are used deliberately. Opengrep's C# parser
still misses modern constructs, in local testing it silently failed to match
the null-conditional, expression-bodied form of a log-sanitizer helper
(`=> s?.ReplaceLineEndings(string.Empty)`), which would make a semantic C# rule
a silent false-negative and a false sense of coverage. The inline-log-sanitizer
invariant therefore stays guarded by CodeQL `cs/log-forging` and the CodeRabbit
config rather than a fragile Opengrep rule; the SAML/OIDC no-default-accept
invariant is likewise deferred until it can be expressed without false
positives. A working narrow gate beats a broad broken one.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

CI/supply-chain hardening only, additive lint gate. It does not touch the
login path, crypto, config persistence, or the publish/release pipeline logic;
it adds a rule that *guards* the release-immutability invariant. The new
workflow is written to pass the zizmor workflow-security gate (SHA-pinned
action, `persist-credentials: false`, workflow-level `permissions: {}` plus
job-level `contents: read`, `pull_request` trigger, no template injection into
`run:`). The download is pinned by SHA-256.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (No C# changed; CI
      build unaffected.)
- [x] `dotnet test` is green. (No C# changed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None;
      YAML is outside the Prettier glob.)

Opengrep was run locally (v1.25.0) against the tree: 2 rules on 49 files, 0
findings, exit 0. Positive tests confirmed each rule fires on an injected
violation and that read-only `gh release view` and the existing
`Select(... ReplaceLineEndings ...)` lambda are not flagged.

## Notes

Bump `OPENGREP_VERSION` and `OPENGREP_SHA256` together when the pin moves.
Follow-up invariants (inline-log-sanitizer, SAML/OIDC no-default-accept) are
deferred out of this PR to keep the gate green and non-flaky; they are added
later if/when they can be expressed without false positives.
