### PR TITLE
Add architecture-conformance fitness tests as a mandatory per-PR check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,10 @@ persistence, or the release pipeline.
 - [ ] No duplicated logic; new logic lives in a small, single-purpose,
       testable unit.
 - [ ] The change adds no more code than the problem requires.
+- [ ] The code is self-documenting (readable without comments; comments explain
+      why, not what) and matches the target architecture (#318).
+- [ ] Architecture-conformance tests pass, and any new structural property this
+      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
 
 ## Verification
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.SSO_Auth;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Architecture-conformance fitness functions for the target architecture planned in #318. These run as
+/// part of the ordinary test suite, so every PR is checked — a change that drifts from the agreed
+/// structure fails CI. The rules encode structural invariants that hold TODAY and are part of the target;
+/// as each migration step lands a new structural property, add the rule that locks it in here so it
+/// cannot regress. Keep rules type-level (reflection over the production assembly); call-level invariants
+/// stay guarded by CodeQL/CodeRabbit and the pinning tests.
+/// </summary>
+public class ArchitectureConformanceTests
+{
+    // Suffixes that mark a pure, single-responsibility helper in the target layering (a "gate", store, or
+    // mapper). By the "one unified OO architecture" + "default internal" principles these are internal
+    // implementation detail, never part of the plugin's public surface.
+    private static readonly string[] HelperSuffixes =
+    {
+        "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor",
+    };
+
+    private static IEnumerable<Type> PluginTypes =>
+        typeof(SSOPlugin).Assembly
+            .GetTypes()
+            .Where(t => t.IsClass && !IsCompilerGenerated(t));
+
+    [Fact]
+    public void SingleResponsibilityHelpers_AreInternal_NotPartOfThePublicSurface()
+    {
+        var leaked = PluginTypes
+            .Where(t => HelperSuffixes.Any(s => t.Name.EndsWith(s, StringComparison.Ordinal)))
+            .Where(t => t.IsPublic || t.IsNestedPublic)
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(leaked.Count == 0, "These helper types must be internal (target: default-internal, thin public surface): " + string.Join(", ", leaked));
+    }
+
+    [Fact]
+    public void SingleResponsibilityHelpers_AreSealedOrStatic_NotAnInheritanceBase()
+    {
+        // A pure helper is a leaf: `static` (abstract+sealed in IL) or `sealed`. An open helper base is a
+        // divergent one-off pattern the unified architecture rules out.
+        var open = PluginTypes
+            .Where(t => HelperSuffixes.Any(s => t.Name.EndsWith(s, StringComparison.Ordinal)))
+            .Where(t => !t.IsSealed && !t.IsAbstract)
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(open.Count == 0, "These helper types must be sealed or static (a pure helper is a leaf, not an inheritance base): " + string.Join(", ", open));
+    }
+
+    [Fact]
+    public void Controllers_DeriveFromControllerBase()
+    {
+        var stray = PluginTypes
+            .Where(t => t.Name.EndsWith("Controller", StringComparison.Ordinal))
+            .Where(t => !typeof(ControllerBase).IsAssignableFrom(t))
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(stray.Count == 0, "Types named *Controller must derive from ControllerBase: " + string.Join(", ", stray));
+    }
+
+    [Fact]
+    public void EverythingLivesUnderThePluginRootNamespace()
+    {
+        // The whole plugin stays under one root namespace; the migration reorganises the sub-namespaces
+        // (Http/Flows/Oidc/Saml/Config/Shared/…) but never leaks a type outside the root.
+        var outside = PluginTypes
+            .Where(t => t.Namespace is not null)
+            .Where(t => !t.Namespace!.StartsWith("Jellyfin.Plugin.SSO_Auth", StringComparison.Ordinal))
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(outside.Count == 0, "All plugin types must live under the Jellyfin.Plugin.SSO_Auth root namespace: " + string.Join(", ", outside));
+    }
+
+    private static bool IsCompilerGenerated(Type t) =>
+        t.Name.Contains('<', StringComparison.Ordinal)
+        || t.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is not null;
+}


### PR DESCRIPTION
# What & why

Establishes the **mandatory per-PR structure check** for the target architecture (#318): reflection-based architecture-conformance fitness functions in `SSO-Auth.Tests/ArchitectureConformanceTests`. They run as part of the ordinary test suite, so **every PR is checked in CI**, a change that drifts from the agreed structure fails `dotnet test`. No new dependency (custom reflection over the production assembly, in keeping with the supply-chain-caution and least-code principles).

Initial rules, all green today, all part of the #318 target:
- single-responsibility helpers (`*Validator`/`*Cache`/`*Builder`/`*Mapper`/`*Policy`/`*Probe`/`*Store`/`*Revoker`/`*Extractor`) are `internal`, not part of the public surface (default-internal, thin public surface);
- those helpers are `sealed` or `static` (a pure helper is a leaf, not an inheritance base);
- types named `*Controller` derive from `ControllerBase`;
- every plugin type lives under the `Jellyfin.Plugin.SSO_Auth` root namespace.

The rule set is designed to **grow with the migration**: each step that establishes a new structural property locks it in here so it cannot regress. The PR template now requires this check plus self-documenting, target-matching code.

Refs #318

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] N/A for the running product, test-only + PR-template change; no production code is touched. The architecture tests assert structural properties, they do not change behaviour, so the adversarial-review gate does not apply.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires. (custom reflection, no new dependency)
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in. (this PR establishes the check itself)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (584 tests, incl. the 4 new architecture rules).
- [x] Prettier is clean for the `.md` change.

## Notes

- The local operating manual (CLAUDE.md, git-ignored) is also updated to record architecture conformance as a mandatory check and the self-documenting / unified-OO standard.
- This is step 0 of the #318 migration; the code-restructuring steps follow as separate gated PRs, each tightening these rules.