### PR TITLE
Define the SAML algorithm allow-list predicate once

### DIFF
--- a/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
@@ -83,6 +83,14 @@ public class SamlSignatureAlgorithmsTests
         Assert.False(SamlSignatureAlgorithms.IsAllowed("urn:made:up", new[] { DigestSha256 }));
     }
 
+    [Fact]
+    public void IsAllowed_DisallowedSignatureWithNullDigests_ReturnsFalseWithoutThrowing()
+    {
+        // The signature method is checked first and short-circuits, so a disallowed signature with a
+        // null digest enumerable fails closed rather than dereferencing the null (#395).
+        Assert.False(SamlSignatureAlgorithms.IsAllowed("urn:made:up", null!));
+    }
+
     // --- Canonicalization allowlist (#137) ---
 
     private const string ExcC14n = "http://www.w3.org/2001/10/xml-exc-c14n#";

--- a/SSO-Auth/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/SamlSignatureAlgorithms.cs
@@ -65,24 +65,7 @@ internal static class SamlSignatureAlgorithms
     /// <param name="transforms">The transform-algorithm URIs of one reference, in order.</param>
     /// <returns>True only if there is at least one transform and all are allowed.</returns>
     internal static bool AreTransformsAllowed(IEnumerable<string> transforms)
-    {
-        if (transforms == null)
-        {
-            return false;
-        }
-
-        var any = false;
-        foreach (var transform in transforms)
-        {
-            any = true;
-            if (!AllowedTransforms.Contains(transform ?? string.Empty))
-            {
-                return false;
-            }
-        }
-
-        return any;
-    }
+        => AllOnList(AllowedTransforms, transforms);
 
     /// <summary>
     /// Whether the signature method and every reference digest method are on the allowlist.
@@ -91,22 +74,26 @@ internal static class SamlSignatureAlgorithms
     /// <param name="digestMethods">The digest-method URI of every reference.</param>
     /// <returns>True only if the signature method is allowed and there is at least one reference, all of whose digests are allowed.</returns>
     internal static bool IsAllowed(string signatureMethod, IEnumerable<string> digestMethods)
-    {
-        if (!AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty))
-        {
-            return false;
-        }
+        => AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty)
+           && AllOnList(AllowedDigestMethods, digestMethods);
 
-        if (digestMethods == null)
+    // The fail-closed shape both the transform chain and the reference digests require: a non-null
+    // enumerable with at least one element, every element on the allowlist. A null enumerable is
+    // rejected, an empty chain is rejected (nothing was actually signed/canonicalized), and a null
+    // element normalizes to string.Empty — never on any allowlist — so it is rejected too. Short-circuits
+    // on the first off-list element. Defined once so the two call sites cannot drift apart (#395).
+    private static bool AllOnList(HashSet<string> allow, IEnumerable<string> values)
+    {
+        if (values == null)
         {
             return false;
         }
 
         var any = false;
-        foreach (var digest in digestMethods)
+        foreach (var value in values)
         {
             any = true;
-            if (!AllowedDigestMethods.Contains(digest ?? string.Empty))
+            if (!allow.Contains(value ?? string.Empty))
             {
                 return false;
             }


### PR DESCRIPTION
## What & why

`AreTransformsAllowed` and the digest half of `IsAllowed` in `SamlSignatureAlgorithms` spelled out the same **"non-null enumerable, at least one element, every element on the allow-list"** loop against different sets. Extract it into one private `AllOnList` helper so the fail-closed shape, null rejected, empty chain rejected, any off-list or null element rejected, short-circuit on the first miss, is defined once and the two copies cannot drift apart.

```csharp
internal static bool AreTransformsAllowed(IEnumerable<string> transforms)
    => AllOnList(AllowedTransforms, transforms);

internal static bool IsAllowed(string signatureMethod, IEnumerable<string> digestMethods)
    => AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty)
       && AllOnList(AllowedDigestMethods, digestMethods);
```

Closes #395.

## Type of change
- [x] Quality / tech-debt (behavior-preserving dedup of the SAML algorithm gate)

## Security checklist
- No check weakened or reordered: `IsAllowed` still checks the signature method first and `&&` short-circuits before enumerating the digests, so a disallowed signature method with a null `digestMethods` still returns false rather than throwing. The allow-list sets and `StringComparer.Ordinal` are untouched. SHA-1 signatures, comment-preserving c14n, XPath/XSLT transforms, and empty chains stay rejected.

## Quality checklist
- ~14 lines removed; the fail-closed predicate is defined once so the transform and digest gates can never drift.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **803/803 green** (`SamlSignatureAlgorithmsTests` and the XSW/downgrade `SamlAttackShapeTests` pin every branch).
- Adversarial-review gate (SAML algorithm gate, per the issue): focused bypass + correctness lenses over the extraction, results appended below before merge.