### PR TITLE
Add rel="noopener noreferrer" to the linking.html Help button

### DIFF
--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -41,6 +41,7 @@
               is="emby-button"
               class="raised button-alt headerHelpButton"
               target="_blank"
+              rel="noopener noreferrer"
               href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
               >${Help}</a
             >


### PR DESCRIPTION
# What & why

Add `rel="noopener noreferrer"` to the Help anchor in
`SSO-Auth/Config/linking.html`. That anchor opens the wiki in a new tab
(`target="_blank"`) but carried no `rel`, so the opened page could reach back
through `window.opener` (reverse tabnabbing) and the full referrer was sent.
The identical Help button in `configPage.html` already carries
`rel="noopener noreferrer"`; this brings the two admin pages in line and fully
isolates the new tab. Single static-attribute change; no runtime behavior
change.

Closes #328

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

N/A, this change touches none of those surfaces. It adds a static `rel`
attribute to a Help link on an admin config page; there is no signature,
time-bound, audience, secret, IdP input, or logging involved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

The change is one HTML attribute that mirrors the existing `configPage.html`
Help button verbatim; it establishes no new structural property, so no new
`ArchitectureConformanceTests` rule is needed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Build: 0 warnings / 0 errors. Tests: 589 passed, 0 failed, 0 skipped.
Prettier `--check` on `SSO-Auth/Config/linking.html`: clean.

## Notes

Adversarial-review gate disposition: **N/A**. This diff touches the admin
web-ui only (a `rel` attribute on a Help link), not the login path, crypto
(SAML/OIDC), config persistence, or the release pipeline, and changes no
runtime behavior, so the 4-lens security-review gate does not apply.

Scope is deliberately the single attribute; nothing else in `linking.html` or
elsewhere was touched.
