### PR TITLE
Rename the SAML core types and extract the controller data records (#318 step 1a)

### DIFF
--- a/SSO-Auth.Tests/SamlAttackShapeTests.cs
+++ b/SSO-Auth.Tests/SamlAttackShapeTests.cs
@@ -22,7 +22,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 ///
 /// Every malicious shape must be REJECTED (or, for comment-truncation, must NOT be truncatable)
 /// and the honest baseline ACCEPTED — all against the real signature-validation path in
-/// <see cref="Response"/>, never a mock of the crypto. These are TESTS ONLY: they pin existing
+/// <see cref="SamlResponse"/>, never a mock of the crypto. These are TESTS ONLY: they pin existing
 /// fail-closed behavior; no production change is expected while that behavior holds. A shape that
 /// turns out to be ACCEPTED is a real defect to be filed as its own security finding, not papered
 /// over here.
@@ -32,8 +32,8 @@ public class SamlAttackShapeTests
     private const string SamlNs = "urn:oasis:names:tc:SAML:2.0:assertion";
     private const string DsNs = "http://www.w3.org/2000/09/xmldsig#";
 
-    private static Response Load(SamlFixture fixture, string? certificateBase64 = null)
-        => new Response(certificateBase64 ?? fixture.CertificateBase64, fixture.EncodeResponse());
+    private static SamlResponse Load(SamlFixture fixture, string? certificateBase64 = null)
+        => new SamlResponse(certificateBase64 ?? fixture.CertificateBase64, fixture.EncodeResponse());
 
     [Fact]
     public void IsValid_HonestBaseline_ReturnsTrue()
@@ -98,10 +98,10 @@ public class SamlAttackShapeTests
     [Fact]
     public void IsValid_UnsignedAssertionPrependedToResponseScopeSignature_ReturnsFalse()
     {
-        // The whole Response is signed; the attacker prepends an unsigned assertion carrying a
+        // The whole SamlResponse is signed; the attacker prepends an unsigned assertion carrying a
         // different identity as the FIRST assertion (the one every reader consumes as Assertion[1]).
         // Rejected twice over: the single-assertion invariant now counts two direct-child assertions,
-        // and prepending also perturbs the signed Response so the digest no longer matches.
+        // and prepending also perturbs the signed SamlResponse so the digest no longer matches.
         var fixture = SamlTestFactory.Create(nameId: "alice", scope: SamlTestFactory.SignatureScope.Response);
         var doc = fixture.Document;
         doc.DocumentElement!.PrependChild(BuildEvilAssertion(doc, "attacker"));
@@ -174,9 +174,9 @@ public class SamlAttackShapeTests
     public void IsValid_SignatureRelocatedIntoDecoyWrapper_ReturnsFalse()
     {
         // The enveloped signature is lifted out of the assertion it covers and re-parented under a
-        // decoy wrapper element hung off the Response. The reference still names the assertion ID, but
+        // decoy wrapper element hung off the SamlResponse. The reference still names the assertion ID, but
         // the position-bound signature selection only accepts a ds:Signature that is a direct child of
-        // the Response or the Assertion — a signature buried in a wrapper is not selected at all, so
+        // the SamlResponse or the Assertion — a signature buried in a wrapper is not selected at all, so
         // the response reads as unsigned and is rejected.
         var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
         var doc = fixture.Document;
@@ -197,7 +197,7 @@ public class SamlAttackShapeTests
         // A decoy assertion carrying "attacker" is smuggled into the honest assertion's saml:Advice.
         // Because it is added AFTER signing it is not part of the signed content, yet saml:Advice is a
         // spec-legal container so the response must not be rejected merely for its presence — instead
-        // the readers, scoped to the Response's direct-child Assertion[1]/Subject, must ignore the
+        // the readers, scoped to the SamlResponse's direct-child Assertion[1]/Subject, must ignore the
         // nested decoy and continue to read the signed "alice". This pins assertion/advice confusion
         // resistance: the advice subject never shadows the real one.
         var fixture = SamlTestFactory.Create(nameId: "alice", scope: SamlTestFactory.SignatureScope.Response);
@@ -210,7 +210,7 @@ public class SamlAttackShapeTests
 
         var response = Load(fixture);
 
-        // Adding the (unsigned) advice perturbs the signed Response, so IsValid is false; the
+        // Adding the (unsigned) advice perturbs the signed SamlResponse, so IsValid is false; the
         // load-bearing assertion is that identity extraction never returns the advice's "attacker".
         Assert.False(response.IsValid());
         Assert.NotEqual("attacker", response.GetNameID());

--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// Tests for the malformed-input handling on the SAML callback (#199): <see cref="SamlResponseLoader.TryParse"/>
 /// maps the constructor's malformed-input exceptions to a fail-closed <see langword="false"/> (so the
-/// endpoints return a clean 4xx rather than an unhandled HTTP 500), and <see cref="Response.GetSignatureAlgorithm"/>
+/// endpoints return a clean 4xx rather than an unhandled HTTP 500), and <see cref="SamlResponse.GetSignatureAlgorithm"/>
 /// — a failure-log diagnostic — never throws on a malformed signature element.
 /// </summary>
 public class SamlResponseParsingTests

--- a/SSO-Auth.Tests/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/SamlResponseTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Trust-boundary tests for <see cref="Response"/> — the SAML signature/validation core.
+/// Trust-boundary tests for <see cref="SamlResponse"/> — the SAML signature/validation core.
 /// These pin the CURRENT behavior of the upstream implementation so the P2 hardening
 /// changes (see docs/ROADMAP.md) are deliberate, reviewed flips rather than surprises.
 ///
@@ -16,8 +16,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// </summary>
 public class SamlResponseTests
 {
-    private static Response Load(SamlFixture fixture, string? certificateBase64 = null)
-        => new Response(certificateBase64 ?? fixture.CertificateBase64, fixture.EncodeResponse());
+    private static SamlResponse Load(SamlFixture fixture, string? certificateBase64 = null)
+        => new SamlResponse(certificateBase64 ?? fixture.CertificateBase64, fixture.EncodeResponse());
 
     [Fact]
     public void IsValid_ResponseScopeSignature_ReturnsTrue()
@@ -37,7 +37,7 @@ public class SamlResponseTests
     public void GetRecipient_And_GetInResponseTo_ReadFromSignedAssertion()
     {
         // Recipient and InResponseTo live inside the assertion, so they are covered even when only
-        // the assertion (not the whole Response) is signed — the #156 endpoint/solicited binding.
+        // the assertion (not the whole SamlResponse) is signed — the #156 endpoint/solicited binding.
         var fixture = SamlTestFactory.Create(
             scope: SamlTestFactory.SignatureScope.Assertion,
             recipient: "https://jellyfin.example/sso/SAML/post/idp",
@@ -80,7 +80,7 @@ public class SamlResponseTests
                 "<saml:Assertion><saml:Subject><saml:NameID>&x;</saml:NameID></saml:Subject></saml:Assertion>" +
             "</samlp:Response>";
         Assert.Throws<XmlException>(() =>
-            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(withDoctype)));
+            new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(withDoctype)));
     }
 
     [Fact]
@@ -99,7 +99,7 @@ public class SamlResponseTests
                 "<saml:Assertion><saml:Subject><saml:NameID>&lol3;</saml:NameID></saml:Subject></saml:Assertion>" +
             "</samlp:Response>";
         Assert.Throws<XmlException>(() =>
-            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(billionLaughs)));
+            new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(billionLaughs)));
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class SamlResponseTests
                 "<saml:Assertion><saml:Subject><saml:NameID>&xxe;</saml:NameID></saml:Subject></saml:Assertion>" +
             "</samlp:Response>";
         Assert.Throws<XmlException>(() =>
-            new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xxe)));
+            new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xxe)));
     }
 
     [Fact]
@@ -131,7 +131,7 @@ public class SamlResponseTests
             : "<!DOCTYPE samlp:Response [ <!ENTITY x \"y\"> ]>" + signedXml;
 
         Assert.Throws<XmlException>(() =>
-            new Response(fixture.CertificateBase64, SamlFixture.Encode(withDoctype)));
+            new SamlResponse(fixture.CertificateBase64, SamlFixture.Encode(withDoctype)));
     }
 
     [Fact]
@@ -144,7 +144,7 @@ public class SamlResponseTests
                     "<saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject>" +
                 "</saml:Assertion>" +
             "</samlp:Response>";
-        var response = new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
+        var response = new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
         Assert.False(response.IsValid());
     }
 
@@ -212,7 +212,7 @@ public class SamlResponseTests
     public void IsValid_SignatureRelocatedOutsideSignedElement_ReturnsFalse()
     {
         // Sign the assertion, then move the enveloped signature out of the assertion up to the
-        // Response. The reference still names the assertion ID, but the signature no longer sits
+        // SamlResponse. The reference still names the assertion ID, but the signature no longer sits
         // inside the element it covers — a relocation attack, rejected by the envelopment check.
         var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
         var doc = fixture.Document;
@@ -237,7 +237,7 @@ public class SamlResponseTests
     {
         // A spec-legal supporting assertion nested in saml:Advice (part of the signed content) is a
         // descendant, not a second top-level assertion, so the single-assertion invariant — scoped
-        // to the Response's direct-child assertions — must still accept the response.
+        // to the SamlResponse's direct-child assertions — must still accept the response.
         var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion, includeAdviceAssertion: true);
         Assert.True(Load(fixture).IsValid());
     }
@@ -303,7 +303,7 @@ public class SamlResponseTests
             "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
                 "<saml:Assertion ID=\"_a\" Version=\"2.0\"><saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject></saml:Assertion>" +
             "</samlp:Response>";
-        var response = new Response(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
+        var response = new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(unsigned));
         Assert.Null(response.GetSignatureAlgorithm());
     }
 

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -12,9 +12,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// Builds real, cryptographically-signed SAML 2.0 responses (and deliberately broken variants)
 /// against a throw-away self-signed certificate, so tests exercise the actual signature-validation
-/// path in <see cref="Jellyfin.Plugin.SSO_Auth.Response"/> rather than mocks.
+/// path in <see cref="Jellyfin.Plugin.SSO_Auth.SamlResponse"/> rather than mocks.
 ///
-/// Scoped to what the current <see cref="Jellyfin.Plugin.SSO_Auth.Response"/> validates
+/// Scoped to what the current <see cref="Jellyfin.Plugin.SSO_Auth.SamlResponse"/> validates
 /// (signature, signature scope, SubjectConfirmationData/@NotOnOrAfter). It grows as the
 /// validation surface is hardened (audience, recipient, InResponseTo, ... — see docs/ROADMAP.md).
 /// </summary>

--- a/SSO-Auth.Tests/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/ValidateSamlTests.cs
@@ -13,10 +13,10 @@ public class ValidateSamlTests
 {
     private const string Audience = "https://jellyfin.example.com/sso";
 
-    private static Response SignedResponseFor(string audience)
+    private static SamlResponse SignedResponseFor(string audience)
     {
         var fixture = SamlTestFactory.Create(audience: audience);
-        return new Response(fixture.CertificateBase64, fixture.EncodeResponse());
+        return new SamlResponse(fixture.CertificateBase64, fixture.EncodeResponse());
     }
 
     [Fact]

--- a/SSO-Auth/Api/AuthResponse.cs
+++ b/SSO-Auth/Api/AuthResponse.cs
@@ -1,0 +1,32 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The data the client should pass back to the API.
+/// </summary>
+public class AuthResponse
+{
+    /// <summary>
+    /// Gets or sets the device ID of the client.
+    /// </summary>
+    public string DeviceID { get; set; }
+
+    /// <summary>
+    /// Gets or sets the device name of the client.
+    /// </summary>
+    public string DeviceName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the app name of the client.
+    /// </summary>
+    public string AppName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the app version of the client.
+    /// </summary>
+    public string AppVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the auth data of the client (for authorizing the response).
+    /// </summary>
+    public string Data { get; set; }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -782,7 +782,7 @@ public class SSOController : ControllerBase
                 relayState = "linking";
             }
 
-            var request = new AuthRequest(
+            var request = new SamlAuthnRequest(
                 config.SamlClientId.Trim(),
                 redirectUri);
 
@@ -1679,7 +1679,7 @@ public class SSOController : ControllerBase
     // Returns false when the assertion was already used (or carries no ID — a missing ID stays empty,
     // so TryConsume fails closed). The key is scoped by provider so two IdPs emitting the same assertion
     // ID cannot block each other. Shared by SamlAuth (session mint) and SamlLink (account linking, #219).
-    private bool TryConsumeSamlReplay(Response samlResponse, string provider)
+    private bool TryConsumeSamlReplay(SamlResponse samlResponse, string provider)
     {
         var samlNow = DateTime.UtcNow;
         var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
@@ -1692,7 +1692,7 @@ public class SSOController : ControllerBase
     // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
     // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
     // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
-    private bool IsSamlResponseValid(Response samlResponse, SamlConfig config, string provider)
+    private bool IsSamlResponseValid(SamlResponse samlResponse, SamlConfig config, string provider)
     {
         if (!ValidateSaml(samlResponse, config))
         {
@@ -1740,7 +1740,7 @@ public class SSOController : ControllerBase
     // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
     // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
     // Issuer sent in the AuthnRequest, and an empty SamlAudience falls through to the client id.
-    internal static bool ValidateSaml(Response samlResponse, SamlConfig config)
+    internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
     {
         if (config.DoNotValidateAudience)
         {
@@ -1863,118 +1863,4 @@ public class SSOController : ControllerBase
         Response.Headers.CacheControl = "no-store";
         return Content(render(nonce), MediaTypeNames.Text.Html);
     }
-}
-
-/// <summary>
-/// The data the client should pass back to the API.
-/// </summary>
-public class AuthResponse
-{
-    /// <summary>
-    /// Gets or sets the device ID of the client.
-    /// </summary>
-    public string DeviceID { get; set; }
-
-    /// <summary>
-    /// Gets or sets the device name of the client.
-    /// </summary>
-    public string DeviceName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the app name of the client.
-    /// </summary>
-    public string AppName { get; set; }
-
-    /// <summary>
-    /// Gets or sets the app version of the client.
-    /// </summary>
-    public string AppVersion { get; set; }
-
-    /// <summary>
-    /// Gets or sets the auth data of the client (for authorizing the response).
-    /// </summary>
-    public string Data { get; set; }
-}
-
-/// <summary>
-/// A time-stamped record of an in-flight OpenID authorize state: it ties the authorize-state token to
-/// the provider, the resolved identity (subject/username), and the login privileges, and is held until
-/// the callback redeems it or it expires.
-/// </summary>
-public class TimedAuthorizeState
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TimedAuthorizeState"/> class.
-    /// </summary>
-    /// <param name="state">The AuthorizeState to time.</param>
-    /// <param name="created">When this state was created.</param>
-    public TimedAuthorizeState(AuthorizeState state, DateTime created)
-    {
-        State = state;
-        Created = created;
-    }
-
-    /// <summary>
-    /// Gets or sets the Authorization State of the client.
-    /// </summary>
-    public AuthorizeState State { get; set; }
-
-    /// <summary>
-    /// Gets or sets the provider that minted this state. A state may only be consumed on the same
-    /// provider's endpoints, so it cannot be replayed against another provider's login/role gate.
-    /// </summary>
-    public string Provider { get; set; }
-
-    /// <summary>
-    /// Gets or sets when this object was created to time it out.
-    /// </summary>
-    public DateTime Created { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the user is valid.
-    /// </summary>
-    public bool Valid { get; set; }
-
-    /// <summary>
-    /// Gets or sets the user tied to the state.
-    /// </summary>
-    public string Username { get; set; }
-
-    /// <summary>
-    /// Gets or sets the stable subject identifier (OpenID "sub") that keys the account link (#155).
-    /// Unlike <see cref="Username"/> it does not change when the identity provider renames the user.
-    /// Null for SAML, whose NameID plays the same role directly.
-    /// </summary>
-    public string Subject { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the user is an administrator.
-    /// </summary>
-    public bool Admin { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the state is
-    /// tied to a linking flow (instead of a login flow).
-    /// </summary>
-    public bool IsLinking { get; set; }
-
-    /// <summary>
-    /// Gets or sets the folders the user is allowed access to.
-    /// </summary>
-    public List<string> Folders { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the user is allowed to view live TV.
-    /// </summary>
-    public bool EnableLiveTv { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether the user is allowed to manage live TV.
-    /// </summary>
-    public bool EnableLiveTvManagement { get; set; }
-
-    /// <summary>
-    /// Gets or sets the user avatar url.
-    /// </summary>
-    public string AvatarURL { get; set; }
 }

--- a/SSO-Auth/Api/SamlCertificate.cs
+++ b/SSO-Auth/Api/SamlCertificate.cs
@@ -6,7 +6,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
 /// Validates the per-provider SAML signing certificate (#206). A non-blank but unloadable
-/// <c>SamlCertificate</c> makes the <see cref="Response"/> constructor throw on every callback
+/// <c>SamlCertificate</c> makes the <see cref="SamlResponse"/> constructor throw on every callback
 /// (<see cref="FormatException"/> on non-base64, <see cref="CryptographicException"/> on bytes that are
 /// not a certificate), which escaped as an unhandled HTTP 500. Rejecting an invalid certificate at every
 /// admin write path — and treating it as a parse failure at login — keeps that fail-closed and out of the

--- a/SSO-Auth/Api/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/SamlResponseLoader.cs
@@ -5,8 +5,8 @@ using System.Xml;
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
-/// Safely constructs a <see cref="Response"/> from an untrusted SAML response string (#199). The
-/// <see cref="Response"/> constructor throws on malformed input — <see cref="FormatException"/> for a
+/// Safely constructs a <see cref="SamlResponse"/> from an untrusted SAML response string (#199). The
+/// <see cref="SamlResponse"/> constructor throws on malformed input — <see cref="FormatException"/> for a
 /// non-base64 body and <see cref="XmlException"/> for malformed XML or a prohibited DOCTYPE (the P2#9
 /// XXE guard). Left unhandled, those surface to an unauthenticated caller as an HTTP 500 with a stack
 /// trace; this maps them to a fail-closed <see langword="false"/> so the callback endpoints reject a
@@ -23,13 +23,13 @@ internal static class SamlResponseLoader
 
     /// <summary>
     /// Tries to parse a SAML response, returning <see langword="false"/> (rather than throwing) on the
-    /// malformed-input exceptions the <see cref="Response"/> constructor raises.
+    /// malformed-input exceptions the <see cref="SamlResponse"/> constructor raises.
     /// </summary>
     /// <param name="certificateStr">The identity provider's signing certificate as a Base64 string.</param>
     /// <param name="responseString">The untrusted SAML response (Base64).</param>
     /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
-    internal static bool TryParse(string certificateStr, string responseString, out Response response)
+    internal static bool TryParse(string certificateStr, string responseString, out SamlResponse response)
     {
         // A null or empty body is the most common malformed callback (an absent SAMLResponse form field
         // yields a null string on the unauthenticated ACS endpoint); reject it here rather than let
@@ -50,7 +50,7 @@ internal static class SamlResponseLoader
 
         try
         {
-            response = new Response(certificateStr, responseString);
+            response = new SamlResponse(certificateStr, responseString);
             return true;
         }
         catch (Exception ex) when (ex is FormatException or XmlException or CryptographicException or ArgumentException)

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using Duende.IdentityModel.OidcClient;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// A time-stamped record of an in-flight OpenID authorize state: it ties the authorize-state token to
+/// the provider, the resolved identity (subject/username), and the login privileges, and is held until
+/// the callback redeems it or it expires.
+/// </summary>
+internal sealed class TimedAuthorizeState
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimedAuthorizeState"/> class.
+    /// </summary>
+    /// <param name="state">The AuthorizeState to time.</param>
+    /// <param name="created">When this state was created.</param>
+    public TimedAuthorizeState(AuthorizeState state, DateTime created)
+    {
+        State = state;
+        Created = created;
+    }
+
+    /// <summary>
+    /// Gets or sets the Authorization State of the client.
+    /// </summary>
+    public AuthorizeState State { get; set; }
+
+    /// <summary>
+    /// Gets or sets the provider that minted this state. A state may only be consumed on the same
+    /// provider's endpoints, so it cannot be replayed against another provider's login/role gate.
+    /// </summary>
+    public string Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets when this object was created to time it out.
+    /// </summary>
+    public DateTime Created { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user is valid.
+    /// </summary>
+    public bool Valid { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user tied to the state.
+    /// </summary>
+    public string Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stable subject identifier (OpenID "sub") that keys the account link (#155).
+    /// Unlike <see cref="Username"/> it does not change when the identity provider renames the user.
+    /// Null for SAML, whose NameID plays the same role directly.
+    /// </summary>
+    public string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user is an administrator.
+    /// </summary>
+    public bool Admin { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the state is
+    /// tied to a linking flow (instead of a login flow).
+    /// </summary>
+    public bool IsLinking { get; set; }
+
+    /// <summary>
+    /// Gets or sets the folders the user is allowed access to.
+    /// </summary>
+    public List<string> Folders { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user is allowed to view live TV.
+    /// </summary>
+    public bool EnableLiveTv { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the user is allowed to manage live TV.
+    /// </summary>
+    public bool EnableLiveTvManagement { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user avatar url.
+    /// </summary>
+    public string AvatarURL { get; set; }
+}

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -23,7 +23,7 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// <summary>
 /// Represents a SAML response.
 /// </summary>
-public class Response
+internal sealed class SamlResponse
 {
     // The only positions an enveloped SAML signature may occupy: a direct child of the Response or
     // of the Assertion. Encodes the security-critical "no relocated signature" invariant, so it is a
@@ -36,11 +36,11 @@ public class Response
     private XmlNamespaceManager _xmlNameSpaceManager; // we need this one to run our XPath queries on the SAML XML
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Response"/> class.
+    /// Initializes a new instance of the <see cref="SamlResponse"/> class.
     /// </summary>
     /// <param name="certificateStr">The certificate formatted as a Base64 string.</param>
     /// <param name="responseString">The SAML response formatted as a string.</param>
-    public Response(string certificateStr, string responseString)
+    public SamlResponse(string certificateStr, string responseString)
     {
         // Decode and load the certificate, then load the response — in that exact order, so the exception
         // sequence SamlResponseLoader.TryParse catches is unchanged: FormatException (bad certificate
@@ -461,7 +461,7 @@ public class Response
 /// <summary>
 /// Represents a SAML request.
 /// </summary>
-public class AuthRequest
+internal sealed class SamlAuthnRequest
 {
     private readonly string _id;
     private readonly string _issueInstant;
@@ -470,11 +470,11 @@ public class AuthRequest
     private readonly string _assertionConsumerServiceUrl;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AuthRequest"/> class..
+    /// Initializes a new instance of the <see cref="SamlAuthnRequest"/> class..
     /// </summary>
     /// <param name="issuer">The issuer of the SAML request.</param>
     /// <param name="assertionConsumerServiceUrl">The SAML assertion URL.</param>
-    public AuthRequest(string issuer, string assertionConsumerServiceUrl)
+    public SamlAuthnRequest(string issuer, string assertionConsumerServiceUrl)
     {
         _id = "_" + Guid.NewGuid().ToString();
         _issueInstant = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", System.Globalization.CultureInfo.InvariantCulture);


### PR DESCRIPTION
# What & why

Step 1a of the #318 migration, zero-behavior moves and renames toward the target architecture (thin controller + pure helpers, unified SAML/OIDC naming).

- **`Response` → `SamlResponse`** and **`AuthRequest` → `SamlAuthnRequest`** (in `Saml.cs`), with every C# reference renamed across `SamlResponseLoader`, `SamlCertificate`, `SSOController`, and the SAML tests. The SAML **protocol string literals**, the `/samlp:Response/…` XPath, the written `AuthnRequest` element, the `SAMLResponse` form field, and the `SamlTestFactory.SignatureScope.Response` **enum member** are untouched, and so is **`ControllerBase.Response.Headers`** (CSP / rate-limit headers).
- **`SamlResponse`, `SamlAuthnRequest`, `TimedAuthorizeState` → `internal sealed`** (default-internal, leaf types). **`AuthResponse` stays `public`**, it is a `[FromBody]` action parameter (the JSON wire contract).
- **`AuthResponse` and `TimedAuthorizeState` extracted** out of the 1,980-line `SSOController.cs` into their own files (same namespace), the controller shrinks by **122 lines**.

The `SsoProtocol` enum (mode-string replacement) from the design's step 1 is **deliberately deferred**: the adversarial scoping found it is *not* provably zero-behavior at the public `{mode}` route boundary (culture-sensitive `ToLower`, `Enum.TryParse` numeric acceptance, 500-vs-400 error shape). It will land re-scoped to internal literal sites (or with a documented micro-delta) in its own PR.

Refs #318

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches `Saml.cs` + `SSOController.cs` (login-path/crypto files), so the adversarial-review gate was run even though this is a pure rename/move.

- [x] Fail-closed preserved, no validation logic changed; every SAML protocol string and the signature/audience/recipient/replay paths are byte-identical (the real-signature test suite passes 3x).
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] A security review was performed, gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call. (unchanged)

**Adversarial-review gate:** the #318 step-1 scoping workflow (5 agents, refute-by-default) verified the plan is zero-behavior with a trap list; a 2-lens review on the actual diff - **bypass PASS** (protocol strings / `ControllerBase.Response` / enum / public `AuthResponse` contract all provably intact; accessibility narrowing touches no reachable surface) and **correctness PASS** (extracted members exact, usings correct, references consistent, no logic line changed), confirmed the execution.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires. (net move; controller −122 lines)
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. (No new reflection rule is naturally added by a rename/move step; the existing rigorous rules continue to pass. Later steps that create new structural properties will lock them in.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (584 tests; run 3x for order-independence).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- One deviation from the literal spec, flagged by the correctness lens: the three types also become `sealed` (not just `internal`). It is behavior-preserving, no subclasses exist, and matches the "pure helper / data record is a leaf" target.
- First code-restructuring step of the migration; subsequent steps (micro-primitives, the replay-sweep throttle, the state store, `LoginOutcome`, …) follow as separate gated PRs.