### PR TITLE
Tighten SAML assertion conformance: signatures, audience, bearer

### DIFF
--- a/SSO-Auth.Tests/SamlAttackShapeTests.cs
+++ b/SSO-Auth.Tests/SamlAttackShapeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Xml;
 using Jellyfin.Plugin.SSO_Auth;
 using Xunit;
@@ -215,6 +216,110 @@ public class SamlAttackShapeTests
         Assert.False(response.IsValid());
         Assert.NotEqual("attacker", response.GetNameID());
         Assert.Equal("alice", response.GetNameID());
+    }
+
+    // --- Strict-conformance shapes (#238): single signature, per-restriction audience, bearer method ---
+
+    [Fact]
+    public void IsValid_HonestlySignedOnBothResponseAndAssertion_ReturnsTrue()
+    {
+        // #238 (1): the Web Browser SSO profile permits signing BOTH the Response and the Assertion
+        // (Keycloak "Sign Documents" + "Sign Assertions", Azure AD "Sign response and assertion", ADFS
+        // MessageAndAssertion), so a doubly-signed honest response must be ACCEPTED — every position-bound
+        // signature validates, which is what the validator now requires.
+        Assert.True(Load(SamlTestFactory.CreateDoublySigned()).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_DoublySignedButOneSignatureInvalid_ReturnsFalse()
+    {
+        // #238 (1): with two position-bound signatures EVERY one must validate — not just the first in
+        // document order. The Assertion-level signature stays honest (it is first in document order, so a
+        // first-wins reading would accept the response), but the Response-level signature is corrupted, so
+        // the response is rejected. This pins "validate all, not first-wins" and closes the ambiguity of
+        // multiple signatures without rejecting the honest doubly-signed case above.
+        var fixture = SamlTestFactory.CreateDoublySigned();
+        var doc = fixture.Document;
+        foreach (XmlElement signature in doc.GetElementsByTagName("Signature", DsNs))
+        {
+            // The Response-level signature is the one whose parent is the Response root (the
+            // Assertion-level one's parent is the Assertion). Corrupt only its SignatureValue.
+            if (signature.ParentNode == doc.DocumentElement)
+            {
+                var signatureValue = (XmlElement)signature.GetElementsByTagName("SignatureValue", DsNs)[0]!;
+                // Flip one signature byte and re-encode: still valid base64 (so it is not rejected merely
+                // as malformed at load time) but a wrong signature, so the Response-level signature fails
+                // the actual cryptographic CheckSignature against the pinned cert.
+                var bytes = Convert.FromBase64String(signatureValue.InnerText.Trim());
+                bytes[0] ^= 0xFF;
+                signatureValue.InnerText = Convert.ToBase64String(bytes);
+                break;
+            }
+        }
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValidAudience_PresentInEveryRestriction_ReturnsTrue()
+    {
+        // Positive control for #238 (2): SAML 2.0 allows multiple <AudienceRestriction> blocks; the SP is
+        // addressed when it appears in EVERY one. Our audience is in both, so the response is accepted.
+        var fixture = SamlTestFactory.Create(
+            scope: SamlTestFactory.SignatureScope.Response,
+            audienceRestrictions: new[] { new[] { "https://sp.example.com" }, new[] { "https://sp.example.com", "https://other.example.com" } });
+
+        Assert.True(Load(fixture).IsValid("https://sp.example.com"));
+    }
+
+    [Fact]
+    public void IsValidAudience_PresentInOnlyOneOfTwoRestrictions_ReturnsFalse()
+    {
+        // #238 (2): the first <AudienceRestriction> names ANOTHER SP and only the second names us. SAML
+        // 2.0 requires the SP in every restriction (AND across blocks), so this is not strictly addressed
+        // to us; the old OR-over-the-union accepted it, the AND rejects it.
+        var fixture = SamlTestFactory.Create(
+            scope: SamlTestFactory.SignatureScope.Response,
+            audienceRestrictions: new[] { new[] { "https://other.example.com" }, new[] { "https://sp.example.com" } });
+
+        Assert.False(Load(fixture).IsValid("https://sp.example.com"));
+    }
+
+    [Fact]
+    public void IsValid_NonBearerSubjectConfirmationMethod_ReturnsFalse()
+    {
+        // #238 (3): a holder-of-key confirmation carries no bearer token (its key-possession proof is not
+        // verified here). The Web Browser SSO profile is a bearer profile, so an assertion offering only a
+        // non-bearer confirmation is rejected. A Conditions upper bound is set so the time check is not
+        // what rejects — this isolates the bearer-method check.
+        var fixture = SamlTestFactory.Create(
+            subjectConfirmationMethod: "urn:oasis:names:tc:SAML:2.0:cm:holder-of-key",
+            conditionsNotOnOrAfter: DateTime.UtcNow.AddMinutes(5));
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_SubjectConfirmationWithNoMethod_ReturnsFalse()
+    {
+        // A SubjectConfirmation with no Method at all is likewise not a bearer confirmation. Same
+        // Conditions-bound isolation as above.
+        var fixture = SamlTestFactory.Create(
+            subjectConfirmationMethod: null,
+            conditionsNotOnOrAfter: DateTime.UtcNow.AddMinutes(5));
+
+        Assert.False(Load(fixture).IsValid());
+    }
+
+    [Fact]
+    public void IsValid_BearerConfirmationWithConditionsBound_ReturnsTrue()
+    {
+        // Positive control isolating the bearer-method check: identical to the two rejects above except
+        // the confirmation Method IS bearer, so the response is accepted — proving the method value is
+        // what flips those cases, not the time bound or another guard.
+        var fixture = SamlTestFactory.Create(conditionsNotOnOrAfter: DateTime.UtcNow.AddMinutes(5));
+
+        Assert.True(Load(fixture).IsValid());
     }
 
     // Builds an unsigned attacker-controlled assertion with the given NameID, shaped like a real one

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -62,7 +62,9 @@ internal static class SamlTestFactory
         bool includeAdviceAssertion = false,
         string? recipient = null,
         string? inResponseTo = null,
-        string? destination = null)
+        string? destination = null,
+        string? subjectConfirmationMethod = "urn:oasis:names:tc:SAML:2.0:cm:bearer",
+        string[][]? audienceRestrictions = null)
     {
         var audienceList = audiences ?? (audience == null ? null : new[] { audience });
         const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
@@ -93,8 +95,26 @@ internal static class SamlTestFactory
 
         var subjectConfirmationData = "<saml:SubjectConfirmationData" + subjectConfirmationAttributes + " />";
 
+        // One <AudienceRestriction> per inner array when audienceRestrictions is set (for the multi-block
+        // AND tests), else a single restriction from audienceList as before.
+        var restrictionBlocks = new StringBuilder();
+        var effectiveRestrictions = audienceRestrictions ?? (audienceList == null ? null : new[] { audienceList });
+        if (effectiveRestrictions != null)
+        {
+            foreach (var block in effectiveRestrictions)
+            {
+                var audienceElements = new StringBuilder();
+                foreach (var a in block)
+                {
+                    audienceElements.Append("<saml:Audience>" + a + "</saml:Audience>");
+                }
+
+                restrictionBlocks.Append("<saml:AudienceRestriction>" + audienceElements + "</saml:AudienceRestriction>");
+            }
+        }
+
         var conditions = string.Empty;
-        if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue || audienceList != null)
+        if (conditionsNotBefore.HasValue || conditionsNotOnOrAfter.HasValue || restrictionBlocks.Length > 0)
         {
             var attributes = new StringBuilder();
             if (conditionsNotBefore.HasValue)
@@ -107,21 +127,9 @@ internal static class SamlTestFactory
                 attributes.Append(" NotOnOrAfter=\"" + conditionsNotOnOrAfter.Value.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"");
             }
 
-            var body = string.Empty;
-            if (audienceList != null)
-            {
-                var audienceElements = new StringBuilder();
-                foreach (var a in audienceList)
-                {
-                    audienceElements.Append("<saml:Audience>" + a + "</saml:Audience>");
-                }
-
-                body = "<saml:AudienceRestriction>" + audienceElements + "</saml:AudienceRestriction>";
-            }
-
-            conditions = body.Length == 0
+            conditions = restrictionBlocks.Length == 0
                 ? "<saml:Conditions" + attributes + " />"
-                : "<saml:Conditions" + attributes + ">" + body + "</saml:Conditions>";
+                : "<saml:Conditions" + attributes + ">" + restrictionBlocks + "</saml:Conditions>";
         }
 
         var destinationAttribute = destination == null ? string.Empty : " Destination=\"" + SecurityElement.Escape(destination) + "\"";
@@ -140,7 +148,7 @@ internal static class SamlTestFactory
                     advice +
                     "<saml:Subject>" +
                         (includeNameId ? "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" : string.Empty) +
-                        "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
+                        "<saml:SubjectConfirmation" + (subjectConfirmationMethod == null ? string.Empty : " Method=\"" + SecurityElement.Escape(subjectConfirmationMethod) + "\"") + ">" +
                             subjectConfirmationData +
                         "</saml:SubjectConfirmation>" +
                     "</saml:Subject>" +
@@ -204,6 +212,50 @@ internal static class SamlTestFactory
         var document = new XmlDocument { PreserveWhitespace = true };
         document.LoadXml(xml);
 
+        SignElement(document, responseId, rsa, certificate, useSha1: false, useWithCommentsC14n: false, useInclusiveC14n: false);
+
+        return new SamlFixture(certificate, document, responseId, assertionId);
+    }
+
+    /// <summary>
+    /// Produces a response signed on BOTH the Response element AND the Assertion element (with the same
+    /// key/cert), the ambiguous "two signatures" shape the single-signature invariant (#238) rejects.
+    /// The assertion is signed first, then the response, so the response signature covers the already-signed
+    /// assertion and both verify individually.
+    /// </summary>
+    /// <returns>A fixture whose document carries a Response-level and an Assertion-level signature.</returns>
+    internal static SamlFixture CreateDoublySigned()
+    {
+        const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        var notOnOrAfter = DateTime.UtcNow.AddMinutes(5).ToString(TimeFormat, CultureInfo.InvariantCulture);
+
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test SAML IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var responseId = "_" + Guid.NewGuid().ToString("N");
+        var assertionId = "_" + Guid.NewGuid().ToString("N");
+
+        var xml =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
+                    "<saml:Issuer>https://idp.example.com</saml:Issuer>" +
+                    "<saml:Subject>" +
+                        "<saml:NameID>alice</saml:NameID>" +
+                        "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\">" +
+                            "<saml:SubjectConfirmationData NotOnOrAfter=\"" + notOnOrAfter + "\" />" +
+                        "</saml:SubjectConfirmation>" +
+                    "</saml:Subject>" +
+                    "<saml:AttributeStatement>" +
+                        "<saml:Attribute Name=\"Role\"><saml:AttributeValue>jellyfin-users</saml:AttributeValue></saml:Attribute>" +
+                    "</saml:AttributeStatement>" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(xml);
+
+        SignElement(document, assertionId, rsa, certificate, useSha1: false, useWithCommentsC14n: false, useInclusiveC14n: false);
         SignElement(document, responseId, rsa, certificate, useSha1: false, useWithCommentsC14n: false, useInclusiveC14n: false);
 
         return new SamlFixture(certificate, document, responseId, assertionId);

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -31,6 +31,15 @@ internal sealed class SamlResponse
     private const string SignatureXPath =
         "/samlp:Response/ds:Signature | /samlp:Response/saml:Assertion/ds:Signature";
 
+    // The bearer SubjectConfirmationData required by the SAML 2.0 Web Browser SSO profile: the data
+    // element under a SubjectConfirmation whose Method is the bearer URN. Every SubjectConfirmationData
+    // read is scoped to it so a non-bearer confirmation (e.g. holder-of-key, which the profile pairs with
+    // a key-possession proof this SP does not verify) is never consumed as if it were the bearer token
+    // (#238). Kept as one constant shared by IsValid's presence check and every reader so they cannot
+    // diverge.
+    private const string BearerSubjectConfirmationDataXPath =
+        "/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation[@Method='urn:oasis:names:tc:SAML:2.0:cm:bearer']/saml:SubjectConfirmationData";
+
     private readonly X509Certificate2 _certificate;
     private readonly XmlDocument _xmlDoc;
     private readonly XmlNamespaceManager _xmlNameSpaceManager; // we need this one to run our XPath queries on the SAML XML
@@ -119,17 +128,29 @@ internal sealed class SamlResponse
             return false;
         }
 
-        var signatureElement = (XmlElement)signatureNodes[0];
-
         try
         {
-            var signedXml = new SignedXml(_xmlDoc);
-            signedXml.LoadXml(signatureElement);
+            // EVERY position-bound signature must independently validate — its reference must cover the
+            // Response root or the single Assertion, its algorithms must be allowed, and it must verify
+            // against the pinned certificate (#238). The Web Browser SSO profile permits signing the
+            // Response, the Assertion, or BOTH; validating all of them (rather than only the first in
+            // document order) removes the "which signature is authoritative" ambiguity without rejecting
+            // a conformant IdP that signs both — a second, non-verifying signature rejects the whole
+            // response, so an attacker cannot slip a decoy alongside a valid one.
+            foreach (XmlElement signatureElement in signatureNodes)
+            {
+                var signedXml = new SignedXml(_xmlDoc);
+                signedXml.LoadXml(signatureElement);
 
-            return ValidateSignatureReference(signedXml, signatureElement)
-                && IsSignatureAlgorithmAllowed(signedXml)
-                && signedXml.CheckSignature(_certificate, true)
-                && IsWithinTimeBounds();
+                if (!ValidateSignatureReference(signedXml, signatureElement)
+                    || !IsSignatureAlgorithmAllowed(signedXml)
+                    || !signedXml.CheckSignature(_certificate, true))
+                {
+                    return false;
+                }
+            }
+
+            return IsWithinTimeBounds() && HasBearerSubjectConfirmation();
         }
         catch (Exception ex) when (ex is CryptographicException or ArgumentException or FormatException or XmlException)
         {
@@ -196,7 +217,7 @@ internal sealed class SamlResponse
             return false;
         }
 
-        return GetAudiences().Any(audience => string.Equals(audience, expectedAudience, StringComparison.Ordinal));
+        return IsAddressedTo(expectedAudience);
     }
 
     /// <summary>
@@ -231,26 +252,34 @@ internal sealed class SamlResponse
         }
     }
 
-    private List<string> GetAudiences()
+    // Whether the assertion is addressed to us: SAML 2.0 requires the SP to appear in EVERY
+    // <AudienceRestriction> (AND across restrictions, OR within one). Accepting on a match in ANY single
+    // restriction (the old .Any over the flattened union) would honor an assertion whose first restriction
+    // names a different SP and whose second names us — one not strictly addressed to this service provider
+    // (#238). Fail closed on no restriction at all: an assertion carrying no AudienceRestriction is not
+    // addressed to anyone in particular and must not pass the audience check.
+    private bool IsAddressedTo(string expectedAudience)
     {
-        var output = new List<string>();
-        var nodes = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:Conditions/saml:AudienceRestriction/saml:Audience", _xmlNameSpaceManager);
-        if (nodes != null)
+        var restrictions = _xmlDoc.SelectNodes("/samlp:Response/saml:Assertion[1]/saml:Conditions/saml:AudienceRestriction", _xmlNameSpaceManager);
+        if (restrictions == null || restrictions.Count == 0)
         {
-            foreach (XmlNode node in nodes)
+            return false;
+        }
+
+        foreach (XmlNode restriction in restrictions)
+        {
+            var audiences = restriction.SelectNodes("saml:Audience", _xmlNameSpaceManager);
+            // Trim so a pretty-printed assertion (indentation/newlines around the value) still compares
+            // equal; the assertion is signed, so trimming does not weaken the check.
+            var present = audiences != null && audiences.Cast<XmlNode>()
+                .Any(node => string.Equals(node?.InnerText?.Trim(), expectedAudience, StringComparison.Ordinal));
+            if (!present)
             {
-                // Trim so a pretty-printed assertion (indentation/newlines around the value) still
-                // compares equal; skip whitespace-only audiences. The assertion is signed, so
-                // trimming does not weaken the check.
-                var value = node?.InnerText?.Trim();
-                if (!string.IsNullOrEmpty(value))
-                {
-                    output.Add(value);
-                }
+                return false;
             }
         }
 
-        return output;
+        return true;
     }
 
     /// <summary>
@@ -276,7 +305,7 @@ internal sealed class SamlResponse
         var xpaths = new[]
         {
             "/samlp:Response/saml:Assertion[1]/saml:Conditions",
-            "/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData",
+            BearerSubjectConfirmationDataXPath,
         };
 
         foreach (var xpath in xpaths)
@@ -349,7 +378,7 @@ internal sealed class SamlResponse
     // A missing or unparseable upper bound is a rejection, not an accept-forever (the old behavior).
     private bool IsWithinTimeBounds()
     {
-        var subjectConfirmationData = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager);
+        var subjectConfirmationData = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager);
         var conditions = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Conditions", _xmlNameSpaceManager);
 
         return SamlAssertionTime.IsWithinValidity(
@@ -358,6 +387,15 @@ internal sealed class SamlResponse
             conditions?.Attributes?["NotOnOrAfter"]?.Value,
             DateTime.UtcNow,
             SamlAssertionTime.ClockSkew);
+    }
+
+    // The Web Browser SSO profile is a bearer profile: the (signed) assertion must carry a bearer
+    // SubjectConfirmation with its confirmation data. Asserting its presence — after the signature is
+    // verified — rejects an assertion that offers only a non-bearer confirmation (e.g. holder-of-key),
+    // which would otherwise be consumed with no key-possession proof (#238).
+    private bool HasBearerSubjectConfirmation()
+    {
+        return _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) != null;
     }
 
     /// <summary>
@@ -380,7 +418,7 @@ internal sealed class SamlResponse
     /// <returns>The Recipient attribute, or null when absent.</returns>
     public string GetRecipient()
     {
-        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager) as XmlElement;
+        var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var recipient = node?.GetAttribute("Recipient");
         return string.IsNullOrEmpty(recipient) ? null : recipient;
     }
@@ -394,7 +432,7 @@ internal sealed class SamlResponse
     /// <returns>The InResponseTo attribute, or null when absent.</returns>
     public string GetInResponseTo()
     {
-        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation/saml:SubjectConfirmationData", _xmlNameSpaceManager) as XmlElement;
+        var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var inResponseTo = node?.GetAttribute("InResponseTo");
         return string.IsNullOrEmpty(inResponseTo) ? null : inResponseTo;
     }


### PR DESCRIPTION
# What & why

A standing adversarial SAML review found the core fail-closed with no exploitable bypass on the default posture, but flagged three points where the validator was more permissive than the SAML 2.0 profile requires. Each is a self-contained, fail-closed tightening. Closes #238.

1. **Every position-bound signature must validate.** `IsValid()` used to validate only the first `ds:Signature` in document order and ignore a second one, so which signature was authoritative was decided by position. It now requires ≥1 signature and validates **every** position-bound signature (reference covers the root or the single assertion, allowed algorithms, verifies against the pinned cert).
2. **Audience is AND across restrictions.** `IsValid(expectedAudience)` flattened every `<Audience>` across every `<AudienceRestriction>` and accepted on any match. SAML 2.0 (core §2.5.1.4) requires the SP in **every** `<AudienceRestriction>` (AND across restrictions, OR within one); `IsAddressedTo` now enforces that and fails closed when there is no restriction at all.
3. **A bearer `SubjectConfirmation` is required.** The Web Browser SSO profile (§4.1.4.2) is a bearer profile, but the readers took the first `SubjectConfirmationData` regardless of `Method`. `IsValid()` now requires a `SubjectConfirmation[@Method='...bearer']` with its data, and the Recipient / InResponseTo / time-bound reads are scoped to it, so a non-bearer (holder-of-key) confirmation is never consumed as the bearer token.

**Divergence from the issue's fix #1, made on review evidence:** the issue proposed rejecting `Count != 1`. The adversarial gate (availability + saml-domain lenses) flagged that as a **mass-lockout**: the profile explicitly permits signing **both** the Response and the Assertion (Keycloak "Sign Documents"+"Sign Assertions", Azure AD "Sign response and assertion", ADFS `MessageAndAssertion`), and rejecting `Count>1` would break every login from such a deployment with no security gain (the existing reference-coverage/enveloped-within anchoring already makes the read content signature-covered). The delivered "validate **all** signatures" approach removes the first-wins ambiguity **and** keeps doubly-signing IdPs working, strictly stronger than the old first-wins, with no availability regression. A focused 3-lens re-review of the revision returned PASS across the board.

**No user-facing docs change:** conformant IdPs are unaffected (one authoritative signature set, or both, still accepted, a single AudienceRestriction, and a bearer confirmation), so no `providers.md`/README change is needed.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (851/851; Debug, the Release test host hit the known Smart App Control `0x800711C7` launch flake, which the config-flip confirmed is not a test failure).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).

## Notes

- **Adversarial review, full 4-lens + SAML-domain gate, then a focused 3-lens re-review of the fix-1 revision: all PASS.** The gate caught the fix-1 mass-lockout (see divergence above) and drove the revision; the re-review confirmed the doubly-signed-honest case is now accepted, the doubly-signed-with-a-decoy case is rejected, and the change is strictly stronger than the pre-existing first-wins with no fail-open. FIX 2 and FIX 3 were verified spec-correct (SAML 2.0 core §2.5.1.4 / Web Browser SSO §4.1.4.2) and cannot lock out a conformant IdP.
- Characterization tests (coordinated with #153, in `SamlAttackShapeTests`): honest doubly-signed → accepted; doubly-signed with one signature's bytes flipped → rejected (pins validate-all, and the corruption reaches the real `CheckSignature`, not just base64 well-formedness); audience present in every restriction → accepted; audience present in only one of two → rejected; non-bearer and no-Method confirmations → rejected (isolated from the time-bound check); bearer positive control → accepted. `SamlTestFactory` gained `subjectConfirmationMethod`, `audienceRestrictions`, and `CreateDoublySigned` to build these shapes against the real signature path (no crypto mock).
- The documented residual in #238 (in-process replay/request caches reset on restart) is unchanged and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Strengthened SAML signature validation to check all position-bound signatures and reject invalid or tampered signatures.
  * Improved audience validation to require the service provider in every audience restriction.
  * Enforced bearer-only subject confirmations and rejected missing or unsupported confirmation methods.
  * Added stricter validation for bearer confirmation time limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->