### PR TITLE
Collapse the per-mode twin blocks over ProviderConfigBase

### DIFF
--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -334,20 +334,25 @@ internal sealed class CanonicalLinkService
     {
         return _configStore.Read(configuration =>
         {
-            // A provider stored with a null config object (reachable today via #350's null-body add)
-            // is skipped rather than dereferenced — same fail-closed treatment TryGetLinks gives it,
-            // so the read side cannot NRE into a 500 on a state the write side can produce.
-            var providerList = string.Equals(mode, "saml", StringComparison.Ordinal)
-                ? configuration.SamlConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks))
-                : configuration.OidConfigs.Where(p => p.Value?.CanonicalLinks != null).Select(p => new KeyValuePair<string, SerializableDictionary<string, Guid>>(p.Key, p.Value.CanonicalLinks));
+            // Both arms project (name, links) tuples through ProviderConfigBase.CanonicalLinks, so the
+            // per-mode twin queries are one shape. A provider stored with a null config object (reachable
+            // today via #350's null-body add) yields null links and is skipped rather than dereferenced —
+            // same fail-closed treatment TryGetLinks gives it, so the read side cannot NRE into a 500 on
+            // a state the write side can produce.
+            var providerLinks = string.Equals(mode, "saml", StringComparison.Ordinal)
+                ? configuration.SamlConfigs.Select(p => (p.Key, p.Value?.CanonicalLinks))
+                : configuration.OidConfigs.Select(p => (p.Key, p.Value?.CanonicalLinks));
 
             var mappings = new SerializableDictionary<string, IEnumerable<string>>();
-            foreach (var provider in providerList)
+            foreach (var (provider, links) in providerLinks)
             {
-                mappings[provider.Key] = provider.Value
-                    .Where(link => link.Value == jellyfinUserId)
-                    .Select(link => link.Key)
-                    .ToList();
+                if (links != null)
+                {
+                    mappings[provider] = links
+                        .Where(link => link.Value == jellyfinUserId)
+                        .Select(link => link.Key)
+                        .ToList();
+                }
             }
 
             return mappings;
@@ -367,17 +372,10 @@ internal sealed class CanonicalLinkService
         {
             int removed = 0;
 
-            // Skip a provider stored with a null config object (reachable via #350); it holds no links to
-            // revoke, and dereferencing it would NRE into a 500 — the same fail-closed skip TryGetLinks uses.
-            foreach (var config in configuration.SamlConfigs.Values)
-            {
-                if (config?.CanonicalLinks is { } links)
-                {
-                    removed += CanonicalLinkRevoker.RemoveUser(links, userId);
-                }
-            }
-
-            foreach (var config in configuration.OidConfigs.Values)
+            // One loop over both protocols' providers (covariant Concat over the shared base). Skip a
+            // provider stored with a null config object (reachable via #350); it holds no links to revoke,
+            // and dereferencing it would NRE into a 500 — the same fail-closed skip TryGetLinks uses.
+            foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
             {
                 if (config?.CanonicalLinks is { } links)
                 {
@@ -472,21 +470,25 @@ internal sealed class CanonicalLinkService
         switch (mode.ToLowerInvariant())
         {
             case "saml":
-            {
-                var ok = configuration.SamlConfigs.TryGetValue(provider, out var config);
-                links = config?.CanonicalLinks;
-                return ok && links != null && (!requireEnabled || config.Enabled);
-            }
+                return TryGetLinks(configuration.SamlConfigs, provider, requireEnabled, out links);
 
             case "oid":
-            {
-                var ok = configuration.OidConfigs.TryGetValue(provider, out var config);
-                links = config?.CanonicalLinks;
-                return ok && links != null && (!requireEnabled || config.Enabled);
-            }
+                return TryGetLinks(configuration.OidConfigs, provider, requireEnabled, out links);
 
             default:
                 throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
         }
+    }
+
+    // Generic over the provider config type (both maps hold ProviderConfigBase since #204), so the SAML
+    // and OpenID arms are one body: a missing provider or a null-valued entry returns false; with
+    // requireEnabled a disabled provider also returns false. Reads Enabled only after links != null has
+    // proven config non-null.
+    private static bool TryGetLinks<T>(SerializableDictionary<string, T> configs, string provider, bool requireEnabled, out SerializableDictionary<string, Guid> links)
+        where T : ProviderConfigBase
+    {
+        var ok = configs.TryGetValue(provider, out var config);
+        links = config?.CanonicalLinks;
+        return ok && links != null && (!requireEnabled || config.Enabled);
     }
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -37,14 +37,13 @@ internal static class ProviderConfigValidator
 
         if (incoming.SamlConfigs != null)
         {
+            // One pass runs all three checks per provider, so with several invalid providers the first
+            // error reported follows map order rather than check kind; every invalid save is still
+            // rejected fail-closed before anything is persisted.
             foreach (var kvp in incoming.SamlConfigs)
             {
                 ValidateProviderName("SAML", kvp.Key, isNew: live?.SamlConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
-            }
-
-            foreach (var kvp in incoming.SamlConfigs)
-            {
                 ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
             }
         }

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -27,25 +27,27 @@ internal static class ServerManagedFields
     /// <param name="live">The current live configuration to read server-managed values from.</param>
     internal static void Preserve(PluginConfiguration incoming, PluginConfiguration live)
     {
-        if (incoming?.OidConfigs != null && live?.OidConfigs != null)
+        Preserve(incoming?.OidConfigs, live?.OidConfigs, Preserve);
+        Preserve(incoming?.SamlConfigs, live?.SamlConfigs, Preserve);
+    }
+
+    // One generic loop for both protocols — the maps differ only in the per-provider overload the method
+    // group resolves to. Only providers present in BOTH maps are touched (a deleted provider stays
+    // deleted; a newly added one keeps its own empty map), and a null map on either side (a legacy store,
+    // a partial post) preserves nothing rather than NRE the save.
+    private static void Preserve<T>(SerializableDictionary<string, T> incoming, SerializableDictionary<string, T> live, Action<T, T> preserveProvider)
+        where T : ProviderConfigBase
+    {
+        if (incoming is null || live is null)
         {
-            foreach (var kvp in live.OidConfigs)
-            {
-                if (incoming.OidConfigs.TryGetValue(kvp.Key, out var incomingProvider))
-                {
-                    Preserve(incomingProvider, kvp.Value);
-                }
-            }
+            return;
         }
 
-        if (incoming?.SamlConfigs != null && live?.SamlConfigs != null)
+        foreach (var kvp in live)
         {
-            foreach (var kvp in live.SamlConfigs)
+            if (incoming.TryGetValue(kvp.Key, out var incomingProvider))
             {
-                if (incoming.SamlConfigs.TryGetValue(kvp.Key, out var incomingProvider))
-                {
-                    Preserve(incomingProvider, kvp.Value);
-                }
+                preserveProvider(incomingProvider, kvp.Value);
             }
         }
     }


### PR DESCRIPTION
# What & why

Since #204 moved `CanonicalLinks` and `Enabled` onto `ProviderConfigBase`, five per-mode SAML/OpenID twin blocks that predate the base class carried structurally identical arms that had to be edited twice on every change. This folds each into one body. Closes #392.

- `CanonicalLinkService.TryGetLinks`: both switch arms now call one generic helper over the shared base; the `requireEnabled` truth table is unchanged (`Enabled` is read only after `links != null` proves the config non-null).
- `CanonicalLinkService.LinksByUser`: the twin LINQ queries fold into one tuple projection; the null-config skip moves into the loop unchanged (same result set, including empty-map providers).
- `CanonicalLinkService.RemoveUserEverywhere`: one loop over both protocols' providers via a covariant `Concat` replaces the two identical `foreach` blocks (same elements, same order, same lock).
- `ServerManagedFields.Preserve`: one generic loop takes the per-provider overload as the action; the preserved provider set, iteration direction, and null-map guards are identical, so the `CanonicalLinks` re-injection and the `OidSecret` blank-means-keep rule (`ResolveUpdatedSecret`) run exactly as before.
- `ProviderConfigValidator.Validate`: the two back-to-back `SamlConfigs` loops merge into one running all three checks per provider.

Code-only delta is -11 lines (raw diff +3, the difference being the constraint comments each fold carries).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (804/804).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).

## Notes

- Sole observable delta, accepted on #392: with several invalid SAML providers in one save, the first-reported validation error follows map order rather than check kind. The accept/reject set is bit-identical, every invalid save is still rejected fail-closed before anything is persisted; both surfaces are `ArgumentException`, so the HTTP mapping is unchanged. No test pins the old ordering (all negative tests use single-provider configs).
- Adversarial review (all four lenses: availability/mass-lockout, security-bypass, correctness, integration): PASS across the board. The lenses verified the method-group resolution in `Preserve` binds uniquely to the per-provider overloads, the covariant `Concat` visits the same elements in the same order, nothing lazily enumerable escapes a config-lock callback, and the `requireEnabled` polarity at all five call sites is untouched. One LOW note each: on a hypothetical null protocol map (unreachable via any real load path), `RemoveUserEverywhere` now fails before any in-memory removal instead of after the SAML half, a strictly safer failure shape.
- The conformance link-map scan is confined to `SSOController.cs` (untouched); no new structural property to lock in, the fold removes duplication inside the two homes the existing rule already names.
- Behaviour is pinned by `CanonicalLinkServiceTests`, `SSOControllerLinkTests`, `ConfigPreservationTests`, and the link-map rules in `ArchitectureConformanceTests`.
- The complementary mode-token enum work stays tracked in #369; the `LinksByUser` mode fallthrough (any non-"saml" mode reads OpenID) is pre-existing and belongs to that issue.
