### PR TITLE
Bound the in-flight login state stores per client

### DIFF
--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -359,7 +359,7 @@ public class OidcStateStoreTests
             {
                 for (var i = 0; i < 5000; i++)
                 {
-                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, out _);
+                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, clientKey: null, out _);
                 }
             },
             TestContext.Current.CancellationToken);
@@ -387,8 +387,8 @@ public class OidcStateStoreTests
     {
         var store = Store(maxEntries: 2);
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out var warnA));
-        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, out var warnB));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out var warnA));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var warnB));
         Assert.False(warnA);
         Assert.False(warnB);
         Assert.Equal(2, store.Count);
@@ -398,10 +398,10 @@ public class OidcStateStoreTests
     public void TryAdd_AtCap_RefusesANewKeyAndKeepsTheInFlightState()
     {
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, clientKey: null, out _));
 
         // At the cap, a fresh challenge is refused rather than evicting the user already mid-login.
-        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, clientKey: null, out _));
         Assert.Equal(1, store.Count);
         Assert.NotNull(store.PeekCurrent("in-flight", "p", Now, Binding));
     }
@@ -410,8 +410,8 @@ public class OidcStateStoreTests
     public void TryAdd_DuplicateKey_ReturnsFalse()
     {
         var store = Store(maxEntries: 10);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
-        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
     }
 
     [Fact]
@@ -420,15 +420,15 @@ public class OidcStateStoreTests
         // The warning signal is bounded exactly like the sweeps: the first refusal signals, further
         // refusals inside the interval stay silent, so a flood cannot amplify into log volume.
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, out var firstWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var firstWarn));
         Assert.True(firstWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, out var secondWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, clientKey: null, out var secondWarn));
         Assert.False(secondWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, out var nextIntervalWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, clientKey: null, out var nextIntervalWarn));
         Assert.True(nextIntervalWarn);
     }
 
@@ -450,7 +450,7 @@ public class OidcStateStoreTests
                 {
                     for (var i = 0; i < perTask; i++)
                     {
-                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, out _))
+                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, clientKey: null, out _))
                         {
                             Interlocked.Increment(ref rejected);
                         }
@@ -557,5 +557,96 @@ public class OidcStateStoreTests
         Assert.Equal(Now, summary.Created);
         Assert.True(summary.Valid);
         Assert.True(summary.IsLinking);
+    }
+
+    // --- Per-client sub-cap (#327): global 200 -> per-key 2 unless noted ---
+
+    private static AuthorizeState State(string s) => new AuthorizeState { State = s };
+
+    // Promotes a just-added (Valid=false) state to redeemable via the production path (peek + Complete),
+    // so TryRedeem — which requires a validated state — can exercise the per-client release.
+    private static void Validate(OidcStateStore store, string token) =>
+        store.PeekCurrent(token, "p", Now, Binding)!.Complete(
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", true, false, false, false, new System.Collections.Generic.List<string>(), null));
+
+    [Fact]
+    public void TryAdd_FloodFromOneKey_DoesNotRefuseADifferentKey()
+    {
+        // The core fairness property: filling client "A" to its per-key share must not deny "B".
+        var store = Store(maxEntries: 200); // per-key cap 2
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _));
+        Assert.True(store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _));
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out var warn)); // A at share
+        Assert.True(warn); // the throttled capacity warning fires for the first per-client refusal
+
+        Assert.True(store.TryAdd(State("b1"), "p", false, Now, Binding, clientKey: "B", out _)); // B unaffected
+    }
+
+    [Fact]
+    public void TryAdd_ReleaseOnRedeem_ReadmitsTheSameKey()
+    {
+        var store = Store(maxEntries: 200); // per-key cap 2
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _)); // full
+
+        Validate(store, "a1");
+        Assert.NotNull(store.TryRedeem("a1", "p", Now, Binding)); // frees one A slot
+        Assert.True(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _));
+    }
+
+    [Fact]
+    public void TryAdd_ReleaseOnExpirySweep_ReadmitsTheSameKey()
+    {
+        var store = Store(maxEntries: 200); // per-key cap 2
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
+
+        // Past the lifetime and the prune interval, the sweep removes both A entries and releases their
+        // slots, so A can add again. (Lifetime and PruneInterval are the test fixture's small values.)
+        var later = Now + Lifetime + PruneInterval + TimeSpan.FromSeconds(1);
+        store.PruneExpired(later);
+        Assert.True(store.TryAdd(State("a3"), "p", false, later, Binding, clientKey: "A", out _));
+    }
+
+    [Fact]
+    public void TryAdd_ReleaseOnFailedGlobalInsert_DoesNotLeakTheClientSlot()
+    {
+        // Global cap 2 -> per-key cap 1. Fill the store to the global cap with exempt (null) keys, then
+        // a "A" add reserves A's slot but is refused by the GLOBAL cap and must roll back. After a slot
+        // frees, "A" must still admit — a leaked reservation would leave A at its cap of 1.
+        var store = Store(maxEntries: 2);
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _));
+
+        Assert.False(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // global cap
+        Validate(store, "n1");
+        Assert.NotNull(store.TryRedeem("n1", "p", Now, Binding)); // free one global slot
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // no leak
+    }
+
+    [Fact]
+    public void TryAdd_NullKeyIsExempt_BoundedOnlyByTheGlobalCap()
+    {
+        // Global cap 2 -> per-key cap 1. A null (proxy/unattributable) key is never sub-capped: null adds
+        // succeed past a per-key cap of 1 up to the GLOBAL cap, then are refused by the global cap.
+        var store = Store(maxEntries: 2);
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _)); // past per-key 1
+        Assert.False(store.TryAdd(State("n3"), "p", false, Now, Binding, clientKey: null, out _)); // global cap
+    }
+
+    [Fact]
+    public void TryAdd_DistinctKeys_FillToGlobalCap_ThenRefuseNotEvict()
+    {
+        // The per-key cap must not block distinct keys: fill the store to the global cap with one entry
+        // each per distinct key, then a further distinct key is refused (global cap) and the existing
+        // entries survive (refuse-not-evict).
+        var store = Store(maxEntries: 3); // per-key cap 1
+        Assert.True(store.TryAdd(State("k1"), "p", false, Now, Binding, clientKey: "K1", out _));
+        Assert.True(store.TryAdd(State("k2"), "p", false, Now, Binding, clientKey: "K2", out _));
+        Assert.True(store.TryAdd(State("k3"), "p", false, Now, Binding, clientKey: "K3", out _));
+        Assert.False(store.TryAdd(State("k4"), "p", false, Now, Binding, clientKey: "K4", out _)); // global cap
+        Assert.NotNull(store.PeekCurrent("k1", "p", Now, Binding)); // not evicted
     }
 }

--- a/SSO-Auth.Tests/PerClientBudgetLimiterTests.cs
+++ b/SSO-Auth.Tests/PerClientBudgetLimiterTests.cs
@@ -1,0 +1,144 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="PerClientBudgetLimiter"/> — the per-client occupancy sub-cap the in-flight state
+/// stores use so one source cannot fill the global budget (#327). Reserve is a single CAS, so a per-key
+/// count can never race past the cap; release is idempotent and drops the empty bucket; a null key is
+/// always exempt.
+/// </summary>
+public class PerClientBudgetLimiterTests
+{
+    [Fact]
+    public void Reserve_UpToCap_Succeeds_ThenRefuses()
+    {
+        var limiter = new PerClientBudgetLimiter(3);
+        Assert.True(limiter.TryReserve("A"));
+        Assert.True(limiter.TryReserve("A"));
+        Assert.True(limiter.TryReserve("A"));
+        Assert.False(limiter.TryReserve("A")); // at cap
+    }
+
+    [Fact]
+    public void FromGlobalCap_DerivesTheHundredthShare_WithAFloorOfOne()
+    {
+        Assert.Equal(1000, PerClientBudgetLimiter.FromGlobalCap(100_000).PerKeyCap);
+        Assert.Equal(1, PerClientBudgetLimiter.FromGlobalCap(50).PerKeyCap); // Max(1, 50/100)
+    }
+
+    [Fact]
+    public void Release_ReadmitsAfterCap()
+    {
+        var limiter = new PerClientBudgetLimiter(2);
+        limiter.TryReserve("A");
+        limiter.TryReserve("A");
+        Assert.False(limiter.TryReserve("A"));
+
+        limiter.Release("A");
+        Assert.True(limiter.TryReserve("A"));
+    }
+
+    [Fact]
+    public void Release_ToZero_DropsTheBucket()
+    {
+        var limiter = new PerClientBudgetLimiter(3);
+        limiter.TryReserve("A");
+        limiter.TryReserve("A");
+        Assert.Equal(1, limiter.TrackedKeys);
+
+        limiter.Release("A");
+        limiter.Release("A");
+        Assert.Equal(0, limiter.TrackedKeys); // empty bucket removed, map stays bounded
+    }
+
+    [Fact]
+    public void NullKey_AlwaysReserves_AndIsNeverTracked()
+    {
+        var limiter = new PerClientBudgetLimiter(1);
+        for (var i = 0; i < 100; i++)
+        {
+            Assert.True(limiter.TryReserve(null)); // exempt, never at cap
+        }
+
+        Assert.Equal(0, limiter.TrackedKeys);
+        limiter.Release(null); // no throw, no-op
+    }
+
+    [Fact]
+    public void Release_OfUnknownKey_IsANoOp_NeverNegative()
+    {
+        var limiter = new PerClientBudgetLimiter(2);
+        limiter.Release("never-reserved"); // no throw
+        Assert.Equal(0, limiter.TrackedKeys);
+
+        // A stray extra release must not push the count negative and let the bucket over-admit.
+        limiter.TryReserve("A");
+        limiter.Release("A");
+        limiter.Release("A"); // over-release
+        Assert.True(limiter.TryReserve("A"));
+        Assert.True(limiter.TryReserve("A")); // still exactly cap-2 headroom, not more
+        Assert.False(limiter.TryReserve("A"));
+    }
+
+    [Fact]
+    public async Task Reserve_UnderContentionOnOneKey_GrantsExactlyTheCap()
+    {
+        // The crux: N threads hammer TryReserve on the same key; the CAS makes the cap-check+increment
+        // one atom, so EXACTLY cap reservations succeed — zero overshoot.
+        const int Cap = 50;
+        var limiter = new PerClientBudgetLimiter(Cap);
+        var granted = 0;
+
+        var tasks = new Task[16];
+        for (var t = 0; t < tasks.Length; t++)
+        {
+            tasks[t] = Task.Run(() =>
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    if (limiter.TryReserve("A"))
+                    {
+                        Interlocked.Increment(ref granted);
+                    }
+                }
+            },
+            TestContext.Current.CancellationToken);
+        }
+
+        await Task.WhenAll(tasks);
+        Assert.Equal(Cap, granted); // never more than the cap, even under 16-way contention
+    }
+
+    [Fact]
+    public async Task ReserveRelease_Interleaved_StaysWithinBounds()
+    {
+        var limiter = new PerClientBudgetLimiter(4);
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            var tasks = new Task[8];
+            for (var t = 0; t < tasks.Length; t++)
+            {
+                tasks[t] = Task.Run(() =>
+                {
+                    for (var i = 0; i < 500; i++)
+                    {
+                        if (limiter.TryReserve("A"))
+                        {
+                            limiter.Release("A");
+                        }
+                    }
+                },
+                TestContext.Current.CancellationToken);
+            }
+
+            await Task.WhenAll(tasks);
+        });
+
+        Assert.Null(exception);
+        Assert.True(limiter.TrackedKeys <= 1); // 0 or 1, never corrupt
+    }
+}

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -48,7 +48,7 @@ public class ProviderScopedKeyTests
         Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now));
 
         var requests = new SamlRequestCache();
-        requests.Register(requestKey!, "binding", now.AddMinutes(15), now);
+        requests.Register(requestKey!, "binding", now.AddMinutes(15), now, clientKey: null, out _);
         Assert.False(requests.TryConsume(requestKey!, now, out _));
     }
 }

--- a/SSO-Auth.Tests/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/SamlRequestCacheTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 
@@ -6,20 +7,24 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// Tests for <see cref="SamlRequestCache"/> — the outstanding-AuthnRequest tracking that lets the
-/// callback accept only solicited responses (#156) and carries the browser-binding id minted at the
-/// challenge (#415): a response's InResponseTo must match a request this server issued, each request
-/// answers at most once, an unknown/expired/blank id fails closed, and a successful consume yields the
-/// binding id recorded with the request.
+/// callback accept only solicited responses (#156), carries the browser-binding id minted at the
+/// challenge (#415), and bounds per-client occupancy so one source cannot fill the cache (#327): a
+/// response's InResponseTo must match a request this server issued, each request answers at most once,
+/// an unknown/expired/blank id fails closed, a successful consume yields the binding id recorded with
+/// the request, and one client key may hold at most its per-key share.
 /// </summary>
 public class SamlRequestCacheTests
 {
     private static readonly DateTime Now = new DateTime(2026, 7, 12, 12, 0, 0, DateTimeKind.Utc);
 
+    // A cache whose per-key sub-cap is small and reachable (global 200 -> per-key 2).
+    private static SamlRequestCache SmallCache() => new SamlRequestCache(200, TimeSpan.FromMinutes(1));
+
     [Fact]
     public void Register_ThenConsume_SucceedsOnce_ThenReplayFails()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now);
+        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now, clientKey: null, out _);
 
         Assert.True(cache.TryConsume("_req-1", Now, out var bindingId));
         Assert.Equal("binding-1", bindingId); // the binding id round-trips to the consumer
@@ -37,12 +42,12 @@ public class SamlRequestCacheTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void Consume_BlankId_FailsClosed(string? id)
+    public void Register_BlankId_ReturnsFalse_AndConsumeFails(string? id)
     {
         var cache = new SamlRequestCache();
         // A blank id is never registered and can never be consumed (an unsolicited response with no
         // InResponseTo maps to a blank key).
-        cache.Register(id!, "binding", Now.AddMinutes(15), Now);
+        Assert.False(cache.Register(id!, "binding", Now.AddMinutes(15), Now, clientKey: null, out _));
         Assert.False(cache.TryConsume(id!, Now, out _));
     }
 
@@ -50,7 +55,7 @@ public class SamlRequestCacheTests
     public void Consume_AfterExpiry_FailsClosed()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now);
+        cache.Register("_req-1", "binding-1", Now.AddMinutes(15), Now, clientKey: null, out _);
 
         // The request was never answered within its lifetime; a late response is refused.
         Assert.False(cache.TryConsume("_req-1", Now.AddMinutes(20), out _));
@@ -63,7 +68,7 @@ public class SamlRequestCacheTests
         // solicited but yields an empty binding, which the caller treats as unbound rather than a
         // mismatch — so an upgrade does not break a login already in flight.
         var cache = new SamlRequestCache();
-        cache.Register("_req-1", null!, Now.AddMinutes(15), Now);
+        cache.Register("_req-1", null!, Now.AddMinutes(15), Now, clientKey: null, out _);
 
         Assert.True(cache.TryConsume("_req-1", Now, out var bindingId));
         Assert.Equal(string.Empty, bindingId);
@@ -73,8 +78,8 @@ public class SamlRequestCacheTests
     public void DistinctRequests_EachConsumeOnce_WithTheirOwnBinding()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_a", "binding-a", Now.AddMinutes(15), Now);
-        cache.Register("_b", "binding-b", Now.AddMinutes(15), Now);
+        cache.Register("_a", "binding-a", Now.AddMinutes(15), Now, clientKey: null, out _);
+        cache.Register("_b", "binding-b", Now.AddMinutes(15), Now, clientKey: null, out _);
 
         Assert.True(cache.TryConsume("_a", Now, out var a));
         Assert.Equal("binding-a", a);
@@ -87,11 +92,11 @@ public class SamlRequestCacheTests
     public void Register_ExpiredEntriesArePrunedOnLaterOperation()
     {
         var cache = new SamlRequestCache();
-        cache.Register("_old", "binding-old", Now.AddMinutes(1), Now);
+        cache.Register("_old", "binding-old", Now.AddMinutes(1), Now, clientKey: null, out _);
 
         // A later registration prunes the expired entry; the old id is gone (would fail consume).
         // (TryConsume also rejects it on expiry, so this additionally relies on it not being present.)
-        cache.Register("_new", "binding-new", Now.AddMinutes(35), Now.AddMinutes(20));
+        cache.Register("_new", "binding-new", Now.AddMinutes(35), Now.AddMinutes(20), clientKey: null, out _);
         Assert.False(cache.TryConsume("_old", Now.AddMinutes(20), out _));
         Assert.True(cache.TryConsume("_new", Now.AddMinutes(20), out _));
     }
@@ -101,21 +106,107 @@ public class SamlRequestCacheTests
     {
         // The cap is the reason the eviction code exists; it was the untested path that threw an
         // ArgumentException under concurrent LINQ eviction. Register an early "in-flight" id, then
-        // flood well past the cap: registration must never throw, and the pre-existing in-flight id
-        // must NOT be evicted (a flood of fresh challenges cannot displace a user mid-login).
+        // flood well past the cap with exempt (null) keys: registration must never throw, and the
+        // pre-existing in-flight id must NOT be evicted (a flood cannot displace a user mid-login).
         var cache = new SamlRequestCache();
         var expiry = Now.AddMinutes(15);
-        cache.Register("_inflight", "binding-inflight", expiry, Now);
+        cache.Register("_inflight", "binding-inflight", expiry, Now, clientKey: null, out _);
 
         var exception = Record.Exception(() =>
         {
             for (var i = 0; i < 100_050; i++)
             {
-                cache.Register("_flood-" + i.ToString(System.Globalization.CultureInfo.InvariantCulture), "b", expiry, Now);
+                cache.Register("_flood-" + i.ToString(CultureInfo.InvariantCulture), "b", expiry, Now, clientKey: null, out _);
             }
         });
 
         Assert.Null(exception);
         Assert.True(cache.TryConsume("_inflight", Now, out _));
+    }
+
+    // --- Per-client sub-cap (#327) ---
+
+    [Fact]
+    public void Register_FloodFromOneKey_DoesNotRefuseADifferentKey()
+    {
+        // The core fairness property: filling client "A" to its per-key share must not deny a login
+        // from client "B".
+        var cache = SmallCache(); // per-key cap 2
+        var expiry = Now.AddMinutes(15);
+        Assert.True(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _));
+        Assert.True(cache.Register("_a2", "b", expiry, Now, clientKey: "A", out _));
+        Assert.False(cache.Register("_a3", "b", expiry, Now, clientKey: "A", out var warn)); // A at its share
+        Assert.True(warn); // the throttled capacity warning fires for the first refusal in the interval
+
+        Assert.True(cache.Register("_b1", "b", expiry, Now, clientKey: "B", out _)); // B is unaffected
+    }
+
+    [Fact]
+    public void Register_ReleaseOnConsume_ReadmitsTheSameKey()
+    {
+        var cache = SmallCache(); // per-key cap 2
+        var expiry = Now.AddMinutes(15);
+        cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _);
+        cache.Register("_a2", "b", expiry, Now, clientKey: "A", out _);
+        Assert.False(cache.Register("_a3", "b", expiry, Now, clientKey: "A", out _)); // full
+
+        Assert.True(cache.TryConsume("_a1", Now, out _)); // frees one A slot
+        Assert.True(cache.Register("_a3", "b", expiry, Now, clientKey: "A", out _));
+    }
+
+    [Fact]
+    public void Register_ReleaseOnExpiry_ReadmitsTheSameKey()
+    {
+        var cache = SmallCache(); // per-key cap 2
+        cache.Register("_a1", "b", Now.AddMinutes(1), Now, clientKey: "A", out _);
+        cache.Register("_a2", "b", Now.AddMinutes(1), Now, clientKey: "A", out _);
+
+        // Advance past expiry and past the prune interval; the next Register prunes both expired A
+        // entries (releasing their slots), so A can register again.
+        var later = Now.AddMinutes(5);
+        Assert.True(cache.Register("_a3", "b", later.AddMinutes(15), later, clientKey: "A", out _));
+    }
+
+    [Fact]
+    public void Register_ReleaseOnFailedGlobalInsert_DoesNotLeakTheClientSlot()
+    {
+        // Global cap 2 -> per-key cap 1. Fill the store to the global cap with exempt (null) entries,
+        // then a Register for "A" reserves A's slot but is refused by the GLOBAL cap and must roll the
+        // reservation back. After freeing a global slot, "A" must still be admittable — if the rollback
+        // had leaked, A would already sit at its cap of 1 and this would be refused.
+        var cache = new SamlRequestCache(2, TimeSpan.FromMinutes(1));
+        var expiry = Now.AddMinutes(15);
+        Assert.True(cache.Register("_n1", "b", expiry, Now, clientKey: null, out _));
+        Assert.True(cache.Register("_n2", "b", expiry, Now, clientKey: null, out _));
+
+        Assert.False(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _)); // refused by the global cap
+        Assert.True(cache.TryConsume("_n1", Now, out _)); // free one global slot
+        Assert.True(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _)); // no leak -> A admits
+    }
+
+    [Fact]
+    public void Register_NullKeyIsExempt_BoundedOnlyByTheGlobalCap()
+    {
+        // Global cap 2 -> per-key cap 1. A null (unattributable/proxy) key is never sub-capped: several
+        // null registrations succeed up to the GLOBAL cap, then the next is refused by the global cap.
+        var cache = new SamlRequestCache(2, TimeSpan.FromMinutes(1));
+        var expiry = Now.AddMinutes(15);
+        Assert.True(cache.Register("_n1", "b", expiry, Now, clientKey: null, out _));
+        Assert.True(cache.Register("_n2", "b", expiry, Now, clientKey: null, out _)); // past a per-key cap of 1
+        Assert.False(cache.Register("_n3", "b", expiry, Now, clientKey: null, out _)); // global cap
+    }
+
+    [Fact]
+    public void Register_DuplicateId_IsRefused_AndLeavesTheCountLeakFree()
+    {
+        // The switch to TryAdd refuses a duplicate id; the refused re-register must roll its reservation
+        // back so the count returns to exactly one entry, consumable once.
+        var cache = SmallCache(); // per-key cap 2
+        var expiry = Now.AddMinutes(15);
+        Assert.True(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _));
+        Assert.False(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _)); // duplicate id refused
+
+        Assert.True(cache.TryConsume("_a1", Now, out _)); // the single entry consumes once
+        Assert.True(cache.Register("_a1", "b", expiry, Now, clientKey: "A", out _)); // count was 0 -> re-admits
     }
 }

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -46,6 +46,10 @@ internal sealed class OidcStateStore
     // volume. The gate self-heals a backward wall-clock step.
     private readonly IntervalGate _capWarnGate;
 
+    // Per-client occupancy sub-cap (#327): bounds how much of the global budget one client key can hold,
+    // so a single anonymous source cannot fill the store and lock out everyone else's logins.
+    private readonly PerClientBudgetLimiter _perClient;
+
     internal OidcStateStore()
         : this(DefaultMaxEntries, DefaultLifetime, DefaultPruneInterval)
     {
@@ -59,6 +63,7 @@ internal sealed class OidcStateStore
         _lifetime = lifetime;
         _pruneGate = new IntervalGate(pruneInterval);
         _capWarnGate = new IntervalGate(pruneInterval);
+        _perClient = PerClientBudgetLimiter.FromGlobalCap(maxEntries);
     }
 
     /// <summary>Gets the live entry count. Test-only, like Seed/Clear: production code reads _states.Count directly.</summary>
@@ -79,13 +84,26 @@ internal sealed class OidcStateStore
     /// <param name="isLinking">Whether this flow is a linking request rather than a login.</param>
     /// <param name="now">The current time, recorded as the entry's creation instant.</param>
     /// <param name="bindingId">The browser-binding id to record on the entry, matched at the callback (#326).</param>
+    /// <param name="clientKey">The normalized client key for the per-client sub-cap (#327), or null to exempt.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
-    /// <returns>True if the state was registered; false if refused (cap, or the key already existed).</returns>
-    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, out bool shouldWarnCapacity)
+    /// <returns>True if the state was registered; false if refused (per-client sub-cap, global cap, or the key already existed).</returns>
+    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, string clientKey, out bool shouldWarnCapacity)
     {
-        if ((_states.Count >= _maxEntries && !_states.ContainsKey(state.State))
-            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId }))
+        // Per-client sub-cap (#327): reserve this client's slot BEFORE the global insert so one source
+        // cannot fill the whole budget and lock out every other login. A null key is exempt (the shared
+        // proxy/private-source bucket, still bounded by the global cap below).
+        if (!_perClient.TryReserve(clientKey))
         {
+            shouldWarnCapacity = _capWarnGate.TryEnter(now);
+            return false;
+        }
+
+        if ((_states.Count >= _maxEntries && !_states.ContainsKey(state.State))
+            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId, ClientKey = clientKey }))
+        {
+            // The entry never entered the store (global cap, or a CSPRNG-token collision losing the
+            // atomic add) — release the reservation so the client's bucket does not leak a slot.
+            _perClient.Release(clientKey);
             shouldWarnCapacity = _capWarnGate.TryEnter(now);
             return false;
         }
@@ -130,13 +148,19 @@ internal sealed class OidcStateStore
     /// <returns>The redeemed snapshot, or null when not redeemable, already claimed, or binding-mismatched.</returns>
     internal RedeemedState TryRedeem(string responseData, string provider, DateTime now, string presentedBindingId)
     {
-        return !string.IsNullOrEmpty(responseData)
-            && _states.TryGetValue(responseData, out var state)
-            && IsRedeemableBy(state, responseData, provider, now)
-            && AuthorizeStateBinding.Matches(state.BindingId, presentedBindingId)
-            && _states.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(responseData, state))
-            ? new RedeemedState(state)
-            : null;
+        if (string.IsNullOrEmpty(responseData)
+            || !_states.TryGetValue(responseData, out var state)
+            || !IsRedeemableBy(state, responseData, provider, now)
+            || !AuthorizeStateBinding.Matches(state.BindingId, presentedBindingId)
+            || !_states.TryRemove(new KeyValuePair<string, TimedAuthorizeState>(responseData, state)))
+        {
+            return null;
+        }
+
+        // Only the winner of the atomic TryRemove reaches here, so the client's slot is released exactly
+        // once (#327).
+        _perClient.Release(state.ClientKey);
+        return new RedeemedState(state);
     }
 
     /// <summary>
@@ -158,7 +182,12 @@ internal sealed class OidcStateStore
         // step) is dead weight the predicates already reject; it is swept once the clock passes it.
         foreach (var kvp in _states.Where(kvp => now.Subtract(kvp.Value.Created) > _lifetime))
         {
-            _states.TryRemove(kvp.Key, out _);
+            // Release only on the winning removal so a concurrent redeem does not double-release the
+            // client's slot (#327).
+            if (_states.TryRemove(kvp.Key, out var removed))
+            {
+                _perClient.Release(removed.ClientKey);
+            }
         }
     }
 
@@ -172,7 +201,11 @@ internal sealed class OidcStateStore
         _states.Values.Select(s => new Summary(s.Provider, s.Created, s.Valid, s.IsLinking));
 
     /// <summary>Test-only: drops every entry, restoring a fresh store between tests.</summary>
-    internal void Clear() => _states.Clear();
+    internal void Clear()
+    {
+        _states.Clear();
+        _perClient.Clear();
+    }
 
     /// <summary>Test-only: seeds one entry directly, bypassing the challenge leg.</summary>
     /// <param name="token">The state token to key the entry under.</param>

--- a/SSO-Auth/Api/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/PerClientBudgetLimiter.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// A per-client occupancy sub-cap shared by the in-flight state stores (#327). Each store owns one
+/// instance, calls <see cref="TryReserve"/> before it inserts an entry and <see cref="Release"/> on
+/// every removal, so one client key can hold at most its per-key share of the store's global cap.
+/// This is the availability defense: without it a single anonymous source could fill the whole global
+/// budget with unredeemed in-flight state and, because the stores refuse-at-cap rather than evict,
+/// lock out every other login. Distinct from <see cref="SsoRateLimiter"/>: that bounds request RATE
+/// over a time window; this bounds concurrent OCCUPANCY of a store and is not time-aware. The
+/// check-and-increment is a single CAS, so a per-key count can never race past the cap (tighter than
+/// the stores' own accepted check-then-insert overshoot), with no lock on the anonymous hot path.
+/// </summary>
+internal sealed class PerClientBudgetLimiter
+{
+    // One source may hold at most this fraction of the store's global cap: 1/100, so it takes >=100
+    // distinct attributable public sources to exhaust the budget and no single one can lock out logins,
+    // while >=99% stays free for everyone else. A constant, not config — a login-path safety limit whose
+    // mis-set value would itself be a lockout (too low) or a no-op (too high).
+    internal const int ShareDivisor = 100;
+
+    // clientKey -> live reservations; a key is present only while it holds >=1 (dropped at zero), so
+    // |_counts| <= live entries <= the store's global cap even under an IPv6 key-rotation flood. Ordinal:
+    // the key is an opaque normalized token from SsoRateLimiter.NormalizeClientKey.
+    private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.Ordinal);
+    private readonly int _perKeyCap;
+
+    internal PerClientBudgetLimiter(int perKeyCap) => _perKeyCap = perKeyCap;
+
+    /// <summary>Gets the derived per-key cap. Test-only.</summary>
+    internal int PerKeyCap => _perKeyCap;
+
+    /// <summary>Gets the number of tracked (live) client keys. Test-only.</summary>
+    internal int TrackedKeys => _counts.Count;
+
+    /// <summary>
+    /// Derives a limiter whose per-key share is <see cref="ShareDivisor"/>-th of a store's global cap,
+    /// so the 1/100 policy lives in one place and a small test cap still yields a reachable sub-cap.
+    /// </summary>
+    /// <param name="globalCap">The owning store's global entry cap.</param>
+    /// <returns>A limiter capped at <c>max(1, globalCap / 100)</c> per client key.</returns>
+    internal static PerClientBudgetLimiter FromGlobalCap(int globalCap) =>
+        new(Math.Max(1, globalCap / ShareDivisor));
+
+    /// <summary>
+    /// Reserves one slot for <paramref name="clientKey"/>, or false when it already holds its full share
+    /// (fail closed for that one login). A null key is unattributable — loopback/RFC1918/CGNAT/link-local,
+    /// or a reverse proxy whose forwarded headers Jellyfin was not told to resolve (the socket peer is the
+    /// proxy's private IP) — i.e. the whole userbase behind one bucket, so it is EXEMPT (always reserves,
+    /// never counted); per-client-capping it would re-introduce the mass lockout #327 forbids. The exempt
+    /// bucket is still bounded by the store's global cap.
+    /// </summary>
+    /// <param name="clientKey">The normalized client key, or null for an unattributable/exempt source.</param>
+    /// <returns>True if a slot was reserved (or the key is exempt); false when the key is at its share.</returns>
+    internal bool TryReserve(string clientKey)
+    {
+        if (clientKey is null)
+        {
+            return true;
+        }
+
+        while (true)
+        {
+            if (_counts.TryGetValue(clientKey, out var n))
+            {
+                if (n >= _perKeyCap)
+                {
+                    return false;
+                }
+
+                // Cap-check and increment as one atom: a concurrent increment changes n, the CAS fails,
+                // we re-read — so two threads at cap-1 can never both cross the cap (zero overshoot).
+                if (_counts.TryUpdate(clientKey, n + 1, n))
+                {
+                    return true;
+                }
+            }
+            else if (_counts.TryAdd(clientKey, 1))
+            {
+                return true;
+            }
+
+            // Lost a race for this key — re-read and retry. Lock-free, O(1) amortized, never scans a store.
+        }
+    }
+
+    /// <summary>
+    /// Releases one slot previously reserved for <paramref name="clientKey"/>. Idempotent and never
+    /// negative: an unknown key is a no-op, and the bucket is dropped at zero so the map stays bounded.
+    /// A null key reserved nothing, so it releases nothing. MUST be called exactly once per successful
+    /// reservation, on the single winner of the store's atomic removal — a double release would
+    /// under-count and let the bucket admit past its cap.
+    /// </summary>
+    /// <param name="clientKey">The client key whose slot is freed, or null (a no-op).</param>
+    internal void Release(string clientKey)
+    {
+        if (clientKey is null)
+        {
+            return;
+        }
+
+        while (true)
+        {
+            if (!_counts.TryGetValue(clientKey, out var n))
+            {
+                return;
+            }
+
+            if (n <= 1)
+            {
+                // Drop the empty bucket. The KVP-conditional remove aborts if a concurrent reserve just
+                // bumped n, so a live bucket is never deleted; we loop and decrement instead.
+                if (_counts.TryRemove(new KeyValuePair<string, int>(clientKey, n)))
+                {
+                    return;
+                }
+            }
+            else if (_counts.TryUpdate(clientKey, n - 1, n))
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>Test-only: drops all counts, mirroring the owning store's Clear.</summary>
+    internal void Clear() => _counts.Clear();
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -275,7 +275,10 @@ public class SSOController : ControllerBase
         // IsLinking tracks whether this is a linking request rather than a login. The state value
         // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
         // always the capacity backstop under a flood, and the store throttles its warning signal.
-        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, out var shouldWarnCapacity))
+        // The client key bounds how much of the store one source can occupy (#327); a proxy/private
+        // source normalizes to null and is exempt.
+        var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
+        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, clientKey, out var shouldWarnCapacity))
         {
             if (shouldWarnCapacity)
             {
@@ -324,7 +327,7 @@ public class SSOController : ControllerBase
     // random request id from the emitted AuthnRequest. Same test-only surface as SeedOidStateForTests
     // (internal, InternalsVisibleTo, no endpoint/DI); never reachable in production.
     internal static void SeedSamlRequestForTests(string provider, string requestId, string bindingId, DateTime expiryUtc) =>
-        SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow);
+        SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow, clientKey: null, out _);
 
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
     // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
@@ -800,11 +803,31 @@ public class SSOController : ControllerBase
         if (!isLinking)
         {
             var bindingId = AuthorizeStateBinding.NewId();
-            SamlRequests.Register(
-                ProviderScopedKey.For(provider, request.Id),
-                bindingId,
-                DateTime.UtcNow + SamlRequestLifetime,
-                DateTime.UtcNow);
+
+            // The client key bounds how much of the request cache one source can occupy (#327); a
+            // proxy/private source normalizes to null and is exempt.
+            var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
+            if (!SamlRequests.Register(
+                    ProviderScopedKey.For(provider, request.Id),
+                    bindingId,
+                    DateTime.UtcNow + SamlRequestLifetime,
+                    DateTime.UtcNow,
+                    clientKey,
+                    out var shouldWarnCapacity))
+            {
+                // The per-client sub-cap or the global cap refused this login's outstanding-request
+                // entry (#327). Fail closed HERE rather than redirect to the IdP for a login that could
+                // then only be refused at the callback (no correlation entry). The store throttles the
+                // capacity warning to one signal per interval so a flood cannot amplify into log volume
+                // (CWE-400) — parity with the OpenID challenge refusal.
+                if (shouldWarnCapacity)
+                {
+                    _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                }
+
+                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+            }
+
             Response.Cookies.Append(
                 AuthorizeStateBinding.SamlCookieName,
                 bindingId,

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -18,20 +18,49 @@ internal sealed class SamlRequestCache
     // transiently overshoot by at most the number of in-flight threads — immaterial against a
     // best-effort DoS backstop. Given the short request lifetime, real load never approaches it;
     // rate-limiting at the edge (#128) is the primary defense.
-    private const int MaxEntries = 100_000;
+    internal const int DefaultMaxEntries = 100_000;
 
     // Expired-entry sweeping is throttled to at most once per this interval. The sweep is an O(n)
     // scan; running it on every anonymous challenge would amplify a flood into CPU load. Throttling
     // is safe because it is only memory reclamation — TryConsume independently rejects an expired
     // entry via its own expiry check, so a not-yet-swept entry never grants a login.
-    private static readonly TimeSpan PruneInterval = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan DefaultPruneInterval = TimeSpan.FromMinutes(1);
+
+    private readonly int _maxEntries;
 
     private readonly ConcurrentDictionary<string, Entry> _outstanding = new(StringComparer.Ordinal);
 
-    // Throttles the sweep to one run per PruneInterval; the gate owns the atomic cursor and self-heals
+    // Throttles the sweep to one run per prune interval; the gate owns the atomic cursor and self-heals
     // a backward wall-clock step (the hand-rolled predecessor stalled until the clock re-passed its
     // cursor). See PruneExpired.
-    private readonly IntervalGate _pruneGate = new(PruneInterval);
+    private readonly IntervalGate _pruneGate;
+
+    // Throttles the capacity-full warning to one signal per interval (CWE-400): under a flood every
+    // refused registration would otherwise emit a warning, amplifying the flood into unbounded log
+    // volume. Mirrors OidcStateStore so the SAML refusal has the same observability (#327 review).
+    private readonly IntervalGate _capWarnGate;
+
+    // Per-client occupancy sub-cap (#327): bounds how much of the global budget one client key can hold,
+    // so a single anonymous source cannot fill the cache and deny every other login's callback.
+    private readonly PerClientBudgetLimiter _perClient;
+
+    internal SamlRequestCache()
+        : this(DefaultMaxEntries, DefaultPruneInterval)
+    {
+    }
+
+    // Test constructor: a small cap makes the global-cap and per-client sub-cap paths reachable in unit
+    // tests (the production values are unreachable there).
+    internal SamlRequestCache(int maxEntries, TimeSpan pruneInterval)
+    {
+        _maxEntries = maxEntries;
+        _pruneGate = new IntervalGate(pruneInterval);
+        _capWarnGate = new IntervalGate(pruneInterval);
+        _perClient = PerClientBudgetLimiter.FromGlobalCap(maxEntries);
+    }
+
+    /// <summary>Gets the live entry count. Test-only, like Clear.</summary>
+    internal int Count => _outstanding.Count;
 
     /// <summary>
     /// Records an issued request ID as outstanding until <paramref name="expiryUtc"/>, together with the
@@ -42,25 +71,41 @@ internal sealed class SamlRequestCache
     /// <param name="bindingId">The browser-binding id set as a cookie at the challenge (may be empty).</param>
     /// <param name="expiryUtc">When the entry may be evicted (the request's validity horizon).</param>
     /// <param name="nowUtc">The current time.</param>
-    internal void Register(string requestId, string bindingId, DateTime expiryUtc, DateTime nowUtc)
+    /// <param name="clientKey">The normalized client key for the per-client sub-cap (#327), or null to exempt.</param>
+    /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning (a cap refusal, at most once per interval).</param>
+    /// <returns>True if the entry was registered; false if refused (blank ID, per-client sub-cap, or global cap).</returns>
+    internal bool Register(string requestId, string bindingId, DateTime expiryUtc, DateTime nowUtc, string clientKey, out bool shouldWarnCapacity)
     {
         PruneExpired(nowUtc);
+        shouldWarnCapacity = false;
         if (string.IsNullOrEmpty(requestId))
         {
-            return;
+            return false;
+        }
+
+        // Per-client sub-cap (#327): reserve before the global insert so one source cannot fill the
+        // cache and lock out everyone. A null key is exempt (the shared proxy/private-source bucket).
+        if (!_perClient.TryReserve(clientKey))
+        {
+            shouldWarnCapacity = _capWarnGate.TryEnter(nowUtc);
+            return false;
         }
 
         // At the cap, refuse the NEW registration rather than evicting an existing one: a flood of
         // fresh challenges must not displace a user already mid-login (whose entry we would otherwise
         // drop, failing their callback). A refused challenge simply won't correlate — that one login
-        // fails closed, which under a flood is overwhelmingly attacker traffic. Overwriting an
-        // already-present key (a re-registered id) stays allowed.
-        if (_outstanding.Count >= MaxEntries && !_outstanding.ContainsKey(requestId))
+        // fails closed. TryAdd (not the indexer) also refuses a DUPLICATE id, so this rollback stays
+        // leak-free even if two registrations of the same CSPRNG id ever raced (the loser's TryAdd
+        // fails and releases its reservation); request ids are fresh, so a real duplicate never occurs.
+        if ((_outstanding.Count >= _maxEntries && !_outstanding.ContainsKey(requestId))
+            || !_outstanding.TryAdd(requestId, new Entry(expiryUtc, bindingId ?? string.Empty, clientKey)))
         {
-            return;
+            _perClient.Release(clientKey);
+            shouldWarnCapacity = _capWarnGate.TryEnter(nowUtc);
+            return false;
         }
 
-        _outstanding[requestId] = new Entry(expiryUtc, bindingId ?? string.Empty);
+        return true;
     }
 
     /// <summary>
@@ -82,17 +127,27 @@ internal sealed class SamlRequestCache
             return false;
         }
 
-        if (_outstanding.TryRemove(requestId, out var entry) && entry.ExpiryUtc > nowUtc)
+        if (_outstanding.TryRemove(requestId, out var entry))
         {
-            bindingId = entry.BindingId;
-            return true;
+            // The slot is freed whether or not the entry was still valid — release on any successful
+            // removal (the single winner of TryRemove), so the client's sub-cap slot never leaks (#327).
+            _perClient.Release(entry.ClientKey);
+            if (entry.ExpiryUtc > nowUtc)
+            {
+                bindingId = entry.BindingId;
+                return true;
+            }
         }
 
         return false;
     }
 
     /// <summary>Test-only: drops all outstanding entries so process-wide state cannot leak between tests.</summary>
-    internal void Clear() => _outstanding.Clear();
+    internal void Clear()
+    {
+        _outstanding.Clear();
+        _perClient.Clear();
+    }
 
     // Drops expired entries, at most once per PruneInterval. Enumerating a ConcurrentDictionary yields
     // a safe moving snapshot and TryRemove is atomic, so this is correct under concurrent
@@ -108,16 +163,19 @@ internal sealed class SamlRequestCache
 
         foreach (var kvp in _outstanding)
         {
-            if (kvp.Value.ExpiryUtc <= nowUtc)
+            // Release only on the winning removal (out overload) so a concurrent consume does not
+            // double-release the client's slot (#327).
+            if (kvp.Value.ExpiryUtc <= nowUtc && _outstanding.TryRemove(kvp.Key, out var removed))
             {
-                _outstanding.TryRemove(kvp.Key, out _);
+                _perClient.Release(removed.ClientKey);
             }
         }
     }
 
-    // One outstanding AuthnRequest: when it expires, and the browser-binding id minted alongside it at
-    // the challenge (#415). The binding id ties the eventual response to the browser that started the
-    // flow; it is returned on consume so the session-mint endpoint can require the request's cookie to
-    // match. Empty for entries registered before browser binding existed (treated as unbound).
-    private readonly record struct Entry(DateTime ExpiryUtc, string BindingId);
+    // One outstanding AuthnRequest: when it expires, the browser-binding id minted alongside it at the
+    // challenge (#415), and the client key that reserved its per-client budget slot (#327, null for an
+    // exempt source). The binding id ties the eventual response to the browser that started the flow; it
+    // is returned on consume so the session-mint endpoint can require the request's cookie to match.
+    // Empty binding for entries registered before browser binding existed (treated as unbound).
+    private readonly record struct Entry(DateTime ExpiryUtc, string BindingId, string ClientKey);
 }

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -41,6 +41,13 @@ internal sealed class TimedAuthorizeState
     public string BindingId { get; set; }
 
     /// <summary>
+    /// Gets or sets the normalized client key that reserved this state's per-client budget slot (#327),
+    /// or null for an unattributable/exempt source. Recorded so the store releases the right client's
+    /// slot when this state is redeemed or pruned.
+    /// </summary>
+    public string ClientKey { get; set; }
+
+    /// <summary>
     /// Gets or sets when this object was created to time it out.
     /// </summary>
     public DateTime Created { get; set; }

--- a/providers.md
+++ b/providers.md
@@ -240,6 +240,28 @@ It is automatic, with no configuration. Two consequences worth knowing:
   actually browse, the binding cookie will not travel with them; keep the challenge and callback on the
   same origin (which a working setup already does).
 
+## In-flight login capacity (per-client)
+
+Each started login holds one short-lived in-flight entry (an OpenID authorize state or a SAML
+outstanding-request record) until it is completed or expires (~15 minutes). Those stores are globally
+capped so an abandoned-login flood cannot exhaust memory, and — so a single anonymous source cannot fill
+that global budget and lock out **everyone's** logins — each **client** is additionally bounded to a small
+share of it (1% — up to 1000 concurrent in-flight logins per client). This is automatic, always on, and
+needs no configuration; a real user starting a handful of logins never approaches it.
+
+The per-client share is keyed on the **client IP the plugin sees**, so **set Jellyfin's _Known proxies_**
+if you run behind a reverse proxy. Otherwise the plugin sees the proxy's address for every request:
+
+- If the proxy sits on a **private/loopback** address (the common co-located setup), that address is
+  treated as un-attributable and is **exempt** from the per-client share — correct, since it is your whole
+  userbase behind one hop, but it means the per-client protection does nothing until _Known proxies_ is
+  set so the real client IPs are attributed.
+- If the proxy has a **public** address and _Known proxies_ is unset, your entire userbase is attributed
+  to that one public IP and therefore **shares a single 1000-in-flight bucket** — enough for normal use,
+  but a very large deployment could brush it. Setting _Known proxies_ resolves this (and is the correct
+  configuration regardless). A refused login returns a generic "could not start login; please retry" and
+  logs a throttled capacity warning server-side.
+
 ## Authelia
 
 Authelia is simple to configure, and RBAC is straightforward.


### PR DESCRIPTION
## What & why

The OpenID authorize-state store and the SAML outstanding-request cache are globally capped (100k) so an abandoned-login flood cannot exhaust memory, but with **no per-client accounting** a single anonymous source could fill the whole budget and, because the stores refuse-at-cap rather than evict, lock out **every other login** (an availability-DoS). The built-in rate limiter (#128) is off by default, and the challenge endpoints are anonymous.

Add a **per-client occupancy sub-cap**. A shared `PerClientBudgetLimiter` reserves one slot per normalized client key before a store inserts and releases it on every removal, so one key holds at most **1% of the global cap (1000)**. A **null key** (a proxy/private/unattributable source, per `SsoRateLimiter.NormalizeClientKey`) is **exempt**, it is the whole userbase behind one hop and must not be sub-capped, and stays bounded only by the global cap.

Closes #327.

## Type of change
- [x] Security hardening (availability / anti-DoS on the login-path state stores)

## Security checklist
- **Fail closed:** reserve before the global insert; roll back on any failure; the global refuse-at-cap-not-evict is unchanged. The reserve is a single CAS (cap-check + increment as one atom) → a key **cannot race past its cap** (pinned by a 16-thread test asserting exactly `cap` reservations succeed); `Release` uses a value-conditional remove → never deletes a live bucket, never goes negative. Every removal path (redeem, consume, both prunes, both add-rollbacks, clear) releases **winner-only, exactly once**, no leak, no double-decrement, so the count is always `≥ live-entries` (over-admit is structurally impossible).
- **No new mass-lockout:** the null/proxy exemption keeps the shared-proxy userbase off the sub-cap.
- No per-request lock on the anonymous hot path; O(1) per add; counts are in-memory only (no config/schema change).

## Quality checklist
- One shared, single-purpose helper (`PerClientBudgetLimiter`, named to satisfy the `MutableKeyedState` conformance rule); both stores compose it symmetrically.

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **825/825 green** (21 new tests: the CAS race-free cap under 16-thread contention, two-key fairness, release-on-{redeem,consume,expiry,failed-insert}, null-key exemption, refuse-not-evict, leak-free duplicate id).
- **Full 4-lens adversarial gate:** bypass / correctness / integration **PASS** (over-admit structurally impossible; concurrency-correct; integration-sound). availability first returned NEEDS_IMPROVEMENT, **no code defect**, two residuals: the public-proxy-without-Known-proxies shared bucket was undocumented, and the SAML refusal was silent vs OIDC's throttled warning. **Fixed:** a throttled SAML capacity warning (parity, non-amplifying) and a new `providers.md` "In-flight login capacity" section with the Known-proxies remedy; availability re-review appended below.

## Notes
The design was chosen via a 3-approach design panel (unanimous 9/9/9 for the shared-limiter). The SAML `Register` switched from an indexer overwrite to `TryAdd` (now refuses a duplicate id, a documented tightening that keeps the reservation rollback leak-free; request ids are fresh CSPRNG).
