### PR TITLE
Update ChallengePath cross-reference now that RedirectSegment is suffix-anchored

### DIFF
--- a/SSO-Auth/Api/ChallengePath.cs
+++ b/SSO-Auth/Api/ChallengePath.cs
@@ -12,8 +12,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <c>Contains("/start/")</c> substring test, which a provider literally named <c>start</c> on the
 /// legacy route (<c>.../OID/p/start/</c>) would trip, flipping the spelling and breaking the login at
 /// the IdP's redirect_uri check (#337). Same fix family as <see cref="OidcCallbackPath.RedirectSegment"/>
-/// (#98); that one still scans for the first protocol token and should be moved to the same
-/// suffix-anchored form (#411).
+/// (#98), which now shares this suffix-anchored form (#411).
 /// </summary>
 internal static class ChallengePath
 {


### PR DESCRIPTION
# What & why

The class-level doc comment on `ChallengePath` still described
`OidcCallbackPath.RedirectSegment` as scanning for the first protocol token and
needing to be moved to the suffix-anchored form. #411 (PR #434) landed that
move, so the two helpers now share the suffix-anchored form. We reworded the
cross-reference to state that, dropping the stale "should be moved" wording.

Doc-only; no code or behavior change. The reword was checked against the current
`OidcCallbackPath.RedirectSegment`, whose comment already notes it now uses "the
same robust form as `ChallengePath.IsNewPath`".

Closes #436

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

N/A, this is a doc-comment reword only; no login-path, crypto, config, or
pipeline code is touched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Debug and Release builds both green (0 warnings); 851 tests pass;
`scripts/check-jellyfin-compat.sh` consistent. No `.js/.html/.md/.css` files
changed, so Prettier is not exercised by this diff.

## Notes

Nothing out of scope. Pure comment reword on a single line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify the relationship between two route-detection fixes and suffix-anchored behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->