### PR TITLE
Match the challenge route segment exactly, not as a substring

### DIFF
--- a/SSO-Auth.Tests/ChallengePathTests.cs
+++ b/SSO-Auth.Tests/ChallengePathTests.cs
@@ -1,0 +1,62 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="ChallengePath.IsNewPath"/> — the new-vs-legacy challenge-route decision that
+/// drives the authorization request's redirect_uri spelling. The old inline <c>Contains("/start/")</c>
+/// substring test flipped for a provider literally named <c>start</c> reached via the legacy route
+/// (<c>/sso/OID/p/start/</c>), minting the wrong redirect_uri that the IdP then rejects (#337).
+/// Segment-exact matching keys only on the element right after the protocol.
+/// </summary>
+public class ChallengePathTests
+{
+    [Theory]
+    [InlineData("/sso/OID/start/keycloak")]
+    [InlineData("/sso/SAML/start/adfs")]
+    [InlineData("/SSO/OID/Start/keycloak")]
+    [InlineData("/jellyfin/sso/OID/start/keycloak")]
+    public void IsNewPath_StartRoute_IsTrue(string path)
+    {
+        Assert.True(ChallengePath.IsNewPath(path));
+    }
+
+    [Theory]
+    [InlineData("/sso/OID/p/keycloak")]
+    [InlineData("/sso/SAML/p/adfs")]
+    public void IsNewPath_LegacyRoute_IsFalse(string path)
+    {
+        Assert.False(ChallengePath.IsNewPath(path));
+    }
+
+    [Theory]
+    // The #337 fix: a provider NAMED "start" on the legacy route must not flip the spelling —
+    // including with a trailing slash, which the old substring "/start/" test wrongly matched.
+    [InlineData("/sso/OID/p/start")]
+    [InlineData("/sso/OID/p/start/")]
+    [InlineData("/sso/SAML/p/start")]
+    [InlineData("/sso/OID/p/my-start-provider")]
+    public void IsNewPath_ProviderNamedStart_OnLegacyRoute_IsFalse(string path)
+    {
+        Assert.False(ChallengePath.IsNewPath(path));
+    }
+
+    [Fact]
+    public void IsNewPath_StartRouteWithProviderNamedStart_IsTrue()
+    {
+        // The route segment (after the protocol) decides, so the new-path route stays new even when
+        // the provider is also named "start".
+        Assert.True(ChallengePath.IsNewPath("/sso/OID/start/start"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void IsNewPath_EmptyOrNull_IsFalse(string? path)
+    {
+        Assert.False(ChallengePath.IsNewPath(path));
+    }
+}

--- a/SSO-Auth.Tests/ChallengePathTests.cs
+++ b/SSO-Auth.Tests/ChallengePathTests.cs
@@ -53,6 +53,25 @@ public class ChallengePathTests
     }
 
     [Theory]
+    // A protocol-like reverse-proxy prefix must not decide the spelling: only the route's
+    // {protocol}/{path-kind}/{provider} suffix does. The real route below is legacy (OID/p).
+    [InlineData("/OID/start/proxy/sso/OID/p/provider")]
+    // A doubled internal slash shifts the suffix and must not collapse into a valid new route.
+    [InlineData("/sso/OID//start/provider")]
+    public void IsNewPath_ProtocolLikePrefixOrInternalEmptySegment_IsFalse(string path)
+    {
+        Assert.False(ChallengePath.IsNewPath(path));
+    }
+
+    [Fact]
+    public void IsNewPath_StartRouteBehindProtocolLikePrefix_IsTrue()
+    {
+        // The suffix is the real route (OID/start/provider); a SAML-like prefix earlier in the path
+        // is ignored.
+        Assert.True(ChallengePath.IsNewPath("/SAML/prefix/sso/OID/start/provider"));
+    }
+
+    [Theory]
     [InlineData("")]
     [InlineData(null)]
     public void IsNewPath_EmptyOrNull_IsFalse(string? path)

--- a/SSO-Auth/Api/ChallengePath.cs
+++ b/SSO-Auth/Api/ChallengePath.cs
@@ -1,0 +1,40 @@
+using System;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Decides whether a challenge arrived on the "new", descriptive route
+/// (<c>.../OID/start/{provider}</c> or <c>.../SAML/start/{provider}</c>) rather than the legacy route.
+/// The spelling drives the authorization request's redirect_uri, which the token request must later
+/// match (RFC 6749 section 4.1.3), so it has to be read off the route segment exactly — not by a
+/// <c>Contains("/start/")</c> substring test, which a provider literally named <c>start</c> on the
+/// legacy route (<c>.../OID/p/start/</c>) would trip, flipping the spelling and breaking the login at
+/// the IdP's redirect_uri check (#337). Mirrors <see cref="OidcCallbackPath.RedirectSegment"/> (#98).
+/// </summary>
+internal static class ChallengePath
+{
+    /// <summary>
+    /// Returns true when the route segment after the protocol (<c>OID</c>/<c>SAML</c>) is <c>start</c>.
+    /// </summary>
+    /// <param name="path">The challenge request path, e.g. <c>/sso/OID/start/{provider}</c>.</param>
+    /// <returns>True for the new "start" route, false for the legacy route.</returns>
+    internal static bool IsNewPath(string? path)
+    {
+        var segments = path?.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments is not null)
+        {
+            for (var i = 0; i + 1 < segments.Length; i++)
+            {
+                if (string.Equals(segments[i], "OID", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(segments[i], "SAML", StringComparison.OrdinalIgnoreCase))
+                {
+                    return string.Equals(segments[i + 1], "start", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/ChallengePath.cs
+++ b/SSO-Auth/Api/ChallengePath.cs
@@ -8,33 +8,38 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// Decides whether a challenge arrived on the "new", descriptive route
 /// (<c>.../OID/start/{provider}</c> or <c>.../SAML/start/{provider}</c>) rather than the legacy route.
 /// The spelling drives the authorization request's redirect_uri, which the token request must later
-/// match (RFC 6749 section 4.1.3), so it has to be read off the route segment exactly — not by a
+/// match (RFC 6749 section 4.1.3), so it has to be read off the route exactly — not by a
 /// <c>Contains("/start/")</c> substring test, which a provider literally named <c>start</c> on the
 /// legacy route (<c>.../OID/p/start/</c>) would trip, flipping the spelling and breaking the login at
-/// the IdP's redirect_uri check (#337). Mirrors <see cref="OidcCallbackPath.RedirectSegment"/> (#98).
+/// the IdP's redirect_uri check (#337). Same fix family as <see cref="OidcCallbackPath.RedirectSegment"/>
+/// (#98); that one still scans for the first protocol token and should be moved to the same
+/// suffix-anchored form (#411).
 /// </summary>
 internal static class ChallengePath
 {
     /// <summary>
-    /// Returns true when the route segment after the protocol (<c>OID</c>/<c>SAML</c>) is <c>start</c>.
+    /// Returns true when the route's <c>{protocol}/{path-kind}/{provider}</c> suffix is a
+    /// <c>OID|SAML</c> protocol followed by the <c>start</c> path-kind.
     /// </summary>
     /// <param name="path">The challenge request path, e.g. <c>/sso/OID/start/{provider}</c>.</param>
     /// <returns>True for the new "start" route, false for the legacy route.</returns>
     internal static bool IsNewPath(string? path)
     {
-        var segments = path?.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments is not null)
+        // The challenge route always ends in {protocol}/{path-kind}/{provider}, so anchor to that
+        // three-segment suffix rather than the first protocol token found anywhere in the path: a
+        // protocol-like reverse-proxy prefix (e.g. /OID/start/proxy/...) must not decide the spelling.
+        // Trim only boundary slashes so an internal empty segment (a doubled slash) shifts the suffix
+        // and fails to match rather than being silently collapsed into a valid route.
+        var segments = path?.Trim('/').Split('/');
+        if (segments is null || segments.Length < 3)
         {
-            for (var i = 0; i + 1 < segments.Length; i++)
-            {
-                if (string.Equals(segments[i], "OID", StringComparison.OrdinalIgnoreCase)
-                    || string.Equals(segments[i], "SAML", StringComparison.OrdinalIgnoreCase))
-                {
-                    return string.Equals(segments[i + 1], "start", StringComparison.OrdinalIgnoreCase);
-                }
-            }
+            return false;
         }
 
-        return false;
+        var protocol = segments[^3];
+        var pathKind = segments[^2];
+        var isProtocol = string.Equals(protocol, "OID", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(protocol, "SAML", StringComparison.OrdinalIgnoreCase);
+        return isProtocol && string.Equals(pathKind, "start", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -336,7 +336,7 @@ public class SSOController : ControllerBase
             return currentNewPath;
         }
 
-        var newPath = Request.Path.Value.Contains("/start/", StringComparison.InvariantCultureIgnoreCase);
+        var newPath = ChallengePath.IsNewPath(Request.Path.Value);
         record(newPath);
         return newPath;
     }


### PR DESCRIPTION
# What & why

`ResolveChallengeNewPath` decided the authorization request's redirect_uri spelling with a substring test: `Request.Path.Value.Contains("/start/")`. A provider literally named `start` reached via the legacy route (`/sso/OID/p/start/`) contains `/start/` as a substring, so `newPath` flipped, the challenge minted the new-path redirect_uri, and the login then failed at the IdP's redirect_uri check.

Extract `ChallengePath.IsNewPath`, which matches the route segment exactly, the element right after the `OID`/`SAML` protocol token, so the provider name can no longer flip the spelling. This mirrors `OidcCallbackPath.RedirectSegment`, which made the same substring→exact-segment fix on the callback side (#98). The helper handles both protocols because `ResolveChallengeNewPath` is shared by the OID and SAML challenges.

A misclassification was always fail-closed (the IdP rejects a mismatched redirect_uri); this removes the false positive that broke a `start`-named provider.

Closes #337

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — The adversarial review confirmed every misclassification is fail-closed at the IdP (a wrong redirect_uri spelling is rejected, never a bypass); null/empty path defaults to the legacy spelling.
- [x] No secrets logged; secrets are redacted on config export., Unchanged.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — 4-lens adversarial review, all PASS. The helper only returns a bool selecting between two fixed plugin-served route literals; no attacker-controlled URL text reaches the redirect_uri.
- [x] Log inputs from the IdP are sanitized inline at the log call., No new log calls.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. — `ChallengePath.IsNewPath`, mirroring the sibling `OidcCallbackPath`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). — A pure `Api/` helper consistent with `OidcCallbackPath`.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. — No new structural property; existing rules pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., 0 warnings, 0 errors.
- [x] `dotnet test` is green., 778 passed, 0 failed (14 new).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., No such files changed.

## Notes

Non-blocking, pre-existing parity note: like the already-merged `OidcCallbackPath.RedirectSegment` (#98), the first-match loop keys off the first `OID`/`SAML` segment, so an operator-controlled reverse-proxy base path literally containing an `OID`/`SAML` segment could misclassify. It is operator-controlled (not attacker-reachable) and still fails closed at the IdP, identical to the accepted #98 behavior, so no action taken here.
