### PR TITLE
Compact the helpers: record struct, dead guards, constant parameter

### DIFF
--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -58,6 +58,19 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task AddCanonicalLink_AdminWithoutPreferenceAccess_Returns403()
+    {
+        // Pins the EnableUserPreferenceAccess term of AssertCanUpdateUser (#397 folded it from an
+        // always-true parameter into the helper): even an administrator is refused without it, so a
+        // future edit dropping the term cannot pass silently.
+        var harness = ForCaller(isAdmin: true, callerId: Target, enableUserPreferenceAccess: false);
+
+        var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse());
+
+        Assert.Equal(403, Assert.IsType<ObjectResult>(result).StatusCode);
+    }
+
+    [Fact]
     public async Task GetOidLinksByUser_NonAdminQueryingAnotherUser_Returns403()
     {
         var harness = ForCaller(isAdmin: false, callerId: Other);
@@ -324,13 +337,13 @@ public class SSOControllerLinkTests
     }
 
     // Builds a harness whose mocked IAuthorizationContext resolves the request to the given caller. An
-    // admin (or the target user themselves) passes AssertCanUpdateUser; a non-admin editing another user
-    // is refused.
-    private static SsoControllerHarness ForCaller(bool isAdmin, Guid callerId, Action<PluginConfiguration>? configure = null)
+    // admin (or the target user themselves) with preference access passes AssertCanUpdateUser; a
+    // non-admin editing another user, or any caller without EnableUserPreferenceAccess, is refused.
+    private static SsoControllerHarness ForCaller(bool isAdmin, Guid callerId, Action<PluginConfiguration>? configure = null, bool enableUserPreferenceAccess = true)
     {
         var harness = new SsoControllerHarness(configure);
 
-        var user = new User("caller", "SSO-Auth", "Default") { Id = callerId, EnableUserPreferenceAccess = true };
+        var user = new User("caller", "SSO-Auth", "Default") { Id = callerId, EnableUserPreferenceAccess = enableUserPreferenceAccess };
         user.SetPermission(PermissionKind.IsAdministrator, isAdmin);
 
         // AuthorizationInfo.UserId is derived from User.Id, so setting the user fixes the caller identity.

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -23,25 +23,9 @@ internal enum AccountLinkAction
 /// <summary>
 /// A resolved account-link decision: the action and the Jellyfin user id it applies to.
 /// </summary>
-internal readonly struct AccountLinkDecision
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AccountLinkDecision"/> struct.
-    /// </summary>
-    /// <param name="action">The action to take.</param>
-    /// <param name="userId">The Jellyfin user id the action applies to (empty when creating/rejecting).</param>
-    internal AccountLinkDecision(AccountLinkAction action, Guid userId)
-    {
-        Action = action;
-        UserId = userId;
-    }
-
-    /// <summary>Gets the action to take.</summary>
-    internal AccountLinkAction Action { get; }
-
-    /// <summary>Gets the Jellyfin user id the action applies to.</summary>
-    internal Guid UserId { get; }
-}
+/// <param name="Action">The action to take.</param>
+/// <param name="UserId">The Jellyfin user id the action applies to (empty when creating/rejecting).</param>
+internal readonly record struct AccountLinkDecision(AccountLinkAction Action, Guid UserId);
 
 /// <summary>
 /// Pure decision logic mapping an SSO identity to a Jellyfin account. An identity already linked to

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -105,8 +105,8 @@ internal static class OidcAuthorizeStateBuilder
     }
 
     // Resolves the avatar URL by substituting @{claimType} tokens in the configured format, or null
-    // when no format is configured. For a duplicate claim type the first occurrence wins (after the
-    // first Replace the token is gone).
+    // when no format is configured. For a duplicate claim type the first occurrence wins: after the
+    // first Replace the token is gone, and Replace on an absent token returns the instance unchanged.
     private static string? ResolveAvatarUrl(IReadOnlyList<Claim> claims, OidConfig config)
     {
         if (config.AvatarUrlFormat is null)
@@ -116,7 +116,7 @@ internal static class OidcAuthorizeStateBuilder
 
         return claims.Aggregate(
             config.AvatarUrlFormat,
-            (s, claim) => s.Contains($"@{{{claim.Type}}}") ? s.Replace($"@{{{claim.Type}}}", claim.Value) : s);
+            (s, claim) => s.Replace($"@{{{claim.Type}}}", claim.Value));
     }
 
     // Splits the configured role-claim path on unescaped dots; escaped "\." are normalized to ".".
@@ -137,12 +137,15 @@ internal static class OidcAuthorizeStateBuilder
     {
         var roleClaimSegments = SplitRoleClaimPath(config);
 
+        // Depends only on the configuration, so it is resolved once, not per claim.
+        var usernameClaimType = config.DefaultUsernameClaim?.Trim() ?? "preferred_username";
+
         string? username = null;
         var valid = false;
         var roles = new List<string>();
         foreach (var claim in claims)
         {
-            if (string.Equals(claim.Type, config.DefaultUsernameClaim?.Trim() ?? "preferred_username", StringComparison.Ordinal))
+            if (string.Equals(claim.Type, usernameClaimType, StringComparison.Ordinal))
             {
                 username = claim.Value;
                 if (config.Roles == null || config.Roles.Length == 0)

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -61,6 +61,7 @@ internal sealed class OidcStateStore
         _capWarnGate = new IntervalGate(pruneInterval);
     }
 
+    /// <summary>Gets the live entry count. Test-only, like Seed/Clear: production code reads _states.Count directly.</summary>
     internal int Count => _states.Count;
 
     /// <summary>

--- a/SSO-Auth/Api/RequestHelpers.cs
+++ b/SSO-Auth/Api/RequestHelpers.cs
@@ -27,21 +27,16 @@ public static class RequestHelpers
     /// <param name="authContext">Instance of the <see cref="IAuthorizationContext"/> interface.</param>
     /// <param name="requestContext">The <see cref="HttpRequest"/>.</param>
     /// <param name="userId">The user id.</param>
-    /// <param name="restrictUserPreferences">Whether to restrict the user preferences.</param>
     /// <returns>A <see cref="bool"/> whether the user can update the entry.</returns>
-    internal static async Task<bool> AssertCanUpdateUser(IAuthorizationContext authContext, HttpRequest requestContext, Guid userId, bool restrictUserPreferences)
+    internal static async Task<bool> AssertCanUpdateUser(IAuthorizationContext authContext, HttpRequest requestContext, Guid userId)
     {
         var auth = await authContext.GetAuthorizationInfo(requestContext).ConfigureAwait(false);
 
         var authenticatedUser = auth.User;
 
-        // If they're going to update the record of another user, they must be an administrator
-        if ((!userId.Equals(auth.UserId) && !authenticatedUser.HasPermission(PermissionKind.IsAdministrator))
-            || (restrictUserPreferences && !authenticatedUser.EnableUserPreferenceAccess))
-        {
-            return false;
-        }
-
-        return true;
+        // Updating the record of another user requires an administrator; every caller edits user
+        // preferences, so the upstream restrictUserPreferences flag is folded in as always-on here.
+        return (userId.Equals(auth.UserId) || authenticatedUser.HasPermission(PermissionKind.IsAdministrator))
+            && authenticatedUser.EnableUserPreferenceAccess;
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1058,7 +1058,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult> AddCanonicalLink([FromRoute] string mode, [FromRoute] string provider, [FromRoute] Guid jellyfinUserId, [FromBody] AuthResponse authResponse)
     {
-        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId, true).ConfigureAwait(false))
+        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId).ConfigureAwait(false))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to link SSO providers.");
         }
@@ -1088,7 +1088,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult> DeleteCanonicalLink([FromRoute] string mode, [FromRoute] string provider, [FromRoute] Guid jellyfinUserId, [FromRoute] string canonicalName)
     {
-        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId, true).ConfigureAwait(false))
+        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId).ConfigureAwait(false))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
         }
@@ -1114,7 +1114,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult<SerializableDictionary<string, IEnumerable<string>>>> GetSamlLinksByUser(Guid jellyfinUserId)
     {
-        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId, true).ConfigureAwait(false))
+        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId).ConfigureAwait(false))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
@@ -1132,7 +1132,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult<SerializableDictionary<string, IEnumerable<string>>>> GetOidLinksByUser(Guid jellyfinUserId)
     {
-        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId, true).ConfigureAwait(false))
+        if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId).ConfigureAwait(false))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -199,6 +199,9 @@ public abstract class ProviderConfigBase
 /// <summary>
 /// The configuration required for a SAML flow.
 /// </summary>
+// Load-bearing, not copy-paste cruft: this names the element SerializableDictionary.WriteXml persists
+// via new XmlSerializer(typeof(TValue)); removing it renames that element and every stored provider
+// entry on disk stops deserializing.
 [XmlRoot("PluginConfiguration")]
 public class SamlConfig : ProviderConfigBase
 {
@@ -249,6 +252,9 @@ public class SamlConfig : ProviderConfigBase
 /// <summary>
 /// The configuration required for a OpenID flow.
 /// </summary>
+// Load-bearing, not copy-paste cruft: this names the element SerializableDictionary.WriteXml persists
+// via new XmlSerializer(typeof(TValue)); removing it renames that element and every stored provider
+// entry on disk stops deserializing.
 [XmlRoot("PluginConfiguration")]
 public class OidConfig : ProviderConfigBase
 {

--- a/SSO-Auth/Config/WriteOnlySecretConverter.cs
+++ b/SSO-Auth/Config/WriteOnlySecretConverter.cs
@@ -18,7 +18,7 @@ internal sealed class WriteOnlySecretConverter : JsonConverter<string>
 {
     /// <inheritdoc />
     public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        => reader.TokenType == JsonTokenType.Null ? null : reader.GetString();
+        => reader.GetString();
 
     /// <inheritdoc />
     public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -14,7 +14,7 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// <see cref="ProviderConfigStore"/> (#318); the public methods below remain the plugin's
 /// configuration facade and delegate to it.
 /// </summary>
-public class SSOPlugin : BasePlugin<PluginConfiguration>, IPlugin, IHasWebPages
+public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOPlugin"/> class.

--- a/SSO-Auth/SerializableDictionary.cs
+++ b/SSO-Auth/SerializableDictionary.cs
@@ -14,14 +14,6 @@ public class SerializableDictionary<TKey, TValue>
     : Dictionary<TKey, TValue>, IXmlSerializable
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="SerializableDictionary{TKey,TValue}"/> class.
-    /// </summary>
-    public SerializableDictionary()
-    {
-        // Empty
-    }
-
-    /// <summary>
     /// Gets the schema of the XML object.
     /// </summary>
     /// <returns>Nothing.</returns>

--- a/SSO-Auth/Views/SSOViewsController.cs
+++ b/SSO-Auth/Views/SSOViewsController.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using MediaBrowser.Model;
-using MediaBrowser.Model.Plugins;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -46,38 +43,27 @@ public class SSOViewsController : ControllerBase
     [HttpGet("{viewName}")]
     public ActionResult GetView([FromRoute] string viewName)
     {
-        return ServeView(viewName);
-    }
-
-    private ActionResult ServeView(string viewName)
-    {
         if (SSOPlugin.Instance == null)
         {
             return BadRequest("No plugin instance found");
         }
 
-        IEnumerable<PluginPageInfo> pages = SSOPlugin.Instance.GetViews();
-
-        if (pages == null)
-        {
-            return NotFound("Pages is null or empty");
-        }
-
-        var view = pages.FirstOrDefault(pageInfo => string.Equals(pageInfo.Name, viewName, StringComparison.Ordinal), null);
+        var view = SSOPlugin.Instance.GetViews()
+            .FirstOrDefault(pageInfo => string.Equals(pageInfo.Name, viewName, StringComparison.Ordinal));
 
         if (view == null)
         {
             return NotFound("No matching view found");
         }
-#nullable enable
-        Stream? stream = SSOPlugin.Instance.GetType().Assembly.GetManifestResourceStream(view.EmbeddedResourcePath);
+
+        var stream = SSOPlugin.Instance.GetType().Assembly.GetManifestResourceStream(view.EmbeddedResourcePath);
 
         if (stream == null)
         {
             _logger.LogError("Failed to get resource {Resource}", view.EmbeddedResourcePath);
             return NotFound();
         }
-#nullable disable
+
         return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath), lastModified: null, entityTag: AssetETag);
     }
 }


### PR DESCRIPTION
# What & why

A batch of small, independently verified compactness items across the helpers, in the #370 sweep style. None changes behaviour; together they remove the ceremony the problem never required. Closes #397.

- `AccountLinkDecision`: 19 lines of hand-written constructor + get-only properties collapse to a positional `readonly record struct`, the idiom its file siblings (`RoleGrants`, `OidcAuthorizeState`) already use. All construction is positional, all consumption is member reads.
- `SSOViewsController`: `GetView` no longer forwards to a single-caller `ServeView`; the `pages == null` guard was unreachable (`SSOPlugin.GetViews` returns an array literal, this is asset serving, not a login-path guard); `FirstOrDefault(predicate, null)` was the two-arg overload spelled with its own default; the `#nullable` sandwich and three now-unused usings go with it.
- `SerializableDictionary`: the explicit empty parameterless constructor is exactly what the compiler supplies implicitly (no other constructor exists). `XmlSerializer` constructibility is pinned by the serialization round-trip tests.
- `RequestHelpers.AssertCanUpdateUser`: all four call sites passed `restrictUserPreferences: true`, so the parameter folds in as always-on and the guard collapses to one boolean return with an identical truth table (`(same || admin) && preferenceAccess`). A new test pins the `EnableUserPreferenceAccess` refusal leg, which the fold made load-bearing by convention rather than by parameter.
- `WriteOnlySecretConverter`: `GetString()` already returns null on a Null token, and the serializer never routes a Null token into `Read` for a reference-type converter without `HandleNull`, so the ternary was dead both ways. The `Write` side is untouched: the secret still never serializes outward.
- `OidcAuthorizeStateBuilder`: the `Contains` guard before `Replace` was redundant (`Replace` returns the same instance when nothing matches; first-duplicate-wins unchanged), and the per-claim `DefaultUsernameClaim?.Trim() ?? "preferred_username"` hoists above the loop, it depends only on config, same precedent as the hoisted `SplitRoleClaimPath`.
- `SSOPlugin`: `IPlugin` in the base list was redundant, `BasePlugin<T>` already implements it, and reflection (`GetInterfaces`/`IsAssignableFrom`, what plugin discovery uses) is transitive over base types.
- `OidcStateStore.Count` is documented as the test seam it is, like `Seed`/`Clear`.
- `SamlConfig`/`OidConfig` `[XmlRoot("PluginConfiguration")]` gains a two-line constraint comment: it names the `<value>` element `SerializableDictionary.WriteXml` persists via `new XmlSerializer(typeof(TValue))`, so a future cleanliness pass must never remove it.

Production code delta is -28 lines (+16/-44); raw diff -20 including the added test.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (805/805, one new test).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).

## Notes

- Adversarial review (all four lenses: availability/mass-lockout, security-bypass, correctness, integration): PASS across the board, with empirical probes, `Utf8JsonReader.GetString()` on a Null token returns null (and `JsonConverter<string>` with default `HandleNull` never routes Null into `Read`, so the deleted ternary was dead both ways); `string.Replace` with an absent token returns the same instance (`ReferenceEquals` true); the `AssertCanUpdateUser` truth table is identical in all 8 cells (an admin without `EnableUserPreferenceAccess` is still refused, as before); the decompiled `MediaBrowser.Common` confirms `BasePlugin : IPlugin`, and `IsAssignableFrom`/`GetInterfaces` are transitive, so plugin discovery is unaffected.
- The deleted `pages == null` guard was defense-in-depth against a future nullable `GetViews`; today it is provably dead (array literal, non-virtual, statically-typed instance). We accept the trade under the minimal-code directive and record the decision here.
- The review flagged that the `EnableUserPreferenceAccess` refusal leg had no test while the fold turned that term from parameter-supplied into helper-owned, the new `AddCanonicalLink_AdminWithoutPreferenceAccess_Returns403` pins it.
- Pre-existing, untouched, noted for completeness: a hypothetical `auth.User == null` (pure API-key auth) would NRE in `AssertCanUpdateUser` exactly as before this change; Jellyfin rejects unauthenticated requests before this point.
- Behaviour is pinned by `AccountLinkResolverTests`, `SSOControllerLinkTests`, `ConfigPreservationTests` (secret hidden-serialize + rotation), `SerializableDictionarySerializationTests` (round-trip incl. legacy on-disk format), and `OidcStateStoreTests`.
