### PR TITLE
Make the provider form's save contract explicit and drop the dead sso-json path

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
@@ -228,6 +229,103 @@ public class ArchitectureConformanceTests
             .ToList();
 
         Assert.True(offenders.Count == 0, "SSOPlugin members touching configuration types must stay limited to the delegating facade (config logic lives in Config/): " + string.Join(", ", offenders));
+    }
+
+    [Fact]
+    public void ProviderFormFieldIds_MatchOidConfigProperties()
+    {
+        // The provider settings form's save contract (#365), locked in as a fitness function. config.js
+        // saveProvider persists each marked input as current_config[element.id] = value, so every input
+        // bearing a persisting behavior-marker class MUST have an id equal to a real OidConfig property —
+        // otherwise it renders but silently never saves, because the server drops JSON members that are not
+        // OidConfig properties. The five marker classes mirror config.js listArgumentsByType
+        // (sso-text/sso-line-list/sso-toggle) plus the two populate-helper widgets (sso-folder-list =
+        // EnabledFolders, sso-role-map = FolderRoleMapping). The provider-name input is deliberately
+        // unmarked — its value is the OidConfigs dictionary key, not a property — so it is not scanned.
+        // Matching is token-exact (so sso-role-map does not swallow sso-role-mapping-container), and the
+        // scan is scoped to #sso-new-oidc-provider so a future SAML form (whose fields map to SamlConfig)
+        // would not be checked against OidConfig. The forward check (every marked id is a real property) is
+        // paired below with a reverse pin (every security-critical property is still a marked field), so
+        // neither a mistyped id nor a dropped marker class can silently break a security setting's save.
+        var markerClasses = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
+
+        var form = OidcProviderFormMarkup(
+            File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html")));
+
+        var oidConfigProperties = typeof(OidConfig)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var matchedIds = new HashSet<string>(StringComparer.Ordinal);
+        var offenders = new List<string>();
+        foreach (Match tag in Regex.Matches(form, "<[a-zA-Z][^>]*>", RegexOptions.Singleline))
+        {
+            var classAttr = Regex.Match(tag.Value, "class=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (!classAttr.Success)
+            {
+                continue;
+            }
+
+            var classes = classAttr.Groups[1].Value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (!classes.Any(c => markerClasses.Contains(c, StringComparer.Ordinal)))
+            {
+                continue;
+            }
+
+            // (?<![-\w]) so an attribute whose name merely ends in "id" (a future data-id, gridid, …) is
+            // not misread as the element id; an id attribute is preceded by whitespace or the tag open.
+            var idMatch = Regex.Match(tag.Value, "(?<![-\\w])id=\"([^\"]*)\"", RegexOptions.Singleline);
+            var id = idMatch.Success ? idMatch.Groups[1].Value : "(no id)";
+            matchedIds.Add(id);
+            if (!oidConfigProperties.Contains(id))
+            {
+                offenders.Add($"{id} (classes: {classAttr.Groups[1].Value.Trim()})");
+            }
+        }
+
+        // Guard against a vacuous pass (a broken regex or a renamed form marker silently matching nothing):
+        // one sentinel id per marker class must have been scanned, proving the parser reached the form and
+        // every marker class is live.
+        var sentinels = new[] { "OidEndpoint", "Roles", "Enabled", "EnabledFolders", "FolderRoleMapping" };
+        var missingSentinels = sentinels.Where(s => !matchedIds.Contains(s)).ToList();
+        Assert.True(
+            missingSentinels.Count == 0,
+            "The provider-form scan did not reach expected fields (broken parse or renamed marker class?); missing sentinels: " + string.Join(", ", missingSentinels));
+
+        // Reverse direction: the forward check catches a mistyped id, but dropping a marker class entirely
+        // — the exact operation this contract change performs on the provider-name field — would silently
+        // stop a field persisting while leaving the forward check green. For a security setting that is
+        // fail-open (the server keeps the stored value; the admin can no longer harden it), so pin the
+        // security-critical settings: each MUST remain a marked, correctly-typed persisting field. Extend
+        // this roster in the same PR that adds a new security toggle.
+        var securityCritical = new[]
+        {
+            "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",
+            "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
+            "DoNotLoadProfile", "RequirePkce",
+        };
+        var unsaved = securityCritical.Where(p => !matchedIds.Contains(p)).ToList();
+        Assert.True(
+            unsaved.Count == 0,
+            "These security-critical settings must remain persisting provider-form fields (a marked input whose id equals the OidConfig property); missing or unmarked: " + string.Join(", ", unsaved));
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every persisting provider-form field (sso-text/sso-line-list/sso-toggle/sso-folder-list/sso-role-map) must have an id equal to an OidConfig property; these do not: " + string.Join(" | ", offenders));
+    }
+
+    // The markup of the #sso-new-oidc-provider settings form (from the opening tag's id attribute to its
+    // closing </form>). Forms are not nested here, so the first </form> after the id marker closes it; the
+    // preceding #sso-load-config form is left out because its </form> sits before the marker.
+    private static string OidcProviderFormMarkup(string html)
+    {
+        const string marker = "id=\"sso-new-oidc-provider\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The #sso-new-oidc-provider form was not found in configPage.html.");
+        var end = html.IndexOf("</form>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "The #sso-new-oidc-provider form has no closing </form> tag.");
+        return html[start..end];
     }
 
     // A configuration type for the facade rule: the plugin configuration itself or any provider config

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -166,8 +166,14 @@ const ssoConfigurationPage = {
     const targeted_mapping = evt.target.closest(".sso-role-mapping-container");
     targeted_mapping.remove();
   },
+  // The provider form's save contract, made explicit (#365): every input in #sso-new-oidc-provider
+  // that should persist carries an sso-* class AND an id spelled EXACTLY like the OidConfig property it
+  // writes to (saveProvider does current_config[element.id] = value). A field with the wrong id, a
+  // missing sso-* class, or placed outside this form renders fine but silently never saves — and the
+  // server drops unknown JSON members too. The ArchitectureConformanceTests
+  // ProviderFormFieldIds_MatchOidConfigProperties test locks this in: it fails the build if any
+  // sso-*-classed field id is not a real OidConfig property.
   listArgumentsByType: (page) => {
-    const json_class = ".sso-json";
     const toggle_class = ".sso-toggle";
     const text_class = ".sso-text";
     const text_list_class = ".sso-line-list";
@@ -181,10 +187,6 @@ const ssoConfigurationPage = {
       (e) => e.id,
     );
 
-    const json_fields = [...oidc_form.querySelectorAll(json_class)].map(
-      (e) => e.id,
-    );
-
     const text_list_fields = [
       ...oidc_form.querySelectorAll(text_list_class),
     ].map((e) => e.id);
@@ -194,7 +196,6 @@ const ssoConfigurationPage = {
     );
 
     const output = {
-      json_fields,
       text_list_fields,
       text_fields,
       check_fields,
@@ -229,11 +230,6 @@ const ssoConfigurationPage = {
 
         form_elements.text_fields.forEach((id) => {
           if (provider[id]) page.querySelector("#" + id).value = provider[id];
-        });
-
-        form_elements.json_fields.forEach((id) => {
-          if (provider[id])
-            page.querySelector("#" + id).value = JSON.stringify(provider[id]);
         });
 
         form_elements.text_list_fields.forEach((id) => {
@@ -334,15 +330,6 @@ const ssoConfigurationPage = {
           const value = page.querySelector("#" + id).value;
           if (value) {
             current_config[id] = page.querySelector("#" + id).value;
-          } else {
-            current_config[id] = null;
-          }
-        });
-
-        form_elements.json_fields.forEach((id) => {
-          const value = page.querySelector("#" + id).value;
-          if (value) {
-            current_config[id] = JSON.parse(value);
           } else {
             current_config[id] = null;
           }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -113,6 +113,16 @@
             </div>
           </form>
 
+          <!--
+            Provider settings form — the save contract (#365). Each input here that must persist carries a
+            behavior-marker class (sso-text / sso-line-list / sso-toggle / sso-folder-list / sso-role-map)
+            AND an id spelled EXACTLY like the OidConfig property it writes to: config.js saveProvider does
+            current_config[element.id] = value, and the server drops JSON members that are not OidConfig
+            properties. A field with a mismatched id, a missing marker class, or placed outside this form
+            renders but silently never saves. The provider-name input is the one deliberate non-persisting
+            field — it supplies the OidConfigs dictionary key, not a property — so it carries no marker
+            class. Locked in by ArchitectureConformanceTests.ProviderFormFieldIds_MatchOidConfigProperties.
+          -->
           <form id="sso-new-oidc-provider" class="esqConfigurationForm">
             <div
               is="emby-collapse"
@@ -127,12 +137,17 @@
                     for="OidProviderName"
                     >Name of OpenID Provider:</label
                   >
+                  <!--
+                    No sso-* marker class: this input's value is the OidConfigs dictionary KEY (config.js
+                    reads it as the provider name and does config.OidConfigs[name] = current_config), not an
+                    OidConfig property. listArgumentsByType must not pick it up as a persisting field, and it
+                    is deliberately absent from the ProviderFormFieldIds_MatchOidConfigProperties contract.
+                  -->
                   <input
                     is="emby-input"
                     id="OidProviderName"
                     required=""
                     type="text"
-                    class="sso-text"
                   />
                   <div class="fieldDescription">
                     The name used by Jellyfin to identify the OpenID provider.


### PR DESCRIPTION
# What & why

The admin provider form's persistence contract was entirely implicit. `listArgumentsByType`
scans `#sso-new-oidc-provider` for marker classes and `saveProvider` writes
`current_config[element.id]`, so each field's DOM id must be spelled exactly like the
`OidConfig` property it persists, but nothing stated this and no test covered it, so it
drift-breaks silently: a field with a mistyped id, a missing marker class, or placed outside
the form renders fine and never saves (the server also drops unknown JSON members). On top of
that, the `sso-json` machinery was dead, `config.js` held the only occurrence of the class in
the repo, so `json_fields` was always empty and its two loops (including an unguarded
`JSON.parse`) were unreachable.

This makes the contract explicit and locks it in:

- **Drop the dead `sso-json` path** from `config.js`: the `json_class` selector, the
  `json_fields` query, its member in the returned object, and the two load/save loops.
- **Document the contract**: a comment block above `listArgumentsByType` and an HTML comment
  atop the `#sso-new-oidc-provider` form.
- **Remove `class="sso-text"` from `#OidProviderName`.** Its value is the `OidConfigs`
  dictionary *key*, not an `OidConfig` property; the marker only caused a redundant
  `current_config["OidProviderName"]` write that the server already dropped. Removing it makes
  the persisting-field set *exactly* the `OidConfig` properties, so the fitness function needs
  no exception. Behavior-preserving: the name field is set (from the dict key) and read
  explicitly, and `.sso-text` is a JS marker with no CSS (styling comes from `is="emby-input"`).
- **Lock it in as a fitness function** in `ArchitectureConformanceTests`
  (`ProviderFormFieldIds_MatchOidConfigProperties`): it parses `configPage.html`, scans the
  form for elements bearing a persisting marker class
  (`sso-text`/`sso-line-list`/`sso-toggle`/`sso-folder-list`/`sso-role-map`), and checks their
  ids against `OidConfig` in **both directions**, every marked id is a real property, and every
  security-critical setting is still a marked, correctly-typed field. Matching is token-exact
  (so `sso-role-map` does not swallow `sso-role-mapping-container`), scoped to
  `#sso-new-oidc-provider` (a future SAML form maps to `SamlConfig`), and guarded against a
  vacuous pass by per-marker-class sentinel ids.

The issue text names an `OidParameter` type; the actual reflection target is `OidConfig` (there
is no `OidParameter`).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the change is behavior-preserving, and the new reverse-direction
      pin actively defends the save path of the security toggles (`DisableHttps`,
      `DoNotValidate*`, `RequirePkce`, …) and `OidSecret` — a dropped marker class now fails CI.
- [x] No secrets logged; secrets are redacted on config export. No logging touched; `OidSecret`'s
      write-only converter is untouched and it is now pinned as a must-persist field.
- [x] A security review was performed: the 4-lens refute-by-default adversarial gate
      (bypass / correctness / integration / availability) returned all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call - no log calls added or
      changed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires (net removes dead code; adds one
      focused fitness function).
- [x] The code is self-documenting (readable without comments; comments explain why, not what)
      and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and the new structural property this change
      establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (0 warnings, 0 errors).
- [x] `dotnet test` is green (816/816).
- [x] Prettier is clean for the `.js` / `.html` change.

## Notes

CI cannot execute the browser JS/HTML, so the adversarial-review gate is the primary
verification. All four lenses PASS. Two non-blocking suggestions were **incorporated** rather
than deferred:

- *bypass*, the forward check doesn't catch a security toggle *losing* its marker class (the
  operation this PR performs on the name field). Added a reverse-direction pin: a fixed roster of
  security-critical properties must each remain a marked, correctly-typed field. Empirically
  verified, temporarily dropping the `DisableHttps` marker class fails the build (1/816), then
  restored.
- *correctness*, tightened the id regex to `(?<![-\w])id=` so a future `data-id`-style
  attribute can't be misread as the element id.

Out of scope (pre-existing, not a regression): `AllowExistingAccountLink` is an `OidConfig`
security toggle with no admin-form field, so it cannot be enabled from the UI, the test is
one-directional there by design (server-managed `NewPath`/`CanonicalLinks` and the UI-absent
`AllowExistingAccountLink` are legitimately not form fields). Worth a follow-up on whether that
toggle should be surfaced.

Closes #365


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved saving and loading of OIDC provider settings by aligning form fields with their corresponding configuration properties.
  - Prevented provider names from being incorrectly treated as provider settings.

- **Documentation**
  - Added guidance explaining which provider form fields are persisted and how they must be configured.

- **Tests**
  - Added validation to ensure provider form fields remain synchronized with supported OIDC configuration properties and required security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->