### PR TITLE
Add a controller socket/DNS tripwire to the conformance rules

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -179,13 +179,15 @@ public class ArchitectureConformanceTests
         // Locked in by the AvatarService extraction (#375): the raw-socket/DNS surface lives only in the
         // avatar tier (AvatarService, AvatarUrlValidator) and SsoRateLimiter — the controller orchestrates
         // flows over injected collaborators and never opens a network primitive itself. Same plain source
-        // scan as the link-map rule above. Marker choice: any Socket/NetworkStream/SocketsHttpHandler use
-        // needs the System.Net.Sockets namespace in the file (using directive, alias, or full
-        // qualification), so that one marker subsumes the type names; "NetworkStream" is the
-        // belt-and-braces type-name catch on top; "Dns." catches System.Net.Dns call sites (which need no
-        // Sockets using) and "System.Net.Dns" the static-import form. Bare "Socket"/"Dns" are deliberately
-        // NOT markers — they would false-positive on prose in comments.
-        var markers = new[] { "System.Net.Sockets", "NetworkStream", "Dns.", "System.Net.Dns" };
+        // scan as the link-map rule above. Marker choice: any Socket/NetworkStream use needs the
+        // System.Net.Sockets namespace in the file (using directive, alias, or full qualification), so
+        // that one marker subsumes those type names; "NetworkStream" is the belt-and-braces type-name
+        // catch on top; "SocketsHttpHandler" lives in System.Net.Http, which the controller legitimately
+        // imports, so the namespace marker cannot cover it and it gets its own; "Dns." catches
+        // System.Net.Dns call sites (which need no Sockets using) and "System.Net.Dns" the static-import
+        // form. Bare "Socket"/"Dns" are deliberately NOT markers — they would false-positive on prose in
+        // comments.
+        var markers = new[] { "System.Net.Sockets", "SocketsHttpHandler", "NetworkStream", "Dns.", "System.Net.Dns" };
         var controllerSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SSOController.cs"));
         var socketLines = controllerSource
             .Select((line, index) => (Text: line.Trim(), Number: index + 1))

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -18,9 +18,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// structure fails CI. The rules encode structural invariants that hold today and are part of the target;
 /// as each migration step lands a new structural property, add the rule that locks it in here so it
 /// cannot regress. Most rules are type-level (reflection over the production assembly); call-level
-/// invariants otherwise stay guarded by CodeQL/CodeRabbit and the pinning tests. The one call-level
-/// property locked in here is a source scan — the CONTROLLER touches no provider link map directly
-/// (<see cref="Controller_NeverTouchesProviderLinkMaps"/>) — because the #372 extraction confines
+/// invariants otherwise stay guarded by CodeQL/CodeRabbit and the pinning tests. Two call-level
+/// properties are locked in as source scans — the CONTROLLER touches no provider link map directly
+/// (<see cref="Controller_NeverTouchesProviderLinkMaps"/>) and no raw socket/DNS surface
+/// (<see cref="Controller_NeverTouchesRawSocketsOrDns"/>) — because the #372 extraction confines
 /// link-map access to CanonicalLinkService (the login/admin workflow) and ServerManagedFields.Preserve
 /// (the #157 server-managed re-injection the config tier owns), a boundary worth failing CI on, not just
 /// review; #383 retired the controller's last two inline re-injection sites into that shared Preserve, so
@@ -170,6 +171,31 @@ public class ArchitectureConformanceTests
         Assert.True(
             linkMapLines.Count == 0,
             "SSOController must not access a provider CanonicalLinks map directly; route link-map access through CanonicalLinkService and server-managed re-injection through ServerManagedFields.Preserve. Found: " + string.Join(" | ", linkMapLines));
+    }
+
+    [Fact]
+    public void Controller_NeverTouchesRawSocketsOrDns()
+    {
+        // Locked in by the AvatarService extraction (#375): the raw-socket/DNS surface lives only in the
+        // avatar tier (AvatarService, AvatarUrlValidator) and SsoRateLimiter — the controller orchestrates
+        // flows over injected collaborators and never opens a network primitive itself. Same plain source
+        // scan as the link-map rule above. Marker choice: any Socket/NetworkStream/SocketsHttpHandler use
+        // needs the System.Net.Sockets namespace in the file (using directive, alias, or full
+        // qualification), so that one marker subsumes the type names; "NetworkStream" is the
+        // belt-and-braces type-name catch on top; "Dns." catches System.Net.Dns call sites (which need no
+        // Sockets using) and "System.Net.Dns" the static-import form. Bare "Socket"/"Dns" are deliberately
+        // NOT markers — they would false-positive on prose in comments.
+        var markers = new[] { "System.Net.Sockets", "NetworkStream", "Dns.", "System.Net.Dns" };
+        var controllerSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SSOController.cs"));
+        var socketLines = controllerSource
+            .Select((line, index) => (Text: line.Trim(), Number: index + 1))
+            .Where(l => markers.Any(m => l.Text.Contains(m, StringComparison.Ordinal)))
+            .Select(l => $"line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            socketLines.Count == 0,
+            "SSOController must not touch the raw socket/DNS surface (System.Net.Sockets, Socket, NetworkStream, Dns); outbound network primitives belong to AvatarService/AvatarUrlValidator and SsoRateLimiter. Found: " + string.Join(" | ", socketLines));
     }
 
     [Fact]


### PR DESCRIPTION
# What & why

Since the AvatarService extraction (#375), the raw-socket/DNS surface (`System.Net.Sockets`, `Socket`, `NetworkStream`, `Dns`) lives only in AvatarService, AvatarUrlValidator, and SsoRateLimiter, SSOController.cs no longer references any of it. This adds a source-scan fitness function to `ArchitectureConformanceTests` locking that boundary in, so socket code creeping back into the controller fails CI instead of relying on review to notice. It mirrors the mechanics of the existing `Controller_NeverTouchesProviderLinkMaps` scan (same file location via `RepoRoot()`, same trimmed line scan, same line-numbered failure report), and the class summary is updated from "the one call-level property" to the two scans now present. Closes #386

Marker choice is documented in the test: any `Socket`/`NetworkStream`/`SocketsHttpHandler` use needs the `System.Net.Sockets` namespace in the file (using directive, alias, or full qualification), so that one marker subsumes the type names; `NetworkStream` is kept as a belt-and-braces type-name catch; `Dns.` and `System.Net.Dns` catch the DNS call-site forms, which need no Sockets using. Bare `Socket`/`Dns` are deliberately not markers, they would false-positive on prose in comments.

Verified in both directions: SSOController.cs contains none of the markers today (grepped, and the new test passes), and planting a `using System.Net.Sockets;` plus a `Dns.GetHostEntry` call in the controller fails exactly this test and nothing else.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

Not applicable, test-only change, no runtime code touched. The adversarial lens gate is likewise N/A for this PR (no login-path, crypto, config-persistence, or pipeline change); stating that disposition here explicitly.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Debug and Release both build clean with `--no-incremental --warnaserror` (0 warnings). Test suite: 759 passed, 0 failed, 0 skipped (Release). Negative verification run: with the planted socket/DNS lines in the controller, the suite fails 1/759, exactly `Controller_NeverTouchesRawSocketsOrDns`. Prettier N/A (C# only). `scripts/check-jellyfin-compat.sh` consistent.

## Notes

The scan is deliberately as plain as the link-map rule, no syntax awareness, just ordinal substring markers on trimmed lines; consistency across the conformance rules beats cleverness here. A sibling PR adds a null-body guard to the controller's Add endpoints; it introduces no socket symbols, so there is no semantic conflict with this tripwire.
