### PR TITLE
Anchor OidcCallbackPath.RedirectSegment to the route suffix

### DIFF
--- a/SSO-Auth.Tests/OidcCallbackPathTests.cs
+++ b/SSO-Auth.Tests/OidcCallbackPathTests.cs
@@ -42,6 +42,36 @@ public class OidcCallbackPathTests
         Assert.Equal("redirect", OidcCallbackPath.RedirectSegment("/sso/OID/redirect/redirect"));
     }
 
+    [Theory]
+    // A protocol-like reverse-proxy prefix that itself spells "OID/redirect" must not flip the
+    // classic route: only the {protocol}/{path-kind}/{provider} suffix decides, so the real "r"
+    // route stays "r" no matter what the mount prefix looks like (#411).
+    [InlineData("/OID/redirect/proxy/sso/OID/r/keycloak", "r")]
+    // The mirror: a prefix spelling "OID/r" must not flip a real new-path route away from "redirect".
+    [InlineData("/OID/r/proxy/sso/OID/redirect/keycloak", "redirect")]
+    public void RedirectSegment_ProtocolLikePrefix_LetsTheSuffixDecide(string path, string expected)
+    {
+        Assert.Equal(expected, OidcCallbackPath.RedirectSegment(path));
+    }
+
+    [Fact]
+    public void RedirectSegment_LegitReverseProxyBasePath_KeepsNewPathRoute()
+    {
+        // A benign reverse-proxy base path in front of a real new-path callback keeps the intact
+        // OID/redirect/{provider} suffix, so it is still correctly "redirect" — the suffix anchoring
+        // must not misclassify legitimate mounts.
+        Assert.Equal("redirect", OidcCallbackPath.RedirectSegment("/jellyfin/apps/sso/OID/redirect/keycloak"));
+    }
+
+    [Fact]
+    public void RedirectSegment_InternalDoubledSlash_FailsSafeToClassic()
+    {
+        // An internal doubled slash inserts an empty segment that shifts the suffix, so the malformed
+        // path no longer matches OID/redirect/{provider} and fails safe to the classic "r" spelling
+        // rather than being silently collapsed into a valid new-path route (#411).
+        Assert.Equal("r", OidcCallbackPath.RedirectSegment("/sso/OID/redirect//keycloak"));
+    }
+
     [Fact]
     public void RedirectSegment_EmptyPath_DefaultsToClassic()
     {

--- a/SSO-Auth/Api/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/OidcCallbackPath.cs
@@ -10,7 +10,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// IdP delivers the callback on exactly the route the authorization request advertised — so the
 /// segment is read off the callback's own path. The previous expression tested for "/start/", a
 /// challenge-route segment that never occurs on callback routes, so the new-path flow sent a
-/// mismatched redirect_uri that spec-enforcing IdPs reject (#98).
+/// mismatched redirect_uri that spec-enforcing IdPs reject (#98). The route is now read off its
+/// <c>{protocol}/{path-kind}/{provider}</c> suffix — the same robust form as
+/// <see cref="ChallengePath.IsNewPath"/> — so a protocol-like reverse-proxy prefix cannot decide
+/// the spelling (#411).
 /// </summary>
 internal static class OidcCallbackPath
 {
@@ -18,24 +21,26 @@ internal static class OidcCallbackPath
     /// Returns the redirect-path segment ("redirect" or "r") matching the callback route in the given path.
     /// </summary>
     /// <param name="path">The callback request path, e.g. <c>/sso/OID/redirect/{provider}</c>.</param>
-    /// <returns>"redirect" when the route segment (the element after "OID") is "redirect", otherwise "r".</returns>
+    /// <returns>"redirect" when the route's <c>OID/{path-kind}/{provider}</c> suffix names the "redirect" path-kind, otherwise "r".</returns>
     internal static string RedirectSegment(string? path)
     {
-        // Match the route segment exactly (the element after "OID"), not by substring: a provider
-        // literally named "redirect" must never flip the classic route, regardless of trailing
-        // slashes or where "redirect" appears in the provider name.
-        var segments = path?.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        if (segments is not null)
+        // The callback route always ends in {protocol}/{path-kind}/{provider}, so anchor to that
+        // three-segment suffix rather than the first "OID" token found anywhere in the path: a
+        // protocol-like reverse-proxy prefix (e.g. /OID/redirect/proxy/...) must not decide the
+        // spelling. Trim only boundary slashes so an internal empty segment (a doubled slash) shifts
+        // the suffix and fails to match rather than being silently collapsed into a valid route.
+        // Same suffix-anchored form as ChallengePath.IsNewPath (#411).
+        var segments = path?.Trim('/').Split('/');
+        if (segments is null || segments.Length < 3)
         {
-            for (var i = 0; i + 1 < segments.Length; i++)
-            {
-                if (string.Equals(segments[i], "OID", StringComparison.OrdinalIgnoreCase))
-                {
-                    return string.Equals(segments[i + 1], "redirect", StringComparison.OrdinalIgnoreCase) ? "redirect" : "r";
-                }
-            }
+            return "r";
         }
 
-        return "r";
+        var protocol = segments[^3];
+        var pathKind = segments[^2];
+        return string.Equals(protocol, "OID", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(pathKind, "redirect", StringComparison.OrdinalIgnoreCase)
+                ? "redirect"
+                : "r";
     }
 }


### PR DESCRIPTION
# What & why

`OidcCallbackPath.RedirectSegment` scanned for the **first** `OID` segment
anywhere in the callback path and read the next segment, so a protocol-like
reverse-proxy prefix (a base path that itself contains an `OID` segment) could
misclassify the callback spelling. PR #410 already moved the sibling
`ChallengePath.IsNewPath` to a **suffix-anchored** form, it reads the route off
its `{protocol}/{path-kind}/{provider}` suffix, trimming only boundary slashes.
This converges `RedirectSegment` on the same robust pattern so the challenge side
and the callback side classify the route identically.

The value only picks the `r`/`redirect` segment used to rebuild the token
request's `redirect_uri`; the segment is operator/proxy-controlled and a mismatch
still fails closed at the IdP token endpoint (RFC 6749 §4.1.3), so this is a
robustness tightening, not a behavior change for well-formed callbacks.

- Read the route off the `{protocol}/{path-kind}/{provider}` suffix
  (`segments[^3]`/`[^2]`) instead of the first `OID` token found anywhere.
- Trim only boundary slashes (drop `RemoveEmptyEntries`) so an internal doubled
  slash shifts the suffix and fails safe to the classic `"r"` spelling rather
  than being silently collapsed into a valid route.
- Add regression tests: a protocol-like reverse-proxy prefix (both directions),
  a legitimate base-path mount that must stay `"redirect"`, and an internal
  doubled slash.

Closes #411.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — Unchanged. The classifier picks only
      the redirect segment; a wrong choice yields a mismatched `redirect_uri`
      that the IdP rejects at the token endpoint, and the `"r"` default is the
      fail-safe classic spelling.
- [x] No secrets logged; secrets are redacted on config export. - No logging or
      secret handling in this path.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — Adversarial 4-lens review
      ran (verdicts under Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call. - N/A, no
      logging added.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      — No new structural property; the pure-helper shape is already covered.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green., 820 passed, 0 failed.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., N/A,
      only `.cs` files touched.

## Notes

**Adversarial 4-lens review, all PASS.**

- **Availability / mass-lockout, PASS.** Suffix-anchoring leaves the common-case
  classification identical and correct; it fails safe only on paths a real OIDC
  callback can never produce, and it aligns the callback side with the
  already-merged challenge side (#410), removing a latent asymmetry rather than
  introducing a lockout vector.
- **Security-bypass / fail-open, PASS.** The return is a literal (`"redirect"`
  or `"r"`) that no security decision keys on; a misclassification fails at the
  IdP and never authenticates. The `"r"` default is fail-closed; no
  bypass/fail-open is reachable.
- **Correctness, PASS.** The `Length >= 3` guard makes the `segments[^3]`/`[^2]`
  indexing throw-proof; null/empty/`"/"`/`"//"`/single-segment/trailing-slash/
  mixed-case inputs all handled; `OrdinalIgnoreCase` avoids culture pitfalls;
  behavior is identical to the old code for every well-formed callback path.
- **Integration, PASS.** The OID challenge (`OID/start|p/{provider}`) and
  callback (`OID/redirect|r/{provider}`) routes share the same
  `{controller}/OID/{path-kind}/{provider}` shape; `Request.Path` has the
  reverse-proxy base path stripped into `PathBase`, so the suffix window is
  stable. Both helpers now derive their `redirect_uri` spelling from a
  byte-identical routine, so the challenge-advertised and callback-rebuilt
  `redirect_uri` match under any base-path or proxy layout.

Docs: no operator-visible behavior change (it only tightens misclassification of
an operator-controlled path that already fails closed), so no user-facing doc
update is needed.

Out of scope: `ChallengePath.cs`'s class comment still says `RedirectSegment`
"should be moved to the same suffix-anchored form (#411)", after this change
that line is stale, but `ChallengePath.cs` is out of scope here; folding the
one-line comment fix into the next touch of that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO callback path detection when applications run behind reverse proxies or URL prefixes.
  * Correctly identifies supported callback routes while safely falling back for malformed paths, including doubled slashes.
* **Tests**
  * Added coverage for prefixed callback paths, valid reverse-proxy routes, and malformed callback URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->