### PR TITLE
Store the avatar with a real dotted file extension

### DIFF
--- a/SSO-Auth.Tests/AvatarContentTypeTests.cs
+++ b/SSO-Auth.Tests/AvatarContentTypeTests.cs
@@ -10,16 +10,19 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class AvatarContentTypeTests
 {
     [Theory]
-    [InlineData("image/png", "png")]
-    [InlineData("image/jpeg", "jpeg")]
-    [InlineData("image/jpg", "jpeg")]
-    [InlineData("image/gif", "gif")]
-    [InlineData("image/webp", "webp")]
-    [InlineData("IMAGE/PNG", "png")]
-    public void AllowedRasterTypes_Resolve(string mediaType, string expected)
+    [InlineData("image/png", ".png")]
+    [InlineData("image/jpeg", ".jpeg")]
+    [InlineData("image/jpg", ".jpeg")]
+    [InlineData("image/gif", ".gif")]
+    [InlineData("image/webp", ".webp")]
+    [InlineData("IMAGE/PNG", ".png")]
+    public void AllowedRasterTypes_ResolveWithLeadingDot(string mediaType, string expected)
     {
+        // The extension carries the leading dot so the store appends it directly (#384); a bare form
+        // produced dotless filenames like profilepng.
         Assert.True(AvatarContentType.TryResolveExtension(mediaType, out var extension));
         Assert.Equal(expected, extension);
+        Assert.StartsWith(".", extension);
     }
 
     [Theory]

--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -234,19 +234,15 @@ public class AvatarServiceTests
     }
 
     [Fact]
-    public async Task TrySetAsync_AllowedImage_FetchesAndStores()
+    public async Task TrySetAsync_AllowedImage_FetchesAndStoresWithDottedExtension()
     {
         // The happy path end to end over the seam: an allowed raster type within the cap is fetched and
-        // saved under the user's profile path with the media type carried through. The exact filename
-        // (the missing extension dot) is #384's concern, so it is not pinned here.
+        // saved to the resolved profile path — with a real dotted extension since #384.
         using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
         var (service, providers, _, _) = Build(response);
 
         await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
 
-        await providers.Received(1).SaveImage(
-            Arg.Any<Stream>(),
-            "image/png",
-            Arg.Is<string>(path => path.Contains("alice") && path.Contains("profile")));
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
     }
 }

--- a/SSO-Auth/Api/AvatarContentType.cs
+++ b/SSO-Auth/Api/AvatarContentType.cs
@@ -12,17 +12,21 @@ internal static class AvatarContentType
     /// Tries to map an avatar content type to a safe stored file extension.
     /// </summary>
     /// <param name="mediaType">The response media type (case-insensitive), with parameters already stripped.</param>
-    /// <param name="extension">The bare file extension (no leading dot) when allowed; otherwise null.</param>
+    /// <param name="extension">
+    /// The stored file extension <b>including the leading dot</b> (e.g. <c>.png</c>) when allowed;
+    /// otherwise null. The dot is included so the value is a real extension the store appends directly —
+    /// a bare form produced dotless filenames like <c>profilepng</c> (#384).
+    /// </param>
     /// <returns><c>true</c> when the media type is an allowed raster image; otherwise <c>false</c>.</returns>
     internal static bool TryResolveExtension(string mediaType, out string extension)
     {
         extension = (mediaType ?? string.Empty).ToLowerInvariant() switch
         {
-            "image/png" => "png",
-            "image/jpeg" => "jpeg",
-            "image/jpg" => "jpeg",
-            "image/gif" => "gif",
-            "image/webp" => "webp",
+            "image/png" => ".png",
+            "image/jpeg" => ".jpeg",
+            "image/jpg" => ".jpeg",
+            "image/gif" => ".gif",
+            "image/webp" => ".webp",
             _ => null,
         };
 


### PR DESCRIPTION
## What & why

`AvatarContentType.TryResolveExtension` returned bare extensions (`"png"`), and the store appends them as `"profile" + extension`, so avatars were written as `profilepng` / `profilejpeg` with no real extension, leaving Jellyfin's image serving to fall back to `application/octet-stream` on content-type inference (surfaced in the #375 review, carried verbatim through the AvatarService extraction).

Return the extension **with its leading dot** (`.png`) at the source, so the value is a real extension the store appends directly and the dotless-filename footgun is gone. The allow-list and the media type carried to `SaveImage` are unchanged.

Closes #384.

## Type of change
- [x] Bug fix (avatar store path)

## Security checklist
- No security-posture change: the raster-only allow-list is untouched (still rejects `image/svg+xml`), only the returned extension now carries the dot. The media type sent to `SaveImage` is unchanged.

## Quality checklist
- Root-cause fix at the resolver rather than a call-site patch; the dotted result is pinned in `AvatarContentTypeTests` and the avatar happy-path test now asserts `profile.png`.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **803/803 green**.
- Login-path file, but a trivial extension-string correctness fix with no logic or flow change, fully covered by tests, no separate adversarial gate warranted.