### PR TITLE
Extract the once-per-interval throttle into IntervalGate

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -25,7 +25,7 @@ public class ArchitectureConformanceTests
     // implementation detail, never part of the plugin's public surface.
     private static readonly string[] HelperSuffixes =
     {
-        "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor",
+        "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor", "Gate",
     };
 
     // Every production type, compiler-generated ones excluded — the base sequence for structural rules

--- a/SSO-Auth.Tests/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/IntervalGateTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests pinning IntervalGate's once-per-interval semantics — the shared throttle the
+/// anonymous-path sweeps and log signals rely on to not amplify a flood into CPU or log volume (#246,
+/// #195). The wall-clock cases (boundary, backward step) are the primary evidence for the #318 step 2b
+/// unification because CI cannot move real time, and each adopting site's Interlocked original had exactly
+/// these semantics: guard on a non-negative sub-interval span, then a single CAS winner per interval.
+/// </summary>
+public class IntervalGateTests
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(1);
+
+    private static DateTime At(int hour, int minute, int second = 0) =>
+        new DateTime(2026, 1, 1, hour, minute, second, DateTimeKind.Utc);
+
+    [Fact]
+    public void TryEnter_FirstCall_Enters()
+    {
+        // Cursor starts at MinValue, so the onset always sees a full interval and enters at once.
+        Assert.True(new IntervalGate(Interval).TryEnter(At(0, 0)));
+    }
+
+    [Fact]
+    public void TryEnter_SecondCallWithinInterval_IsThrottled()
+    {
+        var gate = new IntervalGate(Interval);
+        Assert.True(gate.TryEnter(At(0, 0)));
+        Assert.False(gate.TryEnter(At(0, 0, 59)));
+    }
+
+    [Fact]
+    public void TryEnter_AtExactlyTheInterval_Enters()
+    {
+        // Elapsed == interval fails the strict sub-interval guard, so the next call enters.
+        var gate = new IntervalGate(Interval);
+        var t0 = At(0, 0);
+        Assert.True(gate.TryEnter(t0));
+        Assert.True(gate.TryEnter(t0 + Interval));
+    }
+
+    [Fact]
+    public void TryEnter_OneTickBeforeTheInterval_IsThrottled()
+    {
+        var gate = new IntervalGate(Interval);
+        var t0 = At(0, 0);
+        Assert.True(gate.TryEnter(t0));
+        Assert.False(gate.TryEnter(t0 + Interval - TimeSpan.FromTicks(1)));
+    }
+
+    [Fact]
+    public void TryEnter_BackwardClockStep_EntersAndReAnchors()
+    {
+        // #246 self-heal: a wall-clock correction (now earlier than the last entry) must not stall the
+        // gate. It enters and re-anchors to the earlier time, so throttling then resumes from there.
+        var gate = new IntervalGate(Interval);
+        Assert.True(gate.TryEnter(At(12, 0)));
+
+        var backward = At(11, 30);
+        Assert.True(gate.TryEnter(backward));                     // backward step enters (self-heal)
+        Assert.False(gate.TryEnter(backward.AddSeconds(30)));     // re-anchored to 11:30: throttled again
+        Assert.True(gate.TryEnter(backward + Interval));          // a full interval past the new anchor: enters
+    }
+
+    [Fact]
+    public void TryEnter_AfterEntering_ReAnchorsToTheEntryTime()
+    {
+        var gate = new IntervalGate(Interval);
+        var t0 = At(0, 0);
+        Assert.True(gate.TryEnter(t0));
+        Assert.True(gate.TryEnter(t0 + Interval));                // enters, re-anchors to t0 + interval
+        Assert.False(gate.TryEnter(t0 + Interval + TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public async Task TryEnter_ConcurrentCallersInOneInterval_AdmitExactlyOne()
+    {
+        // The CAS guarantees a single winner per interval, so a flood of concurrent anonymous hits runs the
+        // throttled action at most once — the property that makes it a DoS-safe throttle at every call site.
+        var gate = new IntervalGate(Interval);
+        var now = At(0, 0);
+        var winners = 0;
+        var token = TestContext.Current.CancellationToken;
+        using var start = new ManualResetEventSlim(false);
+
+        var tasks = new Task[32];
+        for (var i = 0; i < tasks.Length; i++)
+        {
+            tasks[i] = Task.Run(
+                () =>
+                {
+                    start.Wait(token);
+                    if (gate.TryEnter(now))
+                    {
+                        Interlocked.Increment(ref winners);
+                    }
+                },
+                token);
+        }
+
+        start.Set();
+        await Task.WhenAll(tasks);
+        Assert.Equal(1, winners);
+    }
+}

--- a/SSO-Auth.Tests/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/IntervalGateTests.cs
@@ -27,6 +27,14 @@ public class IntervalGateTests
         Assert.True(new IntervalGate(Interval).TryEnter(At(0, 0)));
     }
 
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public void Ctor_NonPositiveInterval_ThrowsInsteadOfSilentlyDisablingTheThrottle(long ticks)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new IntervalGate(TimeSpan.FromTicks(ticks)));
+    }
+
     [Fact]
     public void TryEnter_SecondCallWithinInterval_IsThrottled()
     {

--- a/SSO-Auth.Tests/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/IntervalGateTests.cs
@@ -77,6 +77,23 @@ public class IntervalGateTests
     }
 
     [Fact]
+    public void TryEnter_StaleOlderSample_AdmitsAndReAnchors_TheDocumentedFailOpenResidual()
+    {
+        // A caller whose captured 'now' is older than the cursor (a thread descheduled between reading the
+        // clock and entering) is indistinguishable from a wall-clock correction, so it enters and re-anchors
+        // — one extra admission, with the next interval measured from the older time. This is the documented
+        // residual of the self-heal guard, bounded to fail-open noise (an extra sweep or log line); the
+        // dangerous direction, a stall, cannot occur because a backward re-anchor only shortens the wait.
+        var gate = new IntervalGate(Interval);
+        Assert.True(gate.TryEnter(At(12, 0)));
+
+        var stale = At(11, 59, 59);
+        Assert.True(gate.TryEnter(stale));                        // stale sample admits (the residual)
+        Assert.False(gate.TryEnter(At(12, 0, 58)));               // re-anchored to 11:59:59: still throttled
+        Assert.True(gate.TryEnter(stale + Interval));             // and open again one interval after the anchor
+    }
+
+    [Fact]
     public void TryEnter_AfterEntering_ReAnchorsToTheEntryTime()
     {
         var gate = new IntervalGate(Interval);

--- a/SSO-Auth.Tests/SsoRateLimiterTests.cs
+++ b/SSO-Auth.Tests/SsoRateLimiterTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 
@@ -182,6 +184,43 @@ public class SsoRateLimiterTests
         Assert.Equal(0, limiter.RecordThrottledHit(Now.AddSeconds(1)));
 
         Assert.Equal(2, limiter.RecordThrottledHit(Now.AddMinutes(-5)));
+    }
+
+    [Fact]
+    public async Task RecordThrottledHit_ConcurrentHitsAndDrains_ConserveEveryHit()
+    {
+        // Conservation: every refusal lands in exactly one drain's returned count — an increment racing
+        // with the winner's Exchange is included either in that drain or in a later one, never erased
+        // (Interlocked increment and exchange on the same location are serialized atomic operations).
+        // Advancing per-thread clocks force frequent gate wins, maximizing drain/increment races.
+        var limiter = new SsoRateLimiter();
+        var baseTime = Now;
+        long drained = 0;
+        const int Threads = 8;
+        const int HitsPerThread = 5_000;
+        var token = TestContext.Current.CancellationToken;
+
+        var tasks = new Task[Threads];
+        for (var t = 0; t < Threads; t++)
+        {
+            var offset = t * HitsPerThread;
+            tasks[t] = Task.Run(
+                () =>
+                {
+                    for (var i = 0; i < HitsPerThread; i++)
+                    {
+                        var drainedNow = limiter.RecordThrottledHit(baseTime.AddMinutes(offset + i));
+                        Interlocked.Add(ref drained, drainedNow);
+                    }
+                },
+                token);
+        }
+
+        await Task.WhenAll(tasks);
+
+        // One final far-future refusal wins the gate uncontended and drains the residue (plus itself).
+        drained += limiter.RecordThrottledHit(baseTime.AddYears(1));
+        Assert.Equal((Threads * HitsPerThread) + 1, drained);
     }
 
     [Fact]

--- a/SSO-Auth/Api/IntervalGate.cs
+++ b/SSO-Auth/Api/IntervalGate.cs
@@ -24,7 +24,7 @@ internal sealed class IntervalGate
         // A non-positive interval would silently disable the throttle (every call enters), turning the
         // gate into the flood amplifier it exists to prevent — e.g. via a field-ordering mistake that
         // passes default(TimeSpan). Fail loudly at construction instead.
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(interval.Ticks, nameof(interval));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(interval.Ticks);
         _intervalTicks = interval.Ticks;
     }
 

--- a/SSO-Auth/Api/IntervalGate.cs
+++ b/SSO-Auth/Api/IntervalGate.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// A once-per-interval throttle cursor shared by the anonymous-path sweeps and log signals that must
+/// not amplify a flood into CPU or log volume (#246, #195). <see cref="TryEnter"/> returns true for at
+/// most one caller per interval — chosen by an atomic compare-and-swap — and false for every other
+/// caller in that interval; it decides only <em>whether</em>, so the throttled action (sweep, log line,
+/// tally drain) stays at the call site. The caller owns the clock: pass one consistent source per gate
+/// (all-UTC or all-local), since the gate compares only ticks.
+/// </summary>
+internal sealed class IntervalGate
+{
+    private readonly long _intervalTicks;
+
+    // Atomic cursor holding the last entry time as ticks, read/written via Interlocked (a long is not
+    // torn-read-safe). Starts at MinValue so the first call always sees a full interval and enters.
+    private long _cursor = DateTime.MinValue.Ticks;
+
+    internal IntervalGate(TimeSpan interval) => _intervalTicks = interval.Ticks;
+
+    /// <summary>
+    /// Reports whether the caller may run the throttled action now, entering the interval if so.
+    /// </summary>
+    /// <param name="now">The current time, from a source consistent with prior calls on this gate.</param>
+    /// <returns>True for the single CAS winner per interval; false when throttled.</returns>
+    internal bool TryEnter(DateTime now)
+    {
+        var nowTicks = now.Ticks;
+        var last = Interlocked.Read(ref _cursor);
+
+        // Suppress only when a non-negative, sub-interval span has elapsed. A backward wall-clock step
+        // (nowTicks < last) fails the first term, so it does NOT suppress — it enters and re-anchors the
+        // cursor below, so a clock correction can never stall the gate and leave a capped store refusing.
+        if (nowTicks >= last && nowTicks - last < _intervalTicks)
+        {
+            return false;
+        }
+
+        // Exactly one CAS winner enters per interval; a loser reads false and is throttled, matching the
+        // CAS-lose = skip behavior of every call site the gate replaces.
+        return Interlocked.CompareExchange(ref _cursor, nowTicks, last) == last;
+    }
+}

--- a/SSO-Auth/Api/IntervalGate.cs
+++ b/SSO-Auth/Api/IntervalGate.cs
@@ -19,7 +19,14 @@ internal sealed class IntervalGate
     // torn-read-safe). Starts at MinValue so the first call always sees a full interval and enters.
     private long _cursor = DateTime.MinValue.Ticks;
 
-    internal IntervalGate(TimeSpan interval) => _intervalTicks = interval.Ticks;
+    internal IntervalGate(TimeSpan interval)
+    {
+        // A non-positive interval would silently disable the throttle (every call enters), turning the
+        // gate into the flood amplifier it exists to prevent — e.g. via a field-ordering mistake that
+        // passes default(TimeSpan). Fail loudly at construction instead.
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(interval.Ticks, nameof(interval));
+        _intervalTicks = interval.Ticks;
+    }
 
     /// <summary>
     /// Reports whether the caller may run the throttled action now, entering the interval if so.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -76,9 +76,11 @@ public class SSOController : ControllerBase
     // The expired-state sweep (Invalidate) is an O(n) scan; throttling it to at most once per this interval
     // stops an anonymous challenge flood from amplifying into CPU load (mirrors SamlRequestCache). This only
     // defers memory reclamation — IsCurrentFor/IsRedeemableBy reject an expired state independently, so a
-    // not-yet-swept entry never grants a login. Its atomic cursor (_lastStatePruneTicks) is a mutable field
-    // and so sits after the readonly static fields below (#246).
+    // not-yet-swept entry never grants a login (#246).
     private static readonly TimeSpan StatePruneInterval = TimeSpan.FromMinutes(1);
+
+    // Throttles that sweep to one run per StatePruneInterval; the gate owns the atomic cursor. See Invalidate.
+    private static readonly IntervalGate StatePruneGate = new(StatePruneInterval);
 
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
@@ -103,10 +105,6 @@ public class SSOController : ControllerBase
     // computed once since the assembly version does not change at runtime.
     private static readonly string UserAgentString =
         $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
-
-    // Atomic cursor for the throttled authorize-state sweep (#246), read/written via Interlocked (a long is
-    // not torn-read-safe). Mutable, so it sits after the readonly static fields to satisfy field ordering.
-    private static long _lastStatePruneTicks = DateTime.MinValue.Ticks;
 
     // Atomic cursor for throttling the capacity-full warning (#246, CWE-400): under a flood every refused
     // challenge would otherwise emit a warning, amplifying the flood into unbounded log volume. Warn at
@@ -1653,26 +1651,14 @@ public class SSOController : ControllerBase
     private static void Invalidate()
     {
         // Throttle the O(n) expired-state sweep to at most once per StatePruneInterval so an anonymous
-        // challenge flood does not amplify into CPU load; the CAS makes exactly one thread per interval
-        // run it (#246). The store keeps InvalidateExpired itself pure/unthrottled — the throttle lives
-        // here, at its sole call site.
+        // challenge flood does not amplify into CPU load; the gate lets exactly one thread per interval
+        // run it (#246). AuthStateStore.InvalidateExpired stays pure/unthrottled — the throttle lives here,
+        // at its sole call site. The same captured 'now' drives both the gate and the sweep.
         var now = DateTime.Now;
-        var last = Interlocked.Read(ref _lastStatePruneTicks);
-
-        // Skip only when a non-negative, sub-interval amount of time has passed. A backward wall-clock step
-        // (now.Ticks < last) does NOT skip — it prunes and resets the cursor — so a clock correction cannot
-        // stall the sweep and leave the capped store refusing fresh challenges (#246).
-        if (now.Ticks >= last && now.Ticks - last < StatePruneInterval.Ticks)
+        if (StatePruneGate.TryEnter(now))
         {
-            return;
+            AuthStateStore.InvalidateExpired(StateManager, now, StateLifetime);
         }
-
-        if (Interlocked.CompareExchange(ref _lastStatePruneTicks, now.Ticks, last) != last)
-        {
-            return;
-        }
-
-        AuthStateStore.InvalidateExpired(StateManager, now, StateLifetime);
     }
 
     // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -216,9 +216,10 @@ internal sealed class SsoRateLimiter
         Interlocked.Increment(ref _throttledHits);
 
         // Only the gate's single winner per interval drains the tally; everyone else returns 0 (suppressed).
-        // A racing increment between the gate entry and the drain is folded into the next interval's count,
-        // not lost outright. The gate self-heals a backward clock, so a correction cannot stall the signal,
-        // and on the first refusal (cursor at MinValue) the onset signals at once.
+        // An increment racing with the winner's drain lands either in that drain's returned count or in the
+        // tally for a later drain — never erased, since increment and exchange on one location are serialized
+        // atomic operations (pinned by the conservation test). The gate self-heals a backward clock, so a
+        // correction cannot stall the signal; the first refusal (cursor at MinValue) signals the onset at once.
         return _signalGate.TryEnter(nowUtc) ? Interlocked.Exchange(ref _throttledHits, 0) : 0;
     }
 

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -39,15 +39,17 @@ internal sealed class SsoRateLimiter
     // key" path never touches it.
     private readonly object _capLock = new object();
 
+    // Throttles the #195 observability signal to one drain per SignalInterval; the gate owns the atomic
+    // cursor. The tally (_throttledHits) it drains stays a mutable field below — see RecordThrottledHit.
+    private readonly IntervalGate _signalGate = new(SignalInterval);
+
     // Last sweep time as ticks, read/written atomically (DateTime is not torn-read-safe).
     private long _lastPruneTicks = DateTime.MinValue.Ticks;
 
-    // Bounded observability signal (#195). Every refusal increments the tally; a signal drains it into
-    // a single log line at most once per SignalInterval. Interlocked keeps both atomic; a hit lost or
-    // double-counted around the drain is harmless for a best-effort operator signal (never a security
-    // decision). Last signal time as ticks, read/written atomically like _lastPruneTicks.
+    // Bounded observability signal (#195). Every refusal increments the tally; RecordThrottledHit drains it
+    // into a single log line at most once per SignalInterval via _signalGate. A hit lost or double-counted
+    // around the drain is harmless for a best-effort operator signal (never a security decision).
     private long _throttledHits;
-    private long _lastSignalTicks = DateTime.MinValue.Ticks;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SsoRateLimiter"/> class.
@@ -213,25 +215,11 @@ internal sealed class SsoRateLimiter
     {
         Interlocked.Increment(ref _throttledHits);
 
-        var last = Interlocked.Read(ref _lastSignalTicks);
-
-        // Suppress only when a non-negative, sub-interval amount of time has passed since the last
-        // signal (mirrors the #246 warning throttle). A backward wall-clock step does NOT suppress —
-        // it signals and resets the cursor — so a clock correction cannot stall the signal. On the
-        // first refusal (cursor at MinValue) the elapsed span is huge, so the onset signals at once.
-        if (nowUtc.Ticks >= last && nowUtc.Ticks - last < SignalInterval.Ticks)
-        {
-            return 0;
-        }
-
-        // Only the CAS winner drains the tally; losers fall back to suppressed. A racing increment
-        // between the CAS and the Exchange is folded into the next interval's count, not lost outright.
-        if (Interlocked.CompareExchange(ref _lastSignalTicks, nowUtc.Ticks, last) != last)
-        {
-            return 0;
-        }
-
-        return Interlocked.Exchange(ref _throttledHits, 0);
+        // Only the gate's single winner per interval drains the tally; everyone else returns 0 (suppressed).
+        // A racing increment between the gate entry and the drain is folded into the next interval's count,
+        // not lost outright. The gate self-heals a backward clock, so a correction cannot stall the signal;
+        // on the first refusal (cursor at MinValue) the onset signals at once.
+        return _signalGate.TryEnter(nowUtc) ? Interlocked.Exchange(ref _throttledHits, 0) : 0;
     }
 
     // Drops counters whose window has long passed, at most once per PruneInterval. Enumerating a

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -217,8 +217,8 @@ internal sealed class SsoRateLimiter
 
         // Only the gate's single winner per interval drains the tally; everyone else returns 0 (suppressed).
         // A racing increment between the gate entry and the drain is folded into the next interval's count,
-        // not lost outright. The gate self-heals a backward clock, so a correction cannot stall the signal;
-        // on the first refusal (cursor at MinValue) the onset signals at once.
+        // not lost outright. The gate self-heals a backward clock, so a correction cannot stall the signal,
+        // and on the first refusal (cursor at MinValue) the onset signals at once.
         return _signalGate.TryEnter(nowUtc) ? Interlocked.Exchange(ref _throttledHits, 0) : 0;
     }
 

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -47,8 +47,9 @@ internal sealed class SsoRateLimiter
     private long _lastPruneTicks = DateTime.MinValue.Ticks;
 
     // Bounded observability signal (#195). Every refusal increments the tally; RecordThrottledHit drains it
-    // into a single log line at most once per SignalInterval via _signalGate. A hit lost or double-counted
-    // around the drain is harmless for a best-effort operator signal (never a security decision).
+    // into a single log line at most once per SignalInterval via _signalGate. A racing increment is never
+    // lost — it lands in that drain or a later one (see RecordThrottledHit) — which is harmless timing slack
+    // for a best-effort operator signal (never a security decision).
     private long _throttledHits;
 
     /// <summary>


### PR DESCRIPTION
# What & why

Step 2b of the #318 architecture migration (Refs #318). The anonymous-path sweeps and log signals each re-implemented the same once-per-interval throttle by hand: read an atomic tick cursor, skip when a non-negative sub-interval span has elapsed, then let one CAS winner per interval run the action. This PR collapses that shape into a single `IntervalGate` primitive, `internal sealed`, one atomic `long` cursor, `bool TryEnter(DateTime now)`, and adopts it at exactly the two sites whose inline code already had the monotonic self-heal guard, so both adoptions are byte-for-byte zero-behavior refactors:

- `SSOController.Invalidate`, the throttled O(n) expired-authorize-state sweep (#246). The same captured `now` drives gate and sweep, as before.
- `SsoRateLimiter.RecordThrottledHit`, the #195 bounded observability signal. The tally increment stays before the gate; only the gate winner drains it; suppressed callers and CAS losers still return 0.

The gate decides only *whether*; the throttled action stays at the call site, so the primitive stays a two-member class with no callback surface.

The three remaining interval-throttle sites (`SSOController` capacity warning, `SamlRequestCache.PruneExpired`, `SsoRateLimiter.PruneStale`) carry a small, documented backward-clock behavior delta when they adopt the gate, so they are deliberately **not** in this diff, they follow in a separate PR where that posture change can be reviewed on its own.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (`Gate` joins the enforced helper suffixes: `*Gate` types must be
      internal and sealed/static).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (596 tests, run three times, no flakes).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this diff).

## Notes

**Primary evidence is the characterization suite**, since CI cannot move the wall clock: `IntervalGateTests` pins first-call entry, the exact interval boundary (elapsed == interval enters; one tick less does not), the backward-clock self-heal (#246, a clock correction enters and re-anchors instead of stalling the gate), post-entry re-anchoring, and the single-CAS-winner property under 32 concurrent callers.

**Backward-clock residual (documented, unchanged by this PR):** after a backward wall-clock step the gate re-anchors to the earlier time, so the next interval is measured from there; a clock oscillating backward repeatedly could enter once per oscillation. That is the pre-existing behavior of both adopted sites (they had this exact guard inline) and is the safe direction for both, a sweep or signal firing once too often is bounded noise, a stalled sweep on a capped store is a login outage.

**Adversarial review (4 lenses, refute-by-default): all PASS.**

- *Availability / mass-lockout*: could not construct a clock path, initializer ordering, or interleaving that stalls the sweep (capped store refusing logins) or the signal, or double-runs them under flood; the guard+CAS is textually identical logic to both replaced blocks, and static field ordering (`StatePruneInterval` before `StatePruneGate`) is verified correct.
- *Security bypass / fail-open*: the gate never influences a deny/grant decision, `IsAllowed` and the expiry rejections (`IsCurrentFor`/`IsRedeemableBy`) are provably independent of it; the removed cursor fields have no orphaned readers; the conformance-rule change only tightens.
- *Correctness / races*: single cursor read reused for guard and CAS (no TOCTOU), strict sub-interval suppression, exact-boundary and backward-clock semantics identical, increment-before-gate and the drain-race shape in `RecordThrottledHit` preserved; the test suite pins the sliding-window mutant.
- *Integration / lifetime*: static gate replaces static cursor, instance gate replaces instance cursor on the same singleton; no existing test weakened; no other `*Gate` type collides with the new conformance rule; no clock-source mixing per gate.

The review's one actionable finding, an unvalidated constructor interval, where `default(TimeSpan)` from a future field-ordering mistake would silently disable the throttle, is fixed in this PR: the constructor now rejects non-positive intervals loudly (second commit).

Both call sites remain strictly off the grant path: expired-state rejection stays independent of the sweep (`IsCurrentFor`/`IsRedeemableBy` reject on their own), and `RecordThrottledHit` observes but never influences `IsAllowed`'s throttling decision.
