### PR TITLE
Persist the default provider in the single session-mint write

### DIFF
--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -167,9 +167,14 @@ public class SessionMinterTests
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
+        // Capture the id at the write boundary, not off the shared user after MintAsync returns —
+        // otherwise the assertion passes even if the id is set AFTER the write, defeating the point (#391).
+        string? providerAtWrite = null;
+        users.UpdateUserAsync(Arg.Do<User>(u => providerAtWrite = u.AuthenticationProviderId)).Returns(Task.CompletedTask);
+
         await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), () => "203.0.113.7");
 
-        Assert.Equal("SSO-Auth", user.AuthenticationProviderId);
+        Assert.Equal("SSO-Auth", providerAtWrite);
         await users.Received(1).UpdateUserAsync(user);
     }
 }

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -157,13 +157,11 @@ public class SessionMinterTests
     }
 
     [Fact]
-    public async Task MintAsync_DefaultProviderSet_SetsItAndWritesTheUserTwice()
+    public async Task MintAsync_DefaultProviderSet_SetsItInASingleWrite()
     {
-        // When a default provider is configured the user's AuthenticationProviderId is set, which the
-        // pre-extraction Authenticate persisted with a SECOND UpdateUserAsync (once after
-        // permissions/avatar, once after the provider id). This pins that verbatim two-write behavior; a
-        // single-write optimization would be an observable change, tracked separately, not folded into the
-        // behavior-preserving extraction.
+        // When a default provider is configured the user's AuthenticationProviderId is set before the
+        // one UpdateUserAsync, so it persists in a single write (#391) — the pre-extraction Authenticate
+        // wrote the user a second time just for this field.
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
         users.GetUserById(UserId).Returns(user);
@@ -172,6 +170,6 @@ public class SessionMinterTests
         await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), () => "203.0.113.7");
 
         Assert.Equal("SSO-Auth", user.AuthenticationProviderId);
-        await users.Received(2).UpdateUserAsync(user);
+        await users.Received(1).UpdateUserAsync(user);
     }
 }

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -66,6 +66,14 @@ internal sealed class SessionMinter
 
         await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);
 
+        // Set the default-provider id before the single user write so it persists in one round-trip
+        // (#391). The pre-extraction Authenticate wrote the user a second time just for this field.
+        if (!string.IsNullOrEmpty(parameters.DefaultProvider))
+        {
+            user.AuthenticationProviderId = parameters.DefaultProvider;
+            _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
+        }
+
         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
         var authRequest = new AuthenticationRequest();
@@ -85,12 +93,6 @@ internal sealed class SessionMinter
         // client byte-for-byte.
         authRequest.RemoteEndPoint = remoteEndPointResolver();
         _logger.LogInformation("Auth request created...");
-        if (!string.IsNullOrEmpty(parameters.DefaultProvider))
-        {
-            user.AuthenticationProviderId = parameters.DefaultProvider;
-            await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
-            _logger.LogInformation("Set default login provider to {DefaultProvider}", parameters.DefaultProvider);
-        }
 
         return await _sessionManager.AuthenticateDirect(authRequest).ConfigureAwait(false);
     }


### PR DESCRIPTION
# What & why

`SessionMinter.MintAsync` wrote the user twice when a default provider was configured: once after the permission/avatar updates, then again only to persist `AuthenticationProviderId`, verbatim from the pre-extraction `Authenticate`.

Set `AuthenticationProviderId` before the single `UpdateUserAsync` so it persists in one write. `authRequest` never reads the field and `AuthenticateDirect` still runs after the write, so the final persisted state is identical; only the redundant second round-trip is gone, and the one write is now atomic (permissions, avatar, and the provider id land together instead of in two steps, the adversarial review noted this removes the old partial-persist window).

Closes #391

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — Unchanged; if the single write throws, `AuthenticateDirect` never runs and no session is minted (the review confirmed no fail-open path and no new timing window).
- [x] No secrets logged; secrets are redacted on config export., Unchanged; the same log line moved with the block.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — 4-lens adversarial review, all PASS; final persisted state byte-identical, only the write count drops 2→1.
- [x] Log inputs from the IdP are sanitized inline at the log call., No new log calls; `DefaultProvider` is an admin-configured value.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires., A block move plus one deleted write.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. — No new structural property.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., 0 warnings, 0 errors.
- [x] `dotnet test` is green., 781 passed, 0 failed; the default-provider test now asserts `Received(1)`.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., No such files changed.

## Notes

Behavior-observable only in the write count; the final persisted user state (permissions, preferences, avatar, `AuthenticationProviderId`) is identical, and `AuthenticationProviderId` is still committed before `AuthenticateDirect`.
