### PR TITLE
Strip the dead browser-detection code from the auth page script

### DIFF
--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -6,12 +6,12 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// <summary>
 /// A helper class to return HTML for the client's auth flow.
 /// </summary>
-public static class WebResponse
+internal static class WebResponse
 {
     /// <summary>
     /// The shared HTML between all of the responses.
     /// </summary>
-    public static readonly string Base = @"<!DOCTYPE html>
+    internal static readonly string Base = @"<!DOCTYPE html>
 <html><head>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
 <style nonce=""{{NONCE}}"">
@@ -63,162 +63,11 @@ function isWeb0s() {
         || userAgent.indexOf('web0s') !== -1;
 }
 
-function isMobile(userAgent) {
-    const terms = [
-        'mobi',
-        'ipad',
-        'iphone',
-        'ipod',
-        'silk',
-        'gt-p1000',
-        'nexus 7',
-        'kindle fire',
-        'opera mini'
-    ];
-
-    const lower = userAgent.toLowerCase();
-
-    for (let i = 0, length = terms.length; i < length; i++) {
-        if (lower.indexOf(terms[i]) !== -1) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-function hasKeyboard(browser) {
-    if (browser.touch) {
-        return true;
-    }
-
-    if (browser.xboxOne) {
-        return true;
-    }
-
-    if (browser.ps4) {
-        return true;
-    }
-
-    if (browser.edgeUwp) {
-        // This is OK for now, but this won't always be true
-        // Should we use this?
-        // https://gist.github.com/wagonli/40d8a31bd0d6f0dd7a5d
-        return true;
-    }
-
-    return !!browser.tv;
-}
-
-function iOSversion() {
-    // MacIntel: Apple iPad Pro 11 iOS 13.1
-    if (/iP(hone|od|ad)|MacIntel/.test(navigator.platform)) {
-        const tests = [
-            // Original test for getting full iOS version number in iOS 2.0+
-            /OS (\d+)_(\d+)_?(\d+)?/,
-            // Test for iPads running iOS 13+ that can only get the major OS version
-            /Version\/(\d+)/
-        ];
-        for (const test of tests) {
-            const matches = (navigator.appVersion).match(test);
-            if (matches) {
-                return [
-                    parseInt(matches[1], 10),
-                    parseInt(matches[2] || 0, 10),
-                    parseInt(matches[3] || 0, 10)
-                ];
-            }
-        }
-    }
-    return [];
-}
-
-function web0sVersion(browser) {
-    // Detect webOS version by web engine version
-
-    if (browser.chrome) {
-        const userAgent = navigator.userAgent.toLowerCase();
-
-        if (userAgent.indexOf('netcast') !== -1) {
-            // The built-in browser (NetCast) may have a version that doesn't correspond to the actual web engine
-            // Since there is no reliable way to detect webOS version, we return an undefined version
-
-            console.warn('Unable to detect webOS version - NetCast');
-
-            return undefined;
-        }
-
-        // The next is only valid for the app
-
-        if (browser.versionMajor >= 94) {
-            return 23;
-        } else if (browser.versionMajor >= 87) {
-            return 22;
-        } else if (browser.versionMajor >= 79) {
-            return 6;
-        } else if (browser.versionMajor >= 68) {
-            return 5;
-        } else if (browser.versionMajor >= 53) {
-            return 4;
-        } else if (browser.versionMajor >= 38) {
-            return 3;
-        } else if (browser.versionMajor >= 34) {
-            // webOS 2 browser
-            return 2;
-        } else if (browser.versionMajor >= 26) {
-            // webOS 1 browser
-            return 1;
-        }
-    } else if (browser.versionMajor >= 538) {
-        // webOS 2 app
-        return 2;
-    } else if (browser.versionMajor >= 537) {
-        // webOS 1 app
-        return 1;
-    }
-
-    console.error('Unable to detect webOS version');
-
-    return undefined;
-}
-
-let _supportsCssAnimation;
-let _supportsCssAnimationWithPrefix;
-function supportsCssAnimation(allowPrefix) {
-    // TODO: Assess if this is still needed, as all of our targets should natively support CSS animations.
-    if (allowPrefix && (_supportsCssAnimationWithPrefix === true || _supportsCssAnimationWithPrefix === false)) {
-        return _supportsCssAnimationWithPrefix;
-    }
-    if (_supportsCssAnimation === true || _supportsCssAnimation === false) {
-        return _supportsCssAnimation;
-    }
-
-    let animation = false;
-    const domPrefixes = ['Webkit', 'O', 'Moz'];
-    const elm = document.createElement('div');
-
-    if (elm.style.animationName !== undefined) {
-        animation = true;
-    }
-
-    if (animation === false && allowPrefix) {
-        for (const domPrefix of domPrefixes) {
-            if (elm.style[domPrefix + 'AnimationName'] !== undefined) {
-                animation = true;
-                break;
-            }
-        }
-    }
-
-    if (allowPrefix) {
-        _supportsCssAnimationWithPrefix = animation;
-        return _supportsCssAnimationWithPrefix;
-    } else {
-        _supportsCssAnimation = animation;
-        return _supportsCssAnimation;
-    }
-}
-
+// Browser detection derived from jellyfin-web's browser.js. Trimmed (#364) to only what the served
+// page reads — getDeviceName() below consumes tizen/web0s/operaTv/xboxOne/ps4/chrome/edgeChromium/
+// edge/firefox/opera/safari/ipad/iphone/android — so the mobile/keyboard/iOS-version/webOS-version/
+// CSS-animation detections and their flags are dropped. Re-sync this blob (isTv / isWeb0s / uaMatch /
+// the browser-flag assembly below) from upstream rather than editing it in place.
 const uaMatch = function (ua) {
     ua = ua.toLowerCase();
 
@@ -280,8 +129,6 @@ const browser = {};
 
 if (matched.browser) {
     browser[matched.browser] = true;
-    browser.version = matched.version;
-    browser.versionMajor = matched.versionMajor;
 }
 
 if (matched.platform) {
@@ -308,31 +155,18 @@ if (userAgent.toLowerCase().indexOf('playstation 4') !== -1) {
     browser.tv = true;
 }
 
-if (isMobile(userAgent)) {
-    browser.mobile = true;
-}
-
 if (userAgent.toLowerCase().indexOf('xbox') !== -1) {
     browser.xboxOne = true;
     browser.tv = true;
 }
-browser.animate = typeof document !== 'undefined' && document.documentElement.animate != null;
-browser.hisense = userAgent.toLowerCase().includes('hisense');
 browser.tizen = userAgent.toLowerCase().indexOf('tizen') !== -1 || window.tizen != null;
-browser.vidaa = userAgent.toLowerCase().includes('vidaa');
 browser.web0s = isWeb0s();
 browser.edgeUwp = browser.edge && (userAgent.toLowerCase().indexOf('msapphost') !== -1 || userAgent.toLowerCase().indexOf('webview') !== -1);
 
-if (browser.web0s) {
-    browser.web0sVersion = web0sVersion(browser);
-} else if (browser.tizen) {
-    // UserAgent string contains 'Safari' and 'safari' is set by matched browser, but we only want 'tizen' to be true
+if (browser.tizen) {
+    // A Tizen UserAgent contains 'Safari' and 'safari' is set by the matched browser, but we only
+    // want 'tizen' to be true so getDeviceName reports the Samsung TV, not Safari.
     delete browser.safari;
-
-    const v = (navigator.appVersion).match(/Tizen (\d+).(\d+)/);
-    browser.tizenVersion = parseInt(v[1], 10);
-} else {
-    browser.orsay = userAgent.toLowerCase().indexOf('smarthub') !== -1;
 }
 
 if (browser.edgeUwp) {
@@ -341,28 +175,6 @@ if (browser.edgeUwp) {
 
 browser.tv = isTv();
 browser.operaTv = browser.tv && userAgent.toLowerCase().indexOf('opr/') !== -1;
-
-if (browser.mobile || browser.tv) {
-    browser.slow = true;
-}
-
-/* eslint-disable-next-line compat/compat */
-if (typeof document !== 'undefined' && ('ontouchstart' in window) || (navigator.maxTouchPoints > 0)) {
-    browser.touch = true;
-}
-
-browser.keyboard = hasKeyboard(browser);
-browser.supportsCssAnimation = supportsCssAnimation;
-
-browser.iOS = browser.ipad || browser.iphone || browser.ipod;
-
-if (browser.iOS) {
-    browser.iOSVersion = iOSversion();
-
-    if (browser.iOSVersion && browser.iOSVersion.length >= 2) {
-        browser.iOSVersion = browser.iOSVersion[0] + (browser.iOSVersion[1] / 10);
-    }
-}
 
 function getDeviceName() {
 	var deviceName = '';


### PR DESCRIPTION
## What & why

The served auth/callback page embedded ~350 lines of browser detection copied from jellyfin-web, ~half provably dead: the only consumer of the `browser` object is `getDeviceName()`, which reads exactly `tizen, web0s, operaTv, xboxOne, ps4, chrome, edgeChromium, edge, firefox, opera, safari, ipad, iphone, android`.

- Delete the unread functions (`isMobile`, `hasKeyboard`, `iOSversion`, `web0sVersion`, `supportsCssAnimation`) and every flag write nothing reads (`mobile`, `animate`, `hisense`, `vidaa`, `web0sVersion`, `tizenVersion`, `orsay`, `slow`, `touch`, `keyboard`, `supportsCssAnimation`, `iOS`/`iOSVersion`, `version`, `versionMajor`).
- Collapse the tizen 3-way branch to its one live effect, `if (browser.tizen) delete browser.safari`.
- Keep every detection `getDeviceName` reads, including the `osx`→`ipad` and `edgeUwp`→`edge` fixups and `operaTv` via `browser.tv`/`isTv()`, and `uaMatch` verbatim.
- Add a provenance comment (derived from jellyfin-web) so the blob is re-synced from upstream rather than edited in place.
- Take `WebResponse` `internal` (it was `public` in a default-internal plugin; `InternalsVisibleTo` already covers the tests).

Net −188 lines. Closes #364.

## Type of change
- [x] Quality / dead-code removal (web-ui; behavior-preserving)

## Verification
- `dotnet build --no-incremental --warnaserror`: 0/0. `dotnet test`: **815/815 green**. CI cannot execute the browser JS, so:
  - **Adversarial review (integration lens), PASS**: traced all 14 consumed flags to a surviving producer, confirmed the tizen collapse is behaviorally equivalent for all realistic UAs (and the dropped `tizenVersion` even removed a latent null-deref), verified syntactic validity and that no reference to a deleted name survives, and confirmed `public`→`internal` is safe against every caller (`SSOController`, same assembly) and the test assembly (`InternalsVisibleTo`).
  - A `node --check` of the trimmed detection script passed.
- The device-name spot-check on a real client (web + a TV/console UA) stays on `docs/E2E-CHECKLIST.md`, standard for this file.

## Notes
`uaMatch` is kept verbatim (including its now-unused internal version computation) for upstream re-sync fidelity. The `appName`/`appVersion` client identity rides #310, not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined browser detection used during authentication responses.
  * Reduced exposure of internal response and HTML template components.
  * Removed legacy device, browser capability, and version detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->