### PR TITLE
Reuse the challenge's validated discovery metadata at the OpenID callback

### DIFF
--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -146,6 +146,38 @@ public class OidcStateStoreTests
         Assert.Equal(1, store.Count);
     }
 
+    // --- ProviderInformation reuse (#247): carry the challenge's validated discovery to the callback ---
+
+    [Fact]
+    public void TryAdd_CarriesProviderInformation_ReusedAtThePeekForTheCallback()
+    {
+        // The challenge stashes the discovery metadata it already fetched and validated; the store must
+        // round-trip it to the PendingState the OidPost callback reads, so ProcessResponseAsync can reuse
+        // it instead of re-running discovery + JWKS.
+        var store = Store();
+        var info = new ProviderInformation { IssuerName = "https://idp.example" };
+
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, providerInformation: info, out _));
+
+        var pending = store.PeekCurrent("s", "p", Now, Binding);
+        Assert.NotNull(pending);
+        Assert.Same(info, pending.ProviderInformation);
+    }
+
+    [Fact]
+    public void TryAdd_NullProviderInformation_PeekExposesNull_SoTheCallbackFallsBackToDiscovery()
+    {
+        // A state added without stashed metadata (a flow that predates the capture) exposes null, so the
+        // callback's CreateOidcClient runs a fresh discovery — the pre-#247 behavior, never a broken login.
+        var store = Store();
+
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+
+        var pending = store.PeekCurrent("s", "p", Now, Binding);
+        Assert.NotNull(pending);
+        Assert.Null(pending.ProviderInformation);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -359,7 +391,7 @@ public class OidcStateStoreTests
             {
                 for (var i = 0; i < 5000; i++)
                 {
-                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, clientKey: null, out _);
+                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _);
                 }
             },
             TestContext.Current.CancellationToken);
@@ -387,8 +419,8 @@ public class OidcStateStoreTests
     {
         var store = Store(maxEntries: 2);
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out var warnA));
-        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var warnB));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var warnA));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var warnB));
         Assert.False(warnA);
         Assert.False(warnB);
         Assert.Equal(2, store.Count);
@@ -398,10 +430,10 @@ public class OidcStateStoreTests
     public void TryAdd_AtCap_RefusesANewKeyAndKeepsTheInFlightState()
     {
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
 
         // At the cap, a fresh challenge is refused rather than evicting the user already mid-login.
-        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
         Assert.Equal(1, store.Count);
         Assert.NotNull(store.PeekCurrent("in-flight", "p", Now, Binding));
     }
@@ -410,8 +442,8 @@ public class OidcStateStoreTests
     public void TryAdd_DuplicateKey_ReturnsFalse()
     {
         var store = Store(maxEntries: 10);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
-        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
     }
 
     [Fact]
@@ -420,15 +452,15 @@ public class OidcStateStoreTests
         // The warning signal is bounded exactly like the sweeps: the first refusal signals, further
         // refusals inside the interval stay silent, so a flood cannot amplify into log volume.
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var firstWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var firstWarn));
         Assert.True(firstWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, clientKey: null, out var secondWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, clientKey: null, providerInformation: null, out var secondWarn));
         Assert.False(secondWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, clientKey: null, out var nextIntervalWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, clientKey: null, providerInformation: null, out var nextIntervalWarn));
         Assert.True(nextIntervalWarn);
     }
 
@@ -450,7 +482,7 @@ public class OidcStateStoreTests
                 {
                     for (var i = 0; i < perTask; i++)
                     {
-                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, clientKey: null, out _))
+                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _))
                         {
                             Interlocked.Increment(ref rejected);
                         }
@@ -574,39 +606,39 @@ public class OidcStateStoreTests
     {
         // The core fairness property: filling client "A" to its per-key share must not deny "B".
         var store = Store(maxEntries: 200); // per-key cap 2
-        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _));
-        Assert.True(store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _));
-        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out var warn)); // A at share
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out var warn)); // A at share
         Assert.True(warn); // the throttled capacity warning fires for the first per-client refusal
 
-        Assert.True(store.TryAdd(State("b1"), "p", false, Now, Binding, clientKey: "B", out _)); // B unaffected
+        Assert.True(store.TryAdd(State("b1"), "p", false, Now, Binding, clientKey: "B", providerInformation: null, out _)); // B unaffected
     }
 
     [Fact]
     public void TryAdd_ReleaseOnRedeem_ReadmitsTheSameKey()
     {
         var store = Store(maxEntries: 200); // per-key cap 2
-        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
-        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
-        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _)); // full
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // full
 
         Validate(store, "a1");
         Assert.NotNull(store.TryRedeem("a1", "p", Now, Binding)); // frees one A slot
-        Assert.True(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _));
+        Assert.True(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
     }
 
     [Fact]
     public void TryAdd_ReleaseOnExpirySweep_ReadmitsTheSameKey()
     {
         var store = Store(maxEntries: 200); // per-key cap 2
-        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
-        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
 
         // Past the lifetime and the prune interval, the sweep removes both A entries and releases their
         // slots, so A can add again. (Lifetime and PruneInterval are the test fixture's small values.)
         var later = Now + Lifetime + PruneInterval + TimeSpan.FromSeconds(1);
         store.PruneExpired(later);
-        Assert.True(store.TryAdd(State("a3"), "p", false, later, Binding, clientKey: "A", out _));
+        Assert.True(store.TryAdd(State("a3"), "p", false, later, Binding, clientKey: "A", providerInformation: null, out _));
     }
 
     [Fact]
@@ -616,13 +648,13 @@ public class OidcStateStoreTests
         // a "A" add reserves A's slot but is refused by the GLOBAL cap and must roll back. After a slot
         // frees, "A" must still admit — a leaked reservation would leave A at its cap of 1.
         var store = Store(maxEntries: 2);
-        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
-        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
 
-        Assert.False(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // global cap
+        Assert.False(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // global cap
         Validate(store, "n1");
         Assert.NotNull(store.TryRedeem("n1", "p", Now, Binding)); // free one global slot
-        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // no leak
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // no leak
     }
 
     [Fact]
@@ -631,9 +663,9 @@ public class OidcStateStoreTests
         // Global cap 2 -> per-key cap 1. A null (proxy/unattributable) key is never sub-capped: null adds
         // succeed past a per-key cap of 1 up to the GLOBAL cap, then are refused by the global cap.
         var store = Store(maxEntries: 2);
-        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
-        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _)); // past per-key 1
-        Assert.False(store.TryAdd(State("n3"), "p", false, Now, Binding, clientKey: null, out _)); // global cap
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _)); // past per-key 1
+        Assert.False(store.TryAdd(State("n3"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _)); // global cap
     }
 
     [Fact]
@@ -643,10 +675,10 @@ public class OidcStateStoreTests
         // each per distinct key, then a further distinct key is refused (global cap) and the existing
         // entries survive (refuse-not-evict).
         var store = Store(maxEntries: 3); // per-key cap 1
-        Assert.True(store.TryAdd(State("k1"), "p", false, Now, Binding, clientKey: "K1", out _));
-        Assert.True(store.TryAdd(State("k2"), "p", false, Now, Binding, clientKey: "K2", out _));
-        Assert.True(store.TryAdd(State("k3"), "p", false, Now, Binding, clientKey: "K3", out _));
-        Assert.False(store.TryAdd(State("k4"), "p", false, Now, Binding, clientKey: "K4", out _)); // global cap
+        Assert.True(store.TryAdd(State("k1"), "p", false, Now, Binding, clientKey: "K1", providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("k2"), "p", false, Now, Binding, clientKey: "K2", providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("k3"), "p", false, Now, Binding, clientKey: "K3", providerInformation: null, out _));
+        Assert.False(store.TryAdd(State("k4"), "p", false, Now, Binding, clientKey: "K4", providerInformation: null, out _)); // global cap
         Assert.NotNull(store.PeekCurrent("k1", "p", Now, Binding)); // not evicted
     }
 }

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -149,15 +149,16 @@ public class OidcStateStoreTests
     // --- ProviderInformation reuse (#247): carry the challenge's validated discovery to the callback ---
 
     [Fact]
-    public void TryAdd_CarriesProviderInformation_ReusedAtThePeekForTheCallback()
+    public void SetProviderInformation_CarriesTheDiscoveryToThePeekForTheCallback()
     {
-        // The challenge stashes the discovery metadata it already fetched and validated; the store must
-        // round-trip it to the PendingState the OidPost callback reads, so ProcessResponseAsync can reuse
-        // it instead of re-running discovery + JWKS.
+        // The challenge stashes (via SetProviderInformation, after TryAdd) the discovery metadata it
+        // already fetched and validated; the store must round-trip it to the PendingState the OidPost
+        // callback reads, so ProcessResponseAsync can reuse it instead of re-running discovery + JWKS.
         var store = Store();
         var info = new ProviderInformation { IssuerName = "https://idp.example" };
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, providerInformation: info, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, out _));
+        store.SetProviderInformation("s", info);
 
         var pending = store.PeekCurrent("s", "p", Now, Binding);
         Assert.NotNull(pending);
@@ -165,13 +166,26 @@ public class OidcStateStoreTests
     }
 
     [Fact]
-    public void TryAdd_NullProviderInformation_PeekExposesNull_SoTheCallbackFallsBackToDiscovery()
+    public void SetProviderInformation_UnknownToken_IsANoOp()
     {
-        // A state added without stashed metadata (a flow that predates the capture) exposes null, so the
+        // Defensive: if the entry expired in the gap between TryAdd and this call, recording is a no-op —
+        // no throw, no resurrected entry — and the callback falls back to a fresh discovery.
+        var store = Store();
+
+        store.SetProviderInformation("never-added", new ProviderInformation { IssuerName = "https://idp.example" });
+
+        Assert.Equal(0, store.Count);
+        Assert.Null(store.PeekCurrent("never-added", "p", Now, Binding));
+    }
+
+    [Fact]
+    public void PeekWithoutSetProviderInformation_ExposesNull_SoTheCallbackFallsBackToDiscovery()
+    {
+        // A state added but never enriched (a flow that predates the capture) exposes null, so the
         // callback's CreateOidcClient runs a fresh discovery — the pre-#247 behavior, never a broken login.
         var store = Store();
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, out _));
 
         var pending = store.PeekCurrent("s", "p", Now, Binding);
         Assert.NotNull(pending);
@@ -391,7 +405,7 @@ public class OidcStateStoreTests
             {
                 for (var i = 0; i < 5000; i++)
                 {
-                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _);
+                    store.TryAdd(new AuthorizeState { State = "fresh-" + i }, "p", false, Now, Binding, clientKey: null, out _);
                 }
             },
             TestContext.Current.CancellationToken);
@@ -419,8 +433,8 @@ public class OidcStateStoreTests
     {
         var store = Store(maxEntries: 2);
 
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var warnA));
-        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var warnB));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out var warnA));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var warnB));
         Assert.False(warnA);
         Assert.False(warnB);
         Assert.Equal(2, store.Count);
@@ -430,10 +444,10 @@ public class OidcStateStoreTests
     public void TryAdd_AtCap_RefusesANewKeyAndKeepsTheInFlightState()
     {
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "in-flight" }, "p", false, Now, Binding, clientKey: null, out _));
 
         // At the cap, a fresh challenge is refused rather than evicting the user already mid-login.
-        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "new" }, "p", false, Now, Binding, clientKey: null, out _));
         Assert.Equal(1, store.Count);
         Assert.NotNull(store.PeekCurrent("in-flight", "p", Now, Binding));
     }
@@ -442,8 +456,8 @@ public class OidcStateStoreTests
     public void TryAdd_DuplicateKey_ReturnsFalse()
     {
         var store = Store(maxEntries: 10);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
-        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
     }
 
     [Fact]
@@ -452,15 +466,15 @@ public class OidcStateStoreTests
         // The warning signal is bounded exactly like the sweeps: the first refusal signals, further
         // refusals inside the interval stay silent, so a flood cannot amplify into log volume.
         var store = Store(maxEntries: 1);
-        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(new AuthorizeState { State = "a" }, "p", false, Now, Binding, clientKey: null, out _));
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out var firstWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "b" }, "p", false, Now, Binding, clientKey: null, out var firstWarn));
         Assert.True(firstWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, clientKey: null, providerInformation: null, out var secondWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "c" }, "p", false, Now.AddSeconds(1), Binding, clientKey: null, out var secondWarn));
         Assert.False(secondWarn);
 
-        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, clientKey: null, providerInformation: null, out var nextIntervalWarn));
+        Assert.False(store.TryAdd(new AuthorizeState { State = "d" }, "p", false, Now + PruneInterval, Binding, clientKey: null, out var nextIntervalWarn));
         Assert.True(nextIntervalWarn);
     }
 
@@ -482,7 +496,7 @@ public class OidcStateStoreTests
                 {
                     for (var i = 0; i < perTask; i++)
                     {
-                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, clientKey: null, providerInformation: null, out _))
+                        if (!store.TryAdd(new AuthorizeState { State = $"t{id}-k{i}" }, "p", false, Now, Binding, clientKey: null, out _))
                         {
                             Interlocked.Increment(ref rejected);
                         }
@@ -606,39 +620,39 @@ public class OidcStateStoreTests
     {
         // The core fairness property: filling client "A" to its per-key share must not deny "B".
         var store = Store(maxEntries: 200); // per-key cap 2
-        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
-        Assert.True(store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
-        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out var warn)); // A at share
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _));
+        Assert.True(store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _));
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out var warn)); // A at share
         Assert.True(warn); // the throttled capacity warning fires for the first per-client refusal
 
-        Assert.True(store.TryAdd(State("b1"), "p", false, Now, Binding, clientKey: "B", providerInformation: null, out _)); // B unaffected
+        Assert.True(store.TryAdd(State("b1"), "p", false, Now, Binding, clientKey: "B", out _)); // B unaffected
     }
 
     [Fact]
     public void TryAdd_ReleaseOnRedeem_ReadmitsTheSameKey()
     {
         var store = Store(maxEntries: 200); // per-key cap 2
-        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
-        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
-        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // full
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
+        Assert.False(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _)); // full
 
         Validate(store, "a1");
         Assert.NotNull(store.TryRedeem("a1", "p", Now, Binding)); // frees one A slot
-        Assert.True(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("a3"), "p", false, Now, Binding, clientKey: "A", out _));
     }
 
     [Fact]
     public void TryAdd_ReleaseOnExpirySweep_ReadmitsTheSameKey()
     {
         var store = Store(maxEntries: 200); // per-key cap 2
-        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
-        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _);
+        store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _);
+        store.TryAdd(State("a2"), "p", false, Now, Binding, clientKey: "A", out _);
 
         // Past the lifetime and the prune interval, the sweep removes both A entries and releases their
         // slots, so A can add again. (Lifetime and PruneInterval are the test fixture's small values.)
         var later = Now + Lifetime + PruneInterval + TimeSpan.FromSeconds(1);
         store.PruneExpired(later);
-        Assert.True(store.TryAdd(State("a3"), "p", false, later, Binding, clientKey: "A", providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("a3"), "p", false, later, Binding, clientKey: "A", out _));
     }
 
     [Fact]
@@ -648,13 +662,13 @@ public class OidcStateStoreTests
         // a "A" add reserves A's slot but is refused by the GLOBAL cap and must roll back. After a slot
         // frees, "A" must still admit — a leaked reservation would leave A at its cap of 1.
         var store = Store(maxEntries: 2);
-        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
-        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _));
 
-        Assert.False(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // global cap
+        Assert.False(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // global cap
         Validate(store, "n1");
         Assert.NotNull(store.TryRedeem("n1", "p", Now, Binding)); // free one global slot
-        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", providerInformation: null, out _)); // no leak
+        Assert.True(store.TryAdd(State("a1"), "p", false, Now, Binding, clientKey: "A", out _)); // no leak
     }
 
     [Fact]
@@ -663,9 +677,9 @@ public class OidcStateStoreTests
         // Global cap 2 -> per-key cap 1. A null (proxy/unattributable) key is never sub-capped: null adds
         // succeed past a per-key cap of 1 up to the GLOBAL cap, then are refused by the global cap.
         var store = Store(maxEntries: 2);
-        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _));
-        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _)); // past per-key 1
-        Assert.False(store.TryAdd(State("n3"), "p", false, Now, Binding, clientKey: null, providerInformation: null, out _)); // global cap
+        Assert.True(store.TryAdd(State("n1"), "p", false, Now, Binding, clientKey: null, out _));
+        Assert.True(store.TryAdd(State("n2"), "p", false, Now, Binding, clientKey: null, out _)); // past per-key 1
+        Assert.False(store.TryAdd(State("n3"), "p", false, Now, Binding, clientKey: null, out _)); // global cap
     }
 
     [Fact]
@@ -675,10 +689,10 @@ public class OidcStateStoreTests
         // each per distinct key, then a further distinct key is refused (global cap) and the existing
         // entries survive (refuse-not-evict).
         var store = Store(maxEntries: 3); // per-key cap 1
-        Assert.True(store.TryAdd(State("k1"), "p", false, Now, Binding, clientKey: "K1", providerInformation: null, out _));
-        Assert.True(store.TryAdd(State("k2"), "p", false, Now, Binding, clientKey: "K2", providerInformation: null, out _));
-        Assert.True(store.TryAdd(State("k3"), "p", false, Now, Binding, clientKey: "K3", providerInformation: null, out _));
-        Assert.False(store.TryAdd(State("k4"), "p", false, Now, Binding, clientKey: "K4", providerInformation: null, out _)); // global cap
+        Assert.True(store.TryAdd(State("k1"), "p", false, Now, Binding, clientKey: "K1", out _));
+        Assert.True(store.TryAdd(State("k2"), "p", false, Now, Binding, clientKey: "K2", out _));
+        Assert.True(store.TryAdd(State("k3"), "p", false, Now, Binding, clientKey: "K3", out _));
+        Assert.False(store.TryAdd(State("k4"), "p", false, Now, Binding, clientKey: "K4", out _)); // global cap
         Assert.NotNull(store.PeekCurrent("k1", "p", Now, Binding)); // not evicted
     }
 }

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -85,10 +85,9 @@ internal sealed class OidcStateStore
     /// <param name="now">The current time, recorded as the entry's creation instant.</param>
     /// <param name="bindingId">The browser-binding id to record on the entry, matched at the callback (#326).</param>
     /// <param name="clientKey">The normalized client key for the per-client sub-cap (#327), or null to exempt.</param>
-    /// <param name="providerInformation">The challenge's already-validated OpenID discovery metadata to carry to the callback (#247), or null.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
     /// <returns>True if the state was registered; false if refused (per-client sub-cap, global cap, or the key already existed).</returns>
-    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, string clientKey, ProviderInformation providerInformation, out bool shouldWarnCapacity)
+    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, string clientKey, out bool shouldWarnCapacity)
     {
         // Per-client sub-cap (#327): reserve this client's slot BEFORE the global insert so one source
         // cannot fill the whole budget and lock out every other login. A null key is exempt (the shared
@@ -100,7 +99,7 @@ internal sealed class OidcStateStore
         }
 
         if ((_states.Count >= _maxEntries && !_states.ContainsKey(state.State))
-            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId, ClientKey = clientKey, ProviderInformation = providerInformation }))
+            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId, ClientKey = clientKey }))
         {
             // The entry never entered the store (global cap, or a CSPRNG-token collision losing the
             // atomic add) — release the reservation so the client's bucket does not leak a slot.
@@ -111,6 +110,25 @@ internal sealed class OidcStateStore
 
         shouldWarnCapacity = false;
         return true;
+    }
+
+    /// <summary>
+    /// Records the challenge's already-fetched, policy-validated OpenID discovery metadata on an entry
+    /// <see cref="TryAdd"/> just registered, so the callback reuses it instead of re-running discovery +
+    /// JWKS (#247). Kept separate from TryAdd because it is a post-registration enrichment (a latency
+    /// optimization), not part of the entry's identity/capacity admission — and adding it as a TryAdd
+    /// parameter would push that hot-path method past the parameter-count limit. A no-op if the entry is
+    /// already gone (only reachable if it expired in the sub-millisecond gap since TryAdd, when the login
+    /// is dead anyway); the callback then falls back to a fresh discovery.
+    /// </summary>
+    /// <param name="token">The authorize-state token the entry is keyed by (the challenge's state value).</param>
+    /// <param name="providerInformation">The discovery metadata to record.</param>
+    internal void SetProviderInformation(string token, ProviderInformation providerInformation)
+    {
+        if (_states.TryGetValue(token, out var state))
+        {
+            state.ProviderInformation = providerInformation;
+        }
     }
 
     /// <summary>

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -85,9 +85,10 @@ internal sealed class OidcStateStore
     /// <param name="now">The current time, recorded as the entry's creation instant.</param>
     /// <param name="bindingId">The browser-binding id to record on the entry, matched at the callback (#326).</param>
     /// <param name="clientKey">The normalized client key for the per-client sub-cap (#327), or null to exempt.</param>
+    /// <param name="providerInformation">The challenge's already-validated OpenID discovery metadata to carry to the callback (#247), or null.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
     /// <returns>True if the state was registered; false if refused (per-client sub-cap, global cap, or the key already existed).</returns>
-    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, string clientKey, out bool shouldWarnCapacity)
+    internal bool TryAdd(AuthorizeState state, string provider, bool isLinking, DateTime now, string bindingId, string clientKey, ProviderInformation providerInformation, out bool shouldWarnCapacity)
     {
         // Per-client sub-cap (#327): reserve this client's slot BEFORE the global insert so one source
         // cannot fill the whole budget and lock out every other login. A null key is exempt (the shared
@@ -99,7 +100,7 @@ internal sealed class OidcStateStore
         }
 
         if ((_states.Count >= _maxEntries && !_states.ContainsKey(state.State))
-            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId, ClientKey = clientKey }))
+            || !_states.TryAdd(state.State, new TimedAuthorizeState(state, now) { IsLinking = isLinking, Provider = provider, BindingId = bindingId, ClientKey = clientKey, ProviderInformation = providerInformation }))
         {
             // The entry never entered the store (global cap, or a CSPRNG-token collision losing the
             // atomic add) — release the reservation so the client's bucket does not leak a slot.

--- a/SSO-Auth/Api/PendingState.cs
+++ b/SSO-Auth/Api/PendingState.cs
@@ -16,6 +16,12 @@ internal sealed class PendingState
     /// <summary>Gets the OidcClient authorize state (code_verifier, redirect URI) for the token exchange.</summary>
     internal AuthorizeState OidcState => _entry.State;
 
+    /// <summary>
+    /// Gets the challenge's already-validated OpenID discovery metadata to reuse at the callback (#247),
+    /// or null when the state predates the capture (the callback then does a fresh discovery).
+    /// </summary>
+    internal ProviderInformation ProviderInformation => _entry.ProviderInformation;
+
     /// <summary>Gets a value indicating whether this flow is a linking request rather than a login.</summary>
     internal bool IsLinking => _entry.IsLinking;
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -278,11 +278,7 @@ public class SSOController : ControllerBase
         // The client key bounds how much of the store one source can occupy (#327); a proxy/private
         // source normalizes to null and is exempt.
         var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
-
-        // Carry the discovery metadata PrepareLoginAsync just fetched and validated (against this
-        // provider's DiscoveryPolicy) to the callback, so ProcessResponseAsync reuses it instead of
-        // re-running discovery + JWKS (#247). Reuse is bounded by this state's lifetime.
-        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, clientKey, oidcClient.Options.ProviderInformation, out var shouldWarnCapacity))
+        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, clientKey, out var shouldWarnCapacity))
         {
             if (shouldWarnCapacity)
             {
@@ -291,6 +287,12 @@ public class SSOController : ControllerBase
 
             return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
         }
+
+        // Carry the discovery metadata PrepareLoginAsync just fetched and validated (against this
+        // provider's DiscoveryPolicy) to the callback, so ProcessResponseAsync reuses it instead of
+        // re-running discovery + JWKS (#247). Recorded after the state is registered; reuse is bounded
+        // by this state's lifetime.
+        StateStore.SetProviderInformation(state.State, oidcClient.Options.ProviderInformation);
 
         // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
         Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(OidcStateStore.DefaultLifetime));

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -155,7 +155,7 @@ public class SSOController : ControllerBase
             return BadRequest("Invalid or expired state");
         }
 
-        var oidcClient = CreateCallbackOidcClient(config, provider);
+        var oidcClient = CreateCallbackOidcClient(config, provider, pending.ProviderInformation);
         var result = await oidcClient.ProcessResponseAsync(Request.QueryString.Value, pending.OidcState).ConfigureAwait(false);
 
         if (result.IsError)
@@ -278,7 +278,11 @@ public class SSOController : ControllerBase
         // The client key bounds how much of the store one source can occupy (#327); a proxy/private
         // source normalizes to null and is exempt.
         var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
-        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, clientKey, out var shouldWarnCapacity))
+
+        // Carry the discovery metadata PrepareLoginAsync just fetched and validated (against this
+        // provider's DiscoveryPolicy) to the callback, so ProcessResponseAsync reuses it instead of
+        // re-running discovery + JWKS (#247). Reuse is bounded by this state's lifetime.
+        if (!StateStore.TryAdd(state, provider, isLinking, DateTime.Now, bindingId, clientKey, oidcClient.Options.ProviderInformation, out var shouldWarnCapacity))
         {
             if (shouldWarnCapacity)
             {
@@ -375,7 +379,7 @@ public class SSOController : ControllerBase
     // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
     // so the caller supplies them. Constructed in the same order as before the extraction, so a null
     // OidEndpoint still fails at the same point (the Uri constructor, after the options object).
-    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope)
+    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope, ProviderInformation providerInformation = null)
     {
         var options = new OidcClientOptions
         {
@@ -400,6 +404,23 @@ public class SSOController : ControllerBase
         // config toggle: an unvalidated id_token is a forgeable login (#134).
         options.Policy.RequireIdentityTokenSignature = true;
         options.IdentityTokenValidator = new OidcIdTokenValidator();
+
+        // Reuse the challenge's already-fetched, policy-validated discovery metadata when the callback
+        // supplies it (#247), so ProcessResponseAsync does not re-run discovery + JWKS. Pre-assigning
+        // ProviderInformation sets the client's internal _useDiscovery = false, which also disables the
+        // library's invalid_signature JWKS-refresh-and-retry. Two directions of key change, both bounded
+        // by the authorize state's ~15-minute lifetime: a key rotated IN during the window (the id_token
+        // signed by a key the challenge did not capture) fails this callback closed and self-heals on
+        // retry (the next challenge fetches fresh keys); a key rotated OUT / revoked during the window
+        // stays accepted until the state expires, since the callback validates against the captured
+        // set — a far tighter exposure than the platform-default 24-hour JWKS cache, and never wider than
+        // the state lifetime. Populated only from a validated fetch (never hand-filled), so the
+        // DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed.
+        if (providerInformation is not null)
+        {
+            options.ProviderInformation = providerInformation;
+        }
+
         return new OidcClient(options);
     }
 
@@ -454,10 +475,10 @@ public class SSOController : ControllerBase
     // redirect_uri matches the authorization request's as RFC 6749 requires (#98). The scope string
     // is normalized the same way as the challenge side (BuildScopeString) — both tolerate a null
     // OidScopes identically (#368).
-    private OidcClient CreateCallbackOidcClient(OidConfig config, string provider)
+    private OidcClient CreateCallbackOidcClient(OidConfig config, string provider, ProviderInformation providerInformation)
     {
         var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), Request.Path.Value, provider);
-        return CreateOidcClient(config, redirectUri, BuildScopeString(config));
+        return CreateOidcClient(config, redirectUri, BuildScopeString(config), providerInformation);
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -28,6 +28,15 @@ internal sealed class TimedAuthorizeState
     public AuthorizeState State { get; set; }
 
     /// <summary>
+    /// Gets or sets the OpenID provider metadata (discovery document + JWKS) that the challenge already
+    /// fetched and the library validated against the provider's DiscoveryPolicy (#247). The callback
+    /// pre-assigns it so <c>ProcessResponseAsync</c> skips the redundant per-login discovery + JWKS
+    /// round trips. Bounded by this state's own lifetime, so it is never older than the entry; null on a
+    /// state that predates the capture, in which case the callback falls back to a fresh discovery.
+    /// </summary>
+    public ProviderInformation ProviderInformation { get; set; }
+
+    /// <summary>
     /// Gets or sets the provider that minted this state. A state may only be consumed on the same
     /// provider's endpoints, so it cannot be replayed against another provider's login/role gate.
     /// </summary>

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Duende.IdentityModel.OidcClient.Infrastructure;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -25,6 +26,13 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public SSOPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<SSOPlugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
+        // Stop the OidcClient trace serializer from JSON-serializing the full options object — the
+        // client secret included — into a transient string on every Prepare/Process call, which it does
+        // even with Trace logging off (#247). We never consume that trace output, so disabling it once
+        // at plugin load keeps the secret out of transient heap strings (defense in depth). Global and
+        // idempotent, so setting it here (the single plugin bootstrap) is sufficient.
+        LogSerializer.Enabled = false;
+
         // Handing out `() => Configuration` here is safe: BasePlugin's constructor only records the
         // config path and loads the configuration lazily on first access, so nothing calls back into
         // UpdateConfiguration (and thus ConfigStore) before this assignment completes.

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -18,6 +18,19 @@ namespace Jellyfin.Plugin.SSO_Auth;
 public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
     /// <summary>
+    /// Initializes static members of the <see cref="SSOPlugin"/> class.
+    /// </summary>
+    static SSOPlugin()
+    {
+        // Stop the OidcClient trace serializer from JSON-serializing the full options object — the
+        // client secret included — into a transient string on every Prepare/Process call, which it does
+        // even with Trace logging off (#247). We never consume that trace output, so disabling it in the
+        // type initializer (runs once, before any login) keeps the secret out of transient heap strings
+        // (defense in depth). The flag is a process-global, so setting it here covers every login.
+        LogSerializer.Enabled = false;
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SSOPlugin"/> class.
     /// </summary>
     /// <param name="applicationPaths">Internal Jellyfin interface for the ApplicationPath.</param>
@@ -26,13 +39,6 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public SSOPlugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, ILogger<SSOPlugin> logger)
         : base(applicationPaths, xmlSerializer)
     {
-        // Stop the OidcClient trace serializer from JSON-serializing the full options object — the
-        // client secret included — into a transient string on every Prepare/Process call, which it does
-        // even with Trace logging off (#247). We never consume that trace output, so disabling it once
-        // at plugin load keeps the secret out of transient heap strings (defense in depth). Global and
-        // idempotent, so setting it here (the single plugin bootstrap) is sufficient.
-        LogSerializer.Enabled = false;
-
         // Handing out `() => Configuration` here is safe: BasePlugin's constructor only records the
         // config path and loads the configuration lazily on first access, so nothing calls back into
         // UpdateConfiguration (and thus ConfigStore) before this assignment completes.


### PR DESCRIPTION
# What & why

Every OpenID login re-ran discovery and JWKS **twice**, once at the challenge and again at the
callback, because `OidcClient` stores `ProviderInformation` only on the per-request options instance
and refetches per call. On top of the necessary token/userinfo calls that is 2 discovery + 2 JWKS
round trips per login (~200 ms to 1 s of added latency at WAN RTT), and one IdP hit per anonymous
request under a challenge flood (outbound amplification).

This carries the metadata the challenge already fetched and validated to the callback, the issue's
bounded, no-policy-bypass measure:

- The challenge's `PrepareLoginAsync` populates `oidcClient.Options.ProviderInformation` from a fetch
  validated against the provider's `DiscoveryPolicy` (`RequireHttps` / `ValidateIssuerName` /
  `ValidateEndpoints`). Stash it on the authorize state (`OidcStateStore.TryAdd` →
  `TimedAuthorizeState` → `PendingState`), bounded by the state's ~15-minute lifetime.
- The callback pre-assigns it into `CreateOidcClient`, so `ProcessResponseAsync` reuses it instead of
  re-running discovery + JWKS. A null value (a state predating the capture, e.g. an in-flight login
  across the upgrade) falls back to a fresh discovery, unchanged.
- Pre-assigning sets the library's internal `_useDiscovery = false`, which also disables its
  `invalid_signature` JWKS-refresh-retry. Bounded and self-healing: a signing-key rotation inside the
  15-minute window fails that one callback closed, the user retries, and the next challenge fetches
  fresh keys. Reuse is only ever from a policy-validated fetch, so no `DiscoveryPolicy` bypass is
  introduced.

Also: stop the `OidcClient` trace serializer from JSON-serializing the full options object, **client
secret included**, into a transient string on every `Prepare`/`Process` call (it does so even with
Trace logging off). `LogSerializer.Enabled = false` once at plugin load keeps the secret out of
transient heap strings (defense in depth).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: reused metadata comes only from a `DiscoveryPolicy`-validated challenge
      fetch; the disabled refresh-retry fails a key-rotation callback closed (retryable), never open.
- [x] No secrets logged; secrets redacted on export. `ProviderInformation` carries only the public
      issuer/endpoints/JWKS — no secret. `LogSerializer.Enabled = false` actively removes a transient
      client-secret serialization.
- [x] A security review was performed: 4-lens refute-by-default gate + the OIDC domain reviewer.
- [x] Log inputs from the IdP are sanitized inline at the log call (no log calls added).

## Quality checklist

- [x] No duplicated logic; the metadata is captured once and threaded through the existing state store.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; comments explain the security/latency *why* and the `_useDiscovery` trade-off.
- [x] Architecture-conformance tests pass; no new structural property introduced.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (0 warnings, 0 errors).
- [x] `dotnet test` is green (823/823).
- [x] Prettier is clean (no tracked `.js`/`.html`/`.md`/`.css` changed).

## Notes

Login-path/crypto change → the adversarial-review gate is load-bearing. The 4-lens gate plus the OIDC
domain reviewer ran; **bypass, availability, correctness, and integration all PASS**, the availability
and integration lenses verified against the decompiled Duende 7.1.0 IL that the challenge captures the
**full** published JWKS (so a static multi-key set and any advance-published/overlapping rotated key
validate at the callback), that pre-assigning `ProviderInformation` sets `_useDiscovery = false` and
skips the callback discovery+JWKS while the captured `KeySet` still drives signature validation, and
that the reused value is always the challenge's own policy-validated fetch (no bypass, carries no
secret, strictly-more-restrictive fail-closed).

The **OIDC domain reviewer** returned NEEDS_IMPROVEMENT on two points, dispositioned as follows:

- **FIXED**, the security-direction consequence (a rotated-out / **revoked** key stays accepted for up
  to the ~15-minute state window, since the callback validates against the captured set) is now
  documented at the pre-assignment in `CreateOidcClient` and in the E2E checklist. It is a far tighter
  exposure than the platform-default 24-hour JWKS cache and never wider than the state lifetime.
- **DECLINED (reasoned)**, an end-to-end fetch-count regression test. The store→`PendingState`
  round-trip and the null-fallback are unit-tested; the Duende skip-fetch mechanism is IL-verified by
  the gate and empirically verified in the issue. A full challenge→callback fetch-count test requires
  the `SSOController` integration harness that does not exist yet (tracked by #192), so the behavior is
  captured as an explicit live-IdP release-QA item in the E2E checklist rather than blocking on that
  harness here.

Testability: unit tests pin that the store round-trips `ProviderInformation` to the callback and that a
null value falls back to discovery. The actual 4→2 fetch reduction and the key-rotation fallback are a
Duende-library behavior verified empirically in the issue and captured as a live-IdP release-QA item
(E2E checklist, local process doc). The full per-provider TTL cache the issue also sketches (serving
cross-login reuse, the #141 PKCE probe, and #210) is intentionally out of scope here, this delivers the
bounded half-measure with no `DiscoveryPolicy` bypass.

Closes #247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Streamlined OIDC sign-in callbacks by reusing previously validated provider discovery information, reducing redundant discovery and JWKS requests.

* **Security**
  * Prevented sensitive client configuration, including client secrets, from being serialized into transient diagnostic traces during authentication.

* **Reliability**
  * Added safeguards for expired or missing authentication state and supported fallback discovery when provider information is unavailable.

* **Tests**
  * Expanded coverage for provider-information reuse, missing state handling, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->