### PR TITLE
Require the legacy link's target to still bear the presented name before following it

### DIFF
--- a/SSO-Auth.Tests/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/AccountLinkResolverTests.cs
@@ -61,7 +61,7 @@ public class AccountLinkResolverTests
     [InlineData(true)]
     public void ResolveCanonicalLink_SubjectKeyed_IsUsed_WithoutMigration(bool allow)
     {
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, legacyNameKeyedUserId: null, allow);
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, legacyNameKeyedUserId: null, legacyNameStillHeldByTarget: false, allowExistingAccountLink: allow);
         Assert.Equal(Subject, linkedUserId);
         Assert.False(migrate);
     }
@@ -71,8 +71,9 @@ public class AccountLinkResolverTests
     [InlineData(true)]
     public void ResolveCanonicalLink_SubjectKeyed_WinsOverLegacy_NoMigration(bool allow)
     {
-        // Once a subject-keyed link exists, the legacy name-keyed one is never consulted or migrated.
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, Legacy, allow);
+        // Once a subject-keyed link exists, the legacy name-keyed one is never consulted or migrated —
+        // even when the name is still held by its target (legacyNameStillHeldByTarget: true).
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(Subject, Legacy, legacyNameStillHeldByTarget: true, allowExistingAccountLink: allow);
         Assert.Equal(Subject, linkedUserId);
         Assert.False(migrate);
     }
@@ -80,11 +81,24 @@ public class AccountLinkResolverTests
     [Fact]
     public void ResolveCanonicalLink_OnlyLegacy_WithOptIn_IsAdopted_AndMigrated()
     {
-        // No subject-keyed link yet, but a legacy name-keyed one resolves and the provider permits
-        // name-based matching: adopt it and signal the one-time re-key to the subject.
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, allowExistingAccountLink: true);
+        // No subject-keyed link yet, but a legacy name-keyed one resolves, the provider permits
+        // name-based matching, AND the target still bears the name: adopt it and signal the one-time
+        // re-key to the subject.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, legacyNameStillHeldByTarget: true, allowExistingAccountLink: true);
         Assert.Equal(Legacy, linkedUserId);
         Assert.True(migrate);
+    }
+
+    [Fact]
+    public void ResolveCanonicalLink_OnlyLegacy_WithOptIn_ButNameRenamedAway_IsIgnored()
+    {
+        // The #361 fix: the flag is on and a legacy name-keyed link resolves, but the account it points
+        // at no longer bears the presented name (it was renamed away). Following it would hand the login
+        // an account selected by a stale, provider-controlled name (CWE-287), so it must NOT be followed
+        // or migrated; the login falls through to the adoption gate over the CURRENT name-holder instead.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, legacyNameStillHeldByTarget: false, allowExistingAccountLink: true);
+        Assert.Null(linkedUserId);
+        Assert.False(migrate);
     }
 
     [Fact]
@@ -92,8 +106,9 @@ public class AccountLinkResolverTests
     {
         // The security-critical case (#354): the legacy key is the mutable preferred_username, so with
         // AllowExistingAccountLink off a login must NOT be handed the account that key points at, and
-        // nothing may be migrated. The login falls through to Resolve(), whose adoption gate fails closed.
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, allowExistingAccountLink: false);
+        // nothing may be migrated — even while the name is still held by its target. The login falls
+        // through to Resolve(), whose adoption gate fails closed.
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(subjectKeyedUserId: null, Legacy, legacyNameStillHeldByTarget: true, allowExistingAccountLink: false);
         Assert.Null(linkedUserId);
         Assert.False(migrate);
     }
@@ -103,7 +118,7 @@ public class AccountLinkResolverTests
     [InlineData(true)]
     public void ResolveCanonicalLink_NeitherLink_ResolvesNothing(bool allow)
     {
-        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(null, null, allow);
+        var (linkedUserId, migrate) = AccountLinkResolver.ResolveCanonicalLink(null, null, legacyNameStillHeldByTarget: false, allowExistingAccountLink: allow);
         Assert.Null(linkedUserId);
         Assert.False(migrate);
     }

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -203,27 +203,63 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
-    public async Task ResolveOrCreateAsync_FlagOnRenamedLegacyOwner_HandsOutTheRecordedAccount()
+    public async Task ResolveOrCreateAsync_FlagOnRenamedLegacyOwner_DoesNotHandOverTheRenamedAccount()
     {
-        // Characterization of the flag-ON residual (#361, surfaced on #358): the legacy arm resolves
-        // the RECORDED name key even when no live account bears that name anymore (the owner was
-        // renamed), a strict superset of same-name adoption — so during an enable-the-flag migration
-        // window, a login presenting a foreign sub and the pre-rename name is handed the account and
-        // re-keys it. This pins the current behavior empirically; the #361 fix will flip it.
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        // The #361 fix (residual surfaced on #358): with the flag on, a legacy name-keyed link whose
+        // target was renamed away from the presented name must NOT be followed — otherwise a login with a
+        // foreign sub and the pre-rename name is handed the renamed account and re-keys it (a stale-name
+        // superset of same-name adoption, CWE-287). No live account bears "oldname", so the login instead
+        // provisions a FRESH account under its own sub; the renamed victim's account and the legacy entry
+        // are left untouched, and the orphan warning fires.
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
         });
         users.GetUserById(Existing).Returns(UserNamed("newname", Existing));
         users.GetUserByName("oldname").Returns((User?)null); // renamed: no live account bears the key
+        var created = UserNamed("oldname", Other);
+        users.CreateUserAsync("oldname").Returns(created);
+        users.GetUserById(Other).Returns(created);
 
         var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
 
-        Assert.Equal(Existing, resolved);
+        Assert.Equal(Other, resolved); // a fresh account, NOT the renamed victim (Existing)
+        await users.Received(1).CreateUserAsync("oldname");
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
-        Assert.Equal(Existing, links["attacker-sub"]); // re-keyed to the presented sub
-        Assert.False(links.ContainsKey("oldname"));
+        Assert.Equal(Existing, links["oldname"]); // the legacy entry is untouched, not re-keyed
+        Assert.Equal(Other, links["attacker-sub"]); // the fresh account is linked under the login's own sub
+
+        // The orphan warning fires (the legacy link is now stale), not mislabeled a "refused" login.
+        var warnings = log.Entries.FindAll(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+        Assert.Single(warnings);
+        Assert.Contains("orphaned", warnings[0].Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("refused", warnings[0].Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_FlagOnRenamedLegacyOwner_NameNowHeldByAnother_AdoptsTheCurrentHolderNotTheVictim()
+    {
+        // The #361 fix, the case where a DIFFERENT account has since taken the pre-rename name: the legacy
+        // link still points at the renamed victim (Existing), but the account currently named "oldname" is
+        // a third party (Other). The stale legacy key must not be followed; the login falls through to
+        // ordinary same-name adoption of the CURRENT holder (Other), never the renamed victim (Existing).
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("newname", Existing)); // the victim, renamed away
+        users.GetUserByName("oldname").Returns(UserNamed("oldname", Other)); // a different account now holds the name
+        users.GetUserById(Other).Returns(UserNamed("oldname", Other));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
+
+        Assert.Equal(Other, resolved); // adopts the current name-holder, NOT the renamed victim (Existing)
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["oldname"]); // the victim's legacy entry is untouched
+        Assert.Equal(Other, links["attacker-sub"]); // the adopted (current-holder) account is linked under the sub
     }
 
     [Fact]
@@ -585,7 +621,9 @@ public class CanonicalLinkServiceTests
         // is disabled before the migration transaction. Without the guard the caller would still return
         // UseExistingLink and mint with pre-disable settings; with it the migration rejects and the
         // legacy key stays un-migrated. The flip runs inside the GetUserById stub, which the read
-        // consults after its own guard has already passed.
+        // consults after its own guard has already passed. The name is still held by the legacy target
+        // (GetUserByName -> Existing), so the #361 follow-gate lets the migrate be attempted — the point
+        // this test exercises — rather than short-circuiting to a fresh account.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
         {
             Enabled = true,
@@ -596,6 +634,7 @@ public class CanonicalLinkServiceTests
             cfg.OidConfigs["kc"].Enabled = false;
             return UserNamed("alice", Existing);
         });
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));

--- a/SSO-Auth/Api/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/AccountLinkResolver.cs
@@ -76,6 +76,15 @@ internal static class AccountLinkResolver
     /// The user id linked under the legacy username key, if that link exists and its user still exists.
     /// Pass <c>null</c> when the subject and username are identical (there is nothing to migrate).
     /// </param>
+    /// <param name="legacyNameStillHeldByTarget">
+    /// Whether the account the legacy link points at STILL bears the presented username (i.e. the
+    /// account currently named <c>username</c> is that same legacy target). The legacy key is the
+    /// mutable name, so a target that has since been renamed away from it must not be followed: the
+    /// identity provider controls <c>preferred_username</c> and could present the pre-rename name of an
+    /// account it does not own and be handed it (a stale-name superset of same-name matching, #361,
+    /// CWE-287). Requiring the name to still resolve to the same target collapses the legacy arm back to
+    /// true same-name matching. Meaningless when <paramref name="legacyNameKeyedUserId"/> is null.
+    /// </param>
     /// <param name="allowExistingAccountLink">
     /// Whether the provider permits matching an account by its mutable name. The legacy key IS the
     /// mutable username, so following it hands the login an account selected by a name the identity
@@ -85,13 +94,15 @@ internal static class AccountLinkResolver
     /// </param>
     /// <returns>
     /// The linked user id (or null when neither link resolves), and whether the legacy link must be
-    /// re-keyed to the subject. Migration is requested only when there is no subject-keyed link yet but
-    /// a legacy one resolves and name-based matching is permitted — a one-time, idempotent hand-off:
-    /// once re-keyed, later logins hit the subject key directly and never consult the name again.
+    /// re-keyed to the subject. Migration is requested only when there is no subject-keyed link yet, a
+    /// legacy one resolves, name-based matching is permitted, AND the legacy target still bears the
+    /// name — a one-time, idempotent hand-off: once re-keyed, later logins hit the subject key directly
+    /// and never consult the name again.
     /// </returns>
     internal static (Guid? LinkedUserId, bool MigrateLegacy) ResolveCanonicalLink(
         Guid? subjectKeyedUserId,
         Guid? legacyNameKeyedUserId,
+        bool legacyNameStillHeldByTarget,
         bool allowExistingAccountLink)
     {
         if (subjectKeyedUserId.HasValue)
@@ -99,7 +110,7 @@ internal static class AccountLinkResolver
             return (subjectKeyedUserId.Value, false);
         }
 
-        if (legacyNameKeyedUserId.HasValue && allowExistingAccountLink)
+        if (legacyNameKeyedUserId.HasValue && allowExistingAccountLink && legacyNameStillHeldByTarget)
         {
             return (legacyNameKeyedUserId.Value, true);
         }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -100,7 +100,9 @@ internal sealed class CanonicalLinkService
         // detach it. Because the legacy key is a name the identity provider controls, following it is
         // name-based account matching, so it honors AllowExistingAccountLink exactly like same-named
         // adoption below (#354): with the flag off, a login whose preferred_username points at another
-        // user's entry is refused by the adoption gate instead of being handed that account.
+        // user's entry is refused by the adoption gate instead of being handed that account. Even with
+        // the flag on it is followed ONLY while the recorded target still bears the name (#361 below);
+        // a target renamed away from it is not handed over on the strength of a stale name key.
         // Only OpenID differs key from name; SAML passes key == name.
         // Both candidates are read in ONE pass under the config lock: with separate reads, a
         // concurrent login's migration could commit between them, so this login would see the subject
@@ -134,7 +136,16 @@ internal sealed class CanonicalLinkService
             return (bySubject, byName);
         });
 
-        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink, allowExistingAccountLink);
+        // The account currently bearing the display name, resolved once (outside the config lock — it is
+        // a user-manager read, not a config read). It is both the same-name adoption candidate for the
+        // Resolve gate below AND, when it IS the legacy link's target, the proof that following the legacy
+        // username key is still true same-name matching rather than handing over an account that was
+        // renamed away from this name (#361). A legacy link whose target no longer holds the name is left
+        // for the terminal branches to label (a fresh-account orphan, or a reject), never followed.
+        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
+        bool legacyNameStillHeldByTarget = legacyLink.HasValue && existingAccountUserId == legacyLink;
+
+        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink, legacyNameStillHeldByTarget, allowExistingAccountLink);
         if (migrateLegacy)
         {
             MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
@@ -144,9 +155,10 @@ internal sealed class CanonicalLinkService
                 provider?.ReplaceLineEndings(string.Empty));
         }
 
-        // A legacy link that survives here un-migrated (flag off, #354) is not logged at this point:
-        // its terminal outcome decides the right message. It splits into a refusal (the name is still
-        // taken) or a fresh-account creation (the name was freed by a rename), and only the outcome
+        // A legacy link that survives here un-migrated (flag off — or flag on but the name no longer
+        // resolves to the recorded target, #354/#361) is not logged at this point: its terminal outcome
+        // decides the right message. It splits into a refusal (the name is still taken) or a
+        // fresh-account creation (the name was freed by a rename), and only the outcome
         // branch below can label it accurately — the fresh-account case is a SUCCESSFUL login that
         // silently orphans the original account, not a "refused" one, so a single pre-gate line would
         // mislabel exactly the event an operator most needs to see. Each terminal branch emits one
@@ -154,9 +166,7 @@ internal sealed class CanonicalLinkService
         // per-request service, which would leak across tests), so during an upgrade window it is a
         // stream — enough to identify who still needs migrating, scanned expecting volume.
 
-        // Adoption of a pre-existing unlinked account still matches on the display name.
-        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
-
+        // Adoption of a pre-existing unlinked account still matches on the display name resolved above.
         var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
         switch (decision.Action)
         {
@@ -180,16 +190,17 @@ internal sealed class CanonicalLinkService
             {
                 if (legacyLink.HasValue)
                 {
-                    // The dangerous, previously-silent case (#354): a legacy username-keyed link exists,
-                    // the flag is off so it was not followed, AND no live account bears the name anymore
-                    // (the account was renamed on the Jellyfin side). We are about to provision a FRESH
-                    // account under this subject, leaving the original — the one the legacy key points at
-                    // — permanently orphaned. This warning is the single observable signal of that
-                    // irreversible outcome; recover by linking the original account to this subject via
-                    // the admin endpoints, or enable AllowExistingAccountLink before the next login. See
-                    // the upgrade runbook in providers.md.
+                    // The dangerous, previously-silent case (#354/#361): a legacy username-keyed link
+                    // exists and its target still exists, but no live account bears the name anymore (the
+                    // account was renamed on the Jellyfin side), so the legacy link was NOT followed —
+                    // whether adoption is off, or on but the name no longer resolves to the recorded target
+                    // (#361, the stale-name superset the flag-on arm used to hand over). We are about to
+                    // provision a FRESH account under this subject, leaving the original — the one the
+                    // legacy key points at — orphaned from this identity. This warning is the single
+                    // observable signal of that outcome; recover by linking the original account to this
+                    // subject via the admin endpoints. See the upgrade runbook in providers.md.
                     _logger.LogWarning(
-                        "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but AllowExistingAccountLink is off and no live account bears the name, so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints (or enable AllowExistingAccountLink before the next login).",
+                        "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
                         username?.ReplaceLineEndings(string.Empty),
                         mode,
                         provider?.ReplaceLineEndings(string.Empty));

--- a/providers.md
+++ b/providers.md
@@ -98,30 +98,34 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   3. **Migrate.** The safest route is to link each account explicitly via the admin API
      (`AddCanonicalLink`) — it needs no name trust. If instead you enable `AllowExistingAccountLink` to
      let logins self-migrate, treat it as a **maintenance window, not a standing setting**: while it is
-     on, that provider is back to trusting `preferred_username`, so whoever logs in first with a given
-     name claims that account **irreversibly** (an attacker who knows a victim's old username can take it,
-     and the victim is then orphaned). Keep the window short and controlled, migrate your users in it,
+     on, that provider is back to trusting `preferred_username`, so whoever logs in first with a name a
+     live account currently bears claims that account **irreversibly** (an attacker who knows a victim's
+     current username can take that account first). The flag now self-migrates a legacy link only while
+     the recorded account still bears that name (#361), so a name already renamed away no longer reaches
+     the old account — but any name a live account currently holds is still fair game. Keep the window
+     short and controlled, migrate your users in it,
      and turn the flag back off immediately.
-  4. **Renamed accounts — know which case you have.** A legacy link is keyed on the username _as it
-     was when the link was created_, and enabling the flag matches on that recorded key, not on the
-     account's current display name. Which case you are in decides recovery:
-     - If the account was renamed **on the Jellyfin side** but the identity provider still sends the
-       **original** name, enabling `AllowExistingAccountLink` (step 3) _does_ migrate it — but only
-       through the very same first-login-wins takeover window step 3 describes (an attacker who knows
-       the original name can claim the account first). Treat it exactly like step 3: prefer per-account
-       admin linking, and keep any flag window short and controlled.
-     - It is genuinely **not** recoverable by the flag when the identity provider now sends a
-       **different** name than the legacy key (an IdP-side rename, so the recorded key is never
-       matched), or when the user has **already logged in** without the flag and now sits on a fresh
-       `sub`-keyed account (that link wins and the old entry is never consulted again). For those,
-       recover by hand — as admin, delete the fresh account's link (`DeleteCanonicalLink`) and
-       `AddCanonicalLink` the original account to the user's current `sub`.
+  4. **Renamed accounts are admin-recovery only.** A legacy link is keyed on the username _as it was
+     when the link was created_. Enabling the flag self-migrates a legacy link **only while the account
+     it points at still bears that name** (#361), so it recovers the common case — a user whose name
+     never changed — but **not** an account that has since been renamed, on either side:
+     - **Jellyfin-side rename** (the account was renamed, but the identity provider still sends the
+       original name): the recorded target no longer bears that name, so enabling `AllowExistingAccountLink`
+       does **not** migrate it — and must not, since following a name the account no longer holds is
+       exactly the stale-name takeover #361 closed.
+     - **IdP-side rename** (the provider now sends a **different** name than the legacy key, so the
+       recorded key is never matched), or a user who has **already logged in** without the flag and now
+       sits on a fresh `sub`-keyed account (that link wins and the old entry is never consulted again).
+       For all of these, recover by hand — as admin, delete any fresh account's link (`DeleteCanonicalLink`)
+       and `AddCanonicalLink` the original account to the user's current `sub`.
 
-  A server log line (`WARNING`) is emitted for every login that encounters a pending legacy link while
-  the flag is off, naming the account — whether the login is **refused** (a live account still bears
-  the name) or lands on a **fresh account** (the name was freed by a rename, so the original is
-  orphaned; the warning is worded to flag that case explicitly, since no 403 accompanies it). Watch
-  for both so you can see who still needs migrating. Note that the self-service linking page now lists OpenID links by their
+  A server log line (`WARNING`) marks a login that carries a pending legacy link and is either
+  **refused** (flag off, a live account still bears the name) or lands on a **fresh account** (no live
+  account bears the name, so the original is orphaned — now under the flag on as well as off, #361; the
+  warning is worded to flag this case explicitly, since no 403 accompanies it). A flag-on login that
+  instead adopts a **different** account currently bearing the name is recorded in the audit log as an
+  ordinary adoption, not by this warning. Watch the refuse/orphan warnings so you can see who still
+  needs migrating. Note that the self-service linking page now lists OpenID links by their
   `sub` value, which for many providers is an opaque identifier rather than a readable name. If you run
   the anonymous SSO endpoints with rate limiting available, enable it during the window to blunt an
   attacker probing names while the flag is on. This runbook is mirrored on the


### PR DESCRIPTION
# What & why

The OpenID legacy username-keyed link (#155) was followed whenever its recorded target user still
**existed** (`GetUserById != null`), without checking the target still **bore** the presented name.
With `AllowExistingAccountLink` on, the state the #354 migration runbook tells admins to enable
during the upgrade window, an attacker presenting a foreign `sub` and a victim's **old** username
(one the victim had since been renamed away from) was handed and re-keyed the victim's account: a
stale-name superset of same-name adoption (#361, CWE-287).

The fix gates the follow on the name still resolving to the same target:

- `AccountLinkResolver.ResolveCanonicalLink` takes a `legacyNameStillHeldByTarget` flag; the migrate
  arm now requires it alongside the existing opt-in. When the recorded target no longer bears the
  name, the legacy link is **not** followed and the login falls through to the adoption gate over the
  **current** name-holder - adopt it (flag on, a live account bears the name), or create/reject - 
  never the renamed-away account.
- `CanonicalLinkService` resolves the display-name holder **once** (moved before the resolve) and
  passes whether it is the legacy target (`existingAccountUserId == legacyLink`). `legacyLink` itself
  is unchanged ("target exists"); only the follow/migrate is newly gated. The `CreateNewAccount`
  orphan warning, now reachable with the flag on too, is reworded flag-agnostic (still names the
  orphaning).
- `providers.md`: a Jellyfin-side-renamed account is no longer flag-migratable; recover it by admin
  re-linking. The migration window now only self-migrates links whose account still bears the
  recorded name.

SAML is unaffected, its canonical key equals the name, so the legacy arm is structurally dormant.

Case matrix (subject link absent, target exists): **(1)** the account currently named `<username>`
IS the legacy target → flag on migrates (unchanged), flag off rejects; **(2)** a *different* account
now bears `<username>` → adopt that current holder (flag on) or reject (flag off), never the renamed
victim; **(3)** nobody bears `<username>` → create fresh + orphan warning, the renamed victim keeps
their account.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the legacy link is now followed only when the presented name still
      resolves to the recorded target; every other case falls through to the fail-closed adoption gate.
- [x] No secrets logged; the reworded warning logs only the sanitized name/mode/provider (unchanged
      `ReplaceLineEndings` inline sanitization).
- [x] A security review was performed: 4-lens refute-by-default gate + the OIDC domain reviewer.
- [x] Log inputs from the IdP are sanitized inline at the log call (`?.ReplaceLineEndings(string.Empty)`).

## Quality checklist

- [x] No duplicated logic; the name-holder is resolved once and reused; the decision stays in the pure
      `AccountLinkResolver`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain the security *why*.
- [x] Architecture-conformance tests pass; no new structural property introduced.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (0 warnings, 0 errors).
- [x] `dotnet test` is green (818/818).
- [x] Prettier is clean for the `providers.md` change.

## Notes

Login-path authz change → the adversarial-review gate is load-bearing. We ran a 4-lens
refute-by-default gate plus the OpenID domain reviewer: **bypass, availability, correctness, and OIDC
all PASS**, the follow arm now collapses to genuine same-name matching (`existingAccountUserId ==
legacyLink`), the takeover is fully closed, no new 403/lockout is reachable (a flag-on hand-off only
ever narrows to adopt-current-holder or fresh-account), and SAML stays dormant. The **integration**
lens returned NEEDS_IMPROVEMENT on one point - the reworded WARNING paragraph over-claimed a warning
for *every* non-migrated legacy login, whereas the flag-on "adopt a different current name-holder"
outcome (Case 2) is recorded as an audit, not a warning, which we fixed in `providers.md` in this
same change.

Reject-path message nuance (pre-existing, unchanged): in the rare case 2 (target renamed away AND a
different account now holds the old name) with the flag off, the reject still emits the
"migratable pending-legacy-link" hint though enabling the flag would adopt the current holder rather
than migrate the victim. This reachability is identical to before the fix (`legacyLink` unchanged), so
it is not worsened here; left as-is to keep the change focused on the takeover.

Closes #361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale legacy username links from being followed after an account is renamed.
  * Ensured logins adopt the account currently holding a legacy name rather than the former owner.
  * Improved handling of orphaned links, including administrator-led recovery guidance.

* **Documentation**
  * Clarified migration behavior, first-login ownership risks, renamed-account recovery, and warning messages when enabling existing account linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->