### PR TITLE
Reject a null provider body at the Add endpoints

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -71,6 +71,26 @@ public class ConfigPreservationTests
     }
 
     [Fact]
+    public void Preserve_NullProviderEntry_DoesNotThrow()
+    {
+        // A malformed Add before #350 could store a null provider entry; preserving with a null on
+        // either side must skip it, not NRE the whole config-page save.
+        var live = new PluginConfiguration();
+        live.OidConfigs["null-in-live"] = null;
+        live.OidConfigs["null-in-incoming"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub"] = User } };
+        live.SamlConfigs["saml-null-in-live"] = null;
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["null-in-live"] = new OidConfig();
+        incoming.OidConfigs["null-in-incoming"] = null;
+        incoming.SamlConfigs["saml-null-in-live"] = new SamlConfig();
+
+        var exception = Record.Exception(() => ServerManagedFields.Preserve(incoming, live));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
     public void CanonicalLinks_AreOmittedFromJson_ButKeptInXml()
     {
         var config = new OidConfig

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -42,6 +42,27 @@ public class SSOControllerAddTests
     }
 
     [Fact]
+    public void OidAdd_NullBody_Throws_AndDoesNotPersist()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("keycloak", null));
+
+        // Fail-closed: a null [FromBody] is rejected at the door, so no null entry is stored (#350).
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("keycloak")));
+    }
+
+    [Fact]
+    public void SamlAdd_NullBody_Throws_AndDoesNotPersist()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.Throws<ArgumentException>(() => harness.Controller.SamlAdd("adfs", null));
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("adfs")));
+    }
+
+    [Fact]
     public void OidAdd_ReSaveOfExisting_PreservesCanonicalLinks()
     {
         var harness = new SsoControllerHarness(c =>

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -464,6 +464,19 @@ public class SSOController : ControllerBase
         }
     }
 
+    // Rejects a null provider body at the Add endpoints (#350). ASP.NET model binding hands a null
+    // [FromBody] object for an empty or literal "null" JSON payload; storing it would put a null entry
+    // in the config map that then NREs the config-page save (ServerManagedFields.Preserve). Reject at
+    // the door so the store never holds a null provider — the same fail-closed posture as the other
+    // Add-endpoint gates.
+    internal static void RejectNullProviderBody(object config)
+    {
+        if (config is null)
+        {
+            throw new ArgumentException("The provider configuration body must not be empty.");
+        }
+    }
+
     // Rejects a provider name containing URI-reserved or control characters when it would register a NEW
     // provider (#336, #360): the name is appended raw to the callback URLs handed to the identity provider
     // (SsoUrlBuilder), so '%' breaks route decoding, '/' dead-ends the IdP redirect on a path no route
@@ -489,7 +502,8 @@ public class SSOController : ControllerBase
     [HttpPost("OID/Add/{provider}")]
     public void OidAdd(string provider, [FromBody] OidConfig config)
     {
-        RejectInvalidBaseUrlOverride(config?.BaseUrlOverride);
+        RejectNullProviderBody(config);
+        RejectInvalidBaseUrlOverride(config.BaseUrlOverride);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,
@@ -500,7 +514,7 @@ public class SSOController : ControllerBase
             // Re-inject the server-managed fields this API cannot carry — CanonicalLinks ([JsonIgnore],
             // #157) and the write-only secret's blank-means-keep rule (#189) — through the one shared
             // ServerManagedFields.Preserve the config-page save also uses, so every write path agrees.
-            if (config != null && providerExists)
+            if (providerExists)
             {
                 ServerManagedFields.Preserve(config, existing);
             }
@@ -775,8 +789,9 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/Add/{provider}")]
     public OkResult SamlAdd(string provider, [FromBody] SamlConfig newConfig)
     {
-        RejectInvalidBaseUrlOverride(newConfig?.BaseUrlOverride);
-        RejectInvalidSamlCertificate(newConfig?.SamlCertificate);
+        RejectNullProviderBody(newConfig);
+        RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
+        RejectInvalidSamlCertificate(newConfig.SamlCertificate);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,
@@ -787,7 +802,7 @@ public class SSOController : ControllerBase
             // Preserve the server-managed canonical links (#157), as OidAdd does, through the shared
             // ServerManagedFields.Preserve: the posted config never carries them ([JsonIgnore]), so
             // re-inject the live map before the wholesale replace so an API save cannot wipe links.
-            if (newConfig != null && providerExists)
+            if (providerExists)
             {
                 ServerManagedFields.Preserve(newConfig, existing);
             }

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -53,6 +53,13 @@ internal static class ServerManagedFields
     // Links + secret: an OpenID provider carries both server-managed fields (#157/#189).
     internal static void Preserve(OidConfig incoming, OidConfig live)
     {
+        // A null provider entry (a malformed Add before #350, or a legacy store) carries no
+        // server-managed fields; skip it rather than NRE the whole config-page save.
+        if (incoming is null || live is null)
+        {
+            return;
+        }
+
         incoming.CanonicalLinks = live.CanonicalLinks;
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
@@ -60,6 +67,11 @@ internal static class ServerManagedFields
     // Links only: a SAML provider has no write-only secret (#157).
     internal static void Preserve(SamlConfig incoming, SamlConfig live)
     {
+        if (incoming is null || live is null)
+        {
+            return;
+        }
+
         incoming.CanonicalLinks = live.CanonicalLinks;
     }
 


### PR DESCRIPTION
# What & why

The admin `OID/Add` and `SAML/Add` endpoints upserted the posted `[FromBody]` object unconditionally. Nullable reference types are off for this project, so ASP.NET does not auto-reject an empty / `"null"` JSON body, it binds to a **null** config object, and the endpoint stored a `null` entry in the provider map (`OidConfigs[provider] = null`). A null entry then NREs the config-page save (`ServerManagedFields.Preserve` dereferences it) → HTTP 500, and the admin can no longer save the config page. Admin-only (`RequiresElevation`), so self-inflicted, not attacker-reachable.

Fix, two layers:

- **Reject the null body at the door**, `RejectNullProviderBody` is the first line of both Add endpoints, before any mutation, mirroring the sibling `RejectInvalid*` gates. Nothing is persisted on rejection. With null rejected first, the following `config?.` guards simplify to `config.`.
- **Defense-in-depth**, the per-provider `ServerManagedFields.Preserve` overloads early-return when either side is null, so a legacy null entry (or a null `existing` during an Add) no longer NREs the save and can be overwritten to heal the wedged entry.

Closes #350

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — The null body is rejected fail-closed; the adversarial review confirmed a null entry can never authenticate (login treats a null provider config as "no provider" → reject).
- [x] No secrets logged; secrets are redacted on config export., Unchanged. The `Preserve` null-guard skips only genuinely null entries (which carry no secret); the #189 blank-means-keep secret rule is untouched for every non-null config.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — 4-lens adversarial review, all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call., No new log calls.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. — One `RejectNullProviderBody` gate reused by both endpoints.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). — Gate mirrors the existing `RejectInvalid*` pattern; the `Preserve` guard sits with the shared re-injection rule.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. — No new structural property; existing rules pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., 0 warnings, 0 errors.
- [x] `dotnet test` is green., 764 passed, 0 failed (3 new).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., No such files changed.

## Notes

The bypass lens noted one admin-only, non-blocking behavior: on the config-page save path, a *deliberately* null-posted provider entry that previously NRE'd (accidental fail-closed) now early-returns and the null entry persists, replacing the real provider. This is reachable only by a malicious/compromised admin who can already delete or omit that provider via the wholesale replace or `OID/Del`, so it grants no new capability and is unreachable by any unprivileged user. A legitimate stale-client save posts the real object (secret withheld/blank), not null, so it still hits the #189 `ResolveUpdatedSecret` path.
