### PR TITLE
Extract the provider-scoped one-time-use key into ProviderScopedKey (#318 step 2)

### DIFF
--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 
@@ -32,5 +33,22 @@ public class ProviderScopedKeyTests
     public void For_DistinctProviders_ProduceDistinctKeysForTheSameId()
     {
         Assert.NotEqual(ProviderScopedKey.For("a", "id"), ProviderScopedKey.For("b", "id"));
+    }
+
+    [Fact]
+    public void For_MissingId_ProducesAKeyBothOneTimeCachesRefuse()
+    {
+        // The security boundary the empty-id passthrough relies on: a missing correlation id yields a
+        // blank key, and both one-time-use caches fail closed on a blank key, so it can never be
+        // registered or consumed — no replay or InResponseTo-correlation bypass.
+        var now = DateTime.UtcNow;
+        var replayKey = ProviderScopedKey.For("kc", string.Empty);
+        var requestKey = ProviderScopedKey.For("kc", null);
+
+        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now));
+
+        var requests = new SamlRequestCache();
+        requests.Register(requestKey!, now.AddMinutes(15), now);
+        Assert.False(requests.TryConsume(requestKey!, now));
     }
 }

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -1,0 +1,36 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests pinning the exact provider-scoped one-time-use key format, so the SAML replay
+/// and outstanding-request caches keep isolating keys per provider and the empty-id passthrough is
+/// preserved after the helper extraction (#318 step 2).
+/// </summary>
+public class ProviderScopedKeyTests
+{
+    [Fact]
+    public void For_NonEmptyId_PrefixesTheProviderWithANewlineSeparator()
+    {
+        Assert.Equal("keycloak\nassertion-1", ProviderScopedKey.For("keycloak", "assertion-1"));
+    }
+
+    [Fact]
+    public void For_EmptyId_PassesTheEmptyValueThrough()
+    {
+        Assert.Equal(string.Empty, ProviderScopedKey.For("keycloak", string.Empty));
+    }
+
+    [Fact]
+    public void For_NullId_PassesNullThrough()
+    {
+        Assert.Null(ProviderScopedKey.For("keycloak", null));
+    }
+
+    [Fact]
+    public void For_DistinctProviders_ProduceDistinctKeysForTheSameId()
+    {
+        Assert.NotEqual(ProviderScopedKey.For("a", "id"), ProviderScopedKey.For("b", "id"));
+    }
+}

--- a/SSO-Auth/Api/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/ProviderScopedKey.cs
@@ -1,0 +1,15 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Forms the provider-scoped one-time-use key for the SAML replay and outstanding-AuthnRequest caches,
+/// so a key issued under one provider can never be consumed on another provider's callback (#156, #219).
+/// An empty or null id passes through unchanged — the caller treats an absent correlation id as its own
+/// case rather than keying on a bare provider prefix.
+/// </summary>
+internal static class ProviderScopedKey
+{
+    // The newline separator cannot occur in a Guid-based AuthnRequest id, and both parts come from the
+    // same trusted config/flow, so it partitions the key space by provider without collision.
+    internal static string For(string provider, string id) =>
+        string.IsNullOrEmpty(id) ? id : provider + "\n" + id;
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -793,7 +793,7 @@ public class SSOController : ControllerBase
             // linking request would only leave an id to expire unused.
             if (config.ValidateInResponseTo && !isLinking)
             {
-                SamlRequests.Register(provider + "\n" + request.Id, DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
+                SamlRequests.Register(ProviderScopedKey.For(provider, request.Id), DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
             }
 
             return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
@@ -897,7 +897,7 @@ public class SSOController : ControllerBase
             if (config.ValidateInResponseTo)
             {
                 var inResponseTo = samlResponse.GetInResponseTo();
-                var requestKey = string.IsNullOrEmpty(inResponseTo) ? inResponseTo : provider + "\n" + inResponseTo;
+                var requestKey = ProviderScopedKey.For(provider, inResponseTo);
                 if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow))
                 {
                     _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
@@ -1684,7 +1684,7 @@ public class SSOController : ControllerBase
         var samlNow = DateTime.UtcNow;
         var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
         var assertionId = samlResponse.GetAssertionId();
-        var replayKey = string.IsNullOrEmpty(assertionId) ? assertionId : provider + "\n" + assertionId;
+        var replayKey = ProviderScopedKey.For(provider, assertionId);
         return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
     }
 


### PR DESCRIPTION
# What & why

Step 2 (first micro-primitive) of the #318 migration. The SAML **replay cache** (#219 one-time-use) and the **outstanding-AuthnRequest cache** (#156 solicited-only) both form their key as `provider + "\n" + id`, inlined at three sites in `SSOController`. This extracts it into a pure `ProviderScopedKey.For` helper, so the provider-isolation convention lives in one documented place.

`For(provider, id) => string.IsNullOrEmpty(id) ? id : provider + "\n" + id`

- Sites `SSOController.cs:900` (InResponseTo) and `:1687` (assertion replay) were already this exact ternary, byte-identical.
- Site `:796` (register) was the unconditional `provider + "\n" + request.Id`; `request.Id` is always `"_" + Guid` (`SamlAuthnRequest`), so the empty-passthrough branch is unreachable there and the result is identical.

Four characterization tests pin the format and the empty/null passthrough.

Refs #318

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches `SSOController.cs` (login-path, and the keys guard replay/correlation), so the adversarial-review gate was run.

- [x] Fail-closed preserved, the caches still fail closed on an empty/null key (`SamlRequestCache`/`SamlReplayCache` reject blank); cross-provider isolation and one-time-use are unchanged (same `provider`-prefix keying).
- [x] No secrets logged; secrets are redacted on config export. (unchanged)
- [x] A security review was performed, gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call. (unchanged)

**Adversarial-review gate (2 lenses on the diff):** bypass **PASS** (byte-for-byte-equivalent key at all three sites; the unconditional site's empty branch is provably unreachable and even fail-*safe*; no separator/ordering/injection/isolation change) and correctness **PASS** (helper reproduces each expression exactly, correctly scoped/visible, tests pin the true contract).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. (the raw concatenation now exists in exactly one place)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. (No new reflection rule for this step; the existing rules pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (both projects).
- [x] `dotnet test` is green (588 tests).
- [x] Prettier, N/A (no `.js` / `.html` / `.md` / `.css` change).

## Notes

- Next in step 2: `IntervalGate` (unify the once-per-interval throttle used by the cap-warning #246, the rate-limit observability #195, and the state prune) and `SsoUrlBuilder`, each its own gated PR, since the `IntervalGate` sites have subtly different semantics that need per-site characterization first.