### PR TITLE
Tighten the architecture-conformance rules (close the #322 review gaps)

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -11,13 +11,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// Architecture-conformance fitness functions for the target architecture planned in #318. These run as
 /// part of the ordinary test suite, so every PR is checked — a change that drifts from the agreed
-/// structure fails CI. The rules encode structural invariants that hold TODAY and are part of the target;
+/// structure fails CI. The rules encode structural invariants that hold today and are part of the target;
 /// as each migration step lands a new structural property, add the rule that locks it in here so it
-/// cannot regress. Keep rules type-level (reflection over the production assembly); call-level invariants
+/// cannot regress. Rules are type-level (reflection over the production assembly); call-level invariants
 /// stay guarded by CodeQL/CodeRabbit and the pinning tests.
 /// </summary>
 public class ArchitectureConformanceTests
 {
+    private const string Root = "Jellyfin.Plugin.SSO_Auth";
+
     // Suffixes that mark a pure, single-responsibility helper in the target layering (a "gate", store, or
     // mapper). By the "one unified OO architecture" + "default internal" principles these are internal
     // implementation detail, never part of the plugin's public surface.
@@ -26,17 +28,25 @@ public class ArchitectureConformanceTests
         "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor",
     };
 
-    private static IEnumerable<Type> PluginTypes =>
-        typeof(SSOPlugin).Assembly
-            .GetTypes()
-            .Where(t => t.IsClass && !IsCompilerGenerated(t));
+    // Every production type, compiler-generated ones excluded — the base sequence for structural rules
+    // that must cover interfaces/enums/structs/delegates too (e.g. the namespace boundary).
+    private static IEnumerable<Type> AllPluginTypes =>
+        typeof(SSOPlugin).Assembly.GetTypes().Where(t => !IsCompilerGenerated(t));
+
+    // The class subset, for rules that only make sense on classes (helper shape, controller base type).
+    private static IEnumerable<Type> PluginClasses => AllPluginTypes.Where(t => t.IsClass);
+
+    private static bool IsHelper(Type t) =>
+        HelperSuffixes.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal));
 
     [Fact]
     public void SingleResponsibilityHelpers_AreInternal_NotPartOfThePublicSurface()
     {
-        var leaked = PluginTypes
-            .Where(t => HelperSuffixes.Any(s => t.Name.EndsWith(s, StringComparison.Ordinal)))
-            .Where(t => t.IsPublic || t.IsNestedPublic)
+        // Any externally-visible accessibility leaks the helper: public, or a nested member reachable by a
+        // consumer or a derived type (protected / protected-internal count as leaks too).
+        var leaked = PluginClasses
+            .Where(IsHelper)
+            .Where(t => t.IsPublic || t.IsNestedPublic || t.IsNestedFamily || t.IsNestedFamORAssem)
             .Select(t => t.FullName)
             .ToList();
 
@@ -46,11 +56,12 @@ public class ArchitectureConformanceTests
     [Fact]
     public void SingleResponsibilityHelpers_AreSealedOrStatic_NotAnInheritanceBase()
     {
-        // A pure helper is a leaf: `static` (abstract+sealed in IL) or `sealed`. An open helper base is a
-        // divergent one-off pattern the unified architecture rules out.
-        var open = PluginTypes
-            .Where(t => HelperSuffixes.Any(s => t.Name.EndsWith(s, StringComparison.Ordinal)))
-            .Where(t => !t.IsSealed && !t.IsAbstract)
+        // A pure helper is a leaf: `static` (abstract+sealed in IL) or `sealed`. Anything not sealed — an
+        // ordinary class OR an abstract base — is an open inheritance point the unified architecture rules
+        // out. (A static class is sealed, so it passes.)
+        var open = PluginClasses
+            .Where(IsHelper)
+            .Where(t => !t.IsSealed)
             .Select(t => t.FullName)
             .ToList();
 
@@ -60,8 +71,8 @@ public class ArchitectureConformanceTests
     [Fact]
     public void Controllers_DeriveFromControllerBase()
     {
-        var stray = PluginTypes
-            .Where(t => t.Name.EndsWith("Controller", StringComparison.Ordinal))
+        var stray = PluginClasses
+            .Where(t => SimpleName(t).EndsWith("Controller", StringComparison.Ordinal))
             .Where(t => !typeof(ControllerBase).IsAssignableFrom(t))
             .Select(t => t.FullName)
             .ToList();
@@ -73,14 +84,25 @@ public class ArchitectureConformanceTests
     public void EverythingLivesUnderThePluginRootNamespace()
     {
         // The whole plugin stays under one root namespace; the migration reorganises the sub-namespaces
-        // (Http/Flows/Oidc/Saml/Config/Shared/…) but never leaks a type outside the root.
-        var outside = PluginTypes
-            .Where(t => t.Namespace is not null)
-            .Where(t => !t.Namespace!.StartsWith("Jellyfin.Plugin.SSO_Auth", StringComparison.Ordinal))
-            .Select(t => t.FullName)
+        // (Http/Flows/Oidc/Saml/Config/Shared/…) but never leaks a type outside the root. Covers ALL types
+        // (interfaces/enums/structs/delegates too), rejects the global namespace, and matches the root
+        // exactly or as a "Root."-prefixed descendant — so a sibling like "…SSO_AuthEvil" does not pass.
+        var outside = AllPluginTypes
+            .Where(t => !t.IsNested) // a nested type inherits its declaring type's namespace; check the outers
+            .Where(t => t.Namespace is not { } ns || !(ns == Root || ns.StartsWith(Root + ".", StringComparison.Ordinal)))
+            .Select(t => t.FullName ?? t.Name)
             .ToList();
 
-        Assert.True(outside.Count == 0, "All plugin types must live under the Jellyfin.Plugin.SSO_Auth root namespace: " + string.Join(", ", outside));
+        Assert.True(outside.Count == 0, "All plugin types must live under the " + Root + " root namespace: " + string.Join(", ", outside));
+    }
+
+    // The reflection Name of a generic type carries a `1 arity suffix (e.g. "Cache`1"); strip it so suffix
+    // matching sees the source name.
+    private static string SimpleName(Type t)
+    {
+        var name = t.Name;
+        var tick = name.IndexOf('`', StringComparison.Ordinal);
+        return tick < 0 ? name : name[..tick];
     }
 
     private static bool IsCompilerGenerated(Type t) =>


### PR DESCRIPTION
# What & why

Follow-up to #322: CodeRabbit found five real gaps where the architecture-conformance fitness functions were **weaker than they claimed**, a fitness function that gives false assurance is worse than none, so these are fixed here.

- **Namespace boundary** now covers **all** types (interfaces/enums/structs/delegates), not just classes; rejects the global namespace (null); and matches the root **exactly or a `Root.`-prefixed descendant**, so a sibling namespace like `…SSO_AuthEvil` no longer slips through (the previous `StartsWith("Jellyfin.Plugin.SSO_Auth")` accepted it).
- **Helper-internal rule** also flags **protected / protected-internal nested** helpers (`IsNestedFamily` / `IsNestedFamORAssem`), not only `public`/`nested-public`.
- **Sealed-or-static rule** now uses `!IsSealed`, an **abstract unsealed** helper (an open inheritance base) is caught; a static class is sealed and still passes.
- **Suffix matching** strips the generic-arity backtick (`Cache\`1` → `Cache`), so a generic helper cannot escape the rule.

All rules stay green, the current tree already satisfies the stricter checks; this only removes the blind spots.

Refs #318

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] N/A for the running product, test-only change; no production code is touched. It tightens architecture assertions, changing no behaviour, so the adversarial-review gate does not apply.
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] N/A, no SAML/OIDC validation, config persistence, or release-pipeline code changed.
- [x] N/A, no new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass (they are the subject of this change and are now rigorous).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (584 tests; the tightened rules still pass on the current tree).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Process note: #322 was merged before its CodeRabbit findings were dispositioned (a merge-and-check-in-one-step slip); this PR closes those findings and each is replied to on #322. The process rule to prevent recurrence is recorded.