### PR TITLE
Introduce LoginOutcome and LoginStatusMapper

### DIFF
--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Controller.Authentication;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins the single outcome-to-HTTP translation (#318): every public rejection category maps to
+/// exactly one status and fixed plain-text body, byte-identical to the ReturnError responses the
+/// mapper replaced, and the closed sum admits no path to a client-caused 500.
+/// </summary>
+public class LoginStatusMapperTests
+{
+    [Fact]
+    public void Rejected_MapsEveryReasonToTheExactStatusAndBody()
+    {
+        // A table Fact rather than a Theory: PublicReason is internal, and a public Theory parameter
+        // may not be less accessible than the test method.
+        var expected = new (PublicReason Reason, int Status, string Body)[]
+        {
+            (PublicReason.SsoResponseInvalid, 400, "SSO response validation failed"),
+            (PublicReason.SamlResponseInvalid, 400, "SAML response validation failed"),
+            (PublicReason.PkceNotSupported, 400, "The identity provider does not advertise the required PKCE (S256) support."),
+            (PublicReason.PkceUnverifiable, 400, "The identity provider's PKCE (S256) support could not be verified."),
+        };
+
+        // The table itself must stay total: a new member without a row fails here.
+        Assert.Equal(Enum.GetValues<PublicReason>().Order(), expected.Select(e => e.Reason).Order());
+
+        foreach (var (reason, status, body) in expected)
+        {
+            var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(reason)));
+
+            Assert.Equal(status, result.StatusCode);
+            Assert.Equal(body, result.Content);
+            Assert.Equal("text/plain", result.ContentType);
+        }
+    }
+
+    [Fact]
+    public void EveryPublicReason_MapsWithoutThrowing_AndNeverToA5xx()
+    {
+        // The executable form of "client-caused conditions structurally cannot become 500s": a future
+        // PublicReason member without a mapper entry, or one mapped to a 5xx, fails here before it
+        // can ship.
+        foreach (var reason in Enum.GetValues<PublicReason>())
+        {
+            var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(reason)));
+            Assert.True(result.StatusCode < 500, $"{reason} must not map to a server-error status");
+        }
+    }
+
+    [Fact]
+    public void UnmappedReasonValue_ThrowsInsteadOfDefaultAccepting()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected((PublicReason)999)));
+    }
+
+    [Fact]
+    public void ForeignOutcomeSubtype_ThrowsInsteadOfDefaultAccepting()
+    {
+        // The record copy constructor lets an in-assembly (or InternalsVisibleTo) type slip past the
+        // private primary constructor — exactly the loophole the sum's doc names. The mapper's unknown-
+        // subtype arm turns that misuse into a throw (genuine 500), never a default-accept.
+        Assert.Throws<InvalidOperationException>(() =>
+            LoginStatusMapper.ToActionResult(new ForeignOutcome(new LoginOutcome.Denied())));
+    }
+
+    private sealed record ForeignOutcome : LoginOutcome
+    {
+        public ForeignOutcome(LoginOutcome original)
+            : base(original)
+        {
+        }
+    }
+
+    [Fact]
+    public void Denied_MapsToTheUniformUninformative401()
+    {
+        var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Denied()));
+
+        Assert.Equal(401, result.StatusCode);
+        Assert.Equal("Error. Check permissions.", result.Content);
+        Assert.Equal("text/plain", result.ContentType);
+    }
+
+    [Fact]
+    public void Success_ReturnsTheSameSessionInstanceAs200Json()
+    {
+        var session = new AuthenticationResult();
+
+        var result = Assert.IsType<OkObjectResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Success(session)));
+
+        Assert.Same(session, result.Value);
+    }
+}

--- a/SSO-Auth/Api/LoginOutcome.cs
+++ b/SSO-Auth/Api/LoginOutcome.cs
@@ -1,0 +1,34 @@
+using MediaBrowser.Controller.Authentication;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The closed set of results a login flow can produce (#318). There is deliberately no Error case:
+/// anything unexpected propagates as an exception and surfaces as a genuine 500, so a client-caused
+/// condition structurally cannot become a 500. The hierarchy is closed within the assembly by
+/// convention: the internal type cannot be named outside it, and while an in-assembly subtype can
+/// still derive through the compiler-synthesized record copy constructor, the mapper throws on any
+/// unknown subtype, so a foreign case fails closed. <see cref="LoginStatusMapper"/> is the single place outcomes become HTTP
+/// responses. A throttled case joins this sum with the rate-limit filter step — the Retry-After
+/// header needs response access a pure mapper does not have, and the 429 is byte-identical today.
+/// </summary>
+internal abstract record LoginOutcome
+{
+    private LoginOutcome()
+    {
+    }
+
+    /// <summary>A minted session; the mapper returns it as the 200 JSON body unchanged.</summary>
+    /// <param name="Session">The authentication result the client consumes.</param>
+    internal sealed record Success(AuthenticationResult Session) : LoginOutcome;
+
+    /// <summary>A client-caused rejection with a categorized, deliberately uninformative public reason.</summary>
+    /// <param name="Reason">The public rejection category the mapper translates.</param>
+    internal sealed record Rejected(PublicReason Reason) : LoginOutcome;
+
+    /// <summary>
+    /// A policy denial (role allow-list, unresolved identity). Deliberately carries no reason at all:
+    /// every denial maps to the one uniform 401 body, so a cause cannot leak even by construction.
+    /// </summary>
+    internal sealed record Denied : LoginOutcome;
+}

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Net.Mime;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The single translation from a <see cref="LoginOutcome"/> to an HTTP response. Rejection bodies
+/// are plain text and deliberately uniform per category, so a response does not reveal why it was
+/// rejected beyond what the category already states publicly — the server log disambiguates. The
+/// rate-limit 429 stays with the rate limiter until the filter step (Retry-After needs the response).
+/// </summary>
+internal static class LoginStatusMapper
+{
+    /// <summary>The uniform denial body for any rejected login — deliberately uninformative.</summary>
+    internal const string PermissionDeniedMessage = "Error. Check permissions.";
+
+    internal static ActionResult ToActionResult(LoginOutcome outcome) => outcome switch
+    {
+        LoginOutcome.Success success => new OkObjectResult(success.Session),
+        LoginOutcome.Denied => Emit(StatusCodes.Status401Unauthorized, PermissionDeniedMessage),
+        LoginOutcome.Rejected rejected => ToActionResult(rejected.Reason),
+        // Unreachable while the sum stays closed, but the compiler cannot prove it; an impossible
+        // case is a genuine server fault, so it throws (500) — never a default-accept.
+        _ => throw new InvalidOperationException($"Unhandled login outcome: {outcome.GetType().Name}"),
+    };
+
+    private static ContentResult ToActionResult(PublicReason reason) => reason switch
+    {
+        PublicReason.SsoResponseInvalid => Emit(StatusCodes.Status400BadRequest, "SSO response validation failed"),
+        PublicReason.SamlResponseInvalid => Emit(StatusCodes.Status400BadRequest, "SAML response validation failed"),
+        PublicReason.PkceNotSupported => Emit(StatusCodes.Status400BadRequest, "The identity provider does not advertise the required PKCE (S256) support."),
+        PublicReason.PkceUnverifiable => Emit(StatusCodes.Status400BadRequest, "The identity provider's PKCE (S256) support could not be verified."),
+        // A new PublicReason member without a mapper entry fails loudly here, and the totality test
+        // enumerating every member catches it before it can ship — never a fall-through.
+        _ => throw new InvalidOperationException($"Unmapped public reason: {reason}"),
+    };
+
+    // Reproduces the controller's ReturnError shape exactly (ContentResult, text/plain), so every
+    // converted call site is byte-identical on the wire.
+    private static ContentResult Emit(int statusCode, string message) => new ContentResult
+    {
+        Content = message,
+        ContentType = MediaTypeNames.Text.Plain,
+        StatusCode = statusCode,
+    };
+}

--- a/SSO-Auth/Api/PublicReason.cs
+++ b/SSO-Auth/Api/PublicReason.cs
@@ -1,0 +1,22 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Client-visible rejection categories. Each member maps to exactly one status and fixed message in
+/// <see cref="LoginStatusMapper"/>; a new rejection cause requires a new member AND a mapper entry —
+/// never a fall-through. Members exist only once a call site constructs them, so the enum grows with
+/// the conversion steps of #318.
+/// </summary>
+internal enum PublicReason
+{
+    /// <summary>OIDC callback validation failed (the RFC 9207 issuer mix-up check).</summary>
+    SsoResponseInvalid,
+
+    /// <summary>SAML assertion malformed, invalid, unsolicited, or replayed — one body for all (#199, #156, #219).</summary>
+    SamlResponseInvalid,
+
+    /// <summary>RequirePkce is set but the authorization server does not advertise S256 (#141). Operator-facing by design.</summary>
+    PkceNotSupported,
+
+    /// <summary>RequirePkce is set but the discovery document could not be read (#141). Operator-facing by design.</summary>
+    PkceUnverifiable,
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -40,11 +40,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 [Route("[controller]")]
 public class SSOController : ControllerBase
 {
-    // Client-facing error messages: unresolved provider names, and the generic denial for any
-    // rejected login (deliberately uniform so the response does not reveal why it was rejected).
+    // Client-facing messages for unresolved provider names; the uniform-rejection policy and its
+    // denial body live on LoginStatusMapper, where the messages are defined (#318).
     private const string NoMatchingProviderMessage = "No matching provider found";
     private const string ProviderDoesNotExistMessage = "Provider does not exist";
-    private const string PermissionDeniedMessage = "Error. Check permissions.";
 
     // Display names for the audit log (the internal link-map mode tokens are the lowercase "oid"/"saml").
     private const string OpenIdProtocol = "OpenID";
@@ -175,7 +174,7 @@ public class SSOController : ControllerBase
                 && OidcResponseIssuer.IsMismatch(Request.Query["iss"], result.IdentityToken))
             {
                 _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer did not match the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
-                return ReturnError(StatusCodes.Status400BadRequest, "SSO response validation failed");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
             }
 
             // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
@@ -190,7 +189,7 @@ public class SSOController : ControllerBase
             if (derived.Valid && string.IsNullOrWhiteSpace(derived.Subject))
             {
                 _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
-                return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
             }
 
             pending.Complete(derived);
@@ -210,7 +209,7 @@ public class SSOController : ControllerBase
                     result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
                     config.Roles);
 
-                return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
             }
         }
 
@@ -248,7 +247,7 @@ public class SSOController : ControllerBase
                 if (config.RequirePkce)
                 {
                     _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-                    return ReturnError(StatusCodes.Status400BadRequest, "The identity provider does not advertise the required PKCE (S256) support.");
+                    return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
                 }
 
                 SsoAudit.PkceNotAdvertised(_logger, provider);
@@ -256,7 +255,7 @@ public class SSOController : ControllerBase
             else if (pkceSupported is null && config.RequirePkce)
             {
                 _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-                return ReturnError(StatusCodes.Status400BadRequest, "The identity provider's PKCE (S256) support could not be verified.");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceUnverifiable));
             }
 
             bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
@@ -619,7 +618,7 @@ public class SSOController : ControllerBase
                 AvatarUrl = redeemed.AvatarUrl,
             }).ConfigureAwait(false);
             SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, redeemed.Username, redeemed.Admin);
-            return Ok(authenticationResult);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
         }
 
         return Problem("Something went wrong");
@@ -672,7 +671,7 @@ public class SSOController : ControllerBase
             {
                 // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
                 // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
-                return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
             }
 
             if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
@@ -692,7 +691,7 @@ public class SSOController : ControllerBase
                 samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
                 samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
                 config.Roles);
-            return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 
         return ReturnError(StatusCodes.Status400BadRequest, "No active providers found");
@@ -831,7 +830,7 @@ public class SSOController : ControllerBase
                 || !IsSamlResponseValid(samlResponse, config, provider))
             {
                 // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
-                return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
             }
 
             // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
@@ -857,7 +856,7 @@ public class SSOController : ControllerBase
                 _logger.LogWarning(
                     "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
                     samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
-                return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
             }
 
             // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
@@ -881,7 +880,7 @@ public class SSOController : ControllerBase
             if (string.IsNullOrWhiteSpace(nameId))
             {
                 _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
-                return ReturnError(StatusCodes.Status401Unauthorized, PermissionDeniedMessage);
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
             }
 
             Guid userId;
@@ -910,7 +909,7 @@ public class SSOController : ControllerBase
                 AvatarUrl = null,
             }).ConfigureAwait(false);
             SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
-            return Ok(authenticationResult);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
         }
 
         return Problem("Something went wrong");
@@ -1321,7 +1320,7 @@ public class SSOController : ControllerBase
             || !IsSamlResponseValid(samlResponse, config, provider))
         {
             // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
-            return ReturnError(StatusCodes.Status400BadRequest, "SAML response validation failed");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
         // Enforce one-time use here too (#219): without it, a captured, still-valid assertion could be


### PR DESCRIPTION
# What & why

First half of #346 (Refs #346, Refs #318). The controller rejects logins through four divergent mechanisms, `BadRequest`, `ReturnError`, `Problem()`, and thrown `ArgumentException`, held together by call-site convention. This PR introduces the closed `LoginOutcome` sum (`Success | Rejected(PublicReason) | Denied`) and the single `LoginStatusMapper`, and converts every exit whose response is **byte-identical on the wire**: thirteen sites that previously used `ReturnError` (whose `ContentResult`/text-plain shape the mapper's `Emit` reproduces exactly, same strings) or `Ok(authenticationResult)` (definitionally `new OkObjectResult(value)`, the same result the mapper emits).

The sum deliberately has **no Error case**, anything unexpected propagates as an exception and surfaces as a genuine 500, so a client-caused condition structurally cannot become a 500, and `Denied` deliberately carries **no reason at all**, so a denial cause cannot leak even by construction. A new rejection reason forces a new enum member and a mapper entry; the totality test makes a missing entry or a 5xx mapping fail before it ships. The uniform-rejection policy comment moves to the mapper, where the messages now live.

Out of scope, by design (they change bytes and get their own reviewed PR, the second half of #346): the client-caused `Problem()` 500s, the thrown provider rejections, the disabled-vs-unknown oracle closure (including the `[Produces(application/json)]` endpoints, whose `BadRequest` guards emit JSON-quoted bodies), and the corresponding enum members (`UnknownProvider`, `InvalidState`, `AccountLinkForbidden`), members exist only once a call site constructs them. The rate-limit 429 joins the sum with the filter step (Retry-After needs response access a pure mapper does not have). `ReturnError` itself stays with five remaining call sites: two dynamic-text rejections (their fixed-wording decision is a named follow-up), the capacity 500, the "No active providers found" site (second half), and the 429.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted (the mapper has no default-accept arm;
      impossible cases throw).
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call (no log changes).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires (the controller
      net-deletes; the three types are the typed belt the #318 design mandates).
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the `Mapper` suffix rules capture the
      new type automatically ("Outcome" is deliberately not a helper suffix — the
      abstract sum base would fail the sealed-or-static rule).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (632 tests, three consecutive runs) with **zero
      edits to existing assertions** — the byte-identical proof.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this diff).

## Notes

**Adversarial review (4 lenses, refute-by-default): all PASS.** The bypass lens byte-diffed every mapper literal against the origin/main strings (including the apostrophe and trailing periods) and reconciled all 13 conversions against the old 16-site `ReturnError` inventory; availability confirmed no status a client retries on changes and the `[Produces(application/json)]` negotiation path is untouched for the identical `OkObjectResult`; correctness verified each mechanically converted line in context; integration confirmed the conformance rules capture the mapper and deliberately not the abstract sum base. The lenses' two notes are addressed in this PR: the closed-sum doc now names the record copy-constructor loophole explicitly, and a test constructs a foreign subtype through it to pin the unknown-subtype throw arm (misuse becomes a genuine 500, never a default-accept).
