### PR TITLE
Normalize null OidScopes so the challenge does not 500

### DIFF
--- a/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
+++ b/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins <see cref="SSOController.BuildScopeString"/> — the shared OpenID scope-string builder used by
+/// both the challenge and the callback client. Guards #368: a provider stored without scopes leaves
+/// <see cref="OidConfig.OidScopes"/> null, which previously threw an unhandled 500 on the anonymous
+/// challenge (<c>OidScopes.Prepend</c> on null) and null-padded the callback scope string
+/// (<c>new string[2]</c> → trailing separators). The builder normalizes null to empty so both sides
+/// emit the same clean, base-prefixed string.
+/// </summary>
+public class SSOControllerScopeStringTests
+{
+    [Fact]
+    public void NullScopes_YieldBaseScopesOnly_NoThrow()
+    {
+        var config = new OidConfig { OidScopes = null };
+
+        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void EmptyScopes_YieldBaseScopesOnly()
+    {
+        var config = new OidConfig { OidScopes = Array.Empty<string>() };
+
+        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void ConfiguredScopes_ArePrefixedWithBaseScopes()
+    {
+        var config = new OidConfig { OidScopes = new[] { "email", "groups" } };
+
+        Assert.Equal("openid profile email groups", SSOController.BuildScopeString(config));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -263,7 +263,7 @@ public class SSOController : ControllerBase
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
 
-        var oidcClient = CreateOidcClient(config, redirectUri, string.Join(" ", config.OidScopes.Prepend("openid profile")));
+        var oidcClient = CreateOidcClient(config, redirectUri, BuildScopeString(config));
         var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
 
         if (state.IsError)
@@ -340,6 +340,13 @@ public class SSOController : ControllerBase
         record(newPath);
         return newPath;
     }
+
+    // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".
+    // OidScopes is null when a provider was stored without scopes (#368, e.g. via the OID/Add API) —
+    // normalize to empty so neither the challenge nor the callback throws (an unhandled 500 on the
+    // anonymous challenge endpoint) or pads the scope string with null entries. Shared by both sites.
+    internal static string BuildScopeString(OidConfig config)
+        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>()).Prepend("openid profile"));
 
     // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
@@ -421,14 +428,13 @@ public class SSOController : ControllerBase
 
     // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls
     // back on exactly the route the authorization request advertised), so the token request's
-    // redirect_uri matches the authorization request's as RFC 6749 requires (#98). A null scopes
-    // array is tolerated here but not on the challenge side — a pre-existing asymmetry deliberately
-    // preserved.
+    // redirect_uri matches the authorization request's as RFC 6749 requires (#98). The scope string
+    // is normalized the same way as the challenge side (BuildScopeString) — both tolerate a null
+    // OidScopes identically (#368).
     private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
     {
-        var scopes = config.OidScopes == null ? new string[2] : config.OidScopes;
         var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), Request.Path.Value, provider);
-        return CreateOidcClient(config, redirectUri, string.Join(" ", scopes.Prepend("openid profile")));
+        return CreateOidcClient(config, redirectUri, BuildScopeString(config));
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist


### PR DESCRIPTION
# What & why

A provider stored without scopes (reachable via the `OID/Add` API, #350) left `OidConfig.OidScopes` null, and the two OpenID client-building sites handled it differently:

- **Challenge** (anonymous endpoint): `config.OidScopes.Prepend("openid profile")` threw a `NullReferenceException` → an unhandled **HTTP 500** on an anonymous endpoint, the same unhandled-500 class fixed in #199/#206.
- **Callback**: `config.OidScopes == null ? new string[2] : config.OidScopes` padded the scope string with two null entries → `"openid profile  "` with trailing separators.

Both sites now route through one shared helper, `BuildScopeString`, that normalizes a null array to empty. The challenge proceeds with the base `openid profile` scopes instead of crashing, and both sites emit the same clean string. The populated-scopes path is byte-identical to before.

Closes #368

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — Unchanged. The old challenge-side crash was not a fail-closed control; the adversarial review confirmed the monotonic privilege model means base-only scopes can only reduce or leave access unchanged, and a role allow-list still fails closed when its claim is absent.
- [x] No secrets logged; secrets are redacted on config export., No logging changed; removing the 500 also stops leaking a stack trace.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — 4-lens adversarial review, all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call., No new log calls.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. — The two divergent scope-string sites are unified into `BuildScopeString`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). — `internal static` pure helper on the thin controller, consistent with the sibling helpers.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. — No new structural property; existing rules pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., 0 warnings, 0 errors.
- [x] `dotnet test` is green., 761 passed, 0 failed (3 new).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., No such files changed.

## Notes

Null/empty/whitespace **elements** inside a non-null `OidScopes` array (e.g. `["email", null]`) still render as empty via `string.Join`, a separate, non-impactful latent case (unchanged from the old path; scope is not validated downstream), tracked as a follow-up in #407 with a `.Where(s => !string.IsNullOrWhiteSpace(s))` fix so this PR stays scoped to the null-array bug the issue describes.
