### PR TITLE
Make client-caused login rejections 4xx, not 500

### DIFF
--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -21,6 +21,9 @@ public class LoginStatusMapperTests
         // may not be less accessible than the test method.
         var expected = new (PublicReason Reason, int Status, string Body)[]
         {
+            (PublicReason.UnknownProvider, 400, "No matching provider found"),
+            (PublicReason.InvalidState, 400, "Invalid or expired state"),
+            (PublicReason.AccountLinkForbidden, 403, "SSO login is not permitted for this account."),
             (PublicReason.SsoResponseInvalid, 400, "SSO response validation failed"),
             (PublicReason.SamlResponseInvalid, 400, "SAML response validation failed"),
             (PublicReason.PkceNotSupported, 400, "The identity provider does not advertise the required PKCE (S256) support."),

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -76,8 +76,8 @@ public class SSOControllerChallengeTests
             clientIp: IPAddress.Parse("8.8.4.4"));
 
         // The first call passes the limiter and spends the single-attempt budget; the unknown provider
-        // then throws, but that is after the budget is spent.
-        Assert.Throws<ArgumentException>(() => harness.Controller.SamlChallenge("does-not-exist"));
+        // then rejects with the uniform 400, but that is after the budget is spent.
+        Assert.Equal(400, Assert.IsType<ContentResult>(harness.Controller.SamlChallenge("does-not-exist")).StatusCode);
 
         // The second is over budget and is throttled with a 429 before the provider is even looked up.
         var throttled = harness.Controller.SamlChallenge("does-not-exist");

--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -29,39 +29,54 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public async Task OidChallenge_UnknownProvider_Throws()
+    public async Task OidChallenge_UnknownProvider_RejectsWithUniform400()
     {
+        // Unknown and disabled providers now share one in-process 400 (the answer no longer depends on
+        // host middleware mapping a thrown ArgumentException), so neither can be probed apart (#318).
         var harness = new SsoControllerHarness();
 
-        await Assert.ThrowsAsync<ArgumentException>(() => harness.Controller.OidChallenge("does-not-exist"));
+        var result = await harness.Controller.OidChallenge("does-not-exist");
+
+        AssertUnknownProvider(result);
     }
 
     [Fact]
-    public async Task OidAuth_UnknownProvider_ReturnsBadRequest()
+    public async Task OidAuth_UnknownProvider_RejectsWithUniform400()
     {
         var harness = new SsoControllerHarness();
 
         var result = await harness.Controller.OidAuth("does-not-exist", new AuthResponse { Data = "x" });
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertUnknownProvider(result);
     }
 
     [Fact]
-    public void SamlPost_UnknownProvider_ReturnsBadRequest()
+    public void SamlPost_UnknownProvider_RejectsWithUniform400()
     {
         var harness = new SsoControllerHarness();
 
         var result = harness.Controller.SamlPost("does-not-exist");
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertUnknownProvider(result);
     }
 
     [Fact]
-    public void SamlChallenge_UnknownProvider_Throws()
+    public void SamlChallenge_UnknownProvider_RejectsWithUniform400()
     {
         var harness = new SsoControllerHarness();
 
-        Assert.Throws<ArgumentException>(() => harness.Controller.SamlChallenge("does-not-exist"));
+        var result = harness.Controller.SamlChallenge("does-not-exist");
+
+        AssertUnknownProvider(result);
+    }
+
+    // The uniform unknown/disabled-provider rejection: a text/plain 400 with the one shared body, so a
+    // caller cannot distinguish an unknown provider from a disabled one on any endpoint (no oracle).
+    private static void AssertUnknownProvider(ActionResult result)
+    {
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
     }
 
     [Fact]
@@ -100,13 +115,13 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public void SamlChallenge_DisabledProvider_Throws()
+    public void SamlChallenge_DisabledProvider_RejectsAsUnknownProvider()
     {
-        // A configured-but-disabled provider skips the challenge block and hits the same throwing
-        // fallthrough as an unknown provider (SSOController.cs) — pin that so it stays fail-closed.
+        // A configured-but-disabled provider shares the unknown provider's uniform 400, so the two
+        // cannot be told apart (no enumeration oracle) — fail-closed either way.
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
 
-        Assert.Throws<ArgumentException>(() => harness.Controller.SamlChallenge("adfs"));
+        AssertUnknownProvider(harness.Controller.SamlChallenge("adfs"));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -34,25 +34,31 @@ public class SSOControllerOidAuthTests
     }
 
     [Fact]
-    public async Task OidAuth_DisabledProvider_ReturnsProblem()
+    public async Task OidAuth_DisabledProvider_RejectsAsUnknownProvider()
     {
         var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
 
-        // The provider exists but is disabled, so the redeem guard short-circuits to a problem, not a session.
+        // A disabled provider is a client-caused rejection, not a server fault: a uniform 400 that is
+        // byte-identical to the unknown-provider case, so the two cannot be told apart (#318).
         var result = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "state-token" });
 
-        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
     }
 
     [Fact]
-    public async Task OidAuth_UnknownState_ReturnsProblem()
+    public async Task OidAuth_UnknownState_RejectsAsInvalidState()
     {
         var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        // No state was seeded, so the token does not resolve and no session is minted.
+        // No state was seeded, so the token does not resolve — a client-caused 400, not a 500, and the
+        // same body an expired or replayed state gets, so a replay is indistinguishable from an expiry.
         var result = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "no-such-state" });
 
-        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Invalid or expired state", content.Content);
     }
 
     [Fact]
@@ -78,9 +84,12 @@ public class SSOControllerOidAuthTests
         Assert.IsType<OkObjectResult>(result);
         await harness.UserManager.Received(1).CreateUserAsync("alice");
 
-        // The state is claimed atomically (TryRemove), so a replay of the same token no longer redeems.
+        // The state is claimed atomically (TryRemove), so a replay of the same token no longer redeems —
+        // it rejects as an invalid state (a client-caused 400), indistinguishable from an expiry.
         var replay = await harness.Controller.OidAuth("kc", new AuthResponse { Data = "state-token" });
-        Assert.Equal(500, Assert.IsType<ObjectResult>(replay).StatusCode);
+        var content = Assert.IsType<ContentResult>(replay);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Invalid or expired state", content.Content);
     }
 
     // Seeds a valid, redeemable login state for provider "kc" bound to a new user "alice", and mocks the

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -82,7 +82,6 @@ public class SSOControllerOidAuthTests
         });
 
         Assert.IsType<OkObjectResult>(result);
-        await harness.UserManager.Received(1).CreateUserAsync("alice");
 
         // The state is claimed atomically (TryRemove), so a replay of the same token no longer redeems —
         // it rejects as an invalid state (a client-caused 400), indistinguishable from an expiry.
@@ -90,6 +89,9 @@ public class SSOControllerOidAuthTests
         var content = Assert.IsType<ContentResult>(replay);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Invalid or expired state", content.Content);
+
+        // The replay minted nothing: the account was provisioned exactly once, by the first redemption.
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
 
     // Seeds a valid, redeemable login state for provider "kc" bound to a new user "alice", and mocks the

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -23,11 +23,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class SSOControllerOidChallengeTests
 {
     [Fact]
-    public async Task OidChallenge_DisabledProvider_Throws()
+    public async Task OidChallenge_DisabledProvider_RejectsAsUnknownProvider()
     {
         var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
 
-        await Assert.ThrowsAsync<ArgumentException>(() => harness.Controller.OidChallenge("kc"));
+        // A disabled provider shares the unknown provider's uniform in-process 400, so the two cannot
+        // be told apart (no enumeration oracle) — fail-closed either way (#318).
+        var content = Assert.IsType<ContentResult>(await harness.Controller.OidChallenge("kc"));
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -22,13 +22,63 @@ public class SSOControllerSamlAuthTests
     private static readonly Guid UserId = Guid.Parse("88888888-8888-8888-8888-888888888888");
 
     [Fact]
-    public async Task SamlAuth_DisabledProvider_ReturnsProblem()
+    public async Task SamlAuth_DisabledProvider_RejectsAsUnknownProvider()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
 
         var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = "irrelevant" });
 
-        Assert.Equal(500, Assert.IsType<ObjectResult>(result).StatusCode);
+        // A disabled provider is a client-caused 400 byte-identical to the unknown-provider case, not a
+        // 500, so neither can be probed apart (#318).
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
+    }
+
+    [Fact]
+    public async Task SamlAuth_ReplayedAssertion_RejectsAsInvalidWithoutDisclosingTheReplay()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+        var payload = fixture.EncodeResponse();
+
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = payload }));
+
+        // The replay is refused by the one-time-use cache, now as a client-caused 400 in the uniform
+        // SAML body (never a 500) that does not disclose the replay cache to the attacker who replayed.
+        var replay = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = payload }));
+        Assert.Equal(400, replay.StatusCode);
+        Assert.Equal("SAML response validation failed", replay.Content);
+    }
+
+    [Fact]
+    public async Task SamlAuth_UnsolicitedResponse_RejectsInTheUniformBody()
+    {
+        // With ValidateInResponseTo on and no AuthnRequest issued, the response carries no correlated
+        // InResponseTo and is refused — a client-caused 400 in the uniform SAML body, not a 500, and it
+        // no longer discloses the InResponseTo correlation to the submitter.
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            ValidateInResponseTo = true,
+        });
+
+        var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerSamlPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlPostTests.cs
@@ -21,7 +21,11 @@ public class SSOControllerSamlPostTests
 
         var result = harness.Controller.SamlPost("adfs", formSamlResponse: "irrelevant");
 
-        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+        // Shares the unknown-provider body now (the unique "No active providers found" wording is
+        // retired), so a disabled provider cannot be told apart from an unknown one (#318).
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
     }
 
     [Fact]

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -16,6 +16,13 @@ internal static class LoginStatusMapper
     /// <summary>The uniform denial body for any rejected login — deliberately uninformative.</summary>
     internal const string PermissionDeniedMessage = "Error. Check permissions.";
 
+    /// <summary>
+    /// The body for an unresolved provider — one wording for both the unknown and the disabled case,
+    /// so the two cannot be told apart (no provider-enumeration oracle). Shared with the controller's
+    /// remaining direct provider-lookup rejections so the wording is defined once.
+    /// </summary>
+    internal const string NoMatchingProviderMessage = "No matching provider found";
+
     internal static ActionResult ToActionResult(LoginOutcome outcome) => outcome switch
     {
         LoginOutcome.Success success => new OkObjectResult(success.Session),
@@ -28,6 +35,9 @@ internal static class LoginStatusMapper
 
     private static ContentResult ToActionResult(PublicReason reason) => reason switch
     {
+        PublicReason.UnknownProvider => Emit(StatusCodes.Status400BadRequest, NoMatchingProviderMessage),
+        PublicReason.InvalidState => Emit(StatusCodes.Status400BadRequest, "Invalid or expired state"),
+        PublicReason.AccountLinkForbidden => Emit(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account."),
         PublicReason.SsoResponseInvalid => Emit(StatusCodes.Status400BadRequest, "SSO response validation failed"),
         PublicReason.SamlResponseInvalid => Emit(StatusCodes.Status400BadRequest, "SAML response validation failed"),
         PublicReason.PkceNotSupported => Emit(StatusCodes.Status400BadRequest, "The identity provider does not advertise the required PKCE (S256) support."),

--- a/SSO-Auth/Api/PublicReason.cs
+++ b/SSO-Auth/Api/PublicReason.cs
@@ -8,6 +8,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal enum PublicReason
 {
+    /// <summary>Unknown OR disabled provider — deliberately indistinguishable, so neither can be probed (no enumeration oracle).</summary>
+    UnknownProvider,
+
+    /// <summary>Authorize state unknown, expired, minted for another provider, or already redeemed (replay) — one body for all.</summary>
+    InvalidState,
+
+    /// <summary>The account-link policy refused the login (name taken with adoption off, or an unresolved identity).</summary>
+    AccountLinkForbidden,
+
     /// <summary>OIDC callback validation failed (the RFC 9207 issuer mix-up check).</summary>
     SsoResponseInvalid,
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -40,10 +40,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 [Route("[controller]")]
 public class SSOController : ControllerBase
 {
-    // Client-facing messages for unresolved provider names; the uniform-rejection policy and its
-    // denial body live on LoginStatusMapper, where the messages are defined (#318).
-    private const string NoMatchingProviderMessage = "No matching provider found";
-    private const string ProviderDoesNotExistMessage = "Provider does not exist";
+    // The uniform-rejection policy and its bodies live on LoginStatusMapper; the direct provider-lookup
+    // rejections that stay in the controller reuse its NoMatchingProviderMessage so the wording is
+    // defined once (#318).
+    private const string NoMatchingProviderMessage = LoginStatusMapper.NoMatchingProviderMessage;
 
     // Display names for the audit log (the internal link-map mode tokens are the lowercase "oid"/"saml").
     private const string OpenIdProtocol = "OpenID";
@@ -233,60 +233,62 @@ public class SSOController : ControllerBase
         }
 
         StateStore.PruneExpired(DateTime.Now);
-        var config = FindOidConfig(provider) ?? throw new ArgumentException(ProviderDoesNotExistMessage);
-
-        if (config.Enabled)
+        var config = FindOidConfig(provider);
+        if (config is not { Enabled: true })
         {
-            // RFC 9700 §2.1.1: confirm the authorization server advertises PKCE (S256) before relying on
-            // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
-            // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
-            // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
-            var pkceSupported = await ProviderAdvertisesPkceS256Async(config, provider).ConfigureAwait(false);
-            if (pkceSupported == false)
-            {
-                if (config.RequirePkce)
-                {
-                    _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-                    return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
-                }
-
-                SsoAudit.PkceNotAdvertised(_logger, provider);
-            }
-            else if (pkceSupported is null && config.RequirePkce)
-            {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceUnverifiable));
-            }
-
-            bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
-
-            string redirectUri = SsoUrlBuilder.OidRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
-
-            var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
-            var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
-
-            if (state.IsError)
-            {
-                return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
-            }
-
-            // IsLinking tracks whether this is a linking request rather than a login. The state value
-            // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
-            // always the capacity backstop under a flood, and the store throttles its warning signal.
-            if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, out var shouldWarnCapacity))
-            {
-                if (shouldWarnCapacity)
-                {
-                    _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
-                }
-
-                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
-            }
-
-            return Redirect(state.StartUrl);
+            // Unknown and disabled providers share one rejection so neither can be probed apart (no
+            // enumeration oracle), and the answer no longer depends on host middleware mapping a thrown
+            // ArgumentException — the in-process 400 is fail-closed regardless of the deployment (#318).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        throw new ArgumentException(ProviderDoesNotExistMessage);
+        // RFC 9700 §2.1.1: confirm the authorization server advertises PKCE (S256) before relying on
+        // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
+        // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
+        // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
+        var pkceSupported = await ProviderAdvertisesPkceS256Async(config, provider).ConfigureAwait(false);
+        if (pkceSupported == false)
+        {
+            if (config.RequirePkce)
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
+            }
+
+            SsoAudit.PkceNotAdvertised(_logger, provider);
+        }
+        else if (pkceSupported is null && config.RequirePkce)
+        {
+            _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceUnverifiable));
+        }
+
+        bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
+
+        string redirectUri = SsoUrlBuilder.OidRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
+
+        var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
+        var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
+
+        if (state.IsError)
+        {
+            return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
+        }
+
+        // IsLinking tracks whether this is a linking request rather than a login. The state value
+        // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
+        // always the capacity backstop under a flood, and the store throttles its warning signal.
+        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, out var shouldWarnCapacity))
+        {
+            if (shouldWarnCapacity)
+            {
+                _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
+            return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+        }
+
+        return Redirect(state.StartUrl);
     }
 
     // Test-only reset of the process-wide OpenID caches this controller keeps as private statics: the
@@ -583,45 +585,49 @@ public class SSOController : ControllerBase
             return BadRequest("Missing data");
         }
 
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // unifies the previously JSON unknown-provider body and the disabled provider's 500 into the
+        // one uniform 400, and a disabled provider does not consume the state (the guard precedes the
+        // redeem, as before).
         var config = FindOidConfig(provider);
-        if (config is null)
+        if (config is not { Enabled: true })
         {
-            return BadRequest(NoMatchingProviderMessage);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        // One-time atomic claim — details on OidcStateStore.TryRedeem. A disabled provider does not
-        // consume the state: config.Enabled short-circuits before the redeem, same as before.
-        if (config.Enabled
-            && StateStore.TryRedeem(response.Data, provider, DateTime.Now) is { } redeemed)
+        // One-time atomic claim — details on OidcStateStore.TryRedeem. A miss (unknown, expired,
+        // provider-mismatched, or already-redeemed) is a client-caused rejection, not a server fault:
+        // one uniform body, so a replay is indistinguishable from an expiry and replay stays hidden.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now) is not { } redeemed)
         {
-            Guid userId;
-            try
-            {
-                userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, redeemed.Subject, redeemed.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
-            }
-            catch (AccountLinkForbiddenException)
-            {
-                return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
-            }
-
-            var authenticationResult = await Authenticate(new SessionParameters
-            {
-                UserId = userId,
-                IsAdmin = redeemed.Admin,
-                EnableAuthorization = config.EnableAuthorization,
-                EnableAllFolders = config.EnableAllFolders,
-                EnabledFolders = redeemed.Folders.ToArray(),
-                EnableLiveTv = redeemed.EnableLiveTv,
-                EnableLiveTvManagement = redeemed.EnableLiveTvManagement,
-                AuthResponse = response,
-                DefaultProvider = config.DefaultProvider?.Trim(),
-                AvatarUrl = redeemed.AvatarUrl,
-            }).ConfigureAwait(false);
-            SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, redeemed.Username, redeemed.Admin);
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
 
-        return Problem("Something went wrong");
+        Guid userId;
+        try
+        {
+            userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, redeemed.Subject, redeemed.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
+        }
+        catch (AccountLinkForbiddenException)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
+        }
+
+        var authenticationResult = await Authenticate(new SessionParameters
+        {
+            UserId = userId,
+            IsAdmin = redeemed.Admin,
+            EnableAuthorization = config.EnableAuthorization,
+            EnableAllFolders = config.EnableAllFolders,
+            EnabledFolders = redeemed.Folders.ToArray(),
+            EnableLiveTv = redeemed.EnableLiveTv,
+            EnableLiveTvManagement = redeemed.EnableLiveTvManagement,
+            AuthResponse = response,
+            DefaultProvider = config.DefaultProvider?.Trim(),
+            AvatarUrl = redeemed.AvatarUrl,
+        }).ConfigureAwait(false);
+        SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, redeemed.Username, redeemed.Admin);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
     }
 
     /// <summary>
@@ -646,10 +652,13 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // retires the unique "No active providers found" wording that distinguished the disabled case
+        // (a disabled provider now short-circuits before the relayState log line).
         var config = FindSamlConfig(provider);
-        if (config is null)
+        if (config is not { Enabled: true })
         {
-            return BadRequest(NoMatchingProviderMessage);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
         bool isLinking = string.Equals(relayState, "linking", StringComparison.Ordinal);
@@ -660,41 +669,36 @@ public class SSOController : ControllerBase
             "SAML request has relayState of {RelayState}",
             relayState?.ReplaceLineEndings(string.Empty));
 
-        if (config.Enabled)
+        // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
+        // content-type binds null (the form value provider is skipped, so Request.Form is never
+        // touched and cannot throw the InvalidOperationException that escaped as a 500, #206), and a
+        // null body is rejected the same way as any other malformed response — a clean 400.
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, formSamlResponse, out var samlResponse)
+            || !IsSamlResponseValid(samlResponse, config, provider))
         {
-            // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
-            // content-type binds null (the form value provider is skipped, so Request.Form is never
-            // touched and cannot throw the InvalidOperationException that escaped as a 500, #206), and a
-            // null body is rejected the same way as any other malformed response — a clean 400.
-            if (!SamlResponseLoader.TryParse(config.SamlCertificate, formSamlResponse, out var samlResponse)
-                || !IsSamlResponseValid(samlResponse, config, provider))
-            {
-                // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
-                // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-            }
-
-            if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
-            {
-                return HtmlAuthPage(nonce =>
-                    WebResponse.Generator(
-                        data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
-                        provider: provider,
-                        baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
-                        mode: "SAML",
-                        nonce: nonce,
-                        isLinking: isLinking));
-            }
-
-            _logger.LogWarning(
-                "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-                samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
-                config.Roles);
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+            // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
+            // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        return ReturnError(StatusCodes.Status400BadRequest, "No active providers found");
+        if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
+        {
+            return HtmlAuthPage(nonce =>
+                WebResponse.Generator(
+                    data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
+                    provider: provider,
+                    baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
+                    mode: "SAML",
+                    nonce: nonce,
+                    isLinking: isLinking));
+        }
+
+        _logger.LogWarning(
+            "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
+            samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
+            samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
+            config.Roles);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
     }
 
     /// <summary>
@@ -712,37 +716,38 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        var config = FindSamlConfig(provider) ?? throw new ArgumentException(ProviderDoesNotExistMessage);
-
-        if (config.Enabled)
+        // Unknown and disabled providers share one rejection so neither can be probed apart, and the
+        // answer no longer depends on host middleware mapping a thrown ArgumentException (#318).
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
         {
-            bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
-
-            string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
-            string relayState = null;
-            if (isLinking)
-            {
-                relayState = "linking";
-            }
-
-            var request = new SamlAuthnRequest(
-                config.SamlClientId.Trim(),
-                redirectUri);
-
-            // Solicited-only mode (#156): remember the request ID so the callback can require the
-            // response's InResponseTo to match a request we actually issued. Scoped by provider so
-            // two providers' request IDs cannot satisfy each other's correlation. Only for login
-            // flows — the linking callback (SamlLink) does not consume InResponseTo, so registering a
-            // linking request would only leave an id to expire unused.
-            if (config.ValidateInResponseTo && !isLinking)
-            {
-                SamlRequests.Register(ProviderScopedKey.For(provider, request.Id), DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
-            }
-
-            return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        throw new ArgumentException(ProviderDoesNotExistMessage);
+        bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
+
+        string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
+        string relayState = null;
+        if (isLinking)
+        {
+            relayState = "linking";
+        }
+
+        var request = new SamlAuthnRequest(
+            config.SamlClientId.Trim(),
+            redirectUri);
+
+        // Solicited-only mode (#156): remember the request ID so the callback can require the
+        // response's InResponseTo to match a request we actually issued. Scoped by provider so
+        // two providers' request IDs cannot satisfy each other's correlation. Only for login
+        // flows — the linking callback (SamlLink) does not consume InResponseTo, so registering a
+        // linking request would only leave an id to expire unused.
+        if (config.ValidateInResponseTo && !isLinking)
+        {
+            SamlRequests.Register(ProviderScopedKey.For(provider, request.Id), DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
+        }
+
+        return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
     }
 
     /// <summary>
@@ -818,101 +823,102 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // unifies the previously JSON unknown-provider body and the disabled provider's 500.
         var config = FindSamlConfig(provider);
-        if (config is null)
+        if (config is not { Enabled: true })
         {
-            return BadRequest(NoMatchingProviderMessage);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        if (config.Enabled)
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
+            || !IsSamlResponseValid(samlResponse, config, provider))
         {
-            if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
-                || !IsSamlResponseValid(samlResponse, config, provider))
+            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
+        // an AuthnRequest this server issued. Enforced here (the session-minting endpoint), like
+        // the replay check, so the id is claimed once. An unsolicited (IdP-initiated) response
+        // carries no InResponseTo and is refused; a matching id is one-time-use. The rejection is a
+        // client-caused 400 in the uniform SAML body — never a 500, and the old body that disclosed
+        // the InResponseTo correlation to the submitter is gone (the warning log keeps the diagnosis).
+        if (config.ValidateInResponseTo)
+        {
+            var inResponseTo = samlResponse.GetInResponseTo();
+            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
+            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow))
             {
-                // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+                _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
                 return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
             }
-
-            // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
-            // an AuthnRequest this server issued. Enforced here (the session-minting endpoint), like
-            // the replay check, so the id is claimed once. An unsolicited (IdP-initiated) response
-            // carries no InResponseTo and is refused; a matching id is one-time-use.
-            if (config.ValidateInResponseTo)
-            {
-                var inResponseTo = samlResponse.GetInResponseTo();
-                var requestKey = ProviderScopedKey.For(provider, inResponseTo);
-                if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow))
-                {
-                    _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
-                    return Problem("SAML response was not solicited by this server");
-                }
-            }
-
-            // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
-            // can POST an assertion straight to this session-minting endpoint and skip the page, so
-            // checking it only there would be fail-open.
-            if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
-            {
-                _logger.LogWarning(
-                    "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
-                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-            }
-
-            // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
-            // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
-            // renders the intermediate page, so the two-step post-then-auth flow consumes the id once.
-            if (!TryConsumeSamlReplay(samlResponse, provider))
-            {
-                return Problem("SAML assertion has already been used");
-            }
-
-            // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
-            // the assertion's roles and the provider configuration. Login validity was already decided
-            // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
-            // here.
-            var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
-
-            // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
-            // reject it as an invalid login instead of failing downstream on a null canonical name.
-            // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
-            var nameId = samlResponse.GetNameID();
-            if (string.IsNullOrWhiteSpace(nameId))
-            {
-                _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-            }
-
-            Guid userId;
-            try
-            {
-                // SAML keys the link directly on the NameID, which is already the stable subject
-                // identifier — key and account name are the same value (no migration path needed).
-                userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
-            }
-            catch (AccountLinkForbiddenException)
-            {
-                return StatusCode(StatusCodes.Status403Forbidden, "SSO login is not permitted for this account.");
-            }
-
-            var authenticationResult = await Authenticate(new SessionParameters
-            {
-                UserId = userId,
-                IsAdmin = derived.Admin,
-                EnableAuthorization = config.EnableAuthorization,
-                EnableAllFolders = config.EnableAllFolders,
-                EnabledFolders = derived.Folders.ToArray(),
-                EnableLiveTv = derived.EnableLiveTv,
-                EnableLiveTvManagement = derived.EnableLiveTvManagement,
-                AuthResponse = response,
-                DefaultProvider = config.DefaultProvider?.Trim(),
-                AvatarUrl = null,
-            }).ConfigureAwait(false);
-            SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
         }
 
-        return Problem("Something went wrong");
+        // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
+        // can POST an assertion straight to this session-minting endpoint and skip the page, so
+        // checking it only there would be fail-open.
+        if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
+        {
+            _logger.LogWarning(
+                "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
+                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
+        // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
+        // renders the intermediate page, so the two-step post-then-auth flow consumes the id once. A
+        // replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
+        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
+        if (!TryConsumeSamlReplay(samlResponse, provider))
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
+        // the assertion's roles and the provider configuration. Login validity was already decided
+        // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
+        // here.
+        var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
+
+        // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
+        // reject it as an invalid login instead of failing downstream on a null canonical name.
+        // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
+        var nameId = samlResponse.GetNameID();
+        if (string.IsNullOrWhiteSpace(nameId))
+        {
+            _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        Guid userId;
+        try
+        {
+            // SAML keys the link directly on the NameID, which is already the stable subject
+            // identifier — key and account name are the same value (no migration path needed).
+            userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
+        }
+        catch (AccountLinkForbiddenException)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
+        }
+
+        var authenticationResult = await Authenticate(new SessionParameters
+        {
+            UserId = userId,
+            IsAdmin = derived.Admin,
+            EnableAuthorization = config.EnableAuthorization,
+            EnableAllFolders = config.EnableAllFolders,
+            EnabledFolders = derived.Folders.ToArray(),
+            EnableLiveTv = derived.EnableLiveTv,
+            EnableLiveTvManagement = derived.EnableLiveTvManagement,
+            AuthResponse = response,
+            DefaultProvider = config.DefaultProvider?.Trim(),
+            AvatarUrl = null,
+        }).ConfigureAwait(false);
+        SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
     }
 
     /// <summary>
@@ -1325,10 +1331,12 @@ public class SSOController : ControllerBase
 
         // Enforce one-time use here too (#219): without it, a captured, still-valid assertion could be
         // replayed to bind its NameID to the caller's account. The linking flow issues no AuthnRequest,
-        // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use control.
+        // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use
+        // control. A replay is a client-caused 400 in the uniform SAML body, never a 500, and no longer
+        // discloses the replay cache to the attacker who replayed.
         if (!TryConsumeSamlReplay(samlResponse, provider))
         {
-            return Problem("SAML assertion has already been used");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
         string providerUserId = samlResponse.GetNameID();
@@ -1365,15 +1373,17 @@ public class SSOController : ControllerBase
         }
 
         // One-time atomic claim (see OidcStateStore.TryRedeem): consume the state so one verified
-        // identity cannot be linked repeatedly and cannot then be reused to mint a session.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now) is { } redeemed)
+        // identity cannot be linked repeatedly and cannot then be reused to mint a session. A miss
+        // (unknown, expired, provider-mismatched, or already-redeemed) is a client-caused 400 in the
+        // same uniform body as the login path, not a 500.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now) is not { } redeemed)
         {
-            // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
-            // later provider-side rename does not orphan the link the user just created.
-            return CreateCanonicalLink("oid", provider, jellyfinUserId, redeemed.Subject);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
 
-        return Problem("Something went wrong!");
+        // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
+        // later provider-side rename does not orphan the link the user just created.
+        return CreateCanonicalLink("oid", provider, jellyfinUserId, redeemed.Subject);
     }
 
     private ActionResult CreateCanonicalLink(string mode, string provider, Guid jellyfinUserId, string providerUserId)

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -79,6 +79,7 @@ rules:
       - pattern-either:
           - pattern: Problem(...)
           - pattern: new ProblemDetails
+          - pattern: ProblemDetails(...)
     paths:
       include:
         - "SSO-Auth/**/*Controller.cs"

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -60,6 +60,29 @@ rules:
       include:
         - "SSO-Auth/**/*.cs"
 
+  # Invariant (architecture, #318 login-outcome step): the controller never returns
+  # Problem()/ProblemDetails. A client-caused rejection is a LoginOutcome.Rejected/Denied
+  # mapped to a 4xx by LoginStatusMapper; Problem() produced a 500 for client-caused
+  # conditions (bad state, replay, disabled provider), which both leaks that a rejection
+  # is a "server error" to monitoring and, on the disabled-provider path, distinguished a
+  # disabled provider from an unknown one. Anything genuinely unexpected throws and becomes
+  # a real 500 — never a manually-authored one.
+  - id: no-controller-problem-result
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not return Problem()/ProblemDetails from the SSO controllers. A
+      client-caused rejection is a LoginOutcome mapped to a 4xx by
+      LoginStatusMapper; only genuinely unexpected faults become a 500, by
+      throwing (#318).
+    patterns:
+      - pattern-either:
+          - pattern: Problem(...)
+          - pattern: new ProblemDetails
+    paths:
+      include:
+        - "SSO-Auth/**/*Controller.cs"
+
   # Invariant (architecture, #318 step 2b): once-per-interval throttling goes
   # through IntervalGate, whose guard/CAS semantics were adversarially reviewed
   # once and are pinned by tests (#331). Every hand-rolled predecessor seeded its


### PR DESCRIPTION
# What & why

Closes #346 (second half; Refs #318). Building on the LoginOutcome/LoginStatusMapper mechanism (PR #347), this converts the remaining exits, the client-caused `Problem()` 500s and the thrown provider rejections, into structured 4xx, and closes the disabled-vs-unknown provider enumeration oracle across every endpoint. Every change here is a **named, deliberate, safe-direction behavior delta** (which is why it is separate from the byte-identical PR #347).

**Provider oracle closed (every challenge/auth/post endpoint).** An unknown OR disabled provider now answers with one uniform `text/plain` 400 `No matching provider found`. Previously the disabled case leaked through four divergent shapes, a thrown `ArgumentException` (challenge), a JSON body (auth), a `Problem()` 500 (auth), and the unique `No active providers found` wording (post), each of which let a caller distinguish a disabled provider from an unknown one. The answer also no longer depends on host middleware mapping a thrown exception: the in-process 400 is fail-closed regardless of deployment.

**Client-caused conditions never 500.**
- OidAuth / OidLink state misses (unknown, expired, replayed) → uniform 400 `Invalid or expired state`, so a replay is indistinguishable from an expiry and replay detection stays hidden.
- SamlAuth / SamlLink unsolicited-`InResponseTo` (#156) and replayed-assertion (#219) → the uniform SAML 400 body instead of a 500 that disclosed the correlation check and the replay cache to the submitter. The warning-log diagnosis is unchanged.
- The account-link-forbidden 403 becomes `text/plain` like the rest.

Messages only ever get **less informative**, and monitoring stops seeing replay / stale-state / disabled-provider probes as 5xx (attack noise no longer looks like an outage). `ReturnError` keeps its five remaining sites: the two dynamic IdP-error texts (a fixed-wording follow-up), the capacity 500 (a genuine server fault, deliberately outside the closed sum), and the 429.

An opengrep tripwire (`no-controller-problem-result`) bans `Problem()`/`ProblemDetails` in the controllers so the pattern cannot regress.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: every converted site still rejects; only the numeral
      and (where noted) the body change. No acceptance path is added.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed (the 4-lens adversarial gate; results in Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call (the warning
      logs that disambiguate the now-uniform bodies are unchanged, sanitizers intact).

## Quality checklist

- [x] No duplicated logic; the rejection wording lives once in the mapper.
- [x] The change adds no more code than the problem requires (the controller
      net-changes; the guard-clause restructures de-nest four method bodies).
- [x] The code is self-documenting; each delta carries a why-comment naming the
      oracle/never-500 rationale.
- [x] Architecture-conformance holds; the invariant is locked by the new opengrep
      `no-controller-problem-result` rule (a call-site property, greppable not reflectable).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (634 tests, three consecutive runs).
- [x] Prettier is clean (E2E-CHECKLIST.md updated and checked).

## Notes

**Every status-code change, per endpoint + condition:**

| Endpoint · condition | Before | After |
| --- | --- | --- |
| OidChallenge · unknown / disabled | thrown `ArgumentException` (middleware 400 `Provider does not exist`) | 400 `No matching provider found` |
| OidAuth · unknown / disabled | 400 JSON / 500 | 400 `No matching provider found` |
| OidAuth · state unknown/expired/replayed | 500 | 400 `Invalid or expired state` |
| OidAuth · account-link forbidden | 403 JSON | 403 `SSO login is not permitted for this account.` |
| SamlChallenge · unknown / disabled | thrown `ArgumentException` | 400 `No matching provider found` |
| SamlPost · unknown / disabled | 400 JSON / 400 `No active providers found` | 400 `No matching provider found` |
| SamlAuth · unknown / disabled | 400 JSON / 500 | 400 `No matching provider found` |
| SamlAuth · unsolicited InResponseTo | 500 | 400 `SAML response validation failed` |
| SamlAuth · replayed assertion | 500 | 400 `SAML response validation failed` |
| SamlAuth · account-link forbidden | 403 JSON | 403 `SSO login is not permitted for this account.` |
| SamlLink · replayed assertion | 500 | 400 `SAML response validation failed` |
| OidLink · state redeem miss | 500 | 400 `Invalid or expired state` |

Statuses correct today are byte-identical (all `BadRequest` "missing data" / malformed-input 400s, the role-denial 401s, the 429, the capacity 500). A minor non-observable delta: a disabled SamlPost now short-circuits before the relayState log line.

**Adversarial review (4 lenses, refute-by-default): all PASS.** Availability confirmed the five de-indented methods preserve every statement in order and that the one transient failure (store capacity) correctly keeps its 500 while only permanent client faults flatten to 4xx. Bypass, the primary lens, walked the boolean accept-condition of every inverted guard (old `config.Enabled **Adversarial review (4 lenses, refute-by-default):** GATE_RESULTS_PLACEHOLDER**Adversarial review (4 lenses, refute-by-default):** GATE_RESULTS_PLACEHOLDER TryRedeem is {}` vs new split guards) and confirmed the accept set is identical and the Enabled guard precedes the redeem, so a disabled provider still cannot consume a state; it verified oracle closure is byte-identical on all five endpoints and no 500→400 turns a rejection into a success. Correctness verified the `is not { Enabled: true }` semantics, that no pin was weakened (several strengthened), and the two new fail-closed SamlAuth pins. Integration confirmed the opengrep rule is valid and passes on a clean tree, that `[Produces(application/json)]` honors the text/plain `ContentResult` (already shipped in #347), and that the login JS branches only on `status===200`/`429` so the JSON→text/plain flips are invisible to consumers. Non-blocking nits were doc-completeness only.