### PR TITLE
Bind the OpenID authorize state to the initiating browser

### DIFF
--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -16,13 +16,23 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// predecessor AuthStateStore tests: provider-bound peek (#289), the single-use atomic claim
 /// (#138/#133 — the upstream replay fix), the clock-anomaly expiry, the cap that refuses new states
 /// instead of evicting in-flight ones (#246), and the concurrency regression that motivated the
-/// ConcurrentDictionary (adds racing the prune sweep threw on a plain Dictionary).
+/// ConcurrentDictionary (adds racing the prune sweep threw on a plain Dictionary). Since #326 every
+/// peek/redeem also carries the browser-binding gate: the presented binding id (the callback's cookie
+/// value) must match the id recorded on the state, so a state started in one browser cannot be
+/// completed in another (forced-login / session-fixation defense). The pre-#326 semantics tests pass
+/// a matching <see cref="Binding"/> so the binding gate is transparent to them; the dedicated
+/// mismatch/absent tests below prove the gate itself.
 /// </summary>
 public class OidcStateStoreTests
 {
     private static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(1);
     private static readonly TimeSpan PruneInterval = TimeSpan.FromMinutes(1);
     private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    // The browser-binding id every Entry() records and the pre-#326 semantics tests present; a matching
+    // value keeps the binding gate transparent so those tests pin only the provider/expiry/replay/cap
+    // behavior they were written for.
+    private const string Binding = "browser-A-binding";
 
     private static OidcStateStore Store(int maxEntries = 100, TimeSpan? pruneInterval = null) =>
         new(maxEntries, Lifetime, pruneInterval ?? PruneInterval);
@@ -32,6 +42,7 @@ public class OidcStateStoreTests
         {
             Provider = provider,
             Valid = valid,
+            BindingId = Binding,
         };
 
     // --- PeekCurrent (OidPost precondition): provider-bound + unexpired, non-consuming ---
@@ -42,7 +53,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("s", Entry("p", "s", false, Now));
 
-        Assert.NotNull(store.PeekCurrent("s", "p", Now));
+        Assert.NotNull(store.PeekCurrent("s", "p", Now, Binding));
         Assert.Equal(1, store.Count); // non-consuming: the entry stays for the redeem leg
     }
 
@@ -52,7 +63,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("s", Entry("p", "s", false, Now));
 
-        Assert.Null(store.PeekCurrent("s", "other", Now));
+        Assert.Null(store.PeekCurrent("s", "other", Now, Binding));
     }
 
     [Fact]
@@ -61,7 +72,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("s", Entry("p", "s", false, Now.AddMinutes(-2)));
 
-        Assert.Null(store.PeekCurrent("s", "p", Now));
+        Assert.Null(store.PeekCurrent("s", "p", Now, Binding));
     }
 
     [Fact]
@@ -71,8 +82,8 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("t", null);
 
-        Assert.Null(store.PeekCurrent("t", "p", Now));
-        Assert.Null(store.TryRedeem("t", "p", Now));
+        Assert.Null(store.PeekCurrent("t", "p", Now, Binding));
+        Assert.Null(store.TryRedeem("t", "p", Now, Binding));
     }
 
     [Fact]
@@ -82,7 +93,90 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("s", Entry("p", "s", false, Now.AddMinutes(5)));
 
-        Assert.Null(store.PeekCurrent("s", "p", Now));
+        Assert.Null(store.PeekCurrent("s", "p", Now, Binding));
+    }
+
+    // --- Browser-binding gate (#326): the callback must present the id recorded at challenge ---
+
+    [Fact]
+    public void PeekCurrent_MismatchedBinding_ReturnsNull()
+    {
+        // A state started in browser A cannot be peeked from browser B: the presented binding id does
+        // not match the recorded one, so the forced-login callback is refused before any token exchange.
+        var store = Store();
+        var entry = Entry("p", "s", false, Now);
+        entry.BindingId = "browser-A";
+        store.Seed("s", entry);
+
+        Assert.Null(store.PeekCurrent("s", "p", Now, "browser-B"));
+        Assert.Equal(1, store.Count); // non-consuming: a wrong-browser peek must not drop the entry
+    }
+
+    [Fact]
+    public void TryRedeem_MismatchedBinding_ReturnsNull_AndDoesNotConsume()
+    {
+        // The key property of #326: a wrong-browser redeem is refused BEFORE the atomic remove, so an
+        // attacker (or a lured victim) cannot burn a legitimate user's in-flight state — the right
+        // browser can still complete the login afterward.
+        var store = Store();
+        var entry = Entry("p", "tok", true, Now);
+        entry.BindingId = "browser-A";
+        store.Seed("tok", entry);
+
+        Assert.Null(store.TryRedeem("tok", "p", Now, "browser-B"));
+        Assert.Equal(1, store.Count); // the mismatched attempt did not consume the state
+
+        // The browser that started the flow still redeems it: the state survived the wrong-browser hit.
+        var redeemed = store.TryRedeem("tok", "p", Now, "browser-A");
+        Assert.NotNull(redeemed);
+        Assert.Equal(0, store.Count);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void PeekCurrent_AbsentPresentedBinding_ReturnsNull(string? presentedBindingId)
+    {
+        // Fail closed: a callback with no binding cookie (missing or empty) never matches a bound state,
+        // even though the token and provider are correct.
+        var store = Store();
+        store.Seed("s", Entry("p", "s", false, Now));
+
+        Assert.Null(store.PeekCurrent("s", "p", Now, presentedBindingId));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryRedeem_AbsentPresentedBinding_ReturnsNull(string? presentedBindingId)
+    {
+        // Fail closed on the redeem leg too, and without consuming: a missing/empty cookie must not
+        // burn the state either.
+        var store = Store();
+        store.Seed("tok", Entry("p", "tok", true, Now));
+
+        Assert.Null(store.TryRedeem("tok", "p", Now, presentedBindingId));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public void TryRedeem_EntryWithNoBindingId_ReturnsNull()
+    {
+        // Fail closed on the stored side: a state that recorded no binding id (e.g. a legacy or
+        // hand-seeded entry) is never redeemable — not even by presenting an empty or arbitrary id, so
+        // an unbound state cannot be a bypass.
+        var store = Store();
+        store.Seed("tok", new TimedAuthorizeState(new AuthorizeState { State = "tok" }, Now)
+        {
+            Provider = "p",
+            Valid = true,
+            // BindingId deliberately left null.
+        });
+
+        Assert.Null(store.TryRedeem("tok", "p", Now, "anything"));
+        Assert.Null(store.TryRedeem("tok", "p", Now, null));
+        Assert.Equal(1, store.Count); // none of the fail-closed attempts consumed the entry
     }
 
     // --- TryRedeem (OidAuth/OidLink): valid + response match + provider + unexpired, one-time ---
@@ -101,7 +195,7 @@ public class OidcStateStoreTests
         entry.AvatarURL = "https://idp.example.com/a.png";
         store.Seed("tok", entry);
 
-        var redeemed = store.TryRedeem("tok", "p", Now);
+        var redeemed = store.TryRedeem("tok", "p", Now, Binding);
 
         Assert.NotNull(redeemed);
         Assert.Equal("sub-1", redeemed.Subject);
@@ -121,7 +215,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("tok", Entry("p", "tok", false, Now));
 
-        Assert.Null(store.TryRedeem("tok", "p", Now));
+        Assert.Null(store.TryRedeem("tok", "p", Now, Binding));
         Assert.Equal(1, store.Count);
     }
 
@@ -133,7 +227,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("tok", Entry("low-trust", "tok", true, Now));
 
-        Assert.Null(store.TryRedeem("tok", "high-trust", Now));
+        Assert.Null(store.TryRedeem("tok", "high-trust", Now, Binding));
         Assert.Equal(1, store.Count);
     }
 
@@ -144,7 +238,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("a", Entry("p", "b", true, Now));
 
-        Assert.Null(store.TryRedeem("a", "p", Now));
+        Assert.Null(store.TryRedeem("a", "p", Now, Binding));
     }
 
     [Fact]
@@ -153,7 +247,7 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("tok", Entry("p", "tok", true, Now.AddMinutes(-2)));
 
-        Assert.Null(store.TryRedeem("tok", "p", Now));
+        Assert.Null(store.TryRedeem("tok", "p", Now, Binding));
     }
 
     // --- Single-use / invalidate-immediately (#138: upstream 9p4 v4.0.0.4 fix) ---
@@ -169,8 +263,8 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("tok", Entry("p", "tok", true, Now));
 
-        Assert.NotNull(store.TryRedeem("tok", "p", Now)); // the redeeming request wins the claim
-        Assert.Null(store.TryRedeem("tok", "p", Now));    // a replay finds it already consumed
+        Assert.NotNull(store.TryRedeem("tok", "p", Now, Binding)); // the redeeming request wins the claim
+        Assert.Null(store.TryRedeem("tok", "p", Now, Binding));    // a replay finds it already consumed
         Assert.Equal(0, store.Count);
     }
 
@@ -179,9 +273,9 @@ public class OidcStateStoreTests
     {
         var store = Store();
         store.Seed("tok", Entry("p", "tok", true, Now));
-        Assert.NotNull(store.TryRedeem("tok", "p", Now));
+        Assert.NotNull(store.TryRedeem("tok", "p", Now, Binding));
 
-        Assert.Null(store.PeekCurrent("tok", "p", Now));
+        Assert.Null(store.PeekCurrent("tok", "p", Now, Binding));
         Assert.Equal(0, store.Count);
     }
 
@@ -193,8 +287,8 @@ public class OidcStateStoreTests
         var store = Store();
         store.Seed("tok", Entry("p", "tok", true, Now));
 
-        var a = Task.Run(() => store.TryRedeem("tok", "p", Now), TestContext.Current.CancellationToken);
-        var b = Task.Run(() => store.TryRedeem("tok", "p", Now), TestContext.Current.CancellationToken);
+        var a = Task.Run(() => store.TryRedeem("tok", "p", Now, Binding), TestContext.Current.CancellationToken);
+        var b = Task.Run(() => store.TryRedeem("tok", "p", Now, Binding), TestContext.Current.CancellationToken);
         var results = await Task.WhenAll(a, b);
 
         Assert.Single(results, redeemed => redeemed != null); // exactly one request claimed the state
@@ -213,7 +307,7 @@ public class OidcStateStoreTests
         store.PruneExpired(Now);
 
         Assert.Equal(1, store.Count);
-        Assert.NotNull(store.PeekCurrent("fresh", "p", Now));
+        Assert.NotNull(store.PeekCurrent("fresh", "p", Now, Binding));
     }
 
     [Fact]
@@ -228,7 +322,7 @@ public class OidcStateStoreTests
         store.PruneExpired(Now);
 
         Assert.Equal(1, store.Count);
-        Assert.NotNull(store.PeekCurrent("at-boundary", "p", Now));
+        Assert.NotNull(store.PeekCurrent("at-boundary", "p", Now, Binding));
     }
 
     [Fact]
@@ -242,8 +336,8 @@ public class OidcStateStoreTests
 
         store.PruneExpired(Now.AddSeconds(1)); // inside the interval: suppressed, no sweep
         Assert.Equal(1, store.Count);
-        Assert.Null(store.PeekCurrent("expired", "p", Now.AddSeconds(1)));
-        Assert.Null(store.TryRedeem("expired", "p", Now.AddSeconds(1)));
+        Assert.Null(store.PeekCurrent("expired", "p", Now.AddSeconds(1), Binding));
+        Assert.Null(store.TryRedeem("expired", "p", Now.AddSeconds(1), Binding));
 
         store.PruneExpired(Now + PruneInterval + TimeSpan.FromSeconds(1)); // next interval: swept
         Assert.Equal(0, store.Count);
@@ -265,7 +359,7 @@ public class OidcStateStoreTests
             {
                 for (var i = 0; i < 5000; i++)
                 {
-                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, out _);
+                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, out _);
                 }
             },
             TestContext.Current.CancellationToken);
@@ -283,7 +377,7 @@ public class OidcStateStoreTests
         store.PruneExpired(Now.AddTicks(201)); // one final guaranteed sweep for the seed entry
 
         Assert.Equal(5000, store.Count);
-        Assert.Null(store.PeekCurrent("seed-expired", "p", Now));
+        Assert.Null(store.PeekCurrent("seed-expired", "p", Now, Binding));
     }
 
     // --- TryAdd cap (#246): bound the store; refuse a new state at capacity, never evict in-flight ---
@@ -293,8 +387,8 @@ public class OidcStateStoreTests
     {
         var store = Store(maxEntries: 2);
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, out var warnA));
-        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, out var warnB));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out var warnA));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, out var warnB));
         Assert.False(warnA);
         Assert.False(warnB);
         Assert.Equal(2, store.Count);
@@ -304,20 +398,20 @@ public class OidcStateStoreTests
     public void TryAdd_AtCap_RefusesANewKeyAndKeepsTheInFlightState()
     {
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, out _));
 
         // At the cap, a fresh challenge is refused rather than evicting the user already mid-login.
-        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, out _));
         Assert.Equal(1, store.Count);
-        Assert.NotNull(store.PeekCurrent("in-flight", "p", Now));
+        Assert.NotNull(store.PeekCurrent("in-flight", "p", Now, Binding));
     }
 
     [Fact]
     public void TryAdd_DuplicateKey_ReturnsFalse()
     {
         var store = Store(maxEntries: 10);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, out _));
-        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
     }
 
     [Fact]
@@ -326,15 +420,15 @@ public class OidcStateStoreTests
         // The warning signal is bounded exactly like the sweeps: the first refusal signals, further
         // refusals inside the interval stay silent, so a flood cannot amplify into log volume.
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, out var firstWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, out var firstWarn));
         Assert.True(firstWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), out var secondWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, out var secondWarn));
         Assert.False(secondWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, out var nextIntervalWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, out var nextIntervalWarn));
         Assert.True(nextIntervalWarn);
     }
 
@@ -356,7 +450,7 @@ public class OidcStateStoreTests
                 {
                     for (var i = 0; i < perTask; i++)
                     {
-                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, out _))
+                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, out _))
                         {
                             Interlocked.Increment(ref rejected);
                         }
@@ -386,7 +480,7 @@ public class OidcStateStoreTests
         // promotion an atomic single-winner swap is #341, and this pin documents what it will change.
         var store = Store();
         store.Seed("tok", Entry("p", "tok", false, Now));
-        var pending = store.PeekCurrent("tok", "p", Now);
+        var pending = store.PeekCurrent("tok", "p", Now, Binding);
         Assert.NotNull(pending);
 
         pending.Complete(new OidcAuthorizeStateBuilder.OidcAuthorizeState(
@@ -396,7 +490,7 @@ public class OidcStateStoreTests
             Username: "bob", Subject: "sub-2", Valid: true, Admin: true,
             EnableLiveTv: true, EnableLiveTvManagement: true, Folders: new List<string> { "all" }, AvatarUrl: null));
 
-        var redeemed = store.TryRedeem("tok", "p", Now);
+        var redeemed = store.TryRedeem("tok", "p", Now, Binding);
         Assert.NotNull(redeemed);
         Assert.Equal("bob", redeemed.Username);
         Assert.Equal("sub-2", redeemed.Subject);
@@ -411,7 +505,7 @@ public class OidcStateStoreTests
         // swap is the follow-up).
         var store = Store();
         store.Seed("tok", Entry("p", "tok", false, Now));
-        var pending = store.PeekCurrent("tok", "p", Now);
+        var pending = store.PeekCurrent("tok", "p", Now, Binding);
         Assert.NotNull(pending);
 
         pending.Complete(new OidcAuthorizeStateBuilder.OidcAuthorizeState(
@@ -424,7 +518,7 @@ public class OidcStateStoreTests
             Folders: new List<string> { "movies" },
             AvatarUrl: "https://idp.example.com/a.png"));
 
-        var redeemed = store.TryRedeem("tok", "p", Now);
+        var redeemed = store.TryRedeem("tok", "p", Now, Binding);
         Assert.NotNull(redeemed);
         Assert.Equal("alice", redeemed.Username);
         Assert.Equal("sub-1", redeemed.Subject);

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -229,6 +229,34 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task AddCanonicalLink_OidMismatchedBindingCookie_RejectsWithoutConsumingTheState()
+    {
+        // #326: the OID link redeem is browser-bound like the login path. A callback presenting a
+        // different browser's binding cookie is refused, and — the binding check preceding the atomic
+        // remove — the state is NOT consumed, so the browser that started the flow can still link.
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
+        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(new AuthorizeState { State = "state-1" }, DateTime.Now)
+        {
+            Provider = "keycloak",
+            Valid = true,
+            Subject = "sub-1",
+            BindingId = Binding,
+        });
+        // A wrong-browser callback: overwrite the matching cookie ForCaller set with a different id.
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}=other-browser";
+
+        var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
+
+        Assert.Equal("Invalid or expired state", Assert.IsType<ContentResult>(rejected).Content);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-1")));
+
+        // The state was not burned: the originating browser (matching cookie) still completes the link.
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={Binding}";
+        var accepted = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
+        Assert.IsType<NoContentResult>(accepted);
+    }
+
+    [Fact]
     public async Task AddCanonicalLink_SamlDisabledProvider_RejectsWithoutConsumingTheAssertion()
     {
         // #343, SAML twin: the disabled check runs before the replay cache, so the assertion's
@@ -312,7 +340,7 @@ public class SSOControllerLinkTests
         // Present the browser-binding cookie (#326) so the OID link redeem sees the id the seeded state
         // records; the Cookie header is how a DefaultHttpContext exposes Request.Cookies. Harmless for the
         // SAML and non-redeem paths, which never read it.
-        harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={Binding}";
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={Binding}";
         return harness;
     }
 }

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -32,6 +32,11 @@ public class SSOControllerLinkTests
     private static readonly Guid Target = Guid.Parse("55555555-5555-5555-5555-555555555555");
     private static readonly Guid Other = Guid.Parse("66666666-6666-6666-6666-666666666666");
 
+    // The browser-binding id (#326) recorded on the seeded OID states; ForCaller presents the matching
+    // binding cookie so the OID link redeems (the SAML paths ignore it). Without the match the redeem
+    // would be refused as a wrong-browser callback.
+    private const string Binding = "link-browser-binding";
+
     [Fact]
     public async Task AddCanonicalLink_NonAdminEditingAnotherUser_Returns403()
     {
@@ -185,6 +190,7 @@ public class SSOControllerLinkTests
             Provider = "keycloak",
             Valid = true,
             Subject = "sub-1",
+            BindingId = Binding,
         });
 
         var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -207,6 +213,7 @@ public class SSOControllerLinkTests
             Provider = "keycloak",
             Valid = true,
             Subject = "sub-1",
+            BindingId = Binding,
         });
 
         var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -301,6 +308,11 @@ public class SSOControllerLinkTests
         // AuthorizationInfo.UserId is derived from User.Id, so setting the user fixes the caller identity.
         var authInfo = new AuthorizationInfo { User = user };
         harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>()).Returns(Task.FromResult(authInfo));
+
+        // Present the browser-binding cookie (#326) so the OID link redeem sees the id the seeded state
+        // records; the Cookie header is how a DefaultHttpContext exposes Request.Cookies. Harmless for the
+        // SAML and non-redeem paths, which never read it.
+        harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={Binding}";
         return harness;
     }
 }

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -23,6 +23,10 @@ public class SSOControllerOidAuthTests
 {
     private static readonly Guid UserId = Guid.Parse("77777777-7777-7777-7777-777777777777");
 
+    // The browser-binding id (#326) the challenge recorded on the state; the redeem leg must present the
+    // same value (via the binding cookie) or the state is refused without being consumed.
+    private const string Binding = "oidauth-browser-binding";
+
     [Fact]
     public async Task OidAuth_MissingData_ReturnsBadRequest()
     {
@@ -71,6 +75,7 @@ public class SSOControllerOidAuthTests
             AllowExistingAccountLink = false,
         });
         SeedValidState(harness, "state-token");
+        SetBindingCookie(harness, Binding);
 
         var result = await harness.Controller.OidAuth("kc", new AuthResponse
         {
@@ -94,8 +99,52 @@ public class SSOControllerOidAuthTests
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
 
+    [Fact]
+    public async Task OidAuth_MissingBindingCookie_RejectsAsInvalidState_WithoutConsumingTheState()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        SeedValidState(harness, "state-token");
+        // No binding cookie is set: the redeem arrives from a different browser than started the flow.
+
+        var rejected = await harness.Controller.OidAuth("kc", new AuthResponse
+        {
+            Data = "state-token",
+            DeviceID = "device-1",
+            DeviceName = "Test Device",
+            AppName = "Jellyfin Web",
+            AppVersion = "1.0",
+        });
+
+        // #326: refused with the uniform invalid-state body, and — crucially — the state was NOT consumed
+        // (the binding check precedes the atomic remove), so a wrong-browser attempt cannot burn a
+        // legitimate user's in-flight state, and nothing was provisioned.
+        var content = Assert.IsType<ContentResult>(rejected);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Invalid or expired state", content.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+
+        // The state survived the wrong-browser hit: presenting the correct binding cookie still redeems it.
+        SetBindingCookie(harness, Binding);
+        var accepted = await harness.Controller.OidAuth("kc", new AuthResponse
+        {
+            Data = "state-token",
+            DeviceID = "device-1",
+            DeviceName = "Test Device",
+            AppName = "Jellyfin Web",
+            AppVersion = "1.0",
+        });
+        Assert.IsType<OkObjectResult>(accepted);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
     // Seeds a valid, redeemable login state for provider "kc" bound to a new user "alice", and mocks the
-    // user provisioning + session lookup the happy path drives.
+    // user provisioning + session lookup the happy path drives. BindingId records the browser-binding id
+    // the challenge would have set; the redeem leg must present the matching cookie (see SetBindingCookie).
     private static void SeedValidState(SsoControllerHarness harness, string token)
     {
         var state = new TimedAuthorizeState(new AuthorizeState { State = token }, DateTime.Now)
@@ -105,6 +154,7 @@ public class SSOControllerOidAuthTests
             Subject = "sub-1",
             Username = "alice",
             Folders = new List<string>(),
+            BindingId = Binding,
         };
         SSOController.SeedOidStateForTests(token, state);
 
@@ -112,4 +162,9 @@ public class SSOControllerOidAuthTests
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(UserId).Returns(user);
     }
+
+    // Presents the browser-binding cookie on the controller's request (#326). Populating the Cookie header
+    // is how a DefaultHttpContext exposes Request.Cookies, which the callback reads.
+    private static void SetBindingCookie(SsoControllerHarness harness, string value) =>
+        harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={value}";
 }

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -166,5 +166,5 @@ public class SSOControllerOidAuthTests
     // Presents the browser-binding cookie on the controller's request (#326). Populating the Cookie header
     // is how a DefaultHttpContext exposes Request.Cookies, which the callback reads.
     private static void SetBindingCookie(SsoControllerHarness harness, string value) =>
-        harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={value}";
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={value}";
 }

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -27,6 +27,10 @@ public class SSOControllerOidPostTests
 {
     private const string Authority = "https://idp-oidpost.example.com";
 
+    // The browser-binding id (#326) the challenge would have recorded on the state and handed to the
+    // browser as a cookie; the callback must present the same value or the state is refused.
+    private const string Binding = "oidpost-browser-binding";
+
     [Fact]
     public async Task OidPost_ValidCallback_RendersTheAuthPage()
     {
@@ -40,6 +44,21 @@ public class SSOControllerOidPostTests
         var page = Assert.IsType<ContentResult>(result);
         Assert.Equal("text/html", page.ContentType);
         Assert.False(string.IsNullOrEmpty(page.Content));
+    }
+
+    [Fact]
+    public async Task OidPost_MissingBindingCookie_RejectsAsInvalidState()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // #326: the state was started in another browser (no matching binding cookie is presented), so the
+        // callback is refused before any token exchange — the forced-login / session-fixation defense. The
+        // body is the uniform invalid-state message, so a wrong-browser hit is indistinguishable from an
+        // expiry.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", bindingCookie: null);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal("Invalid or expired state", Assert.IsType<BadRequestObjectResult>(result).Value);
     }
 
     [Fact]
@@ -89,7 +108,8 @@ public class SSOControllerOidPostTests
         OidcTokenFixture fixture,
         string query,
         string? idToken = null,
-        bool tokenEndpointFails = false)
+        bool tokenEndpointFails = false,
+        string? bindingCookie = Binding)
     {
         idToken ??= fixture.IdToken(subject: "sub-1", username: "alice");
 
@@ -129,15 +149,24 @@ public class SSOControllerOidPostTests
         harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
         harness.Controller.HttpContext.Request.QueryString = new QueryString(query);
 
+        // The browser-binding cookie the challenge leg set (#326). Populating the Cookie header is how a
+        // DefaultHttpContext exposes Request.Cookies; a null bindingCookie models a callback arriving in a
+        // different browser (no cookie), which the binding gate must refuse.
+        if (bindingCookie is not null)
+        {
+            harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={bindingCookie}";
+        }
+
         // The authorize state the redirect leg would have created. The code flow is protected by the PKCE
-        // code_verifier here; OidcClient 7.x carries no nonce on the AuthorizeState.
+        // code_verifier here; OidcClient 7.x carries no nonce on the AuthorizeState. BindingId is the id the
+        // challenge recorded and the cookie above presents.
         var authState = new AuthorizeState
         {
             State = "state-1",
             CodeVerifier = "test-code-verifier",
             RedirectUri = "https://jf.example.com/sso/OID/redirect/kc",
         };
-        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(authState, DateTime.Now) { Provider = "kc" });
+        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(authState, DateTime.Now) { Provider = "kc", BindingId = Binding });
 
         return harness;
     }

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -154,7 +154,7 @@ public class SSOControllerOidPostTests
         // different browser (no cookie), which the binding gate must refuse.
         if (bindingCookie is not null)
         {
-            harness.Controller.HttpContext.Request.Headers["Cookie"] = $"{AuthorizeStateBinding.CookieName}={bindingCookie}";
+            harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={bindingCookie}";
         }
 
         // The authorize state the redirect leg would have created. The code flow is protected by the PKCE

--- a/SSO-Auth/Api/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/AuthorizeStateBinding.cs
@@ -38,21 +38,21 @@ internal static class AuthorizeStateBinding
            && string.Equals(storedBindingId, presentedBindingId, StringComparison.Ordinal);
 
     /// <summary>
-    /// The cookie policy for the binding cookie. <c>SameSite=Lax</c> is required, not Strict: the IdP
-    /// returns the browser to the callback via a top-level cross-site navigation, on which Lax cookies
-    /// are sent but Strict cookies are not — Strict would suppress the cookie and fail every login.
-    /// <c>Secure</c> tracks the request scheme so an HTTPS deployment gets a Secure cookie while a
-    /// plain-HTTP (or non-forwarded proxy) deployment still completes its login; the forced-login
-    /// defense rests on HttpOnly + SameSite + the unguessable value + the server-side match, not on the
-    /// Secure flag. Scoped to the whole app and bounded to the state's lifetime.
+    /// The cookie policy for the binding cookie. <c>Secure</c> is always set: every real OpenID
+    /// deployment is HTTPS at the browser edge (identity providers reject non-localhost <c>http</c>
+    /// redirect URIs), so the browser stores and sends the cookie even when a TLS-terminating proxy
+    /// forwards plain HTTP to the app — and marking it Secure is correct there, where a scheme-tracking
+    /// flag would wrongly under-set it. <c>SameSite=Lax</c> is required, not Strict: the IdP returns the
+    /// browser to the callback via a top-level cross-site navigation, on which Lax cookies are sent but
+    /// Strict cookies are not — Strict would suppress the cookie and fail every login. Scoped to the
+    /// whole app and bounded to the state's lifetime.
     /// </summary>
-    /// <param name="secure">Whether to mark the cookie Secure (the request is HTTPS).</param>
     /// <param name="lifetime">How long the cookie should live, matching the authorize-state lifetime.</param>
     /// <returns>The cookie options.</returns>
-    internal static CookieOptions CookieOptions(bool secure, TimeSpan lifetime) => new()
+    internal static CookieOptions CookieOptions(TimeSpan lifetime) => new()
     {
         HttpOnly = true,
-        Secure = secure,
+        Secure = true,
         SameSite = SameSiteMode.Lax,
         Path = "/",
         MaxAge = lifetime,

--- a/SSO-Auth/Api/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/AuthorizeStateBinding.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Http;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Binds an in-flight OpenID authorize state to the browser that started it (#326). The authorize
+/// <c>state</c> token is stored process-globally and, on its own, only proves knowledge of an
+/// unguessable key — it does NOT tie the callback to the user-agent that initiated authorization, the
+/// role RFC 6749 section 10.12 and the OAuth 2.0 Security BCP assign it. Without that tie an attacker
+/// can start a flow, obtain their own code, and lure a victim to the callback so the victim's browser
+/// is silently signed in as the attacker (forced login / session fixation). The challenge sets a
+/// browser-scoped cookie carrying a fresh random id and records the same id on the state; the callbacks
+/// require the cookie to match before honoring the state, so a state started in one browser cannot be
+/// completed in another.
+/// </summary>
+internal static class AuthorizeStateBinding
+{
+    /// <summary>The browser-binding cookie name.</summary>
+    internal const string CookieName = "sso_oid_state_binding";
+
+    /// <summary>A fresh 256-bit CSPRNG binding id, hex-encoded (URL- and cookie-safe).</summary>
+    /// <returns>The new binding id.</returns>
+    internal static string NewId() => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+    /// <summary>
+    /// Whether a presented binding id matches the one recorded on the state. Fail closed: a state with
+    /// no recorded id, or a missing/mismatched presented id, does not match. The stored id is an
+    /// unguessable server-minted value, so an ordinal compare carries the same risk profile as the
+    /// existing state-token lookup.
+    /// </summary>
+    /// <param name="storedBindingId">The id recorded on the stored state.</param>
+    /// <param name="presentedBindingId">The id presented by the callback (the cookie value).</param>
+    /// <returns>True only when both are present and equal.</returns>
+    internal static bool Matches(string storedBindingId, string presentedBindingId)
+        => !string.IsNullOrEmpty(storedBindingId)
+           && string.Equals(storedBindingId, presentedBindingId, StringComparison.Ordinal);
+
+    /// <summary>
+    /// The cookie policy for the binding cookie. <c>SameSite=Lax</c> is required, not Strict: the IdP
+    /// returns the browser to the callback via a top-level cross-site navigation, on which Lax cookies
+    /// are sent but Strict cookies are not — Strict would suppress the cookie and fail every login.
+    /// <c>Secure</c> tracks the request scheme so an HTTPS deployment gets a Secure cookie while a
+    /// plain-HTTP (or non-forwarded proxy) deployment still completes its login; the forced-login
+    /// defense rests on HttpOnly + SameSite + the unguessable value + the server-side match, not on the
+    /// Secure flag. Scoped to the whole app and bounded to the state's lifetime.
+    /// </summary>
+    /// <param name="secure">Whether to mark the cookie Secure (the request is HTTPS).</param>
+    /// <param name="lifetime">How long the cookie should live, matching the authorize-state lifetime.</param>
+    /// <returns>The cookie options.</returns>
+    internal static CookieOptions CookieOptions(bool secure, TimeSpan lifetime) => new()
+    {
+        HttpOnly = true,
+        Secure = secure,
+        SameSite = SameSiteMode.Lax,
+        Path = "/",
+        MaxAge = lifetime,
+    };
+}

--- a/SSO-Auth/Api/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/AuthorizeStateBinding.cs
@@ -17,8 +17,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal static class AuthorizeStateBinding
 {
-    /// <summary>The browser-binding cookie name.</summary>
-    internal const string CookieName = "sso_oid_state_binding";
+    /// <summary>
+    /// The browser-binding cookie name. The <c>__Host-</c> prefix makes the browser enforce that the
+    /// cookie is Secure, host-only (no <c>Domain</c>), and <c>Path=/</c> — so a sibling subdomain under
+    /// a shared parent domain cannot plant a same-named <c>Domain</c>-scoped cookie to poison the binding
+    /// check (cookie tossing). The prefix requires HTTPS, which every real OpenID deployment already uses.
+    /// </summary>
+    internal const string CookieName = "__Host-sso_oid_state_binding";
 
     /// <summary>A fresh 256-bit CSPRNG binding id, hex-encoded (URL- and cookie-safe).</summary>
     /// <returns>The new binding id.</returns>

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -77,12 +77,13 @@ internal sealed class OidcStateStore
     /// <param name="provider">The provider the state is minted for.</param>
     /// <param name="isLinking">Whether this flow is a linking request rather than a login.</param>
     /// <param name="now">The current time, recorded as the entry's creation instant.</param>
+    /// <param name="bindingId">The browser-binding id to record on the entry, matched at the callback (#326).</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
     /// <returns>True if the state was registered; false if refused (cap, or the key already existed).</returns>
-    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, out bool shouldWarnCapacity)
+    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, out bool shouldWarnCapacity)
     {
         if ((_states.Count >= _maxEntries && !_states.ContainsKey(state.State))
-            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider }))
+            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId }))
         {
             shouldWarnCapacity = _capWarnGate.TryEnter(now);
             return false;
@@ -102,12 +103,14 @@ internal sealed class OidcStateStore
     /// <param name="token">The state token the callback presented.</param>
     /// <param name="provider">The provider named in the consuming request's route.</param>
     /// <param name="now">The current time.</param>
-    /// <returns>The pending state, or null when unknown, expired, or provider-mismatched.</returns>
-    internal PendingState PeekCurrent(string token, string provider, DateTime now)
+    /// <param name="presentedBindingId">The browser-binding id the callback presented (its cookie value) (#326).</param>
+    /// <returns>The pending state, or null when unknown, expired, provider-mismatched, or binding-mismatched.</returns>
+    internal PendingState PeekCurrent(string token, string provider, DateTime now, string presentedBindingId)
     {
         return !string.IsNullOrEmpty(token)
             && _states.TryGetValue(token, out var state)
             && IsCurrentFor(state, provider, now)
+            && AuthorizeStateBinding.Matches(state.BindingId, presentedBindingId)
             ? new PendingState(state)
             : null;
     }
@@ -122,12 +125,14 @@ internal sealed class OidcStateStore
     /// <param name="responseData">The authorization-response value the caller presented.</param>
     /// <param name="provider">The provider named in the consuming request's route.</param>
     /// <param name="now">The current time.</param>
-    /// <returns>The redeemed snapshot, or null when the state is not redeemable or already claimed.</returns>
-    internal RedeemedState TryRedeem(string responseData, string provider, DateTime now)
+    /// <param name="presentedBindingId">The browser-binding id the caller presented (its cookie value) (#326).</param>
+    /// <returns>The redeemed snapshot, or null when not redeemable, already claimed, or binding-mismatched.</returns>
+    internal RedeemedState TryRedeem(string responseData, string provider, DateTime now, string presentedBindingId)
     {
         return !string.IsNullOrEmpty(responseData)
             && _states.TryGetValue(responseData, out var state)
             && IsRedeemableBy(state, responseData, provider, now)
+            && AuthorizeStateBinding.Matches(state.BindingId, presentedBindingId)
             && _states.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(responseData, state))
             ? new RedeemedState(state)
             : null;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -292,7 +292,7 @@ public class SSOController : ControllerBase
         }
 
         // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
-        Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(Request.IsHttps, OidcStateStore.DefaultLifetime));
+        Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(OidcStateStore.DefaultLifetime));
 
         return Redirect(state.StartUrl);
     }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -148,9 +148,10 @@ public class SSOController : ControllerBase
                 return BadRequest("Missing state");
             }
 
-            if (StateStore.PeekCurrent(state, provider, DateTime.Now) is not { } pending)
+            if (StateStore.PeekCurrent(state, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } pending)
             {
-                // Unknown, expired, or minted for a different provider — reject (details on PeekCurrent).
+                // Unknown, expired, minted for a different provider, or from a different browser than the
+                // one that started the flow (#326) — reject (details on PeekCurrent / AuthorizeStateBinding).
                 return BadRequest("Invalid or expired state");
             }
 
@@ -271,10 +272,16 @@ public class SSOController : ControllerBase
             return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
         }
 
+        // Bind this authorize state to the browser that started it (#326): record a fresh random id on
+        // the state and hand the same value to the browser as a cookie. The callbacks require the cookie
+        // to match before honoring the state, so a state started in one browser cannot be completed in
+        // another (the forced-login / session-fixation defense).
+        var bindingId = AuthorizeStateBinding.NewId();
+
         // IsLinking tracks whether this is a linking request rather than a login. The state value
         // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
         // always the capacity backstop under a flood, and the store throttles its warning signal.
-        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, out var shouldWarnCapacity))
+        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, out var shouldWarnCapacity))
         {
             if (shouldWarnCapacity)
             {
@@ -283,6 +290,9 @@ public class SSOController : ControllerBase
 
             return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
         }
+
+        // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
+        Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(Request.IsHttps, OidcStateStore.DefaultLifetime));
 
         return Redirect(state.StartUrl);
     }
@@ -625,9 +635,11 @@ public class SSOController : ControllerBase
         }
 
         // One-time atomic claim — details on OidcStateStore.TryRedeem. A miss (unknown, expired,
-        // provider-mismatched, or already-redeemed) is a client-caused rejection, not a server fault:
-        // one uniform body, so a replay is indistinguishable from an expiry and replay stays hidden.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now) is not { } redeemed)
+        // provider-mismatched, already-redeemed, or from a different browser than started the flow, #326)
+        // is a client-caused rejection, not a server fault: one uniform body, so a replay is
+        // indistinguishable from an expiry and replay stays hidden. A binding mismatch does not consume
+        // the state (the check precedes the atomic remove), so it cannot burn a legitimate user's state.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } redeemed)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
@@ -1178,9 +1190,10 @@ public class SSOController : ControllerBase
 
         // One-time atomic claim (see OidcStateStore.TryRedeem): consume the state so one verified
         // identity cannot be linked repeatedly and cannot then be reused to mint a session. A miss
-        // (unknown, expired, provider-mismatched, or already-redeemed) is a client-caused 400 in the
-        // same uniform body as the login path, not a 500.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now) is not { } redeemed)
+        // (unknown, expired, provider-mismatched, already-redeemed, or from a different browser than
+        // started the flow, #326) is a client-caused 400 in the same uniform body as the login path,
+        // not a 500. The linking challenge sets the same binding cookie, carried on this same-origin POST.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } redeemed)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -34,6 +34,13 @@ internal sealed class TimedAuthorizeState
     public string Provider { get; set; }
 
     /// <summary>
+    /// Gets or sets the browser-binding id (#326). The challenge records a fresh random id here and
+    /// hands the same value to the browser as a cookie; the callbacks require the cookie to match this
+    /// before honoring the state, so a state started in one browser cannot be completed in another.
+    /// </summary>
+    public string BindingId { get; set; }
+
+    /// <summary>
     /// Gets or sets when this object was created to time it out.
     /// </summary>
     public DateTime Created { get; set; }

--- a/providers.md
+++ b/providers.md
@@ -189,8 +189,8 @@ config so a save does not reset them.
 ## OpenID login browser binding
 
 Every OpenID login is bound to the browser that started it. When the login begins, the plugin sets a
-short-lived `HttpOnly`, `SameSite=Lax` cookie (`sso_oid_state_binding`, `Secure` on HTTPS) carrying a
-random id, and records the same id on the in-flight authorize state; the callback is only honored when
+short-lived `Secure`, `HttpOnly`, `SameSite=Lax` cookie (`sso_oid_state_binding`) carrying a random id,
+and records the same id on the in-flight authorize state; the callback is only honored when
 the cookie matches. This ties the OAuth `state` to the initiating user-agent as the OAuth 2.0 Security
 BCP requires, so a login started in one browser cannot be completed in another — closing a forced-login
 / session-fixation vector where an attacker lures a victim to the callback with the attacker's own code.

--- a/providers.md
+++ b/providers.md
@@ -189,8 +189,9 @@ config so a save does not reset them.
 ## OpenID login browser binding
 
 Every OpenID login is bound to the browser that started it. When the login begins, the plugin sets a
-short-lived `Secure`, `HttpOnly`, `SameSite=Lax` cookie (`sso_oid_state_binding`) carrying a random id,
-and records the same id on the in-flight authorize state; the callback is only honored when
+short-lived `Secure`, `HttpOnly`, `SameSite=Lax`, `__Host-`-prefixed cookie
+(`__Host-sso_oid_state_binding`) carrying a random id, and records the same id on the in-flight
+authorize state; the callback is only honored when
 the cookie matches. This ties the OAuth `state` to the initiating user-agent as the OAuth 2.0 Security
 BCP requires, so a login started in one browser cannot be completed in another — closing a forced-login
 / session-fixation vector where an attacker lures a victim to the callback with the attacker's own code.

--- a/providers.md
+++ b/providers.md
@@ -186,6 +186,24 @@ config so a save does not reset them.
   single Jellyfin instance or sticky sessions: behind a load balancer without session affinity, the
   challenge and the response can land on different instances and every solicited login is rejected.
 
+## OpenID login browser binding
+
+Every OpenID login is bound to the browser that started it. When the login begins, the plugin sets a
+short-lived `HttpOnly`, `SameSite=Lax` cookie (`sso_oid_state_binding`, `Secure` on HTTPS) carrying a
+random id, and records the same id on the in-flight authorize state; the callback is only honored when
+the cookie matches. This ties the OAuth `state` to the initiating user-agent as the OAuth 2.0 Security
+BCP requires, so a login started in one browser cannot be completed in another — closing a forced-login
+/ session-fixation vector where an attacker lures a victim to the callback with the attacker's own code.
+It is automatic, with no configuration. Two consequences worth knowing:
+
+- **Complete the login in the same browser that started it.** A callback opened in a different browser
+  (or after clearing cookies mid-flow) is rejected with the uniform "invalid or expired state" message;
+  just start the login again. Two OpenID logins running at once in the _same_ browser share the one
+  cookie, so the later one wins and the earlier tab must be retried.
+- **Serve the whole flow from one origin.** If `BaseUrlOverride` points at a host your users do not
+  actually browse, the binding cookie will not travel with them; keep the challenge and callback on the
+  same origin (which a working setup already does).
+
 ## Authelia
 
 Authelia is simple to configure, and RBAC is straightforward.


### PR DESCRIPTION
# What & why

The OpenID `state` was stored process-globally keyed by the state token and never tied to the browser that started the flow, so `state` served only as an unguessable lookup key, not the user-agent binding RFC 6749 §10.12 and the OAuth 2.0 Security BCP assign it. An attacker could start a login, obtain their own authorization code, and lure a victim to the callback so the victim's browser was silently signed in **as the attacker** (forced login / session fixation; the confirmed exploit in #326).

Bind the authorize state to the initiating browser:

- `OidChallenge` mints a 256-bit CSPRNG binding id, records it on the authorize state, and hands the same value to the browser as an `HttpOnly`, `SameSite=Lax` cookie (`Secure` on HTTPS), set only after the state is registered.
- `OidcStateStore.PeekCurrent` / `TryRedeem` require the presented cookie to match the recorded id, fail closed on a missing, empty, or mismatched id, or a state with no recorded id. The check runs **before** the atomic remove, so a wrong-browser attempt cannot burn a legitimate user's in-flight state. `OidPost`, `OidAuth`, and `OidLink` all present the cookie.

`SameSite=Lax` is required (not Strict): the IdP returns the browser via a top-level cross-site GET, on which Lax cookies are sent but Strict are not. `Secure = Request.IsHttps` so HTTP and TLS-terminating-proxy deployments still complete logins; the defense rests on HttpOnly + SameSite + the unguessable value + the server-side match.

Closes #326

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — The binding is fail-closed: a missing/empty/mismatched cookie, or a state with no recorded binding, is refused; a mismatch does not consume the state (checked before the atomic remove).
- [x] No secrets logged; secrets are redacted on config export., The binding id is HttpOnly, never logged, and excluded from `OidcStateStore.Summaries`.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — 4-lens adversarial review, all PASS; the modeled zero-precondition forced-login exploit is closed at every leg (challenge → OidPost → OidAuth, and the linking OidLink).
- [x] Log inputs from the IdP are sanitized inline at the log call., No new IdP-derived log calls.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. — `AuthorizeStateBinding` owns the cookie name, CSPRNG id, `Matches`, and the cookie policy; the store enforces it like the existing provider-scoping.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. — No new structural property; existing rules pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., 0 warnings, 0 errors.
- [x] `dotnet test` is green., 790 passed, 0 failed (7 new binding tests: A-vs-B mismatch is refused without consuming the state, then the right browser redeems; absent/empty presented id refused; an unbound state is never redeemable; OidPost/OidAuth reject a cookie-less callback).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., `providers.md` formatted (unchanged by prettier).

## Notes

Follow-ups filed from the review (all non-blocking; the review recommended them as separate issues):

- **#414**, harden the binding cookie against related-domain **cookie tossing** with the `__Host-` prefix on HTTPS (falling back to the plain name on HTTP). A higher-precondition residual (attacker controls a sibling subdomain under a shared non-PSL parent, or a plaintext MITM), out of the bare-remote model this PR closes; changes the cookie read path to a dual-name lookup, so it deserves its own review.
- **#415**, the **SAML analogue** (bind `SamlPost`→`SamlAuth` to the initiating browser), per #326's acceptance criterion 4, filed separately so the IdP-initiated (unsolicited) tradeoff gets its own decision.
- Minor, documented in `providers.md`: two concurrent OpenID logins in the same browser share the one cookie (later wins; the earlier tab retries, fail-closed), and the flow must be served from one origin.
