### PR TITLE
Serialize the per-user avatar store against concurrent logins

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -214,6 +214,63 @@ public class AvatarServiceTests
     }
 
     [Fact]
+    public async Task StoreAsync_TwoOverlappingStores_SerializeAndTheLaterStoreWins()
+    {
+        // #400 acceptance criterion #2, the full shape: TWO real concurrent StoreAsync calls for the same
+        // user must serialize the whole save + profile-image transition, and the later store's record must
+        // be the final one (last-writer-consistent, no clobber). Deterministic via TaskCompletionSource
+        // gates, no timing: the first store's SaveImage parks mid-critical-section (holding the per-user
+        // lock) until we release it, so the second store provably cannot enter until then.
+        var locks = new KeyedLockStore(StringComparer.Ordinal);
+        var (service, providers, users, _) = Build(locks);
+        var user = UserNamed("racer");
+        var ct = TestContext.Current.CancellationToken;
+
+        var pngPath = ProfilePath("racer", ".png"); // the first store's target
+        var jpgPath = ProfilePath("racer", ".jpg"); // the second store's target (different path -> a real transition)
+        var firstInsideCriticalSection = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        providers.SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(ci =>
+            {
+                // The first store's write parks here — inside the critical section, holding the lock —
+                // until the test releases it; the second store's write completes at once.
+                if (string.Equals(ci.ArgAt<string>(2), pngPath, StringComparison.Ordinal))
+                {
+                    firstInsideCriticalSection.TrySetResult();
+                    return releaseFirst.Task;
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var first = service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+        await firstInsideCriticalSection.Task.WaitAsync(ct); // the first store now holds the per-user lock
+
+        var second = service.StoreAsync(user, new MemoryStream(new byte[] { 2 }), "image/jpeg", ".jpg");
+
+        // The second store cannot enter the critical section while the first holds the lock: its write is
+        // never issued, so the sequence is serialized rather than interleaved.
+        Assert.False(second.IsCompleted);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), "image/jpeg", jpgPath);
+
+        releaseFirst.SetResult();
+        await first;
+        await second;
+
+        // Last-writer-consistent: the final record is the second store's, written only after the first
+        // fully completed. Each store wrote exactly once, and the .png -> .jpg transition cleared the old
+        // record only after the new bytes were on disk (#377), so there is no clobber.
+        Assert.Equal(jpgPath, user.ProfileImage?.Path);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", pngPath);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/jpeg", jpgPath);
+        await users.Received(1).ClearProfileImageAsync(user);
+        Assert.Equal(0, locks.TrackedKeys); // both holders left; the map is collected
+    }
+
+    [Fact]
     public async Task StoreAsync_NoPreviousImage_AssignsWithoutClearing()
     {
         var (service, providers, users, _) = Build();

--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -51,6 +51,20 @@ public class AvatarServiceTests
         return (service, providers, users, log);
     }
 
+    // Builds a service whose store step serializes on the supplied lock, so a test can drive the #400
+    // per-user serialization deterministically (hold the key, prove StoreAsync parks). The stub handler
+    // is never invoked — these tests call StoreAsync directly, not the fetch path.
+    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build(KeyedLockStore userStoreLocks)
+    {
+        var users = Substitute.For<IUserManager>();
+        var providers = Substitute.For<IProviderManager>();
+        var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
+        var log = new CapturingLogger();
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", () => new StubHandler(new HttpResponseMessage()), userStoreLocks);
+        return (service, providers, users, log);
+    }
+
     // An allowed public URL: the stub handler answers before any connection, so the URL only needs to
     // clear the allow-list — the SSRF transport guard (ConnectCallback) is never reached here.
     private const string AllowedUrl = "https://cdn.example.com/avatar.png";
@@ -167,6 +181,36 @@ public class AvatarServiceTests
             users.ClearProfileImageAsync(user);
         });
         Assert.Equal(ProfilePath("alice", ".png"), user.ProfileImage?.Path);
+    }
+
+    [Fact]
+    public async Task StoreAsync_ConcurrentSameUser_IsSerializedAndLeavesAConsistentRecord()
+    {
+        // #400, a deterministic overlapping-call test via the injected per-user lock seam: we take the
+        // user's lock to stand in for a store already mid-flight for the SAME user, then start a real
+        // StoreAsync. While the lock is held it cannot reach SaveImage — it is serialized behind the
+        // in-flight store, proven by the held handle rather than by timing. Releasing the lock lets it run
+        // to a single consistent record. (Unrelated users never block each other — KeyedLockStoreTests.)
+        var locks = new KeyedLockStore(StringComparer.Ordinal);
+        var (service, providers, users, _) = Build(locks);
+        var user = UserNamed("racer");
+
+        Task store;
+        using (await locks.AcquireAsync(user.Username, TestContext.Current.CancellationToken))
+        {
+            store = service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+            Assert.False(store.IsCompleted); // parked before the write while the per-user lock is held
+            await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        }
+
+        await store;
+
+        // Once the in-flight store released, ours ran exactly once and left a single consistent record.
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("racer", ".png"));
+        Assert.Equal(ProfilePath("racer", ".png"), user.ProfileImage?.Path);
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        Assert.Equal(0, locks.TrackedKeys); // both holders left; the map is collected
     }
 
     [Fact]

--- a/SSO-Auth.Tests/KeyedLockStoreTests.cs
+++ b/SSO-Auth.Tests/KeyedLockStoreTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="KeyedLockStore"/> — the per-key async mutual-exclusion primitive the avatar store
+/// serializes on (#400). The overlap tests are deterministic: a held handle keeps the second acquirer
+/// parked by construction, never by timing. The collectible property (a key's holder is dropped once its
+/// last acquirer leaves) is what keeps the map from leaking a semaphore per key ever seen.
+/// </summary>
+public class KeyedLockStoreTests
+{
+    [Fact]
+    public async Task AcquireAsync_SameKey_ParksTheSecondUntilTheFirstReleases()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+
+        var first = await store.AcquireAsync("A", ct);
+        var second = store.AcquireAsync("A", ct);
+
+        // The permit is held, so the second acquire cannot complete — deterministic, not a timing race.
+        Assert.False(second.IsCompleted);
+
+        first.Dispose();
+
+        var secondHandle = await second; // now the permit is free
+        secondHandle.Dispose();
+        Assert.Equal(0, store.TrackedKeys);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_DifferentKeys_DoNotBlockEachOther()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+
+        using var a = await store.AcquireAsync("A", ct);
+        using var b = await store.AcquireAsync("B", ct); // must not wait on A's holder
+
+        Assert.Equal(2, store.TrackedKeys);
+    }
+
+    [Fact]
+    public async Task Release_DropsTheHolder_SoTheMapStaysBounded()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+
+        (await store.AcquireAsync("A", ct)).Dispose();
+        (await store.AcquireAsync("A", ct)).Dispose();
+
+        // Each key's holder is collected on its last release, so churning many one-shot keys leaks nothing.
+        Assert.Equal(0, store.TrackedKeys);
+    }
+
+    [Fact]
+    public async Task Dispose_IsIdempotent_ReleasingThePermitExactlyOnce()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+
+        var handle = await store.AcquireAsync("A", ct);
+        handle.Dispose();
+        handle.Dispose(); // a double dispose must not over-release the semaphore
+
+        // If the double dispose had leaked a permit, two acquirers could hold "A" at once. Prove it did
+        // not: while one handle is held, a second acquire stays parked.
+        using var held = await store.AcquireAsync("A", ct);
+        var contender = store.AcquireAsync("A", ct);
+        Assert.False(contender.IsCompleted);
+
+        held.Dispose();
+        (await contender).Dispose();
+        Assert.Equal(0, store.TrackedKeys);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_CancelledWait_AcquiresNothingAndLeaksNothing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        using (await store.AcquireAsync("A", ct))
+        {
+            // A wait cancelled while the permit is held must throw and drop its reference, not leave a
+            // dangling waiter that pins the holder forever.
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => store.AcquireAsync("A", cancelled.Token));
+            Assert.Equal(1, store.TrackedKeys); // only the live holder remains
+        }
+
+        Assert.Equal(0, store.TrackedKeys); // holder collected once released
+    }
+
+    [Fact]
+    public async Task AcquireAsync_UnderContentionOnOneKey_NeverAdmitsTwoAtOnce()
+    {
+        // The crux, mirroring PerClientBudgetLimiter's contention test: many tasks race the same key; the
+        // per-key semaphore admits exactly one at a time, so the observed occupancy never exceeds one.
+        var store = new KeyedLockStore(StringComparer.Ordinal);
+        var active = 0;
+        var maxActive = 0;
+        var sync = new object();
+
+        var tasks = new Task[16];
+        for (var t = 0; t < tasks.Length; t++)
+        {
+            tasks[t] = Task.Run(
+                async () =>
+                {
+                    for (var i = 0; i < 50; i++)
+                    {
+                        using (await store.AcquireAsync("A", TestContext.Current.CancellationToken))
+                        {
+                            var n = Interlocked.Increment(ref active);
+                            lock (sync)
+                            {
+                                maxActive = Math.Max(maxActive, n);
+                            }
+
+                            Interlocked.Decrement(ref active);
+                        }
+                    }
+                },
+                TestContext.Current.CancellationToken);
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(1, maxActive); // never two holders of one key at once
+        Assert.Equal(0, store.TrackedKeys); // fully collected once uncontended
+    }
+}

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -25,12 +25,20 @@ internal sealed class AvatarService
     /// <summary>The maximum avatar size accepted, enforced both against Content-Length and while streaming (#220).</summary>
     internal const long MaxAvatarBytes = 10 * 1024 * 1024;
 
+    // Serializes the store step per user across ALL logins (#400). Static because the controller builds a
+    // fresh AvatarService per request, so two concurrent same-user logins hold different instances — an
+    // instance lock would not serialize them. Keyed by user, so unrelated users never block each other,
+    // and collectible, so the map cannot leak a semaphore per username ever seen. Ordinal because the key
+    // is exactly the profile-path determinant (Path.Combine on user.Username below).
+    private static readonly KeyedLockStore SharedUserStoreLocks = new KeyedLockStore(StringComparer.Ordinal);
+
     private readonly IUserManager _userManager;
     private readonly IProviderManager _providerManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly ILogger _logger;
     private readonly string _userAgent;
     private readonly Func<HttpMessageHandler> _handlerFactory;
+    private readonly KeyedLockStore _userStoreLocks;
 
     internal AvatarService(
         IUserManager userManager,
@@ -54,13 +62,15 @@ internal sealed class AvatarService
     /// <param name="logger">The logger.</param>
     /// <param name="userAgent">The outbound User-Agent.</param>
     /// <param name="handlerFactory">Builds the message handler used for each fetch; called once per fetch and disposed after.</param>
+    /// <param name="userStoreLocks">The per-user store lock (#400); null uses the process-wide shared one. A test injects its own so it can drive the serialization deterministically.</param>
     internal AvatarService(
         IUserManager userManager,
         IProviderManager providerManager,
         IServerConfigurationManager serverConfigurationManager,
         ILogger logger,
         string userAgent,
-        Func<HttpMessageHandler> handlerFactory)
+        Func<HttpMessageHandler> handlerFactory,
+        KeyedLockStore userStoreLocks = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
         _providerManager = providerManager ?? throw new ArgumentNullException(nameof(providerManager));
@@ -68,6 +78,7 @@ internal sealed class AvatarService
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _userAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
         _handlerFactory = handlerFactory ?? throw new ArgumentNullException(nameof(handlerFactory));
+        _userStoreLocks = userStoreLocks ?? SharedUserStoreLocks;
     }
 
     /// <summary>
@@ -152,6 +163,21 @@ internal sealed class AvatarService
     /// <param name="extension">The stored extension resolved from the content-type allow-list.</param>
     /// <returns>A <see cref="Task"/> that completes when the avatar is stored and the user updated.</returns>
     internal async Task StoreAsync(User user, Stream image, string mediaType, string extension)
+    {
+        // Serialize the whole write-and-transition against other logins for THIS user (#400): two
+        // concurrent stores must not interleave the SaveImage + profile-image check/clear/assign, or one
+        // can clear or overwrite the other's record. The lock spans only the store; the HTTP fetch runs
+        // before this call (in TrySetAsync), so a slow endpoint never holds the per-user gate. Keyed by
+        // user, so unrelated users never wait on each other.
+        using (await _userStoreLocks.AcquireAsync(user.Username, CancellationToken.None).ConfigureAwait(false))
+        {
+            await StoreLockedAsync(user, image, mediaType, extension).ConfigureAwait(false);
+        }
+    }
+
+    // The store sequence proper, run under the per-user lock (#400). Extracted so the lock acquisition
+    // reads as one guarded block and the write -> transition ordering (#377) stays a single unit.
+    private async Task StoreLockedAsync(User user, Stream image, string mediaType, string extension)
     {
         var newPath = Path.Combine(
             _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,

--- a/SSO-Auth/Api/KeyedLockStore.cs
+++ b/SSO-Auth/Api/KeyedLockStore.cs
@@ -95,6 +95,9 @@ internal sealed class KeyedLockStore
     // global contention), the same per-key lock idiom SsoRateLimiter.Counter uses.
     private sealed class Holder
     {
+        // Never Dispose()d: SemaphoreSlim allocates an OS wait handle only if AvailableWaitHandle is
+        // accessed (it never is here), so a retired/GC'd holder is pure managed garbage — the same
+        // reason SsoRateLimiter.Counter needs no disposal.
         internal SemaphoreSlim Gate { get; } = new SemaphoreSlim(1, 1);
 
         internal int Waiters { get; set; }

--- a/SSO-Auth/Api/KeyedLockStore.cs
+++ b/SSO-Auth/Api/KeyedLockStore.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// A per-key async mutual-exclusion primitive: at most one holder per key at a time, while unrelated
+/// keys never block each other. Each key's semaphore is reference-counted and dropped the moment its
+/// last holder leaves, so the map stays bounded by the keys contending RIGHT NOW — not by the number of
+/// distinct keys ever seen. That is what keeps a churn of one-shot keys (e.g. a login flood over many
+/// usernames) from leaking one <see cref="SemaphoreSlim"/> per key without bound. Acquire returns a
+/// disposable whose disposal releases the key; the lock is not reentrant.
+/// </summary>
+internal sealed class KeyedLockStore
+{
+    // key -> its live holder; a key is present only while at least one acquirer references it (dropped
+    // at zero, under the holder's own lock), so |_holders| <= keys contended now. The comparer decides
+    // key identity: the avatar store passes Ordinal so the key is exactly the profile-path determinant.
+    private readonly ConcurrentDictionary<string, Holder> _holders;
+
+    internal KeyedLockStore(IEqualityComparer<string> comparer)
+    {
+        _holders = new ConcurrentDictionary<string, Holder>(comparer ?? throw new ArgumentNullException(nameof(comparer)));
+    }
+
+    /// <summary>Gets the number of keys currently contended (live holders). Test-only: proves the map stays bounded.</summary>
+    internal int TrackedKeys => _holders.Count;
+
+    /// <summary>
+    /// Acquires exclusive access for <paramref name="key"/>, waiting until any current holder releases.
+    /// Dispose the returned handle to release it; unrelated keys are never blocked.
+    /// </summary>
+    /// <param name="key">The key to serialize on.</param>
+    /// <param name="cancellationToken">Cancels the wait; a cancelled wait acquires nothing and leaks nothing.</param>
+    /// <returns>A handle whose disposal releases the key.</returns>
+    internal async Task<IDisposable> AcquireAsync(string key, CancellationToken cancellationToken = default)
+    {
+        var holder = Claim(key);
+        try
+        {
+            await holder.Gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            // The wait was cancelled before it took the permit (SemaphoreSlim.WaitAsync is atomic: it
+            // either returns having taken a permit or throws having taken none), so drop only the
+            // reference — releasing the gate here would hand out a permit we never held.
+            Unclaim(key, holder);
+            throw;
+        }
+
+        return new Releaser(this, key, holder);
+    }
+
+    // Attaches this acquirer to the key's live holder, creating one if none exists. Retries when it
+    // races a Release that is retiring the holder it just observed, so it can never attach to a holder
+    // already removed from the map (which would give two acquirers of one key two different semaphores).
+    private Holder Claim(string key)
+    {
+        while (true)
+        {
+            var holder = _holders.GetOrAdd(key, _ => new Holder());
+            lock (holder)
+            {
+                if (!holder.Retired)
+                {
+                    holder.Waiters++;
+                    return holder;
+                }
+            }
+        }
+    }
+
+    // Detaches one acquirer from the key's holder and, when it was the last, retires and removes the
+    // holder so the map does not accumulate idle semaphores. Retire + remove happen under the holder's
+    // lock, atomically against Claim's Retired check, so no acquirer keeps a reference to a removed
+    // holder. The conditional TryRemove only deletes while the key still maps to this exact holder.
+    private void Unclaim(string key, Holder holder)
+    {
+        lock (holder)
+        {
+            if (--holder.Waiters == 0)
+            {
+                holder.Retired = true;
+                _holders.TryRemove(new KeyValuePair<string, Holder>(key, holder));
+            }
+        }
+    }
+
+    // One key's mutual-exclusion state: the semaphore plus the reference count and retirement flag that
+    // govern its collectible lifetime. Accessed only under its own monitor lock (brief, per-key — no
+    // global contention), the same per-key lock idiom SsoRateLimiter.Counter uses.
+    private sealed class Holder
+    {
+        internal SemaphoreSlim Gate { get; } = new SemaphoreSlim(1, 1);
+
+        internal int Waiters { get; set; }
+
+        internal bool Retired { get; set; }
+    }
+
+    // The acquired-lock handle. Disposal releases the semaphore and detaches the acquirer; idempotent,
+    // so a double dispose (or a using plus an explicit Dispose) releases exactly once — a second release
+    // would let two holders into one key's critical section.
+    private sealed class Releaser : IDisposable
+    {
+        private readonly KeyedLockStore _owner;
+        private readonly string _key;
+        private readonly Holder _holder;
+        private int _disposed;
+
+        internal Releaser(KeyedLockStore owner, string key, Holder holder)
+        {
+            _owner = owner;
+            _key = key;
+            _holder = holder;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            _holder.Gate.Release();
+            _owner.Unclaim(_key, _holder);
+        }
+    }
+}


### PR DESCRIPTION
# What & why

Two concurrent SSO logins for the same user could interleave the `SaveImage` +
profile-image check/clear/assign in `AvatarService.StoreAsync`, so one login
could clear or overwrite the other's record. The outcome self-heals on the next
login (and Jellyfin's own image-replace endpoint has the same unsynchronized
sequence), but it is an avoidable interleaving on the login path.

We serialize the store step per user with a keyed async lock, so the
write-and-transition runs as one unit per user while unrelated users never block
each other and the avatar HTTP fetch stays outside the lock.

- New `KeyedLockStore`: a collectible per-key async mutex, a reference-counted
  `SemaphoreSlim` dropped the moment its last holder leaves, so the map cannot
  grow one semaphore per username ever seen (bounded by the keys contended right
  now). It mirrors the per-key `lock (counter)` idiom `SsoRateLimiter` already
  uses.
- `AvatarService.StoreAsync` acquires the per-user lock (keyed on
  `user.Username`, `Ordinal`, exactly the profile-path determinant) then
  delegates to the unchanged sequence in `StoreLockedAsync`. The lock is
  `static` so it serializes across the per-request `AvatarService` instances the
  controller builds; the fetch and its SSRF / size-cap / content-type guards
  stay in `TrySetAsync`, before the lock.

Closes #400

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Login-path concurrency hardening filed as a `quality` / `priority: low` item
(the outcome self-heals, so it is defence-in-depth, not a vulnerability); the
security checklist below is completed because it touches the login path.

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the change makes no accept/reject auth decision.
      The avatar is best-effort — a lock or store failure is caught in
      `TrySetAsync` and the login proceeds without the avatar (fail-closed for
      the cosmetic avatar). The fetch guards (URL allow-list, SSRF
      `ConnectCallback`, content-type allow-list #217, Content-Length + streamed
      size cap #220) are untouched and still fail closed, and none moved into or
      out of the lock.
- [x] No secrets logged; secrets are redacted on config export. `KeyedLockStore`
      has no logger and emits nothing; the new `AvatarService` code adds no log
      calls.
- [x] A security review was performed: the adversarial gate ran three
      refute-by-default lenses (availability, correctness, bypass) — all PASS.
      See Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged - 
      the existing inline `ReplaceLineEndings` sanitizers on the URL and
      media-type warnings are untouched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit (`KeyedLockStore`).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. The new `*Store` type fits the
      existing structural rules (a keyed dictionary living inside a
      `*Store`/`*Cache`/`*Limiter`, `MutableKeyedState_LivesOnlyInsideStoreLikeTypes`;
      internal + sealed helper), so it establishes no new property needing a new
      rule.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0
      warnings). `sh scripts/check-jellyfin-compat.sh` is consistent.
- [x] `dotnet test` is green (858 passed, 0 failed, 7 new tests).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (n/a - 
      no web files touched).

## Notes

**Adversarial self-review, we tried to refute this change and could not.**
Three refute-by-default lenses reviewed the diff against the actual code:

- **Availability / mass-lockout, PASS.** The lock is non-reentrant and acquired
  exactly once per login; it is never held across the HTTP fetch, `UpdateUserAsync`,
  or `AuthenticateDirect`. Contention is strictly per user (distinct usernames
  get distinct holders), so there is no cross-user or mass-lockout surface. The
  map is collectible, so a username-spraying login flood leaks no semaphores.
- **Correctness / concurrency, PASS.** The classic keyed-lock bug (two acquirers
  of one key getting different semaphores) cannot occur: retire + conditional
  `TryRemove` happen under `lock(holder)`, atomically against `Claim`'s `Retired`
  re-check, so a claimer never attaches to a removed holder. Dispose is
  idempotent (no over-release), and the cancelled-wait path drops its reference
  without releasing a permit, verified empirically (`SemaphoreSlim.WaitAsync`
  is take-or-throw atomic). The lens also confirmed the overlap test has teeth:
  removing the lock from `StoreAsync` makes exactly the serialization test fail.
- **Security-bypass / fail-open, PASS.** No security control moved relative to
  the lock; the key (`user.Username`) is not attacker-collidable into another
  account (host-enforced username uniqueness), and a collision would only
  serialize, never corrupt cross-user. The #232 revocation-gate ordering and the
  #377 write-before-clear invariant are preserved verbatim.

**Accepted / out of scope (documented):**

- The store-lock acquire uses `CancellationToken.None`, so the wait is not
  time-bounded. This matches the pre-change posture, `IProviderManager.SaveImage`
  itself carries no timeout, and the blast radius of a hung `SaveImage` is
  confined to concurrent logins of the *same* user, no worse than before.
  Threading a request-abort token through is a possible future hardening.
- `Ordinal` keying is stricter than the case-insensitive Windows profile path.
  For the #400 same-user scenario the key string is always identical; a
  case-variant that Jellyfin's case-insensitive username uniqueness makes
  unreachable is the only divergence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar “store + profile-image transition” reliability by serializing updates per user, preventing interleaved writes.
  * Ensured concurrent updates produce a consistent final profile image record without conflicting clear/set behavior.
  * Strengthened cancellation and cleanup handling during overlapping avatar operations.

* **Tests**
  * Added concurrency-focused avatar storage tests covering same-user serialization and “later write wins.”
  * Added a dedicated test suite validating keyed async mutual-exclusion behavior, including isolation, cancellation, idempotent disposal, contention, and bounded cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->