### PR TITLE
Extract the SSO URL construction into SsoUrlBuilder

### DIFF
--- a/SSO-Auth.Tests/SsoUrlBuilderTests.cs
+++ b/SSO-Auth.Tests/SsoUrlBuilderTests.cs
@@ -1,0 +1,105 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Characterization tests pinning the exact bytes SsoUrlBuilder produces. These strings are validated
+/// byte-for-byte on the other side (the IdP's redirect_uri registration; the SAML Recipient echo,
+/// compared Ordinal by SamlRecipientValidator), so the pins here are the primary evidence that the
+/// #318 extraction changed nothing — the end-to-end suites assert only URL prefixes and parameter
+/// presence, not full bytes.
+/// </summary>
+public class SsoUrlBuilderTests
+{
+    private const string Base = "https://jf.example.com";
+
+    [Fact]
+    public void OidRedirectUri_ClassicRoute_UsesTheLegacySpelling()
+    {
+        Assert.Equal("https://jf.example.com/sso/OID/r/kc", SsoUrlBuilder.OidRedirectUri(Base, newPath: false, "kc"));
+    }
+
+    [Fact]
+    public void OidRedirectUri_NewPathRoute_UsesTheRedirectSpelling()
+    {
+        Assert.Equal("https://jf.example.com/sso/OID/redirect/kc", SsoUrlBuilder.OidRedirectUri(Base, newPath: true, "kc"));
+    }
+
+    [Fact]
+    public void OidRedirectUri_BaseWithPathBase_KeepsItAheadOfTheSsoSegment()
+    {
+        // CanonicalBaseUrl.Resolve hands over a trailing-slash-free base including the server's path
+        // base; the builder's "/sso/..." concatenation relies on exactly that contract.
+        Assert.Equal(
+            "https://jf.example.com/jellyfin/sso/OID/r/kc",
+            SsoUrlBuilder.OidRedirectUri("https://jf.example.com/jellyfin", newPath: false, "kc"));
+    }
+
+    [Theory]
+    [InlineData("/sso/OID/redirect/kc", "https://jf.example.com/sso/OID/redirect/kc")]
+    [InlineData("/sso/OID/r/kc", "https://jf.example.com/sso/OID/r/kc")]
+    public void OidCallbackRedirectUri_EchoesTheCallbackPathSpelling(string callbackPath, string expected)
+    {
+        Assert.Equal(expected, SsoUrlBuilder.OidCallbackRedirectUri(Base, callbackPath, "kc"));
+    }
+
+    [Fact]
+    public void OidCallbackRedirectUri_ProviderNamedRedirectOnTheClassicRoute_StaysLegacy()
+    {
+        // The spelling is decided by the exact segment after OID, not by substring matching, so a
+        // provider literally named "redirect" cannot flip it (#98, pinned end-to-end here on top of
+        // OidcCallbackPathTests).
+        Assert.Equal(
+            "https://jf.example.com/sso/OID/r/redirect",
+            SsoUrlBuilder.OidCallbackRedirectUri(Base, "/sso/OID/r/redirect", "redirect"));
+    }
+
+    [Fact]
+    public void OidCallbackRedirectUri_NullPath_DefaultsToTheLegacySpelling()
+    {
+        Assert.Equal("https://jf.example.com/sso/OID/r/kc", SsoUrlBuilder.OidCallbackRedirectUri(Base, null, "kc"));
+    }
+
+    [Theory]
+    [InlineData(false, "https://jf.example.com/sso/SAML/p/idp")]
+    [InlineData(true, "https://jf.example.com/sso/SAML/post/idp")]
+    public void SamlAcsUrl_SpellingFollowsTheRouteVariant(bool newPath, string expected)
+    {
+        Assert.Equal(expected, SsoUrlBuilder.SamlAcsUrl(Base, newPath, "idp"));
+    }
+
+    [Fact]
+    public void SamlExpectedAcsUrls_ReturnsBothSpellings_NewPathFirst()
+    {
+        // Exact array and order: the Recipient binding iterates this set, and the challenge-time ACS
+        // is definitionally one of its members, so the validator cannot drift from the challenge.
+        Assert.Equal(
+            new[] { "https://jf.example.com/sso/SAML/post/idp", "https://jf.example.com/sso/SAML/p/idp" },
+            SsoUrlBuilder.SamlExpectedAcsUrls(Base, "idp"));
+    }
+
+    [Theory]
+    [InlineData("my provider", "https://jf.example.com/sso/OID/r/my provider")]
+    [InlineData("käse", "https://jf.example.com/sso/OID/r/käse")]
+    public void OidRedirectUri_ProviderIsAppendedRaw_NeverReEncoded(string provider, string expected)
+    {
+        // Characterizes the contract, not an endorsement: the server never encodes the provider —
+        // re-encoding would change the bytes IdPs already have registered and break every working
+        // deployment. Rejecting problematic names at registration is #336.
+        Assert.Equal(expected, SsoUrlBuilder.OidRedirectUri(Base, newPath: false, provider));
+    }
+
+    [Theory]
+    [InlineData(true, "redirect")]
+    [InlineData(false, "r")]
+    public void ChallengeAndCallbackLegs_ProduceTheSameRedirectUri(bool newPath, string segment)
+    {
+        // RFC 6749 section 4.1.3: the token request must repeat the authorization request's
+        // redirect_uri byte-for-byte. The challenge leg derives the spelling from newPath, the
+        // callback leg re-derives it from its own path — this pins that the two constructions agree.
+        Assert.Equal(
+            SsoUrlBuilder.OidRedirectUri(Base, newPath, "kc"),
+            SsoUrlBuilder.OidCallbackRedirectUri(Base, $"/sso/OID/{segment}/kc", "kc"));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -297,7 +297,7 @@ public class SSOController : ControllerBase
 
             bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
 
-            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/OID/{(newPath ? "redirect" : "r")}/" + provider;
+            string redirectUri = SsoUrlBuilder.OidRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
 
             var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
             var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
@@ -475,7 +475,7 @@ public class SSOController : ControllerBase
     private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
     {
         var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
-        var redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/OID/{OidcCallbackPath.RedirectSegment(Request.Path.Value)}/" + provider;
+        var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), Request.Path.Value, provider);
         return CreateOidcClient(config, redirectUri, string.Join(" ", scopes.Prepend("openid profile")));
     }
 
@@ -770,7 +770,7 @@ public class SSOController : ControllerBase
         {
             bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
 
-            string redirectUri = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + $"/sso/SAML/{(newPath ? "post" : "p")}/" + provider;
+            string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
             string relayState = null;
             if (isLinking)
             {
@@ -1713,11 +1713,8 @@ public class SSOController : ControllerBase
     // Jellyfin's Known/Trusted Proxies (or set BaseUrlOverride) so the Host cannot be spoofed, or an
     // attacker controlling the Host can make the expected URL match a captured assertion's Recipient
     // (defense-in-depth, not a hard guarantee).
-    private string[] ExpectedAcsUrls(SamlConfig config, string provider)
-    {
-        var baseUrl = GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride) + "/sso/SAML/";
-        return new[] { baseUrl + "post/" + provider, baseUrl + "p/" + provider };
-    }
+    private string[] ExpectedAcsUrls(SamlConfig config, string provider) =>
+        SsoUrlBuilder.SamlExpectedAcsUrls(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), provider);
 
     // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
     // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling

--- a/SSO-Auth/Api/SsoUrlBuilder.cs
+++ b/SSO-Auth/Api/SsoUrlBuilder.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Composes the SSO URLs this service provider hands to identity providers: the OIDC redirect_uri
+/// and the SAML AssertionConsumerServiceURL, plus the expected-ACS set the Recipient/Destination
+/// binding (#156) compares against. These strings are validated byte-for-byte on the other side
+/// (RFC 6749 section 4.1.3 redirect_uri equality; the SAML Recipient echo is compared Ordinal), so
+/// every method concatenates exactly what the previously scattered call sites produced: lowercase
+/// "/sso/", the protocol segment, the route-spelling variant, and the route-decoded provider name
+/// appended raw — never re-encoded, since encoding would change the bytes identity providers
+/// already have registered.
+/// </summary>
+internal static class SsoUrlBuilder
+{
+    /// <summary>Builds the challenge-time OIDC redirect_uri; the spelling follows the route the login started on.</summary>
+    /// <param name="baseUrl">The canonical base URL, trailing-slash free (from <see cref="CanonicalBaseUrl.Resolve"/>).</param>
+    /// <param name="newPath">Whether the login started on the new-path route, choosing "redirect" over "r".</param>
+    /// <param name="provider">The route-decoded provider name, appended raw.</param>
+    /// <returns>The absolute redirect_uri to register the authorization request under.</returns>
+    internal static string OidRedirectUri(string baseUrl, bool newPath, string provider) =>
+        Build(baseUrl, "OID", newPath ? "redirect" : "r", provider);
+
+    /// <summary>Builds the token-exchange redirect_uri, echoing the spelling of the callback's own path (#98).</summary>
+    /// <param name="baseUrl">The canonical base URL, trailing-slash free.</param>
+    /// <param name="callbackPath">The callback request's path, whose OID segment decides the spelling.</param>
+    /// <param name="provider">The route-decoded provider name, appended raw.</param>
+    /// <returns>The redirect_uri the token request must repeat byte-for-byte.</returns>
+    internal static string OidCallbackRedirectUri(string baseUrl, string? callbackPath, string provider) =>
+        Build(baseUrl, "OID", OidcCallbackPath.RedirectSegment(callbackPath), provider);
+
+    /// <summary>Builds the SAML AssertionConsumerServiceURL advertised in the AuthnRequest.</summary>
+    /// <param name="baseUrl">The canonical base URL, trailing-slash free.</param>
+    /// <param name="newPath">Whether the login started on the new-path route, choosing "post" over "p".</param>
+    /// <param name="provider">The route-decoded provider name, appended raw.</param>
+    /// <returns>The absolute URL the identity provider must POST the assertion to.</returns>
+    internal static string SamlAcsUrl(string baseUrl, bool newPath, string provider) =>
+        Build(baseUrl, "SAML", newPath ? "post" : "p", provider);
+
+    /// <summary>
+    /// Builds both ACS spellings this provider could have advertised. NewPath is process-wide mutable
+    /// configuration a concurrent challenge can flip between challenge and callback, so the Recipient
+    /// binding accepts either spelling; deriving both from <see cref="SamlAcsUrl"/> makes it structural
+    /// that the validator cannot drift from the challenge-time string.
+    /// </summary>
+    /// <param name="baseUrl">The canonical base URL, trailing-slash free.</param>
+    /// <param name="provider">The route-decoded provider name, appended raw.</param>
+    /// <returns>The new-path spelling first, then the legacy spelling.</returns>
+    internal static string[] SamlExpectedAcsUrls(string baseUrl, string provider) =>
+        new[] { SamlAcsUrl(baseUrl, newPath: true, provider), SamlAcsUrl(baseUrl, newPath: false, provider) };
+
+    private static string Build(string baseUrl, string protocol, string segment, string provider) =>
+        baseUrl + "/sso/" + protocol + "/" + segment + "/" + provider;
+}


### PR DESCRIPTION
# What & why

Next step of the #318 architecture migration (Refs #318). Four controller sites hand-built the URLs this service provider hands to identity providers, the OIDC redirect_uri (challenge and token exchange), the SAML AssertionConsumerServiceURL, and the expected-ACS set the Recipient binding compares against, each repeating the `/sso/{protocol}/{spelling}/{provider}` shape inline. `SsoUrlBuilder` (internal static, pure) now owns that shape; the call sites keep resolving the base URL (`CanonicalBaseUrl` via `GetRequestBase`) and the `newPath` flag, because both are flow concerns, not string composition. `OidcCallbackPath` stays as-is and the builder delegates to it, its #98 exact-segment rationale and tests are already pinned.

These strings are validated byte-for-byte on the other side, RFC 6749 §4.1.3 redirect_uri equality at the IdP, and the SAML Recipient echo compared Ordinal by `SamlRecipientValidator`, so the extraction is behavior-preserving by contract: identical concatenation order and literals, provider appended raw with no re-encoding (the bytes IdPs have registered must not change), and the expected-ACS array keeps its exact order.

The structural payoff: `SamlExpectedAcsUrls` is now definitionally `{SamlAcsUrl(true), SamlAcsUrl(false)}`, so the Recipient validator can no longer drift from the challenge-time ACS string, that agreement used to be a convention across two hand-written string expressions ~950 lines apart.

Out-of-scope findings from the scoping pass are tracked separately: provider-name validation at registration (#336), the `/start/` substring hazard in `ResolveChallengeNewPath` (#337, deliberately not fixed here, this step is behavior-preserving), and the stale providers.md ACS documentation (#338).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires (the spelling
      knowledge existed four times; it now exists once).
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the existing `*Builder` rules
      (internal + sealed/static) capture the new type automatically, so no new
      rule is needed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (617 tests, three consecutive runs).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this diff).

## Notes

**The byte evidence is `SsoUrlBuilderTests`** - 14 characterization pins covering both spellings per protocol, path-base retention, the callback-path echo (including a provider literally named `redirect` and a null path), the exact expected-ACS array and order, the raw-provider contract (space and umlaut pass through unencoded, characterized, not endorsed; rejecting such names at registration is #336), and the cross-leg agreement that the challenge and token-exchange constructions produce the same redirect_uri. The end-to-end suites assert only URL prefixes and parameter presence, so these unit pins carry the byte-level proof; zero existing tests were edited, which is itself the regression evidence.

**Adversarial review (4 lenses, refute-by-default): all PASS.**

- *Availability / mass-lockout*: symbolic byte-level derivation at all four call sites across every input class (path base, trailing slash, null base, null callback path, provider edge cases including `redirect`, space, umlaut, empty), no input exists where old and new differ by one byte; the expected-ACS set keeps order and cardinality, and the challenge-ACS membership guarantee is now structural.
- *Security bypass / fail-open*: acceptance set neither widened nor narrowed for any provider or base; the raw-provider bytes are identical at every site; `SamlRecipientValidator` (Ordinal + Trim) and `OidcCallbackPath` (#98 exact-segment) verifiably untouched; no new exposure via `InternalsVisibleTo`.
- *Correctness / edge cases*: interpolation lowers to the same `string.Concat` (no culture involvement); null flows identical; the 14 pins catch swapped segments, missing slashes, and wrong array order; zero existing-test edits confirmed.
- *Integration / conformance*: the existing `*Builder` rules capture the type automatically with no collateral flags; Debug and Release green under `--warnaserror`; declared out-of-scope sites provably untouched; opengrep unaffected. Cosmetic observation (mixed nullable-directive adoption across helpers), non-blocking, resolves naturally as the #318 migration touches each file.
