### PR TITLE
Gate the legacy-link migration behind AllowExistingAccountLink

### DIFF
--- a/SSO-Auth.Tests/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/AccountLinkResolverTests.cs
@@ -50,42 +50,60 @@ public class AccountLinkResolverTests
         Assert.Equal(Guid.Empty, decision.UserId);
     }
 
-    // --- ResolveCanonicalLink: subject-keyed lookup with one-time legacy-name migration (#155) ---
+    // --- ResolveCanonicalLink: subject-keyed lookup with one-time legacy-name migration (#155),
+    // gated behind AllowExistingAccountLink because the legacy key is the mutable username (#354) ---
 
     private static readonly Guid Subject = Guid.Parse("33333333-3333-3333-3333-333333333333");
     private static readonly Guid Legacy = Guid.Parse("44444444-4444-4444-4444-444444444444");
 
-    [Fact]
-    public void ResolveCanonicalLink_SubjectKeyed_IsUsed_WithoutMigration()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveCanonicalLink_SubjectKeyed_IsUsed_WithoutMigration(bool allow)
     {
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, legacyNameKeyedUserId: null);
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, legacyNameKeyedUserId: null, allow);
         Assert.Equal(Subject, linkedUserId);
         Assert.False(migrate);
     }
 
-    [Fact]
-    public void ResolveCanonicalLink_SubjectKeyed_WinsOverLegacy_NoMigration()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveCanonicalLink_SubjectKeyed_WinsOverLegacy_NoMigration(bool allow)
     {
         // Once a subject-keyed link exists, the legacy name-keyed one is never consulted or migrated.
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, Legacy);
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, Legacy, allow);
         Assert.Equal(Subject, linkedUserId);
         Assert.False(migrate);
     }
 
     [Fact]
-    public void ResolveCanonicalLink_OnlyLegacy_IsAdopted_AndMigrated()
+    public void ResolveCanonicalLink_OnlyLegacy_WithOptIn_IsAdopted_AndMigrated()
     {
-        // No subject-keyed link yet, but a legacy name-keyed one resolves: adopt it and signal the
-        // one-time re-key to the subject.
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy);
+        // No subject-keyed link yet, but a legacy name-keyed one resolves and the provider permits
+        // name-based matching: adopt it and signal the one-time re-key to the subject.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, allowExistingAccountLink: true);
         Assert.Equal(Legacy, linkedUserId);
         Assert.True(migrate);
     }
 
     [Fact]
-    public void ResolveCanonicalLink_NeitherLink_ResolvesNothing()
+    public void ResolveCanonicalLink_OnlyLegacy_WithoutOptIn_IsIgnored()
     {
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(null, null);
+        // The security-critical case (#354): the legacy key is the mutable preferred_username, so with
+        // AllowExistingAccountLink off a login must NOT be handed the account that key points at, and
+        // nothing may be migrated. The login falls through to Resolve(), whose adoption gate fails closed.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, allowExistingAccountLink: false);
+        Assert.Null(linkedUserId);
+        Assert.False(migrate);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveCanonicalLink_NeitherLink_ResolvesNothing(bool allow)
+    {
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(null, null, allow);
         Assert.Null(linkedUserId);
         Assert.False(migrate);
     }

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -24,20 +24,21 @@ public class CanonicalLinkServiceTests
 
     private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
 
-    private static (CanonicalLinkService Service, PluginConfiguration Config, IUserManager Users) Build(Action<PluginConfiguration>? seed = null)
+    private static (CanonicalLinkService Service, PluginConfiguration Config, IUserManager Users, CapturingLogger Log) Build(Action<PluginConfiguration>? seed = null)
     {
         var cfg = new PluginConfiguration();
         seed?.Invoke(cfg);
         var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
         var users = Substitute.For<IUserManager>();
-        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
-        return (service, cfg, users);
+        var log = new CapturingLogger();
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, log);
+        return (service, cfg, users, log);
     }
 
     [Fact]
     public async Task ResolveOrCreateAsync_LiveSubjectLink_ReusesItWithoutCreating()
     {
-        var (service, _, users) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
@@ -52,7 +53,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public async Task ResolveOrCreateAsync_NoLinkNoAccount_CreatesAndLinksOnTheSubjectKey()
     {
-        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
         var created = UserNamed("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
@@ -68,7 +69,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
     {
-        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
@@ -85,7 +86,7 @@ public class CanonicalLinkServiceTests
         // The account-takeover guard (#95): a login whose name matches a pre-existing unlinked account,
         // with adoption off, must be refused — not silently take the account over. No controller test
         // reached this path before the extraction; this pins it directly.
-        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
@@ -104,7 +105,7 @@ public class CanonicalLinkServiceTests
     {
         // Fail-closed belt (#95/#155): a blank identity key or username must never create, adopt, or
         // look up an account, even if a caller forgets its own guard.
-        var (service, _, users) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync("oid", "kc", canonicalKey, username, allowExistingAccountLink: true));
@@ -113,18 +114,19 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
-    public async Task ResolveOrCreateAsync_LegacyNameKeyedOidLink_MigratesToTheSubjectKey()
+    public async Task ResolveOrCreateAsync_LegacyNameKeyedOidLink_WithAdoptionAllowed_MigratesToTheSubjectKey()
     {
         // #155: an OpenID login with only a legacy username-keyed link adopts and re-keys it to the
-        // stable subject, so a later provider-side rename cannot detach it.
-        var (service, cfg, users) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        // stable subject, so a later provider-side rename cannot detach it. The legacy key is the
+        // mutable username, so this name-based hand-off requires AllowExistingAccountLink (#354).
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
         Assert.Equal(Existing, resolved);
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
@@ -133,9 +135,64 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_LegacyLinkButAdoptionDisabled_RefusesAndMigratesNothing()
+    {
+        // The account-takeover characterization (#354, CWE-287): preferred_username is chosen at the
+        // identity provider, so a login with a foreign sub and a victim's name as preferred_username
+        // must NOT be handed the account the legacy name-keyed entry points at while adoption is off.
+        // The entry stays untouched: no migration, no link under the attacker's sub.
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "alice", allowExistingAccountLink: false));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["alice"]); // the legacy entry is untouched
+        Assert.False(links.ContainsKey("attacker-sub"));
+
+        // The operator breadcrumb: after an upgrade from a username-keyed version, this warning is
+        // what separates "migration pending — enable AllowExistingAccountLink" from an ordinary
+        // name-taken refusal in a wall of 403s.
+        Assert.Contains(log.Entries, e =>
+            e.Level == Microsoft.Extensions.Logging.LogLevel.Warning
+            && e.Message.Contains("legacy username-keyed link exists", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LegacyLinkAdoptionDisabledAndNameFree_CreatesNewInsteadOfFollowingIt()
+    {
+        // With adoption off and no live account under the login's name (e.g. the linked user was
+        // renamed), the ignored legacy entry must not resolve either: the login provisions a fresh
+        // account and the foreign entry survives for its real owner to migrate later (#354).
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("renamed-alice", Existing));
+        users.GetUserByName("alice").Returns((User?)null);
+        var created = UserNamed("alice", Other);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Other, resolved);
+        await users.Received(1).CreateUserAsync("alice");
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["alice"]); // the legacy entry is untouched
+        Assert.Equal(Other, links["attacker-sub"]); // the fresh account is linked under the login's own sub
+    }
+
+    [Fact]
     public void RemoveUserEverywhere_RemovesTheUsersLinksAcrossAllProviders_AndCountsThem()
     {
-        var (service, cfg, _) = Build(c =>
+        var (service, cfg, _, _) = Build(c =>
         {
             c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
             c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -156,12 +156,13 @@ public class CanonicalLinkServiceTests
         Assert.Equal(Existing, links["alice"]); // the legacy entry is untouched
         Assert.False(links.ContainsKey("attacker-sub"));
 
-        // The operator breadcrumb: after an upgrade from a username-keyed version, this warning is
-        // what separates "migration pending — enable AllowExistingAccountLink" from an ordinary
-        // name-taken refusal in a wall of 403s.
-        Assert.Contains(log.Entries, e =>
-            e.Level == Microsoft.Extensions.Logging.LogLevel.Warning
-            && e.Message.Contains("legacy username-keyed link exists", StringComparison.Ordinal));
+        // The operator breadcrumb, emitted at the terminal refusal (not pre-gate): it marks this 403
+        // as a migratable pending-legacy-link case, distinct from an ordinary name collision. Exactly
+        // one warning fires for the reject path (no pre-gate double-log).
+        var warnings = log.Entries.FindAll(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+        Assert.Single(warnings);
+        Assert.Contains("legacy username-keyed link", warnings[0].Message, StringComparison.Ordinal);
+        Assert.Contains("refused", warnings[0].Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -170,7 +171,7 @@ public class CanonicalLinkServiceTests
         // With adoption off and no live account under the login's name (e.g. the linked user was
         // renamed), the ignored legacy entry must not resolve either: the login provisions a fresh
         // account and the foreign entry survives for its real owner to migrate later (#354).
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
@@ -187,6 +188,14 @@ public class CanonicalLinkServiceTests
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
         Assert.Equal(Existing, links["alice"]); // the legacy entry is untouched
         Assert.Equal(Other, links["attacker-sub"]); // the fresh account is linked under the login's own sub
+
+        // CR#1 on #358: this is a SUCCESSFUL login that silently orphans the original account, so it
+        // must emit its own accurate warning (not mislabeled "refused"). Exactly one warning, naming
+        // the orphaning.
+        var warnings = log.Entries.FindAll(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+        Assert.Single(warnings);
+        Assert.Contains("orphaned", warnings[0].Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("refused", warnings[0].Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -190,6 +190,49 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_FlagOnRenamedLegacyOwner_HandsOutTheRecordedAccount()
+    {
+        // Characterization of the flag-ON residual (#361, surfaced on #358): the legacy arm resolves
+        // the RECORDED name key even when no live account bears that name anymore (the owner was
+        // renamed), a strict superset of same-name adoption — so during an enable-the-flag migration
+        // window, a login presenting a foreign sub and the pre-rename name is handed the account and
+        // re-keys it. This pins the current behavior empirically; the #361 fix will flip it.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("newname", Existing));
+        users.GetUserByName("oldname").Returns((User?)null); // renamed: no live account bears the key
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
+
+        Assert.Equal(Existing, resolved);
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["attacker-sub"]); // re-keyed to the presented sub
+        Assert.False(links.ContainsKey("oldname"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_SubFallbackShape_NeverEngagesTheLegacyArm()
+    {
+        // The opaque-sub / sub-fallback provider shape (e.g. Google without preferred_username):
+        // the username IS the sub, so canonicalKey == username, the inequality guard keeps the
+        // legacy arm structurally dormant, and the link resolves subject-keyed with no migration —
+        // independent of AllowExistingAccountLink, proving no name trust is involved.
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["opaque-sub-123"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "opaque-sub-123", "opaque-sub-123", allowExistingAccountLink: false);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["opaque-sub-123"]); // untouched, not re-keyed
+        Assert.DoesNotContain(log.Entries, e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+    }
+
+    [Fact]
     public void RemoveUserEverywhere_RemovesTheUsersLinksAcrossAllProviders_AndCountsThem()
     {
         var (service, cfg, _, _) = Build(c =>

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -92,22 +92,30 @@ internal static class AccountLinkResolver
     /// The user id linked under the legacy username key, if that link exists and its user still exists.
     /// Pass <c>null</c> when the subject and username are identical (there is nothing to migrate).
     /// </param>
+    /// <param name="allowExistingAccountLink">
+    /// Whether the provider permits matching an account by its mutable name. The legacy key IS the
+    /// mutable username, so following it hands the login an account selected by a name the identity
+    /// provider controls — the exact trust this flag governs for same-named account adoption (#354,
+    /// CWE-287). With the flag off the legacy link is ignored and the login falls through to the
+    /// name-adoption gate, which fails closed.
+    /// </param>
     /// <returns>
     /// The linked user id (or null when neither link resolves), and whether the legacy link must be
     /// re-keyed to the subject. Migration is requested only when there is no subject-keyed link yet but
-    /// a legacy one resolves — a one-time, idempotent hand-off: once re-keyed, later logins hit the
-    /// subject key directly and never consult the name again.
+    /// a legacy one resolves and name-based matching is permitted — a one-time, idempotent hand-off:
+    /// once re-keyed, later logins hit the subject key directly and never consult the name again.
     /// </returns>
     internal static (Guid? LinkedUserId, bool MigrateLegacy) ResolveCanonicalLink(
         Guid? subjectKeyedUserId,
-        Guid? legacyNameKeyedUserId)
+        Guid? legacyNameKeyedUserId,
+        bool allowExistingAccountLink)
     {
         if (subjectKeyedUserId.HasValue)
         {
             return (subjectKeyedUserId.Value, false);
         }
 
-        if (legacyNameKeyedUserId.HasValue)
+        if (legacyNameKeyedUserId.HasValue && allowExistingAccountLink)
         {
             return (legacyNameKeyedUserId.Value, true);
         }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -138,12 +138,12 @@ internal sealed class CanonicalLinkService
                     // the upgrade runbook in providers.md.
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is off and no live account bears the name, so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints (or enable AllowExistingAccountLink before the next login).",
-                        username.ReplaceLineEndings(string.Empty),
+                        username?.ReplaceLineEndings(string.Empty),
                         mode,
                         provider?.ReplaceLineEndings(string.Empty));
                 }
 
-                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
+                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username?.ReplaceLineEndings(string.Empty));
                 var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
                 user.AuthenticationProviderId = typeof(SSOController).FullName;
                 // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
@@ -164,7 +164,7 @@ internal sealed class CanonicalLinkService
                     // ordinary #95 name collision. One line, so the reject path is not double-logged.
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
-                        username.ReplaceLineEndings(string.Empty),
+                        username?.ReplaceLineEndings(string.Empty),
                         mode,
                         provider?.ReplaceLineEndings(string.Empty));
                 }
@@ -172,7 +172,7 @@ internal sealed class CanonicalLinkService
                 {
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                        username.ReplaceLineEndings(string.Empty),
+                        username?.ReplaceLineEndings(string.Empty),
                         mode,
                         provider?.ReplaceLineEndings(string.Empty));
                 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -59,9 +59,12 @@ internal sealed class CanonicalLinkService
 
         // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the
         // mutable username instead; when no subject-keyed link exists yet but a legacy one resolves,
-        // adopt and re-key it — the one login that migrates reuses the exact decision the old
-        // name-keyed lookup would have made, then locks it to the subject so a later provider-side
-        // rename cannot detach it. Only OpenID differs key from name; SAML passes key == name.
+        // adopt and re-key it, locking it to the subject so a later provider-side rename cannot
+        // detach it. Because the legacy key is a name the identity provider controls, following it is
+        // name-based account matching, so it honors AllowExistingAccountLink exactly like same-named
+        // adoption below (#354): with the flag off, a login whose preferred_username points at another
+        // user's entry is refused by the adoption gate instead of being handed that account.
+        // Only OpenID differs key from name; SAML passes key == name.
         // Both candidates are read in ONE pass under the config lock: with separate reads, a
         // concurrent login's migration could commit between them, so this login would see the subject
         // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
@@ -79,12 +82,24 @@ internal sealed class CanonicalLinkService
             return (bySubject, byName);
         });
 
-        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink);
+        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink, allowExistingAccountLink);
         if (migrateLegacy)
         {
             MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
+                mode,
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+        else if (legacyLink.HasValue)
+        {
+            // The legacy candidate only survives to here un-migrated when the flag is off (#354).
+            // After an upgrade from a username-keyed version this line is the one breadcrumb that
+            // separates "migration pending — enable AllowExistingAccountLink" from an ordinary
+            // name-taken refusal, so post-upgrade mass-403 triage is one glance, not guesswork.
+            _logger.LogWarning(
+                "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is disabled for this provider; the link is not followed or migrated. Enable AllowExistingAccountLink (or link the account via the admin endpoints) to migrate it.",
+                username.ReplaceLineEndings(string.Empty),
                 mode,
                 provider?.ReplaceLineEndings(string.Empty));
         }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -91,21 +91,16 @@ internal sealed class CanonicalLinkService
                 mode,
                 provider?.ReplaceLineEndings(string.Empty));
         }
-        else if (legacyLink.HasValue)
-        {
-            // The legacy candidate only survives to here un-migrated when the flag is off (#354).
-            // After an upgrade from a username-keyed version this breadcrumb separates "migration
-            // pending — enable AllowExistingAccountLink" from an ordinary name-taken refusal. It is
-            // one line per refused attempt (not deduplicated: a working cross-request throttle would
-            // need process-wide state on this per-request service, which would leak across tests), so
-            // during the upgrade window it is a stream, not a single alert — enough to identify who
-            // still needs migrating, but scan it expecting volume.
-            _logger.LogWarning(
-                "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is disabled for this provider; the link is not followed or migrated. Enable AllowExistingAccountLink (or link the account via the admin endpoints) to migrate it.",
-                username.ReplaceLineEndings(string.Empty),
-                mode,
-                provider?.ReplaceLineEndings(string.Empty));
-        }
+
+        // A legacy link that survives here un-migrated (flag off, #354) is not logged at this point:
+        // its terminal outcome decides the right message. It splits into a refusal (the name is still
+        // taken) or a fresh-account creation (the name was freed by a rename), and only the outcome
+        // branch below can label it accurately — the fresh-account case is a SUCCESSFUL login that
+        // silently orphans the original account, not a "refused" one, so a single pre-gate line would
+        // mislabel exactly the event an operator most needs to see. Each terminal branch emits one
+        // line (not deduplicated: a cross-request throttle would need process-wide state on this
+        // per-request service, which would leak across tests), so during an upgrade window it is a
+        // stream — enough to identify who still needs migrating, scanned expecting volume.
 
         // Adoption of a pre-existing unlinked account still matches on the display name.
         Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
@@ -131,6 +126,23 @@ internal sealed class CanonicalLinkService
 
             case AccountLinkAction.CreateNewAccount:
             {
+                if (legacyLink.HasValue)
+                {
+                    // The dangerous, previously-silent case (#354): a legacy username-keyed link exists,
+                    // the flag is off so it was not followed, AND no live account bears the name anymore
+                    // (the account was renamed on the Jellyfin side). We are about to provision a FRESH
+                    // account under this subject, leaving the original — the one the legacy key points at
+                    // — permanently orphaned. This warning is the single observable signal of that
+                    // irreversible outcome; recover by linking the original account to this subject via
+                    // the admin endpoints, or enable AllowExistingAccountLink before the next login. See
+                    // the upgrade runbook in providers.md.
+                    _logger.LogWarning(
+                        "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is off and no live account bears the name, so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints (or enable AllowExistingAccountLink before the next login).",
+                        username.ReplaceLineEndings(string.Empty),
+                        mode,
+                        provider?.ReplaceLineEndings(string.Empty));
+                }
+
                 _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
                 var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
                 user.AuthenticationProviderId = typeof(SSOController).FullName;
@@ -145,11 +157,26 @@ internal sealed class CanonicalLinkService
             }
 
             case AccountLinkAction.RejectNameTaken:
-                _logger.LogWarning(
-                    "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                    username.ReplaceLineEndings(string.Empty),
-                    mode,
-                    provider?.ReplaceLineEndings(string.Empty));
+                if (legacyLink.HasValue)
+                {
+                    // Refused, but specifically because a legacy username-keyed link (#354) is pending
+                    // and a live account still bears the name — the migratable case, distinct from an
+                    // ordinary #95 name collision. One line, so the reject path is not double-logged.
+                    _logger.LogWarning(
+                        "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
+                        username.ReplaceLineEndings(string.Empty),
+                        mode,
+                        provider?.ReplaceLineEndings(string.Empty));
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
+                        username.ReplaceLineEndings(string.Empty),
+                        mode,
+                        provider?.ReplaceLineEndings(string.Empty));
+                }
+
                 throw new AccountLinkForbiddenException();
 
             default:

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -94,9 +94,12 @@ internal sealed class CanonicalLinkService
         else if (legacyLink.HasValue)
         {
             // The legacy candidate only survives to here un-migrated when the flag is off (#354).
-            // After an upgrade from a username-keyed version this line is the one breadcrumb that
-            // separates "migration pending — enable AllowExistingAccountLink" from an ordinary
-            // name-taken refusal, so post-upgrade mass-403 triage is one glance, not guesswork.
+            // After an upgrade from a username-keyed version this breadcrumb separates "migration
+            // pending — enable AllowExistingAccountLink" from an ordinary name-taken refusal. It is
+            // one line per refused attempt (not deduplicated: a working cross-request throttle would
+            // need process-wide state on this per-request service, which would leak across tests), so
+            // during the upgrade window it is a stream, not a single alert — enough to identify who
+            // still needs migrating, but scan it expecting volume.
             _logger.LogWarning(
                 "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is disabled for this provider; the link is not followed or migrated. Enable AllowExistingAccountLink (or link the account via the admin endpoints) to migrate it.",
                 username.ReplaceLineEndings(string.Empty),

--- a/providers.md
+++ b/providers.md
@@ -75,20 +75,43 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   that mints a _different_ `sub` for the same user on every login (a misconfigured pairwise-subject
   setup) will work exactly once and then be refused — fix the IdP configuration; there is nothing
   safe to anchor the identity to otherwise.
-- **Upgrading from a username-keyed version:** links created by older plugin versions are keyed on
-  the username — and a username is something the identity provider can reassign, so following one is
-  name-based account matching, governed by the same `AllowExistingAccountLink` opt-in as adopting a
-  same-named account. **With the flag enabled**, each user's next login migrates their link to `sub`
-  automatically (matching on the _current_ username; a user renamed at the IdP before upgrading gets
-  a fresh account — the same outcome a rename already had before). **With the flag disabled (the
-  default), legacy links are not followed:** a login whose name matches an existing account is
-  refused (HTTP 403, with a server log line naming the pending legacy link), and a login whose name
-  is free gets a fresh account instead of the old one. So after upgrading, enable
-  `AllowExistingAccountLink` for the provider — temporarily, if you prefer — **before** affected
-  users log in again, or link their accounts explicitly via the admin API; once a user has logged in
-  without it, their fresh `sub`-keyed link wins and the old entry is never migrated. Note that the
-  self-service linking page now lists OpenID links by their `sub` value, which for many providers is
-  an opaque identifier rather than a readable name.
+- **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
+  plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
+  identity provider can reassign, so following such a link is name-based account matching, governed by
+  the same `AllowExistingAccountLink` opt-in as adopting a same-named account. Because 4.0.0.4 keyed
+  **every** OpenID link on the username and predates the flag (it deserializes to `false`), the first
+  build with this change **refuses every OpenID login on a straight upgrade** — with the flag off the
+  legacy link is not followed, so a login whose name still matches its account is refused (HTTP 403)
+  and a login whose name is free gets a fresh, empty account. This is deliberate: with only a `sub` and
+  a mutable `preferred_username` to go on, the plugin cannot tell a returning user from an attacker who
+  set their `preferred_username` to a victim's name, so it fails closed. Plan the migration:
+
+  1. **Keep a break-glass admin that does _not_ depend on SSO.** SSO-provisioned accounts get a random
+     password, so if your only admins sign in through OpenID they will be locked out by the 403 above
+     with no way back in-band. **Before upgrading**, make sure at least one Jellyfin administrator has a
+     normal password login (Dashboard → Users), or you will be left editing config on disk (next point).
+  2. **Fully locked out?** Stop Jellyfin, open the plugin's `config.xml` in its data directory, set
+     `<AllowExistingAccountLink>true</AllowExistingAccountLink>` inside the affected provider's config
+     block, restart, and complete the migration below; then set it back to `false`.
+  3. **Migrate.** The safest route is to link each account explicitly via the admin API
+     (`AddCanonicalLink`) — it needs no name trust. If instead you enable `AllowExistingAccountLink` to
+     let logins self-migrate, treat it as a **maintenance window, not a standing setting**: while it is
+     on, that provider is back to trusting `preferred_username`, so whoever logs in first with a given
+     name claims that account **irreversibly** (an attacker who knows a victim's old username can take it,
+     and the victim is then orphaned). Keep the window short and controlled, migrate your users in it,
+     and turn the flag back off immediately.
+  4. **Users renamed on the Jellyfin side are a special case.** If an account was renamed after its
+     legacy link was created, it is not recoverable by the flag at all: the login lands on a fresh empty
+     account, and once that `sub`-keyed link exists the old entry is never consulted again. Recover such
+     a user by hand — as admin, delete the new empty account's link (`DeleteCanonicalLink`) and
+     `AddCanonicalLink` the original account to the user's current `sub`.
+
+  A server log line (`WARNING`) names each pending legacy link on every refused login, so you can see
+  who still needs migrating. Note that the self-service linking page now lists OpenID links by their
+  `sub` value, which for many providers is an opaque identifier rather than a readable name. If you run
+  the anonymous SSO endpoints with rate limiting available, enable it during the window to blunt an
+  attacker probing names while the flag is on. This runbook is mirrored on the
+  [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) wiki page.
 
 ## Canonical base URL (recommended hardening)
 

--- a/providers.md
+++ b/providers.md
@@ -106,8 +106,11 @@ expiry). A few provider settings must therefore match, or login is refused (fail
      a user by hand — as admin, delete the new empty account's link (`DeleteCanonicalLink`) and
      `AddCanonicalLink` the original account to the user's current `sub`.
 
-  A server log line (`WARNING`) names each pending legacy link on every refused login, so you can see
-  who still needs migrating. Note that the self-service linking page now lists OpenID links by their
+  A server log line (`WARNING`) is emitted for every login that encounters a pending legacy link while
+  the flag is off, naming the account — whether the login is **refused** (a live account still bears
+  the name) or lands on a **fresh account** (the name was freed by a rename, so the original is
+  orphaned; the warning is worded to flag that case explicitly, since no 403 accompanies it). Watch
+  for both so you can see who still needs migrating. Note that the self-service linking page now lists OpenID links by their
   `sub` value, which for many providers is an opaque identifier rather than a readable name. If you run
   the anonymous SSO endpoints with rate limiting available, enable it during the window to blunt an
   attacker probing names while the flag is on. This runbook is mirrored on the

--- a/providers.md
+++ b/providers.md
@@ -75,12 +75,20 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   that mints a _different_ `sub` for the same user on every login (a misconfigured pairwise-subject
   setup) will work exactly once and then be refused — fix the IdP configuration; there is nothing
   safe to anchor the identity to otherwise.
-- **Upgrading from a username-keyed version:** links created by older plugin versions migrate to
-  `sub` automatically on each user's next login. The migration matches on the _current_ username, so
-  a user renamed at the IdP before upgrading cannot be matched to their old link (they get a fresh
-  account — the same outcome a rename already had before). Note that the self-service linking page
-  now lists OpenID links by their `sub` value, which for many providers is an opaque identifier
-  rather than a readable name.
+- **Upgrading from a username-keyed version:** links created by older plugin versions are keyed on
+  the username — and a username is something the identity provider can reassign, so following one is
+  name-based account matching, governed by the same `AllowExistingAccountLink` opt-in as adopting a
+  same-named account. **With the flag enabled**, each user's next login migrates their link to `sub`
+  automatically (matching on the _current_ username; a user renamed at the IdP before upgrading gets
+  a fresh account — the same outcome a rename already had before). **With the flag disabled (the
+  default), legacy links are not followed:** a login whose name matches an existing account is
+  refused (HTTP 403, with a server log line naming the pending legacy link), and a login whose name
+  is free gets a fresh account instead of the old one. So after upgrading, enable
+  `AllowExistingAccountLink` for the provider — temporarily, if you prefer — **before** affected
+  users log in again, or link their accounts explicitly via the admin API; once a user has logged in
+  without it, their fresh `sub`-keyed link wins and the old entry is never migrated. Note that the
+  self-service linking page now lists OpenID links by their `sub` value, which for many providers is
+  an opaque identifier rather than a readable name.
 
 ## Canonical base URL (recommended hardening)
 

--- a/providers.md
+++ b/providers.md
@@ -79,12 +79,14 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
   identity provider can reassign, so following such a link is name-based account matching, governed by
   the same `AllowExistingAccountLink` opt-in as adopting a same-named account. Because 4.0.0.4 keyed
-  **every** OpenID link on the username and predates the flag (it deserializes to `false`), the first
-  build with this change **refuses every OpenID login on a straight upgrade** — with the flag off the
-  legacy link is not followed, so a login whose name still matches its account is refused (HTTP 403)
-  and a login whose name is free gets a fresh, empty account. This is deliberate: with only a `sub` and
-  a mutable `preferred_username` to go on, the plugin cannot tell a returning user from an attacker who
-  set their `preferred_username` to a victim's name, so it fails closed. Plan the migration:
+  **every** OpenID link on the username and predates the flag (it deserializes to `false`), a straight
+  upgrade **breaks OpenID sign-in for your whole userbase** until you migrate — though not identically
+  for everyone: with the flag off the legacy link is not followed, so a user whose name still matches
+  their account is **refused** (HTTP 403), while a user whose name was freed by a rename silently lands
+  on a **fresh, empty account** instead of their own (a successful login, not a 403). Either way no
+  OpenID user reaches their existing account. This is deliberate: with only a `sub` and a mutable
+  `preferred_username` to go on, the plugin cannot tell a returning user from an attacker who set their
+  `preferred_username` to a victim's name, so it fails closed. Plan the migration:
 
   1. **Keep a break-glass admin that does _not_ depend on SSO.** SSO-provisioned accounts get a random
      password, so if your only admins sign in through OpenID they will be locked out by the 403 above
@@ -100,11 +102,20 @@ expiry). A few provider settings must therefore match, or login is refused (fail
      name claims that account **irreversibly** (an attacker who knows a victim's old username can take it,
      and the victim is then orphaned). Keep the window short and controlled, migrate your users in it,
      and turn the flag back off immediately.
-  4. **Users renamed on the Jellyfin side are a special case.** If an account was renamed after its
-     legacy link was created, it is not recoverable by the flag at all: the login lands on a fresh empty
-     account, and once that `sub`-keyed link exists the old entry is never consulted again. Recover such
-     a user by hand — as admin, delete the new empty account's link (`DeleteCanonicalLink`) and
-     `AddCanonicalLink` the original account to the user's current `sub`.
+  4. **Renamed accounts — know which case you have.** A legacy link is keyed on the username _as it
+     was when the link was created_, and enabling the flag matches on that recorded key, not on the
+     account's current display name. Which case you are in decides recovery:
+     - If the account was renamed **on the Jellyfin side** but the identity provider still sends the
+       **original** name, enabling `AllowExistingAccountLink` (step 3) _does_ migrate it — but only
+       through the very same first-login-wins takeover window step 3 describes (an attacker who knows
+       the original name can claim the account first). Treat it exactly like step 3: prefer per-account
+       admin linking, and keep any flag window short and controlled.
+     - It is genuinely **not** recoverable by the flag when the identity provider now sends a
+       **different** name than the legacy key (an IdP-side rename, so the recorded key is never
+       matched), or when the user has **already logged in** without the flag and now sits on a fresh
+       `sub`-keyed account (that link wins and the old entry is never consulted again). For those,
+       recover by hand — as admin, delete the fresh account's link (`DeleteCanonicalLink`) and
+       `AddCanonicalLink` the original account to the user's current `sub`.
 
   A server log line (`WARNING`) is emitted for every login that encounters a pending legacy link while
   the flag is off, naming the account — whether the login is **refused** (a live account still bears


### PR DESCRIPTION
# What & why

Closes #354 (CWE-287). The OpenID legacy-link migration (#155) resolved a login by looking a canonical-links entry up by the **mutable `preferred_username`** and handed the login that user's account **before** the `AllowExistingAccountLink` adoption gate was consulted: an actor who obtains a `preferred_username` equal to a victim's legacy link key was handed the victim's Jellyfin account.

The legacy key IS the mutable username, so following it is name-based account matching, the exact trust `AllowExistingAccountLink` governs for same-named adoption. `AccountLinkResolver.ResolveCanonicalLink` now takes the flag and ignores the legacy candidate when it is off; such a login falls through to the adoption gate, which fails closed (403 when the name is taken, a fresh account when it is free), and nothing is migrated. With the flag on, behavior is unchanged (adopt + one-time re-key to the stable subject). SAML is structurally unaffected (it passes canonical key == username, so the legacy arm never engages).

**Deliberate behavior delta, reviewed for blast radius:** 4.0.0.4 keyed every OpenID link on the username and predates `AllowExistingAccountLink` (deserializes `false`), so upgrading installs see OpenID logins refused until the admin enables the flag (temporarily) or links accounts via the admin endpoints. The genuine legacy user and an attacker presenting the same name are informationally identical, any grandfather path IS the hole, so the gate must hold for both. The trade is operationalized: a dedicated warning log names the pending legacy link (post-upgrade mass-403 triage is one glance), and providers.md replaces the now-false automatic-migration promise with the flag-gated upgrade procedure, including that the flag must be enabled **before** affected users log in again (a fresh subject-keyed link wins from then on).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property: the gate lives in the existing pure resolver.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (661 tests; +7 for the gate matrix, the takeover
      characterization, the untouched foreign entry, the fresh-account path,
      and the operator warning).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

The adversarial review gate ran before this PR (4 lenses, refute-by-default); results are posted as the first comment. Two lens findings were folded in pre-push: the ignored-legacy-link warning log and the providers.md upgrade note. Out of scope: the wiki Security-Model page gets the same upgrade note once this merges (wiki edits are not PR-reviewable), and the release notes for whichever release first ships this must carry the upgrade-impact warning (tracked for /release-prep).
