### PR TITLE
Adopt IntervalGate at the three remaining throttle sites

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -82,6 +82,12 @@ public class SSOController : ControllerBase
     // Throttles that sweep to one run per StatePruneInterval; the gate owns the atomic cursor. See Invalidate.
     private static readonly IntervalGate StatePruneGate = new(StatePruneInterval);
 
+    // Throttles the capacity-full warning (#246, CWE-400) to one line per StatePruneInterval: under a
+    // flood every refused challenge would otherwise emit a warning, amplifying the flood into unbounded
+    // log volume. The gate self-heals a backward wall-clock step (the hand-rolled predecessor stayed
+    // suppressed until the clock re-climbed past its cursor).
+    private static readonly IntervalGate CapWarnGate = new(StatePruneInterval);
+
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
 
@@ -105,11 +111,6 @@ public class SSOController : ControllerBase
     // computed once since the assembly version does not change at runtime.
     private static readonly string UserAgentString =
         $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
-
-    // Atomic cursor for throttling the capacity-full warning (#246, CWE-400): under a flood every refused
-    // challenge would otherwise emit a warning, amplifying the flood into unbounded log volume. Warn at
-    // most once per StatePruneInterval.
-    private static long _lastCapWarnTicks = DateTime.MinValue.Ticks;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
@@ -312,13 +313,9 @@ public class SSOController : ControllerBase
             if (!AuthStateStore.TryAdd(StateManager, state.State, new TimedAuthorizeState(state, DateTime.Now) { IsLinking = isLinking, Provider = provider }, MaxStateEntries))
             {
                 // The state value is a CSPRNG token, so a collision is effectively impossible; a refusal
-                // here is almost always the capacity backstop under a flood. Throttle the warning to at
-                // most once per interval so the flood cannot amplify into unbounded log volume (#246).
-                var warnNow = DateTime.Now.Ticks;
-                var lastWarn = Interlocked.Read(ref _lastCapWarnTicks);
-                if (warnNow >= lastWarn
-                    && warnNow - lastWarn >= StatePruneInterval.Ticks
-                    && Interlocked.CompareExchange(ref _lastCapWarnTicks, warnNow, lastWarn) == lastWarn)
+                // here is almost always the capacity backstop under a flood. The gate throttles the warning
+                // to at most once per interval so the flood cannot amplify into unbounded log volume (#246).
+                if (CapWarnGate.TryEnter(DateTime.Now))
                 {
                     _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
                 }

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Threading;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
@@ -29,8 +28,10 @@ internal sealed class SamlRequestCache
 
     private readonly ConcurrentDictionary<string, DateTime> _outstanding = new(StringComparer.Ordinal);
 
-    // Last sweep time as ticks, read/written atomically (DateTime is not torn-read-safe).
-    private long _lastPruneTicks = DateTime.MinValue.Ticks;
+    // Throttles the sweep to one run per PruneInterval; the gate owns the atomic cursor and self-heals
+    // a backward wall-clock step (the hand-rolled predecessor stalled until the clock re-passed its
+    // cursor). See PruneExpired.
+    private readonly IntervalGate _pruneGate = new(PruneInterval);
 
     /// <summary>
     /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>. A blank ID is
@@ -86,14 +87,7 @@ internal sealed class SamlRequestCache
     // registration cap, not by eviction here.
     private void PruneExpired(DateTime nowUtc)
     {
-        var last = Interlocked.Read(ref _lastPruneTicks);
-        if (nowUtc.Ticks - last < PruneInterval.Ticks)
-        {
-            return;
-        }
-
-        // Only one thread should run the sweep per interval; the winner of the CAS does it.
-        if (Interlocked.CompareExchange(ref _lastPruneTicks, nowUtc.Ticks, last) != last)
+        if (!_pruneGate.TryEnter(nowUtc))
         {
             return;
         }

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -43,8 +43,10 @@ internal sealed class SsoRateLimiter
     // cursor. The tally (_throttledHits) it drains stays a mutable field below — see RecordThrottledHit.
     private readonly IntervalGate _signalGate = new(SignalInterval);
 
-    // Last sweep time as ticks, read/written atomically (DateTime is not torn-read-safe).
-    private long _lastPruneTicks = DateTime.MinValue.Ticks;
+    // Throttles the stale-counter sweep to one run per PruneInterval; the gate owns the atomic cursor
+    // and self-heals a backward wall-clock step (the hand-rolled predecessor stalled until the clock
+    // re-passed its cursor). See PruneStale.
+    private readonly IntervalGate _pruneGate = new(PruneInterval);
 
     // Bounded observability signal (#195). Every refusal increments the tally; RecordThrottledHit drains it
     // into a single log line at most once per SignalInterval via _signalGate. A racing increment is never
@@ -230,14 +232,7 @@ internal sealed class SsoRateLimiter
     // loses that thread's tally to a fresh window — harmless for a best-effort limiter.
     private void PruneStale(TimeSpan window, DateTime nowUtc)
     {
-        var last = Interlocked.Read(ref _lastPruneTicks);
-        if (nowUtc.Ticks - last < PruneInterval.Ticks)
-        {
-            return;
-        }
-
-        // Only one thread should run the sweep per interval; the winner of the CAS does it.
-        if (Interlocked.CompareExchange(ref _lastPruneTicks, nowUtc.Ticks, last) != last)
+        if (!_pruneGate.TryEnter(nowUtc))
         {
             return;
         }

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -59,3 +59,24 @@ rules:
     paths:
       include:
         - "SSO-Auth/**/*.cs"
+
+  # Invariant (architecture, #318 step 2b): once-per-interval throttling goes
+  # through IntervalGate, whose guard/CAS semantics were adversarially reviewed
+  # once and are pinned by tests (#331). Every hand-rolled predecessor seeded its
+  # tick cursor with `DateTime.MinValue.Ticks`; that idiom reappearing outside
+  # IntervalGate means someone is re-rolling a throttle cursor, re-introducing
+  # the subtle backward-clock and CAS races the primitive was extracted to end.
+  - id: no-inline-interval-throttle-cursor
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not hand-roll a once-per-interval throttle cursor. Use IntervalGate;
+      its suppression guard, single-CAS-winner, and backward-clock semantics are
+      reviewed and pinned by tests (#318, #331).
+    patterns:
+      - pattern: = DateTime.MinValue.Ticks
+    paths:
+      include:
+        - "SSO-Auth/**/*.cs"
+      exclude:
+        - "SSO-Auth/Api/IntervalGate.cs"


### PR DESCRIPTION
# What & why

Second half of #318 step 2b (Refs #318), completing the throttle unification started in #331: the three remaining hand-rolled once-per-interval cursors now run behind `IntervalGate`.

- `SamlRequestCache.PruneExpired`, the outstanding-AuthnRequest sweep.
- `SsoRateLimiter.PruneStale`, the stale-counter sweep.
- `SSOController` capacity-full warning, the #246 log throttle on the refused-challenge branch.

Steady-state behavior is unchanged at all three sites (same suppression guard, same single-CAS-winner-per-interval, same boundary: elapsed == interval enters). Each site carries **one deliberate backward-clock delta, in the safe direction**, which is why these three were split out of #331 (whose contract was zero-change):

- The two sweeps had **no monotonic guard**: a backward wall-clock correction made the elapsed span negative, which read as "inside the interval", so the sweep **stalled** until the wall clock re-passed the stale cursor. They now self-heal, sweep once and re-anchor. For the SAML request cache this removes a latent availability hazard: a stalled sweep on a capped cache holds memory and, at the cap, refuses fresh registrations longer than necessary.
- The capacity warning had the monotonic term, but combined guard and CAS in one condition chain, so a backward step suppressed **without re-anchoring** (no warning until the clock re-climbed). It now fires one line and re-anchors.

All three throttled actions are memory reclamation or a single log line, never a grant/deny decision, so the worst case of any delta is one extra bounded action.

With the last hand-rolled cursor gone, the unification is locked in as a greppable invariant: an opengrep rule now bans the cursor-seed idiom (`= DateTime.MinValue.Ticks`) outside `IntervalGate.cs`, so a new inline throttle cannot quietly bypass the reviewed primitive.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires (net deletion:
      three inline guard+CAS blocks collapse into gate calls).
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the structural property this change
      completes (all interval throttling behind `IntervalGate`) is locked in as
      the `no-inline-interval-throttle-cursor` opengrep invariant, since a
      method-body property is greppable but not reflectable.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (603 tests).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this diff).

## Notes

**Why no new tests in this diff:** the gate semantics the three sites now share, boundary, backward-clock self-heal, stale-sample residual, single concurrent winner, constructor validation, are already pinned deterministically by `IntervalGateTests` (#331). The per-site backward-clock deltas are confined to *when* an unobservable reclamation sweep runs (or one throttled log line fires) and are provably unreachable through the public API: the correlation and expiry decisions (`TryConsume`'s expiry check, `IsAllowed`'s window logic) are independent of sweep timing by design, and every constructible call sequence ends in the same visible state. The existing `SamlRequestCacheTests` / `SsoRateLimiterTests` cover the observable prune effects (cap-slot reclaim, entry expiry) and continue to pass unchanged.

**Backward-clock residuals:** the stale-sample re-admission residual documented on #331 applies to these sites identically and is tracked in #334, to be hardened once for all five sites.

**Adversarial review (4 lenses, refute-by-default): all PASS.**

- *Availability / mass-lockout*: the old stall-until-the-clock-re-climbs behavior was itself the mass-lockout-adjacent risk, a SAML request cache pinned at its cap refuses logins fail-closed; the self-heal un-pins it on the next call after any clock correction. All three gates receive provably positive intervals on every initialization path (static and instance), so a type-initialization failure is unreachable.
- *Security bypass / fail-open*: the fail-closed correlation, replay, and rate-limit predicates are untouched; the removed cursor fields leave no stragglers; the rate limiter's fail-open-at-cap invariant is preserved; log sanitization stays inline at the call.
- *Correctness / races*: per-site truth tables (guard polarity, elapsed == interval boundary, first call, CAS-winner selection, sample ordering) are exactly equivalent in the forward-clock domain; the only divergences are the three documented backward-clock deltas; the existing prune tests pass for the mechanistically right reasons.
- *Integration / lifetime / pipeline*: field-initialization order safe at both static and instance sites; using-directive changes exact; no test references the removed internals; the opengrep rule follows the file's generic-mode conventions with a unique id and zero findings on the current tree.

Accepted non-blocking residuals from the review: the opengrep tripwire is deliberately narrow (an implicit zero-seeded cursor would evade it, the conformance tests and review remain the primary defense; noted on #334 for the eventual hardening pass), and the rule was verified textually against the engine conventions, the PR's own "Enforce greppable invariants" check is the empirical run and is confirmed green before merge.
