### PR TITLE
Make the avatar fetch path unit-testable behind a handler seam

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -1,5 +1,9 @@
 using System;
 using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -32,6 +36,46 @@ public class AvatarServiceTests
         var log = new CapturingLogger();
         var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0");
         return (service, providers, users, log);
+    }
+
+    // Builds a service whose HTTP fetch is served by a stub handler returning the given response, so the
+    // fetch path (content-type gate, size cap, happy path) runs without live HTTP (#385 seam).
+    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build(HttpResponseMessage response)
+    {
+        var users = Substitute.For<IUserManager>();
+        var providers = Substitute.For<IProviderManager>();
+        var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
+        var log = new CapturingLogger();
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", () => new StubHandler(response));
+        return (service, providers, users, log);
+    }
+
+    // An allowed public URL: the stub handler answers before any connection, so the URL only needs to
+    // clear the allow-list — the SSRF transport guard (ConnectCallback) is never reached here.
+    private const string AllowedUrl = "https://cdn.example.com/avatar.png";
+
+    private static HttpResponseMessage ImageResponse(string mediaType, byte[] body, long? contentLength = null)
+    {
+        var content = new StreamContent(new MemoryStream(body));
+        content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(mediaType);
+        if (contentLength is { } length)
+        {
+            content.Headers.ContentLength = length;
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
+    }
+
+    // Returns a single canned response for every request, standing in for the live HTTP fetch.
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StubHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(_response);
     }
 
     private static string ProfilePath(string username, string extension)
@@ -136,5 +180,73 @@ public class AvatarServiceTests
         Assert.Equal(ProfilePath("alice", ".png"), user.ProfileImage?.Path);
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public async Task ReadCappedAsync_BodyOverTheCap_Throws()
+    {
+        // #220, the single most security-relevant untested branch: a body larger than the cap — the
+        // shape a hostile or Content-Length-lying endpoint produces — is aborted rather than buffered.
+        using var response = ImageResponse("image/png", new byte[11]);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await AvatarService.ReadCappedAsync(response, maxBytes: 10, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReadCappedAsync_BodyAtTheCap_RoundTripsRewound()
+    {
+        // A body exactly at the cap is accepted and returned ready to read (Position 0) for the store step.
+        var body = new byte[10];
+        using var response = ImageResponse("image/png", body);
+
+        using var result = await AvatarService.ReadCappedAsync(response, maxBytes: 10, CancellationToken.None);
+
+        Assert.Equal(10, result.Length);
+        Assert.Equal(0, result.Position);
+    }
+
+    [Fact]
+    public async Task TrySetAsync_DisallowedContentType_RefusesWithoutStoring()
+    {
+        // The content-type allow-list (#217): a non-raster type (here text/html, the shape an SVG or an
+        // HTML error page would take) is refused after the fetch, before anything is written.
+        using var response = ImageResponse("text/html", Encoding.UTF8.GetBytes("<html></html>"));
+        var (service, providers, users, log) = Build(response);
+
+        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("disallowed content type"));
+    }
+
+    [Fact]
+    public async Task TrySetAsync_ContentLengthOverTheCap_RefusesWithoutStoring()
+    {
+        // The Content-Length pre-check rejects an oversized advertised body before streaming a byte.
+        using var response = ImageResponse("image/png", new byte[1], contentLength: AvatarService.MaxAvatarBytes + 1);
+        var (service, providers, _, _) = Build(response);
+
+        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task TrySetAsync_AllowedImage_FetchesAndStores()
+    {
+        // The happy path end to end over the seam: an allowed raster type within the cap is fetched and
+        // saved under the user's profile path with the media type carried through. The exact filename
+        // (the missing extension dot) is #384's concern, so it is not pinned here.
+        using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
+        var (service, providers, _, _) = Build(response);
+
+        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+
+        await providers.Received(1).SaveImage(
+            Arg.Any<Stream>(),
+            "image/png",
+            Arg.Is<string>(path => path.Contains("alice") && path.Contains("profile")));
     }
 }

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -22,11 +22,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal sealed class AvatarService
 {
+    /// <summary>The maximum avatar size accepted, enforced both against Content-Length and while streaming (#220).</summary>
+    internal const long MaxAvatarBytes = 10 * 1024 * 1024;
+
     private readonly IUserManager _userManager;
     private readonly IProviderManager _providerManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly ILogger _logger;
     private readonly string _userAgent;
+    private readonly Func<HttpMessageHandler> _handlerFactory;
 
     internal AvatarService(
         IUserManager userManager,
@@ -34,12 +38,36 @@ internal sealed class AvatarService
         IServerConfigurationManager serverConfigurationManager,
         ILogger logger,
         string userAgent)
+        : this(userManager, providerManager, serverConfigurationManager, logger, userAgent, CreateHardenedHandler)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvatarService"/> class with an injected HTTP message
+    /// handler factory. This is the test seam (#385): a stub handler makes the content-type gate, the
+    /// size cap, the happy path, and the timeout reachable without live HTTP. Production uses the
+    /// five-argument constructor, which supplies the hardened SSRF-safe <see cref="SocketsHttpHandler"/>.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager.</param>
+    /// <param name="providerManager">The Jellyfin provider manager (image saving).</param>
+    /// <param name="serverConfigurationManager">The server configuration manager (user data paths).</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="userAgent">The outbound User-Agent.</param>
+    /// <param name="handlerFactory">Builds the message handler used for each fetch; called once per fetch and disposed after.</param>
+    internal AvatarService(
+        IUserManager userManager,
+        IProviderManager providerManager,
+        IServerConfigurationManager serverConfigurationManager,
+        ILogger logger,
+        string userAgent,
+        Func<HttpMessageHandler> handlerFactory)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
         _providerManager = providerManager ?? throw new ArgumentNullException(nameof(providerManager));
         _serverConfigurationManager = serverConfigurationManager ?? throw new ArgumentNullException(nameof(serverConfigurationManager));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _userAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
+        _handlerFactory = handlerFactory ?? throw new ArgumentNullException(nameof(handlerFactory));
     }
 
     /// <summary>
@@ -65,20 +93,7 @@ internal sealed class AvatarService
 
         try
         {
-            // Route every connection (including redirect targets) through a callback that rejects
-            // private/loopback addresses, closing the SSRF and DNS-rebinding vectors. Redirects stay
-            // enabled (many avatar URLs redirect) but are bounded, each hop is IP-validated, and both
-            // the request and the download are bounded.
-            using var handler = new SocketsHttpHandler
-            {
-                AllowAutoRedirect = true,
-                MaxAutomaticRedirections = 5,
-                ConnectCallback = ConnectCallback,
-
-                // A system proxy would be the connection target, so the ConnectCallback would
-                // validate the proxy's address rather than the avatar host's - bypassing the guard.
-                UseProxy = false,
-            };
+            using var handler = _handlerFactory();
             using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
 
             client.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
@@ -109,7 +124,6 @@ internal sealed class AvatarService
                 throw new InvalidOperationException("Avatar content type is not an allowed raster image.");
             }
 
-            const long MaxAvatarBytes = 10 * 1024 * 1024;
             if (avatarResponse.Content.Headers.ContentLength > MaxAvatarBytes)
             {
                 throw new InvalidOperationException("Avatar exceeds the maximum allowed size.");
@@ -172,9 +186,24 @@ internal sealed class AvatarService
         }
     }
 
+    // The production handler: routes every connection (including redirect targets) through a callback
+    // that rejects private/loopback addresses, closing the SSRF and DNS-rebinding vectors. Redirects
+    // stay enabled (many avatar URLs redirect) but are bounded, each hop is IP-validated, and both the
+    // request and the download are bounded. A fresh handler is built per fetch and disposed by the caller.
+    private static HttpMessageHandler CreateHardenedHandler() => new SocketsHttpHandler
+    {
+        AllowAutoRedirect = true,
+        MaxAutomaticRedirections = 5,
+        ConnectCallback = ConnectToAllowedAddressAsync,
+
+        // A system proxy would be the connection target, so the connect callback would validate the
+        // proxy's address rather than the avatar host's - bypassing the guard.
+        UseProxy = false,
+    };
+
     // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that
     // resolves to an internal address - including via DNS rebinding on a redirect hop - cannot be reached.
-    private static async ValueTask<Stream> ConnectCallback(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    private static async ValueTask<Stream> ConnectToAllowedAddressAsync(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
     {
         var addresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
 
@@ -224,8 +253,10 @@ internal sealed class AvatarService
     }
 
     // Copies the response body into memory, aborting if it exceeds the cap, so a hostile endpoint cannot
-    // exhaust resources with an unbounded (or Content-Length-lying) download.
-    private static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes, CancellationToken cancellationToken)
+    // exhaust resources with an unbounded (or Content-Length-lying) download. Internal so the streamed
+    // size cap (#220) — the most security-relevant branch — is unit-testable over a StreamContent body
+    // without live HTTP (#385).
+    internal static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes, CancellationToken cancellationToken)
     {
         var buffer = new MemoryStream();
         var source = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## What & why

`TrySetAsync` constructed its `SocketsHttpHandler`/`HttpClient` inline, so the content-type gate, the Content-Length pre-check, the streamed size cap (#220), the happy path, and the timeout were unreachable by unit tests, only the two early returns were covered, which was the bulk of the accepted coverage-only gap from the #375 review.

- Extract the hardened handler into a `CreateHardenedHandler` factory taken through a new **internal** constructor overload (`Func<HttpMessageHandler>`): the five-argument constructor passes the hardened factory, tests inject a stub. Production is hard-wired to the SSRF-safe handler; the seam is reachable only from the test assembly via `InternalsVisibleTo`.
- Make `ReadCappedAsync` and `MaxAvatarBytes` `internal` so the streamed size cap, the most security-relevant untested branch, is pinned directly over a `StreamContent` body, no live HTTP.
- Rename the self-named `ConnectCallback` to `ConnectToAllowedAddressAsync`.

Closes #385.

## Type of change
- [x] Quality / testability refactor (behavior-preserving)

## Security checklist
- Behavior-preserving: `CreateHardenedHandler` is byte-for-byte the previous inline handler (`AllowAutoRedirect`, `MaxAutomaticRedirections=5`, the SSRF `ConnectCallback`, `UseProxy=false`); per-call create/dispose unchanged.
- The factory-injecting ctor and the new `internal` members are test-only (InternalsVisibleTo); the sole production construction (`SSOController` ctor) uses the five-arg ctor → hardened handler. No production path can supply an un-hardened handler.

## Quality checklist
- Advances the new-code-coverage goal: five new tests cover the over-cap / at-cap size checks, the disallowed-content-type refusal, the Content-Length pre-check, and the happy path.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **803/803 green** (Debug and Release).
- Focused adversarial bypass review (login-path file): **PASS**, confirmed no production reach to an un-hardened handler, no SSRF/redirect/proxy guard weakened, the internal-visibility changes add no runtime/DI/endpoint surface, and per-call handler disposal is unchanged.

## Notes
The missing extension dot (`profile` + `png` → `profilepng`) is unchanged and stays #384; the happy-path test deliberately does not pin the exact filename.
