### PR TITLE
Extract the login-path account linking into CanonicalLinkService

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -27,7 +27,7 @@ public class ArchitectureConformanceTests
     // implementation detail, never part of the plugin's public surface.
     private static readonly string[] HelperSuffixes =
     {
-        "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor", "Gate", "State",
+        "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor", "Gate", "State", "Resolver",
     };
 
     // Every production type, compiler-generated ones excluded — the base sequence for structural rules
@@ -68,6 +68,22 @@ public class ArchitectureConformanceTests
             .ToList();
 
         Assert.True(open.Count == 0, "These helper types must be sealed or static (a pure helper is a leaf, not an inheritance base): " + string.Join(", ", open));
+    }
+
+    [Fact]
+    public void FlowServices_AreInternalAndSealed()
+    {
+        // The flow tier (#318): a *Service is a stateful collaborator (holds IUserManager, the config
+        // store, …) that orchestrates pure helpers — distinct from the leaf *Helper suffixes above, so
+        // it gets its own rule rather than joining HelperSuffixes. It is still internal-by-default and a
+        // sealed leaf, never an inheritance base or part of the public surface.
+        var stray = PluginClasses
+            .Where(t => SimpleName(t).EndsWith("Service", StringComparison.Ordinal))
+            .Where(t => t.IsPublic || t.IsNestedPublic || t.IsNestedFamily || t.IsNestedFamORAssem || !t.IsSealed)
+            .Select(t => t.FullName)
+            .ToList();
+
+        Assert.True(stray.Count == 0, "Flow services (*Service) must be internal and sealed collaborators: " + string.Join(", ", stray));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct tests of <see cref="CanonicalLinkService"/> — the account-linking workflow extracted from the
+/// controller (#318). The service is constructible without a plugin instance (its config lives behind a
+/// <see cref="ProviderConfigStore"/> built over an in-memory <see cref="PluginConfiguration"/>), so these
+/// pin the resolve/adopt/create/reject decision, the legacy-key migration (#155), and the revoke loop as
+/// unit tests — including the account-takeover reject path (#95), which no controller test exercised today.
+/// </summary>
+public class CanonicalLinkServiceTests
+{
+    private static readonly Guid Existing = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
+
+    private static (CanonicalLinkService Service, PluginConfiguration Config, IUserManager Users) Build(Action<PluginConfiguration>? seed = null)
+    {
+        var cfg = new PluginConfiguration();
+        seed?.Invoke(cfg);
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+        return (service, cfg, users);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LiveSubjectLink_ReusesItWithoutCreating()
+    {
+        var (service, _, users) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Existing, resolved);
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NoLinkNoAccount_CreatesAndLinksOnTheSubjectKey()
+    {
+        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var created = UserNamed("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Other, resolved);
+        await users.Received(1).CreateUserAsync("alice");
+        Assert.Equal(Other, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
+    {
+        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Existing, resolved);
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ExistingAccountButAdoptionDisabled_RefusesWithoutCreatingOrLinking()
+    {
+        // The account-takeover guard (#95): a login whose name matches a pre-existing unlinked account,
+        // with adoption off, must be refused — not silently take the account over. No controller test
+        // reached this path before the extraction; this pins it directly.
+        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Theory]
+    [InlineData("", "alice")]
+    [InlineData("   ", "alice")]
+    [InlineData("sub-1", "")]
+    [InlineData("sub-1", "  ")]
+    public async Task ResolveOrCreateAsync_UnresolvedIdentity_FailsClosedWithoutCreating(string canonicalKey, string username)
+    {
+        // Fail-closed belt (#95/#155): a blank identity key or username must never create, adopt, or
+        // look up an account, even if a caller forgets its own guard.
+        var (service, _, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", canonicalKey, username, allowExistingAccountLink: true));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LegacyNameKeyedOidLink_MigratesToTheSubjectKey()
+    {
+        // #155: an OpenID login with only a legacy username-keyed link adopts and re-keys it to the
+        // stable subject, so a later provider-side rename cannot detach it.
+        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Existing, resolved);
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["sub-1"]);
+        Assert.False(links.ContainsKey("alice")); // the legacy key is gone
+    }
+
+    [Fact]
+    public void RemoveUserEverywhere_RemovesTheUsersLinksAcrossAllProviders_AndCountsThem()
+    {
+        var (service, cfg, _) = Build(c =>
+        {
+            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
+            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        });
+
+        var removed = service.RemoveUserEverywhere(Existing);
+
+        Assert.Equal(2, removed); // one OID link + one SAML link
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+        Assert.True(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-2")); // the other user's link survives
+        Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
+    }
+}

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Cryptography;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The account-linking workflow behind the SSO login and admin endpoints: it resolves an SSO identity
+/// to a Jellyfin account (reusing an existing canonical link, adopting a pre-existing account, or
+/// creating one), migrates legacy username-keyed links to the stable subject key (#155), and revokes
+/// links. The controller keeps the HTTP boundary, the authorization guards, and the one-time-use
+/// replay/state consume; this service keeps the account-resolution decision (via the pure
+/// <see cref="AccountLinkResolver"/>) and every read/write of a provider's canonical-links map, all
+/// through the <see cref="ProviderConfigStore"/> facade so each check-then-write stays under one lock.
+/// </summary>
+internal sealed class CanonicalLinkService
+{
+    private readonly IUserManager _userManager;
+    private readonly ICryptoProvider _cryptoProvider;
+    private readonly ProviderConfigStore _configStore;
+    private readonly ILogger _logger;
+
+    internal CanonicalLinkService(
+        IUserManager userManager,
+        ICryptoProvider cryptoProvider,
+        ProviderConfigStore configStore,
+        ILogger logger)
+    {
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
+        _configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Resolves the SSO login's stable identity to a Jellyfin user, creating or adopting the account per
+    /// the provider's policy, and returns its id. Throws <see cref="AccountLinkForbiddenException"/> when
+    /// the login must be refused (no identity resolved, or a pre-existing account may not be adopted).
+    /// </summary>
+    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="provider">The provider the login authenticated against.</param>
+    /// <param name="canonicalKey">The stable identity key (OpenID sub / SAML NameID).</param>
+    /// <param name="username">The display name the account is provisioned/adopted under.</param>
+    /// <param name="allowExistingAccountLink">Whether adopting a pre-existing unlinked account is permitted.</param>
+    /// <returns>The resolved Jellyfin user id.</returns>
+    internal async Task<Guid> ResolveOrCreateAsync(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
+    {
+        // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
+        // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
+        // reject such logins before calling here; this belt keeps the invariant if a caller forgets.
+        if (string.IsNullOrWhiteSpace(canonicalKey) || string.IsNullOrWhiteSpace(username))
+        {
+            throw new AccountLinkForbiddenException("The SSO login did not resolve an identity; refusing to create or link an account.");
+        }
+
+        // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the
+        // mutable username instead; when no subject-keyed link exists yet but a legacy one resolves,
+        // adopt and re-key it — the one login that migrates reuses the exact decision the old
+        // name-keyed lookup would have made, then locks it to the subject so a later provider-side
+        // rename cannot detach it. Only OpenID differs key from name; SAML passes key == name.
+        // Both candidates are read in ONE pass under the config lock: with separate reads, a
+        // concurrent login's migration could commit between them, so this login would see the subject
+        // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
+        // user off the adoption gate with a spurious 403. A link whose target user was deleted counts
+        // as absent (dangling links are dead, not identities).
+        var (subjectLink, legacyLink) = _configStore.Read(configuration =>
+        {
+            var links = LinksFor(configuration, mode, provider);
+            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
+                ? s : null;
+            Guid? byName = bySubject is null
+                && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
+                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
+                ? n : (Guid?)null;
+            return (bySubject, byName);
+        });
+
+        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink);
+        if (migrateLegacy)
+        {
+            MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
+            _logger.LogInformation(
+                "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
+                mode,
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
+        // Adoption of a pre-existing unlinked account still matches on the display name.
+        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
+
+        var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
+        switch (decision.Action)
+        {
+            case AccountLinkAction.UseExistingLink:
+                return decision.UserId;
+
+            case AccountLinkAction.AdoptExistingAccount:
+            {
+                // Atomic check-then-link (#133): if a concurrent first-login already linked this
+                // identity, that winner is used and no second write or duplicate audit occurs.
+                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
+                if (wrote)
+                {
+                    SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? "OpenID" : "SAML", provider, username);
+                }
+
+                return adoptedUserId;
+            }
+
+            case AccountLinkAction.CreateNewAccount:
+            {
+                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
+                var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
+                user.AuthenticationProviderId = typeof(SSOController).FullName;
+                // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
+                user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+
+                // Atomic check-then-link (#133): if a concurrent first-login for the same identity
+                // linked meanwhile, use its account — this freshly created user is left unlinked rather
+                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login).
+                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id);
+                return effectiveUserId;
+            }
+
+            case AccountLinkAction.RejectNameTaken:
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
+                    username.ReplaceLineEndings(string.Empty),
+                    mode,
+                    provider?.ReplaceLineEndings(string.Empty));
+                throw new AccountLinkForbiddenException();
+
+            default:
+                throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
+        }
+    }
+
+    /// <summary>
+    /// Removes every canonical link pointing at the given user across all SAML and OpenID providers, so
+    /// an SSO login no longer resolves to the account. Runs under the config lock and returns the number
+    /// of links removed.
+    /// </summary>
+    /// <param name="userId">The Jellyfin user whose links are revoked.</param>
+    /// <returns>The number of links removed.</returns>
+    internal int RemoveUserEverywhere(Guid userId)
+    {
+        return _configStore.Mutate(configuration =>
+        {
+            int removed = 0;
+            foreach (var config in configuration.SamlConfigs.Values)
+            {
+                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+            }
+
+            foreach (var config in configuration.OidConfigs.Values)
+            {
+                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+            }
+
+            return removed;
+        });
+    }
+
+    // Atomically links canonicalKey to candidateUserId unless a live link already exists for it (#133).
+    // The existence check and the write are ONE Mutate read-modify-write, so two concurrent first-logins
+    // for the same identity cannot both write or both adopt: the loser observes the winner's link and
+    // reports WroteLink=false (so the caller does not re-emit the adoption audit). The link write goes
+    // straight into the config (no discarded ActionResult), so a failure to persist propagates rather
+    // than falling through as a successful adoption.
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(string mode, string provider, string canonicalKey, Guid candidateUserId)
+    {
+        return _configStore.Mutate(configuration =>
+        {
+            var links = LinksFor(configuration, mode, provider);
+            Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null
+                ? current
+                : (Guid?)null;
+
+            var (effectiveUserId, wroteLink) = AccountLinkResolver.ResolveLinkWrite(existing, candidateUserId);
+            if (wroteLink)
+            {
+                links[canonicalKey] = effectiveUserId;
+            }
+
+            return (effectiveUserId, wroteLink);
+        });
+    }
+
+    // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).
+    // Idempotent under concurrency: if oldKey is already gone (a concurrent login migrated first) the
+    // move is a no-op, and a LIVE newKey entry is never overwritten — only a dangling one (its target
+    // user deleted), which would otherwise block the hand-off on every subsequent login.
+    private void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
+    {
+        _configStore.Mutate(configuration =>
+        {
+            var links = LinksFor(configuration, mode, provider);
+            if (links.TryGetValue(oldKey, out var userId)
+                && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
+            {
+                links.Remove(oldKey);
+                links[newKey] = userId;
+            }
+        });
+    }
+
+    // The provider's canonical-links map; callers must hold the config lock (Read / Mutate) while
+    // touching it. The map is self-healing (CanonicalLinks lazily creates and stores it), so mutating
+    // the returned map persists directly. The provider is always present on the paths that reach here
+    // (the login callbacks resolved it first); a guarded accessor for the reachable-unknown-provider
+    // admin paths, finishing the #241 KeyNotFoundException removal, lands with those endpoints.
+    private static SerializableDictionary<string, Guid> LinksFor(PluginConfiguration configuration, string mode, string provider)
+    {
+        return mode.ToLowerInvariant() switch
+        {
+            "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
+            "oid" => configuration.OidConfigs[provider].CanonicalLinks,
+            _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
+        };
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -58,6 +58,10 @@ public class SSOController : ControllerBase
     private readonly IProviderManager _providerManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly IHttpClientFactory _httpClientFactory;
+
+    // The account-linking workflow (resolve/adopt/create, legacy re-key, revoke); the controller keeps
+    // the authz guards, the one-time-use replay/state consume, and the HTTP mapping (#318).
+    private readonly CanonicalLinkService _canonicalLinks;
     // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal
     // all live inside; see OidcStateStore). One process-wide instance, like the SAML caches below.
     private static readonly OidcStateStore StateStore = new();
@@ -118,6 +122,7 @@ public class SSOController : ControllerBase
         _providerManager = providerManager;
         _serverConfigurationManager = serverConfigurationManager;
         _httpClientFactory = httpClientFactory;
+        _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -606,7 +611,7 @@ public class SSOController : ControllerBase
         Guid userId;
         try
         {
-            userId = await CreateCanonicalLinkAndUserIfNotExist("oid", provider, redeemed.Subject, redeemed.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
+            userId = await _canonicalLinks.ResolveOrCreateAsync("oid", provider, redeemed.Subject, redeemed.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {
@@ -897,7 +902,7 @@ public class SSOController : ControllerBase
         {
             // SAML keys the link directly on the NameID, which is already the stable subject
             // identifier — key and account name are the same value (no migration path needed).
-            userId = await CreateCanonicalLinkAndUserIfNotExist("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
+            userId = await _canonicalLinks.ResolveOrCreateAsync("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {
@@ -943,7 +948,7 @@ public class SSOController : ControllerBase
         // AllowExistingAccountLink enabled, the same-named account can be re-adopted on the next SSO login,
         // so a hard revoke there also needs the local account disabled or renamed; with the fail-closed
         // default (adoption off) the revoke is durable.
-        var revoked = RemoveCanonicalLinksForUser(user.Id);
+        var revoked = _canonicalLinks.RemoveUserEverywhere(user.Id);
 
         // Switch the account back to the requested auth provider and PERSIST it — the previous version set
         // this in memory only and never called UpdateUserAsync, so the switch was silently discarded.
@@ -953,28 +958,6 @@ public class SSOController : ControllerBase
         _logger.LogInformation("Unregistered SSO for user {UserId}: removed {Count} canonical link(s).", user.Id, revoked);
 
         return Ok();
-    }
-
-    // Removes every canonical link pointing at the given user across all SAML and OpenID providers, so an
-    // SSO login no longer resolves to the account. Runs under the config lock and returns the number of
-    // links removed.
-    private static int RemoveCanonicalLinksForUser(Guid userId)
-    {
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
-        {
-            int removed = 0;
-            foreach (var config in configuration.SamlConfigs.Values)
-            {
-                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
-            }
-
-            foreach (var config in configuration.OidConfigs.Values)
-            {
-                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
-            }
-
-            return removed;
-        });
     }
 
     // Applies a mutation to a provider's canonical-links map on the LIVE configuration. The map is
@@ -996,141 +979,6 @@ public class SSOController : ControllerBase
             "oid" => configuration.OidConfigs[provider].CanonicalLinks,
             _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
         };
-    }
-
-    private async Task<Guid> CreateCanonicalLinkAndUserIfNotExist(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
-    {
-        // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
-        // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
-        // reject such logins before calling here; this belt keeps the invariant if a caller forgets.
-        if (string.IsNullOrWhiteSpace(canonicalKey) || string.IsNullOrWhiteSpace(username))
-        {
-            throw new AccountLinkForbiddenException("The SSO login did not resolve an identity; refusing to create or link an account.");
-        }
-
-        // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the
-        // mutable username instead; when no subject-keyed link exists yet but a legacy one resolves,
-        // adopt and re-key it — the one login that migrates reuses the exact decision the old
-        // name-keyed lookup would have made, then locks it to the subject so a later provider-side
-        // rename cannot detach it. Only OpenID differs key from name; SAML passes key == name.
-        // Both candidates are read in ONE pass under the config lock: with separate reads, a
-        // concurrent login's migration could commit between them, so this login would see the subject
-        // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
-        // user off the adoption gate with a spurious 403. A link whose target user was deleted counts
-        // as absent (dangling links are dead, not identities).
-        var (subjectLink, legacyLink) = SSOPlugin.Instance.ReadConfiguration(configuration =>
-        {
-            var links = GetLinks(configuration, mode, provider);
-            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
-                ? s : null;
-            Guid? byName = bySubject is null
-                && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
-                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
-                ? n : (Guid?)null;
-            return (bySubject, byName);
-        });
-
-        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink);
-        if (migrateLegacy)
-        {
-            MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
-            _logger.LogInformation(
-                "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
-                mode,
-                provider?.ReplaceLineEndings(string.Empty));
-        }
-
-        // Adoption of a pre-existing unlinked account still matches on the display name.
-        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
-
-        var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
-        switch (decision.Action)
-        {
-            case AccountLinkAction.UseExistingLink:
-                return decision.UserId;
-
-            case AccountLinkAction.AdoptExistingAccount:
-            {
-                // Atomic check-then-link (#133): if a concurrent first-login already linked this
-                // identity, that winner is used and no second write or duplicate audit occurs.
-                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
-                if (wrote)
-                {
-                    SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? OpenIdProtocol : SamlProtocol, provider, username);
-                }
-
-                return adoptedUserId;
-            }
-
-            case AccountLinkAction.CreateNewAccount:
-            {
-                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
-                var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
-                user.AuthenticationProviderId = GetType().FullName;
-                // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
-                user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
-
-                // Atomic check-then-link (#133): if a concurrent first-login for the same identity
-                // linked meanwhile, use its account — this freshly created user is left unlinked rather
-                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login).
-                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id);
-                return effectiveUserId;
-            }
-
-            case AccountLinkAction.RejectNameTaken:
-                _logger.LogWarning(
-                    "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                    username.ReplaceLineEndings(string.Empty),
-                    mode,
-                    provider?.ReplaceLineEndings(string.Empty));
-                throw new AccountLinkForbiddenException();
-
-            default:
-                throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
-        }
-    }
-
-    // Atomically links canonicalKey to candidateUserId unless a live link already exists for it (#133).
-    // The existence check and the write are ONE MutateConfiguration read-modify-write, so two concurrent
-    // first-logins for the same identity cannot both write or both adopt: the loser observes the
-    // winner's link and reports WroteLink=false (so the caller does not re-emit the adoption audit).
-    // The link write goes straight into the config (no discarded ActionResult), so a failure to persist
-    // propagates rather than falling through as a successful adoption.
-    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(string mode, string provider, string canonicalKey, Guid candidateUserId)
-    {
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
-        {
-            var links = GetLinks(configuration, mode, provider);
-            Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null
-                ? current
-                : (Guid?)null;
-
-            var (effectiveUserId, wroteLink) = AccountLinkResolver.ResolveLinkWrite(existing, candidateUserId);
-            if (wroteLink)
-            {
-                links[canonicalKey] = effectiveUserId;
-            }
-
-            return (effectiveUserId, wroteLink);
-        });
-    }
-
-    // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).
-    // Idempotent under concurrency: if oldKey is already gone (a concurrent login migrated first) the
-    // move is a no-op, and a LIVE newKey entry is never overwritten — only a dangling one (its target
-    // user deleted), which would otherwise block the hand-off on every subsequent login.
-    private void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
-    {
-        SSOPlugin.Instance.MutateConfiguration(configuration =>
-            MutateLinks(configuration, mode, provider, links =>
-            {
-                if (links.TryGetValue(oldKey, out var userId)
-                    && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
-                {
-                    links.Remove(oldKey);
-                    links[newKey] = userId;
-                }
-            }));
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

Step of the #318 architecture migration (Refs #318 #133 #155). The account-resolution workflow — resolve an SSO identity to a Jellyfin account (reuse an existing canonical link, adopt a pre-existing account, or create one), migrate a legacy username-keyed link to the stable subject key, and revoke a user's links, moves out of the controller into a new `CanonicalLinkService` (internal sealed, in `Api/Linking/`). The controller keeps the HTTP boundary, the authorization guards, and the one-time-use replay/state consume that must run *before* the link write; the service keeps the account-resolution decision (via the unchanged pure `AccountLinkResolver`) and every read and write of a provider's canonical-links map.

Behaviour-preserving: the moved bodies are verbatim, every security comment travels with them (#95 fail-closed belt, #155 subject-keying and the one-pass dual read, #133 atomic check-then-link), and the log-forging inline sanitizers stay at the call. All config access goes through the injected `ProviderConfigStore` facade under its lock, never the live `Configuration`, so the check-then-writes stay atomic and the `no-config-store-bypass` invariant holds; passing the store in the constructor makes the service DI-ready for the later flows step.

The service is constructible without a plugin instance, so its behaviour is now pinned by **direct unit tests**, including the **account-takeover reject path** (a pre-existing unlinked account with adoption off), which no controller test exercised before. Conformance locks in two structural properties: `Resolver` joins the enforced helper suffixes, and a new `FlowServices_AreInternalAndSealed` rule pins the `*Service` flow tier as internal, sealed collaborators.

The admin-surface link endpoints (manual link/unlink, the link-by-user projection) and the final `KeyNotFoundException` removal that lets `MutateLinks`/`GetLinks` go follow in the second half.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the blank-identity belt, the adoption-off-by-default takeover guard, and the one-time-use replay/state consume are all intact (the last two in the controller, ahead of the service).
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed (the 4-lens adversarial gate; results in Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call (the moved log lines keep their inline `ReplaceLineEndings`).

## Quality checklist

- [x] No duplicated logic; the workflow lives in one single-purpose collaborator.
- [x] The change adds no more code than the problem requires (controller net −136 lines).
- [x] The code is self-documenting; every moved security comment travels with its code.
- [x] Architecture-conformance holds and locks in the new structural properties (`Resolver` suffix + `FlowServices_AreInternalAndSealed`).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (655 tests, three consecutive runs; 7 new direct service tests incl. the account-takeover reject path).
- [x] Prettier clean (no `.js` / `.html` / `.md` / `.css` change).

## Notes

**Adversarial review (4 lenses, refute-by-default): all PASS.** Availability confirmed the #155 one-pass dual read stays a single `Read` and the #133 check-then-link a single `Mutate` (no torn-read spurious-403, no duplicate-account race), that `ProviderConfigStore` holds the same process-wide lock on the live config, and that no legitimate login is newly refused. Bypass, the primary lens, verified the takeover guard still throws-and-rejects (never succeeds), the fail-closed belt is unreachable-to-bypass, the #219 replay/state consume still runs in the controller **before** the service call at both callbacks, authz is untouched and controller-side, the service never touches `SSOPlugin.Instance.Configuration`, the new-account `AuthenticationProviderId` string is byte-identical (`typeof(SSOController).FullName`), and the adoption-audit protocol arg is unchanged. Correctness diffed each moved body line-by-line and confirmed the new tests pin each branch. Integration confirmed the conformance rules hit the right types, the opengrep invariant holds, and both builds are green under `--warnaserror`.

The admin-surface half (manual link/unlink, `LinksByUser`, and deleting `MutateLinks`/`GetLinks` + the two `KeyNotFoundException` catches to finish #241) follows as its own PR.
