### PR TITLE
Reject linking through a disabled provider

### DIFF
--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -221,7 +221,8 @@ public class SSOControllerLinkTests
 
         var rejected = await harness.Controller.AddCanonicalLink("saml", "adfs", Target, new AuthResponse { Data = fixture.EncodeResponse() });
 
-        Assert.IsType<BadRequestObjectResult>(rejected);
+        // Same body as the unknown-provider rejection, so the two cases cannot be probed apart.
+        Assert.Equal("No matching provider found", Assert.IsType<BadRequestObjectResult>(rejected).Value);
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice")));
 
         // The assertion survived the rejection: re-enabling the provider lets the same response link.

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -163,7 +163,7 @@ public class SSOControllerLinkTests
     [Fact]
     public async Task AddCanonicalLink_AuthorizedOidWithRedeemableState_LinksAndReturnsNoContent()
     {
-        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig());
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         // The OID link path redeems an authorize state the redirect leg validated; seed a redeemable one.
         SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(new AuthorizeState { State = "state-1" }, DateTime.Now)
         {
@@ -180,11 +180,63 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task AddCanonicalLink_OidDisabledProvider_RejectsWithoutConsumingTheState()
+    {
+        // #343: a state validated shortly before an administrator disables the provider must not stay
+        // usable to create a link, and the disabled provider must not burn the state either — the
+        // rejection mirrors OidAuth's short-circuit order and shares the unknown-provider response, so
+        // the two cases cannot be probed apart.
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = false });
+        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(new AuthorizeState { State = "state-1" }, DateTime.Now)
+        {
+            Provider = "keycloak",
+            Valid = true,
+            Subject = "sub-1",
+        });
+
+        var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
+
+        // Same body as the unknown-provider rejection, so the two cases cannot be probed apart.
+        Assert.Equal("No matching provider found", Assert.IsType<BadRequestObjectResult>(rejected).Value);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-1")));
+
+        // The state survived the rejection: re-enabling the provider lets the same token link.
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["keycloak"].Enabled = true);
+        var accepted = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
+        Assert.IsType<NoContentResult>(accepted);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_SamlDisabledProvider_RejectsWithoutConsumingTheAssertion()
+    {
+        // #343, SAML twin: the disabled check runs before the replay cache, so the assertion's
+        // one-time-use ID is not burned by a rejected attempt against a disabled provider.
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = false,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+        });
+
+        var rejected = await harness.Controller.AddCanonicalLink("saml", "adfs", Target, new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.IsType<BadRequestObjectResult>(rejected);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice")));
+
+        // The assertion survived the rejection: re-enabling the provider lets the same response link.
+        SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"].Enabled = true);
+        var accepted = await harness.Controller.AddCanonicalLink("saml", "adfs", Target, new AuthResponse { Data = fixture.EncodeResponse() });
+        Assert.IsType<NoContentResult>(accepted);
+    }
+
+    [Fact]
     public async Task AddCanonicalLink_AuthorizedSamlWithSignedResponse_LinksAndReturnsNoContent()
     {
         var fixture = SamlTestFactory.Create(nameId: "alice");
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.SamlConfigs["adfs"] = new SamlConfig
         {
+            Enabled = true,
             SamlCertificate = fixture.CertificateBase64,
             DoNotValidateAudience = true, // audience validation is covered separately
         });

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1308,8 +1308,11 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     private ActionResult SamlLink(string provider, Guid jellyfinUserId, AuthResponse response)
     {
+        // A disabled provider must neither create a link nor consume the assertion's one-time-use ID
+        // (#343): an administrator disabling a provider takes effect immediately for linking, and the
+        // unknown and disabled cases share one response so neither can be probed apart.
         var config = FindSamlConfig(provider);
-        if (config is null)
+        if (config is not { Enabled: true })
         {
             return BadRequest(NoMatchingProviderMessage);
         }
@@ -1353,7 +1356,11 @@ public class SSOController : ControllerBase
             return BadRequest("Missing data");
         }
 
-        if (FindOidConfig(provider) is null)
+        // A disabled provider must neither create a link nor consume the state (#343), mirroring
+        // OidAuth's short-circuit order: an administrator disabling a provider takes effect for
+        // in-flight linking states immediately, not after their 15-minute lifetime. The unknown and
+        // disabled cases share one response, so neither can be probed apart (no enumeration oracle).
+        if (FindOidConfig(provider) is not { Enabled: true })
         {
             return BadRequest(NoMatchingProviderMessage);
         }


### PR DESCRIPTION
# What & why

Closes #343. `OidAuth` short-circuits on `config.Enabled` before redeeming a state, so a disabled provider can neither mint a session nor burn a state, but both linking paths only checked that the provider exists. A state or signed assertion validated shortly before an administrator disabled the provider stayed usable for up to its lifetime to create an account link (CWE-863). During implementation the SAML twin turned out to carry the identical gap, so both are fixed symmetrically: `OidLink` and `SamlLink` now require an enabled provider before touching the one-time-use artifact.

Deliberate, named behavior change: disabling a provider now takes effect immediately for linking (previously up to 15 minutes of residue). The unknown and disabled cases share one response body, so neither can be probed apart, matching the login paths' anti-enumeration posture. The guard precedes both consumers, so a rejected attempt burns nothing.

Incidental evidence the gap was real: both pre-existing happy-path linking tests passed with `Enabled` at its default of `false`, they linked through disabled providers. They now set `Enabled = true` explicitly.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted (the new guard is itself fail-closed:
      null and disabled both reject).
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call (no new log lines).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit (one property-pattern guard per twin, mirroring the login paths).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; no new structural property to lock in.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (626 tests; the two new reject-path tests prove the rejection AND that the state/assertion survives it, re-enabling lets the same artifact link).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this diff).

## Notes

**Adversarial review (4 lenses, refute-by-default): all PASS.** Availability: no existing deployment's linking breaks, `Enabled` round-trips the XML serializer, and any deployment where login works has proven it persists (the login paths have gated on the same property all along); the only newly rejected flow is the closed vulnerability window itself, and unlinking (`DeleteCanonicalLink`) deliberately keeps working on disabled providers so stale links stay cleanable. Bypass: the property pattern is exactly `null or disabled → reject`; the auto-login link creation was already gated; reads/deletes are deliberately not gated (privilege-reducing, authz-gated). Correctness: the non-consumption proofs are genuine (both artifact stores are process statics; a consumed artifact could not re-link). Integration: the inherent microsecond TOCTOU between the Enabled read and the redeem matches `OidAuth`'s existing pattern and fails closed.

Non-blocking review observations filed separately: the linking page offers disabled providers and swallows the rejection (#344); the challenge endpoints' unknown-vs-disabled response asymmetry is part of the login-outcome unification step (#318).
