### PR TITLE
Re-check the identity link before minting an SSO session

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -208,18 +208,27 @@ public class ArchitectureConformanceTests
         // revocation predicate (identityStillLinked) as the last gate before it authenticates the session,
         // so a refactor cannot silently drop it or reorder it after the mint and reopen the TOCTOU between
         // link-resolution (under the config lock) and AuthenticateDirect (outside it). Call-level property,
-        // so it is a source scan like the controller rules above: the predicate INVOCATION must appear and
-        // its line must precede the single AuthenticateDirect call. The invocation "identityStillLinked()"
-        // is distinct from the parameter declaration/param-doc (no parentheses), so it matches only the gate.
+        // so it is a source scan like the controller rules above. The invocation "identityStillLinked()"
+        // is distinct from the parameter declaration/param-doc (no parentheses), so it matches only a gate.
+        // The FINAL gate is what closes the race, so this pins the LAST invocation before the mint (an
+        // earlier pre-mutation gate must not satisfy the rule) AND that no user-mutating side effect sits
+        // between that final gate and AuthenticateDirect — otherwise a revocation during that work would go
+        // unre-checked.
         var minterSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SessionMinter.cs"));
-        var recheckLine = Array.FindIndex(minterSource, l => l.Contains("identityStillLinked()", StringComparison.Ordinal));
         var mintLine = Array.FindIndex(minterSource, l => l.Contains("AuthenticateDirect(", StringComparison.Ordinal));
-
-        Assert.True(recheckLine >= 0, "SessionMinter.MintAsync must invoke the identityStillLinked revocation re-check (#232).");
         Assert.True(mintLine >= 0, "SessionMinter.MintAsync must call AuthenticateDirect to mint the session.");
-        Assert.True(
-            recheckLine < mintLine,
-            "The #232 revocation re-check must run BEFORE AuthenticateDirect — it is the last fail-closed gate before the session mint.");
+
+        var finalGate = Array.FindLastIndex(minterSource, mintLine - 1, l => l.Contains("identityStillLinked()", StringComparison.Ordinal));
+        Assert.True(finalGate >= 0, "SessionMinter.MintAsync must invoke the identityStillLinked revocation re-check before AuthenticateDirect (#232).");
+
+        var mutationMarkers = new[] { "UpdateUserAsync", "SetPermission", "SetPreference", "TrySetAsync", "AuthenticationProviderId =" };
+        var interveningMutation = minterSource
+            .Skip(finalGate + 1)
+            .Take(mintLine - finalGate - 1)
+            .Any(l => mutationMarkers.Any(m => l.Contains(m, StringComparison.Ordinal)));
+        Assert.False(
+            interveningMutation,
+            "No user-mutating side effect may sit between the final #232 revocation re-check and AuthenticateDirect — the re-check must be the last gate before the mint.");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -202,6 +202,27 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void SessionMinter_RechecksRevocationImmediatelyBeforeTheMint()
+    {
+        // Locked in by the in-flight revocation gate (#232): MintAsync must evaluate the caller-supplied
+        // revocation predicate (identityStillLinked) as the last gate before it authenticates the session,
+        // so a refactor cannot silently drop it or reorder it after the mint and reopen the TOCTOU between
+        // link-resolution (under the config lock) and AuthenticateDirect (outside it). Call-level property,
+        // so it is a source scan like the controller rules above: the predicate INVOCATION must appear and
+        // its line must precede the single AuthenticateDirect call. The invocation "identityStillLinked()"
+        // is distinct from the parameter declaration/param-doc (no parentheses), so it matches only the gate.
+        var minterSource = File.ReadAllLines(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "SessionMinter.cs"));
+        var recheckLine = Array.FindIndex(minterSource, l => l.Contains("identityStillLinked()", StringComparison.Ordinal));
+        var mintLine = Array.FindIndex(minterSource, l => l.Contains("AuthenticateDirect(", StringComparison.Ordinal));
+
+        Assert.True(recheckLine >= 0, "SessionMinter.MintAsync must invoke the identityStillLinked revocation re-check (#232).");
+        Assert.True(mintLine >= 0, "SessionMinter.MintAsync must call AuthenticateDirect to mint the session.");
+        Assert.True(
+            recheckLine < mintLine,
+            "The #232 revocation re-check must run BEFORE AuthenticateDirect — it is the last fail-closed gate before the session mint.");
+    }
+
+    [Fact]
     public void SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade()
     {
         // Locked in by the ProviderConfigStore extraction (#318): SSOPlugin is bootstrap + page

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -574,6 +574,128 @@ public class CanonicalLinkServiceTests
         Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
     }
 
+    // --- IsIdentityStillLinked (#232): the in-flight revocation gate re-checked just before the mint ---
+
+    [Fact]
+    public void IsIdentityStillLinked_LiveEnabledLink_ReturnsTrue()
+    {
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        Assert.True(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_SamlLiveEnabledLink_ReturnsTrue()
+    {
+        // Both protocols share the gate; SAML keys on the NameID.
+        var (service, _, users, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        Assert.True(service.IsIdentityStillLinked("saml", "adfs", "alice", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_AfterRevocation_ReturnsFalse()
+    {
+        // The #232 scenario: the link was resolved, then RemoveUserEverywhere (Unregister) removed it, so
+        // the mint-time re-check now fails closed even though the user still exists.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        service.RemoveUserEverywhere(Existing);
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_ProviderDisabledMidFlight_ReturnsFalse()
+    {
+        // #380: a provider disabled between resolution and the mint fails the re-check, so the login
+        // cannot mint with the provider's pre-disable settings.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        cfg.OidConfigs["kc"].Enabled = false;
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_UnknownProvider_ReturnsFalse()
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        Assert.False(service.IsIdentityStillLinked("oid", "does-not-exist", "sub-1", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_UnknownKey_ReturnsFalse()
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-unknown", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_LinkedToADifferentUser_ReturnsFalse()
+    {
+        // Fail closed if the link now points at another user (e.g. the identity was re-linked): the
+        // resolved user must still be the one the link names.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Other },
+        });
+        users.GetUserById(Other).Returns(UserNamed("bob", Other));
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+    }
+
+    [Fact]
+    public void IsIdentityStillLinked_DanglingLinkTargetDeleted_ReturnsFalse()
+    {
+        // A link whose target user was deleted is dead, not an identity — GetUserById returns null.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns((User?)null);
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsIdentityStillLinked_EmptyOrWhitespaceKey_ReturnsFalse(string? canonicalKey)
+    {
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        Assert.False(service.IsIdentityStillLinked("oid", "kc", canonicalKey, Existing));
+    }
+
     [Fact]
     public async Task ResolveOrCreateAsync_ProviderDisabled_RefusesLikeADeletedOne()
     {

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -66,11 +66,14 @@ public class SessionMinterTests
         users.GetUserById(UserId).Returns((User?)null);
         var resolverInvoked = false;
 
-        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () =>
-        {
-            resolverInvoked = true;
-            return "203.0.113.7";
-        }));
+        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(
+            Params(),
+            () =>
+            {
+                resolverInvoked = true;
+                return "203.0.113.7";
+            },
+            () => true));
 
         await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
         // The deferred-evaluation contract of the resolver (the reason it is a Func): the fail-closed
@@ -89,7 +92,7 @@ public class SessionMinterTests
         AuthenticationRequest? captured = null;
         sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(), () => "203.0.113.7");
+        await minter.MintAsync(Params(), () => "203.0.113.7", () => true);
 
         Assert.NotNull(captured);
         Assert.Equal("203.0.113.7", captured!.RemoteEndPoint);
@@ -113,7 +116,8 @@ public class SessionMinterTests
 
         await minter.MintAsync(
             Params(enableAuthorization: true, isAdmin: true, enableAllFolders: false, enabledFolders: new[] { "lib-1" }, enableLiveTv: true, enableLiveTvManagement: true),
-            () => "203.0.113.7");
+            () => "203.0.113.7",
+            () => true);
 
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value);
         Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value); // flipped from the seeded true
@@ -133,7 +137,7 @@ public class SessionMinterTests
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), () => "203.0.113.7");
+        await minter.MintAsync(Params(enableAuthorization: true, enableAllFolders: true), () => "203.0.113.7", () => true);
 
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableAllFolders && perm.Value); // flipped from the seeded restriction
     }
@@ -151,7 +155,7 @@ public class SessionMinterTests
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
-        await minter.MintAsync(Params(enableAuthorization: false, isAdmin: false), () => "203.0.113.7");
+        await minter.MintAsync(Params(enableAuthorization: false, isAdmin: false), () => "203.0.113.7", () => true);
 
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value); // seeded admin left untouched
     }
@@ -172,9 +176,57 @@ public class SessionMinterTests
         string? providerAtWrite = null;
         users.UpdateUserAsync(Arg.Do<User>(u => providerAtWrite = u.AuthenticationProviderId)).Returns(Task.CompletedTask);
 
-        await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), () => "203.0.113.7");
+        await minter.MintAsync(Params(defaultProvider: "SSO-Auth"), () => "203.0.113.7", () => true);
 
         Assert.Equal("SSO-Auth", providerAtWrite);
         await users.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task MintAsync_IdentityRevokedInFlight_ThrowsAndMintsNoSession()
+    {
+        // #232: the account resolved under the config lock, but an admin revocation (Unregister / link
+        // delete / provider disable) committed before the mint, so the revocation re-check returns false
+        // and the mint is refused — fail closed exactly like the deleted-user guard, no session minted.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+
+        await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () => "203.0.113.7", () => false));
+
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+    }
+
+    [Fact]
+    public async Task MintAsync_RevocationRecheck_RunsAfterTheUserWrite_AndImmediatelyBeforeTheMint()
+    {
+        // Pins the placement that makes the #232 window as small as possible: the re-check is the LAST
+        // gate — it runs after the permission/avatar/default-provider user write and immediately before
+        // AuthenticateDirect. A recording predicate captures the order: UpdateUserAsync must have happened
+        // before it fires, and AuthenticateDirect must not have happened yet.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        users.GetUserById(UserId).Returns(user);
+
+        var userWritten = false;
+        var mintCalled = false;
+        users.UpdateUserAsync(Arg.Any<User>()).Returns(_ => { userWritten = true; return Task.CompletedTask; });
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(_ => { mintCalled = true; return new AuthenticationResult(); });
+
+        var writtenAtRecheck = false;
+        var mintedAtRecheck = false;
+        await minter.MintAsync(
+            Params(),
+            () => "203.0.113.7",
+            () =>
+            {
+                writtenAtRecheck = userWritten;
+                mintedAtRecheck = mintCalled;
+                return true;
+            });
+
+        Assert.True(writtenAtRecheck); // the user write already happened when the re-check ran
+        Assert.False(mintedAtRecheck); // the mint had not happened yet
+        Assert.True(mintCalled); // and with a true re-check the mint did proceed
     }
 }

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -183,27 +183,29 @@ public class SessionMinterTests
     }
 
     [Fact]
-    public async Task MintAsync_IdentityRevokedInFlight_ThrowsAndMintsNoSession()
+    public async Task MintAsync_IdentityRevokedInFlight_ThrowsWithoutWritingTheUserOrMintingASession()
     {
         // #232: the account resolved under the config lock, but an admin revocation (Unregister / link
-        // delete / provider disable) committed before the mint, so the revocation re-check returns false
-        // and the mint is refused — fail closed exactly like the deleted-user guard, no session minted.
+        // delete / provider disable) committed before the mint, so the revocation re-check returns false.
+        // The first gate refuses BEFORE any user side effect, so no grants are persisted and no session is
+        // minted — fail closed exactly like the deleted-user guard.
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
         users.GetUserById(UserId).Returns(user);
 
         await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () => "203.0.113.7", () => false));
 
-        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>()); // no grants/avatar/provider persisted
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>()); // no session
     }
 
     [Fact]
-    public async Task MintAsync_RevocationRecheck_RunsAfterTheUserWrite_AndImmediatelyBeforeTheMint()
+    public async Task MintAsync_RevocationRecheck_RunsBeforeTheUserWrite_AndAgainImmediatelyBeforeTheMint()
     {
-        // Pins the placement that makes the #232 window as small as possible: the re-check is the LAST
-        // gate — it runs after the permission/avatar/default-provider user write and immediately before
-        // AuthenticateDirect. A recording predicate captures the order: UpdateUserAsync must have happened
-        // before it fires, and AuthenticateDirect must not have happened yet.
+        // Pins the two-gate placement (#232): the predicate is evaluated once BEFORE the user side
+        // effects (so a revoked login persists no grants) and once as the LAST gate after the write and
+        // immediately before AuthenticateDirect (so a revocation landing mid-mint still yields no session).
+        // A recording predicate captures the state at each firing.
         var (minter, users, sessions) = Build();
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
         users.GetUserById(UserId).Returns(user);
@@ -213,20 +215,20 @@ public class SessionMinterTests
         users.UpdateUserAsync(Arg.Any<User>()).Returns(_ => { userWritten = true; return Task.CompletedTask; });
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(_ => { mintCalled = true; return new AuthenticationResult(); });
 
-        var writtenAtRecheck = false;
-        var mintedAtRecheck = false;
+        var states = new System.Collections.Generic.List<(bool Written, bool Minted)>();
         await minter.MintAsync(
             Params(),
             () => "203.0.113.7",
             () =>
             {
-                writtenAtRecheck = userWritten;
-                mintedAtRecheck = mintCalled;
+                states.Add((userWritten, mintCalled));
                 return true;
             });
 
-        Assert.True(writtenAtRecheck); // the user write already happened when the re-check ran
-        Assert.False(mintedAtRecheck); // the mint had not happened yet
-        Assert.True(mintCalled); // and with a true re-check the mint did proceed
+        Assert.Equal(2, states.Count); // both gates fired
+        Assert.False(states[0].Written); // the first gate ran before the user write
+        Assert.True(states[^1].Written); // the final gate ran after the user write
+        Assert.False(states[^1].Minted); // and before the mint
+        Assert.True(mintCalled); // with both gates true, the mint proceeded
     }
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -409,11 +409,13 @@ internal sealed class CanonicalLinkService
     /// The in-flight revocation gate (#232): a login resolves the account under the config lock but the
     /// session mint runs after the lock is released, so an admin Unregister (or a link delete, or a
     /// provider disable) that lands in that gap would otherwise still mint a session for the just-revoked
-    /// identity. Re-reading the authoritative link map here, as the last check before the mint, fails such
-    /// a login closed. It does not close the race outright — a revocation committing between this read and
-    /// the mint call still mints once — but it shrinks the window to that single unavoidable gap (the mint
-    /// cannot be held under the lock, which is async). Every unknown resolves to false (missing/whitespace
-    /// key, missing or disabled provider, missing/mismatched link, deleted target), so it is fail closed.
+    /// identity. The mint flow re-reads this predicate twice — before applying the user side effects (so a
+    /// revoked login persists no grants) and again as the last check before the mint (so a revocation
+    /// landing mid-mint still yields no session). The final check does not close the race outright — a
+    /// revocation committing between it and the mint call still mints once — but it shrinks the window to
+    /// that single unavoidable gap (the mint cannot be held under the lock, which is async). Every unknown
+    /// resolves to false (missing/whitespace key, missing or disabled provider, missing/mismatched link,
+    /// deleted target), so it is fail closed.
     /// </remarks>
     /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
     /// <param name="provider">The provider the login authenticated against.</param>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -398,6 +398,42 @@ internal sealed class CanonicalLinkService
         });
     }
 
+    /// <summary>
+    /// Whether the SSO identity may still mint a session for the given user: the provider exists and is
+    /// enabled, its canonical-links map still holds <paramref name="canonicalKey"/> pointing at
+    /// <paramref name="userId"/>, and that user still exists. Read under the config lock, so it is
+    /// linearized against a concurrent revocation (<see cref="RemoveUserEverywhere"/> /
+    /// <see cref="TryRemoveLink"/>) or a mid-flight provider disable.
+    /// </summary>
+    /// <remarks>
+    /// The in-flight revocation gate (#232): a login resolves the account under the config lock but the
+    /// session mint runs after the lock is released, so an admin Unregister (or a link delete, or a
+    /// provider disable) that lands in that gap would otherwise still mint a session for the just-revoked
+    /// identity. Re-reading the authoritative link map here, as the last check before the mint, fails such
+    /// a login closed. It does not close the race outright — a revocation committing between this read and
+    /// the mint call still mints once — but it shrinks the window to that single unavoidable gap (the mint
+    /// cannot be held under the lock, which is async). Every unknown resolves to false (missing/whitespace
+    /// key, missing or disabled provider, missing/mismatched link, deleted target), so it is fail closed.
+    /// </remarks>
+    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="provider">The provider the login authenticated against.</param>
+    /// <param name="canonicalKey">The stable identity key the link is stored under (OpenID sub / SAML NameID).</param>
+    /// <param name="userId">The Jellyfin user the login resolved to.</param>
+    /// <returns>True only when a live, enabled link for this identity still points at the user.</returns>
+    internal bool IsIdentityStillLinked(string mode, string provider, string canonicalKey, Guid userId)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalKey))
+        {
+            return false;
+        }
+
+        return _configStore.Read(configuration =>
+            TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links)
+            && links.TryGetValue(canonicalKey, out var linkedId)
+            && linkedId == userId
+            && _userManager.GetUserById(linkedId) != null);
+    }
+
     // Atomically links canonicalKey to candidateUserId unless a live link already exists for it (#133).
     // The existence check and the write are ONE Mutate read-modify-write, so two concurrent first-logins
     // for the same identity cannot both write or both adopt: the loser observes the winner's link and

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -690,7 +690,7 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
         }
 
-        var authenticationResult = await Authenticate(new SessionParameters
+        var sessionParameters = new SessionParameters
         {
             UserId = userId,
             IsAdmin = redeemed.Admin,
@@ -702,7 +702,10 @@ public class SSOController : ControllerBase
             AuthResponse = response,
             DefaultProvider = config.DefaultProvider?.Trim(),
             AvatarUrl = redeemed.AvatarUrl,
-        }).ConfigureAwait(false);
+        };
+        var authenticationResult = await Authenticate(
+            sessionParameters,
+            () => _canonicalLinks.IsIdentityStillLinked("oid", provider, redeemed.Subject, userId)).ConfigureAwait(false);
         SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, redeemed.Username, redeemed.Admin);
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
     }
@@ -1043,7 +1046,7 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
         }
 
-        var authenticationResult = await Authenticate(new SessionParameters
+        var sessionParameters = new SessionParameters
         {
             UserId = userId,
             IsAdmin = derived.Admin,
@@ -1055,7 +1058,10 @@ public class SSOController : ControllerBase
             AuthResponse = response,
             DefaultProvider = config.DefaultProvider?.Trim(),
             AvatarUrl = null,
-        }).ConfigureAwait(false);
+        };
+        var authenticationResult = await Authenticate(
+            sessionParameters,
+            () => _canonicalLinks.IsIdentityStillLinked("saml", provider, nameId, userId)).ConfigureAwait(false);
         SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
     }
@@ -1312,8 +1318,8 @@ public class SSOController : ControllerBase
     // logic of its own) to the SessionMinter flow. The resolver is passed rather than the value so the
     // flow evaluates it at the exact original point (after avatar/persistence, and NOT at all on the
     // fail-closed deleted-user path) — the pre-extraction Authenticate read it inline there.
-    private Task<AuthenticationResult> Authenticate(SessionParameters parameters) =>
-        _sessionMinter.MintAsync(parameters, () => HttpContext.GetNormalizedRemoteIP().ToString());
+    private Task<AuthenticationResult> Authenticate(SessionParameters parameters, Func<bool> identityStillLinked) =>
+        _sessionMinter.MintAsync(parameters, () => HttpContext.GetNormalizedRemoteIP().ToString(), identityStillLinked);
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
     // request may proceed, else a 429 carrying Retry-After. Reads the settings under the config

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -36,7 +36,7 @@ internal sealed class SessionMinter
     /// </summary>
     /// <param name="parameters">The resolved user, granted privileges, and client identity.</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (the controller reads it from <c>HttpContext</c>, #177). Invoked at the original point below — after avatar/persistence, and not at all on the fail-closed path — to preserve evaluation order.</param>
-    /// <param name="identityStillLinked">The in-flight revocation gate (#232): re-checks, under the config lock, that the resolved identity is still linked. Evaluated as the last act before the session mint; false fails closed. Required (no default) so a mint path cannot silently omit it and fail open.</param>
+    /// <param name="identityStillLinked">The in-flight revocation gate (#232): re-checks, under the config lock, that the resolved identity is still linked. Evaluated twice — before any user side effect (so a revoked login persists no grants) and again as the last act before the session mint (so a revocation landing mid-method still yields no session); false fails closed. Required (no default) so a mint path cannot silently omit it and fail open.</param>
     /// <returns>The authenticated session result.</returns>
     internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, Func<string> remoteEndPointResolver, Func<bool> identityStillLinked)
     {
@@ -46,6 +46,16 @@ internal sealed class SessionMinter
             // Fail closed: the account resolved for this SSO login no longer exists (e.g. it was
             // deleted between resolution and this call), so no session may be minted for it.
             throw new AuthenticationException("SSO authentication aborted: the target user does not exist.");
+        }
+
+        // First revocation gate (#232), BEFORE any user side effect: a login already revoked between
+        // resolution (under the config lock) and here must not persist the SSO-derived permission,
+        // avatar, or default-provider changes onto the account an admin is locking down. The final gate
+        // below still catches a revocation that commits later in this method. Fail closed exactly like
+        // the deleted-user guard above; the same AuthenticationException, no new error contract.
+        if (!identityStillLinked())
+        {
+            throw new AuthenticationException("SSO authentication aborted: the identity is no longer linked (revoked in flight).");
         }
 
         if (parameters.EnableAuthorization)
@@ -95,10 +105,9 @@ internal sealed class SessionMinter
         authRequest.RemoteEndPoint = remoteEndPointResolver();
         _logger.LogInformation("Auth request created...");
 
-        // Last gate before the mint (#232): resolution ran under the config lock but everything since —
-        // permissions, avatar, the user write — has not, so an admin revocation (Unregister / link delete
-        // / provider disable) that landed in that gap must still stop the session. Fail closed exactly like
-        // the deleted-user guard above; the same AuthenticationException, no new error contract.
+        // Final revocation gate (#232), the LAST act before the mint: a revocation that committed during
+        // the permission/avatar/user-write work above must still stop the session. This is the gate that
+        // closes the login race; the earlier one only spares the side effects. Same fail-closed abort.
         if (!identityStillLinked())
         {
             throw new AuthenticationException("SSO authentication aborted: the identity is no longer linked (revoked in flight).");

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -36,8 +36,9 @@ internal sealed class SessionMinter
     /// </summary>
     /// <param name="parameters">The resolved user, granted privileges, and client identity.</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (the controller reads it from <c>HttpContext</c>, #177). Invoked at the original point below — after avatar/persistence, and not at all on the fail-closed path — to preserve evaluation order.</param>
+    /// <param name="identityStillLinked">The in-flight revocation gate (#232): re-checks, under the config lock, that the resolved identity is still linked. Evaluated as the last act before the session mint; false fails closed. Required (no default) so a mint path cannot silently omit it and fail open.</param>
     /// <returns>The authenticated session result.</returns>
-    internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, Func<string> remoteEndPointResolver)
+    internal async Task<AuthenticationResult> MintAsync(SessionParameters parameters, Func<string> remoteEndPointResolver, Func<bool> identityStillLinked)
     {
         User user = _userManager.GetUserById(parameters.UserId);
         if (user is null)
@@ -93,6 +94,15 @@ internal sealed class SessionMinter
         // client byte-for-byte.
         authRequest.RemoteEndPoint = remoteEndPointResolver();
         _logger.LogInformation("Auth request created...");
+
+        // Last gate before the mint (#232): resolution ran under the config lock but everything since —
+        // permissions, avatar, the user write — has not, so an admin revocation (Unregister / link delete
+        // / provider disable) that landed in that gap must still stop the session. Fail closed exactly like
+        // the deleted-user guard above; the same AuthenticationException, no new error contract.
+        if (!identityStillLinked())
+        {
+            throw new AuthenticationException("SSO authentication aborted: the identity is no longer linked (revoked in flight).");
+        }
 
         return await _sessionManager.AuthenticateDirect(authRequest).ConfigureAwait(false);
     }


### PR DESCRIPTION
# What & why

An SSO login resolves the account under the config lock (`CanonicalLinkService.ResolveOrCreateAsync`), but the session mint (`SessionMinter.MintAsync` → `ISessionManager.AuthenticateDirect`) runs after the lock is released. An admin revocation that commits in that gap, `Unregister` removing the canonical links, a link delete, or a provider disable, would otherwise still mint one session for the just-revoked identity (#232, TOCTOU / CWE-863). Closes #232.

Design chosen via a 3-approach design panel (revocation-epoch vs. session-termination vs. in-lock re-check), judged against the repo order **security > minimal code > readability**. The **in-lock link re-check** won: identical race-closure to the epoch with **zero new state**, cannot mass-lock by construction, and additionally fail-closes an in-flight login whose link was removed via `DeleteCanonicalLink` or whose provider was disabled mid-flight (#380). (Design 2, immediate session termination via `ISessionManager.RevokeUserTokens`, does not close the race and is tracked as its own hardening item, see Notes.)

- `CanonicalLinkService.IsIdentityStillLinked(mode, provider, canonicalKey, userId)`: a pure predicate that reads the authoritative link map under the config lock (reusing `TryGetLinks(..., requireEnabled: true)`) and returns true only when the provider exists and is enabled, its map still holds `canonicalKey → userId`, and that user still exists. Empty/whitespace key → false. Every unknown → false, so it fails closed.
- `SessionMinter.MintAsync` gains a **required** `Func<bool>` gate (no default, so a mint path cannot silently omit it and fail open), evaluated immediately before `AuthenticateDirect`; false throws the same `AuthenticationException` the deleted-user guard uses, no session, no new error contract.
- Both callbacks thread the protocol-specific key through the shared `Authenticate` helper: OpenID re-checks `redeemed.Subject`, SAML re-checks `nameId`, the same keys the resolution linked under.
- `ArchitectureConformanceTests.SessionMinter_RechecksRevocationImmediatelyBeforeTheMint` pins (source scan) that the re-check runs before `AuthenticateDirect`, so a refactor cannot silently drop or reorder it.

The re-check and the revocation take the same static config lock, so they linearize (the mint sees either the pre- or post-revocation state, never torn). This shrinks the window to the irreducible gap between the lock release and `AuthenticateDirect`, unclosable without holding the lock across the async mint, which would serialize every login; documented on the method.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (844/844, new predicate matrix, mint-gate, ordering, and conformance tests).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).

## Notes

- **Adversarial review (full 4-lens gate: availability/mass-lockout, security-bypass, correctness, integration): PASS across the board.** The lenses independently verified: the re-check and the revoker take the *same* static `Sync` lock (so they genuinely linearize, the fix is not illusory); `AuthenticateDirect` has exactly one call site and `MintAsync` one caller, both gated, with the required param making a fail-open-by-omission impossible; `requireEnabled: true` is the correct grant-path polarity; the re-check keys on the exact key every resolution arm commits (reuse/adopt/create/#133-race-loser/#155-legacy-migration), so no legitimate login is falsely rejected; the throw is not swallowed into a success; the config lock is released before the async mint (the availability property is preserved); no NRE/500 or secret-log regression.
- **Two-phase gate (addresses a CodeRabbit CWE-863 comment, folded into this PR):** the review flagged that on a revoked-in-flight *deny* the permission/avatar/`AuthenticationProviderId` `UpdateUserAsync` write had already committed before the re-check refused, so a revoked account would keep updated grants (though still no session). `MintAsync` now re-checks revocation **twice**: an early gate before any user side effect (so a revoked login persists no grants) and the retained final gate immediately before the mint (the one that closes the login race). A follow-up commit strengthened the conformance rule to pin the *last* re-check before the mint with no user mutation between it and `AuthenticateDirect`. Both CodeRabbit comments (the CWE-863 finding and the conformance-rule brittleness) were fixed and confirmed by an independent bypass-lens re-review of the delta (no happy-path false-reject; the early gate is strictly additive fail-closed).
- **Design 2 tracked separately:** immediate termination of the user's existing sessions on `Unregister` via `ISessionManager.RevokeUserTokens(user.Id, null)` is a complementary measure (it kills *already-established* sessions but does not close the in-flight race), filed as its own hardening issue.
- Behaviour is pinned by `SessionMinterTests` (revoked→throws+no-mint, ordering), `CanonicalLinkServiceTests` (the full predicate matrix: live/revoked/disabled/unknown-provider/unknown-key/wrong-user/dangling-target/empty-key, exercising the real in-memory config-lock `Read`), and the new `ArchitectureConformanceTests` rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Added an in-flight “last gate” validation to ensure the SSO identity is still linked immediately before session minting.
  - Session issuance now fails closed if the identity is revoked/unlinked, the provider becomes invalid/disabled, the canonical key is unknown/invalid, the link no longer matches the resolved user, or the target user is deleted.
  - Applies to both OpenID and SAML flows, with a two-step recheck.

- **Tests**
  - Expanded canonical-link coverage for true/false scenarios and input validation.
  - Updated session-minting tests for the new validation predicate, including timing/sequencing expectations.
  - Added an architecture conformance check for the recheck ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->