### PR TITLE
Reject unsafe usernames when building the avatar profile path

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -283,6 +283,89 @@ public class AvatarServiceTests
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
     }
 
+    [Theory]
+    [InlineData("..")] // parent-directory escape: Path.Combine(root, "..", ...) writes into the PARENT of the user-config dir
+    [InlineData(".")] // current-directory component
+    [InlineData("../evil")] // separator + traversal
+    [InlineData("a/b")] // forward slash
+    [InlineData("a\\b")] // backslash
+    public async Task StoreAsync_UnsafeUsername_SkipsWriteWithoutThrowingOrEscaping(string username)
+    {
+        // #447: user.Username is IdP-controlled (OIDC preferred_username / SAML NameID) and only the host's
+        // own CreateUserAsync validates it — a regex that ADMITS '.' and '..'. A username of ".." would make
+        // Path.Combine write the fetched image into the PARENT of the user-config directory. The store must
+        // fail closed: no out-of-directory write (SaveImage is never called with any path), no throw (login
+        // is best-effort and must still complete), and no profile-image record.
+        var (service, providers, users, log) = Build();
+        var user = UserNamed(username);
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        Assert.Null(user.ProfileImage);
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("safe path component"));
+    }
+
+    [Fact]
+    public async Task StoreAsync_UnsafeUsername_LeavesAnExistingProfileImageUntouched()
+    {
+        // Fail-closed must not be destructive either: a rejected ".." username skips the write AND leaves
+        // any previously set profile-image record exactly as it was (no clear, no re-point).
+        var (service, providers, users, _) = Build();
+        var user = UserNamed("..");
+        var previous = new ImageInfo(ProfilePath("alice", ".jpg"));
+        user.ProfileImage = previous;
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        Assert.Same(previous, user.ProfileImage);
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task StoreAsync_WindowsTrailingDotUsername_DoesNotWriteIntoAnotherUsersDirectory()
+    {
+        // #447 layer-2 (the round-trip containment check, the branch the character check can't reach):
+        // the host username regex admits a trailing dot, and Windows strips it, so "victim." would fold
+        // onto another user's "victim" directory — an in-root cross-user avatar overwrite. The guard must
+        // reject any username whose resolved path is not exactly root/username. On POSIX nothing is
+        // stripped, so "victim." is a distinct literal directory and the avatar stores there normally.
+        // Either way there is no cross-user write and no escape.
+        var (service, providers, users, log) = Build();
+        var user = UserNamed("victim.");
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        if (OperatingSystem.IsWindows())
+        {
+            await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+            await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+            Assert.Null(user.ProfileImage);
+            Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("safe path component"));
+        }
+        else
+        {
+            await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("victim.", ".png"));
+            Assert.Equal(ProfilePath("victim.", ".png"), user.ProfileImage?.Path);
+        }
+    }
+
+    [Fact]
+    public async Task StoreAsync_LegitimateUsernameWithDotAndAt_StillStoresUnchanged()
+    {
+        // Behavior preserved for legitimate usernames the host allows (dots and '@' are valid — e.g. an
+        // email-style preferred_username): the store path is unchanged and the write happens as before.
+        var (service, providers, _, _) = Build();
+        var user = UserNamed("first.last@example.com");
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("first.last@example.com", ".png"));
+        Assert.Equal(ProfilePath("first.last@example.com", ".png"), user.ProfileImage?.Path);
+    }
+
     [Fact]
     public async Task ReadCappedAsync_BodyOverTheCap_Throws()
     {

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -179,10 +179,24 @@ internal sealed class AvatarService
     // reads as one guarded block and the write -> transition ordering (#377) stays a single unit.
     private async Task StoreLockedAsync(User user, Stream image, string mediaType, string extension)
     {
-        var newPath = Path.Combine(
-            _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath,
-            user.Username,
-            "profile" + extension);
+        var root = _serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath;
+
+        // The profile path's middle component is user.Username, which for an SSO login is IdP-controlled
+        // (OIDC preferred_username / SAML NameID). The only host-side check is CreateUserAsync's username
+        // regex ^(?!\s)[\w \-'._@+]+(?<!\s)$ — which the plugin cannot even reference (it lives in the
+        // server, off the Controller/Model surface) and which ADMITS '.' and '..' (#447). A username of
+        // ".." makes Path.Combine write the fetched image into the PARENT of the user-config directory.
+        // Treat the username as untrusted and fail closed: an unsafe component skips the avatar entirely.
+        // The store is best-effort, so login still succeeds with no avatar — we never throw from here.
+        if (!IsUsernameSafeForProfilePath(root, user.Username))
+        {
+            _logger.LogWarning(
+                "Refusing to store the SSO avatar: username is not a safe path component: {Username}",
+                user.Username?.ReplaceLineEndings(string.Empty));
+            return;
+        }
+
+        var newPath = Path.Combine(root, user.Username, "profile" + extension);
 
         // The write comes FIRST: if it throws, nothing below runs, so the user keeps the previous
         // profile-image record instead of a cleared record plus a dangling path to a file that was
@@ -210,6 +224,49 @@ internal sealed class AvatarService
             await _userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
             user.ProfileImage = new ImageInfo(newPath);
         }
+    }
+
+    // Fail-closed guard for the IdP-controlled profile-path component (#447). The username must be a single
+    // safe path component that resolves to exactly the intended per-user directory. Two independent layers:
+    // (1) a character check that rejects '.'/'..', either separator, and any invalid file-name char on every
+    // platform (GetInvalidFileNameChars excludes '\' on Linux, so both separators are rejected explicitly);
+    // (2) belt-and-suspenders, an exact round-trip check — Path.GetFullPath(root/username) must equal
+    // root/username with nothing normalized away. That keeps the write under the root AND rejects platform
+    // tricks the character check can't see: Windows silently strips trailing dots/spaces, so "victim." would
+    // otherwise fold onto another user's "victim" directory (an in-root cross-user overwrite), and an
+    // absolute/drive-relative/device form would resolve elsewhere. Returns false (skip the avatar) rather
+    // than throwing, so the best-effort store never affects login.
+    private static bool IsUsernameSafeForProfilePath(string root, string username)
+    {
+        if (string.IsNullOrEmpty(username)
+            || string.Equals(username, ".", StringComparison.Ordinal)
+            || string.Equals(username, "..", StringComparison.Ordinal)
+            || username.Contains('/')
+            || username.Contains('\\')
+            || username.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            return false;
+        }
+
+        string fullRoot;
+        string fullCandidate;
+        try
+        {
+            fullRoot = Path.GetFullPath(root);
+            fullCandidate = Path.GetFullPath(Path.Combine(root, username));
+        }
+        catch (Exception e) when (e is ArgumentException or IOException or NotSupportedException)
+        {
+            // The path could not be resolved (e.g. an over-long component) — not provably the intended
+            // directory, so fail closed rather than trust it. Never let this bubble into the login path.
+            return false;
+        }
+
+        // Require the resolved path to be EXACTLY <root>/<username> (case-insensitively on Windows, where
+        // the filesystem is): any normalization the OS applied means the on-disk target is not the literal
+        // per-user directory we intended, so reject it.
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        return string.Equals(fullCandidate, Path.Combine(fullRoot, username), comparison);
     }
 
     // The production handler: routes every connection (including redirect targets) through a callback


### PR DESCRIPTION
# What & why

The SSO avatar store built the profile-image path directly from
`user.Username`, which for an SSO login is IdP-controlled (OIDC
`preferred_username` / SAML `NameID`). A username of `..` made
`Path.Combine(root, "..", "profile.<ext>")` write the fetched (size-capped,
fixed-name) image into the **parent** of `UserConfigurationDirectoryPath` - 
a single-level directory escape on the login path.

We guard the username fail-closed before the path is built, in two independent
layers inside `AvatarService`:

- **Character check**, reject `.` / `..`, either separator (`/` or `\`), and
  any `Path.GetInvalidFileNameChars()`. `GetInvalidFileNameChars()` excludes
  `\` on Linux, so both separators are rejected explicitly on every platform.
- **Round-trip containment (belt-and-suspenders)** - 
  `Path.GetFullPath(root/username)` must equal `root/username` exactly. This
  keeps the write under the root and also rejects normalisation the character
  check can't see: Windows silently strips trailing dots/spaces, so `victim.`
  would otherwise fold onto another user's `victim/` directory (an in-root
  cross-user overwrite); absolute / drive-relative / device forms would resolve
  elsewhere.

A rejected username skips only the **best-effort** avatar and logs a warning
(username line-ending-sanitised inline at the call, per the CodeQL
`cs/log-forging` invariant); the login still succeeds with no avatar. The guard
never throws into the login path, and the stored path is byte-for-byte
unchanged for every legitimate username (the write still uses the original
`Path.Combine(root, user.Username, "profile"+extension)`; `GetFullPath` is used
only for the decision).

Closes #447

## Empirical reachability (acceptance item)

We confirmed the traversal is genuinely reachable, and that the fix does not
depend on the host:

- Jellyfin's `UserManager.CreateUserAsync` validates usernames with
  `^(?!\s)[\w \-'._@+]+(?<!\s)$`. That regex **admits `.` and `..`** (period is
  in the allowed class) and **rejects `/` and `\`** (not in the class). So `..`
  passes host validation, the escape is real.
- The `User` entity constructor only does `ArgumentException.ThrowIfNullOrEmpty`
 , no character validation. (Verified against the pinned Jellyfin 10.11
  sources.)
- The validator lives in `Jellyfin.Server.Implementations`, which is **off the
  plugin's reference surface** (the plugin references Controller / Model /
  Database.Implementations only), the plugin cannot even call it, which is why
  the guard is fail-closed regardless of host policy.
- The avatar profile path is the **only** username-keyed filesystem sink in the
  plugin (full-plugin scan for `Path.Combine` / `File.*` / `SaveImage` /
  stream-to-file keyed on the username; the sole other `StreamWriter` wraps an
  in-memory SAML buffer). No separate follow-up sink issue is warranted (issue
  #447 Notes).

## Adversarial review (4-lens gate, login-path change)

- **Availability, PASS.** The guard is avatar-only and fully enclosed in
  `TrySetAsync`'s best-effort catch, so it can never fail or throw into login;
  every realistic host-admitted username (email-style, dotted, `@`/`+`/hyphen/
  underscore/unicode/internal-space) is untouched; no lock contention or
  migration. Only degenerate traversal payloads lose their avatar.
- **Bypass, PASS (on re-review).** First pass flagged a residual: the initial
  `StartsWith` containment accepted the Windows trailing-dot fold (`victim.` →
  `victim/`, an in-root cross-user overwrite) and `...` → root. We switched to
  the exact round-trip equality, which empirically rejects `victim.`,
  `victim `, `...`, whitespace-cloaked escapes like `.. `, and the `NUL` device
  form, while being strictly tighter than the prefix check (no new
  false-accepts). No write outside the exact intended per-user directory and no
  cross-user clobber could be constructed.
- **Correctness, PASS (on re-review).** First pass flagged (1) a too-narrow
  `catch (ArgumentException)` that let `PathTooLongException` (a ~32K-char
  username) escape the "never throws" contract, and (2) the containment-reject
  branch being untested. We widened the catch to
  `when (e is ArgumentException or IOException or NotSupportedException)`
  (covers the bare `IOException`/`PathTooLongException` empirically thrown by
  `GetFullPath`; the catch wraps only pure string ops, so it can't mask a disk
  error) and added a deterministic layer-2-reject test. `#377` write-then-
  transition ordering, the `#400` per-user lock release, non-destructive
  fail-closed, and null/empty-safety all re-confirmed.
- **Integration, PASS.** The plugin owns the profile path (`SaveImage` takes an
  explicit caller path; the host does not re-derive it), so skipping is
  non-corrupting; the lock-key (Ordinal) vs containment (OrdinalIgnoreCase on
  Windows) difference is inert; correct on Linux and Windows.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: an unsafe (IdP-controlled) username is rejected and
      the avatar skipped, never written to an unintended path.
- [x] No secrets logged; the username is not a secret and is line-ending-
      sanitised inline at the log call.
- [x] A security review was performed (4-lens adversarial gate, above).
- [x] Log inputs from the IdP are sanitized inline at the log call
      (`user.Username?.ReplaceLineEndings(string.Empty)`).

## Quality checklist

- [x] No duplicated logic; the guard is one small, single-purpose static helper
      within `AvatarService`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comments explain the *why* (IdP-
      controlled component → fail closed) and match the target architecture.
- [x] Architecture-conformance tests pass; this change establishes no new
      structural property to lock in.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (0 warnings, 0 errors).
- [x] `dotnet test` is green (867 tests, 0 failures).
- [x] Prettier: N/A, only `.cs` files changed.

## Notes

- We deliberately did **not** take the alternative fix of deriving the profile
  directory from the immutable `user.Id` (GUID): that changes **where** avatars
  are stored for existing users (an avatar-migration concern) and is a storage-
  semantics decision. The validate-and-fail-closed approach keeps legitimate
  usernames' storage paths unchanged, no migration.
- The new layer-2 test branches on `OperatingSystem.IsWindows()`: on Windows
  `victim.` is rejected (no write); on POSIX it is a distinct literal directory
  and stores normally there, either way no escape and no cross-user write.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar storage protection against unsafe usernames and path traversal.
  * Unsafe usernames now skip avatar writes without interrupting login or removing existing profile images.
  * Added safeguards for platform-specific path normalization issues on Windows.
  * Preserved avatar storage for legitimate usernames containing dots and `@` symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->