### PR TITLE
Reject a provider disabled mid-flight on every grant path

### DIFF
--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -40,6 +40,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
@@ -53,7 +54,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public async Task ResolveOrCreateAsync_NoLinkNoAccount_CreatesAndLinksOnTheSubjectKey()
     {
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
         var created = UserNamed("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
@@ -69,7 +70,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
     {
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
@@ -86,7 +87,7 @@ public class CanonicalLinkServiceTests
         // The account-takeover guard (#95): a login whose name matches a pre-existing unlinked account,
         // with adoption off, must be refused — not silently take the account over. No controller test
         // reached this path before the extraction; this pins it directly.
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
@@ -105,7 +106,7 @@ public class CanonicalLinkServiceTests
     {
         // Fail-closed belt (#95/#155): a blank identity key or username must never create, adopt, or
         // look up an account, even if a caller forgets its own guard.
-        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync("oid", "kc", canonicalKey, username, allowExistingAccountLink: true));
@@ -121,6 +122,7 @@ public class CanonicalLinkServiceTests
         // mutable username, so this name-based hand-off requires AllowExistingAccountLink (#354).
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
@@ -143,6 +145,7 @@ public class CanonicalLinkServiceTests
         // The entry stays untouched: no migration, no link under the attacker's sub.
         var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
@@ -173,6 +176,7 @@ public class CanonicalLinkServiceTests
         // account and the foreign entry survives for its real owner to migrate later (#354).
         var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("renamed-alice", Existing));
@@ -208,6 +212,7 @@ public class CanonicalLinkServiceTests
         // re-keys it. This pins the current behavior empirically; the #361 fix will flip it.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("newname", Existing));
@@ -230,6 +235,7 @@ public class CanonicalLinkServiceTests
         // independent of AllowExistingAccountLink, proving no name trust is involved.
         var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["opaque-sub-123"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
@@ -265,7 +271,7 @@ public class CanonicalLinkServiceTests
         // no-op and let the already-resolved legacy user through UseExistingLink for a gone provider
         // (#373). Simulated deterministically: drop the provider right before the migrate transaction.
         var cfg = new PluginConfiguration();
-        cfg.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         var users = Substitute.For<IUserManager>();
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
@@ -302,7 +308,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public void TryCreateLink_KnownProvider_WritesTheLinkAndReturnsCreated()
     {
-        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryCreateLink("oid", "kc", "sub-1", Existing);
 
@@ -315,7 +321,7 @@ public class CanonicalLinkServiceTests
     [InlineData("   ")]
     public void TryCreateLink_EmptyKey_ReturnsEmptyKey_WithoutWriting(string providerUserId)
     {
-        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryCreateLink("oid", "kc", providerUserId, Existing);
 
@@ -326,7 +332,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public void TryCreateLink_UnknownProvider_ReturnsUnknownProvider()
     {
-        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryCreateLink("oid", "does-not-exist", "sub-1", Existing);
 
@@ -339,7 +345,7 @@ public class CanonicalLinkServiceTests
         // The two refusals map to DIFFERENT response bodies, so the order is observable: an unresolved
         // identity is reported as EmptyKey even when the provider is also unknown (the empty-key guard
         // runs first). Locks the check ordering the controller's distinct 400 bodies depend on.
-        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryCreateLink("oid", "does-not-exist", "   ", Existing);
 
@@ -354,6 +360,7 @@ public class CanonicalLinkServiceTests
         // silently overwrites the prior binding — an admin correcting a mis-link, not a defect.
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
@@ -397,7 +404,7 @@ public class CanonicalLinkServiceTests
         // a user's links cannot NRE into a 500 on the #350 state.
         var (service, _, _, _) = Build(c =>
         {
-            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
+            c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
             c.OidConfigs["broken"] = null;
         });
 
@@ -412,6 +419,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
@@ -428,6 +436,7 @@ public class CanonicalLinkServiceTests
         // directly, since TryGetLinks dispatches saml vs oid to different config dictionaries.
         var (service, cfg, _, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
 
@@ -440,7 +449,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public void TryRemoveLink_UnknownCanonicalName_ReturnsNotFound()
     {
-        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryRemoveLink("oid", "kc", "does-not-exist", Existing);
 
@@ -452,6 +461,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
+            Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
@@ -464,7 +474,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public void TryRemoveLink_UnknownProvider_ReturnsUnknownProvider()
     {
-        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig());
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         var result = service.TryRemoveLink("oid", "does-not-exist", "sub-1", Existing);
 
@@ -476,9 +486,9 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c =>
         {
-            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
-            c.OidConfigs["authelia"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-3"] = Existing } };
-            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+            c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
+            c.OidConfigs["authelia"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-3"] = Existing } };
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         });
 
         var oid = service.LinksByUser("oid", Existing);
@@ -501,8 +511,8 @@ public class CanonicalLinkServiceTests
         // providers — the mirror of the OID test above, pinning the saml branch directly.
         var (service, _, _, _) = Build(c =>
         {
-            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing, ["bob"] = Other } };
-            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing, ["bob"] = Other } };
+            c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
         });
 
         var saml = service.LinksByUser("saml", Existing);
@@ -516,8 +526,8 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c =>
         {
-            c.OidConfigs["kc"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
-            c.SamlConfigs["adfs"] = new SamlConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+            c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other } };
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         });
 
         var removed = service.RemoveUserEverywhere(Existing);
@@ -526,5 +536,102 @@ public class CanonicalLinkServiceTests
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
         Assert.True(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-2")); // the other user's link survives
         Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ProviderDisabled_RefusesLikeADeletedOne()
+    {
+        // #380: a provider disabled between the controller's Enabled gate and the service's read must be
+        // rejected exactly like a deleted one — even a live subject link must not resolve, because the
+        // mint would run with the provider's pre-disable settings.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // link untouched
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ProviderDisabledBetweenResolveAndLinkWrite_RefusesWithoutLinking()
+    {
+        // #380, the race the issue names: the provider passes the resolve-read enabled, then is disabled
+        // before the link-write transaction of the adopt arm. The write-side guard must reject rather
+        // than persist a link (and mint) with the pre-disable settings. The flip runs inside the
+        // GetUserByName stub, which the flow consults exactly between the two transactions.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice").Returns(_ =>
+        {
+            cfg.OidConfigs["kc"].Enabled = false;
+            return UserNamed("alice", Existing);
+        });
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1")); // no link written
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ProviderDisabledBeforeLegacyMigration_RefusesInsteadOfMinting()
+    {
+        // #380 on the #155 legacy path: the candidate-resolving read passes enabled, then the provider
+        // is disabled before the migration transaction. Without the guard the caller would still return
+        // UseExistingLink and mint with pre-disable settings; with it the migration rejects and the
+        // legacy key stays un-migrated. The flip runs inside the GetUserById stub, which the read
+        // consults after its own guard has already passed.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(_ =>
+        {
+            cfg.OidConfigs["kc"].Enabled = false;
+            return UserNamed("alice", Existing);
+        });
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+
+        Assert.True(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("alice")); // not re-keyed
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void TryCreateLink_ProviderDisabled_ReturnsUnknownProviderWithoutWriting()
+    {
+        // Link creation is a GRANT of future login capability, so it takes the same disabled-is-absent
+        // treatment as the login-path guards (#380): a provider disabled between the controller's Enabled
+        // gate and this transaction must not gain a dormant link that would mint on re-enable.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
+
+        var result = service.TryCreateLink("oid", "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkWriteResult.UnknownProvider, result);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void TryRemoveLink_ProviderDisabled_StillRemoves()
+    {
+        // The admin paths deliberately keep working on a disabled provider (#380): disable-then-clean-up
+        // is the normal workflow, so only absence maps to UnknownProvider there.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var result = service.TryRemoveLink("oid", "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
     }
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -109,13 +109,20 @@ internal sealed class CanonicalLinkService
         // as absent (dangling links are dead, not identities).
         var (subjectLink, legacyLink) = _configStore.Read(configuration =>
         {
-            // The login callbacks resolve the provider before calling, so it is normally present. If it
-            // was deleted in the race between that lookup and here, fail CLOSED: refuse rather than fall
-            // through to the adoption gate, whose create/adopt arms would otherwise mint a session for a
-            // provider that no longer exists (a missing provider must never default the login to valid).
-            if (!TryGetLinks(configuration, mode, provider, out var links))
+            // The login callbacks resolve the provider before calling, so it is normally present and
+            // enabled. If it was deleted OR DISABLED in the race between that lookup and here, fail
+            // CLOSED: refuse rather than fall through to the adoption gate, whose create/adopt arms
+            // would otherwise mint a session with the provider's pre-delete/pre-disable settings (#373,
+            // #380 — a missing provider must never default the login to valid, and the same holds for a
+            // disabled one). Residual window, documented honestly: the mint itself always runs OUTSIDE
+            // the config lock, so a delete/disable after the LAST guarded transaction of any arm — this
+            // single read on the UseExistingLink path, the link write on adopt/create, the migration on
+            // the legacy path — still mints once. The guards move the final checkpoint later; #343's
+            // "disabling takes effect immediately" stays best-effort for an in-flight request unless the
+            // lock were held through minting.
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
-                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to resolve or create an account.");
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to resolve or create an account.");
             }
 
             Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
@@ -251,7 +258,13 @@ internal sealed class CanonicalLinkService
 
         return _configStore.Mutate(configuration =>
         {
-            if (!TryGetLinks(configuration, mode, provider, out var links))
+            // Link creation is a GRANT of future login capability, and both callers (the self-or-admin
+            // link endpoints) already gate Enabled at the controller — so requiring it here too costs no
+            // reachable workflow and closes the same mid-flight-disable window the login-path write guard
+            // closes (#380): without it, a link could still be written for a provider disabled between
+            // the controller gate and this transaction, surviving a cleanup sweep and minting on
+            // re-enable. Steady-state result is unchanged (UnknownProvider, as the controller yields).
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
                 return CanonicalLinkWriteResult.UnknownProvider;
             }
@@ -285,7 +298,10 @@ internal sealed class CanonicalLinkService
         // mutate would avoid the write but reintroduce the resolve/act race this deliberately excludes.
         return _configStore.Mutate(configuration =>
         {
-            if (!TryGetLinks(configuration, mode, provider, out var links))
+            // Removal REVOKES a grant, so it must keep working on a disabled provider —
+            // disable-then-clean-up is the normal workflow, and gating a revocation on Enabled would
+            // fail-open nothing while blocking exactly that cleanup (#380). Only absence is unknown here.
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links))
             {
                 return CanonicalLinkRemoveResult.UnknownProvider;
             }
@@ -383,12 +399,13 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Mutate(configuration =>
         {
-            // The login path resolved the provider before reaching here. If it was deleted in the race
-            // since, fail CLOSED: refuse rather than return a session with no link written. A freshly
-            // created user may be left orphaned, the same benign outcome as the #133 race loser.
-            if (!TryGetLinks(configuration, mode, provider, out var links))
+            // The login path resolved the provider before reaching here. If it was deleted or disabled
+            // in the race since, fail CLOSED: refuse rather than return a session with no link written
+            // (#373, #380). A freshly created user may be left orphaned, the same benign outcome as the
+            // #133 race loser.
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
-                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to link an account.");
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to link an account.");
             }
 
             Guid? existing = links.TryGetValue(canonicalKey, out var current) && _userManager.GetUserById(current) != null
@@ -414,12 +431,13 @@ internal sealed class CanonicalLinkService
         _configStore.Mutate(configuration =>
         {
             // Migration is a SECOND transaction after the candidate-resolving read. If the provider was
-            // deleted in that window, fail CLOSED: throw rather than no-op, because the caller still
-            // holds the legacy user id from the pre-deletion snapshot and would otherwise return
-            // UseExistingLink, minting a session for a provider that no longer exists (#373).
-            if (!TryGetLinks(configuration, mode, provider, out var links))
+            // deleted or disabled in that window, fail CLOSED: throw rather than no-op, because the
+            // caller still holds the legacy user id from the pre-deletion snapshot and would otherwise
+            // return UseExistingLink, minting a session for a provider that no longer exists or was just
+            // switched off (#373, #380).
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
-                throw new AccountLinkForbiddenException("The SSO provider is no longer configured; refusing to migrate the account link.");
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to migrate the account link.");
             }
 
             // A no-op here (unlike the throwing miss above) is the GOOD idempotent case: the provider
@@ -439,13 +457,17 @@ internal sealed class CanonicalLinkService
     // UnknownProvider — finishing the #241 removal of KeyNotFoundException-as-control-flow. Returns true
     // and a non-null map only when the provider exists AND has a config object; a missing provider — or a
     // null-valued entry (reachable today via the null-body add, #350) — returns false, so the caller fails
-    // closed (UnknownProvider on admin paths, a reject on login paths) instead of dereferencing null. The
-    // map is self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map
-    // persists directly; callers must hold the config lock (Read / Mutate) while touching it. An
-    // unrecognized mode is not an unknown provider but a caller contract violation, so it throws — note the
-    // DELETE route forwards mode unvalidated (unlike the AddCanonicalLink dispatch), so that throw is
-    // reachable there; #369 tracks parsing mode once at the HTTP boundary into an internal enum.
-    private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, out SerializableDictionary<string, Guid> links)
+    // closed (UnknownProvider on admin paths, a reject on login paths) instead of dereferencing null. With
+    // requireEnabled, a DISABLED provider is treated like an absent one — every GRANT path (the login
+    // guards and the link-create write) passes true so a provider disabled mid-flight is rejected exactly
+    // like a deleted one (#380), while removal passes false because revoking must keep working on a
+    // disabled provider (disable-then-clean-up). The map is
+    // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
+    // directly; callers must hold the config lock (Read / Mutate) while touching it. An unrecognized mode
+    // is not an unknown provider but a caller contract violation, so it throws — note the DELETE route
+    // forwards mode unvalidated (unlike the AddCanonicalLink dispatch), so that throw is reachable there;
+    // #369 tracks parsing mode once at the HTTP boundary into an internal enum.
+    private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, bool requireEnabled, out SerializableDictionary<string, Guid> links)
     {
         switch (mode.ToLowerInvariant())
         {
@@ -453,14 +475,14 @@ internal sealed class CanonicalLinkService
             {
                 var ok = configuration.SamlConfigs.TryGetValue(provider, out var config);
                 links = config?.CanonicalLinks;
-                return ok && links != null;
+                return ok && links != null && (!requireEnabled || config.Enabled);
             }
 
             case "oid":
             {
                 var ok = configuration.OidConfigs.TryGetValue(provider, out var config);
                 links = config?.CanonicalLinks;
-                return ok && links != null;
+                return ok && links != null && (!requireEnabled || config.Enabled);
             }
 
             default:


### PR DESCRIPTION
## What & why

A provider disabled between the controller's `Enabled` gate and the service's transactions still resolved, adopted/created, wrote links, and minted a session with its pre-disable settings. #373 closed this race for **deletion**; its own rationale applies verbatim to **disablement**, and #343's "disabling takes effect immediately" was best-effort for an in-flight request.

`TryGetLinks` gains a `requireEnabled` flag; **every grant path passes `true`**, the resolve read, the adopt/create link write, the legacy migration (#155), and the manual link create, so a disabled provider is treated exactly like an absent one. **Removal deliberately stays exempt** (revocation must keep working on a disabled provider, or disable-then-clean-up breaks). The residual window is documented honestly at the resolve guard: the mint runs outside the config lock, so a disable after an arm's *last* guarded transaction still mints once.

Closes #380.

## Type of change
- [x] Security hardening (login/link path, fail-closed)

## Security checklist
- Fail-closed: every miss-branch throws (`AccountLinkForbiddenException` → the same caught 403 as the deleted-provider case) or returns `UnknownProvider` (→ the same `BadRequest` the controller yields steady-state, the #343 anti-enumeration property holds even in the race window).
- Gating rule respected: all four `requireEnabled: true` sites gate **grants**; the one `false` site is a **revocation**.
- No secrets, no new logging of untrusted data.

## Quality checklist
- Minimal: one flag, five named-argument call sites, comments carry the why.
- Tests: five new state-based tests, disabled-at-entry, two deterministic mid-flight flips (between the guarded transactions, injected via the user-manager stubs the flow consults exactly there), the create-arm no-write pin, and the remove-still-works control. Existing seeds now set `Enabled = true`, mirroring the controller's gate.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **758/758 green**.
- Full adversarial gate (sensitive diff): availability **PASS** (every `requireEnabled: true` site sits behind an existing controller gate; unlink/list/unregister keep working on disabled providers; all guards map to a caught 403, no lockout surface). bypass/correctness/integration first returned **NEEDS_IMPROVEMENT** with one convergent finding, the manual link create originally kept `requireEnabled: false` under a wrong "RequiresElevation/manageability" rationale, leaving the same window open on a grant write, **fixed** (flipped to `true`, comments corrected, no-write test added); re-run: **PASS / PASS / PASS**.

## Notes
Delivery item from the integration lens: one line on provider-disable semantics goes onto the Security-Model wiki page with this merge.
