### PR TITLE
Add a CRLF/pretty-printed signed-SAML interop regression test

### DIFF
--- a/SSO-Auth.Tests/SamlCrlfInteropTests.cs
+++ b/SSO-Auth.Tests/SamlCrlfInteropTests.cs
@@ -1,0 +1,101 @@
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Interop regression tests pinning that a conformantly-signed, PRETTY-PRINTED SAML response — real
+/// inter-element line breaks and indentation on the wire, the shape production IdP signing stacks emit
+/// — still validates through <see cref="SamlResponse"/> (#120). Follow-up to the P2#9 XML hardening,
+/// which moved the parser from <c>XmlDocument.LoadXml</c> to an <see cref="System.Xml.XmlReader"/>
+/// (<see cref="System.Xml.DtdProcessing.Prohibit"/>): the reader normalizes CR/CRLF line endings to LF
+/// per XML 1.0 §2.11 before building the DOM. The rest of the SAML suite exercises only COMPACT
+/// single-line fixtures, so nothing pins that real-world CRLF/indentation interop survives; a
+/// regression to a non-normalizing parser would break it while passing every existing test.
+///
+/// The whitespace between elements is signature-covered — <c>PreserveWhitespace</c> keeps it and
+/// exclusive C14N includes it — so this shape is what actually exercises line-ending handling. The
+/// three cases together make the pin non-vacuous and guard the load-bearing correctness point the
+/// issue calls out (the <c>OuterXml</c>-escaping pitfall):
+///
+/// <list type="bullet">
+///   <item><see cref="IsValid_WireWithRawCrlfBetweenElements_NormalizesAndValidates"/> — RAW CRLF bytes
+///     (0x0D 0x0A) on the wire, encoded directly, validate against a signature computed over the LF
+///     form: the core interop property.</item>
+///   <item><see cref="IsValid_InterElementWhitespaceAltered_FailsClosed"/> — altering the whitespace
+///     CONTENT (an extra space the IdP never signed) is a digest mismatch and is rejected. This proves
+///     the whitespace is genuinely signature-covered, so the case above passes because of line-ending
+///     NORMALIZATION (CRLF ≡ LF), not because the parser ignores whitespace.</item>
+///   <item><see cref="IsValid_LineEndingCrAsCharacterReference_StillValidates"/> — the same line ending
+///     written as a <c>&amp;#xD;</c> character reference (what serializing a CR-bearing DOM via
+///     <c>OuterXml</c> emits) is exempt from §2.11 normalization, yet .NET's C14N in
+///     <see cref="System.Security.Cryptography.Xml.SignedXml"/> normalizes line-ending CR as well, so
+///     this form ALSO validates. A "CRLF" test built via <c>OuterXml</c> would therefore go green while
+///     shipping <c>&amp;#xD;</c> instead of raw CRLF — passing for the wrong reason. Pinning this is why
+///     the positive test encodes raw wire bytes and asserts the wire carries CR, not <c>&amp;#xD;</c>.
+///     No security impact: only the line-ending REPRESENTATION is normalized; the content stays
+///     covered (previous case).</item>
+/// </list>
+///
+/// All three drive the real signature-validation path in <see cref="SamlResponse"/> against a genuinely
+/// signed fixture (<see cref="SamlTestFactory.CreateIndented"/>), never a mock of the crypto.
+/// </summary>
+public class SamlCrlfInteropTests
+{
+    [Fact]
+    public void IsValid_WireWithRawCrlfBetweenElements_NormalizesAndValidates()
+    {
+        var fixture = SamlTestFactory.CreateIndented();
+
+        // The signed document serializes to an LF baseline with no stray CR — confirm that before
+        // reshaping it, so the CRLF on the wire below is introduced here, not already present.
+        var lfBaseline = fixture.Document.OuterXml;
+        Assert.Contains("\n", lfBaseline);
+        Assert.DoesNotContain("\r", lfBaseline);
+        Assert.DoesNotContain("&#xD;", lfBaseline);
+
+        // Put RAW CRLF bytes on the wire between elements — the shape a conformant IdP emits — and
+        // encode those bytes directly (never via OuterXml, which would escape CR to &#xD;). The reader
+        // normalizes CRLF -> LF to reproduce the signed form, so the signature verifies.
+        var wire = lfBaseline.Replace("\n", "\r\n");
+        Assert.Contains("\r\n", wire);
+        Assert.DoesNotContain("&#xD;", wire); // raw CR bytes on the wire, not the OuterXml escape
+
+        var response = new SamlResponse(fixture.CertificateBase64, SamlFixture.Encode(wire));
+
+        Assert.True(response.IsValid());
+        Assert.Equal("alice", response.GetNameID()); // end-to-end read-through, not just the signature
+    }
+
+    [Fact]
+    public void IsValid_InterElementWhitespaceAltered_FailsClosed()
+    {
+        // Vacuity guard for the raw-CRLF case: the inter-element whitespace is signature-covered, so
+        // changing its CONTENT — here one extra indentation space the IdP never signed — is a digest
+        // mismatch and is rejected. This is what makes the raw-CRLF acceptance meaningful: it is
+        // specifically line-ending normalization (CRLF ≡ LF), not the parser ignoring whitespace.
+        var fixture = SamlTestFactory.CreateIndented();
+        var altered = fixture.Document.OuterXml.Replace("\n", "\r\n "); // CRLF plus an extra space per break
+
+        var response = new SamlResponse(fixture.CertificateBase64, SamlFixture.Encode(altered));
+
+        Assert.False(response.IsValid());
+    }
+
+    [Fact]
+    public void IsValid_LineEndingCrAsCharacterReference_StillValidates()
+    {
+        // The OuterXml-escaping pitfall, pinned: the CR of the line ending expressed as a &#xD; character
+        // reference (exactly what serializing a CR-bearing DOM via OuterXml produces) is exempt from XML
+        // 1.0 §2.11 normalization, yet .NET's C14N normalizes line-ending CR as well, so this validates
+        // too. A "CRLF" test built via OuterXml would thus pass while shipping &#xD; rather than raw
+        // CRLF — passing for the wrong reason; the positive test encodes raw bytes precisely to avoid it.
+        var fixture = SamlTestFactory.CreateIndented();
+        var charRefWire = fixture.Document.OuterXml.Replace("\n", "&#xD;\n");
+        Assert.Contains("&#xD;", charRefWire);
+
+        var response = new SamlResponse(fixture.CertificateBase64, SamlFixture.Encode(charRefWire));
+
+        Assert.True(response.IsValid());
+    }
+}

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -159,6 +159,56 @@ internal static class SamlTestFactory
         return new SamlFixture(certificate, document, responseId, assertionId);
     }
 
+    /// <summary>
+    /// Produces a Response-scope-signed fixture whose XML carries REAL inter-element line breaks and
+    /// indentation — the pretty-printed shape a conformant IdP serializes and signs over — instead of
+    /// the compact single line <see cref="Create"/> emits. The template uses LF line endings, so the
+    /// signed digest is computed over the EOL-normalized form the service provider reconstructs; the
+    /// interop test (#120) rewrites those line breaks to raw CRLF on the wire to exercise the reader's
+    /// XML 1.0 EOL normalization. Whitespace between elements is signature-covered (PreserveWhitespace),
+    /// so this shape is what actually pins the normalization property.
+    /// </summary>
+    /// <param name="notOnOrAfter">SubjectConfirmationData/@NotOnOrAfter; defaults to five minutes in the future.</param>
+    /// <returns>A fixture whose <see cref="SamlFixture.Document"/> serializes to the LF baseline.</returns>
+    internal static SamlFixture CreateIndented(DateTime? notOnOrAfter = null)
+    {
+        const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        var notOnOrAfterValue = (notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5))
+            .ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture);
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test SAML IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var responseId = "_" + Guid.NewGuid().ToString("N");
+        var assertionId = "_" + Guid.NewGuid().ToString("N");
+
+        // LF line breaks and indentation between elements, exactly as a conformant IdP serializes before
+        // signing. Kept as LF here (the interop test converts them to raw CRLF for the on-the-wire bytes).
+        var xml =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\">\n" +
+            "  <saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">\n" +
+            "    <saml:Issuer>https://idp.example.com</saml:Issuer>\n" +
+            "    <saml:Subject>\n" +
+            "      <saml:NameID>alice</saml:NameID>\n" +
+            "      <saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">\n" +
+            "        <saml:SubjectConfirmationData NotOnOrAfter=\"" + notOnOrAfterValue + "\" />\n" +
+            "      </saml:SubjectConfirmation>\n" +
+            "    </saml:Subject>\n" +
+            "    <saml:AttributeStatement>\n" +
+            "      <saml:Attribute Name=\"Role\"><saml:AttributeValue>jellyfin-users</saml:AttributeValue></saml:Attribute>\n" +
+            "    </saml:AttributeStatement>\n" +
+            "  </saml:Assertion>\n" +
+            "</samlp:Response>";
+
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(xml);
+
+        SignElement(document, responseId, rsa, certificate, useSha1: false, useWithCommentsC14n: false, useInclusiveC14n: false);
+
+        return new SamlFixture(certificate, document, responseId, assertionId);
+    }
+
     private static void SignElement(XmlDocument document, string referenceId, RSA signingKey, X509Certificate2 certificate, bool useSha1, bool useWithCommentsC14n, bool useInclusiveC14n)
     {
         var signedXml = new SignedXml(document) { SigningKey = signingKey };


### PR DESCRIPTION
# What & why

Follow-up to the P2#9 XML hardening. The SAML parser moved from
`XmlDocument.LoadXml` to an `XmlReader` (`DtdProcessing.Prohibit`), which
normalizes CR/CRLF line endings to LF per XML 1.0 §2.11 before building the DOM - 
the form conformant IdP signing stacks compute their digest against. The SAML
suite otherwise covers only **compact single-line** fixtures, so nothing pinned
that a real-world pretty-printed response (inter-element CRLF + indentation on
the wire) still validates through `Response`. A regression to a non-normalizing
parser would break interop with conformant IdPs while passing every existing
test.

This adds `SamlCrlfInteropTests`, three cases against the **real**
signature-validation path in `SamlResponse` (genuinely signed fixture, no crypto
mocks):

- **`IsValid_WireWithRawCrlfBetweenElements_NormalizesAndValidates`**, RAW CRLF
  bytes (0x0D 0x0A) on the wire, encoded directly, validate against a signature
  computed over the LF form. The core interop property.
- **`IsValid_InterElementWhitespaceAltered_FailsClosed`**, altering the
  whitespace *content* (an extra space the IdP never signed) is a digest mismatch
  and is rejected. This proves the whitespace is genuinely signature-covered, so
  the case above passes because of line-ending **normalization** (CRLF ≡ LF), not
  because the parser ignores whitespace. Without this guard the positive test
  would be vacuous.
- **`IsValid_LineEndingCrAsCharacterReference_StillValidates`**, the same line
  ending written as a `&#xD;` character reference also validates.

Adds an additive `SamlTestFactory.CreateIndented` helper (builds and signs a
pretty-printed LF/indented response, reusing the existing signer). **No
production code changes.**

## Avoiding the `OuterXml`-escaping pitfall (the load-bearing correctness point)

The issue calls this out: serializing a CR-bearing DOM via `OuterXml` escapes CR
to the `&#xD;` character reference, which XML 1.0 §2.11 does **not** normalize. A
"CRLF" test built via `OuterXml` would therefore ship `&#xD;` instead of raw
CRLF and pass **for the wrong reason** (not exercising raw-CRLF normalization).
The positive test avoids this by encoding the **raw multi-line wire bytes**
directly (`Replace("\n", "\r\n")` on the serialized LF form, never
`Document.OuterXml` of a CR-bearing DOM) and asserting the wire carries raw
`\r\n` and **not** `&#xD;`. It signs over, and validates against, the exact
form the service provider reconstructs.

## Empirical finding (documented, not a defect)

Probing the real path showed the line-ending CR is normalized in **two** layers - 
the `XmlReader` (§2.11) *and* `SignedXml`'s C14N, so even the `&#xD;`
character-reference form validates (the third case pins this and explains why an
`OuterXml`-built test passes for the wrong reason). The interop is thus more
robust than the reader alone; this is a strengthening, not a weakening. **No
security impact:** only the line-ending *representation* is normalized; the
whitespace *content* stays fully signature-covered, verified empirically
(altering content, doubling newlines, tab-for-spaces, and tampering the NameID
all reject), and the second test locks that in.

## Adversarial-review gate

**Disposition: N/A**, this is a test-only addition that changes no product
runtime code (login path, crypto, config persistence, and release pipeline are
untouched; diff is `SSO-Auth.Tests/` only). The 4-lens gate covers changes to
those surfaces; here **the test is the verification**. Behavior was confirmed
empirically against the real validation path (see the finding above), and the
suite stays green.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. *(No product change; the added tests
      assert fail-closed rejection on altered signed whitespace.)*
- [x] No secrets logged; secrets are redacted on config export. *(N/A, test-only.)*
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. *(N/A — no such change; the
      SAML behavior was verified empirically, not modified.)*
- [x] Log inputs from the IdP are sanitized inline at the log call. *(N/A, test-only.)*

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. *(The factory helper reuses the existing `SignElement`.)*
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      *(No new structural property; existing conformance tests pass.)*

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. *(Debug + Release, 0 warnings.)*
- [x] `dotnet test` is green. *(592 total, 0 failed, 3 new.)*
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. *(N/A, no web files touched.)*

## Notes

Test-only; no behavior, config, or security-posture change, so no README /
`providers.md` / wiki update is needed. The empirical finding above is a
documented nuance (stronger-than-assumed interop, no security weakening), not a
defect, so no separate issue is filed.

Closes #120
