### PR TITLE
Semi-halt notice, stewardship handover, iderex-only merge gate, and drop the public AI claim

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,29 +1,33 @@
 # Code owners for jellyfin-plugin-sso
 #
-# Auto-requests the maintainer's review on changes, with extra emphasis on the
+# Requests both maintainers' review on changes, with extra emphasis on the
 # security-critical paths (the SSO login path, crypto, config persistence, and
 # the release pipeline).
 #
-# Note: this only requests review; it is not a hard merge gate. GitHub can
-# require approvals, but a PR author cannot approve their own PR, so with a solo
-# maintainer as the only Code Owner a required-approval count (or "require
-# review from Code Owners") would deadlock every maintainer-authored PR — it is
-# therefore intentionally left off in the ruleset. The maintainer sign-off is
-# instead a process gate: every PR gets a mandatory consolidated `iderex`
-# review before merge that documents the review findings and their resolution
-# (a Comment-event review on iderex-authored PRs, an approval on others).
+# Governance (two maintainers, equal Admin rights): every change to a protected
+# branch needs the OTHER maintainer's approval. GitHub forbids self-approval, so
+# with two code owners the "Require review from Code Owners" + one required
+# approval rule means a PR authored by one maintainer must be approved by the
+# other — genuine four-eyes, and neither can merge past the other. This holds
+# only while the ruleset's bypass list stays empty (the Admin role by itself
+# does not grant a bypass). A listed owner is enforced only once that account
+# has write access to the repository.
+#
+# Requiring TWO approvals is deliberately NOT used: with exactly two maintainers
+# it would deadlock every maintainer-authored PR (the author cannot approve, so
+# a second approval is unreachable). One required code-owner approval is correct.
 
-# Default owner for everything in the repo.
-*                        @iderex
+# Default owners for everything in the repo.
+*                        @iderex @TheRealStroopwafel
 
 # SSO login path and crypto: SAML core, controller/API helpers, admin config.
-/SSO-Auth/Saml.cs        @iderex
-/SSO-Auth/Api/           @iderex
-/SSO-Auth/Config/        @iderex
+/SSO-Auth/Saml.cs        @iderex @TheRealStroopwafel
+/SSO-Auth/Api/           @iderex @TheRealStroopwafel
+/SSO-Auth/Config/        @iderex @TheRealStroopwafel
 
 # Release pipeline and CI.
-/.github/workflows/      @iderex
-/build.yaml              @iderex
+/.github/workflows/      @iderex @TheRealStroopwafel
+/build.yaml              @iderex @TheRealStroopwafel
 
 # Security policy.
-/SECURITY.md             @iderex
+/SECURITY.md             @iderex @TheRealStroopwafel

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > [!WARNING]
 >
-> ## ⛔ In-Development — do NOT install this on a production system
+> ## 🟠 Semi-halted — do NOT install this on a production system
 >
-> **Development is currently stopped.** There is no active work on this plugin at the moment, and if it is picked up again at all, that will realistically be **weeks to months** away. Until then, expect no fixes, no new features, and no support.
+> **This project is semi-halted.** iderex, who revived it, currently isn't in a position to carry it forward, so **[TheRealStroopwafel](https://github.com/TheRealStroopwafel)** has taken it on and now continues it — at a slow, best-effort pace. Expect long gaps between changes, and no promise of support.
 >
-> This plugin is at the **In-Development** stage — the first rung of its maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). It exists **exclusively for developers to test** — nothing else. Under **no circumstances** should it be installed on a production system or put in front of a real Jellyfin instance with real user accounts: it is a login path under reconstruction that was left mid-hardening, and you must expect **breaking changes, incomplete features, and security gaps that are still open**. Wait for a **Full Release** before using it anywhere that matters.
+> This plugin is still at the **In-Development** stage — the first rung of its maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). It exists **exclusively for developers to test** — nothing else. Under **no circumstances** should it be installed on a production system or put in front of a real Jellyfin instance with real user accounts: it is a login path still under reconstruction, hardened slowly and with long pauses, and you must expect **breaking changes, incomplete features, and security gaps that are still open**. Wait for a **Full Release** before using it anywhere that matters.
 
 <h1 align="center">Jellyfin SSO Plugin</h1>
 
@@ -29,13 +29,13 @@
 Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia, authentik, Entra ID, Google, and more — over <b>OpenID&nbsp;Connect</b> or <b>SAML&nbsp;2.0</b>, instead of a separate Jellyfin password.
 </p>
 
-> ### ⏸️ Revival — currently on hold
+> ### 🔁 Revival — handed over, continuing slowly
 >
-> This is a revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continued from the last upstream release (**4.0.0.x**, Jellyfin 10.11 / .NET 9) and was being taken forward **security-first** — an automated test suite was added and the login path was hardened step by step — but that work is **currently stopped** (see the notice above). Huge thanks to the original author and contributors for the foundation.
+> This is a revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continued from the last upstream release (**4.0.0.x**, Jellyfin 10.11 / .NET 9) and was taken forward **security-first** — an automated test suite was added and the login path hardened step by step. iderex has since stepped back, and **[TheRealStroopwafel](https://github.com/TheRealStroopwafel)** now continues the work at a slow, best-effort pace. Huge thanks to the original author and contributors for the foundation.
 >
-> Its hardened sibling project, **`jellyfin-plugin-sso-V2`** (private), is the reference this repository draws on — a good deal still remains to be ported across from there, and that porting is on hold along with the rest of the work.
+> Its hardened sibling project, **`jellyfin-plugin-sso-V2`** (private), is the reference this repository draws on — a good deal still remains to be ported across from there, deliberately, one reviewed change at a time as time allows.
 >
-> **Status:** **In-Development**, paused — the first stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — for now the only path is building from source; a packaged release would only follow once the security-hardening pass resumes and advances the maturity stages.
+> **Status:** **In-Development**, slow — the first stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — for now the only path is building from source; a packaged release would only follow once the security-hardening pass has advanced the maturity stages.
 
 > ### 🤖 A note on AI and on contributions
 >

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 
 > ### 🤖 A note on AI and on contributions
 >
-> I am a non-native English speaker, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) assists me in two ways: it **translates documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments — and it **helps generate and analyse code** during development.
+> We are non-native English speakers, so **[Claude](https://www.anthropic.com/claude)** (Anthropic) assists us in two ways: it **translates documentation and comments into English** — the README, the wiki, the in-repo guides, and code comments — and it **helps generate and analyse code** during development.
 >
-> - **A human owns and reviews everything.** Claude never produces finished code, a complete pull request, or any other artifact that lands unexamined. Every AI-assisted change — translated text or code — is reviewed, understood, edited, and evaluated by me before it merges; I hold responsibility for it. The AI proposes; the human decides.
+> - **A human owns and reviews everything.** Claude never produces finished code, a complete pull request, or any other artifact that lands unexamined. Every AI-assisted change — translated text or code — is reviewed, understood, edited, and evaluated by a maintainer before it merges, and with two maintainers a change one of us authors is approved by the other; we hold responsibility for it. The AI proposes; the humans decide.
 > - **The AI is not in the product.** It plays **no role at runtime**, in authentication, or in processing your users' data.
 >
 > The review discipline around this is modelled — as far as is practical for a volunteer project — on the change-control expected of **TÜV/BSI-certified software in critical sectors such as healthcare**: every change is issue-driven, adversarially reviewed on the login path, and documented before it merges. It is an approximation of that practice, not a certification.


### PR DESCRIPTION
# What & why

Governance + status update, per my decision.

**README**, the top banner now says the project is **semi-halted**: iderex, who revived it, currently isn't in a position to carry it forward, and **[TheRealStroopwafel](https://github.com/TheRealStroopwafel)** has taken it on to continue it at a slow, best-effort pace (replacing the earlier "development stopped" notice from #351). The revival section and the status line are updated to match.

**CODEOWNERS**, both code owners are now listed on every path (default and the security-critical login/crypto/config/release paths). This sets up the intended **four-eyes governance**: with two code owners and "Require review from Code Owners" + one required approval, a PR authored by one of the two must be approved by the other (self-approval is forbidden), so neither can merge past the other. It takes effect once TheRealStroopwafel has write access and the branch ruleset requires code-owner review with an **empty bypass list** (the Admin role alone does not grant a bypass).

Docs/config only; no code, no behaviour change.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, documentation and CODEOWNERS only.

## Quality checklist

- [x] No duplicated logic; docs/config only.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting.
- [x] Architecture-conformance unaffected.

## Verification

- [x] Prettier clean (`README.md`; CODEOWNERS is not in the format gate's file set).
- [x] No build/test impact.

## Notes to myself

The account/permissions steps stay with you and are **not** part of this PR (they can't be done from a PR):

1. Create the second account and accept the collaborator invite (repo Settings â†’ Collaborators â†’ add `TheRealStroopwafel` as **Admin**).
2. In the **Protect main** ruleset: enable **Require review from Code Owners**, set **Required approvals = 1**, and keep the **bypass list empty**. (This also disables the `gh pr merge --admin` path used for coverage-only-red SonarCloud checks.)

Until TheRealStroopwafel has write access, GitHub will show the CODEOWNERS entry as unenforced, expected; it activates when the collaborator is added.

The **"A note on AI"** section is still written first-person as iderex ("assists me", "I hold responsibility"). It was deliberately left unchanged here rather than putting words in my mouth, worth a follow-up to make it role-neutral or restate it under the new stewardship.

