### PR TITLE
Harden the OIDC RFC 9207 authorization-response issuer check

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -134,14 +134,15 @@ public class ArchitectureConformanceTests
         // Locked in by the OidcStateStore consolidation (#318): a raw dictionary holding runtime state
         // outside a *Store/*Cache/*Limiter type is how the pre-consolidation controller accumulated its
         // scattered cap/lifetime/sweep conventions. Two documented exemptions:
-        // - SSOController.PkceSupportCache: the PKCE-discovery cache still lives on the controller and
-        //   moves into its own probe type in a later #318 step; naming the exact field keeps anything
-        //   new from hiding behind the exemption.
+        // - SSOController.DiscoveryFactsCache: the per-discovery-URL facts cache (PKCE-S256 support #141 +
+        //   the RFC 9207 response-iss advertisement #210) still lives on the controller and moves into its
+        //   own probe type in a later #318 step; naming the exact field keeps anything new from hiding
+        //   behind the exemption.
         // - ProviderConfigBase._canonicalLinks: the persisted account-link map — serialized plugin
         //   configuration mutated only under the config lock, so a runtime store type would be the
         //   wrong home; it is config state, not in-flight state.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "SSOController.PkceSupportCache", "ProviderConfigBase._canonicalLinks" };
+        var exemptions = new[] { "SSOController.DiscoveryFactsCache", "ProviderConfigBase._canonicalLinks" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/OidcResponseIssuerTests.cs
+++ b/SSO-Auth.Tests/OidcResponseIssuerTests.cs
@@ -5,13 +5,15 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for <see cref="OidcResponseIssuer"/> — the RFC 9207 authorization-response issuer check (#125).
-/// A present response <c>iss</c> must equal the id_token issuer; absence is tolerated; anything that
-/// cannot be shown to agree is a mismatch (fail closed).
+/// Tests for <see cref="OidcResponseIssuer"/> — the RFC 9207 authorization-response issuer check (#125,
+/// hardened #210). A present response <c>iss</c> must equal the authorization server's discovery issuer
+/// OR the id_token issuer (the id_token anchor keeps templated / <c>DoNotValidateIssuerName</c> setups
+/// working); absence is tolerated only when the server did not advertise the parameter, and rejected
+/// when it did (§2.4); anything that cannot be shown to agree fails closed.
 /// </summary>
 public class OidcResponseIssuerTests
 {
-    private const string Issuer = "https://idp.example.com";
+    private const string DiscoveryIssuer = "https://idp.example.com";
 
     // Builds a parseable (unsigned) id_token carrying the given iss. The check never verifies the
     // signature — it only reads the issuer — so a JWS with a throwaway signature segment is enough.
@@ -26,45 +28,84 @@ public class OidcResponseIssuerTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void IsMismatch_AbsentResponseIssuer_False(string? responseIssuer)
+    public void IsRejected_AbsentAndNotAdvertised_False(string? responseIssuer)
     {
-        // Many IdPs do not emit iss; requiring it would lock them out, so absence is tolerated.
-        Assert.False(OidcResponseIssuer.IsMismatch(responseIssuer, IdToken(Issuer)));
+        // Many IdPs do not emit iss; when the server did not advertise the parameter, requiring it would
+        // lock them out, so absence is tolerated.
+        Assert.False(OidcResponseIssuer.IsRejected(responseIssuer, DiscoveryIssuer, IdToken(DiscoveryIssuer), required: false));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void IsRejected_AbsentButAdvertised_True(string? responseIssuer)
+    {
+        // RFC 9207 §2.4: once the AS advertises authorization_response_iss_parameter_supported, a missing
+        // iss is a downgrade and must be rejected.
+        Assert.True(OidcResponseIssuer.IsRejected(responseIssuer, DiscoveryIssuer, IdToken(DiscoveryIssuer), required: true));
     }
 
     [Fact]
-    public void IsMismatch_ResponseIssuerMatchesToken_False()
+    public void IsRejected_PresentAndMatchesDiscoveryIssuer_False()
     {
-        Assert.False(OidcResponseIssuer.IsMismatch(Issuer, IdToken(Issuer)));
+        Assert.False(OidcResponseIssuer.IsRejected(DiscoveryIssuer, DiscoveryIssuer, IdToken(DiscoveryIssuer), required: false));
+        Assert.False(OidcResponseIssuer.IsRejected(DiscoveryIssuer, DiscoveryIssuer, IdToken(DiscoveryIssuer), required: true));
     }
 
     [Fact]
-    public void IsMismatch_ResponseIssuerDiffersFromToken_True()
+    public void IsRejected_PresentAndMatchesIdTokenIssuerButNotDiscovery_False()
     {
-        Assert.True(OidcResponseIssuer.IsMismatch("https://attacker.example", IdToken(Issuer)));
+        // The DoNotValidateIssuerName / templated / multi-tenant case: the discovery issuer is a template
+        // that the concrete response iss (== the id_token iss) does not equal, but the login must NOT be
+        // locked out — the id_token issuer is an accepted anchor.
+        const string concrete = "https://idp.example.com/tenant-42";
+        Assert.False(OidcResponseIssuer.IsRejected(concrete, DiscoveryIssuer, IdToken(concrete), required: false));
+        Assert.False(OidcResponseIssuer.IsRejected(concrete, DiscoveryIssuer, IdToken(concrete), required: true));
     }
 
     [Fact]
-    public void IsMismatch_CaseDifferenceOnly_True()
+    public void IsRejected_PresentButMatchesNeitherAnchor_True()
+    {
+        Assert.True(OidcResponseIssuer.IsRejected("https://attacker.example", DiscoveryIssuer, IdToken(DiscoveryIssuer), required: false));
+    }
+
+    [Fact]
+    public void IsRejected_CaseDifferenceOnly_True()
     {
         // Issuer comparison is ordinal (RFC 9207 / OIDC simple string comparison): a case flip is a mismatch.
-        Assert.True(OidcResponseIssuer.IsMismatch(Issuer.ToUpperInvariant(), IdToken(Issuer)));
+        Assert.True(OidcResponseIssuer.IsRejected(DiscoveryIssuer.ToUpperInvariant(), DiscoveryIssuer, IdToken(DiscoveryIssuer), required: false));
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("not-a-jwt")]
-    public void IsMismatch_PresentResponseIssuerButUnreadableToken_True(string? identityToken)
+    public void IsRejected_PresentResponseIssuerButBothAnchorsUnknown_True(string? identityToken)
     {
-        // A response issuer that cannot be shown to match (no/garbage token, or a token with no iss)
-        // fails closed rather than being waved through.
-        Assert.True(OidcResponseIssuer.IsMismatch(Issuer, identityToken));
+        // A response issuer that cannot be shown to match either anchor (unknown discovery issuer and a
+        // no/garbage token, or a token with no iss) fails closed rather than being waved through.
+        Assert.True(OidcResponseIssuer.IsRejected(DiscoveryIssuer, discoveryIssuer: null, identityToken, required: false));
     }
 
     [Fact]
-    public void IsMismatch_TokenWithoutIssuerClaim_True()
+    public void IsRejected_TokenWithoutIssuerClaimAndDiscoveryMismatch_True()
     {
-        Assert.True(OidcResponseIssuer.IsMismatch(Issuer, IdToken(null)));
+        Assert.True(OidcResponseIssuer.IsRejected(DiscoveryIssuer, "https://other.example", IdToken(null), required: false));
+    }
+
+    [Theory]
+    [InlineData("{\"authorization_response_iss_parameter_supported\":true}", true)]
+    [InlineData("{\"authorization_response_iss_parameter_supported\":false}", false)]
+    [InlineData("{\"issuer\":\"https://idp.example.com\"}", false)] // absent
+    [InlineData("{\"authorization_response_iss_parameter_supported\":\"true\"}", false)] // string, not boolean
+    [InlineData("{\"authorization_response_iss_parameter_supported\":1}", false)] // number, not boolean
+    [InlineData("not json", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void DiscoveryAdvertisesResponseIssuer_ParsesTheFlag(string? discoveryJson, bool expected)
+    {
+        // Only an explicit boolean true advertises the parameter; everything else is tolerant (false), so
+        // an unreadable/absent flag never turns into a lockout.
+        Assert.Equal(expected, OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(discoveryJson));
     }
 }

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -192,6 +192,50 @@ public class OidcStateStoreTests
         Assert.Null(pending.ProviderInformation);
     }
 
+    // --- RFC 9207 response-iss requirement (#210): carry the "advertised" flag to the callback ---
+
+    [Fact]
+    public void MarkResponseIssuerRequired_CarriesTheFlagToThePeekForTheCallback()
+    {
+        // The challenge marks a state (via MarkResponseIssuerRequired, after TryAdd) when discovery
+        // advertises the RFC 9207 response-iss parameter; the store must round-trip the flag to the
+        // PendingState the OidPost callback reads so it requires iss to be present.
+        var store = Store();
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, out _));
+
+        store.MarkResponseIssuerRequired("s");
+
+        var pending = store.PeekCurrent("s", "p", Now, Binding);
+        Assert.NotNull(pending);
+        Assert.True(pending.ResponseIssuerRequired);
+    }
+
+    [Fact]
+    public void ResponseIssuerRequired_DefaultsFalse_WhenNotMarked()
+    {
+        // The tolerant default: a state whose provider did not advertise the parameter (never marked)
+        // exposes false, so the callback keeps tolerating an absent iss — no lockout of older IdPs.
+        var store = Store();
+        Assert.True(store.TryAdd(new AuthorizeState { State = "s" }, "p", false, Now, Binding, clientKey: null, out _));
+
+        var pending = store.PeekCurrent("s", "p", Now, Binding);
+        Assert.NotNull(pending);
+        Assert.False(pending.ResponseIssuerRequired);
+    }
+
+    [Fact]
+    public void MarkResponseIssuerRequired_UnknownToken_IsANoOp()
+    {
+        // Defensive: if the entry expired in the gap between TryAdd and this call, marking is a no-op —
+        // no throw, no resurrected entry.
+        var store = Store();
+
+        store.MarkResponseIssuerRequired("never-added");
+
+        Assert.Equal(0, store.Count);
+        Assert.Null(store.PeekCurrent("never-added", "p", Now, Binding));
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/SSO-Auth.Tests/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/OidcTokenFixture.cs
@@ -38,9 +38,12 @@ internal sealed class OidcTokenFixture : IDisposable
 
     /// <summary>
     /// Produces a signed id_token for the given username. A non-empty <paramref name="subject"/> is
-    /// emitted as the "sub" claim; passing null/empty omits it (for the missing-sub rejection path).
+    /// emitted as the "sub" claim; passing null/empty omits it (for the missing-sub rejection path). A
+    /// non-null <paramref name="issuer"/> overrides the token's <c>iss</c> (defaults to the fixture
+    /// issuer) so a test can model a provider whose id_token issuer differs from its discovery issuer
+    /// (templated / <c>DoNotValidateIssuerName</c> setups, #210).
     /// </summary>
-    internal string IdToken(string? subject, string username)
+    internal string IdToken(string? subject, string username, string? issuer = null)
     {
         var now = DateTime.UtcNow;
         var claims = new Dictionary<string, object> { ["preferred_username"] = username };
@@ -51,7 +54,7 @@ internal sealed class OidcTokenFixture : IDisposable
 
         var descriptor = new SecurityTokenDescriptor
         {
-            Issuer = Issuer,
+            Issuer = issuer ?? Issuer,
             Audience = ClientId,
             IssuedAt = now - TimeSpan.FromMinutes(1),
             NotBefore = now - TimeSpan.FromMinutes(1),
@@ -66,8 +69,13 @@ internal sealed class OidcTokenFixture : IDisposable
     internal string TokenEndpointJson(string idToken) =>
         "{\"access_token\":\"test-access-token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"id_token\":\"" + idToken + "\"}";
 
-    /// <summary>The discovery document advertising this fixture's issuer and endpoints (all on the issuer).</summary>
-    internal string Discovery() =>
+    /// <summary>
+    /// The discovery document advertising this fixture's issuer and endpoints (all on the issuer). When
+    /// <paramref name="advertiseResponseIssuer"/> is set it also advertises the RFC 9207
+    /// <c>authorization_response_iss_parameter_supported</c> flag (§2.4, #210), so a challenge captures
+    /// the requirement onto its authorize state.
+    /// </summary>
+    internal string Discovery(bool advertiseResponseIssuer = false) =>
         "{\"issuer\":\"" + Issuer + "\","
         + "\"authorization_endpoint\":\"" + Issuer + "/authorize\","
         + "\"token_endpoint\":\"" + Issuer + "/token\","
@@ -77,6 +85,7 @@ internal sealed class OidcTokenFixture : IDisposable
         + "\"subject_types_supported\":[\"public\"],"
         + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
         + "\"grant_types_supported\":[\"authorization_code\"],"
+        + (advertiseResponseIssuer ? "\"authorization_response_iss_parameter_supported\":true," : string.Empty)
         + "\"code_challenge_methods_supported\":[\"S256\"]}";
 
     /// <summary>The URL the fixture serves each document at.</summary>

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -226,7 +226,11 @@ public class SSOControllerOidPostTests
 
         var result = await harness.Controller.OidPost("kc", state);
 
-        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+        // Pin the 400 to the RFC 9207 reject specifically, not the shared token-exchange-error 400: assert
+        // the SsoResponseInvalid body so a 400 from a different source cannot satisfy this test.
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("SSO response validation failed", content.Content);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -116,13 +116,76 @@ public class SSOControllerOidPostTests
     public async Task OidPost_ResponseIssuerMismatch_Returns400()
     {
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        // RFC 9207 (#125): the authorization-response `iss` names a different issuer than the id_token's,
-        // which is an authorization-server mix-up and must be rejected even though the token itself is valid.
+        // RFC 9207 (#125, hardened #210): the authorization-response `iss` names a different issuer than
+        // the authorization server's discovery issuer, which is an authorization-server mix-up and must be
+        // rejected even though the token itself is valid.
         var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1&iss=https://attacker.example.com");
 
         var result = await harness.Controller.OidPost("kc", "state-1");
 
         Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidPost_TemplatedIssuerUnderDoNotValidateIssuerName_ResponseIssMatchesIdToken_RendersTheAuthPage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // Availability regression guard (#210 review): with DoNotValidateIssuerName the id_token issuer
+        // legitimately differs from the discovery issuer (templated / multi-tenant). The RFC 9207 response
+        // `iss` equals the concrete id_token issuer, NOT the templated discovery issuer — comparing to the
+        // discovery issuer alone would lock this supported config out, so the id_token issuer is an
+        // accepted anchor and the login must proceed.
+        const string concreteIssuer = Authority + "/tenant-42";
+        var harness = ArrangeCallback(
+            fixture,
+            query: $"?code=test-code&state=state-1&iss={concreteIssuer}",
+            idToken: fixture.IdToken(subject: "sub-1", username: "alice", issuer: concreteIssuer),
+            doNotValidateIssuerName: true);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(result).ContentType);
+    }
+
+    [Fact]
+    public async Task OidPost_ResponseIssuerRequiredButAbsent_Returns400()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // RFC 9207 §2.4 (#210): the challenge saw the AS advertise the response-iss parameter, so a
+        // callback that omits `iss` is a downgrade and must be rejected — even though the id_token is valid.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", responseIssuerRequired: true);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidPost_ResponseIssuerRequiredAndPresentMatchingDiscovery_RendersTheAuthPage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // The complement of the downgrade case: when the AS advertised the parameter AND the response
+        // carries an `iss` equal to the discovery issuer, the login proceeds. Proves the requirement is
+        // satisfied by a correct value, not merely by the flag being set.
+        var harness = ArrangeCallback(fixture, query: $"?code=test-code&state=state-1&iss={Authority}", responseIssuerRequired: true);
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(result).ContentType);
+    }
+
+    [Fact]
+    public async Task OidPost_ResponseIssuerNotAdvertisedAndAbsent_RendersTheAuthPage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // No lockout of older IdPs (#210): a provider whose discovery did not advertise the parameter
+        // (ResponseIssuerRequired defaults false) and that omits `iss` must still log in — the tolerant
+        // path RFC 9207 §2.4 preserves.
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1");
+
+        var result = await harness.Controller.OidPost("kc", "state-1");
+
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(result).ContentType);
     }
 
     [Fact]
@@ -151,6 +214,121 @@ public class SSOControllerOidPostTests
         Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
     }
 
+    [Fact]
+    public async Task OidChallengeToCallback_ResponseIssuerAdvertisedThenAbsent_Returns400()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // End-to-end (#210): a real challenge whose discovery advertises the RFC 9207 response-iss
+        // parameter must capture the requirement onto the authorize state, so the callback that omits
+        // `iss` is rejected — pinning the challenge-side capture the seeded callback tests above assume.
+        var (harness, state) = await DriveAdvertisedChallenge(fixture);
+        harness.Controller.HttpContext.Request.QueryString = new QueryString($"?code=test-code&state={state}");
+
+        var result = await harness.Controller.OidPost("kc", state);
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public async Task OidChallengeToCallback_ResponseIssuerAdvertisedThenPresent_RendersTheAuthPage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // The positive end-to-end: with the same advertised challenge, a callback carrying `iss` equal to
+        // the discovery issuer satisfies the captured requirement and the login proceeds.
+        var (harness, state) = await DriveAdvertisedChallenge(fixture);
+        harness.Controller.HttpContext.Request.QueryString = new QueryString($"?code=test-code&state={state}&iss={Authority}");
+
+        var result = await harness.Controller.OidPost("kc", state);
+
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(result).ContentType);
+    }
+
+    // Drives a real OidChallenge whose served discovery advertises the RFC 9207 response-iss parameter, so
+    // the challenge captures the requirement onto its authorize state; returns the harness (its context
+    // re-pointed at the callback route, browser-binding cookie attached) plus the state token the callback
+    // must present. The token endpoint returns a valid signed id_token, leaving the response-iss
+    // requirement as the only thing left to decide at the callback.
+    private static async Task<(SsoControllerHarness Harness, string State)> DriveAdvertisedChallenge(OidcTokenFixture fixture)
+    {
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = Authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                DoNotLoadProfile = true,
+            },
+            httpResponder: request =>
+            {
+                var url = request.RequestUri!.AbsoluteUri;
+                if (url == fixture.DiscoveryUrl)
+                {
+                    return Json(fixture.Discovery(advertiseResponseIssuer: true));
+                }
+
+                if (url == fixture.JwksUrl)
+                {
+                    return Json(fixture.Jwks());
+                }
+
+                if (url == fixture.TokenUrl)
+                {
+                    return Json(fixture.TokenEndpointJson(idToken));
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+
+        var state = QueryValue(challenge.Url, "state");
+        Assert.False(string.IsNullOrEmpty(state));
+        var binding = BindingCookie(harness.Controller.Response);
+        Assert.False(string.IsNullOrEmpty(binding));
+
+        // Re-point the same context at the callback route the IdP returns to, carrying the browser-binding
+        // cookie the challenge set (#326) so the state's binding gate is satisfied.
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={binding}";
+        return (harness, state);
+    }
+
+    // Reads a single query-parameter value out of the challenge's authorization redirect URL.
+    private static string QueryValue(string url, string key)
+    {
+        foreach (var pair in new Uri(url).Query.TrimStart('?').Split('&'))
+        {
+            var kv = pair.Split('=', 2);
+            if (kv.Length == 2 && kv[0] == key)
+            {
+                return Uri.UnescapeDataString(kv[1]);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    // Extracts the browser-binding cookie value the challenge wrote to the response's Set-Cookie header.
+    private static string BindingCookie(Microsoft.AspNetCore.Http.HttpResponse response)
+    {
+        var prefix = AuthorizeStateBinding.CookieName + "=";
+        foreach (var header in response.Headers.SetCookie)
+        {
+            if (header is not null && header.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                var value = header.Substring(prefix.Length);
+                var end = value.IndexOf(';');
+                return end >= 0 ? value.Substring(0, end) : value;
+            }
+        }
+
+        return string.Empty;
+    }
+
     // Builds a harness whose HTTP responder serves the fixture's discovery/JWKS/token endpoints, seeds the
     // matching authorize state, and sets the callback request path and query. The token endpoint returns
     // <paramref name="idToken"/> (a valid signed token by default), or a 400 when
@@ -161,7 +339,9 @@ public class SSOControllerOidPostTests
         string? idToken = null,
         bool tokenEndpointFails = false,
         string? bindingCookie = Binding,
-        string? secondProvider = null)
+        string? secondProvider = null,
+        bool responseIssuerRequired = false,
+        bool doNotValidateIssuerName = false)
     {
         idToken ??= fixture.IdToken(subject: "sub-1", username: "alice");
 
@@ -173,6 +353,7 @@ public class SSOControllerOidPostTests
             OidScopes = Array.Empty<string>(),
             DisablePushedAuthorization = true,
             DoNotLoadProfile = true, // the id_token carries sub + preferred_username; skip the userinfo fetch
+            DoNotValidateIssuerName = doNotValidateIssuerName,
         };
 
         var harness = new SsoControllerHarness(
@@ -230,7 +411,10 @@ public class SSOControllerOidPostTests
             CodeVerifier = "test-code-verifier",
             RedirectUri = "https://jf.example.com/sso/OID/redirect/kc",
         };
-        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(authState, DateTime.Now) { Provider = "kc", BindingId = Binding });
+        // ResponseIssuerRequired models a challenge whose discovery advertised the RFC 9207 response-iss
+        // parameter (#210), so the callback must require iss; false is the tolerant default (the challenge
+        // capture path itself is pinned end-to-end by OidChallengeToCallback_* below).
+        SSOController.SeedOidStateForTests("state-1", new TimedAuthorizeState(authState, DateTime.Now) { Provider = "kc", BindingId = Binding, ResponseIssuerRequired = responseIssuerRequired });
 
         return harness;
     }

--- a/SSO-Auth/Api/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/OidcResponseIssuer.cs
@@ -1,41 +1,79 @@
 using System;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 #nullable enable
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
-/// RFC 9207 authorization-response issuer check (OpenID Connect mix-up defense, #125). The library the
-/// plugin uses (Duende.IdentityModel.OidcClient 7.1.0) parses the response <c>iss</c> parameter but never
-/// validates it, and strips it from the resulting claims, so the check has to live here. The expected
-/// issuer is the <c>iss</c> of the id_token the code redeemed to: that token has already been
-/// signature-validated and issuer-matched against the discovery document by <see cref="OidcIdTokenValidator"/>,
-/// so it is a trusted stand-in for "the provider this callback is bound to". When the authorization
-/// response advertises a different issuer, the response came from a different authorization server than
-/// the one whose token we hold — a mix-up signal — and the caller rejects the login (fail closed).
+/// RFC 9207 authorization-response issuer check (OpenID Connect mix-up defense, #125, hardened in #210).
+/// The library the plugin uses (Duende.IdentityModel.OidcClient 7.1.0) parses the response <c>iss</c>
+/// parameter but never validates it, and strips it from the resulting claims, so the check has to live
+/// here. A present response <c>iss</c> must match the authorization server this callback is bound to —
+/// identified by its discovery issuer (<see cref="Duende.IdentityModel.OidcClient.ProviderInformation.IssuerName"/>,
+/// the value RFC 9207 §2.4 names) OR by the redeemed id_token's own issuer. Both are accepted because a
+/// provider whose issuer legitimately differs from its discovery location (the <c>DoNotValidateIssuerName</c>
+/// escape hatch — templated / multi-tenant setups) emits a response <c>iss</c> equal to the concrete
+/// id_token issuer, not the templated discovery issuer; requiring the discovery issuer alone would lock
+/// that supported configuration out. A response <c>iss</c> that matches neither means the response came
+/// from a different authorization server than the one this callback is bound to — a mix-up — so reject.
 /// </summary>
 internal static class OidcResponseIssuer
 {
     /// <summary>
-    /// Determines whether a present authorization-response <c>iss</c> disagrees with the id_token issuer.
-    /// Absence of <paramref name="responseIssuer"/> is tolerated (many IdPs do not yet emit it, and
-    /// requiring it would lock them out); a present value that does not match the token issuer is a
-    /// mismatch. If the token issuer cannot be read while a response issuer is present, that also counts
-    /// as a mismatch — the safe default when the two cannot be shown to agree.
+    /// Decides whether the RFC 9207 check rejects this authorization response. A present
+    /// <paramref name="responseIssuer"/> is accepted only when it ordinally equals the discovery issuer
+    /// (<paramref name="discoveryIssuer"/>) or the id_token issuer; matching neither is a mix-up and is
+    /// rejected, as is a present response issuer while both anchors are unknown. Absence of a response
+    /// issuer is tolerated only when the server did not advertise the parameter (<paramref name="required"/>
+    /// is false), so IdPs that never emit <c>iss</c> keep working; when the server advertises
+    /// <c>authorization_response_iss_parameter_supported</c> (RFC 9207 §2.4) its absence is a downgrade
+    /// and is rejected.
     /// </summary>
     /// <param name="responseIssuer">The <c>iss</c> query parameter from the authorization response, if any.</param>
-    /// <param name="identityToken">The redeemed id_token (already validated upstream).</param>
-    /// <returns><see langword="true"/> when a present response issuer does not match the token issuer.</returns>
-    internal static bool IsMismatch(string? responseIssuer, string? identityToken)
+    /// <param name="discoveryIssuer">The authorization server's discovery issuer identifier, or null when it could not be determined.</param>
+    /// <param name="identityToken">The redeemed id_token (already validated upstream), whose issuer is the second accepted anchor.</param>
+    /// <param name="required">Whether the server advertised the response-<c>iss</c> parameter, making its presence mandatory.</param>
+    /// <returns><see langword="true"/> when the response must be rejected.</returns>
+    internal static bool IsRejected(string? responseIssuer, string? discoveryIssuer, string? identityToken, bool required)
     {
         if (string.IsNullOrEmpty(responseIssuer))
+        {
+            return required;
+        }
+
+        return !string.Equals(responseIssuer, discoveryIssuer, StringComparison.Ordinal)
+            && !string.Equals(responseIssuer, TokenIssuer(identityToken), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reports whether the discovery document advertises the RFC 9207 authorization-response <c>iss</c>
+    /// parameter (<c>authorization_response_iss_parameter_supported: true</c>, §2.4). Read at challenge
+    /// and carried on the authorize state so the callback can require <c>iss</c> without a second fetch.
+    /// Fails tolerant (<c>false</c>) on absence, a non-true value, or malformed/blank JSON — an
+    /// unreadable flag must not lock out a provider that omits <c>iss</c>.
+    /// </summary>
+    /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
+    /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
+    internal static bool DiscoveryAdvertisesResponseIssuer(string? discoveryJson)
+    {
+        if (string.IsNullOrWhiteSpace(discoveryJson))
         {
             return false;
         }
 
-        return !string.Equals(responseIssuer, TokenIssuer(identityToken), StringComparison.Ordinal);
+        try
+        {
+            return JObject.Parse(discoveryJson)["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
+                && value.Value<bool>();
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     // The id_token was validated by OidcIdTokenValidator before this runs, so it parses; the guard and

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -132,6 +132,24 @@ internal sealed class OidcStateStore
     }
 
     /// <summary>
+    /// Marks an entry <see cref="TryAdd"/> just registered as one whose authorization server advertises
+    /// the RFC 9207 response-<c>iss</c> parameter, so the callback requires <c>iss</c> to be present
+    /// (#210). Captured at challenge from the discovery document the PKCE probe already fetched, so the
+    /// callback needs no second fetch. Only ever called when discovery advertised the parameter, so the
+    /// tolerant default (false, set on absence/unreadable discovery) never has to be written back. A
+    /// no-op if the entry is already gone (same sub-millisecond race as
+    /// <see cref="SetProviderInformation"/>), which only tightens a login that is already dead.
+    /// </summary>
+    /// <param name="token">The authorize-state token the entry is keyed by (the challenge's state value).</param>
+    internal void MarkResponseIssuerRequired(string token)
+    {
+        if (_states.TryGetValue(token, out var state))
+        {
+            state.ResponseIssuerRequired = true;
+        }
+    }
+
+    /// <summary>
     /// The callback's non-consuming check: returns the pending state only when it exists, was minted
     /// for this provider, and is within its lifetime; null otherwise, so a state issued for one
     /// provider cannot be validated on another's callback. No removal: the value is an unguessable

--- a/SSO-Auth/Api/PendingState.cs
+++ b/SSO-Auth/Api/PendingState.cs
@@ -22,6 +22,12 @@ internal sealed class PendingState
     /// </summary>
     internal ProviderInformation ProviderInformation => _entry.ProviderInformation;
 
+    /// <summary>
+    /// Gets a value indicating whether the authorization server advertised the RFC 9207
+    /// authorization-response <c>iss</c> parameter, so the callback must require <c>iss</c> (#210).
+    /// </summary>
+    internal bool ResponseIssuerRequired => _entry.ResponseIssuerRequired;
+
     /// <summary>Gets a value indicating whether this flow is a linking request rather than a login.</summary>
     internal bool IsLinking => _entry.IsLinking;
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -69,11 +69,13 @@ public class SSOController : ControllerBase
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
-    // Cache of per-discovery-URL PKCE-S256 support (#141), so a login does not fetch discovery every time
-    // (the document changes rarely). Only definitive results are cached; a fetch failure is not cached, so
-    // it retries on the next login. The short TTL bounds how long a provider's changed support is stale.
-    private static readonly ConcurrentDictionary<string, (bool Supported, DateTime FetchedAt)> PkceSupportCache = new();
-    private static readonly TimeSpan PkceSupportCacheTtl = TimeSpan.FromMinutes(15);
+    // Cache of the two per-discovery-URL facts the challenge reads in one fetch — PKCE-S256 support (#141)
+    // and whether the AS advertises the RFC 9207 response-`iss` parameter (#210) — so a login does not
+    // fetch discovery every time (the document changes rarely). Only definitive results are cached; a
+    // fetch failure is not cached, so it retries on the next login. The short TTL bounds how long a
+    // provider's changed metadata is stale.
+    private static readonly ConcurrentDictionary<string, (bool PkceS256, bool ResponseIssuerAdvertised, DateTime FetchedAt)> DiscoveryFactsCache = new();
+    private static readonly TimeSpan DiscoveryFactsCacheTtl = TimeSpan.FromMinutes(15);
 
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
     // (challenge -> IdP login/MFA -> POST back -> mint), matching OidcStateStore.DefaultLifetime.
@@ -163,14 +165,19 @@ public class SSOController : ControllerBase
             return ReturnError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
         }
 
-        // RFC 9207 (#125): the library parses the authorization-response `iss` but never checks it.
-        // When present it must name the same issuer as the redeemed id_token (which OidcIdTokenValidator
-        // already validated against the discovery issuer); a mismatch means the response came from a
-        // different authorization server than the one we hold a token for — a mix-up — so reject.
+        // RFC 9207 (#125, hardened #210): the library parses the authorization-response `iss` but never
+        // checks it. When present it must match the authorization server this callback is bound to — its
+        // discovery issuer (§2.4's canonical anchor, from the reused #247 or freshly-discovered
+        // ProviderInformation) OR the redeemed id_token's issuer. Both are accepted so a provider whose
+        // issuer legitimately differs from its discovery location (DoNotValidateIssuerName / templated /
+        // multi-tenant) is not locked out — there the response iss equals the concrete id_token iss, not
+        // the templated discovery iss. A response iss matching neither is a mix-up, so reject. When the
+        // server advertised the parameter (captured at challenge), a missing iss is a downgrade and is
+        // likewise rejected; otherwise absence is tolerated so IdPs that never emit `iss` keep working.
         if (!config.DoNotValidateResponseIssuer
-            && OidcResponseIssuer.IsMismatch(Request.Query["iss"], result.IdentityToken))
+            && OidcResponseIssuer.IsRejected(Request.Query["iss"], oidcClient.Options.ProviderInformation?.IssuerName, result.IdentityToken, pending.ResponseIssuerRequired))
         {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer did not match the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+            _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
         }
 
@@ -237,7 +244,11 @@ public class SSOController : ControllerBase
         // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
         // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
         // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
-        var pkceSupported = await ProviderAdvertisesPkceS256Async(config, provider).ConfigureAwait(false);
+        // One discovery read yields both facts the challenge needs: PKCE-S256 support (gated below) and
+        // whether the AS advertises the RFC 9207 response-`iss` parameter (persisted on the state below,
+        // so the callback can require `iss` without a second fetch) (#210).
+        var discoveryFacts = await ReadDiscoveryFactsAsync(config, provider).ConfigureAwait(false);
+        var pkceSupported = discoveryFacts.PkceS256;
         if (pkceSupported == false)
         {
             if (config.RequirePkce)
@@ -294,6 +305,15 @@ public class SSOController : ControllerBase
         // by this state's lifetime.
         StateStore.SetProviderInformation(state.State, oidcClient.Options.ProviderInformation);
 
+        // RFC 9207 §2.4 (#210): if this provider's discovery advertises the response-`iss` parameter,
+        // carry that on the state so the callback requires `iss` to be present (its absence would be a
+        // downgrade). Only set when advertised; the state's tolerant default keeps providers that never
+        // advertise it working. Read from the same discovery fetch above, so the callback needs no second.
+        if (discoveryFacts.ResponseIssuerAdvertised)
+        {
+            StateStore.MarkResponseIssuerRequired(state.State);
+        }
+
         // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
         Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(OidcStateStore.DefaultLifetime));
 
@@ -301,7 +321,7 @@ public class SSOController : ControllerBase
     }
 
     // Test-only reset of the process-wide OpenID caches this controller keeps as private statics: the
-    // in-flight authorize-state store and the PKCE-discovery cache. A test that drives the login flow
+    // in-flight authorize-state store and the discovery-facts cache. A test that drives the login flow
     // mutates these, so without a reset the state leaks into a sibling test in the same non-parallel
     // collection. The other static caches are deliberately not cleared here: the SAML replay/request
     // caches key on random IDs and the rate limiter is isolated by per-test client IP, so they cannot
@@ -311,7 +331,7 @@ public class SSOController : ControllerBase
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
-        PkceSupportCache.Clear();
+        DiscoveryFactsCache.Clear();
     }
 
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
@@ -426,18 +446,17 @@ public class SSOController : ControllerBase
         return new OidcClient(options);
     }
 
-    // Fetches the provider's OpenID discovery document and reports whether it advertises PKCE S256 (#141):
-    // true when advertised, false when the document was read but does not advertise it, null when it could
-    // not be fetched/read. The discovery URL is the admin-configured authority + the well-known path (the
-    // same document OidcClient uses); the fetch is bounded by a timeout and never throws — a transient
-    // failure returns null so the caller decides (fail closed only under RequirePkce). Best-effort: this
-    // does not replace OidcClient's own discovery, which fails the login if the provider is truly down.
-    private async Task<bool?> ProviderAdvertisesPkceS256Async(OidConfig config, string provider)
+    // Fetches the provider's OpenID discovery document and reports the discovery facts. The discovery URL is
+    // the admin-configured authority + the well-known path (the same document OidcClient uses); the fetch
+    // is bounded by a timeout and never throws — a transient failure returns the tolerant default so the
+    // caller decides (PKCE fails closed only under RequirePkce; response-`iss` stays optional). Best-effort:
+    // this does not replace OidcClient's own discovery, which fails the login if the provider is truly down.
+    private async Task<DiscoveryFacts> ReadDiscoveryFactsAsync(OidConfig config, string provider)
     {
         var authority = config.OidEndpoint?.Trim();
         if (string.IsNullOrEmpty(authority) || !Uri.TryCreate(authority, UriKind.Absolute, out _))
         {
-            return null;
+            return new DiscoveryFacts(null, false);
         }
 
         // OidEndpoint is usually the issuer/authority, but some providers (e.g. PocketID) configure the
@@ -448,9 +467,9 @@ public class SSOController : ControllerBase
             ? trimmed
             : trimmed + "/.well-known/openid-configuration";
 
-        if (PkceSupportCache.TryGetValue(discoveryUrl, out var cached) && DateTime.UtcNow - cached.FetchedAt < PkceSupportCacheTtl)
+        if (DiscoveryFactsCache.TryGetValue(discoveryUrl, out var cached) && DateTime.UtcNow - cached.FetchedAt < DiscoveryFactsCacheTtl)
         {
-            return cached.Supported;
+            return new DiscoveryFacts(cached.PkceS256, cached.ResponseIssuerAdvertised);
         }
 
         try
@@ -458,9 +477,10 @@ public class SSOController : ControllerBase
             using var client = SsoHttp.CreateClient(_httpClientFactory);
             client.Timeout = TimeSpan.FromSeconds(10);
             var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
-            var supported = PkceDiscovery.SupportsS256(json);
-            PkceSupportCache[discoveryUrl] = (supported, DateTime.UtcNow);
-            return supported;
+            var pkceS256 = PkceDiscovery.SupportsS256(json);
+            var responseIssuerAdvertised = OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json);
+            DiscoveryFactsCache[discoveryUrl] = (pkceS256, responseIssuerAdvertised, DateTime.UtcNow);
+            return new DiscoveryFacts(pkceS256, responseIssuerAdvertised);
         }
         catch (Exception e)
         {
@@ -468,7 +488,7 @@ public class SSOController : ControllerBase
                 e,
                 "Could not fetch the OpenID discovery document for provider {Provider} to verify PKCE support; proceeding unless RequirePkce is set.",
                 provider?.ReplaceLineEndings(string.Empty));
-            return null;
+            return new DiscoveryFacts(null, false);
         }
     }
 
@@ -1474,4 +1494,11 @@ public class SSOController : ControllerBase
         Response.Headers.CacheControl = "no-store";
         return Content(render(nonce), MediaTypeNames.Text.Html);
     }
+
+    // The two discovery-document facts the challenge reads in one fetch: PKCE-S256 support (#141) — true
+    // when advertised, false when the document was read but does not advertise it, null when it could not
+    // be fetched/read — and whether the AS advertises the RFC 9207 response-`iss` parameter (#210), which
+    // is tolerant (false) whenever the document could not be read so an unreadable flag never locks out a
+    // provider that omits `iss`.
+    private readonly record struct DiscoveryFacts(bool? PkceS256, bool ResponseIssuerAdvertised);
 }

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -37,6 +37,15 @@ internal sealed class TimedAuthorizeState
     public ProviderInformation ProviderInformation { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the authorization server advertised the RFC 9207
+    /// authorization-response <c>iss</c> parameter (<c>authorization_response_iss_parameter_supported</c>,
+    /// §2.4) in the discovery document the challenge read (#210). When true the callback requires
+    /// <c>iss</c> to be present; captured at challenge so the callback needs no second discovery fetch.
+    /// Default false keeps IdPs that never advertise it (or whose discovery could not be read) working.
+    /// </summary>
+    public bool ResponseIssuerRequired { get; set; }
+
+    /// <summary>
     /// Gets or sets the provider that minted this state. A state may only be consumed on the same
     /// provider's endpoints, so it cannot be replayed against another provider's login/role gate.
     /// </summary>

--- a/providers.md
+++ b/providers.md
@@ -57,10 +57,15 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   issuer (some templated or multi-tenant setups), set `DoNotValidateIssuerName: true` for that
   provider — this relaxes only the issuer check; signature, audience and expiry stay enforced.
 - **Authorization-response issuer (RFC 9207).** When the provider adds an `iss` parameter to the
-  authorization response (a mix-up defense), it is checked against the id_token issuer and a mismatch
-  is rejected. Providers that do not send `iss` are unaffected. If a provider legitimately sends a
-  different `iss` there, set `DoNotValidateResponseIssuer: true` for that provider to relax only this
-  check.
+  authorization response (a mix-up defense), it is checked against the authorization server's issuer —
+  its discovery issuer (RFC 9207 §2.4) or the id_token issuer — and a value matching neither is
+  rejected. Accepting the id_token issuer too keeps templated / multi-tenant providers working under
+  `DoNotValidateIssuerName`, where the response `iss` equals the concrete id_token issuer rather than
+  the templated discovery issuer. If the provider's discovery document advertises
+  `authorization_response_iss_parameter_supported` (RFC 9207 §2.4), a missing `iss` is treated as a
+  downgrade and rejected too; providers that do not advertise it and omit `iss` are unaffected. If a
+  provider legitimately sends a different `iss` there, set `DoNotValidateResponseIssuer: true` for that
+  provider to relax only this check.
 - **PKCE (RFC 9700 §2.1.1).** The plugin always sends a PKCE `code_challenge` (S256), but a server that
   ignores PKCE would silently downgrade cross-session authorization-code-injection protection. On login
   the provider's discovery document is checked for `S256` in `code_challenge_methods_supported`; if it is


### PR DESCRIPTION
# What & why

Two RFC 9207 hardening refinements on top of the shipped authorization-response `iss` check in the OpenID callback (#125), both gated behind reading/persisting discovery metadata. Closes #210.

1. **Compare against the discovery issuer too.** The response `iss` is now accepted when it matches the authorization server's discovery issuer (RFC 9207 §2.4's canonical anchor, read from the `ProviderInformation` the callback already holds, reused per #247 or freshly discovered) **or** the redeemed id_token's issuer. Matching neither is a mix-up and is rejected. The discovery issuer is the RFC-correct anchor; keeping the id_token issuer accepted is deliberate, a provider whose issuer legitimately differs from its discovery location (`DoNotValidateIssuerName`, templated / multi-tenant setups) emits a response `iss` equal to the concrete id_token issuer, not the templated discovery issuer, so requiring the discovery issuer alone would lock that supported configuration out.
2. **Require `iss` when the AS advertises it.** When discovery advertises `authorization_response_iss_parameter_supported` (RFC 9207 §2.4), a missing `iss` at the callback is now a downgrade and is rejected. The flag is read once at challenge, folded into the existing PKCE discovery fetch, so there is no new network round-trip, and carried on the authorize state (`TimedAuthorizeState.ResponseIssuerRequired`, surfaced via `OidcStateStore.MarkResponseIssuerRequired` / `PendingState.ResponseIssuerRequired`), so the callback needs no second fetch. Providers that do not advertise it and omit `iss` keep working, no lockout of older IdPs.

`DoNotValidateResponseIssuer` still relaxes the whole check (both the mismatch and the required-absent paths).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing-but-advertised `iss`, or a present `iss` matching neither anchor, is rejected; an unknown expected issuer with a present `iss` also fails closed.
- [x] No secrets logged; secrets are redacted on config export. (No `iss`/issuer/token value is logged; the denial line logs only the provider name, sanitized inline.)
- [x] A security review was performed, the four-lens adversarial gate ran (see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call (`provider?.ReplaceLineEndings(string.Empty)`).

## Quality checklist

- [x] No duplicated logic; the RFC 9207 decision and the discovery-flag parse live in `OidcResponseIssuer`; the two discovery facts are read in one fetch.
- [x] The change adds no more code than the problem requires (one discovery read yields both facts; the advertised flag rides the existing `ProviderInformation`-persistence pattern).
- [x] The code is self-documenting; comments explain why (the id_token-issuer anchor, the tolerant defaults).
- [x] Architecture-conformance tests pass; the renamed controller-resident discovery cache keeps its documented `MutableKeyedState` exemption (`PkceSupportCache` → `DiscoveryFactsCache`).

## Verification

- [x] `dotnet build -c Debug --warnaserror` and `-c Release --warnaserror` are green (0 warnings).
- [x] `dotnet test` is green (871 tests).
- [x] `sh scripts/check-jellyfin-compat.sh` is green.
- [x] Prettier is clean for the `providers.md` change.

## Notes

**Tests added.** Unit tests for the decision function (`IsRejected`: present/absent × required × each anchor, including the templated case where the response `iss` matches the id_token issuer but not the discovery issuer) and the discovery-flag parse (`DiscoveryAdvertisesResponseIssuer`: boolean-true only); a store round-trip for `MarkResponseIssuerRequired` plus its default-false and unknown-token cases; seeded-callback tests (required-but-absent → 400, advertised-and-present → login, not-advertised-and-absent → login); an end-to-end challenge→callback pair driving a real challenge whose discovery advertises the parameter (absent `iss` → 400, present `iss` → login), which pins the challenge-side capture; and a templated-issuer regression guard under `DoNotValidateIssuerName` (empirically confirms OidcClient accepts `iss` ≠ discovery there, and that the login is not locked out).

**Adversarial self-review (four refute-by-default lenses; two findings caught and fixed, final all-PASS).**

- **Availability / mass-lockout, caught + fixed → PASS.** The first cut compared the response `iss` to the discovery issuer *only*, which locks out templated / multi-tenant providers under `DoNotValidateIssuerName` (their response `iss` equals the concrete id_token issuer, not the templated discovery issuer), a HIGH availability regression. Fixed by accepting a match on *either* anchor and adding the empirical regression test above. Re-verified PASS: the two-anchor fix is a strict availability superset, preserves every fail-closed property, no new fail-open. Fail-open on discovery-probe failure is intentional (a transient/failed fetch leaves `required` false, tolerating an absent `iss`) and bounded; requiring it would reintroduce the lockout hazard.
- **Security bypass / fail-open, PASS.** The check is strictly ≥ the prior strictness (it never accepts a present `iss` the old code rejected, and adds the absent-but-advertised rejection); every absent-required / mismatch / unknown-issuer path fails closed; the escape hatch stays opt-out with a secure, audited default; the expected issuer is bound to the correct AS (reused #247 metadata, TLS-fetched), beyond callback-attacker influence.
- **Correctness, PASS.** PKCE gating is byte-for-byte preserved through the `DiscoveryFacts` refactor (a fetch failure is still not cached and retries); the cache reshape is consistent; the flag parse returns true only for explicit boolean `true`; the challenge-side mutations carry no live race (single-threaded before the binding cookie is issued; `MarkResponseIssuerRequired` is a guarded no-op if the entry is gone).
- **Integration, caught + fixed → PASS.** Verified empirically (library decompilation) that `oidcClient.Options.ProviderInformation.IssuerName` is guaranteed populated after a non-error `ProcessResponseAsync` (both the pre-seeded #247 path and the fresh-discovery path), and that Duende `ProviderInformation` does not expose `authorization_response_iss_parameter_supported` (so capturing the flag at challenge is necessary). The first cut was on a stale base that would have reverted PR #443's conformance-scan hardening; fixed by rebasing onto current `origin/main` (f1b206a), #443's `ControllerSourceFiles`/reflection-sentinel work is intact and the only change to `ArchitectureConformanceTests.cs` is the exemption rename. Re-verified PASS: the accept-either-issuer change fixes the lockout without weakening the mix-up defense for standard providers.

**Out of scope / follow-ups:** none required for this change. The `DiscoveryFactsCache` still lives on the controller pending its extraction into a probe type in a later #318 step (documented exemption).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Hardened OpenID Connect callback validation using RFC 9207 response-issuer (`response-iss`) rules.
  * Now rejects missing or mismatched `iss` when the provider advertises support, matching against either discovery metadata or the redeemed token issuer.
  * Respects existing issuer-tolerance behavior (e.g., when issuer-name validation is disabled) and preserves compatibility when not advertised.
* **Documentation**
  * Updated provider guidance describing the revised `iss` validation and its configuration-dependent behavior.
* **Tests**
  * Added expanded unit and end-to-end coverage for required vs. optional, advertised vs. not advertised, mismatched, and case-sensitive scenarios, including challenge-to-callback flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->