### PR TITLE
Reuse the resolved subject for the OpenID sub fallback

### DIFF
--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -65,10 +65,17 @@ internal static class OidcAuthorizeStateBuilder
         var enableLiveTvManagement = config.EnableLiveTvManagement || grants.EnableLiveTvManagement;
         folders.AddRange(grants.Folders);
 
-        // If the provider doesn't supply the preferred-username claim, fall back to the "sub" claim.
-        if (!valid)
+        // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
+        // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning
+        // the claims a second time. Faithful to the original: unlike the preferred-username branch, this
+        // does NOT null-check config.Roles, so a null Roles array throws here (an admin misconfiguration
+        // where RBAC is off and the provider supplies only "sub") — the null-forgiving operator keeps
+        // that exact fail-closed behavior, tracked in #89. Reached only when a sub exists (subject is
+        // non-null), matching the old loop, which touched Roles only inside a sub-claim iteration.
+        if (!valid && subject != null)
         {
-            (username, valid) = ResolveSubFallback(claimList, config, username);
+            username = subject;
+            valid = config.Roles!.Length == 0;
         }
 
         // Fail closed (#95): a valid login must also have resolved an identity. A role matching the
@@ -151,31 +158,6 @@ internal static class OidcAuthorizeStateBuilder
         }
 
         return (username, valid, roles);
-    }
-
-    // The "sub"-claim fallback, entered only when nothing validated the login (so validity starts
-    // false here): the LAST sub claim wins as the username.
-    private static (string? Username, bool Valid) ResolveSubFallback(IReadOnlyList<Claim> claims, OidConfig config, string? username)
-    {
-        var valid = false;
-        foreach (var claim in claims)
-        {
-            if (string.Equals(claim.Type, "sub", StringComparison.Ordinal))
-            {
-                username = claim.Value;
-
-                // Faithful to the original: unlike the preferred-username branch in ScanClaims, this
-                // does NOT null-check config.Roles, so a null Roles array here throws (an admin
-                // misconfiguration where RBAC is off and the provider supplies only "sub"). The
-                // null-forgiving operator keeps that exact fail-closed behavior; tracked in #89.
-                if (config.Roles!.Length == 0)
-                {
-                    valid = true;
-                }
-            }
-        }
-
-        return (username, valid);
     }
 
     /// <summary>


### PR DESCRIPTION
## What & why

`OidcAuthorizeStateBuilder` scanned the claim list for the `sub` claim **twice** per login: `ResolveSubject` computes the last-`sub`-wins value (stored as the account-link key), then `ResolveSubFallback` re-derived the identical value with a second O(n) loop on the login hot path.

Fold the fallback inline, reusing the already-computed `subject`:

```csharp
if (!valid && subject != null)
{
    username = subject;
    valid = config.Roles!.Length == 0;
}
```

Behavior-identical, including the documented quirks, last `sub` wins, the invalid-login-still-adopts-the-`sub` case, and the deliberate NRE on a null `Roles` array (#89). One private method and a redundant hot-path claim scan removed (~20 lines); the fail-closed belts (`valid && !IsNullOrWhiteSpace(username)`, and the subject-required callback rejection) are untouched.

Closes #394.

## Type of change
- [x] Quality / tech-debt (behavior-preserving dedup)

## Security checklist
- No security check touched: identity resolution is unchanged (`subject != null` triggers under exactly the same condition as the old loop, the #89 fail-closed NRE fires identically, and the whitespace belt is unchanged).

## Quality checklist
- Removes a duplicated O(n) claim scan from the login hot path and one private method.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **803/803 green**, the characterization tests pinning every quirk (`SubFallback_LastSubClaimWins`, `InvalidLogin_SubClaimStillOverwritesUsername`, `SubFallback_NullRolesArray_Throws`, the already-valid/no-reach cases) all pass unchanged.
- Focused adversarial correctness review (identity path): **PASS**, a statement-by-statement equivalence proof over all cases (entry condition, last-sub-wins incl. empty/whitespace, the null-Roles NRE, the no-sub and already-valid branches, the fail-closed belt) found no divergence.