### PR TITLE
Centralize outbound HTTP client creation in SsoHttp

### DIFF
--- a/SSO-Auth.Tests/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/SsoHttpTests.cs
@@ -1,0 +1,27 @@
+using System.Net.Http;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SsoHttp"/> — the single factory for the plugin's outbound HTTP clients (#318).
+/// It must return a factory-pooled client with the plugin User-Agent applied, so every server-to-provider
+/// call is identifiable in one place.
+/// </summary>
+public class SsoHttpTests
+{
+    [Fact]
+    public void CreateClient_AppliesTheUserAgentToTheFactoryClient()
+    {
+        using var pooled = new HttpClient();
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient().Returns(pooled);
+
+        var client = SsoHttp.CreateClient(factory, "Jellyfin-Plugin-SSO-Auth +1.2.3 (https://example.test)");
+
+        Assert.Same(pooled, client); // the factory's client is used, not a fresh one
+        Assert.Contains("Jellyfin-Plugin-SSO-Auth", client.DefaultRequestHeaders.UserAgent.ToString());
+    }
+}

--- a/SSO-Auth.Tests/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/SsoHttpTests.cs
@@ -6,25 +6,28 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for <see cref="SsoHttp"/> — the single factory for the plugin's outbound HTTP clients (#318).
-/// It must return a factory-pooled client with the plugin User-Agent applied, so every server-to-provider
-/// call is identifiable in one place.
+/// Tests for <see cref="SsoHttp"/> — the single home for the plugin's outbound HTTP policy (#318, #378).
+/// <see cref="SsoHttp.CreateClient"/> must return the factory's client (over the factory's pooled handler
+/// stack, not a fresh standalone client) with the plugin User-Agent applied, so every server-to-provider
+/// call is identifiable from one definition.
 /// </summary>
 public class SsoHttpTests
 {
     [Fact]
-    public void CreateClient_AppliesTheUserAgentToTheFactoryClient()
+    public void CreateClient_AppliesThePluginUserAgentToTheFactoryClient()
     {
-        using var pooled = new HttpClient();
+        using var factoryClient = new HttpClient();
         var factory = Substitute.For<IHttpClientFactory>();
-        factory.CreateClient().Returns(pooled);
-        const string userAgent = "Jellyfin-Plugin-SSO-Auth +1.2.3 (https://example.test)";
+        // factory.CreateClient() is the HttpClientFactoryExtensions extension method, which forwards to
+        // the interface's CreateClient(Options.DefaultName) — NSubstitute latches onto that forwarded
+        // interface call, so this Returns covers the parameterless extension too.
+        factory.CreateClient().Returns(factoryClient);
 
-        var client = SsoHttp.CreateClient(factory, userAgent);
+        var client = SsoHttp.CreateClient(factory);
 
-        Assert.Same(pooled, client); // the factory's client is used, not a fresh one
-        // The whole User-Agent must round-trip, not just the product token — a wrong version or URL
-        // would slip past a substring check.
-        Assert.Equal(userAgent, client.DefaultRequestHeaders.UserAgent.ToString());
+        Assert.Same(factoryClient, client); // the factory's client is used, not a fresh one
+        // The whole User-Agent must round-trip against the single-sourced constant — a wrong version or
+        // URL would slip past a substring check.
+        Assert.Equal(SsoHttp.UserAgent, client.DefaultRequestHeaders.UserAgent.ToString());
     }
 }

--- a/SSO-Auth.Tests/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/SsoHttpTests.cs
@@ -18,10 +18,13 @@ public class SsoHttpTests
         using var pooled = new HttpClient();
         var factory = Substitute.For<IHttpClientFactory>();
         factory.CreateClient().Returns(pooled);
+        const string userAgent = "Jellyfin-Plugin-SSO-Auth +1.2.3 (https://example.test)";
 
-        var client = SsoHttp.CreateClient(factory, "Jellyfin-Plugin-SSO-Auth +1.2.3 (https://example.test)");
+        var client = SsoHttp.CreateClient(factory, userAgent);
 
         Assert.Same(pooled, client); // the factory's client is used, not a fresh one
-        Assert.Contains("Jellyfin-Plugin-SSO-Auth", client.DefaultRequestHeaders.UserAgent.ToString());
+        // The whole User-Agent must round-trip, not just the product token — a wrong version or URL
+        // would slip past a substring check.
+        Assert.Equal(userAgent, client.DefaultRequestHeaders.UserAgent.ToString());
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,11 +82,6 @@ public class SSOController : ControllerBase
     // Opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128).
     private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
 
-    // Single canonical User-Agent for the plugin's outbound HTTP (discovery, avatar fetch),
-    // computed once since the assembly version does not change at runtime.
-    private static readonly string UserAgentString =
-        $"Jellyfin-Plugin-SSO-Auth +{System.Diagnostics.FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
     /// </summary>
@@ -119,7 +113,7 @@ public class SSOController : ControllerBase
         _loggerFactory = loggerFactory;
         _httpClientFactory = httpClientFactory;
         _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
-        _avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, UserAgentString);
+        _avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -363,7 +357,7 @@ public class SSOController : ControllerBase
             DisablePushedAuthorization = config.DisablePushedAuthorization,
             LoggerFactory = _loggerFactory,
             LoadProfile = !config.DoNotLoadProfile,
-            HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory, UserAgentString)
+            HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory)
         };
         var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
         options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
@@ -408,7 +402,7 @@ public class SSOController : ControllerBase
 
         try
         {
-            using var client = SsoHttp.CreateClient(_httpClientFactory, UserAgentString);
+            using var client = SsoHttp.CreateClient(_httpClientFactory);
             client.Timeout = TimeSpan.FromSeconds(10);
             var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
             var supported = PkceDiscovery.SupportsS256(json);

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -363,12 +363,7 @@ public class SSOController : ControllerBase
             DisablePushedAuthorization = config.DisablePushedAuthorization,
             LoggerFactory = _loggerFactory,
             LoadProfile = !config.DoNotLoadProfile,
-            HttpClientFactory = o =>
-            {
-                var client = _httpClientFactory.CreateClient();
-                client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
-                return client;
-            }
+            HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory, UserAgentString)
         };
         var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
         options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
@@ -413,9 +408,8 @@ public class SSOController : ControllerBase
 
         try
         {
-            using var client = _httpClientFactory.CreateClient();
+            using var client = SsoHttp.CreateClient(_httpClientFactory, UserAgentString);
             client.Timeout = TimeSpan.FromSeconds(10);
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgentString);
             var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
             var supported = PkceDiscovery.SupportsS256(json);
             PkceSupportCache[discoveryUrl] = (supported, DateTime.UtcNow);

--- a/SSO-Auth/Api/SsoHttp.cs
+++ b/SSO-Auth/Api/SsoHttp.cs
@@ -1,0 +1,25 @@
+using System.Net.Http;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Creates the plugin's outbound HTTP clients from the shared <see cref="IHttpClientFactory"/> with the
+/// plugin's User-Agent applied, so every server-to-provider call (OpenID discovery, the PKCE-support
+/// probe) is identifiable and configured in one place. The SSRF-guarded avatar fetch uses its own
+/// hardened handler and does not go through here.
+/// </summary>
+internal static class SsoHttp
+{
+    /// <summary>
+    /// Returns a pooled <see cref="HttpClient"/> from the factory with the plugin User-Agent set.
+    /// </summary>
+    /// <param name="factory">The shared HTTP client factory.</param>
+    /// <param name="userAgent">The plugin User-Agent header value.</param>
+    /// <returns>A client with the User-Agent applied.</returns>
+    internal static HttpClient CreateClient(IHttpClientFactory factory, string userAgent)
+    {
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+        return client;
+    }
+}

--- a/SSO-Auth/Api/SsoHttp.cs
+++ b/SSO-Auth/Api/SsoHttp.cs
@@ -1,25 +1,33 @@
+using System.Diagnostics;
 using System.Net.Http;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
-/// Creates the plugin's outbound HTTP clients from the shared <see cref="IHttpClientFactory"/> with the
-/// plugin's User-Agent applied, so every server-to-provider call (OpenID discovery, the PKCE-support
-/// probe) is identifiable and configured in one place. The SSRF-guarded avatar fetch uses its own
-/// hardened handler and does not go through here.
+/// The one home for the plugin's outbound HTTP policy: the User-Agent value and the factory-client
+/// creation it is applied to, so every server-to-provider call (OpenID discovery, the PKCE-support
+/// probe) is identifiable and configured in one place. The SSRF-guarded avatar fetch builds its own
+/// hardened handler and does not go through <see cref="CreateClient"/>, but consumes
+/// <see cref="UserAgent"/> so the identity stays single-sourced. Enforced by the opengrep rule
+/// no-raw-outbound-httpclient.
 /// </summary>
 internal static class SsoHttp
 {
     /// <summary>
-    /// Returns a pooled <see cref="HttpClient"/> from the factory with the plugin User-Agent set.
+    /// The plugin's outbound User-Agent: product token, assembly file version, and project URL.
+    /// </summary>
+    internal static readonly string UserAgent =
+        $"Jellyfin-Plugin-SSO-Auth +{FileVersionInfo.GetVersionInfo(typeof(SsoHttp).Assembly.Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
+
+    /// <summary>
+    /// Returns a factory client (over the factory's pooled handler stack) with <see cref="UserAgent"/> applied.
     /// </summary>
     /// <param name="factory">The shared HTTP client factory.</param>
-    /// <param name="userAgent">The plugin User-Agent header value.</param>
-    /// <returns>A client with the User-Agent applied.</returns>
-    internal static HttpClient CreateClient(IHttpClientFactory factory, string userAgent)
+    /// <returns>A client with the plugin User-Agent applied.</returns>
+    internal static HttpClient CreateClient(IHttpClientFactory factory)
     {
         var client = factory.CreateClient();
-        client.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
         return client;
     }
 }

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -124,3 +124,24 @@ rules:
     paths:
       include:
         - "SSO-Auth/**/*.cs"
+
+  # Invariant (architecture, #318/#378 outbound policy): factory-based outbound
+  # HTTP clients are created only through SsoHttp.CreateClient, so the
+  # User-Agent and any future outbound policy (timeouts, headers) stay in one
+  # place. The SSRF-guarded avatar fetch is the documented exception and builds
+  # its own hardened SocketsHttpHandler (it never uses the factory). SsoHttp
+  # itself receives the factory as a parameter named `factory`, so the clean
+  # tree has zero findings for the controller-field pattern below.
+  - id: no-raw-outbound-httpclient
+    languages: [generic]
+    severity: ERROR
+    message: >-
+      Do not create outbound HTTP clients from the factory directly. Go through
+      SsoHttp.CreateClient so the User-Agent and future outbound policy stay in
+      one place (#318, #378). The SSRF-guarded avatar fetch is the documented
+      exception and builds its own hardened handler.
+    patterns:
+      - pattern: _httpClientFactory.CreateClient(...)
+    paths:
+      include:
+        - "SSO-Auth/**/*.cs"


### PR DESCRIPTION
# What & why

Closes #378, continues the #318 belt. The two factory-based outbound calls, the OIDC discovery client (in `CreateOidcClient`) and the PKCE-support probe (`ProviderAdvertisesPkceS256Async`), each created a client and applied the plugin User-Agent inline. `SsoHttp` now owns both the User-Agent **value** (`SsoHttp.UserAgent`, single-sourced from the assembly file version) and its application: `SsoHttp.CreateClient(factory)` is the one way to make a factory-based outbound client, **CI-enforced** by the new opengrep tripwire `no-raw-outbound-httpclient`. The SSRF-guarded avatar fetch keeps its own hardened `SocketsHttpHandler` (documented exception; it never uses the factory) but consumes `SsoHttp.UserAgent`, so the identity has exactly one definition.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no validation/identity logic touched; the discovery/PKCE calls target the admin-configured authority (trusted), not attacker input.
- [x] No secrets logged.
- [x] A security review was performed (focused bypass + correctness gate, results below).
- [x] Log inputs from the IdP are sanitized inline at the log call. (No logging touched.)

## Quality checklist

- [x] No duplicated logic; the CreateClient+User-Agent pattern is now one factory.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the doc comment states the avatar path is excluded.
- [x] Architecture-conformance tests pass; `SsoHttp` is `internal static`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (733 on the rebased base incl. #373/#375; +1 SsoHttp test).
- [x] Prettier: no `.js/.html/.md/.css` changes.

## Notes

Focused gate (bypass + correctness), **both PASS**, empirical: byte-identical client construction (the PKCE `Timeout`/`ParseAdd` reorder is inert, independent property writes before any request), the SSRF-guarded avatar path is untouched and does not route through `SsoHttp`, single correct User-Agent, and the new test is mutation-proven non-vacuous. Full results in the first comment.


---
**Review rounds:** CodeRabbit r1 (exact-UA assertion) fixed in `ccdb667`; team review (opengrep tripwire `no-raw-outbound-httpclient`, UA constant moved into `SsoHttp`, wording/test nits) in `387f3ec`, which also rebases onto current main.

