### PR TITLE
Correct the Keycloak SAML assertion URL in providers.md

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -310,9 +310,11 @@ Ensure that the following configuration options are set:
 - Sign Documents on
 - Sign Assertions off
 - Client Signature Required off
-- Redirect URI: [https://myjellyfin.example.com/sso/SAML/start/PROVIDER_NAME](https://myjellyfin.example.com/sso/SAML/start/PROVIDER_NAME)
+- Redirect URI: [https://myjellyfin.example.com/sso/SAML/post/PROVIDER_NAME](https://myjellyfin.example.com/sso/SAML/post/PROVIDER_NAME)
 - Base URL: [https://myjellyfin.example.com](https://myjellyfin.example.com)
-- Master SAML processing URL: [https://myjellyfin.example.com/sso/SAML/start/PROVIDER_NAME](https://myjellyfin.example.com/sso/SAML/start/PROVIDER_NAME)
+- Master SAML processing URL: [https://myjellyfin.example.com/sso/SAML/post/PROVIDER_NAME](https://myjellyfin.example.com/sso/SAML/post/PROVIDER_NAME)
+
+These two URLs are the assertion consumer service endpoint Keycloak POSTs the SAML response to. The plugin accepts both the `sso/SAML/post/PROVIDER_NAME` spelling and the legacy `sso/SAML/p/PROVIDER_NAME` spelling; use either, consistently. (The challenge route `sso/SAML/start/PROVIDER_NAME` is only the URL a login starts from — it cannot process assertions.)
 
 Press the "Save" button at the bottom of the page.
 


### PR DESCRIPTION
# What & why

The Keycloak SAML section of providers.md registered the challenge route (`sso/SAML/start/PROVIDER_NAME`) as both the Redirect URI and the Master SAML processing URL. That route only starts a login, an IdP configured per the doc POSTs the assertion to it and the login fails. Both fields now point at the assertion consumer route, and a short note states the two accepted spellings (`sso/SAML/post/PROVIDER_NAME` and the legacy `sso/SAML/p/PROVIDER_NAME`) and clarifies the role of the challenge route. Verified against the routes in `SSOController.cs`: the assertion POST handlers are `SAML/p/{provider}` and `SAML/post/{provider}`; `SAML/start/{provider}` is the GET challenge route. The general callback-URL guidance earlier in the file already lists the correct spellings and is unchanged. Closes #338

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Docs-only change; no code path is touched, so each item holds unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (603 tests).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change
      (`prettier --check providers.md` passes).

## Notes

Documentation correction only; no behavior change. Surfaced while scoping the URL construction for the #318 SsoUrlBuilder step.