### PR TITLE
Key IPv4-in-IPv6 transition rate-limit sources on the embedded IPv4

### DIFF
--- a/SSO-Auth.Tests/SsoRateLimiterTests.cs
+++ b/SSO-Auth.Tests/SsoRateLimiterTests.cs
@@ -209,6 +209,80 @@ public class SsoRateLimiterTests
     }
 
     [Fact]
+    public void NormalizeClientKey_Nat64WellKnownPrefix_KeysOnEmbeddedIpv4_NotSharedSlash64()
+    {
+        // SIIT-DC synthesizes inbound IPv4 into 64:ff9b::/96, embedding the client IPv4 in the low 32
+        // bits that /64 keying would zero. Two distinct NATed clients must land in distinct buckets
+        // (matching their native-IPv4 keys), not collapse into one 64:ff9b::/64 shared-throttle bucket.
+        var a = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("64:ff9b::808:808")); // 8.8.8.8
+        var b = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("64:ff9b::909:909")); // 9.9.9.9
+
+        Assert.Equal("8.8.8.8", a);
+        Assert.Equal("9.9.9.9", b);
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void NormalizeClientKey_Nat64EmbeddedIpv4_SharesBucketWithNativeIpv4_SameClient()
+    {
+        // The embedded public IPv4 IS the client identity, so a NAT64-translated hit and a native-IPv4
+        // hit from the same address share one bucket — the correct, consistent view, not key confusion.
+        Assert.Equal(
+            SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("8.8.8.8")),
+            SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("64:ff9b::808:808")));
+    }
+
+    [Fact]
+    public void NormalizeClientKey_6to4_KeysOnEmbeddedIpv4_NotSharedSlash64()
+    {
+        // 6to4 (2002::/16) embeds the IPv4 in bytes 2-5; 2002:0808:0808::/48 carries 8.8.8.8. Distinct
+        // embedded IPv4s must not collapse into one 2002:.../64 bucket.
+        var a = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("2002:808:808::1"));   // 8.8.8.8
+        var b = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("2002:909:909::1"));   // 9.9.9.9
+
+        Assert.Equal("8.8.8.8", a);
+        Assert.Equal("9.9.9.9", b);
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void NormalizeClientKey_Ipv4Compatible_KeysOnEmbeddedIpv4_NotSharedSlash64()
+    {
+        // Deprecated IPv4-compatible (::/96): the low 32 bits are the client IPv4. Distinct clients
+        // must separate rather than share the ::/64 bucket.
+        var a = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("::8.8.8.8"));
+        var b = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("::9.9.9.9"));
+
+        Assert.Equal("8.8.8.8", a);
+        Assert.Equal("9.9.9.9", b);
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void NormalizeClientKey_TransitionClients_ThrottleIndependently_NoSharedLockout()
+    {
+        // End-to-end: two distinct NAT64 clients must have independent budgets — one exhausting its
+        // limit must not throttle the other (the shared-bucket lockout class this fix removes).
+        var limiter = new SsoRateLimiter();
+        var abuser = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("64:ff9b::808:808"));
+        var victim = SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("64:ff9b::909:909"));
+
+        Assert.True(limiter.IsAllowed(abuser, 1, Window, Now, out _));
+        Assert.False(limiter.IsAllowed(abuser, 1, Window, Now, out _));
+        Assert.True(limiter.IsAllowed(victim, 1, Window, Now, out _));
+    }
+
+    [Fact]
+    public void NormalizeClientKey_NonTransitionIpv6_StillKeysOnSlash64()
+    {
+        // A regular global-unicast IPv6 (no embedded IPv4) keeps /64 keying, so rotation within one
+        // allocation still cannot evade — the transition handling must not widen this.
+        Assert.Equal(
+            "2001:db8:1:2::/64",
+            SsoRateLimiter.NormalizeClientKey(IPAddress.Parse("2001:db8:1:2:3:4:5:6")));
+    }
+
+    [Fact]
     public void NormalizeClientKey_NullRemote_ReturnsNull_FailOpen()
     {
         Assert.Null(SsoRateLimiter.NormalizeClientKey(null));

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -122,13 +122,16 @@ internal static class AvatarUrlValidator
 
     /// <summary>
     /// Extracts the IPv4 address embedded in an IPv4-in-IPv6 transition address (6to4 <c>2002::/16</c>, the
-    /// NAT64 well-known prefix <c>64:ff9b::/96</c>, or the deprecated IPv4-compatible <c>::/96</c> form), so a
-    /// blocked internal IPv4 cannot be reached by wrapping it in one of these formats.
+    /// NAT64 well-known prefix <c>64:ff9b::/96</c>, or the deprecated IPv4-compatible <c>::/96</c> form). Two
+    /// callers share this single definition so they cannot disagree on what an embedded IPv4 is: the SSRF
+    /// classifier unwraps it so a blocked internal IPv4 cannot be reached by wrapping it in one of these
+    /// formats, and the rate limiter (<see cref="SsoRateLimiter.NormalizeClientKey"/>) keys a transition
+    /// source on its embedded IPv4 instead of collapsing every such client into one shared /64 bucket.
     /// </summary>
     /// <param name="bytes">The 16 bytes of the IPv6 address.</param>
     /// <param name="embedded">The embedded IPv4 address when one is present; otherwise null.</param>
     /// <returns>True when an embedded IPv4 address was extracted.</returns>
-    private static bool TryExtractEmbeddedIPv4(byte[] bytes, out IPAddress embedded)
+    internal static bool TryExtractEmbeddedIPv4(byte[] bytes, out IPAddress embedded)
     {
         embedded = null;
 

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -62,7 +62,10 @@ internal sealed class SsoRateLimiter
     /// Normalizes the client's connection address into a rate-limit key. Returns null (= do not
     /// throttle, fail open) when no address can be attributed. IPv6 is keyed on its /64 prefix —
     /// a single residential allocation — since per-/128 keying is evadable by address rotation;
-    /// IPv4-mapped IPv6 is keyed as the underlying IPv4.
+    /// IPv4-mapped IPv6 is keyed as the underlying IPv4. IPv4-in-IPv6 transition sources (6to4,
+    /// the NAT64 well-known prefix, IPv4-compatible) are keyed on their embedded IPv4, not the
+    /// shared transition /64, so distinct NATed clients behind one prefix are not collapsed into
+    /// one bucket where a single abuser would throttle them all (#194).
     /// </summary>
     /// <param name="remoteIp">The connection's remote address. Deliberately the ONLY input: the
     /// plugin never parses X-Forwarded-For itself. Jellyfin's own forwarded-headers middleware
@@ -102,6 +105,26 @@ internal sealed class SsoRateLimiter
         }
 
         var bytes = ip.GetAddressBytes();
+
+        // IPv4-in-IPv6 transition sources carry the client-identifying IPv4 in bits that /64 keying
+        // treats coarsely. For the well-known NAT64 prefix (64:ff9b::/96) and the IPv4-compatible
+        // form (::/96) the IPv4 sits in the low 64 bits that /64 ZEROS, so every distinct client
+        // behind the prefix collapses into one shared bucket and one abuser would throttle them all
+        // — this fix's target. Key on the embedded IPv4 instead: it is the true client identity, so a
+        // NAT64/IPv4-compatible source now buckets exactly like the same native IPv4. (For 6to4,
+        // 2002::/16, the IPv4 is in bytes 2-5, so this instead COLLAPSES a multi-/64 6to4 site onto
+        // its one gateway IPv4 — the same egress-identity keying a native NAT already gets, and it
+        // closes a rotate-within-your-own-/48 evasion hole; a bounded, deliberate trade for a
+        // deprecated form.) The extraction is the same one IsBlockedAddress applied above, so the two
+        // never disagree, and any source reaching here has a PUBLIC embedded IPv4 (a blocked/internal
+        // one already returned null) — this only re-buckets, never returns null, so throttling is
+        // preserved (fail closed). A network-specific NAT64 prefix (RFC 6052 NSP) is not recognized
+        // and falls through to /64 below, as does any non-transition IPv6.
+        if (AvatarUrlValidator.TryExtractEmbeddedIPv4(bytes, out var embedded))
+        {
+            return embedded.ToString();
+        }
+
         Array.Clear(bytes, 8, 8);
         return string.Create(CultureInfo.InvariantCulture, $"{new IPAddress(bytes)}/64");
     }


### PR DESCRIPTION
# What & why

The opt-in SSO rate limiter (`SsoRateLimiter.NormalizeClientKey`, used by
`SSOController.RateLimitCheck`) keyed every IPv6 source on its `/64` prefix. For
IPv4-in-IPv6 transition sources the client-identifying IPv4 lives in bits that
`/64` keying discards, so distinct NATed clients collapse into one shared bucket
and a single abuser throttles all of them, the shared-bucket lockout class the
limiter defends against everywhere else. In an IPv6-only deployment translating
inbound IPv4 through the NAT64 well-known prefix (SIIT-DC), one abusive client
would throttle every IPv4 client.

Fix: reuse `AvatarUrlValidator.TryExtractEmbeddedIPv4` (promoted `private` →
`internal`) from `NormalizeClientKey`. When a transition source carries an
embedded IPv4, key on that IPv4; otherwise keep the `/64`.

- NAT64 well-known prefix (`64:ff9b::/96`): IPv4 in bytes 12-15, zeroed by `/64`
  → now split per client. Strictly narrows the shared bucket.
- IPv4-compatible (`::/96`, deprecated): IPv4 in the low 32 bits → same.
- 6to4 (`2002::/16`): IPv4 in bytes 2-5 → a multi-`/64` 6to4 site now buckets on
  its one gateway IPv4, i.e. egress-identity keying identical to a native NAT,
  which also closes a rotate-within-your-own-`/48` evasion hole. Bounded,
  deliberate trade for a deprecated form.

It is the same extractor `IsBlockedAddress` already applies, so the SSRF
classifier and the limiter cannot disagree on what an embedded IPv4 is. Because
`IsBlockedAddress` runs first and rejects a blocked/internal embedded IPv4, any
source reaching the keying has a public embedded IPv4. The branch only
re-buckets, never returns null, so throttling is preserved (fail closed). A
network-specific NAT64 prefix (RFC 6052 NSP) is not recognized and falls through
to `/64`, as does any non-transition IPv6.

Closes #194. Refs #128.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (This change only re-buckets a
      throttle key; it never returns a null/blank key where the old code
      returned one, so no source that was throttled now fails open.)
- [x] No secrets logged; secrets are redacted on config export. (No logging or
      secrets touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial gate
      run — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      log calls added.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the existing `TryExtractEmbeddedIPv4`; a single
      pure branch in `NormalizeClientKey`.)
- [x] The change adds no more code than the problem requires.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release.)
- [x] `dotnet test` is green. (567 tests, run 3x for stability.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A - 
      C# only.)

## Notes

Trust model: `NormalizeClientKey`'s only input is the socket peer address, never
a client-supplied header (the plugin never parses X-Forwarded-For), so the
embedded IPv4 is as trustworthy as any source address. An attacker cannot forge
it to evade throttling (rotation now costs a distinct real IPv4, same as native)
or to pin a victim (sourcing from `64:ff9b::<victimV4>` requires routing control
of that prefix, a TCP handshake precludes spoofing).

Adversarial-review gate (4 refute-by-default lenses): availability PASS,
bypass PASS, correctness PASS, integration NEEDS_IMPROVEMENT, the sole
integration finding was two inaccurate phrases in a load-bearing code comment
("never widens it" is false for the 6to4 branch; "SIIT-DC NAT64" overclaimed vs
the well-known-prefix-only implementation). Both were comment-only and are now
corrected; the code and its three PASS verdicts were unaffected. Both lenses
specifically confirmed the change cannot be spoofed to evade or to lock out a
victim, and never fails open.

Out of scope: Teredo and RFC 6052 network-specific NAT64 prefixes are not
unwrapped (neither is by the shared SSRF classifier); those sources keep `/64`
keying. This is a documented gap, not a regression.
