### PR TITLE
Drop blank scope elements in BuildScopeString

### DIFF
--- a/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
+++ b/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
@@ -38,4 +38,28 @@ public class SSOControllerScopeStringTests
 
         Assert.Equal("openid profile email groups", SSOController.BuildScopeString(config));
     }
+
+    [Fact]
+    public void NullElement_IsDropped_NoTrailingSeparator()
+    {
+        var config = new OidConfig { OidScopes = new[] { "email", null } };
+
+        Assert.Equal("openid profile email", SSOController.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void EmptyElement_IsDropped_NoDoubledSeparator()
+    {
+        var config = new OidConfig { OidScopes = new[] { "", "groups" } };
+
+        Assert.Equal("openid profile groups", SSOController.BuildScopeString(config));
+    }
+
+    [Fact]
+    public void AllBlankElements_YieldBaseScopesOnly()
+    {
+        var config = new OidConfig { OidScopes = new[] { "", " ", null } };
+
+        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+    }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -363,9 +363,13 @@ public class SSOController : ControllerBase
     // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".
     // OidScopes is null when a provider was stored without scopes (#368, e.g. via the OID/Add API) —
     // normalize to empty so neither the challenge nor the callback throws (an unhandled 500 on the
-    // anonymous challenge endpoint) or pads the scope string with null entries. Shared by both sites.
+    // anonymous challenge endpoint) or pads the scope string with null entries. Blank elements inside a
+    // non-null array are dropped too, so a persisted null/empty/whitespace scope cannot inject a
+    // doubled or trailing separator (#407). Shared by both sites.
     internal static string BuildScopeString(OidConfig config)
-        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>()).Prepend("openid profile"));
+        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Prepend("openid profile"));
 
     // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,


### PR DESCRIPTION
# What & why

`BuildScopeString` already normalized a null `OidScopes` array to empty, but
null / empty / whitespace-only **elements** inside a non-null array still
rendered through `string.Join`, producing a malformed scope string, e.g.
`["email", null]` → `"openid profile email "` (trailing separator),
`["", "groups"]` → `"openid profile  groups"` (doubled separator). This is not
a regression and is non-impactful today (the scope value is not compared during
token redemption or id_token validation), but the programmatic `OID/Add`
endpoint binds and persists an `OidConfig` verbatim with no scope sanitization,
so a blank element is reachable and should not reach the IdP. We filter blank
elements in the one shared helper; the base `"openid profile"` is prepended
after the filter, so it is never subject to it.

Closes #407

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Adversarial 4-lens review (refute-by-default) ran because the scope string is
built on the OIDC login path. All four returned PASS:

- **Availability / mass-lockout, PASS.** Read-time-only projection; the base
  `openid profile` is always preserved, only never-valid whitespace-only tokens
  are dropped, challenge and callback stay identical. No lockout vector.
- **Security-bypass / fail-open, PASS.** Dropping a scope is dropping a grant
  request, monotonically privilege-reducing, never fail-open. Scope is not
  consumed by any validation or authorization decision (claims are). No
  injection or flow-downgrade path.
- **Correctness, PASS.** `Where` runs before `Prepend`; `IsNullOrWhiteSpace`
  drops exactly null/empty/whitespace; `string.Join` evaluates eagerly. The six
  tests pin the claimed behavior.
- **Integration, PASS.** Output feeds `OidcClientOptions.Scope` via the single
  shared client builder used by both legs; removing empty tokens is strictly
  more RFC 6749-compliant; the `OID/Add` persistence path genuinely justifies
  the server-side normalization.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (819 tests, +3 new).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Prettier: N/A, no `.js` / `.html` / `.md` / `.css` touched. Docs (README /
providers.md): N/A, non-behavioral hardening; the scope string is not part of
any documented, user-configured contract that changes here.

Out of scope: two lenses noted that padded-but-non-blank tokens (e.g. `" email"`)
are not trimmed, pre-existing behavior, tolerated by IdPs, and outside #407's
blank-element scope. The updated comment does not overclaim (it states only
null/empty/whitespace-only elements are dropped), so we leave trimming for a
possible separate follow-up rather than widening this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO scope formatting by ignoring blank, whitespace-only, and null scope entries.
  * Prevented malformed scope strings with extra or trailing separators.

* **Tests**
  * Added coverage for null, empty, whitespace-only, and mixed invalid scope values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->