### PR TITLE
Write the avatar before touching the user's profile-image record

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
@@ -20,15 +21,21 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// </summary>
 public class AvatarServiceTests
 {
+    private static readonly string UserDataRoot = Path.Combine("data", "users");
+
     private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build()
     {
         var users = Substitute.For<IUserManager>();
         var providers = Substitute.For<IProviderManager>();
         var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
         var log = new CapturingLogger();
         var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0");
         return (service, providers, users, log);
     }
+
+    private static string ProfilePath(string username, string extension)
+        => Path.Combine(UserDataRoot, username, "profile" + extension);
 
     private static User UserNamed(string name) => new User(name, "SSO-Auth", "Default");
 
@@ -58,5 +65,76 @@ public class AvatarServiceTests
         await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
         Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("disallowed URL"));
+    }
+
+    [Fact]
+    public async Task StoreAsync_SaveFails_LeavesThePreviousAvatarUntouched()
+    {
+        // The #377 regression: a transient save failure must not downgrade the user from a working
+        // avatar to a cleared record plus a dangling path — the write comes first, the user last.
+        var (service, providers, users, _) = Build();
+        var user = UserNamed("alice");
+        var previous = new ImageInfo(ProfilePath("alice", ".jpg"));
+        user.ProfileImage = previous;
+        providers.SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromException(new IOException("disk full")));
+
+        await Assert.ThrowsAsync<IOException>(
+            () => service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png"));
+
+        Assert.Same(previous, user.ProfileImage); // record untouched, still the old path
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task StoreAsync_SamePathReLogin_OverwritesInPlaceWithoutClearing()
+    {
+        // The common re-login with the same content type overwrites the same file in place; the
+        // record is already correct, so ClearProfileImageAsync (a DB-row removal) must not run —
+        // it would drop and re-insert the record for nothing. The timestamp refresh is what makes
+        // clients re-fetch the changed image.
+        var (service, providers, users, _) = Build();
+        var user = UserNamed("alice");
+        var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = DateTime.UtcNow.AddDays(-1) };
+        user.ProfileImage = previous;
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        Assert.Same(previous, user.ProfileImage); // record kept, not replaced
+        Assert.True(user.ProfileImage.LastModified > DateTime.UtcNow.AddMinutes(-1)); // cache-busting refresh
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public async Task StoreAsync_ChangedPath_ClearsTheOldImageOnlyAfterTheWrite()
+    {
+        // A changed content type moves the stored path: the old record+file are dropped only once
+        // the new bytes are safely on disk (write -> clear order is the rollback-safety property).
+        var (service, providers, users, _) = Build();
+        var user = UserNamed("alice");
+        user.ProfileImage = new ImageInfo(ProfilePath("alice", ".jpg"));
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        Received.InOrder(() =>
+        {
+            providers.SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+            users.ClearProfileImageAsync(user);
+        });
+        Assert.Equal(ProfilePath("alice", ".png"), user.ProfileImage?.Path);
+    }
+
+    [Fact]
+    public async Task StoreAsync_NoPreviousImage_AssignsWithoutClearing()
+    {
+        var (service, providers, users, _) = Build();
+        var user = UserNamed("alice");
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        Assert.Equal(ProfilePath("alice", ".png"), user.ProfileImage?.Path);
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
     }
 }

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -117,23 +117,58 @@ internal sealed class AvatarService
 
             using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes, timeout.Token).ConfigureAwait(false);
 
-            var userDataPath =
-                Path.Combine(
-                    _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
-                    user.Username);
-            if (user.ProfileImage is not null)
-            {
-                await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
-            }
-
-            user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile" + extension));
-
-            await _providerManager.SaveImage(stream, mediaType, user.ProfileImage.Path)
-                .ConfigureAwait(false);
+            await StoreAsync(user, stream, mediaType, extension).ConfigureAwait(false);
         }
         catch (Exception e)
         {
             _logger.LogError(e, "Failed to fetch or save the SSO avatar.");
+        }
+    }
+
+    /// <summary>
+    /// Writes the fetched avatar to disk and only then updates the user's profile-image reference, so a
+    /// failed save leaves the previous profile-image record intact instead of a cleared record pointing
+    /// at a never-written path (#377). (When the target path is unchanged the host writes the file in
+    /// place, so a mid-write failure can still truncate the bytes — that is ImageSaver's contract, not
+    /// ours to fix.) Throws on save failure; <see cref="TrySetAsync"/>'s best-effort catch owns the logging.
+    /// </summary>
+    /// <param name="user">The user whose profile image is set.</param>
+    /// <param name="image">The fetched avatar bytes.</param>
+    /// <param name="mediaType">The validated image media type.</param>
+    /// <param name="extension">The stored extension resolved from the content-type allow-list.</param>
+    /// <returns>A <see cref="Task"/> that completes when the avatar is stored and the user updated.</returns>
+    internal async Task StoreAsync(User user, Stream image, string mediaType, string extension)
+    {
+        var newPath = Path.Combine(
+            _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
+            user.Username,
+            "profile" + extension);
+
+        // The write comes FIRST: if it throws, nothing below runs, so the user keeps the previous
+        // profile-image record instead of a cleared record plus a dangling path to a file that was
+        // never written.
+        await _providerManager.SaveImage(image, mediaType, newPath).ConfigureAwait(false);
+
+        if (user.ProfileImage is null)
+        {
+            user.ProfileImage = new ImageInfo(newPath);
+        }
+        else if (string.Equals(user.ProfileImage.Path, newPath, StringComparison.Ordinal))
+        {
+            // Same target file (the common same-extension re-login), just overwritten in place: the
+            // record is already correct, so clearing it (which removes only the DB row — the host's
+            // ClearProfileImageAsync does not touch the file) would drop and re-insert it for nothing.
+            // Keep the record and refresh the timestamp so clients re-fetch the changed image.
+            user.ProfileImage.LastModified = DateTime.UtcNow;
+        }
+        else
+        {
+            // The content type (and so the stored path) changed: drop the old RECORD only now that the
+            // new bytes are safely on disk, then point the user at them. The old file stays on disk —
+            // ClearProfileImageAsync removes just the DB row, the same residue Jellyfin's own image
+            // replace leaves behind.
+            await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+            user.ProfileImage = new ImageInfo(newPath);
         }
     }
 


### PR DESCRIPTION
## What & why

A transient avatar save failure used to downgrade the user: `TrySetAsync` cleared the old profile-image record and assigned `ProfileImage` a path **before** `SaveImage` ran, so a throw (swallowed by the best-effort catch) left a cleared record pointing at a file that was never written, persisted by the caller's unconditional `UpdateUserAsync`. Pre-existing behavior, surfaced by review on #375.

The store step is now an internal `StoreAsync`, reordered write-first:

- **Save failure** → the previous profile-image record is left untouched.
- **Same-path re-login** (the common case) → the existing record is kept, the host's `ClearProfileImageAsync` removes only the DB row (verified against the Jellyfin 10.11.11 source), so clearing after an in-place overwrite would drop and re-insert it for nothing, and `LastModified` is refreshed so clients re-fetch.
- **Changed path** → the old record is cleared only after the new bytes are on disk.

Path construction moves verbatim (the missing extension dot is #384). Closes #377.

## Type of change
- [x] Bug fix (data integrity on the login path's avatar step)

## Security checklist
- Fail-closed guards (URL allow-list, SSRF transport, content-type allow-list, size cap) are untouched, this only reorders the store step after all guards passed.
- No new logging of untrusted data; no secrets involved.

## Quality checklist
- Store logic is now unit-testable (`StoreAsync`, InternalsVisibleTo); four state-based tests added, including a `Received.InOrder` check pinning the write-then-clear order and a failure-arm test.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0 warnings, 0 errors. `dotnet test`: **753/753 green**.
- Adversarial review (2 lenses, risk-picked: correctness + integration, both reading the full files and the Jellyfin 10.11.11 package sources):
  - **correctness, PASS**: all four arms verified; every constructed failure/interleaving is equal to or strictly better than the old code's outcome.
  - **integration, NEEDS_IMPROVEMENT → resolved**: the fix itself was confirmed sound, host-contract-safe, and merge-order independent across both callers; the findings were three comments asserting a wrong host contract (`ClearProfileImageAsync` does **not** delete the file in 10.11.11, and the "record and file fully intact" doc overstated the same-path failure guarantee given `ImageSaver`'s in-place `FileMode.Create` write). All three comments corrected; no code change needed.

## Notes
The transient window where a changed-path crash leaves the user avatar-less with an orphan file self-heals on the next login; the in-place partial-overwrite risk on a same-path failure is `ImageSaver`'s contract and existed identically before.
