### PR TITLE
Extract session minting into SessionMinter

### DIFF
--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -64,10 +64,18 @@ public class SessionMinterTests
         // resolution and the mint), so no session may be minted — the throw precedes any AuthenticateDirect.
         var (minter, users, sessions) = Build();
         users.GetUserById(UserId).Returns((User?)null);
+        var resolverInvoked = false;
 
-        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () => "203.0.113.7"));
+        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () =>
+        {
+            resolverInvoked = true;
+            return "203.0.113.7";
+        }));
 
         await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        // The deferred-evaluation contract of the resolver (the reason it is a Func): the fail-closed
+        // path rejects before the controller-supplied HttpContext read would ever happen.
+        Assert.False(resolverInvoked);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct tests of <see cref="SessionMinter"/> — the session-minting flow extracted from the controller
+/// (#318). They pin the fail-closed guard (a login whose resolved account no longer exists mints no
+/// session) and that the controller-supplied remote endpoint reaches the authentication request (the one
+/// behavior this extraction changes: the endpoint is passed in rather than read from HttpContext).
+/// </summary>
+public class SessionMinterTests
+{
+    private static readonly Guid UserId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+    private static (SessionMinter Minter, IUserManager Users, ISessionManager Sessions) Build()
+    {
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        // A real AvatarService (its deps stubbed): with a null AvatarUrl its fetch early-returns, so it is
+        // never reached destructively here.
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        return (minter, users, sessions);
+    }
+
+    private static SessionParameters Params() => new SessionParameters
+    {
+        UserId = UserId,
+        IsAdmin = false,
+        EnableAuthorization = false,
+        EnableAllFolders = false,
+        EnabledFolders = Array.Empty<string>(),
+        EnableLiveTv = false,
+        EnableLiveTvManagement = false,
+        AvatarUrl = null,
+        DefaultProvider = null,
+        AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
+    };
+
+    [Fact]
+    public async Task MintAsync_ResolvedAccountDeleted_ThrowsAndMintsNoSession()
+    {
+        // Fail closed (#318): the account resolved for this login no longer exists (deleted between
+        // resolution and the mint), so no session may be minted — the throw precedes any AuthenticateDirect.
+        var (minter, users, sessions) = Build();
+        users.GetUserById(UserId).Returns((User?)null);
+
+        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), "203.0.113.7"));
+
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+    }
+
+    [Fact]
+    public async Task MintAsync_ResolvedAccount_PassesTheSuppliedRemoteEndPointToTheAuthRequest()
+    {
+        // The extraction's one behavior change: the controller resolves the client IP from HttpContext and
+        // passes it in, so it must land on the AuthenticationRequest unchanged (#177) alongside the user.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+        AuthenticationRequest? captured = null;
+        sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(), "203.0.113.7");
+
+        Assert.NotNull(captured);
+        Assert.Equal("203.0.113.7", captured!.RemoteEndPoint);
+        Assert.Equal(UserId, captured.UserId);
+        Assert.Equal("alice", captured.Username);
+    }
+}

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
@@ -104,10 +103,10 @@ public class SessionMinterTests
             Params(enableAuthorization: true, isAdmin: true, enableAllFolders: false, enabledFolders: new[] { "lib-1" }, enableLiveTv: true, enableLiveTvManagement: true),
             "203.0.113.7");
 
-        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value));
-        Assert.False(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value));
-        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableLiveTvAccess && perm.Value));
-        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableLiveTvManagement && perm.Value));
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value);
+        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value);
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableLiveTvAccess && perm.Value);
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableLiveTvManagement && perm.Value);
     }
 
     [Fact]
@@ -122,7 +121,7 @@ public class SessionMinterTests
 
         await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), "203.0.113.7");
 
-        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value));
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value);
     }
 
     [Fact]
@@ -137,7 +136,7 @@ public class SessionMinterTests
 
         await minter.MintAsync(Params(enableAuthorization: false, isAdmin: true), "203.0.113.7");
 
-        Assert.False(user.Permissions.Any(perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value)); // isAdmin ignored while off
+        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value); // isAdmin ignored while off
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
@@ -33,17 +35,25 @@ public class SessionMinterTests
         return (minter, users, sessions);
     }
 
-    private static SessionParameters Params() => new SessionParameters
+    private static SessionParameters Params(
+        bool enableAuthorization = false,
+        bool isAdmin = false,
+        bool enableAllFolders = false,
+        string[]? enabledFolders = null,
+        bool enableLiveTv = false,
+        bool enableLiveTvManagement = false,
+        string? avatarUrl = null,
+        string? defaultProvider = null) => new SessionParameters
     {
         UserId = UserId,
-        IsAdmin = false,
-        EnableAuthorization = false,
-        EnableAllFolders = false,
-        EnabledFolders = Array.Empty<string>(),
-        EnableLiveTv = false,
-        EnableLiveTvManagement = false,
-        AvatarUrl = null,
-        DefaultProvider = null,
+        IsAdmin = isAdmin,
+        EnableAuthorization = enableAuthorization,
+        EnableAllFolders = enableAllFolders,
+        EnabledFolders = enabledFolders ?? Array.Empty<string>(),
+        EnableLiveTv = enableLiveTv,
+        EnableLiveTvManagement = enableLiveTvManagement,
+        AvatarUrl = avatarUrl,
+        DefaultProvider = defaultProvider,
         AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
     };
 
@@ -77,5 +87,75 @@ public class SessionMinterTests
         Assert.Equal("203.0.113.7", captured!.RemoteEndPoint);
         Assert.Equal(UserId, captured.UserId);
         Assert.Equal("alice", captured.Username);
+    }
+
+    [Fact]
+    public async Task MintAsync_EnableAuthorizationWithRestrictedFolders_AppliesAllRoleGrants()
+    {
+        // #215: with the master switch on, all five role-derived grants are applied — including the two
+        // Live TV grants — and folder access is restricted (!EnableAllFolders), which also writes the
+        // enabled-folder list as a preference.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(
+            Params(enableAuthorization: true, isAdmin: true, enableAllFolders: false, enabledFolders: new[] { "lib-1" }, enableLiveTv: true, enableLiveTvManagement: true),
+            "203.0.113.7");
+
+        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value));
+        Assert.False(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value));
+        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableLiveTvAccess && perm.Value));
+        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableLiveTvManagement && perm.Value));
+    }
+
+    [Fact]
+    public async Task MintAsync_EnableAuthorizationWithAllFolders_GrantsAllFolders_SkippingTheFolderRestriction()
+    {
+        // The other side of the EnableAllFolders branch: all folders granted, so the enabled-folder
+        // preference write is skipped (that path is only for the restricted case above).
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), "203.0.113.7");
+
+        Assert.True(user.Permissions.Any(perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value));
+    }
+
+    [Fact]
+    public async Task MintAsync_NoAuthorization_LeavesPermissionsUntouched()
+    {
+        // With the master switch off, no SSO-driven grant is applied — the account keeps whatever it had
+        // (here, a fresh account with no admin grant). Pins that EnableAuthorization gates the whole block.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: false, isAdmin: true), "203.0.113.7");
+
+        Assert.False(user.Permissions.Any(perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value)); // isAdmin ignored while off
+    }
+
+    [Fact]
+    public async Task MintAsync_DefaultProviderSet_SetsItAndWritesTheUserTwice()
+    {
+        // When a default provider is configured the user's AuthenticationProviderId is set, which the
+        // pre-extraction Authenticate persisted with a SECOND UpdateUserAsync (once after
+        // permissions/avatar, once after the provider id). This pins that verbatim two-write behavior; a
+        // single-write optimization would be an observable change, tracked separately, not folded into the
+        // behavior-preserving extraction.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), "203.0.113.7");
+
+        Assert.Equal("SSO-Auth", user.AuthenticationProviderId);
+        await users.Received(2).UpdateUserAsync(user);
     }
 }

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -64,7 +65,7 @@ public class SessionMinterTests
         var (minter, users, sessions) = Build();
         users.GetUserById(UserId).Returns((User?)null);
 
-        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), "203.0.113.7"));
+        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () => "203.0.113.7"));
 
         await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
     }
@@ -80,7 +81,7 @@ public class SessionMinterTests
         AuthenticationRequest? captured = null;
         sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(), "203.0.113.7");
+        await minter.MintAsync(Params(), () => "203.0.113.7");
 
         Assert.NotNull(captured);
         Assert.Equal("203.0.113.7", captured!.RemoteEndPoint);
@@ -96,17 +97,21 @@ public class SessionMinterTests
         // enabled-folder list as a preference.
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        // Seed the OPPOSITE state so the assertions prove the grant flipped, not just that a fresh user
+        // happens to match: start with all-folders granted and no admin.
+        user.SetPermission(PermissionKind.EnableAllFolders, true);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
         await minter.MintAsync(
             Params(enableAuthorization: true, isAdmin: true, enableAllFolders: false, enabledFolders: new[] { "lib-1" }, enableLiveTv: true, enableLiveTvManagement: true),
-            "203.0.113.7");
+            () => "203.0.113.7");
 
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value);
-        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value);
+        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value); // flipped from the seeded true
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableLiveTvAccess && perm.Value);
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableLiveTvManagement && perm.Value);
+        Assert.Contains(user.Preferences, pref => pref.Kind == PreferenceKind.EnabledFolders); // restricted-folder list written
     }
 
     [Fact]
@@ -116,27 +121,31 @@ public class SessionMinterTests
         // preference write is skipped (that path is only for the restricted case above).
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        user.SetPermission(PermissionKind.EnableAllFolders, false); // seed a restriction, so the grant must flip to true
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), "203.0.113.7");
+        await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), () => "203.0.113.7");
 
-        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value);
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value); // flipped from the seeded restriction
     }
 
     [Fact]
     public async Task MintAsync_NoAuthorization_LeavesPermissionsUntouched()
     {
-        // With the master switch off, no SSO-driven grant is applied — the account keeps whatever it had
-        // (here, a fresh account with no admin grant). Pins that EnableAuthorization gates the whole block.
+        // With the master switch off, the whole permission block is skipped, so an EXISTING grant is left
+        // untouched. Seed admin=true and pass isAdmin=false: if the block wrongly ran it would set admin
+        // to false; a correct skip leaves the seeded admin intact. This pins that EnableAuthorization
+        // gates the block AND that it never touches pre-existing permissions when off.
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        user.SetPermission(PermissionKind.IsAdministrator, true);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(enableAuthorization: false, isAdmin: true), "203.0.113.7");
+        await minter.MintAsync(Params(enableAuthorization: false, isAdmin: false), () => "203.0.113.7");
 
-        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value); // isAdmin ignored while off
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value); // seeded admin left untouched
     }
 
     [Fact]
@@ -152,7 +161,7 @@ public class SessionMinterTests
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), "203.0.113.7");
+        await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), () => "203.0.113.7");
 
         Assert.Equal("SSO-Auth", user.AuthenticationProviderId);
         await users.Received(2).UpdateUserAsync(user);

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -47,7 +47,9 @@ public class SSOController : ControllerBase
     private const string SamlProtocol = "SAML";
 
     private readonly IUserManager _userManager;
-    private readonly ISessionManager _sessionManager;
+    // The session-minting flow (#318): permissions + avatar + default-provider, then AuthenticateDirect.
+    // The controller passes the HttpContext-derived remote endpoint in and keeps no session/avatar field.
+    private readonly SessionMinter _sessionMinter;
     private readonly IAuthorizationContext _authContext;
     private readonly ILogger<SSOController> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -57,8 +59,6 @@ public class SSOController : ControllerBase
     // The account-linking workflow (resolve/adopt/create, legacy re-key, revoke); the controller keeps
     // the authz guards, the one-time-use replay/state consume, and the HTTP mapping (#318).
     private readonly CanonicalLinkService _canonicalLinks;
-    // The SSRF-safe avatar fetch/store (#318); the controller only decides when to invoke it.
-    private readonly AvatarService _avatarService;
     // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal
     // all live inside; see OidcStateStore). One process-wide instance, like the SAML caches below.
     private static readonly OidcStateStore StateStore = new();
@@ -105,7 +105,6 @@ public class SSOController : ControllerBase
         IHttpClientFactory httpClientFactory,
         IServerConfigurationManager serverConfigurationManager)
     {
-        _sessionManager = sessionManager;
         _userManager = userManager;
         _authContext = authContext;
         _cryptoProvider = cryptoProvider;
@@ -113,7 +112,8 @@ public class SSOController : ControllerBase
         _loggerFactory = loggerFactory;
         _httpClientFactory = httpClientFactory;
         _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
-        _avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
+        var avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
+        _sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -1180,67 +1180,11 @@ public class SSOController : ControllerBase
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
 
-    /// <summary>
-    /// Mints a Jellyfin session for a resolved SSO login: applies the granted permissions and the
-    /// optional avatar/default-provider updates to the user, then authenticates the client.
-    /// </summary>
-    /// <param name="parameters">The resolved user, granted privileges, and client identity.</param>
-    private async Task<AuthenticationResult> Authenticate(SessionParameters parameters)
-    {
-        User user = _userManager.GetUserById(parameters.UserId);
-        if (user is null)
-        {
-            // Fail closed: the account resolved for this SSO login no longer exists (e.g. it was
-            // deleted between resolution and this call), so no session may be minted for it.
-            throw new AuthenticationException("SSO authentication aborted: the target user does not exist.");
-        }
-
-        if (parameters.EnableAuthorization)
-        {
-            user.SetPermission(PermissionKind.IsAdministrator, parameters.IsAdmin);
-            user.SetPermission(PermissionKind.EnableAllFolders, parameters.EnableAllFolders);
-            if (!parameters.EnableAllFolders)
-            {
-                user.SetPreference(PreferenceKind.EnabledFolders, parameters.EnabledFolders);
-            }
-
-            // Live TV access/management are role-derived grants too, so they must respect the same
-            // EnableAuthorization master switch. Applied unconditionally they let a provider grant (or
-            // silently toggle) Live TV on every login even when the admin turned SSO permission
-            // management off (#215).
-            user.SetPermission(PermissionKind.EnableLiveTvAccess, parameters.EnableLiveTv);
-            user.SetPermission(PermissionKind.EnableLiveTvManagement, parameters.EnableLiveTvManagement);
-        }
-
-        await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);
-
-        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-
-        var authRequest = new AuthenticationRequest();
-        authRequest.UserId = user.Id;
-        authRequest.Username = user.Username;
-        authRequest.App = parameters.AuthResponse.AppName;
-        authRequest.AppVersion = parameters.AuthResponse.AppVersion;
-        authRequest.DeviceId = parameters.AuthResponse.DeviceID;
-        authRequest.DeviceName = parameters.AuthResponse.DeviceName;
-
-        // Record the client IP so the SSO login shows a source address in Jellyfin's activity log,
-        // exactly as password logins do (#177): use Jellyfin's own GetNormalizedRemoteIP, the very
-        // helper its built-in login path uses. It reads the already-resolved connection address (so
-        // the plugin adds no proxy-trust logic of its own — the server's "Known proxies" setting
-        // governs it) and normalizes it the same way (IPv4-mapped IPv6 collapsed to IPv4), so the
-        // SSO entry's source address matches a password entry's for the same client byte-for-byte.
-        authRequest.RemoteEndPoint = HttpContext.GetNormalizedRemoteIP().ToString();
-        _logger.LogInformation("Auth request created...");
-        if (!string.IsNullOrEmpty(parameters.DefaultProvider))
-        {
-            user.AuthenticationProviderId = parameters.DefaultProvider;
-            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-            _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
-        }
-
-        return await _sessionManager.AuthenticateDirect(authRequest).ConfigureAwait(false);
-    }
+    // The HTTP boundary for session minting: resolve the client's normalized remote IP from HttpContext
+    // (#177 — Jellyfin's own GetNormalizedRemoteIP, so the plugin adds no proxy-trust logic of its own)
+    // and hand it, with the resolved parameters, to the SessionMinter flow.
+    private Task<AuthenticationResult> Authenticate(SessionParameters parameters) =>
+        _sessionMinter.MintAsync(parameters, HttpContext.GetNormalizedRemoteIP().ToString());
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
     // request may proceed, else a 429 carrying Retry-After. Reads the settings under the config

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1180,11 +1180,13 @@ public class SSOController : ControllerBase
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
 
-    // The HTTP boundary for session minting: resolve the client's normalized remote IP from HttpContext
-    // (#177 — Jellyfin's own GetNormalizedRemoteIP, so the plugin adds no proxy-trust logic of its own)
-    // and hand it, with the resolved parameters, to the SessionMinter flow.
+    // The HTTP boundary for session minting: hand the resolved parameters and a resolver for the client's
+    // normalized remote IP (#177 — Jellyfin's own GetNormalizedRemoteIP, so the plugin adds no proxy-trust
+    // logic of its own) to the SessionMinter flow. The resolver is passed rather than the value so the
+    // flow evaluates it at the exact original point (after avatar/persistence, and NOT at all on the
+    // fail-closed deleted-user path) — the pre-extraction Authenticate read it inline there.
     private Task<AuthenticationResult> Authenticate(SessionParameters parameters) =>
-        _sessionMinter.MintAsync(parameters, HttpContext.GetNormalizedRemoteIP().ToString());
+        _sessionMinter.MintAsync(parameters, () => HttpContext.GetNormalizedRemoteIP().ToString());
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
     // request may proceed, else a 429 carrying Retry-After. Reads the settings under the config

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Mints a Jellyfin session for a resolved SSO login: applies the granted permissions and the optional
+/// avatar/default-provider updates to the user, then authenticates the client through
+/// <see cref="ISessionManager"/>. The controller keeps the HTTP boundary and passes the already-normalized
+/// client remote endpoint in, so this flow tier holds no <c>HttpContext</c> dependency.
+/// </summary>
+internal sealed class SessionMinter
+{
+    private readonly IUserManager _userManager;
+    private readonly AvatarService _avatarService;
+    private readonly ISessionManager _sessionManager;
+    private readonly ILogger _logger;
+
+    internal SessionMinter(IUserManager userManager, AvatarService avatarService, ISessionManager sessionManager, ILogger logger)
+    {
+        _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+        _avatarService = avatarService ?? throw new ArgumentNullException(nameof(avatarService));
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Applies the resolved login's permissions/avatar/default-provider to the user and mints a session.
+    /// </summary>
+    /// <param name="parameters">The resolved user, granted privileges, and client identity.</param>
+    /// <param name="remoteEndPoint">The normalized client IP for the activity log (the controller reads it from <c>HttpContext</c>, #177).</param>
+    /// <returns>The authenticated session result.</returns>
+    internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, string remoteEndPoint)
+    {
+        User user = _userManager.GetUserById(parameters.UserId);
+        if (user is null)
+        {
+            // Fail closed: the account resolved for this SSO login no longer exists (e.g. it was
+            // deleted between resolution and this call), so no session may be minted for it.
+            throw new AuthenticationException("SSO authentication aborted: the target user does not exist.");
+        }
+
+        if (parameters.EnableAuthorization)
+        {
+            user.SetPermission(PermissionKind.IsAdministrator, parameters.IsAdmin);
+            user.SetPermission(PermissionKind.EnableAllFolders, parameters.EnableAllFolders);
+            if (!parameters.EnableAllFolders)
+            {
+                user.SetPreference(PreferenceKind.EnabledFolders, parameters.EnabledFolders);
+            }
+
+            // Live TV access/management are role-derived grants too, so they must respect the same
+            // EnableAuthorization master switch. Applied unconditionally they let a provider grant (or
+            // silently toggle) Live TV on every login even when the admin turned SSO permission
+            // management off (#215).
+            user.SetPermission(PermissionKind.EnableLiveTvAccess, parameters.EnableLiveTv);
+            user.SetPermission(PermissionKind.EnableLiveTvManagement, parameters.EnableLiveTvManagement);
+        }
+
+        await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);
+
+        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+
+        var authRequest = new AuthenticationRequest();
+        authRequest.UserId = user.Id;
+        authRequest.Username = user.Username;
+        authRequest.App = parameters.AuthResponse.AppName;
+        authRequest.AppVersion = parameters.AuthResponse.AppVersion;
+        authRequest.DeviceId = parameters.AuthResponse.DeviceID;
+        authRequest.DeviceName = parameters.AuthResponse.DeviceName;
+
+        // Record the client IP so the SSO login shows a source address in Jellyfin's activity log,
+        // exactly as password logins do (#177): the controller resolves it with Jellyfin's own
+        // GetNormalizedRemoteIP, the very helper its built-in login path uses. It reads the
+        // already-resolved connection address (so the plugin adds no proxy-trust logic of its own — the
+        // server's "Known proxies" setting governs it) and normalizes it the same way (IPv4-mapped IPv6
+        // collapsed to IPv4), so the SSO entry's source address matches a password entry's for the same
+        // client byte-for-byte.
+        authRequest.RemoteEndPoint = remoteEndPoint;
+        _logger.LogInformation("Auth request created...");
+        if (!string.IsNullOrEmpty(parameters.DefaultProvider))
+        {
+            user.AuthenticationProviderId = parameters.DefaultProvider;
+            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+            _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
+        }
+
+        return await _sessionManager.AuthenticateDirect(authRequest).ConfigureAwait(false);
+    }
+}

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -35,9 +35,9 @@ internal sealed class SessionMinter
     /// Applies the resolved login's permissions/avatar/default-provider to the user and mints a session.
     /// </summary>
     /// <param name="parameters">The resolved user, granted privileges, and client identity.</param>
-    /// <param name="remoteEndPoint">The normalized client IP for the activity log (the controller reads it from <c>HttpContext</c>, #177).</param>
+    /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (the controller reads it from <c>HttpContext</c>, #177). Invoked at the original point below — after avatar/persistence, and not at all on the fail-closed path — to preserve evaluation order.</param>
     /// <returns>The authenticated session result.</returns>
-    internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, string remoteEndPoint)
+    internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, Func<string> remoteEndPointResolver)
     {
         User user = _userManager.GetUserById(parameters.UserId);
         if (user is null)
@@ -83,7 +83,7 @@ internal sealed class SessionMinter
         // server's "Known proxies" setting governs it) and normalizes it the same way (IPv4-mapped IPv6
         // collapsed to IPv4), so the SSO entry's source address matches a password entry's for the same
         // client byte-for-byte.
-        authRequest.RemoteEndPoint = remoteEndPoint;
+        authRequest.RemoteEndPoint = remoteEndPointResolver();
         _logger.LogInformation("Auth request created...");
         if (!string.IsNullOrEmpty(parameters.DefaultProvider))
         {


### PR DESCRIPTION
# What & why

Closes #389, continues the #318 belt. The controller's private `Authenticate`, the session-minting flow (apply the resolved login's permissions gated by `EnableAuthorization` #215, the optional avatar and default-provider updates, then `ISessionManager.AuthenticateDirect`), moves **verbatim** into a new `SessionMinter` (internal sealed). The one intended change is the `HttpContext` coupling: the controller keeps a thin `Authenticate` wrapper that resolves the normalized remote IP (`GetNormalizedRemoteIP`, #177) and passes it into `MintAsync(parameters, remoteEndPoint)`, so the flow tier holds no `HttpContext`.

- The controller constructs `AvatarService` as a ctor local and hands it to `SessionMinter`; the now-unused `_sessionManager`/`_avatarService` fields are dropped (the ctor still takes both to pass them on). Controller −56 lines.
- Adds the direct tests the guard lacked as a controller private.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the deleted-user guard throws before any permission/avatar/session work; the #215 `EnableAuthorization` gate around all five permission sets and the #177 remote-IP handling move byte-identical.
- [x] No secrets logged.
- [x] A security review was performed (full 4-lens gate, results below).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged).

## Quality checklist

- [x] No duplicated logic; the mint flow is one single-responsibility unit.
- [x] The change adds no more code than the problem requires (controller −56 lines).
- [x] The code is self-documenting; the security "why" comments travel with the code.
- [x] Architecture-conformance tests pass; `SessionMinter` is `internal sealed` (the `FlowServices_AreInternalAndSealed` rule).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (734; +2 SessionMinter tests).
- [x] Prettier: no `.js/.html/.md/.css` changes.

## Notes

Full 4-lens adversarial gate (bypass/correctness/availability/integration), **all PASS**, empirical: `MintAsync` is byte-identical to the old `Authenticate` apart from `RemoteEndPoint = remoteEndPoint`; every check (deleted-user throw, #215 gate over all five sets, avatar-before-UpdateUser ordering, default-provider block, `AuthenticateDirect` last) is preserved and ordered identically; the `AuthenticationException` type is unchanged (`MediaBrowser.Controller.Authentication`, not `System.Security`); the endpoint read is security-neutral (side-effect-free); the two dropped fields have zero remaining references; both new tests are non-vacuous; 734 tests green. Full results in the first comment. **Merge-order note:** this and #379 both touch the ctor's `AvatarService` construction line, whichever merges second needs a trivial rebase.
