### PR TITLE
Bind the SP-initiated SAML login to the initiating browser

### DIFF
--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -48,7 +48,7 @@ public class ProviderScopedKeyTests
         Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now));
 
         var requests = new SamlRequestCache();
-        requests.Register(requestKey!, now.AddMinutes(15), now);
-        Assert.False(requests.TryConsume(requestKey!, now));
+        requests.Register(requestKey!, "binding", now.AddMinutes(15), now);
+        Assert.False(requests.TryConsume(requestKey!, now, out _));
     }
 }

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
@@ -36,7 +37,23 @@ public class SSOControllerChallengeTests
     }
 
     [Fact]
-    public void SamlChallenge_LinkingFlow_CarriesTheLinkingRelayState()
+    public void SamlChallenge_LoginFlow_SetsTheBrowserBindingCookie()
+    {
+        // #415: a login challenge sets the browser-binding cookie whose id is recorded against the
+        // AuthnRequest, so the session-mint endpoint can require the response to return in the same
+        // browser. Secure + HttpOnly + the __Host- prefix mirror #326.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = EnabledProvider());
+
+        Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        var setCookie = harness.Controller.HttpContext.Response.Headers.SetCookie.ToString();
+        Assert.Contains(AuthorizeStateBinding.SamlCookieName + "=", setCookie);
+        Assert.Contains("secure", setCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("httponly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void SamlChallenge_LinkingFlow_CarriesTheLinkingRelayState_AndSetsNoBindingCookie()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = EnabledProvider());
 
@@ -45,6 +62,10 @@ public class SSOControllerChallengeTests
         // The linking callback is told apart from a login by the RelayState the challenge sets.
         Assert.Contains("SAMLRequest=", result.Url);
         Assert.Contains("RelayState=linking", result.Url);
+        // Linking is a separate flow that does not consume the outstanding request, so no binding
+        // cookie is minted for it (#415).
+        var setCookie = harness.Controller.HttpContext.Response.Headers.SetCookie.ToString();
+        Assert.DoesNotContain(AuthorizeStateBinding.SamlCookieName, setCookie);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -219,6 +219,35 @@ public class SSOControllerSamlAuthTests
     }
 
     [Fact]
+    public async Task SamlAuth_InResponseToPresentButNoOutstandingRequest_RejectsEvenWithValidateOff()
+    {
+        // The bypass this fix closes: a response that DOES carry an InResponseTo (so it claims to be
+        // solicited) but whose outstanding entry is gone — expired, evicted, lost to a restart or a
+        // non-sticky multi-node hop — must NOT be treated as unsolicited and waved through. Without an
+        // entry there is no binding to check, so a lost correlation fails closed even when
+        // ValidateInResponseTo is off (the default). Otherwise an attacker could defeat the binding by
+        // submitting a signature-valid response after its 15-minute window elapsed.
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: "_authnreq-expired");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+            // ValidateInResponseTo deliberately left off (the default) — the reject must not depend on it.
+        });
+        // No SeedSamlRequestForTests: the outstanding entry does not exist.
+
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
     public async Task SamlAuth_UnsolicitedResponse_NoBindingRequired_StillProvisions()
     {
         // IdP-initiated / unsolicited: no matching outstanding request, so browser binding imposes no

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -145,4 +145,101 @@ public class SSOControllerSamlAuthTests
         Assert.IsType<OkObjectResult>(result);
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
+
+    private const string AuthnRequestId = "_authnreq-415";
+    private const string Binding = "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF001122334455667788";
+
+    // Builds a harness whose "adfs" provider will provision "alice", and seeds an outstanding SAML
+    // AuthnRequest for it carrying the given binding id — the state SamlChallenge would have set (#415).
+    private static SsoControllerHarness SolicitedHarness(SamlFixture fixture, string bindingId)
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+        SSOController.SeedSamlRequestForTests("adfs", AuthnRequestId, bindingId, DateTime.UtcNow.AddMinutes(15));
+        return harness;
+    }
+
+    private static void SetSamlBindingCookie(SsoControllerHarness harness, string value) =>
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.SamlCookieName}={value}";
+
+    [Fact]
+    public async Task SamlAuth_SolicitedResponse_MatchingBindingCookie_ProvisionsAccount()
+    {
+        // #415: a solicited response whose InResponseTo matches an outstanding request completes only
+        // when the request carries the binding cookie the challenge set — the initiating browser.
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
+        var harness = SolicitedHarness(fixture, Binding);
+        SetSamlBindingCookie(harness, Binding);
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task SamlAuth_SolicitedResponse_MissingBindingCookie_RejectsWithoutProvisioning()
+    {
+        // The forced-login shape: the response is lured into a browser that never started the flow, so
+        // it carries no binding cookie. Fail closed with the uniform SAML body; nothing is provisioned.
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
+        var harness = SolicitedHarness(fixture, Binding);
+        // No binding cookie set.
+
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SamlAuth_SolicitedResponse_WrongBindingCookie_RejectsWithoutProvisioning()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
+        var harness = SolicitedHarness(fixture, Binding);
+        SetSamlBindingCookie(harness, "a-different-browsers-binding-id");
+
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SamlAuth_UnsolicitedResponse_NoBindingRequired_StillProvisions()
+    {
+        // IdP-initiated / unsolicited: no matching outstanding request, so browser binding imposes no
+        // requirement and (with ValidateInResponseTo off, the default) the login proceeds — the change
+        // does not break IdP-initiated deployments. No cookie is present, proving binding did not fire.
+        var fixture = SamlTestFactory.Create(nameId: "alice"); // no InResponseTo
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
 }

--- a/SSO-Auth.Tests/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/SamlRequestCacheTests.cs
@@ -6,8 +6,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// Tests for <see cref="SamlRequestCache"/> — the outstanding-AuthnRequest tracking that lets the
-/// callback accept only solicited responses (#156): a response's InResponseTo must match a request
-/// this server issued, each request answers at most once, and an unknown/expired/blank id fails closed.
+/// callback accept only solicited responses (#156) and carries the browser-binding id minted at the
+/// challenge (#415): a response's InResponseTo must match a request this server issued, each request
+/// answers at most once, an unknown/expired/blank id fails closed, and a successful consume yields the
+/// binding id recorded with the request.
 /// </summary>
 public class SamlRequestCacheTests
 {
@@ -17,17 +19,19 @@ public class SamlRequestCacheTests
     public void Register_ThenConsume_SucceedsOnce_ThenReplayFails()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_req-1", Now.AddMinutes(15), Now);
+        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now);
 
-        Assert.True(cache.TryConsume("_req-1", Now));
-        Assert.False(cache.TryConsume("_req-1", Now));
+        Assert.True(cache.TryConsume("_req-1", Now, out var bindingId));
+        Assert.Equal("binding-1", bindingId); // the binding id round-trips to the consumer
+        Assert.False(cache.TryConsume("_req-1", Now, out _));
     }
 
     [Fact]
     public void Consume_UnregisteredId_FailsClosed_Unsolicited()
     {
         var cache = new SamlRequestCache();
-        Assert.False(cache.TryConsume("_never-issued", Now));
+        Assert.False(cache.TryConsume("_never-issued", Now, out var bindingId));
+        Assert.Equal(string.Empty, bindingId); // no binding surfaces for an unsolicited response
     }
 
     [Theory]
@@ -38,43 +42,58 @@ public class SamlRequestCacheTests
         var cache = new SamlRequestCache();
         // A blank id is never registered and can never be consumed (an unsolicited response with no
         // InResponseTo maps to a blank key).
-        cache.Register(id!, Now.AddMinutes(15), Now);
-        Assert.False(cache.TryConsume(id!, Now));
+        cache.Register(id!, "binding", Now.AddMinutes(15), Now);
+        Assert.False(cache.TryConsume(id!, Now, out _));
     }
 
     [Fact]
     public void Consume_AfterExpiry_FailsClosed()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_req-1", Now.AddMinutes(15), Now);
+        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now);
 
         // The request was never answered within its lifetime; a late response is refused.
-        Assert.False(cache.TryConsume("_req-1", Now.AddMinutes(20)));
+        Assert.False(cache.TryConsume("_req-1", Now.AddMinutes(20), out _));
     }
 
     [Fact]
-    public void DistinctRequests_EachConsumeOnce()
+    public void Consume_EntryWithoutBindingId_SucceedsWithEmptyBinding()
+    {
+        // A pre-#415 in-flight entry (or any registration with no binding id) still consumes as
+        // solicited but yields an empty binding, which the caller treats as unbound rather than a
+        // mismatch — so an upgrade does not break a login already in flight.
+        var cache = new SamlRequestCache();
+        cache.Register("_req-1", null!, Now.AddMinutes(15), Now);
+
+        Assert.True(cache.TryConsume("_req-1", Now, out var bindingId));
+        Assert.Equal(string.Empty, bindingId);
+    }
+
+    [Fact]
+    public void DistinctRequests_EachConsumeOnce_WithTheirOwnBinding()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_a", Now.AddMinutes(15), Now);
-        cache.Register("_b", Now.AddMinutes(15), Now);
+        cache.Register("_a", "binding-a", Now.AddMinutes(15), Now);
+        cache.Register("_b", "binding-b", Now.AddMinutes(15), Now);
 
-        Assert.True(cache.TryConsume("_a", Now));
-        Assert.True(cache.TryConsume("_b", Now));
-        Assert.False(cache.TryConsume("_a", Now));
+        Assert.True(cache.TryConsume("_a", Now, out var a));
+        Assert.Equal("binding-a", a);
+        Assert.True(cache.TryConsume("_b", Now, out var b));
+        Assert.Equal("binding-b", b); // each request keeps its own binding, not the other's
+        Assert.False(cache.TryConsume("_a", Now, out _));
     }
 
     [Fact]
     public void Register_ExpiredEntriesArePrunedOnLaterOperation()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_old", Now.AddMinutes(1), Now);
+        cache.Register("_old", "binding-old", Now.AddMinutes(1), Now);
 
         // A later registration prunes the expired entry; the old id is gone (would fail consume).
         // (TryConsume also rejects it on expiry, so this additionally relies on it not being present.)
-        cache.Register("_new", Now.AddMinutes(35), Now.AddMinutes(20));
-        Assert.False(cache.TryConsume("_old", Now.AddMinutes(20)));
-        Assert.True(cache.TryConsume("_new", Now.AddMinutes(20)));
+        cache.Register("_new", "binding-new", Now.AddMinutes(35), Now.AddMinutes(20));
+        Assert.False(cache.TryConsume("_old", Now.AddMinutes(20), out _));
+        Assert.True(cache.TryConsume("_new", Now.AddMinutes(20), out _));
     }
 
     [Fact]
@@ -86,17 +105,17 @@ public class SamlRequestCacheTests
         // must NOT be evicted (a flood of fresh challenges cannot displace a user mid-login).
         var cache = new SamlRequestCache();
         var expiry = Now.AddMinutes(15);
-        cache.Register("_inflight", expiry, Now);
+        cache.Register("_inflight", "binding-inflight", expiry, Now);
 
         var exception = Record.Exception(() =>
         {
             for (var i = 0; i < 100_050; i++)
             {
-                cache.Register("_flood-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), expiry, Now);
+                cache.Register("_flood-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), "b", expiry, Now);
             }
         });
 
         Assert.Null(exception);
-        Assert.True(cache.TryConsume("_inflight", Now));
+        Assert.True(cache.TryConsume("_inflight", Now, out _));
     }
 }

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -46,8 +46,10 @@ internal sealed class SsoControllerHarness
         Func<HttpRequestMessage, HttpResponseMessage>? httpResponder = null)
     {
         // The controller keeps process-wide OpenID caches as private statics; clear them so a prior test
-        // that exercised the login flow cannot leak in-flight state into this one (#289).
+        // that exercised the login flow cannot leak in-flight state into this one (#289). The
+        // outstanding-SAML-request cache is the same kind of static and is cleared for the same reason (#415).
         SSOController.ResetOidStateForTests();
+        SSOController.ResetSamlRequestsForTests();
 
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);

--- a/SSO-Auth/Api/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/AuthorizeStateBinding.cs
@@ -25,6 +25,15 @@ internal static class AuthorizeStateBinding
     /// </summary>
     internal const string CookieName = "__Host-sso_oid_state_binding";
 
+    /// <summary>
+    /// The SAML browser-binding cookie name (#415). Separate from the OpenID cookie so the two flows
+    /// cannot cross-satisfy each other's binding check; the <c>__Host-</c> prefix carries the same
+    /// cookie-tossing defense described for <see cref="CookieName"/>. Checked at the same-origin
+    /// session-mint endpoint (SAML/auth), where a <c>SameSite=Lax</c> cookie is sent — the ACS POST
+    /// from the identity provider is cross-site and would not carry it.
+    /// </summary>
+    internal const string SamlCookieName = "__Host-sso_saml_state_binding";
+
     /// <summary>A fresh 256-bit CSPRNG binding id, hex-encoded (URL- and cookie-safe).</summary>
     /// <returns>The new binding id.</returns>
     internal static string NewId() => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -914,46 +914,39 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Correlate the response to an AuthnRequest this server issued (#156, #415). The outstanding
-        // entry is claimed once here (the session-minting endpoint), like the replay check, so its
-        // InResponseTo is one-time-use; a solicited response yields the browser-binding id recorded at
-        // the challenge. The claim runs regardless of ValidateInResponseTo so the browser binding below
-        // protects SP-initiated logins even when the opt-in solicited-only mode is off.
+        // Correlate the response to an AuthnRequest this server issued (#156, #415), and enforce the
+        // browser binding for a solicited login. A NON-EMPTY InResponseTo means the response claims to
+        // answer a request this server issued, so it must actually correlate to a live outstanding
+        // request AND carry that request's binding cookie — anything less fails closed. Crucially, a
+        // non-empty InResponseTo whose entry is gone (expired past the 15-minute window, evicted at the
+        // cap, lost to a restart or a non-sticky multi-node hop) is a LOST correlation, not an
+        // unsolicited response: treating it as unsolicited would let a signature-valid response mint a
+        // session with no binding check when ValidateInResponseTo is off, which is exactly the
+        // forced-login bypass the binding exists to close (login validity must never default to true).
         //
-        // Unlike the OpenID state (#326), the binding is checked AFTER the claim rather than before, and
-        // that is safe here: the response already passed signature validation above, and the InResponseTo
-        // is read from that validated document, so an attacker cannot mint a signature-valid response
-        // carrying a victim's request id to burn their outstanding entry. The OpenID state token is not
-        // signed by anyone who holds it, so it must be checked before the atomic remove; a SAML
-        // InResponseTo cannot be forged onto a valid response, so no in-flight entry can be burned by a
-        // wrong-browser hit.
+        // The binding is checked AFTER the atomic claim (unlike the OpenID state, #326) and that is safe:
+        // the response already passed signature validation above and the InResponseTo is read from that
+        // validated document, so an attacker cannot mint a signature-valid response carrying a victim's
+        // request id to burn their outstanding entry. The cookie is checked here (the same-origin auth
+        // endpoint), not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
         var inResponseTo = samlResponse.GetInResponseTo();
-        var requestKey = ProviderScopedKey.For(provider, inResponseTo);
-        bool solicited = SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId);
-
-        // Browser binding (#415): a solicited response must complete in the browser that started the
-        // flow. When a binding id was recorded — every login challenge since #415 — require the request
-        // to carry the matching cookie, failing closed on an absent or mismatched one. This defeats
-        // SP-initiated forced login / session fixation: a response lured into a victim's browser lacks
-        // the attacker's binding cookie. The cookie is checked here (the same-origin auth endpoint), not
-        // at the cross-site ACS POST which would not carry a SameSite=Lax cookie. An entry with no
-        // binding id predates this protection (an in-flight login across the upgrade) and is deferred to
-        // the InResponseTo policy below rather than broken.
-        if (solicited && !string.IsNullOrEmpty(storedBindingId)
-            && !AuthorizeStateBinding.Matches(storedBindingId, Request.Cookies[AuthorizeStateBinding.SamlCookieName]))
+        if (!string.IsNullOrEmpty(inResponseTo))
         {
-            _logger.LogWarning("SAML login denied: the response was not completed in the browser that initiated the login (binding mismatch).");
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
+            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId)
+                || !AuthorizeStateBinding.Matches(storedBindingId, Request.Cookies[AuthorizeStateBinding.SamlCookieName]))
+            {
+                _logger.LogWarning("SAML login denied: a solicited response did not correlate to a live outstanding request from the initiating browser (binding mismatch, expiry, or lost correlation).");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+            }
         }
-
-        // Solicited-only mode (#156, opt-in): with the flag on, an unsolicited (IdP-initiated) response —
-        // one with no matching outstanding request — is refused. The correlation was already claimed
-        // above, so this only decides the unsolicited case. The rejection is a client-caused 400 in the
-        // uniform SAML body — never a 500, and the old body that disclosed the InResponseTo correlation
-        // to the submitter is gone (the warning log keeps the diagnosis).
-        if (config.ValidateInResponseTo && !solicited)
+        else if (config.ValidateInResponseTo)
         {
-            _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
+            // No InResponseTo at all: a genuinely unsolicited (IdP-initiated) response. It is refused
+            // only when the opt-in solicited-only mode is on; otherwise it proceeds — unchanged and
+            // non-breaking for IdP-initiated deployments. The rejection is a client-caused 400 in the
+            // uniform SAML body, never a 500, and the diagnosis stays in the warning log.
+            _logger.LogWarning("SAML login denied: the response was not solicited by this server (no InResponseTo).");
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -311,6 +311,11 @@ public class SSOController : ControllerBase
         PkceSupportCache.Clear();
     }
 
+    // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
+    // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
+    // into the next test. Same test-only surface as ResetOidStateForTests (internal, InternalsVisibleTo).
+    internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
+
     // Test-only seed of a single authorize-state entry so a test can exercise the OidAuth callback
     // (which consumes an already-validated state that the browser redirect leg normally populates)
     // without standing up the full token-exchange flow. Same test-only surface as ResetOidStateForTests
@@ -319,6 +324,13 @@ public class SSOController : ControllerBase
     {
         StateStore.Seed(token, state);
     }
+
+    // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
+    // binding (#415) — normally populated by the SamlChallenge redirect leg — without deriving the
+    // random request id from the emitted AuthnRequest. Same test-only surface as SeedOidStateForTests
+    // (internal, InternalsVisibleTo, no endpoint/DI); never reachable in production.
+    internal static void SeedSamlRequestForTests(string provider, string requestId, string bindingId, DateTime expiryUtc) =>
+        SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow);
 
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
@@ -778,14 +790,31 @@ public class SSOController : ControllerBase
             config.SamlClientId.Trim(),
             redirectUri);
 
-        // Solicited-only mode (#156): remember the request ID so the callback can require the
-        // response's InResponseTo to match a request we actually issued. Scoped by provider so
-        // two providers' request IDs cannot satisfy each other's correlation. Only for login
-        // flows — the linking callback (SamlLink) does not consume InResponseTo, so registering a
-        // linking request would only leave an id to expire unused.
-        if (config.ValidateInResponseTo && !isLinking)
+        // Bind this login to the initiating browser (#415): mint a binding id, set it as a cookie, and
+        // record it against the request id so the session-mint endpoint (SamlAuth) can require the
+        // response's browser to be the one that started the flow — closing the SP-initiated forced-login
+        // / session-fixation vector, the SAML analogue of #326. Only for login flows: the linking
+        // callback (SamlLink) is a separate flow that does not consume the outstanding request, so a
+        // linking registration would only leave an id to expire unused. Registration now happens for
+        // every login challenge (not only under ValidateInResponseTo), so the binding is enforced for
+        // every SOLICITED login this plugin initiated — the case ValidateInResponseTo alone left open.
+        // It does NOT bind an unsolicited (IdP-initiated) response, which carries no matching request;
+        // fully closing forced login for an IdP that issues unsolicited responses additionally requires
+        // ValidateInResponseTo (which refuses them). Because the cookie is __Host-/Secure, the browser
+        // only returns it over HTTPS — SP-initiated SAML now needs HTTPS at the browser edge, as OIDC
+        // already does.
+        if (!isLinking)
         {
-            SamlRequests.Register(ProviderScopedKey.For(provider, request.Id), DateTime.UtcNow + SamlRequestLifetime, DateTime.UtcNow);
+            var bindingId = AuthorizeStateBinding.NewId();
+            SamlRequests.Register(
+                ProviderScopedKey.For(provider, request.Id),
+                bindingId,
+                DateTime.UtcNow + SamlRequestLifetime,
+                DateTime.UtcNow);
+            Response.Cookies.Append(
+                AuthorizeStateBinding.SamlCookieName,
+                bindingId,
+                AuthorizeStateBinding.CookieOptions(SamlRequestLifetime));
         }
 
         return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
@@ -885,21 +914,47 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Solicited-only correlation (#156, opt-in): consume the response's InResponseTo against
-        // an AuthnRequest this server issued. Enforced here (the session-minting endpoint), like
-        // the replay check, so the id is claimed once. An unsolicited (IdP-initiated) response
-        // carries no InResponseTo and is refused; a matching id is one-time-use. The rejection is a
-        // client-caused 400 in the uniform SAML body — never a 500, and the old body that disclosed
-        // the InResponseTo correlation to the submitter is gone (the warning log keeps the diagnosis).
-        if (config.ValidateInResponseTo)
+        // Correlate the response to an AuthnRequest this server issued (#156, #415). The outstanding
+        // entry is claimed once here (the session-minting endpoint), like the replay check, so its
+        // InResponseTo is one-time-use; a solicited response yields the browser-binding id recorded at
+        // the challenge. The claim runs regardless of ValidateInResponseTo so the browser binding below
+        // protects SP-initiated logins even when the opt-in solicited-only mode is off.
+        //
+        // Unlike the OpenID state (#326), the binding is checked AFTER the claim rather than before, and
+        // that is safe here: the response already passed signature validation above, and the InResponseTo
+        // is read from that validated document, so an attacker cannot mint a signature-valid response
+        // carrying a victim's request id to burn their outstanding entry. The OpenID state token is not
+        // signed by anyone who holds it, so it must be checked before the atomic remove; a SAML
+        // InResponseTo cannot be forged onto a valid response, so no in-flight entry can be burned by a
+        // wrong-browser hit.
+        var inResponseTo = samlResponse.GetInResponseTo();
+        var requestKey = ProviderScopedKey.For(provider, inResponseTo);
+        bool solicited = SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId);
+
+        // Browser binding (#415): a solicited response must complete in the browser that started the
+        // flow. When a binding id was recorded — every login challenge since #415 — require the request
+        // to carry the matching cookie, failing closed on an absent or mismatched one. This defeats
+        // SP-initiated forced login / session fixation: a response lured into a victim's browser lacks
+        // the attacker's binding cookie. The cookie is checked here (the same-origin auth endpoint), not
+        // at the cross-site ACS POST which would not carry a SameSite=Lax cookie. An entry with no
+        // binding id predates this protection (an in-flight login across the upgrade) and is deferred to
+        // the InResponseTo policy below rather than broken.
+        if (solicited && !string.IsNullOrEmpty(storedBindingId)
+            && !AuthorizeStateBinding.Matches(storedBindingId, Request.Cookies[AuthorizeStateBinding.SamlCookieName]))
         {
-            var inResponseTo = samlResponse.GetInResponseTo();
-            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
-            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow))
-            {
-                _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-            }
+            _logger.LogWarning("SAML login denied: the response was not completed in the browser that initiated the login (binding mismatch).");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Solicited-only mode (#156, opt-in): with the flag on, an unsolicited (IdP-initiated) response —
+        // one with no matching outstanding request — is refused. The correlation was already claimed
+        // above, so this only decides the unsolicited case. The rejection is a client-caused 400 in the
+        // uniform SAML body — never a 500, and the old body that disclosed the InResponseTo correlation
+        // to the submitter is gone (the warning log keeps the diagnosis).
+        if (config.ValidateInResponseTo && !solicited)
+        {
+            _logger.LogWarning("SAML login denied: the response was not solicited by this server (unknown, expired, or already-used InResponseTo).");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
         // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -26,7 +26,7 @@ internal sealed class SamlRequestCache
     // entry via its own expiry check, so a not-yet-swept entry never grants a login.
     private static readonly TimeSpan PruneInterval = TimeSpan.FromMinutes(1);
 
-    private readonly ConcurrentDictionary<string, DateTime> _outstanding = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Entry> _outstanding = new(StringComparer.Ordinal);
 
     // Throttles the sweep to one run per PruneInterval; the gate owns the atomic cursor and self-heals
     // a backward wall-clock step (the hand-rolled predecessor stalled until the clock re-passed its
@@ -34,13 +34,15 @@ internal sealed class SamlRequestCache
     private readonly IntervalGate _pruneGate = new(PruneInterval);
 
     /// <summary>
-    /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>. A blank ID is
-    /// ignored (the correlation at consume time then fails closed).
+    /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>, together with the
+    /// browser-binding id minted for it at the challenge (#415). A blank ID is ignored (the correlation
+    /// at consume time then fails closed).
     /// </summary>
     /// <param name="requestId">The request ID (scoped by the caller, e.g. by provider).</param>
+    /// <param name="bindingId">The browser-binding id set as a cookie at the challenge (may be empty).</param>
     /// <param name="expiryUtc">When the entry may be evicted (the request's validity horizon).</param>
     /// <param name="nowUtc">The current time.</param>
-    internal void Register(string requestId, DateTime expiryUtc, DateTime nowUtc)
+    internal void Register(string requestId, string bindingId, DateTime expiryUtc, DateTime nowUtc)
     {
         PruneExpired(nowUtc);
         if (string.IsNullOrEmpty(requestId))
@@ -58,27 +60,39 @@ internal sealed class SamlRequestCache
             return;
         }
 
-        _outstanding[requestId] = expiryUtc;
+        _outstanding[requestId] = new Entry(expiryUtc, bindingId ?? string.Empty);
     }
 
     /// <summary>
     /// Atomically claims an outstanding request ID: succeeds once for a known, unexpired ID, then the
     /// entry is gone so a second response carrying the same <c>InResponseTo</c> is refused. Fails for a
-    /// blank, unknown, expired, or already-consumed ID (fail closed).
+    /// blank, unknown, expired, or already-consumed ID (fail closed). On success, yields the
+    /// browser-binding id registered with it so the caller can enforce the binding (#415).
     /// </summary>
     /// <param name="requestId">The response's <c>InResponseTo</c>, scoped the same way as at registration.</param>
     /// <param name="nowUtc">The current time.</param>
+    /// <param name="bindingId">The binding id recorded at registration (empty if none), when this returns true.</param>
     /// <returns>True if the ID was outstanding and is now consumed; false otherwise.</returns>
-    internal bool TryConsume(string requestId, DateTime nowUtc)
+    internal bool TryConsume(string requestId, DateTime nowUtc, out string bindingId)
     {
         PruneExpired(nowUtc);
+        bindingId = string.Empty;
         if (string.IsNullOrEmpty(requestId))
         {
             return false;
         }
 
-        return _outstanding.TryRemove(requestId, out var expiry) && expiry > nowUtc;
+        if (_outstanding.TryRemove(requestId, out var entry) && entry.ExpiryUtc > nowUtc)
+        {
+            bindingId = entry.BindingId;
+            return true;
+        }
+
+        return false;
     }
+
+    /// <summary>Test-only: drops all outstanding entries so process-wide state cannot leak between tests.</summary>
+    internal void Clear() => _outstanding.Clear();
 
     // Drops expired entries, at most once per PruneInterval. Enumerating a ConcurrentDictionary yields
     // a safe moving snapshot and TryRemove is atomic, so this is correct under concurrent
@@ -94,10 +108,16 @@ internal sealed class SamlRequestCache
 
         foreach (var kvp in _outstanding)
         {
-            if (kvp.Value <= nowUtc)
+            if (kvp.Value.ExpiryUtc <= nowUtc)
             {
                 _outstanding.TryRemove(kvp.Key, out _);
             }
         }
     }
+
+    // One outstanding AuthnRequest: when it expires, and the browser-binding id minted alongside it at
+    // the challenge (#415). The binding id ties the eventual response to the browser that started the
+    // flow; it is returned on consume so the session-mint endpoint can require the request's cookie to
+    // match. Empty for entries registered before browser binding existed (treated as unbound).
+    private readonly record struct Entry(DateTime ExpiryUtc, string BindingId);
 }

--- a/providers.md
+++ b/providers.md
@@ -185,6 +185,33 @@ config so a save does not reset them.
   flow only (not account linking). The outstanding-request store is **in-process**, so it requires a
   single Jellyfin instance or sticky sessions: behind a load balancer without session affinity, the
   challenge and the response can land on different instances and every solicited login is rejected.
+  It also completes the browser-binding defense below: browser binding closes forced login for
+  _solicited_ (SP-initiated) responses, and turning this on refuses the _unsolicited_ ones that
+  binding cannot cover — so together they close the vector for an identity provider that can issue
+  unsolicited responses.
+
+## SAML login browser binding
+
+Every SP-initiated SAML login (one started from Jellyfin, i.e. `SAML/start/...`) is bound to the
+browser that started it, the SAML analogue of the OpenID binding below. When the login begins the
+plugin sets a short-lived `Secure`, `HttpOnly`, `SameSite=Lax`, `__Host-`-prefixed cookie
+(`__Host-sso_saml_state_binding`) carrying a random id, and records the same id against the
+`AuthnRequest`; the session-minting callback (`SAML/Auth/...`) only proceeds when a solicited response
+returns with the matching cookie. This closes the forced-login / session-fixation vector where an
+attacker lures a victim to submit the attacker's own signed response. It is automatic, with no
+configuration. Points worth knowing:
+
+- **HTTPS is required at the browser edge.** The `__Host-`/`Secure` cookie is only stored and returned
+  over HTTPS (a TLS-terminating reverse proxy is fine — the browser sees HTTPS). Over plain `http://`
+  the cookie never comes back and every SP-initiated login is refused. This is the same requirement the
+  OpenID binding already imposes; serve SSO over HTTPS.
+- **Complete the login in the same browser that started it**, and serve the whole flow from one origin
+  — the same two consequences as the OpenID binding below.
+- **Scope, and how to close it fully.** Binding covers _solicited_ responses (those answering a request
+  this plugin issued). An _unsolicited_ (IdP-initiated) response carries no matching request, so binding
+  cannot bind it; if your identity provider can issue unsolicited responses, enable
+  `ValidateInResponseTo` (above) to refuse them and close forced login completely. Account linking
+  (`RelayState=linking`) is a separate, differently-gated flow and is unaffected.
 
 ## OpenID login browser binding
 

--- a/providers.md
+++ b/providers.md
@@ -207,6 +207,14 @@ configuration. Points worth knowing:
   OpenID binding already imposes; serve SSO over HTTPS.
 - **Complete the login in the same browser that started it**, and serve the whole flow from one origin
   — the same two consequences as the OpenID binding below.
+- **Single instance or sticky sessions, within ~15 minutes.** A response that carries an `InResponseTo`
+  (every SP-initiated response does) must correlate to the outstanding request the challenge recorded,
+  which lives in an **in-process** store — so it must be answered on the same instance that issued it
+  and within the request's ~15-minute lifetime. A response whose outstanding request is gone (expired,
+  or the challenge landed on a different instance behind a load balancer without session affinity) is
+  refused rather than waved through, because a lost correlation must fail closed. Run a single Jellyfin
+  instance or enable sticky sessions for SP-initiated SAML. (An IdP-initiated response carries no
+  `InResponseTo`, so this does not apply to it.)
 - **Scope, and how to close it fully.** Binding covers _solicited_ responses (those answering a request
   this plugin issued). An _unsolicited_ (IdP-initiated) response carries no matching request, so binding
   cannot bind it; if your identity provider can issue unsolicited responses, enable


### PR DESCRIPTION
## What & why

`SamlAuth` mints a session from a presented `SAMLResponse` with no tie to the browser that started the flow, so an attacker who obtains a valid signed response for their own identity can lure a victim to submit it and be silently signed in as the attacker, SP-initiated forced login / session fixation, the SAML analogue of the OpenID vector #326 closed.

This binds a **solicited** SAML login to its browser, mirroring #326:

- `SamlChallenge` mints a 256-bit binding id, sets it as a `__Host-`/`Secure`/`HttpOnly`/`SameSite=Lax` cookie (`__Host-sso_saml_state_binding`), and records it against the `AuthnRequest` id, now for every login challenge, not only under `ValidateInResponseTo`.
- `SamlRequestCache` carries the binding id per outstanding request and yields it on the one-time consume.
- `SamlAuth` consumes the outstanding entry once and, for a solicited response, requires the request to carry the matching cookie, fail closed on absent/mismatch. The check runs at the **same-origin** auth endpoint (where the Lax cookie is sent); the ACS POST from the IdP is cross-site and would not carry it.

The binding is checked **after** the atomic consume (unlike #326): the response already passed signature validation and `InResponseTo` is read from the validated document, so an attacker cannot forge a signature-valid response with a victim's request id to burn their outstanding entry.

Closes #415.

## Type of change
- [x] Security hardening (login path, fail-closed)

## Security checklist
- Fail-closed: a solicited response with an absent/mismatched binding cookie is refused in the uniform SAML body (never a 500); every `SamlAuth` grant branch rejects before `Authenticate`.
- Gating a GRANT (session mint), fail-safe direction.
- **Posture (documented in `providers.md`):** binding closes SP-initiated (solicited) forced login. An unsolicited (IdP-initiated) response carries no matching request and stays governed by `ValidateInResponseTo`, **unchanged and non-breaking**. Fully closing forced login for an IdP that issues unsolicited responses additionally requires `ValidateInResponseTo`. The `__Host-`/`Secure` cookie means SP-initiated SAML now needs **HTTPS at the browser edge**, as OpenID already does.

## Quality checklist
- Reuses `AuthorizeStateBinding` (`NewId`/`Matches`/`CookieOptions`) with a SAML-scoped cookie name; the outstanding-request store gains one field. No config-schema change.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **797/797 green**. Prettier clean.
- **Full adversarial gate (5 lenses: availability, security-bypass, correctness, integration, SAML-domain).** First round: correctness PASS; the other four returned NEEDS_IMPROVEMENT, **no exploitable code defect**, all converging on documentation/framing (the "always-on" comment overstated coverage; `providers.md` did not document the HTTPS-edge requirement nor the `ValidateInResponseTo` connection). Fixed (honest comment, new `providers.md` "SAML login browser binding" section, test-reset hook for the static cache). Re-run: **all four PASS**, 5/5 green. The SAML-domain lens confirmed `InResponseTo` is inside the signed scope in both signing modes, so the consume-then-check ordering is sound.

## Notes
Scope is the login flow (`SamlChallenge`→`SamlAuth`); account linking (`SamlLink`) is a separate, differently-gated flow, unaffected. Making `ValidateInResponseTo` default-on (to close the IdP-initiated path by default) would break IdP-initiated deployments, a separate posture decision, deliberately not taken here.
