### PR TITLE
Move the manual link/unlink admin surface into CanonicalLinkService

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
@@ -15,8 +17,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// part of the ordinary test suite, so every PR is checked — a change that drifts from the agreed
 /// structure fails CI. The rules encode structural invariants that hold today and are part of the target;
 /// as each migration step lands a new structural property, add the rule that locks it in here so it
-/// cannot regress. Rules are type-level (reflection over the production assembly); call-level invariants
-/// stay guarded by CodeQL/CodeRabbit and the pinning tests.
+/// cannot regress. Most rules are type-level (reflection over the production assembly); call-level
+/// invariants otherwise stay guarded by CodeQL/CodeRabbit and the pinning tests. The one call-level
+/// property locked in here is a source scan — the controller touches no provider link map except the
+/// server-managed re-injection (<see cref="Controller_TouchesProviderLinkMapsOnlyForServerManagedReinjection"/>) —
+/// because the #372 extraction makes "all link-map access flows through CanonicalLinkService" a boundary
+/// worth failing CI on, not just review.
 /// </summary>
 public class ArchitectureConformanceTests
 {
@@ -142,6 +148,30 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void Controller_TouchesProviderLinkMapsOnlyForServerManagedReinjection()
+    {
+        // Locked in by the link/unlink admin-surface extraction (#372): every read/write of a provider's
+        // CanonicalLinks map now flows through CanonicalLinkService under the config lock. This is a
+        // call-level property, so it is a source scan rather than a reflection rule (the one exception to
+        // the "call-level invariants stay with CodeQL/CodeRabbit" note in the class summary). The single
+        // permitted controller touch is server-managed-field re-injection on the provider add/update
+        // endpoints (#157): `config.CanonicalLinks = existing.CanonicalLinks`, a Config-tier concern that
+        // stays with provider CRUD, not link workflow. Any other `.CanonicalLinks` occurrence in the
+        // controller means link-map access leaked back out of the service.
+        var controllerSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SSOController.cs"));
+        var offending = controllerSource
+            .Select((line, index) => (Text: line, Number: index + 1))
+            .Where(l => l.Text.Contains(".CanonicalLinks", StringComparison.Ordinal))
+            .Where(l => !l.Text.Contains("= existing.CanonicalLinks", StringComparison.Ordinal))
+            .Select(l => $"line {l.Number}: {l.Text.Trim()}")
+            .ToList();
+
+        Assert.True(
+            offending.Count == 0,
+            "SSOController must not access a provider CanonicalLinks map except the server-managed re-injection (= existing.CanonicalLinks); route link-map access through CanonicalLinkService. Found: " + string.Join(" | ", offending));
+    }
+
+    [Fact]
     public void SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade()
     {
         // Locked in by the ProviderConfigStore extraction (#318): SSOPlugin is bootstrap + page
@@ -200,4 +230,10 @@ public class ArchitectureConformanceTests
     private static bool IsCompilerGenerated(Type t) =>
         t.Name.Contains('<', StringComparison.Ordinal)
         || t.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is not null;
+
+    // The repository root, derived from this test file's compile-time path (<root>/SSO-Auth.Tests/<file>).
+    // CallerFilePath is baked in at build, and CI builds on the same checkout it tests, so the source tree
+    // is present for the source-scan rule above.
+    private static string RepoRoot([CallerFilePath] string thisFilePath = "") =>
+        Directory.GetParent(Path.GetDirectoryName(thisFilePath)!)!.FullName;
 }

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -179,9 +179,18 @@ public class ArchitectureConformanceTests
         Assert.True(
             offending.Count == 0,
             "SSOController must not access a provider CanonicalLinks map except the two server-managed re-injection statements; route link-map access through CanonicalLinkService. Found: " + string.Join(" | ", offending));
-        Assert.True(
-            linkMapLines.Count == 2,
-            $"Expected exactly the two server-managed re-injection sites in SSOController; found {linkMapLines.Count}. A removed site should tighten this rule; a new one needs a conscious exemption update.");
+
+        // Assert each permitted statement exists EXACTLY ONCE, not just that two matching lines exist:
+        // otherwise two copies of the OID re-injection would pass while the SAML one was silently dropped,
+        // no longer preserving SAML canonical links. A removed site should tighten this rule (see #383); a
+        // duplicate needs a conscious update.
+        foreach (var expected in allowedReinjection)
+        {
+            var occurrences = linkMapLines.Count(l => string.Equals(l.Text, expected, StringComparison.Ordinal));
+            Assert.True(
+                occurrences == 1,
+                $"Expected exactly one server-managed re-injection statement '{expected}' in SSOController; found {occurrences}.");
+        }
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -153,22 +153,35 @@ public class ArchitectureConformanceTests
         // Locked in by the link/unlink admin-surface extraction (#372): every read/write of a provider's
         // CanonicalLinks map now flows through CanonicalLinkService under the config lock. This is a
         // call-level property, so it is a source scan rather than a reflection rule (the one exception to
-        // the "call-level invariants stay with CodeQL/CodeRabbit" note in the class summary). The single
-        // permitted controller touch is server-managed-field re-injection on the provider add/update
-        // endpoints (#157): `config.CanonicalLinks = existing.CanonicalLinks`, a Config-tier concern that
-        // stays with provider CRUD, not link workflow. Any other `.CanonicalLinks` occurrence in the
-        // controller means link-map access leaked back out of the service.
+        // the "call-level invariants stay with CodeQL/CodeRabbit" note in the class summary). The only
+        // permitted controller touches are the two server-managed-field re-injection statements on the
+        // provider add/update endpoints (#157), a Config-tier concern that stays with provider CRUD, not
+        // link workflow. The exemption is matched as the WHOLE trimmed statement (not a substring), so an
+        // aliasing line like `var map = existing.CanonicalLinks;` followed by a mutation cannot launder
+        // itself past the scan, and the count is pinned so removing or adding a re-injection site forces a
+        // conscious rule update. #383 will retire these two lines into ServerManagedFields.Preserve, after
+        // which this rule tightens to zero occurrences and drops the exemption entirely.
+        var allowedReinjection = new[]
+        {
+            "config.CanonicalLinks = existing.CanonicalLinks;",
+            "newConfig.CanonicalLinks = existing.CanonicalLinks;",
+        };
         var controllerSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SSOController.cs"));
-        var offending = controllerSource
-            .Select((line, index) => (Text: line, Number: index + 1))
+        var linkMapLines = controllerSource
+            .Select((line, index) => (Text: line.Trim(), Number: index + 1))
             .Where(l => l.Text.Contains(".CanonicalLinks", StringComparison.Ordinal))
-            .Where(l => !l.Text.Contains("= existing.CanonicalLinks", StringComparison.Ordinal))
-            .Select(l => $"line {l.Number}: {l.Text.Trim()}")
+            .ToList();
+        var offending = linkMapLines
+            .Where(l => !allowedReinjection.Contains(l.Text, StringComparer.Ordinal))
+            .Select(l => $"line {l.Number}: {l.Text}")
             .ToList();
 
         Assert.True(
             offending.Count == 0,
-            "SSOController must not access a provider CanonicalLinks map except the server-managed re-injection (= existing.CanonicalLinks); route link-map access through CanonicalLinkService. Found: " + string.Join(" | ", offending));
+            "SSOController must not access a provider CanonicalLinks map except the two server-managed re-injection statements; route link-map access through CanonicalLinkService. Found: " + string.Join(" | ", offending));
+        Assert.True(
+            linkMapLines.Count == 2,
+            $"Expected exactly the two server-managed re-injection sites in SSOController; found {linkMapLines.Count}. A removed site should tighten this rule; a new one needs a conscious exemption update.");
     }
 
     [Fact]
@@ -229,7 +242,7 @@ public class ArchitectureConformanceTests
 
     private static bool IsCompilerGenerated(Type t) =>
         t.Name.Contains('<', StringComparison.Ordinal)
-        || t.GetCustomAttribute<System.Runtime.CompilerServices.CompilerGeneratedAttribute>() is not null;
+        || t.GetCustomAttribute<CompilerGeneratedAttribute>() is not null;
 
     // The repository root, derived from this test file's compile-time path (<root>/SSO-Auth.Tests/<file>).
     // CallerFilePath is baked in at build, and CI builds on the same checkout it tests, so the source tree

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -241,6 +241,22 @@ public class CanonicalLinkServiceTests
         Assert.DoesNotContain(log.Entries, e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
     }
 
+    [Fact]
+    public async Task ResolveOrCreateAsync_ProviderDeletedMidLogin_FailsClosedWithoutCreating()
+    {
+        // TOCTOU (#373 review): the controller resolves the provider, then this runs. If an admin
+        // deletes the provider in that window, the links map is absent — the login must fail CLOSED
+        // (refuse), never fall through to the adoption gate whose create/adopt arms would mint a
+        // session for a provider that no longer exists.
+        var (service, _, users, _) = Build(); // no provider configured
+        users.GetUserByName("alice").Returns((User?)null); // name is free -> the create arm would fire
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "deleted-provider", "sub-1", "alice", allowExistingAccountLink: true));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
     // --- Admin surface: TryCreateLink / TryRemoveLink / LinksByUser (#372, finishing #241) ---
 
     [Fact]
@@ -339,9 +355,9 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
-    public void LinksByUser_ReturnsOnlyTheUsersKeys_PerProvider()
+    public void LinksByUser_ReturnsOnlyTheUsersKeys_PerProvider_AsADetachedSnapshot()
     {
-        var (service, _, _, _) = Build(c =>
+        var (service, cfg, _, _) = Build(c =>
         {
             c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
             c.OidConfigs["authelia"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-3"] = Existing } };
@@ -353,6 +369,12 @@ public class CanonicalLinkServiceTests
         Assert.Equal(new[] { "sub-1" }, oid["kc"]); // the other user's sub-2 is excluded
         Assert.Equal(new[] { "sub-3" }, oid["authelia"]);
         Assert.DoesNotContain("adfs", oid.Keys); // SAML provider is not in the OID projection
+
+        // The projection is materialized (ToList, #157/F-10), not a deferred query over the live map:
+        // a subsequent write to the source must not appear in the already-returned result, or a JSON
+        // serialization could enumerate the live dictionary and tear against a concurrent login.
+        cfg.OidConfigs["kc"].CanonicalLinks["sub-9"] = Existing;
+        Assert.Equal(new[] { "sub-1" }, oid["kc"]);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -257,6 +257,40 @@ public class CanonicalLinkServiceTests
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task ResolveOrCreateAsync_ProviderDeletedBetweenReadAndMigrate_FailsClosed()
+    {
+        // The legacy-migration path runs a second transaction (the re-key) after the read that resolved
+        // the candidate. If the provider is deleted in that window, migration must fail CLOSED too, not
+        // no-op and let the already-resolved legacy user through UseExistingLink for a gone provider
+        // (#373). Simulated deterministically: drop the provider right before the migrate transaction.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        // The first store access is the candidate-resolving Read; the second is the migrate Mutate.
+        // Removing the provider on the second access reproduces an admin delete racing the login.
+        var access = 0;
+        var store = new ProviderConfigStore(
+            () =>
+            {
+                if (++access == 2)
+                {
+                    cfg.OidConfigs.Remove("kc");
+                }
+
+                return cfg;
+            },
+            _ => { },
+            new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+    }
+
     // --- Admin surface: TryCreateLink / TryRemoveLink / LinksByUser (#372, finishing #241) ---
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -241,6 +241,120 @@ public class CanonicalLinkServiceTests
         Assert.DoesNotContain(log.Entries, e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
     }
 
+    // --- Admin surface: TryCreateLink / TryRemoveLink / LinksByUser (#372, finishing #241) ---
+
+    [Fact]
+    public void TryCreateLink_KnownProvider_WritesTheLinkAndReturnsCreated()
+    {
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryCreateLink("oid", "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, result);
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryCreateLink_EmptyKey_ReturnsEmptyKey_WithoutWriting(string providerUserId)
+    {
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryCreateLink("oid", "kc", providerUserId, Existing);
+
+        Assert.Equal(CanonicalLinkWriteResult.EmptyKey, result);
+        Assert.Empty(cfg.OidConfigs["kc"].CanonicalLinks);
+    }
+
+    [Fact]
+    public void TryCreateLink_UnknownProvider_ReturnsUnknownProvider()
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryCreateLink("oid", "does-not-exist", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkWriteResult.UnknownProvider, result);
+    }
+
+    [Fact]
+    public void TryCreateLink_EmptyKeyAndUnknownProvider_ReturnsEmptyKey_NotUnknownProvider()
+    {
+        // The two refusals map to DIFFERENT response bodies, so the order is observable: an unresolved
+        // identity is reported as EmptyKey even when the provider is also unknown (the empty-key guard
+        // runs first). Locks the check ordering the controller's distinct 400 bodies depend on.
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryCreateLink("oid", "does-not-exist", "   ", Existing);
+
+        Assert.Equal(CanonicalLinkWriteResult.EmptyKey, result);
+    }
+
+    [Fact]
+    public void TryRemoveLink_OwnLink_RemovesItAndReturnsRemoved()
+    {
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var result = service.TryRemoveLink("oid", "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void TryRemoveLink_UnknownCanonicalName_ReturnsNotFound()
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryRemoveLink("oid", "kc", "does-not-exist", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.NotFound, result);
+    }
+
+    [Fact]
+    public void TryRemoveLink_LinkedToDifferentUser_ReturnsMismatch_WithoutRemoving()
+    {
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var result = service.TryRemoveLink("oid", "kc", "sub-1", Other);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Mismatch, result);
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // untouched
+    }
+
+    [Fact]
+    public void TryRemoveLink_UnknownProvider_ReturnsUnknownProvider()
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+
+        var result = service.TryRemoveLink("oid", "does-not-exist", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
+    }
+
+    [Fact]
+    public void LinksByUser_ReturnsOnlyTheUsersKeys_PerProvider()
+    {
+        var (service, _, _, _) = Build(c =>
+        {
+            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
+            c.OidConfigs["authelia"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-3"] = Existing } };
+            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        });
+
+        var oid = service.LinksByUser("oid", Existing);
+
+        Assert.Equal(new[] { "sub-1" }, oid["kc"]); // the other user's sub-2 is excluded
+        Assert.Equal(new[] { "sub-3" }, oid["authelia"]);
+        Assert.DoesNotContain("adfs", oid.Keys); // SAML provider is not in the OID projection
+    }
+
     [Fact]
     public void RemoveUserEverywhere_RemovesTheUsersLinksAcrossAllProviders_AndCountsThem()
     {

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -287,8 +287,14 @@ public class CanonicalLinkServiceTests
             new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
 
-        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+        var ex = await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+
+        // Pin the MIGRATE guard specifically, not just any fail-closed throw: the three login-path guards
+        // carry distinct messages, so if the provider were dropped during the wrong transaction the test
+        // would silently cover a different guard. This asserts the migrate transaction is the one that
+        // refused.
+        Assert.Contains("refusing to migrate the account link", ex.Message, StringComparison.Ordinal);
     }
 
     // --- Admin surface: TryCreateLink / TryRemoveLink / LinksByUser (#372, finishing #241) ---
@@ -355,6 +361,22 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public void TryRemoveLink_SamlOwnLink_RemovesItAndReturnsRemoved()
+    {
+        // The SAML branch of the admin surface (mode "saml") was covered only indirectly; pin it
+        // directly, since TryGetLinks dispatches saml vs oid to different config dictionaries.
+        var (service, cfg, _, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+
+        var result = service.TryRemoveLink("saml", "adfs", "alice", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
+    }
+
+    [Fact]
     public void TryRemoveLink_UnknownCanonicalName_ReturnsNotFound()
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
@@ -409,6 +431,23 @@ public class CanonicalLinkServiceTests
         // serialization could enumerate the live dictionary and tear against a concurrent login.
         cfg.OidConfigs["kc"].CanonicalLinks["sub-9"] = Existing;
         Assert.Equal(new[] { "sub-1" }, oid["kc"]);
+    }
+
+    [Fact]
+    public void LinksByUser_Saml_ReturnsTheUsersKeys_AndExcludesOidProviders()
+    {
+        // The SAML projection (mode "saml") reads the SAML config dictionary, and must not fold in OID
+        // providers — the mirror of the OID test above, pinning the saml branch directly.
+        var (service, _, _, _) = Build(c =>
+        {
+            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing, ["bob"] = Other } };
+            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
+        });
+
+        var saml = service.LinksByUser("saml", Existing);
+
+        Assert.Equal(new[] { "alice" }, saml["adfs"]); // the other user's "bob" is excluded
+        Assert.DoesNotContain("kc", saml.Keys); // OID provider is not in the SAML projection
     }
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -347,6 +347,52 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public void TryCreateLink_ExistingKey_RebindsItToTheNewUser()
+    {
+        // Deliberate admin capability (pinned so the last-writer-wins semantics are not changed by
+        // accident): re-linking an already-linked provider identity to a different Jellyfin user
+        // silently overwrites the prior binding — an admin correcting a mis-link, not a defect.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var result = service.TryCreateLink("oid", "kc", "sub-1", Other);
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, result);
+        Assert.Equal(Other, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // rebound to the new user
+    }
+
+    [Fact]
+    public void TryRemoveLink_NullConfigProvider_FailsClosedAsUnknownProvider()
+    {
+        // A provider stored with a null config object (reachable via #350's null-body add) must be read
+        // as absent, not dereferenced into a 500 — same fail-closed treatment as a missing provider.
+        var (service, _, _, _) = Build(c => c.OidConfigs["broken"] = null);
+
+        var result = service.TryRemoveLink("oid", "broken", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
+    }
+
+    [Fact]
+    public void LinksByUser_SkipsNullConfigProviders_WithoutThrowing()
+    {
+        // The read-side companion to the guard above: a null-valued provider entry is skipped, so listing
+        // a user's links cannot NRE into a 500 on the #350 state.
+        var (service, _, _, _) = Build(c =>
+        {
+            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
+            c.OidConfigs["broken"] = null;
+        });
+
+        var oid = service.LinksByUser("oid", Existing);
+
+        Assert.Equal(new[] { "sub-1" }, oid["kc"]);
+        Assert.DoesNotContain("broken", oid.Keys); // the null-config provider is skipped, not thrown on
+    }
+
+    [Fact]
     public void TryRemoveLink_OwnLink_RemovesItAndReturnsRemoved()
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -364,6 +364,21 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public async Task ResolveOrCreateAsync_NullConfigProvider_FailsClosedWithoutCreating()
+    {
+        // The login-path companion to the admin null-config guards: a provider stored as a null config
+        // object (reachable via #350) must REJECT the login (fail closed), never fall through to the
+        // adoption gate whose create/adopt arms would mint a session for an unusable provider.
+        var (service, _, users, _) = Build(c => c.OidConfigs["broken"] = null);
+        users.GetUserByName("alice").Returns((User?)null); // name is free -> the create arm would fire if it fell through
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "broken", "sub-1", "alice", allowExistingAccountLink: true));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
     public void TryRemoveLink_NullConfigProvider_FailsClosedAsUnknownProvider()
     {
         // A provider stored with a null config object (reachable via #350's null-body add) must be read

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -84,6 +84,19 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedButUnknownProvider_ReturnsBadRequest()
+    {
+        // Delete does no provider pre-check (unlike the link endpoints' #343 disabled-provider guard),
+        // so an unknown provider is the live path through the service's UnknownProvider result. It must
+        // map to the same BadRequest(NoMatchingProviderMessage) the old KeyNotFoundException catch did.
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "does-not-exist", Target, "sub-1");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
     public async Task GetSamlLinksByUser_NonAdminQueryingAnotherUser_Returns403()
     {
         var harness = ForCaller(isAdmin: false, callerId: Other);

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -93,7 +93,9 @@ public class SSOControllerLinkTests
 
         var result = await harness.Controller.DeleteCanonicalLink("oid", "does-not-exist", Target, "sub-1");
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        // Assert the body, not just the type: the UnknownProvider result must keep the exact message the
+        // old KeyNotFoundException catch returned, so the mapping is not silently changed.
+        Assert.Equal("No matching provider found", Assert.IsType<BadRequestObjectResult>(result).Value);
     }
 
     [Fact]

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -7,6 +9,41 @@ using MediaBrowser.Model.Cryptography;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The outcome of a manual link-creation request. Closed by convention (the controller's mapper throws
+/// on an unhandled arm), so a new outcome forces a new mapping rather than a silent fall-through.
+/// </summary>
+internal enum CanonicalLinkWriteResult
+{
+    /// <summary>The link was created.</summary>
+    Created,
+
+    /// <summary>The SSO identity did not resolve a usable key; nothing was written.</summary>
+    EmptyKey,
+
+    /// <summary>No provider of that mode/name exists; nothing was written.</summary>
+    UnknownProvider,
+}
+
+/// <summary>
+/// The outcome of a manual unlink request. Closed by convention (the controller's mapper throws on an
+/// unhandled arm).
+/// </summary>
+internal enum CanonicalLinkRemoveResult
+{
+    /// <summary>The link was removed.</summary>
+    Removed,
+
+    /// <summary>No link is registered for that canonical name.</summary>
+    NotFound,
+
+    /// <summary>A link exists but is registered to a different Jellyfin user; nothing was removed.</summary>
+    Mismatch,
+
+    /// <summary>No provider of that mode/name exists; nothing was removed.</summary>
+    UnknownProvider,
+}
 
 /// <summary>
 /// The account-linking workflow behind the SSO login and admin endpoints: it resolves an SSO identity
@@ -72,12 +109,14 @@ internal sealed class CanonicalLinkService
         // as absent (dangling links are dead, not identities).
         var (subjectLink, legacyLink) = _configStore.Read(configuration =>
         {
-            var links = LinksFor(configuration, mode, provider);
-            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
+            // The login callbacks resolved the provider before calling, so it is present here; the
+            // guarded miss still yields fail-safe nulls, which defer to the name-adoption gate.
+            TryGetLinks(configuration, mode, provider, out var links);
+            Guid? bySubject = links is not null && links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
                 ? s : null;
             Guid? byName = bySubject is null
                 && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
-                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
+                && links is not null && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
                 ? n : (Guid?)null;
             return (bySubject, byName);
         });
@@ -185,6 +224,108 @@ internal sealed class CanonicalLinkService
     }
 
     /// <summary>
+    /// Creates a manual canonical link (admin/self linking) from a provider-side identity to a Jellyfin
+    /// user, under the config lock. HTTP-free: the controller maps the returned result to a response.
+    /// </summary>
+    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="providerUserId">The provider-side identity key (OpenID sub / SAML NameID).</param>
+    /// <param name="jellyfinUserId">The Jellyfin user to link the identity to.</param>
+    /// <returns>The write outcome.</returns>
+    internal CanonicalLinkWriteResult TryCreateLink(string mode, string provider, string providerUserId, Guid jellyfinUserId)
+    {
+        // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
+        // create a link — an empty or whitespace key would persist a dead link no login can ever redeem.
+        // Checked BEFORE the provider lookup so the two refusals keep their distinct response bodies
+        // ("did not resolve an identity" vs "no matching provider"); reordering is observable.
+        if (string.IsNullOrWhiteSpace(providerUserId))
+        {
+            return CanonicalLinkWriteResult.EmptyKey;
+        }
+
+        return _configStore.Mutate(configuration =>
+        {
+            if (!TryGetLinks(configuration, mode, provider, out var links))
+            {
+                return CanonicalLinkWriteResult.UnknownProvider;
+            }
+
+            links[providerUserId] = jellyfinUserId;
+            return CanonicalLinkWriteResult.Created;
+        });
+    }
+
+    /// <summary>
+    /// Removes a manual canonical link, but only when it is registered to the given Jellyfin user, under
+    /// the config lock. HTTP-free: the controller maps the returned result to a response. The find,
+    /// ownership check, and removal are one read-modify-write so they cannot interleave with a concurrent
+    /// write to the same map.
+    /// </summary>
+    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="canonicalName">The provider-side identity key whose link is removed.</param>
+    /// <param name="jellyfinUserId">The Jellyfin user the link must belong to.</param>
+    /// <returns>The remove outcome.</returns>
+    internal CanonicalLinkRemoveResult TryRemoveLink(string mode, string provider, string canonicalName, Guid jellyfinUserId)
+    {
+        // Kept as ONE Mutate (find, ownership check, and remove cannot interleave). A no-result outcome
+        // (UnknownProvider / NotFound / Mismatch) still persists the unchanged config, the uniform
+        // Mutate behavior every no-op write already has (RemoveUserEverywhere of zero, the
+        // LinkCanonicalIfAbsent race loser); the response is identical either way. A read-probe-then-
+        // mutate would avoid the write but reintroduce the resolve/act race this deliberately excludes.
+        return _configStore.Mutate(configuration =>
+        {
+            if (!TryGetLinks(configuration, mode, provider, out var links))
+            {
+                return CanonicalLinkRemoveResult.UnknownProvider;
+            }
+
+            if (!links.TryGetValue(canonicalName, out var linkedId))
+            {
+                return CanonicalLinkRemoveResult.NotFound;
+            }
+
+            if (linkedId != jellyfinUserId)
+            {
+                return CanonicalLinkRemoveResult.Mismatch;
+            }
+
+            links.Remove(canonicalName);
+            return CanonicalLinkRemoveResult.Removed;
+        });
+    }
+
+    /// <summary>
+    /// Projects, for one protocol, a provider -> [canonical keys linked to this user] map, materialized
+    /// under the config lock. Each provider's matches are realized with <c>ToList</c> (#157/F-10) so the
+    /// result is a detached snapshot that cannot tear against a concurrent login writing a link during
+    /// JSON serialization.
+    /// </summary>
+    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="jellyfinUserId">The Jellyfin user whose links are listed.</param>
+    /// <returns>A provider -> link-key-list map.</returns>
+    internal SerializableDictionary<string, IEnumerable<string>> LinksByUser(string mode, Guid jellyfinUserId)
+    {
+        return _configStore.Read(configuration =>
+        {
+            var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
+                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
+                : configuration.OidConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
+
+            var mappings = new SerializableDictionary<string, IEnumerable<string>>();
+            foreach (var provider in providerList)
+            {
+                mappings[provider.Key] = provider.Value
+                    .Where(link => link.Value == jellyfinUserId)
+                    .Select(link => link.Key)
+                    .ToList();
+            }
+
+            return mappings;
+        });
+    }
+
+    /// <summary>
     /// Removes every canonical link pointing at the given user across all SAML and OpenID providers, so
     /// an SSO login no longer resolves to the account. Runs under the config lock and returns the number
     /// of links removed.
@@ -220,7 +361,13 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Mutate(configuration =>
         {
-            var links = LinksFor(configuration, mode, provider);
+            // The login path resolved the provider before reaching here; a guarded miss is fail-safe —
+            // write nothing and report the candidate as effective without persisting a link.
+            if (!TryGetLinks(configuration, mode, provider, out var links))
+            {
+                return (candidateUserId, false);
+            }
+
             Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null
                 ? current
                 : (Guid?)null;
@@ -243,8 +390,10 @@ internal sealed class CanonicalLinkService
     {
         _configStore.Mutate(configuration =>
         {
-            var links = LinksFor(configuration, mode, provider);
-            if (links.TryGetValue(oldKey, out var userId)
+            // An unknown provider here is a no-op (impossible in practice: the login path resolved the
+            // provider before migrating) — the correct fail-closed choice rather than a throw.
+            if (TryGetLinks(configuration, mode, provider, out var links)
+                && links.TryGetValue(oldKey, out var userId)
                 && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
             {
                 links.Remove(oldKey);
@@ -253,18 +402,33 @@ internal sealed class CanonicalLinkService
         });
     }
 
-    // The provider's canonical-links map; callers must hold the config lock (Read / Mutate) while
-    // touching it. The map is self-healing (CanonicalLinks lazily creates and stores it), so mutating
-    // the returned map persists directly. The provider is always present on the paths that reach here
-    // (the login callbacks resolved it first); a guarded accessor for the reachable-unknown-provider
-    // admin paths, finishing the #241 KeyNotFoundException removal, lands with those endpoints.
-    private static SerializableDictionary<string, Guid> LinksFor(PluginConfiguration configuration, string mode, string provider)
+    // The provider's canonical-links map via TryGetValue rather than the throwing indexer, so an unknown
+    // provider on the reachable admin link/unlink paths is a false return the caller maps to
+    // UnknownProvider — finishing the #241 removal of KeyNotFoundException-as-control-flow. Returns true
+    // and the map when the provider exists; false with a null map when it does not. The map is
+    // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
+    // directly; callers must hold the config lock (Read / Mutate) while touching it. An invalid mode is a
+    // programming error (the endpoints dispatch on it) rather than an unknown provider, so it throws.
+    private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, out SerializableDictionary<string, Guid> links)
     {
-        return mode.ToLowerInvariant() switch
+        switch (mode.ToLowerInvariant())
         {
-            "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
-            "oid" => configuration.OidConfigs[provider].CanonicalLinks,
-            _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
-        };
+            case "saml":
+            {
+                var ok = configuration.SamlConfigs.TryGetValue(provider, out var config);
+                links = config?.CanonicalLinks;
+                return ok;
+            }
+
+            case "oid":
+            {
+                var ok = configuration.OidConfigs.TryGetValue(provider, out var config);
+                links = config?.CanonicalLinks;
+                return ok;
+            }
+
+            default:
+                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
+        }
     }
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -318,9 +318,12 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Read(configuration =>
         {
+            // A provider stored with a null config object (reachable today via #350's null-body add)
+            // is skipped rather than dereferenced — same fail-closed treatment TryGetLinks gives it,
+            // so the read side cannot NRE into a 500 on a state the write side can produce.
             var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
-                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
-                : configuration.OidConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
+                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
+                : configuration.OidConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
 
             var mappings = new SerializableDictionary<string, IEnumerable<string>>();
             foreach (var provider in providerList)
@@ -347,14 +350,23 @@ internal sealed class CanonicalLinkService
         return _configStore.Mutate(configuration =>
         {
             int removed = 0;
+
+            // Skip a provider stored with a null config object (reachable via #350); it holds no links to
+            // revoke, and dereferencing it would NRE into a 500 — the same fail-closed skip TryGetLinks uses.
             foreach (var config in configuration.SamlConfigs.Values)
             {
-                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+                if (config?.CanonicalLinks is { } links)
+                {
+                    removed += CanonicalLinkRevoker.RemoveUser(links, userId);
+                }
             }
 
             foreach (var config in configuration.OidConfigs.Values)
             {
-                removed += CanonicalLinkRevoker.RemoveUser(config.CanonicalLinks, userId);
+                if (config?.CanonicalLinks is { } links)
+                {
+                    removed += CanonicalLinkRevoker.RemoveUser(links, userId);
+                }
             }
 
             return removed;
@@ -410,10 +422,9 @@ internal sealed class CanonicalLinkService
                 throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to migrate the account link.");
             }
 
-            // A no-op here is the GOOD idempotent case (the provider still exists): oldKey is already
-            // gone because a concurrent login migrated first, or newKey is live. Never overwrite a live
-            // newKey — only a dangling one (its target user deleted), which would otherwise block the
-            // hand-off on every subsequent login.
+            // A no-op here (unlike the throwing miss above) is the GOOD idempotent case: the provider
+            // still exists but oldKey was already re-keyed by a concurrent login, or newKey is live. The
+            // never-overwrite-a-live-newKey rule is on the method summary.
             if (links.TryGetValue(oldKey, out var userId)
                 && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
             {
@@ -427,13 +438,13 @@ internal sealed class CanonicalLinkService
     // provider on the reachable admin link/unlink paths is a false return the caller maps to
     // UnknownProvider — finishing the #241 removal of KeyNotFoundException-as-control-flow. Returns true
     // and a non-null map only when the provider exists AND has a config object; a missing provider — or a
-    // null-valued entry from deserialization — returns false, so the caller fails closed (UnknownProvider
-    // on admin paths, a reject on login paths) instead of dereferencing null. The map is self-healing
-    // (CanonicalLinks lazily creates and stores it), so mutating the returned map persists directly;
-    // callers must hold the config lock (Read / Mutate) while touching it. An unrecognized mode is not an
-    // unknown provider but a caller contract violation, so it throws — note the DELETE route forwards mode
-    // unvalidated (unlike the AddCanonicalLink dispatch), so that throw is reachable there; the #318 mode
-    // normalization step is tracked to validate mode once at the HTTP boundary.
+    // null-valued entry (reachable today via the null-body add, #350) — returns false, so the caller fails
+    // closed (UnknownProvider on admin paths, a reject on login paths) instead of dereferencing null. The
+    // map is self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map
+    // persists directly; callers must hold the config lock (Read / Mutate) while touching it. An
+    // unrecognized mode is not an unknown provider but a caller contract violation, so it throws — note the
+    // DELETE route forwards mode unvalidated (unlike the AddCanonicalLink dispatch), so that throw is
+    // reachable there; #369 tracks parsing mode once at the HTTP boundary into an internal enum.
     private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, out SerializableDictionary<string, Guid> links)
     {
         switch (mode.ToLowerInvariant())

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -275,9 +275,13 @@ internal sealed class CanonicalLinkService
     internal CanonicalLinkRemoveResult TryRemoveLink(string mode, string provider, string canonicalName, Guid jellyfinUserId)
     {
         // Kept as ONE Mutate (find, ownership check, and remove cannot interleave). A no-result outcome
-        // (UnknownProvider / NotFound / Mismatch) still persists the unchanged config, the uniform
-        // Mutate behavior every no-op write already has (RemoveUserEverywhere of zero, the
-        // LinkCanonicalIfAbsent race loser); the response is identical either way. A read-probe-then-
+        // still persists the unchanged config. For NotFound / Mismatch that already matched the old
+        // controller code (its mutate callback ran to completion and persisted a no-op); for
+        // UnknownProvider it is a deliberate small delta — the old code threw KeyNotFoundException out of
+        // the callback before the persist, so the unknown-provider DELETE did not write, whereas this
+        // returns UnknownProvider normally and Mutate<T> then persists. The config content and the HTTP
+        // response are byte-identical either way, it is admin-gated, and it adds no new capability (the
+        // valid-provider + bogus-name DELETE already forced the same no-op write). A read-probe-then-
         // mutate would avoid the write but reintroduce the resolve/act race this deliberately excludes.
         return _configStore.Mutate(configuration =>
         {
@@ -422,10 +426,14 @@ internal sealed class CanonicalLinkService
     // The provider's canonical-links map via TryGetValue rather than the throwing indexer, so an unknown
     // provider on the reachable admin link/unlink paths is a false return the caller maps to
     // UnknownProvider — finishing the #241 removal of KeyNotFoundException-as-control-flow. Returns true
-    // and the map when the provider exists; false with a null map when it does not. The map is
-    // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
-    // directly; callers must hold the config lock (Read / Mutate) while touching it. An invalid mode is a
-    // programming error (the endpoints dispatch on it) rather than an unknown provider, so it throws.
+    // and a non-null map only when the provider exists AND has a config object; a missing provider — or a
+    // null-valued entry from deserialization — returns false, so the caller fails closed (UnknownProvider
+    // on admin paths, a reject on login paths) instead of dereferencing null. The map is self-healing
+    // (CanonicalLinks lazily creates and stores it), so mutating the returned map persists directly;
+    // callers must hold the config lock (Read / Mutate) while touching it. An unrecognized mode is not an
+    // unknown provider but a caller contract violation, so it throws — note the DELETE route forwards mode
+    // unvalidated (unlike the AddCanonicalLink dispatch), so that throw is reachable there; the #318 mode
+    // normalization step is tracked to validate mode once at the HTTP boundary.
     private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, out SerializableDictionary<string, Guid> links)
     {
         switch (mode.ToLowerInvariant())
@@ -434,14 +442,14 @@ internal sealed class CanonicalLinkService
             {
                 var ok = configuration.SamlConfigs.TryGetValue(provider, out var config);
                 links = config?.CanonicalLinks;
-                return ok;
+                return ok && links != null;
             }
 
             case "oid":
             {
                 var ok = configuration.OidConfigs.TryGetValue(provider, out var config);
                 links = config?.CanonicalLinks;
-                return ok;
+                return ok && links != null;
             }
 
             default:

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -322,7 +322,7 @@ internal sealed class CanonicalLinkService
             // is skipped rather than dereferenced — same fail-closed treatment TryGetLinks gives it,
             // so the read side cannot NRE into a 500 on a state the write side can produce.
             var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
-                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
+                ? configuration.SamlConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
                 : configuration.OidConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
 
             var mappings = new SerializableDictionary<string, IEnumerable<string>>();

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -397,10 +397,20 @@ internal sealed class CanonicalLinkService
     {
         _configStore.Mutate(configuration =>
         {
-            // An unknown provider here is a no-op (impossible in practice: the login path resolved the
-            // provider before migrating) — the correct fail-closed choice rather than a throw.
-            if (TryGetLinks(configuration, mode, provider, out var links)
-                && links.TryGetValue(oldKey, out var userId)
+            // Migration is a SECOND transaction after the candidate-resolving read. If the provider was
+            // deleted in that window, fail CLOSED: throw rather than no-op, because the caller still
+            // holds the legacy user id from the pre-deletion snapshot and would otherwise return
+            // UseExistingLink, minting a session for a provider that no longer exists (#373).
+            if (!TryGetLinks(configuration, mode, provider, out var links))
+            {
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to migrate the account link.");
+            }
+
+            // A no-op here is the GOOD idempotent case (the provider still exists): oldKey is already
+            // gone because a concurrent login migrated first, or newKey is live. Never overwrite a live
+            // newKey — only a dangling one (its target user deleted), which would otherwise block the
+            // hand-off on every subsequent login.
+            if (links.TryGetValue(oldKey, out var userId)
                 && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
             {
                 links.Remove(oldKey);

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -109,14 +109,20 @@ internal sealed class CanonicalLinkService
         // as absent (dangling links are dead, not identities).
         var (subjectLink, legacyLink) = _configStore.Read(configuration =>
         {
-            // The login callbacks resolved the provider before calling, so it is present here; the
-            // guarded miss still yields fail-safe nulls, which defer to the name-adoption gate.
-            TryGetLinks(configuration, mode, provider, out var links);
-            Guid? bySubject = links is not null && links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
+            // The login callbacks resolve the provider before calling, so it is normally present. If it
+            // was deleted in the race between that lookup and here, fail CLOSED: refuse rather than fall
+            // through to the adoption gate, whose create/adopt arms would otherwise mint a session for a
+            // provider that no longer exists (a missing provider must never default the login to valid).
+            if (!TryGetLinks(configuration, mode, provider, out var links))
+            {
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to resolve or create an account.");
+            }
+
+            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
                 ? s : null;
             Guid? byName = bySubject is null
                 && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
-                && links is not null && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
+                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
                 ? n : (Guid?)null;
             return (bySubject, byName);
         });
@@ -361,11 +367,12 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Mutate(configuration =>
         {
-            // The login path resolved the provider before reaching here; a guarded miss is fail-safe —
-            // write nothing and report the candidate as effective without persisting a link.
+            // The login path resolved the provider before reaching here. If it was deleted in the race
+            // since, fail CLOSED: refuse rather than return a session with no link written. A freshly
+            // created user may be left orphaned, the same benign outcome as the #133 race loser.
             if (!TryGetLinks(configuration, mode, provider, out var links))
             {
-                return (candidateUserId, false);
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to link an account.");
             }
 
             Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1034,13 +1034,14 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
         }
 
-        return _canonicalLinks.TryRemoveLink(mode, provider, canonicalName, jellyfinUserId) switch
+        var removeResult = _canonicalLinks.TryRemoveLink(mode, provider, canonicalName, jellyfinUserId);
+        return removeResult switch
         {
             CanonicalLinkRemoveResult.Removed => Ok(),
             CanonicalLinkRemoveResult.NotFound => NotFound("No SSO link is registered for that canonical name."),
             CanonicalLinkRemoveResult.Mismatch => StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name."),
             CanonicalLinkRemoveResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
-            _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {mode}/{provider}"),
+            _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {removeResult}"),
         };
     }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -985,27 +985,6 @@ public class SSOController : ControllerBase
         return Ok();
     }
 
-    // Applies a mutation to a provider's canonical-links map on the LIVE configuration. The map is
-    // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
-    // directly. Runs inside MutateConfiguration, so the read-modify-write is serialized and concurrent
-    // first-logins cannot lose each other's links.
-    private static void MutateLinks(PluginConfiguration configuration, string mode, string provider, Action<SerializableDictionary<string, Guid>> mutate)
-    {
-        mutate(GetLinks(configuration, mode, provider));
-    }
-
-    // The provider's canonical-links map; callers must hold the config lock (ReadConfiguration /
-    // MutateConfiguration) while touching it.
-    private static SerializableDictionary<string, Guid> GetLinks(PluginConfiguration configuration, string mode, string provider)
-    {
-        return mode.ToLowerInvariant() switch
-        {
-            "saml" => configuration.SamlConfigs[provider].CanonicalLinks,
-            "oid" => configuration.OidConfigs[provider].CanonicalLinks,
-            _ => throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'"),
-        };
-    }
-
     /// <summary>
     /// Create a canonical link for a given user. Must be performed by the user being changed, or admin.
     /// </summary>
@@ -1055,43 +1034,14 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
         }
 
-        var mismatch = false;
-        var found = false;
-        try
+        return _canonicalLinks.TryRemoveLink(mode, provider, canonicalName, jellyfinUserId) switch
         {
-            SSOPlugin.Instance.MutateConfiguration(configuration => MutateLinks(configuration, mode, provider, links =>
-            {
-                if (!links.TryGetValue(canonicalName, out var linkedId))
-                {
-                    return;
-                }
-
-                found = true;
-                if (linkedId != jellyfinUserId)
-                {
-                    mismatch = true;
-                    return;
-                }
-
-                links.Remove(canonicalName);
-            }));
-        }
-        catch (KeyNotFoundException)
-        {
-            return BadRequest(NoMatchingProviderMessage);
-        }
-
-        if (!found)
-        {
-            return NotFound("No SSO link is registered for that canonical name.");
-        }
-
-        if (mismatch)
-        {
-            return StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name.");
-        }
-
-        return Ok();
+            CanonicalLinkRemoveResult.Removed => Ok(),
+            CanonicalLinkRemoveResult.NotFound => NotFound("No SSO link is registered for that canonical name."),
+            CanonicalLinkRemoveResult.Mismatch => StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name."),
+            CanonicalLinkRemoveResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
+            _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {mode}/{provider}"),
+        };
     }
 
     /// <summary>
@@ -1109,7 +1059,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        return BuildLinksByUser("saml", jellyfinUserId);
+        return _canonicalLinks.LinksByUser("saml", jellyfinUserId);
     }
 
     /// <summary>
@@ -1127,32 +1077,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        return BuildLinksByUser("oid", jellyfinUserId);
-    }
-
-    // Builds the provider -> [link keys for this user] map under the config lock, materializing each
-    // provider's matches with ToList (#157/F-10). The previous version assigned a deferred LINQ query
-    // that enumerated the live CanonicalLinks during JSON serialization — outside any lock — which
-    // could tear against a concurrent login writing a link ("collection modified during enumeration").
-    private static SerializableDictionary<string, IEnumerable<string>> BuildLinksByUser(string mode, Guid jellyfinUserId)
-    {
-        return SSOPlugin.Instance.ReadConfiguration(configuration =>
-        {
-            var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
-                ? (IEnumerable<KeyValuePair<string, SerializableDictionary<string, Guid>>>)configuration.SamlConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
-                : configuration.OidConfigs.Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
-
-            var mappings = new SerializableDictionary<string, IEnumerable<string>>();
-            foreach (var provider in providerList)
-            {
-                mappings[provider.Key] = provider.Value
-                    .Where(link => link.Value == jellyfinUserId)
-                    .Select(link => link.Key)
-                    .ToList();
-            }
-
-            return mappings;
-        });
+        return _canonicalLinks.LinksByUser("oid", jellyfinUserId);
     }
 
     // A shallow copy of a provider map, taken under the config lock so the admin list endpoints
@@ -1214,7 +1139,7 @@ public class SSOController : ControllerBase
 
         string providerUserId = samlResponse.GetNameID();
 
-        return CreateCanonicalLink("saml", provider, jellyfinUserId, providerUserId);
+        return MapWrite(_canonicalLinks.TryCreateLink("saml", provider, providerUserId, jellyfinUserId));
     }
 
     /// <summary>
@@ -1256,31 +1181,19 @@ public class SSOController : ControllerBase
 
         // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
         // later provider-side rename does not orphan the link the user just created.
-        return CreateCanonicalLink("oid", provider, jellyfinUserId, redeemed.Subject);
+        return MapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Subject, jellyfinUserId));
     }
 
-    private ActionResult CreateCanonicalLink(string mode, string provider, Guid jellyfinUserId, string providerUserId)
+    // The HTTP boundary for a manual link creation: maps the service's closed write result to a response.
+    // The empty-key and unknown-provider refusals keep distinct bodies (the service checks the empty key
+    // first), and an unhandled result throws rather than silently returning a wrong status.
+    private ActionResult MapWrite(CanonicalLinkWriteResult result) => result switch
     {
-        // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
-        // create a link — a null key would throw inside the config mutation (500), and an empty or
-        // whitespace key would persist a dead link no login can ever redeem.
-        if (string.IsNullOrWhiteSpace(providerUserId))
-        {
-            return BadRequest("The SSO login did not resolve an identity.");
-        }
-
-        try
-        {
-            SSOPlugin.Instance.MutateConfiguration(configuration =>
-                MutateLinks(configuration, mode, provider, links => links[providerUserId] = jellyfinUserId));
-        }
-        catch (KeyNotFoundException)
-        {
-            return BadRequest(NoMatchingProviderMessage);
-        }
-
-        return NoContent();
-    }
+        CanonicalLinkWriteResult.Created => NoContent(),
+        CanonicalLinkWriteResult.EmptyKey => BadRequest("The SSO login did not resolve an identity."),
+        CanonicalLinkWriteResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
+        _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
+    };
 
     /// <summary>
     /// Mints a Jellyfin session for a resolved SSO login: applies the granted permissions and the


### PR DESCRIPTION
# What & why

Closes #372, continues the #318 `CanonicalLinkService` extraction (login-path resolution moved in #353/#358). The manual link/unlink admin surface now lives beside the login-path logic instead of repeating the config-lock plumbing in the controller.

- `TryCreateLink` → closed `CanonicalLinkWriteResult {Created, EmptyKey, UnknownProvider}`; the empty-key #95 guard is checked **before** the provider lookup so the two 400 bodies stay distinct (order pinned).
- `TryRemoveLink` → `CanonicalLinkRemoveResult {Removed, NotFound, Mismatch, UnknownProvider}`, carrying find/ownership/remove in one `_configStore.Mutate`.
- `LinksByUser` → the provider→[keys] projection, keeping the `ToList` no-tear materialization (#157/F-10).
- The controller keeps only the HTTP boundary (`MapWrite`, the remove switch) plus its `AssertCanUpdateUser` authz, the #343 disabled-provider checks, and the #219 replay/state consume ordering. It loses ~120 lines.

**Finishes #241:** the guarded `TryGetLinks` (`TryGetValue`, not the throwing indexer) replaces both remaining `catch (KeyNotFoundException)` control-flow sites (Delete, Create). An unknown provider is an explicit `UnknownProvider` result → the same `BadRequest(NoMatchingProviderMessage)`. Delete has no provider pre-check, so its unknown-provider path is the live reachable one (new controller test).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the empty-key #95 guard and the adoption gate are unchanged; unknown provider still fails closed.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed (4-lens adversarial gate, results below).
- [x] Log inputs from the IdP are sanitized inline at the log call (moved verbatim).

## Quality checklist

- [x] No duplicated logic; the link map access is now one guarded accessor.
- [x] The change adds no more code than the problem requires (controller −~120 lines).
- [x] The code is self-documenting; comments explain the why (the accepted no-op-persist delta, the fail-safe guarded-miss branches).
- [x] Architecture-conformance tests pass; this PR ADDS a structural rule, `Controller_TouchesProviderLinkMapsOnlyForServerManagedReinjection` (source scan) locks the "controller touches no link map" boundary into CI (#383 will tighten it to zero occurrences).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (725; 706 unchanged behavior + 19 new, across two review rounds).
- [x] Prettier: no `.js/.html/.md/.css` changes.

## Notes

Adversarial gate: 3 PASS (bypass, availability, correctness) + 1 NEEDS_IMPROVEMENT (integration) that asked only for an **explicit disposition** of one benign delta, no fix, details in the first comment.

**Accepted delta (documented):** an authorized DELETE for an *unknown provider* now persists the unchanged config, where the old code threw `KeyNotFoundException` before the persist ran. This makes the no-op-delete persistence **uniform**, the existing `NotFound`/`Mismatch` delete arms, `RemoveUserEverywhere`-of-zero, and the `LinkCanonicalIfAbsent` race loser already persist a no-op through `ProviderConfigStore.Mutate<T>`; the old throw-before-persist was the odd one out. Config content is byte-identical, the HTTP response is byte-identical, it is admin-gated (`AssertCanUpdateUser`), and it adds no new DoS lever (a valid-provider + bogus-name DELETE already forced the same write). The alternative (read-probe then mutate) would avoid the write but reintroduce the resolve/act race #363 deliberately excludes, so it is accepted, not fixed. Documented in a code comment on `TryRemoveLink`.


**Review history:** two rounds of independent review. Round 1 → the mechanical fixes + three tracked follow-ups (#380 disabled-provider race, #369 mode→enum, #382 rate-limiting) in `bc77bb7`; round 2 → the conformance-exemption tightening, null-config read consistency, the overwrite-semantics pin, comment/diagnostic cleanup, plus #383 (retire the re-injection duplication) and the #369/#381 consolidation, in `620ffb5`.
