### PR TITLE
Characterize the OIDC callback against COAT and session fixation

### DIFF
--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -23,7 +23,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <see cref="SSOControllerEndpointTests"/> / <see cref="SSOControllerAdminTests"/>.
 ///
 /// Two of the tests characterize the callback end-to-end against the OAuth 2.0 Security BCP update
-/// draft-ietf-oauth-security-topics-update-01 (2026-07) threat classes that apply to this RP (#176):
+/// (draft-ietf-oauth-security-topics-update, rev -03 dated 2026-07-06) threat classes that apply to
+/// this RP (#176):
 /// Cross-toolkit OAuth Account Takeover (COAT) — a state minted in one named provider's context cannot
 /// complete against another configured provider's callback — and cross-user session fixation — a state
 /// token observed by a party in a different browser cannot complete the flow. The store-level mechanisms
@@ -74,8 +75,8 @@ public class SSOControllerOidPostTests
     public async Task OidPost_StateMintedForAnotherProvider_RejectedOnThisProvidersCallback()
     {
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        // COAT (draft-ietf-oauth-security-topics-update-01, 2026-07, #176): this plugin is a
-        // multi-provider OAuth client (OidConfigs is a dict of named providers), so a response minted in
+        // COAT (OAuth 2.0 Security BCP update, draft-ietf-oauth-security-topics-update, #176): this
+        // plugin is a multi-provider OAuth client (OidConfigs is a dict of named providers), so a response minted in
         // one provider's context must not complete against another's callback. The state is keyed by its
         // token, so the lookup FINDS it under "kc2" — but PeekCurrent rejects it because the route
         // provider does not match the provider recorded on the state, before any token exchange. Both

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -21,6 +21,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// match the id_token issuer is refused (RFC 9207 mix-up check, #125). The guard branches (unknown
 /// provider, missing/invalid/expired state, disabled, rate-limit) are covered in
 /// <see cref="SSOControllerEndpointTests"/> / <see cref="SSOControllerAdminTests"/>.
+///
+/// Two of the tests characterize the callback end-to-end against the OAuth 2.0 Security BCP update
+/// draft-ietf-oauth-security-topics-update-01 (2026-07) threat classes that apply to this RP (#176):
+/// Cross-toolkit OAuth Account Takeover (COAT) — a state minted in one named provider's context cannot
+/// complete against another configured provider's callback — and cross-user session fixation — a state
+/// token observed by a party in a different browser cannot complete the flow. The store-level mechanisms
+/// these rely on are pinned in <see cref="OidcStateStoreTests"/> (provider-scoped peek/redeem, the
+/// browser-binding gate, and the one-time atomic claim); the mint-path one-time-consume is pinned in
+/// <see cref="SSOControllerOidAuthTests"/>.
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerOidPostTests
@@ -55,6 +64,47 @@ public class SSOControllerOidPostTests
         // body is the uniform invalid-state message, so a wrong-browser hit is indistinguishable from an
         // expiry.
         var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", bindingCookie: null);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal("Invalid or expired state", Assert.IsType<BadRequestObjectResult>(result).Value);
+    }
+
+    [Fact]
+    public async Task OidPost_StateMintedForAnotherProvider_RejectedOnThisProvidersCallback()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // COAT (draft-ietf-oauth-security-topics-update-01, 2026-07, #176): this plugin is a
+        // multi-provider OAuth client (OidConfigs is a dict of named providers), so a response minted in
+        // one provider's context must not complete against another's callback. The state is keyed by its
+        // token, so the lookup FINDS it under "kc2" — but PeekCurrent rejects it because the route
+        // provider does not match the provider recorded on the state, before any token exchange. Both
+        // providers are enabled, so this isolates the provider-context binding from the unknown/disabled
+        // guard.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", secondProvider: "kc2");
+
+        var crossContext = await harness.Controller.OidPost("kc2", "state-1");
+        Assert.Equal("Invalid or expired state", Assert.IsType<BadRequestObjectResult>(crossContext).Value);
+
+        // Positive control: PeekCurrent does not consume, so the same state still completes on the
+        // provider it WAS minted for — proving the rejection above is the provider-context binding, not an
+        // unrelated failure of the shared fixture.
+        var sameContext = await harness.Controller.OidPost("kc", "state-1");
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(sameContext).ContentType);
+    }
+
+    [Fact]
+    public async Task OidPost_StateTokenPresentedFromADifferentBrowser_RejectedAsInvalidState()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // Cross-user session fixation (same BCP update, #176): an attacker who observes/fixates the state
+        // token still cannot complete the flow from their own browser. The callback requires the
+        // browser-binding cookie the challenge recorded (#326); the attacker's browser carries a DIFFERENT
+        // value, not the victim's. A present-but-mismatched cookie (not merely an absent one, covered by
+        // OidPost_MissingBindingCookie) is refused, proving the binding check requires equality, not mere
+        // presence. Once the victim completes, the one-time atomic claim prevents replay/handoff (pinned
+        // end-to-end by OidAuth_ValidState_ProvisionsAccountReturnsOk_AndIsSingleUse).
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", bindingCookie: "attacker-other-browser-binding");
 
         var result = await harness.Controller.OidPost("kc", "state-1");
 
@@ -109,19 +159,32 @@ public class SSOControllerOidPostTests
         string query,
         string? idToken = null,
         bool tokenEndpointFails = false,
-        string? bindingCookie = Binding)
+        string? bindingCookie = Binding,
+        string? secondProvider = null)
     {
         idToken ??= fixture.IdToken(subject: "sub-1", username: "alice");
 
+        OidConfig NewProvider() => new()
+        {
+            Enabled = true,
+            OidEndpoint = Authority,
+            OidClientId = "jf",
+            OidScopes = Array.Empty<string>(),
+            DisablePushedAuthorization = true,
+            DoNotLoadProfile = true, // the id_token carries sub + preferred_username; skip the userinfo fetch
+        };
+
         var harness = new SsoControllerHarness(
-            c => c.OidConfigs["kc"] = new OidConfig
+            c =>
             {
-                Enabled = true,
-                OidEndpoint = Authority,
-                OidClientId = "jf",
-                OidScopes = Array.Empty<string>(),
-                DisablePushedAuthorization = true,
-                DoNotLoadProfile = true, // the id_token carries sub + preferred_username; skip the userinfo fetch
+                c.OidConfigs["kc"] = NewProvider();
+
+                // A second enabled provider so a COAT test can hit its callback with a state minted for
+                // "kc" and isolate the provider-context binding from the unknown/disabled-provider guard.
+                if (secondProvider is not null)
+                {
+                    c.OidConfigs[secondProvider] = NewProvider();
+                }
             },
             httpResponder: request =>
             {


### PR DESCRIPTION
# What & why

`draft-ietf-oauth-security-topics-update-01` (IETF, 2026-07-06) adds two OAuth threat classes that apply to this plugin's RP/client role: **Cross-toolkit OAuth Account Takeover (COAT)** and **cross-user session fixation**. This verifies the existing OpenID callback already fails closed against both and pins the two named attack shapes end-to-end. Closes #176.

**Conclusion: both defenses hold by construction, this is test-only, no production change** (exactly the outcome #176 anticipates: "if either test fails closed already, document and close as verified rather than changing code").

- **COAT** is closed by the provider-scoped state lookup. The callback binds the state to the **route** provider, `OidcStateStore.IsCurrentFor` / `IsRedeemableBy` compare `state.Provider` to the route value on *every* consuming path (`OidPost`, `OidAuth`, `OidLink`), and the same route value selects both the state check and the token-exchange config (`FindOidConfig(provider)` / `CreateCallbackOidcClient`), so the initiating and completing contexts cannot be split.
- **Session fixation** is closed by the browser-binding gate (#326). A `__Host-` cookie recorded at challenge must *equal* the id on the state before it is honored (`AuthorizeStateBinding.Matches`), so a state observed by a party in a different browser cannot complete the flow; the `__Host-` prefix blocks cookie-tossing from a sibling subdomain, and the one-time atomic claim (`TryRemove`) then prevents replay/handoff.

Two other BCP classes are out of scope and documented as such: audience injection needs `private_key_jwt` (this plugin uses `ClientSecret`); shared consent needs a broker role (this plugin is an RP, not a broker).

Adds two controller-level characterization tests filling the gaps the store-level suite did not cover end-to-end:

- `OidPost_StateMintedForAnotherProvider_RejectedOnThisProvidersCallback`, with two enabled providers, a state minted for one is rejected on the other's callback. Asserting the invalid-state body (distinct from the unknown-provider body) isolates the provider-context binding from the unknown/disabled-provider guard; a positive control proves the same state still completes on its own provider (`PeekCurrent` is non-consuming).
- `OidPost_StateTokenPresentedFromADifferentBrowser_RejectedAsInvalidState`, a present-but-mismatched binding cookie is refused, proving the binding check requires equality, not mere presence (distinct from the existing absent-cookie test).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (830/830, two new tests).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).

## Notes

- Independent verification: a focused two-lens gate (security-bypass + correctness) read the full production paths, not just the diff, and independently confirmed (a) no COAT or session-fixation bypass exists on any of the three consuming paths (`provider` is always the trusted route value, the binding is checked on every path, `__Host-` blocks cookie-tossing, unbound/absent/empty all fail closed), and (b) both new tests are non-vacuous: each would flip to a failing assertion if its defense were removed or weakened to presence-only. Both returned PASS.
- The two new tests characterize the `OidPost` peek path end-to-end; the redeem-path (`OidAuth`/`OidLink`) and store-primitive equivalents remain pinned in `OidcStateStoreTests` (`TryRedeem_CrossProviderReplay`, `TryRedeem_MismatchedBinding`, `TryRedeem_EntryWithNoBindingId`, `TryRedeem_ClaimSucceedsOnce_ThenReplayIsRejected`) and `SSOControllerOidAuthTests` (`OidAuth_ValidState_...AndIsSingleUse`), which the new tests cross-reference in their docstring.
- Minor, deliberately not changed: `ArrangeCallback` keeps `Request.Path = "/sso/OID/redirect/kc"` even for the COAT test's cross-context call, harmless because that call rejects at `PeekCurrent` before the path is read (the review flagged and cleared this as a non-defect).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for SSO OidPost callback security.
  * Added scenarios to ensure authorization state tokens are rejected when presented to the wrong provider.
  * Added scenarios to ensure state tokens are rejected when presented from a different browser session.
  * Kept a positive control to confirm valid state tokens still complete successfully with the correct provider and matching browser binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->