### PR TITLE
Route server-managed re-injection through ServerManagedFields.Preserve

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -148,49 +148,25 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
-    public void Controller_TouchesProviderLinkMapsOnlyForServerManagedReinjection()
+    public void Controller_NeverTouchesProviderLinkMaps()
     {
-        // Locked in by the link/unlink admin-surface extraction (#372): every read/write of a provider's
-        // CanonicalLinks map now flows through CanonicalLinkService under the config lock. This is a
-        // call-level property, so it is a source scan rather than a reflection rule (the one exception to
-        // the "call-level invariants stay with CodeQL/CodeRabbit" note in the class summary). The only
-        // permitted controller touches are the two server-managed-field re-injection statements on the
-        // provider add/update endpoints (#157), a Config-tier concern that stays with provider CRUD, not
-        // link workflow. The exemption is matched as the WHOLE trimmed statement (not a substring), so an
-        // aliasing line like `var map = existing.CanonicalLinks;` followed by a mutation cannot launder
-        // itself past the scan, and the count is pinned so removing or adding a re-injection site forces a
-        // conscious rule update. #383 will retire these two lines into ServerManagedFields.Preserve, after
-        // which this rule tightens to zero occurrences and drops the exemption entirely.
-        var allowedReinjection = new[]
-        {
-            "config.CanonicalLinks = existing.CanonicalLinks;",
-            "newConfig.CanonicalLinks = existing.CanonicalLinks;",
-        };
+        // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: every read
+        // or write of a provider's CanonicalLinks map flows through CanonicalLinkService under the config
+        // lock, and the two former server-managed re-injection statements now route through the shared
+        // ServerManagedFields.Preserve — so the controller has ZERO direct CanonicalLinks access, and the
+        // earlier re-injection exemption is retired. This is a call-level property, so it is a source scan
+        // rather than a reflection rule (the one exception to the "call-level invariants stay with
+        // CodeQL/CodeRabbit" note in the class summary); a missing source file fails the test loudly.
         var controllerSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SSOController.cs"));
         var linkMapLines = controllerSource
             .Select((line, index) => (Text: line.Trim(), Number: index + 1))
             .Where(l => l.Text.Contains(".CanonicalLinks", StringComparison.Ordinal))
-            .ToList();
-        var offending = linkMapLines
-            .Where(l => !allowedReinjection.Contains(l.Text, StringComparer.Ordinal))
             .Select(l => $"line {l.Number}: {l.Text}")
             .ToList();
 
         Assert.True(
-            offending.Count == 0,
-            "SSOController must not access a provider CanonicalLinks map except the two server-managed re-injection statements; route link-map access through CanonicalLinkService. Found: " + string.Join(" | ", offending));
-
-        // Assert each permitted statement exists EXACTLY ONCE, not just that two matching lines exist:
-        // otherwise two copies of the OID re-injection would pass while the SAML one was silently dropped,
-        // no longer preserving SAML canonical links. A removed site should tighten this rule (see #383); a
-        // duplicate needs a conscious update.
-        foreach (var expected in allowedReinjection)
-        {
-            var occurrences = linkMapLines.Count(l => string.Equals(l.Text, expected, StringComparison.Ordinal));
-            Assert.True(
-                occurrences == 1,
-                $"Expected exactly one server-managed re-injection statement '{expected}' in SSOController; found {occurrences}.");
-        }
+            linkMapLines.Count == 0,
+            "SSOController must not access a provider CanonicalLinks map directly; route link-map access through CanonicalLinkService and server-managed re-injection through ServerManagedFields.Preserve. Found: " + string.Join(" | ", linkMapLines));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -19,11 +19,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// as each migration step lands a new structural property, add the rule that locks it in here so it
 /// cannot regress. Most rules are type-level (reflection over the production assembly); call-level
 /// invariants otherwise stay guarded by CodeQL/CodeRabbit and the pinning tests. The one call-level
-/// property locked in here is a source scan — the controller touches no provider link map at all
-/// (<see cref="Controller_NeverTouchesProviderLinkMaps"/>) — because the #372 extraction makes "all
-/// link-map access flows through CanonicalLinkService" a boundary worth failing CI on, not just review;
-/// #383 retired the last two server-managed re-injection sites into ServerManagedFields.Preserve, so the
-/// scan is now a plain zero-occurrence invariant.
+/// property locked in here is a source scan — the CONTROLLER touches no provider link map directly
+/// (<see cref="Controller_NeverTouchesProviderLinkMaps"/>) — because the #372 extraction confines
+/// link-map access to CanonicalLinkService (the login/admin workflow) and ServerManagedFields.Preserve
+/// (the #157 server-managed re-injection the config tier owns), a boundary worth failing CI on, not just
+/// review; #383 retired the controller's last two inline re-injection sites into that shared Preserve, so
+/// the scan is now a plain zero-occurrence invariant on the controller.
 /// </summary>
 public class ArchitectureConformanceTests
 {
@@ -151,10 +152,11 @@ public class ArchitectureConformanceTests
     [Fact]
     public void Controller_NeverTouchesProviderLinkMaps()
     {
-        // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: every read
-        // or write of a provider's CanonicalLinks map flows through CanonicalLinkService under the config
-        // lock, and the two former server-managed re-injection statements now route through the shared
-        // ServerManagedFields.Preserve — so the controller has ZERO direct CanonicalLinks access, and the
+        // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: the two
+        // legitimate homes for provider-CanonicalLinks access are CanonicalLinkService (the login/admin
+        // link workflow, under the config lock) and ServerManagedFields.Preserve (the #157 re-injection
+        // the config tier owns) — and the controller's two former inline re-injection statements now route
+        // through that shared Preserve, so the CONTROLLER has ZERO direct CanonicalLinks access and the
         // earlier re-injection exemption is retired. This is a call-level property, so it is a source scan
         // rather than a reflection rule (the one exception to the "call-level invariants stay with
         // CodeQL/CodeRabbit" note in the class summary); a missing source file fails the test loudly.

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -19,10 +19,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// as each migration step lands a new structural property, add the rule that locks it in here so it
 /// cannot regress. Most rules are type-level (reflection over the production assembly); call-level
 /// invariants otherwise stay guarded by CodeQL/CodeRabbit and the pinning tests. The one call-level
-/// property locked in here is a source scan — the controller touches no provider link map except the
-/// server-managed re-injection (<see cref="Controller_TouchesProviderLinkMapsOnlyForServerManagedReinjection"/>) —
-/// because the #372 extraction makes "all link-map access flows through CanonicalLinkService" a boundary
-/// worth failing CI on, not just review.
+/// property locked in here is a source scan — the controller touches no provider link map at all
+/// (<see cref="Controller_NeverTouchesProviderLinkMaps"/>) — because the #372 extraction makes "all
+/// link-map access flows through CanonicalLinkService" a boundary worth failing CI on, not just review;
+/// #383 retired the last two server-managed re-injection sites into ServerManagedFields.Preserve, so the
+/// scan is now a plain zero-occurrence invariant.
 /// </summary>
 public class ArchitectureConformanceTests
 {

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -9,9 +9,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// In-process tests of the provider-add endpoints via <see cref="SsoControllerHarness"/>: a valid
-/// config is stored, a malformed base-URL override is rejected fail-closed, a re-save preserves
-/// the server-managed canonical links (#157) that the API body never carries, and a NEW provider
-/// name containing URI-reserved characters is rejected while an existing one stays updatable (#336).
+/// config is stored, a malformed base-URL override is rejected fail-closed, a re-save preserves the
+/// server-managed canonical links (#157) and the write-only OpenID secret (#189 — kept when the provider
+/// identity is unchanged, dropped when the endpoint changes) that the API body never carries, and a NEW
+/// provider name containing URI-reserved characters is rejected while an existing one stays updatable (#336).
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerAddTests
@@ -82,8 +83,12 @@ public class SSOControllerAddTests
 
         harness.Controller.OidAdd("keycloak", new OidConfig { OidSecret = string.Empty, OidEndpoint = "https://attacker.example/", OidClientId = "client-1" });
 
-        var secret = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidSecret);
-        Assert.True(string.IsNullOrEmpty(secret)); // stored secret dropped, not carried to the new endpoint
+        var stored = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"]);
+        // The identity genuinely changed (so the drop is via the ResolveUpdatedSecret identity-change
+        // branch, not the unchanged branch), and the stored secret was dropped, not carried to it — this
+        // arm guards against an always-keep regression (Test 1 covers the links-only/never-keep case).
+        Assert.Equal("https://attacker.example/", stored.OidEndpoint);
+        Assert.True(string.IsNullOrEmpty(stored.OidSecret));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -54,6 +54,39 @@ public class SSOControllerAddTests
     }
 
     [Fact]
+    public void OidAdd_ReSaveWithBlankSecret_UnchangedIdentity_KeepsStoredSecret()
+    {
+        // #189 blank-means-keep at the OidAdd door: a re-save carrying a blank secret (as the write-only
+        // API body does) but the same provider identity keeps the stored secret. Pins the SECRET half of
+        // ServerManagedFields.Preserve at the endpoint — the links half is covered above, but the
+        // zero-occurrence conformance rule (#383) no longer guarantees the Preserve CALL routes the
+        // secret, so a future links-only substitute must fail here rather than silently wipe #189.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] =
+            new OidConfig { OidSecret = "stored-secret", OidEndpoint = "https://idp.example/", OidClientId = "client-1" });
+
+        harness.Controller.OidAdd("keycloak", new OidConfig { OidSecret = string.Empty, OidEndpoint = "https://idp.example/", OidClientId = "client-1" });
+
+        var secret = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidSecret);
+        Assert.Equal("stored-secret", secret);
+    }
+
+    [Fact]
+    public void OidAdd_ReSaveWithBlankSecret_ChangedEndpoint_DropsStoredSecret()
+    {
+        // The #189 exfil guard: a blank secret with a CHANGED endpoint must NOT carry the stored secret
+        // over (it stays blank, failing login closed), so a write-only secret cannot be pulled toward a
+        // different token endpoint. Also pinned at the endpoint now that the conformance rule is
+        // presence-agnostic.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] =
+            new OidConfig { OidSecret = "stored-secret", OidEndpoint = "https://idp.example/", OidClientId = "client-1" });
+
+        harness.Controller.OidAdd("keycloak", new OidConfig { OidSecret = string.Empty, OidEndpoint = "https://attacker.example/", OidClientId = "client-1" });
+
+        var secret = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].OidSecret);
+        Assert.True(string.IsNullOrEmpty(secret)); // stored secret dropped, not carried to the new endpoint
+    }
+
+    [Fact]
     public void SamlAdd_ValidConfig_StoresTheProvider_ReturnsOk()
     {
         var harness = new SsoControllerHarness();

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -503,14 +503,12 @@ public class SSOController : ControllerBase
             var providerExists = configuration.OidConfigs.TryGetValue(provider, out var existing);
             RejectInvalidNewProviderName(provider, providerExists);
 
-            // Re-inject the server-managed fields this API cannot carry: CanonicalLinks is
-            // [JsonIgnore] so the posted config never has them (#157), and the write-only secret
-            // follows the same blank-means-keep rule as the config-page save (#189), centralized in
-            // ResolveUpdatedSecret so both paths agree on rotation and identity-change behavior.
+            // Re-inject the server-managed fields this API cannot carry — CanonicalLinks ([JsonIgnore],
+            // #157) and the write-only secret's blank-means-keep rule (#189) — through the one shared
+            // ServerManagedFields.Preserve the config-page save also uses, so every write path agrees.
             if (config != null && providerExists)
             {
-                config.CanonicalLinks = existing.CanonicalLinks;
-                config.OidSecret = ServerManagedFields.ResolveUpdatedSecret(config, existing);
+                ServerManagedFields.Preserve(config, existing);
             }
 
             configuration.OidConfigs[provider] = config;
@@ -792,12 +790,12 @@ public class SSOController : ControllerBase
             var providerExists = configuration.SamlConfigs.TryGetValue(provider, out var existing);
             RejectInvalidNewProviderName(provider, providerExists);
 
-            // Preserve the server-managed canonical links (#157), as OidAdd does: the posted config
-            // never carries them ([JsonIgnore]), so re-inject the live map before the wholesale
-            // replace so an API save cannot wipe existing account links.
+            // Preserve the server-managed canonical links (#157), as OidAdd does, through the shared
+            // ServerManagedFields.Preserve: the posted config never carries them ([JsonIgnore]), so
+            // re-inject the live map before the wholesale replace so an API save cannot wipe links.
             if (newConfig != null && providerExists)
             {
-                newConfig.CanonicalLinks = existing.CanonicalLinks;
+                ServerManagedFields.Preserve(newConfig, existing);
             }
 
             configuration.SamlConfigs[provider] = newConfig;


### PR DESCRIPTION
# What & why

Closes #383 (from the #373 review, iderex's recommendation). The `OidAdd`/`SamlAdd` endpoints re-injected the server-managed canonical links (and, for OpenID, the write-only secret) with inline statements that duplicated `ServerManagedFields.Preserve` **verbatim**:
- the OID block was exactly `Preserve(OidConfig, OidConfig)`, `CanonicalLinks` + `ResolveUpdatedSecret` (#157/#189);
- the SAML block was exactly `Preserve(SamlConfig, SamlConfig)`, links only.

Both now call the shared `Preserve`, so provider CRUD and the config-page whole-save converge on the one rule. The controller now has **zero** direct provider `CanonicalLinks` access, so the #372 conformance rule tightens from "only the two re-injection statements" to **zero occurrences** and drops its exemption entirely (`Controller_NeverTouchesProviderLinkMaps`).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the write-only-secret blank-means-keep + identity-change-drops-secret rule (#189) is byte-unchanged, it now runs via the same `ResolveUpdatedSecret`, reached through `Preserve`. Argument order (`incoming=config`, `live=existing`) is not swapped.
- [x] No secrets logged.
- [x] A security review was performed (focused correctness + bypass gate, secret-path focus, results below).
- [x] Log inputs from the IdP are sanitized inline at the log call. (No logging touched.)

## Quality checklist

- [x] No duplicated logic; the two inline re-injection blocks are retired into the shared helper.
- [x] The change adds no more code than the problem requires (net negative in the controller).
- [x] The code is self-documenting; the re-injection comments point at `Preserve`.
- [x] Architecture-conformance tests pass, and this PR **tightens** the new structural property it inherits: `Controller_NeverTouchesProviderLinkMaps` now asserts zero occurrences.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (726).
- [x] Prettier: no `.js/.html/.md/.css` changes.

## Notes

Focused gate (correctness + bypass), **both PASS**, empirical and statement-by-statement: the `Preserve` overloads are byte-identical to the inline re-injection including the asymmetric secret argument order (no `incoming`/`live` swap), `ServerManagedFields.cs` is unchanged so the #189 secret logic is byte-for-byte the same, the zero-`.CanonicalLinks` conformance rule is grep-confirmed (the three remaining bare "CanonicalLinks" mentions are dot-less comment prose) and fails closed on a missing source file, and the full 726-test suite is green. Full results in the first comment.
