### PR TITLE
Document the SAML audience validation options in providers.md

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -165,6 +165,26 @@ Exact redirect-URI matching at the provider is the backstop, but it only helps i
   an explicit `:443`/`:80` `redirect_uri` to work around the old port-in-URL behavior, switch it to the
   no-port form.
 
+## SAML audience validation
+
+By default a SAML response is accepted only if its assertion carries an `AudienceRestriction` that
+names **this** service provider; an assertion minted for a different audience is rejected (fail
+closed). This is what stops a response issued for another service that trusts the same identity
+provider from being replayed here. Two per-provider options tune it:
+
+- **`SamlAudience`** sets the SP entity id the `AudienceRestriction` must contain. Leave it blank to
+  use the `SamlClientId` (the value the plugin sends as the request `Issuer`), which is what most
+  deployments want; set it only when your identity provider is configured to address the assertion
+  to an entity id that differs from the client id. The value is compared trimmed.
+- **`DoNotValidateAudience`** (off by default) skips the audience check entirely. Enable it **only**
+  for a provider that cannot emit an `AudienceRestriction` matching this service provider — it
+  removes a fail-closed check, so prefer setting `SamlAudience` correctly over turning validation
+  off.
+
+Both are set through the SAML provider configuration (the `SAML/Add` API, like the other SAML
+options — there is no admin-UI toggle yet); include them whenever you re-post a provider's config so
+a save does not reset them.
+
 ## SAML response binding (optional hardening)
 
 Two per-provider SAML options, both **off by default**, tie a response more tightly to this service


### PR DESCRIPTION
# What & why

providers.md documented the SAML signing-algorithm requirement and the optional response-binding controls (`ValidateRecipient`, `ValidateInResponseTo`), but never the audience-validation options that every SAML provider config already exposes:

- **`SamlAudience`**, the SP entity id the assertion's `AudienceRestriction` must name; falls back to `SamlClientId` when blank (`SSOController.ValidateSaml`).
- **`DoNotValidateAudience`**, off by default; when set, the audience check is skipped (the opt-out for a provider that cannot emit a matching audience).

An admin whose IdP addresses assertions to a non-default entity id, or that cannot emit a matching `AudienceRestriction`, had no documented way to configure this. The README also lists `DoNotValidateAudience` among the "documented per-provider options", so it was referenced as documented while appearing nowhere in the user docs, this closes that gap and makes the README claim accurate.

This adds a "SAML audience validation" subsection to providers.md covering the default fail-closed check, both keys, the `SamlClientId` fallback, and that they are set through the `SAML/Add` API like the other SAML options. Documentation only; no code change.

Closes #453

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

_Not applicable, documentation only; no code, login-path, crypto, config-persistence, or release-pipeline change. The doc describes the existing fail-closed audience default and its opt-out accurately._

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

_Documentation-only change; build/test unaffected. `npx prettier --check providers.md` is clean._

## Notes

Found during a documentation audit against `origin/main` @ 4b69e3c. The audience behavior was read from `SSOController.ValidateSaml` and `SamlConfig` before writing. Follow-ups filed separately from the same audit (see the issue tracker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for SAML audience validation.
  * Documented options to override the expected audience or disable validation when necessary.
  * Clarified secure defaults and configuration requirements when reposting provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->