### PR TITLE
Extract the config boundary into ProviderConfigStore

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -147,6 +147,9 @@ public class ArchitectureConformanceTests
                 .Where(f => !f.Name.Contains('<', StringComparison.Ordinal))
                 .Where(f => MentionsConfiguration(f.FieldType))
                 .Select(f => f.Name))
+            .Concat(typeof(SSOPlugin).GetConstructors(declared)
+                .Where(c => c.GetParameters().Select(p => p.ParameterType).Any(MentionsConfiguration))
+                .Select(c => ".ctor"))
             .ToList();
 
         Assert.True(offenders.Count == 0, "SSOPlugin members touching configuration types must stay limited to the delegating facade (config logic lives in Config/): " + string.Join(", ", offenders));

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -122,6 +124,42 @@ public class ArchitectureConformanceTests
 
         Assert.True(offenders.Count == 0, "Raw dictionary state must live inside a *Store/*Cache/*Limiter type (or carry a documented exemption here): " + string.Join(", ", offenders));
     }
+
+    [Fact]
+    public void SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade()
+    {
+        // Locked in by the ProviderConfigStore extraction (#318): SSOPlugin is bootstrap + page
+        // manifests + a thin facade, and every configuration read/write/validation/preservation rule
+        // lives in Config/ (ProviderConfigStore, ProviderConfigValidator, ServerManagedFields). Any
+        // declared method or field whose signature mentions a configuration type must be one of the
+        // named facade members that delegate to the store. PersistBase is allow-listed by name: it is
+        // the private bridge handing base.UpdateConfiguration to the store, not config logic of its own.
+        // Compiler-generated members (the ctor's `() => Configuration` lambda, backing fields) are
+        // artifacts of the allowed wiring, not declared members — same exclusion as the keyed-state rule.
+        var facade = new[] { "ReadConfiguration", "MutateConfiguration", "UpdateConfiguration", "PersistBase" };
+        const BindingFlags declared = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+        var offenders = typeof(SSOPlugin).GetMethods(declared)
+            .Where(m => !facade.Contains(m.Name) && !m.Name.Contains('<', StringComparison.Ordinal))
+            .Where(m => m.GetParameters().Select(p => p.ParameterType).Append(m.ReturnType).Any(MentionsConfiguration))
+            .Select(m => m.Name)
+            .Concat(typeof(SSOPlugin).GetFields(declared)
+                .Where(f => !f.Name.Contains('<', StringComparison.Ordinal))
+                .Where(f => MentionsConfiguration(f.FieldType))
+                .Select(f => f.Name))
+            .ToList();
+
+        Assert.True(offenders.Count == 0, "SSOPlugin members touching configuration types must stay limited to the delegating facade (config logic lives in Config/): " + string.Join(", ", offenders));
+    }
+
+    // A configuration type for the facade rule: the plugin configuration itself or any provider config
+    // (OidConfig/SamlConfig derive from ProviderConfigBase), including one buried in a generic
+    // (e.g. Func<PluginConfiguration, T>) or array signature.
+    private static bool MentionsConfiguration(Type t) =>
+        typeof(BasePluginConfiguration).IsAssignableFrom(t)
+        || typeof(ProviderConfigBase).IsAssignableFrom(t)
+        || (t.HasElementType && MentionsConfiguration(t.GetElementType()!))
+        || (t.IsGenericType && t.GetGenericArguments().Any(MentionsConfiguration));
 
     // Catches concrete dictionaries (they implement non-generic IDictionary) AND fields declared as the
     // generic IDictionary<,> interface, which does not inherit the non-generic one — otherwise an

--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -66,7 +66,7 @@ public class CanonicalBaseUrlTests
     }
 
     // The OID/SAML Add endpoints persist through MutateConfiguration (the live config object), which
-    // bypasses SSOPlugin.UpdateConfiguration's save-time validation, so they gate the incoming override
+    // bypasses ProviderConfigStore.Save's save-time validation, so they gate the incoming override
     // themselves via SSOController.RejectInvalidBaseUrlOverride. Pin that decision so the Add paths cannot
     // regress into persisting a malformed override that then silently falls back to the request Host.
 

--- a/SSO-Auth.Tests/CapturingLogger.cs
+++ b/SSO-Auth.Tests/CapturingLogger.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Captures every log entry as (level, formatted message) so a test can assert on what was emitted.
+/// Shared by the audit-log tests and the config-store tests.
+/// </summary>
+internal sealed class CapturingLogger : ILogger
+{
+    internal List<(LogLevel Level, string Message)> Entries { get; } = new List<(LogLevel, string)>();
+
+    public IDisposable BeginScope<TState>(TState state)
+        where TState : notnull => null!;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => Entries.Add((logLevel, formatter(state, exception)));
+}

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Xml.Serialization;
-using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
@@ -8,7 +7,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// Tests for the server-managed-field handling (#157): canonical links are preserved across a save
-/// built from a stale client snapshot (<see cref="SSOPlugin.PreserveServerManagedFields"/>), are
+/// built from a stale client snapshot (<see cref="ServerManagedFields.Preserve(PluginConfiguration, PluginConfiguration)"/>), are
 /// withheld from JSON responses ([JsonIgnore]), and still round-trip through the config XML.
 /// </summary>
 public class ConfigPreservationTests
@@ -28,7 +27,7 @@ public class ConfigPreservationTests
         incoming.OidConfigs["idp"] = new OidConfig();
         incoming.SamlConfigs["saml"] = new SamlConfig();
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.Equal(User, incoming.OidConfigs["idp"].CanonicalLinks["sub-1"]);
         Assert.Equal(User, incoming.SamlConfigs["saml"].CanonicalLinks["nameid-1"]);
@@ -41,7 +40,7 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["fresh"] = new OidConfig();
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.Empty(incoming.OidConfigs["fresh"].CanonicalLinks);
     }
@@ -54,7 +53,7 @@ public class ConfigPreservationTests
         live.OidConfigs["gone"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub"] = User } };
         var incoming = new PluginConfiguration();
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.False(incoming.OidConfigs.ContainsKey("gone"));
     }
@@ -66,7 +65,7 @@ public class ConfigPreservationTests
         var live = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
 
         // Fail-safe: a malformed config with missing maps must not NRE the save path.
-        var exception = Record.Exception(() => SSOPlugin.PreserveServerManagedFields(incoming, live));
+        var exception = Record.Exception(() => ServerManagedFields.Preserve(incoming, live));
 
         Assert.Null(exception);
     }
@@ -138,7 +137,7 @@ public class ConfigPreservationTests
     public void Rotation_ThroughJsonThenPreserve_KeepsTheNewSecret()
     {
         // The realistic rotation path: a config PUT carrying a new secret is deserialized, then
-        // PreserveServerManagedFields runs against the live config — the new secret must win.
+        // ServerManagedFields.Preserve runs against the live config — the new secret must win.
         var live = new PluginConfiguration();
         live.OidConfigs["idp"] = new OidConfig { OidSecret = "old-secret" };
 
@@ -146,7 +145,7 @@ public class ConfigPreservationTests
         incoming.OidConfigs["idp"] = System.Text.Json.JsonSerializer.Deserialize<OidConfig>(
             "{\"OidSecret\":\"rotated-secret\"}")!;
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.Equal("rotated-secret", incoming.OidConfigs["idp"].OidSecret);
     }
@@ -165,7 +164,7 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["idp"] = new OidConfig { OidSecret = incomingSecret };
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.Equal("live-secret", incoming.OidConfigs["idp"].OidSecret);
     }
@@ -179,7 +178,7 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["fresh"] = new OidConfig { OidSecret = null };
 
-        SSOPlugin.PreserveServerManagedFields(incoming, live);
+        ServerManagedFields.Preserve(incoming, live);
 
         Assert.True(string.IsNullOrEmpty(incoming.OidConfigs["fresh"].OidSecret));
     }
@@ -190,7 +189,7 @@ public class ConfigPreservationTests
         var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
         var incoming = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "  " };
 
-        Assert.Equal("live", SSOPlugin.ResolveUpdatedSecret(incoming, live));
+        Assert.Equal("live", ServerManagedFields.ResolveUpdatedSecret(incoming, live));
     }
 
     [Fact]
@@ -199,7 +198,7 @@ public class ConfigPreservationTests
         var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
         var incoming = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "rotated" };
 
-        Assert.Equal("rotated", SSOPlugin.ResolveUpdatedSecret(incoming, live));
+        Assert.Equal("rotated", ServerManagedFields.ResolveUpdatedSecret(incoming, live));
     }
 
     [Theory]
@@ -213,7 +212,7 @@ public class ConfigPreservationTests
         var live = new OidConfig { OidEndpoint = "https://idp/.well-known", OidClientId = "cid", OidSecret = "live" };
         var incoming = new OidConfig { OidEndpoint = endpoint, OidClientId = clientId, OidSecret = null };
 
-        Assert.True(string.IsNullOrEmpty(SSOPlugin.ResolveUpdatedSecret(incoming, live)));
+        Assert.True(string.IsNullOrEmpty(ServerManagedFields.ResolveUpdatedSecret(incoming, live)));
     }
 
     // --- Base-URL override validation on save (#139) ---
@@ -227,7 +226,7 @@ public class ConfigPreservationTests
         incoming.SamlConfigs["saml"] = new SamlConfig { BaseUrlOverride = "https://sso.example.com/jellyfin" };
         incoming.SamlConfigs["saml-blank"] = new SamlConfig { BaseUrlOverride = "   " };
 
-        SSOPlugin.ValidateBaseUrlOverrides(incoming);
+        ProviderConfigValidator.Validate(incoming);
     }
 
     [Fact]
@@ -236,7 +235,7 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "not-a-url" };
 
-        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateBaseUrlOverrides(incoming));
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming));
         Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
         Assert.Contains("OpenID", ex.Message, StringComparison.Ordinal);
     }
@@ -247,7 +246,7 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.SamlConfigs["saml"] = new SamlConfig { BaseUrlOverride = "ftp://example.com" };
 
-        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateBaseUrlOverrides(incoming));
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming));
         Assert.Contains("SAML", ex.Message, StringComparison.Ordinal);
     }
 
@@ -256,7 +255,7 @@ public class ConfigPreservationTests
     {
         var incoming = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
 
-        SSOPlugin.ValidateBaseUrlOverrides(incoming);
+        ProviderConfigValidator.Validate(incoming);
     }
 
     [Theory]
@@ -475,7 +474,7 @@ public class ConfigPreservationTests
         incoming.SamlConfigs["ok"] = new SamlConfig { SamlCertificate = SamlTestFactory.Create().CertificateBase64 };
         incoming.SamlConfigs["blank"] = new SamlConfig { SamlCertificate = null };
 
-        SSOPlugin.ValidateSamlCertificates(incoming);
+        ProviderConfigValidator.Validate(incoming);
     }
 
     [Fact]
@@ -484,13 +483,13 @@ public class ConfigPreservationTests
         var incoming = new PluginConfiguration();
         incoming.SamlConfigs["idp"] = new SamlConfig { SamlCertificate = "QUJD" }; // valid base64, not a cert
 
-        var ex = Assert.Throws<ArgumentException>(() => SSOPlugin.ValidateSamlCertificates(incoming));
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming));
         Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
     }
 
     [Fact]
     public void ValidateSamlCertificates_NullMap_DoesNotThrow()
     {
-        SSOPlugin.ValidateSamlCertificates(new PluginConfiguration { SamlConfigs = null });
+        ProviderConfigValidator.Validate(new PluginConfiguration { SamlConfigs = null });
     }
 }

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="ProviderConfigStore"/> — the owner of configuration reads, mutations, and the
+/// validated save pipeline extracted from SSOPlugin (#318). The validation and preservation rules have
+/// their own suite (ConfigPreservationTests); these pin the store's orchestration: what the pipeline
+/// runs for a fresh incoming config, what it skips for the live object, and what reaches the persist
+/// delegate. The store is exercised directly with local delegates, so no plugin instance is involved.
+/// </summary>
+public class ProviderConfigStoreTests
+{
+    private static readonly Guid User = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private static (ProviderConfigStore Store, PluginConfiguration Live, List<BasePluginConfiguration> Persisted) CreateStore(ILogger? logger = null)
+    {
+        var live = new PluginConfiguration();
+        var persisted = new List<BasePluginConfiguration>();
+        return (new ProviderConfigStore(() => live, persisted.Add, logger!), live, persisted);
+    }
+
+    [Fact]
+    public void Read_ReadsTheLiveConfiguration()
+    {
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1" };
+
+        Assert.Equal("client-1", store.Read(c => c.OidConfigs["idp"].OidClientId));
+        Assert.Empty(persisted); // A read never persists.
+    }
+
+    [Fact]
+    public void Mutate_AppliesTheMutation_AndPersistsTheLiveObject()
+    {
+        var (store, live, persisted) = CreateStore();
+
+        store.Mutate(c => c.OidConfigs["idp"] = new OidConfig());
+
+        Assert.True(live.OidConfigs.ContainsKey("idp"));
+        Assert.Same(live, Assert.Single(persisted));
+    }
+
+    [Fact]
+    public void Mutate_WithResult_ReturnsIt_AndPersists()
+    {
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["idp"] = new OidConfig();
+
+        var removed = store.Mutate(c => c.OidConfigs.Remove("idp"));
+
+        Assert.True(removed);
+        Assert.Same(live, Assert.Single(persisted));
+    }
+
+    [Fact]
+    public void Save_FreshConfigWithMalformedOverride_Throws_AndPersistsNothing()
+    {
+        // The fail-closed gate (#139): a replacement config is validated BEFORE anything is persisted.
+        var (store, _, persisted) = CreateStore();
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "not-a-url" };
+
+        Assert.Throws<ArgumentException>(() => store.Save(incoming));
+
+        Assert.Empty(persisted);
+    }
+
+    [Fact]
+    public void Save_FreshConfig_PreservesServerManagedFields_AndPersistsIt()
+    {
+        // The stale-snapshot save (#157/#189): a posted config carrying neither links nor secret must
+        // get both re-injected from the live config before it reaches the persist delegate.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidSecret = "live-secret",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+        };
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig();
+
+        store.Save(incoming);
+
+        Assert.Same(incoming, Assert.Single(persisted));
+        Assert.Equal("live-secret", incoming.OidConfigs["idp"].OidSecret);
+        Assert.Equal(User, incoming.OidConfigs["idp"].CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public void Save_TheLiveObject_SkipsTheFreshConfigPipeline()
+    {
+        // Writes that reuse the live object (Mutate, login-path link writes) are intentionally never
+        // revalidated: even a malformed override already sitting in the live config must not make the
+        // save throw, so the login path can never be blocked by the config-page gate.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "not-a-url" };
+
+        store.Save(live);
+
+        Assert.Same(live, Assert.Single(persisted));
+    }
+
+    [Fact]
+    public void Save_FreshConfigWithInsecureOptions_PersistsAndAuditsThem()
+    {
+        // The #140 audit: saving a provider with a disabled security check emits a warning naming the
+        // provider and the option — after the save, so a logging provider cannot fail a completed save.
+        var logger = new CapturingLogger();
+        var (store, _, persisted) = CreateStore(logger);
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["corp"] = new OidConfig { DisableHttps = true };
+
+        store.Save(incoming);
+
+        Assert.Single(persisted);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("corp", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("DisableHttps", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Save_WithoutALogger_StillPersistsInsecureOptions_WithoutThrowing()
+    {
+        // The audit is best-effort: a missing logger must never turn a valid save into a failure.
+        var (store, _, persisted) = CreateStore(logger: null);
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["corp"] = new OidConfig { DisableHttps = true };
+
+        store.Save(incoming);
+
+        Assert.Single(persisted);
+    }
+
+    [Fact]
+    public void NullArguments_Throw()
+    {
+        var (store, _, _) = CreateStore();
+
+        Assert.Throws<ArgumentNullException>(() => store.Save(null!));
+        Assert.Throws<ArgumentNullException>(() => store.Read<bool>(null!));
+        Assert.Throws<ArgumentNullException>(() => store.Mutate(null!));
+        Assert.Throws<ArgumentNullException>(() => store.Mutate<bool>(null!));
+    }
+}

--- a/SSO-Auth.Tests/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/SsoAuditTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -40,18 +39,5 @@ public class SsoAuditTests
         var message = Assert.Single(logger.Entries).Message;
         Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
         Assert.Contains("corpInjected", message, StringComparison.Ordinal);
-    }
-
-    private sealed class CapturingLogger : ILogger
-    {
-        internal List<(LogLevel Level, string Message)> Entries { get; } = new List<(LogLevel, string)>();
-
-        public IDisposable BeginScope<TState>(TState state)
-            where TState : notnull => null!;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
-            => Entries.Add((logLevel, formatter(state, exception)));
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -442,7 +442,7 @@ public class SSOController : ControllerBase
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
     // through MutateConfiguration, which passes the live configuration object, so they bypass the
-    // config-page save-time validation in SSOPlugin.UpdateConfiguration (which only runs for a fresh
+    // config-page save-time validation in ProviderConfigStore.Save (which only runs for a fresh
     // incoming config). Without this, a malformed override set via the Add API would be persisted and then
     // silently fall back to the request Host at login. Throwing keeps it out of the store, so the
     // "rejected at every admin write path" invariant holds. Blank is valid (the feature is off).
@@ -456,7 +456,7 @@ public class SSOController : ControllerBase
 
     // Rejects a non-loadable SAML signing certificate at the SAML/Add endpoint (#206), which persists
     // through MutateConfiguration and so bypasses the config-page save-time validation in
-    // SSOPlugin.ValidateSamlCertificates. Without this, a garbage certificate set via the Add API would be
+    // ProviderConfigValidator.Validate. Without this, a garbage certificate set via the Add API would be
     // persisted and then throw a CryptographicException on every callback (an unhandled 500). Blank is
     // valid (a half-configured provider).
     internal static void RejectInvalidSamlCertificate(string certificateStr)
@@ -486,7 +486,7 @@ public class SSOController : ControllerBase
             if (config != null && configuration.OidConfigs.TryGetValue(provider, out var existing))
             {
                 config.CanonicalLinks = existing.CanonicalLinks;
-                config.OidSecret = SSOPlugin.ResolveUpdatedSecret(config, existing);
+                config.OidSecret = ServerManagedFields.ResolveUpdatedSecret(config, existing);
             }
 
             configuration.OidConfigs[provider] = config;

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -182,7 +182,7 @@ public abstract class ProviderConfigBase
     // Server-managed (written by logins), not admin-edited: persisted in the config XML but withheld
     // from every JSON response (#157). This stops the account-link map leaking off the server, closes
     // the tear from serializing it while a login writes it, and blocks setting links via a config PUT.
-    // Its preservation on save is handled server-side in SSOPlugin.PreserveServerManagedFields.
+    // Its preservation on save is handled server-side in ServerManagedFields.Preserve.
     [XmlElement("CanonicalLinks")]
     [System.Text.Json.Serialization.JsonIgnore]
     public SerializableDictionary<string, Guid> CanonicalLinks
@@ -269,7 +269,7 @@ public class OidConfig : ProviderConfigBase
     // can be set and rotated), but serialized back out as null, so the plaintext client secret
     // never reaches the admin browser (HAR, proxy log, shared screen) on a config-page load and
     // cannot be read back via a config GET. It is still persisted to the config XML. On save, a
-    // blank incoming value re-injects the live secret (see SSOPlugin.PreserveServerManagedFields),
+    // blank incoming value re-injects the live secret (see ServerManagedFields.Preserve),
     // so leaving the field blank keeps the stored secret; a new value replaces it. A plain
     // [JsonIgnore] is wrong here — it is bidirectional and would also drop the value on save.
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Owns every read and write of the plugin configuration behind one lock (#318): locked reads and
+/// atomic read-modify-writes of the live configuration, plus the validated save pipeline
+/// (validate, preserve server-managed fields, persist, audit) for a replacement configuration such
+/// as an admin config-page save. Extracted from <see cref="SSOPlugin"/>, which keeps only a thin
+/// delegating facade; persistence itself stays with the plugin base class and is reached through
+/// the injected persist delegate.
+/// </summary>
+internal sealed class ProviderConfigStore
+{
+    // Serializes every read-modify-write of the plugin configuration so concurrent mutations
+    // (notably first-logins each writing a canonical link) cannot lose one another's updates.
+    // Static on purpose: it keeps the process-wide serialization of the old SSOPlugin lock, so two
+    // plugin instances (tests construct several; production has one) can never interleave writes.
+    // It becomes an instance field once the store is a DI singleton (#318 step 9).
+    private static readonly object Sync = new object();
+
+    private readonly Func<PluginConfiguration> _live;
+    private readonly Action<BasePluginConfiguration> _persist;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProviderConfigStore"/> class.
+    /// </summary>
+    /// <param name="live">Returns the live plugin configuration (the plugin's lazily loaded <c>Configuration</c>).</param>
+    /// <param name="persist">Persists a configuration through the plugin base class (<c>base.UpdateConfiguration</c>).</param>
+    /// <param name="logger">The logger (used to audit insecure-option saves, #140).</param>
+    internal ProviderConfigStore(Func<PluginConfiguration> live, Action<BasePluginConfiguration> persist, ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        ArgumentNullException.ThrowIfNull(persist);
+        _live = live;
+        _persist = persist;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Reads a value from the live configuration under the same lock as <see cref="Mutate(Action{PluginConfiguration})"/>,
+    /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
+    /// </summary>
+    /// <typeparam name="T">The value read.</typeparam>
+    /// <param name="read">The read to perform against the live configuration.</param>
+    /// <returns>The value returned by <paramref name="read"/>.</returns>
+    public T Read<T>(Func<PluginConfiguration, T> read)
+    {
+        ArgumentNullException.ThrowIfNull(read);
+        lock (Sync)
+        {
+            return read(_live());
+        }
+    }
+
+    /// <summary>
+    /// Applies a mutation to the live configuration under a single lock and persists it, so a
+    /// read-modify-write cannot race another and lose its update.
+    /// </summary>
+    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    public void Mutate(Action<PluginConfiguration> mutate)
+    {
+        ArgumentNullException.ThrowIfNull(mutate);
+        lock (Sync)
+        {
+            var configuration = _live();
+            mutate(configuration);
+
+            // Persists directly instead of routing through Save: the object being written IS the live
+            // one, so Save's fresh-config pipeline (validate/preserve/audit) would be skipped by its
+            // identity guard anyway — same observable behavior, without the reentrant detour.
+            _persist(configuration);
+        }
+    }
+
+    /// <summary>
+    /// Applies a mutation that returns a result (e.g. whether a removal changed anything) under the
+    /// same single lock and persists it, so the read-modify-write and the result observation are one
+    /// atomic operation.
+    /// </summary>
+    /// <typeparam name="T">The value the mutation returns.</typeparam>
+    /// <param name="mutate">The mutation to apply to the live configuration.</param>
+    /// <returns>The value returned by <paramref name="mutate"/>.</returns>
+    public T Mutate<T>(Func<PluginConfiguration, T> mutate)
+    {
+        ArgumentNullException.ThrowIfNull(mutate);
+        lock (Sync)
+        {
+            var configuration = _live();
+            var result = mutate(configuration);
+            _persist(configuration);
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Persists a replacement configuration, re-injecting server-managed fields from the live
+    /// configuration first (#157). The admin settings page saves through this path (Jellyfin core's
+    /// UpdatePluginConfiguration) with a snapshot taken at page load, so a canonical link created by a
+    /// login since then would be absent from the posted config; re-injecting the live links stops the
+    /// save from wiping them. Takes the same lock as <see cref="Mutate(Action{PluginConfiguration})"/>
+    /// and skips the copy when the incoming object is the live one.
+    /// </summary>
+    /// <param name="configuration">The configuration to persist.</param>
+    public void Save(BasePluginConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        List<(string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
+        lock (Sync)
+        {
+            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
+            {
+                // Reject the save fail-closed before anything is persisted if a base-URL override is
+                // malformed (#139) or a SAML signing certificate is not loadable (#206), so a bad value
+                // can never reach the login path. This validates the config-page save (a fresh incoming
+                // config); the OID/SAML Add endpoints write through Mutate (the live object, so this
+                // branch is skipped) and validate their own incoming provider at the controller via
+                // RejectInvalidBaseUrlOverride. Login-path writes (canonical links) also reuse the live
+                // object and are intentionally not revalidated here, so a slow/bad override can never
+                // throw on the login path.
+                ProviderConfigValidator.Validate(incoming);
+
+                ServerManagedFields.Preserve(incoming, _live());
+
+                // Snapshot which providers were saved with an insecure option (#140) while under the
+                // lock, but emit the warnings AFTER releasing it (below) — logging must not run inside
+                // the global config lock, where a slow provider would block concurrent config access.
+                insecureToAudit = CollectInsecureOptions(incoming);
+            }
+
+            _persist(configuration);
+        }
+
+        // Outside the lock, and after the save is durably persisted: a slow or misbehaving logging
+        // provider can neither block config reads/writes nor turn a completed save into a failure.
+        if (insecureToAudit != null && _logger != null)
+        {
+            foreach (var (provider, options) in insecureToAudit)
+            {
+                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", provider, options);
+            }
+        }
+    }
+
+    // Snapshots, under the caller's lock, the OpenID providers saved with a security check disabled
+    // (#140), as (provider, enabled-option-names) pairs. Pure read: it does not log, so the audit
+    // warnings can be emitted after the config lock is released. Only the admin save path reaches
+    // here (a fresh incoming config), so it fires once per save, not per login.
+    private static List<(string Provider, IReadOnlyList<string> Options)> CollectInsecureOptions(PluginConfiguration incoming)
+    {
+        var records = new List<(string, IReadOnlyList<string>)>();
+        if (incoming.OidConfigs == null)
+        {
+            return records;
+        }
+
+        foreach (var kvp in incoming.OidConfigs)
+        {
+            var insecure = OidcInsecureToggles.Enabled(kvp.Value);
+            if (insecure.Count > 0)
+            {
+                records.Add((kvp.Key, insecure));
+            }
+        }
+
+        return records;
+    }
+}

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,0 +1,67 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Rejects invalid provider configuration fail-closed before anything is persisted. The whole-config
+/// <see cref="Validate"/> gates the admin config-page save inside <see cref="ProviderConfigStore.Save"/>;
+/// the per-provider methods apply the same predicates to a single incoming provider, so every admin
+/// write path can share one validation rule (#318). Delegates to the existing
+/// <see cref="CanonicalBaseUrl.IsInvalidOverride"/> and <see cref="SamlCertificate.IsInvalid"/> predicates.
+/// </summary>
+internal static class ProviderConfigValidator
+{
+    // Throws if any provider's canonical base-URL override (#139) is set but not a valid absolute
+    // http/https base URL, or any SAML provider's signing certificate (#206) is set but not a loadable
+    // X.509 certificate — rejecting the save fail-closed before anything is persisted. A blank value is
+    // valid in both cases (the override feature is off; a half-configured provider). Only the admin
+    // config-page save path validates the whole config; the Add endpoints validate their own incoming
+    // provider at the controller, and login-path writes reuse the live object and are never revalidated.
+    internal static void Validate(PluginConfiguration incoming)
+    {
+        if (incoming.OidConfigs != null)
+        {
+            foreach (var kvp in incoming.OidConfigs)
+            {
+                ValidateBaseUrlOverride("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
+            }
+        }
+
+        if (incoming.SamlConfigs != null)
+        {
+            foreach (var kvp in incoming.SamlConfigs)
+            {
+                ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
+            }
+
+            foreach (var kvp in incoming.SamlConfigs)
+            {
+                ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
+            }
+        }
+    }
+
+    // A malformed override would be persisted and then silently fall back to the request Host at
+    // login (#139). The provider name is line-ending-stripped inline in case it reaches a log through
+    // the thrown exception.
+    internal static void ValidateBaseUrlOverride(string protocol, string provider, string baseUrlOverride)
+    {
+        if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
+        {
+            throw new ArgumentException(
+                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.");
+        }
+    }
+
+    // A garbage certificate would be persisted and then throw a CryptographicException on every
+    // callback — an unhandled 500 (#206). Same inline line-ending strip as above.
+    internal static void ValidateSamlCertificate(string provider, string certificate)
+    {
+        if (SamlCertificate.IsInvalid(certificate))
+        {
+            throw new ArgumentException(
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
+        }
+    }
+}

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -1,0 +1,90 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Re-injects the server-managed provider fields a save must not be allowed to clear (#157/#189).
+/// The whole-config <see cref="Preserve(PluginConfiguration, PluginConfiguration)"/> runs inside the
+/// config-page save pipeline (<see cref="ProviderConfigStore.Save"/>); the per-provider overloads are
+/// the single shared rule every admin write path converges on, so a field added to them is preserved
+/// on every door by construction (#318). <c>NewPath</c> is documented as server-managed too but is
+/// deliberately not preserved here: it round-trips through JSON, so a posted config carries the live
+/// value (see <see cref="ProviderConfigBase.NewPath"/>).
+/// </summary>
+internal static class ServerManagedFields
+{
+    /// <summary>
+    /// Copies the server-managed fields from <paramref name="live"/> into <paramref name="incoming"/>,
+    /// so a save built from a stale client snapshot cannot clear them. Only providers present in
+    /// <paramref name="incoming"/> are touched (a deleted provider stays deleted; a newly added one
+    /// keeps its own empty map). Two kinds of field are preserved: the per-provider canonical links
+    /// (always server-owned, #157), and the OpenID client secret (#189) — the latter only when the
+    /// incoming value is blank, since the secret is withheld from JSON responses so a save that did
+    /// not set a new one arrives empty and must keep the stored value (a non-blank incoming value is
+    /// an intentional rotation and is left as-is).
+    /// </summary>
+    /// <param name="incoming">The configuration about to be persisted.</param>
+    /// <param name="live">The current live configuration to read server-managed values from.</param>
+    internal static void Preserve(PluginConfiguration incoming, PluginConfiguration live)
+    {
+        if (incoming?.OidConfigs != null && live?.OidConfigs != null)
+        {
+            foreach (var kvp in live.OidConfigs)
+            {
+                if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
+                {
+                    Preserve(incomingProvider, kvp.Value);
+                }
+            }
+        }
+
+        if (incoming?.SamlConfigs != null && live?.SamlConfigs != null)
+        {
+            foreach (var kvp in live.SamlConfigs)
+            {
+                if (incoming.SamlConfigs.TryGetValue(kvp.Key, out var incomingProvider))
+                {
+                    Preserve(incomingProvider, kvp.Value);
+                }
+            }
+        }
+    }
+
+    // Links + secret: an OpenID provider carries both server-managed fields (#157/#189).
+    internal static void Preserve(OidConfig incoming, OidConfig live)
+    {
+        incoming.CanonicalLinks = live.CanonicalLinks;
+        incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
+    }
+
+    // Links only: a SAML provider has no write-only secret (#157).
+    internal static void Preserve(SamlConfig incoming, SamlConfig live)
+    {
+        incoming.CanonicalLinks = live.CanonicalLinks;
+    }
+
+    /// <summary>
+    /// Decides which OpenID client secret an updated provider should keep (#189), the single rule
+    /// shared by the config-page save and <c>OID/Add</c>. A non-blank incoming secret is an explicit
+    /// rotation and wins. A blank one means "keep the stored secret" — but ONLY while the provider
+    /// identity (endpoint and client id) is unchanged: if either changed, the stored secret is not
+    /// carried over (it stays blank, failing the login closed until an admin supplies one), so a
+    /// write-only secret cannot be exfiltrated by repointing the provider at a different token
+    /// endpoint. Whitespace-only counts as blank, matching the <c>Trim()</c> at the consumption site.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted.</param>
+    /// <param name="live">The current live provider config.</param>
+    /// <returns>The secret to persist for the updated provider.</returns>
+    internal static string ResolveUpdatedSecret(OidConfig incoming, OidConfig live)
+    {
+        if (!string.IsNullOrWhiteSpace(incoming.OidSecret))
+        {
+            return incoming.OidSecret;
+        }
+
+        var identityUnchanged =
+            string.Equals(incoming.OidEndpoint, live.OidEndpoint, StringComparison.Ordinal)
+            && string.Equals(incoming.OidClientId, live.OidClientId, StringComparison.Ordinal);
+        return identityUnchanged ? live.OidSecret : incoming.OidSecret;
+    }
+}

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -11,16 +10,12 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.SSO_Auth;
 
 /// <summary>
-/// The SSO plugin class.
+/// The SSO plugin class: bootstrap and page manifests. All configuration access is owned by
+/// <see cref="ProviderConfigStore"/> (#318); the public methods below remain the plugin's
+/// configuration facade and delegate to it.
 /// </summary>
 public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
 {
-    // Serializes every read-modify-write of the plugin configuration so concurrent mutations
-    // (notably first-logins each writing a canonical link) cannot lose one another's updates.
-    private static readonly object ConfigMutationLock = new object();
-
-    private readonly ILogger<SSOPlugin> _logger;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOPlugin"/> class.
     /// </summary>
@@ -30,7 +25,10 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     public SSOPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<SSOPlugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
-        _logger = logger;
+        // Handing out `() => Configuration` here is safe: BasePlugin's constructor only records the
+        // config path and loads the configuration lazily on first access, so nothing calls back into
+        // UpdateConfiguration (and thus ConfigStore) before this assignment completes.
+        ConfigStore = new ProviderConfigStore(() => Configuration, PersistBase, logger);
         Instance = this;
     }
 
@@ -50,22 +48,18 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     public override Guid Id => Guid.Parse("505ce9d1-d916-42fa-86ca-673ef241d7df");
 
     /// <summary>
+    /// Gets the store that owns every configuration read and write (#318).
+    /// </summary>
+    internal ProviderConfigStore ConfigStore { get; }
+
+    /// <summary>
     /// Applies a mutation to the live configuration under a single lock and persists it, so a
     /// read-modify-write cannot race another and lose its update. All configuration writes must go
     /// through this rather than reading <see cref="BasePlugin{T}.Configuration"/>, mutating, and
     /// calling <c>UpdateConfiguration</c> separately.
     /// </summary>
     /// <param name="mutate">The mutation to apply to the live configuration.</param>
-    public void MutateConfiguration(Action<PluginConfiguration> mutate)
-    {
-        ArgumentNullException.ThrowIfNull(mutate);
-        lock (ConfigMutationLock)
-        {
-            var configuration = Configuration;
-            mutate(configuration);
-            UpdateConfiguration(configuration);
-        }
-    }
+    public void MutateConfiguration(Action<PluginConfiguration> mutate) => ConfigStore.Mutate(mutate);
 
     /// <summary>
     /// Applies a mutation that returns a result (e.g. whether a removal changed anything) under the
@@ -75,223 +69,30 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
     /// <typeparam name="T">The value the mutation returns.</typeparam>
     /// <param name="mutate">The mutation to apply to the live configuration.</param>
     /// <returns>The value returned by <paramref name="mutate"/>.</returns>
-    public T MutateConfiguration<T>(Func<PluginConfiguration, T> mutate)
-    {
-        ArgumentNullException.ThrowIfNull(mutate);
-        lock (ConfigMutationLock)
-        {
-            var configuration = Configuration;
-            var result = mutate(configuration);
-            UpdateConfiguration(configuration);
-            return result;
-        }
-    }
+    public T MutateConfiguration<T>(Func<PluginConfiguration, T> mutate) => ConfigStore.Mutate(mutate);
 
     /// <summary>
-    /// Persists a replacement configuration, re-injecting server-managed fields from the live
-    /// configuration first (#157). The admin settings page saves through this path (Jellyfin core's
-    /// UpdatePluginConfiguration) with a snapshot taken at page load, so a canonical link created by a
-    /// login since then would be absent from the posted config; re-injecting the live links stops the
-    /// save from wiping them. Takes the same lock as <see cref="MutateConfiguration"/> (reentrant, so
-    /// calls from there are safe) and skips the copy when the incoming object is the live one.
-    /// </summary>
-    /// <param name="configuration">The configuration to persist.</param>
-    public override void UpdateConfiguration(BasePluginConfiguration configuration)
-    {
-        ArgumentNullException.ThrowIfNull(configuration);
-        List<(string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
-        lock (ConfigMutationLock)
-        {
-            if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, Configuration))
-            {
-                // Reject the save fail-closed before anything is persisted if a base-URL override is
-                // malformed (#139), so a bad value can never reach the login path. This validates the
-                // config-page save (a fresh incoming config); the OID/SAML Add endpoints write through
-                // MutateConfiguration (the live object, so this branch is skipped) and validate their own
-                // incoming provider at the controller via RejectInvalidBaseUrlOverride. Login-path writes
-                // (canonical links) also reuse the live object and are intentionally not revalidated here,
-                // so a slow/bad override can never throw on the login path.
-                ValidateBaseUrlOverrides(incoming);
-                ValidateSamlCertificates(incoming);
-
-                PreserveServerManagedFields(incoming, Configuration);
-
-                // Snapshot which providers were saved with an insecure option (#140) while under the
-                // lock, but emit the warnings AFTER releasing it (below) — logging must not run inside
-                // the global config lock, where a slow provider would block concurrent config access.
-                insecureToAudit = CollectInsecureOptions(incoming);
-            }
-
-            base.UpdateConfiguration(configuration);
-        }
-
-        // Outside the lock, and after the save is durably persisted: a slow or misbehaving logging
-        // provider can neither block config reads/writes nor turn a completed save into a failure.
-        if (insecureToAudit != null && _logger != null)
-        {
-            foreach (var (provider, options) in insecureToAudit)
-            {
-                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", provider, options);
-            }
-        }
-    }
-
-    // Throws if any provider's canonical base-URL override (#139) is set but not a valid absolute
-    // http/https base URL, rejecting the save fail-closed before anything is persisted. A blank value is
-    // valid (the feature is off). The provider name is line-ending-stripped inline in case it reaches a
-    // log through the thrown exception.
-    internal static void ValidateBaseUrlOverrides(PluginConfiguration incoming)
-    {
-        static void Check(string protocol, string provider, string value)
-        {
-            if (CanonicalBaseUrl.IsInvalidOverride(value))
-            {
-                throw new ArgumentException(
-                    $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.");
-            }
-        }
-
-        if (incoming.OidConfigs != null)
-        {
-            foreach (var kvp in incoming.OidConfigs)
-            {
-                Check("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
-            }
-        }
-
-        if (incoming.SamlConfigs != null)
-        {
-            foreach (var kvp in incoming.SamlConfigs)
-            {
-                Check("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
-            }
-        }
-    }
-
-    // Throws if any SAML provider's signing certificate (#206) is set but not a loadable X.509
-    // certificate, rejecting the save fail-closed before it is persisted so a garbage certificate cannot
-    // make every callback throw an unhandled 500. Blank is valid (a half-configured provider). Only this
-    // admin config-page save path validates here; SAML/Add validates its own incoming provider at the
-    // controller (RejectInvalidSamlCertificate), and login-path writes reuse the live object.
-    internal static void ValidateSamlCertificates(PluginConfiguration incoming)
-    {
-        if (incoming.SamlConfigs == null)
-        {
-            return;
-        }
-
-        foreach (var kvp in incoming.SamlConfigs)
-        {
-            if (SamlCertificate.IsInvalid(kvp.Value?.SamlCertificate))
-            {
-                throw new ArgumentException(
-                    $"SAML provider '{kvp.Key?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
-            }
-        }
-    }
-
-    // Snapshots, under the caller's lock, the OpenID providers saved with a security check disabled
-    // (#140), as (provider, enabled-option-names) pairs. Pure read: it does not log, so the audit
-    // warnings can be emitted after the config lock is released. Only the admin save path reaches
-    // here (a fresh incoming config), so it fires once per save, not per login.
-    private static List<(string Provider, IReadOnlyList<string> Options)> CollectInsecureOptions(PluginConfiguration incoming)
-    {
-        var records = new List<(string, IReadOnlyList<string>)>();
-        if (incoming.OidConfigs == null)
-        {
-            return records;
-        }
-
-        foreach (var kvp in incoming.OidConfigs)
-        {
-            var insecure = OidcInsecureToggles.Enabled(kvp.Value);
-            if (insecure.Count > 0)
-            {
-                records.Add((kvp.Key, insecure));
-            }
-        }
-
-        return records;
-    }
-
-    /// <summary>
-    /// Copies the server-managed fields from <paramref name="live"/> into <paramref name="incoming"/>,
-    /// so a save built from a stale client snapshot cannot clear them. Only providers present in
-    /// <paramref name="incoming"/> are touched (a deleted provider stays deleted; a newly added one
-    /// keeps its own empty map). Two kinds of field are preserved: the per-provider canonical links
-    /// (always server-owned, #157), and the OpenID client secret (#189) — the latter only when the
-    /// incoming value is blank, since the secret is withheld from JSON responses so a save that did
-    /// not set a new one arrives empty and must keep the stored value (a non-blank incoming value is
-    /// an intentional rotation and is left as-is).
-    /// </summary>
-    /// <param name="incoming">The configuration about to be persisted.</param>
-    /// <param name="live">The current live configuration to read server-managed values from.</param>
-    internal static void PreserveServerManagedFields(PluginConfiguration incoming, PluginConfiguration live)
-    {
-        if (incoming?.OidConfigs != null && live?.OidConfigs != null)
-        {
-            foreach (var kvp in live.OidConfigs)
-            {
-                if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
-                {
-                    incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
-                    incomingProvider.OidSecret = ResolveUpdatedSecret(incomingProvider, kvp.Value);
-                }
-            }
-        }
-
-        if (incoming?.SamlConfigs != null && live?.SamlConfigs != null)
-        {
-            foreach (var kvp in live.SamlConfigs)
-            {
-                if (incoming.SamlConfigs.TryGetValue(kvp.Key, out var incomingProvider))
-                {
-                    incomingProvider.CanonicalLinks = kvp.Value.CanonicalLinks;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Decides which OpenID client secret an updated provider should keep (#189), the single rule
-    /// shared by the config-page save and <c>OID/Add</c>. A non-blank incoming secret is an explicit
-    /// rotation and wins. A blank one means "keep the stored secret" — but ONLY while the provider
-    /// identity (endpoint and client id) is unchanged: if either changed, the stored secret is not
-    /// carried over (it stays blank, failing the login closed until an admin supplies one), so a
-    /// write-only secret cannot be exfiltrated by repointing the provider at a different token
-    /// endpoint. Whitespace-only counts as blank, matching the <c>Trim()</c> at the consumption site.
-    /// </summary>
-    /// <param name="incoming">The provider config about to be persisted.</param>
-    /// <param name="live">The current live provider config.</param>
-    /// <returns>The secret to persist for the updated provider.</returns>
-    internal static string ResolveUpdatedSecret(OidConfig incoming, OidConfig live)
-    {
-        if (!string.IsNullOrWhiteSpace(incoming.OidSecret))
-        {
-            return incoming.OidSecret;
-        }
-
-        var identityUnchanged =
-            string.Equals(incoming.OidEndpoint, live.OidEndpoint, StringComparison.Ordinal)
-            && string.Equals(incoming.OidClientId, live.OidClientId, StringComparison.Ordinal);
-        return identityUnchanged ? live.OidSecret : incoming.OidSecret;
-    }
-
-    /// <summary>
-    /// Reads a value from the live configuration under the same lock as <see cref="MutateConfiguration"/>,
+    /// Reads a value from the live configuration under the same lock as <see cref="MutateConfiguration(Action{PluginConfiguration})"/>,
     /// so a read cannot tear against a concurrent write of a (non-thread-safe) configuration collection.
     /// </summary>
     /// <typeparam name="T">The value read.</typeparam>
     /// <param name="read">The read to perform against the live configuration.</param>
     /// <returns>The value returned by <paramref name="read"/>.</returns>
-    public T ReadConfiguration<T>(Func<PluginConfiguration, T> read)
-    {
-        ArgumentNullException.ThrowIfNull(read);
-        lock (ConfigMutationLock)
-        {
-            return read(Configuration);
-        }
-    }
+    public T ReadConfiguration<T>(Func<PluginConfiguration, T> read) => ConfigStore.Read(read);
+
+    /// <summary>
+    /// Persists a replacement configuration through the store's validated save pipeline
+    /// (<see cref="ProviderConfigStore.Save"/>): fail-closed validation (#139/#206), server-managed
+    /// field preservation (#157/#189), and the insecure-option audit (#140). Jellyfin core's
+    /// UpdatePluginConfiguration (the admin config-page save) enters here.
+    /// </summary>
+    /// <param name="configuration">The configuration to persist.</param>
+    public override void UpdateConfiguration(BasePluginConfiguration configuration) => ConfigStore.Save(configuration);
+
+    // The store's only road to disk: persistence stays with the plugin base class, and this named
+    // bridge hands base.UpdateConfiguration to the store so a store save cannot re-enter the
+    // overridden pipeline above.
+    private void PersistBase(BasePluginConfiguration configuration) => base.UpdateConfiguration(configuration);
 
     /// <summary>
     /// Returns the available internal web pages of this plugin.

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -80,3 +80,23 @@ rules:
         - "SSO-Auth/**/*.cs"
       exclude:
         - "SSO-Auth/Api/IntervalGate.cs"
+
+  # Invariant (architecture, #318 config boundary): every configuration access
+  # goes through ProviderConfigStore behind SSOPlugin's facade (ReadConfiguration
+  # / MutateConfiguration / UpdateConfiguration). Reaching into
+  # `SSOPlugin.Instance.Configuration` bypasses the config lock and the validated
+  # save pipeline — the exact door the store extraction closed. The plugin itself
+  # reads the property unqualified, so the clean tree has zero findings.
+  - id: no-config-store-bypass
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not reach into SSOPlugin.Instance.Configuration. Read and write the
+      configuration through SSOPlugin.Instance.ReadConfiguration /
+      MutateConfiguration (the ProviderConfigStore facade), so every access
+      takes the config lock and every save runs the validated pipeline (#318).
+    patterns:
+      - pattern: SSOPlugin.Instance.Configuration
+    paths:
+      include:
+        - "SSO-Auth/**/*.cs"


### PR DESCRIPTION
# What & why

First implementation step of the #318 config boundary (design comment, section 2.3), sliced to be zero-behavior. Refs #318.

`SSOPlugin` shrinks to what its name says, bootstrap, page manifests, and a thin delegating facade, and the configuration logic moves into three single-responsibility types under `Config/`:

- **`ProviderConfigStore`** (internal, sealed) owns the config lock and every read, mutation, and save. `Read`/`Mutate` carry the old `ReadConfiguration`/`MutateConfiguration` bodies; `Save` carries the old `UpdateConfiguration` pipeline, fail-closed validation, server-managed-field preservation, persist, post-lock insecure-option audit, including `CollectInsecureOptions` verbatim and the existing null-logger guard on the audit loop. The store persists through an injected `base.UpdateConfiguration` bridge (`PersistBase`); `Mutate` uses it directly instead of re-entering the virtual `UpdateConfiguration`, whose identity guard skipped the fresh-config pipeline for live-object writes anyway, observably identical, without the reentrant detour.
- **`ProviderConfigValidator`** (internal, static) carries the save-time validation: #139 base-URL overrides and #206 SAML certificates, as the whole-config `Validate` gate plus per-provider predicates. Check order, exception types, and message wording are unchanged; it still delegates to the untouched `CanonicalBaseUrl.IsInvalidOverride` / `SamlCertificate.IsInvalid` predicates.
- **`ServerManagedFields`** (internal, static) carries the preservation rules: #157 canonical links and the #189 write-only secret (`ResolveUpdatedSecret` moved verbatim), decomposed into a whole-config routine over per-provider overloads with identical semantics. The per-provider overloads are the single shared rule the Add endpoints will converge on in a follow-up slice, so a server-managed field added there is preserved on every write door by construction.

`SSOPlugin`'s public surface (`Instance`, `ReadConfiguration`, `MutateConfiguration`, the `UpdateConfiguration` override, `GetPages`/`GetViews`) keeps byte-identical signatures and semantics, so every existing call site compiles unchanged. The existing tests only retarget the moved internal statics (`ConfigPreservationTests` receiver swaps; no assertion changed), they remain the characterization net proving the move is behavior-neutral.

**Invariant residence after this change:**

| Invariant | Lives in |
| --- | --- |
| Malformed base-URL override / SAML certificate rejected fail-closed at the config-page save | `ProviderConfigValidator.Validate`, invoked by `ProviderConfigStore.Save` |
| Same rejection at the OID/SAML Add endpoints | unchanged: `SSOController.RejectInvalid*` (converges on the validator in a later slice) |
| Server-managed fields (links, secret) never wiped by a stale save | `ServerManagedFields.Preserve`, invoked by `ProviderConfigStore.Save`; the Add endpoints call `ServerManagedFields.ResolveUpdatedSecret` |
| Config reads/writes serialized under one process-wide lock | `ProviderConfigStore` (static `Sync`, same scope as the old `ConfigMutationLock`) |
| Insecure-option saves audited after the lock is released | `ProviderConfigStore.Save` |

**Tests:** all 636 pass (3 consecutive runs, no flakes). New pins: `ProviderConfigStoreTests` (validate-before-persist, live-object pipeline skip, server-managed preservation through `Save`, post-save audit, null-logger tolerance, null-argument guards) and a new conformance rule locking the shrink (`SSOPlugin` declares no configuration-typed members beyond the delegating facade and the `PersistBase` bridge; compiler-generated members excluded like the existing keyed-state rule). A new opengrep tripwire forbids `SSOPlugin.Instance.Configuration`, the door around the facade, with zero findings on the clean tree. The audit tests' `CapturingLogger` moved to a shared test helper so the store tests reuse it instead of duplicating it.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. *(Pending: the adversarial
      review gate runs before merge; its results will be recorded on this PR.)*
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. *(No such files changed.)*

## Notes

- **`NewPath` is deliberately not in `ServerManagedFields.Preserve`.** It is documented as server-managed runtime state, but unlike the links and the secret it round-trips through JSON, so a posted config already carries the live value. A stale config-page save clobbering a challenge-recorded spelling flip is pre-existing behavior with nil impact: the SAML expected-ACS set accepts both path spellings by design. The preservation-by-construction property therefore covers fields added to the per-provider overloads, it is not a claim that every documented server-managed field routes through `Preserve`.
- **Constructor ordering assumption, theoretical.** The ctor hands `() => Configuration` and `PersistBase` to the store before `Instance` is set. This assumes `BasePlugin`'s constructor never invokes the virtual `UpdateConfiguration` (it loads the configuration lazily, which holds today). If a future Jellyfin base class changed that, the test harness, which constructs the plugin against a stubbed serializer, would fail immediately.
- **Deliberate deviation from the migration plan's call-site table:** the `ReadConfiguration`/`MutateConfiguration` facade stays and the ~37 call-site retargets are deferred, keeping this slice wire-identical and mechanical; the store is internal plumbing behind an unchanged public surface. Removing the facade is a candidate for the step that makes the store a DI singleton, where the call sites change anyway.
- Scope guard: no `Find*` snapshot methods, no `NewPath` write-path change, no Add-endpoint adoption of the validator/preservation, those are the next slices of the #318 section 2.3 plan.
