### PR TITLE
Gate account adoption on admin status and a verified claim (#218)

### DIFF
--- a/SSO-Auth.Tests/AdoptionEligibilityResolverTests.cs
+++ b/SSO-Auth.Tests/AdoptionEligibilityResolverTests.cs
@@ -1,0 +1,70 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AdoptionEligibilityResolver"/> — the fail-closed gate that hardens same-named
+/// account adoption (#218). Two protocol-agnostic rules: an administrator target is never adopted by name,
+/// and when the provider requires it the login must carry <c>email_verified == true</c>. The full decision
+/// matrix (admin × require × claim) is pinned here so a regression cannot silently re-open the takeover.
+/// </summary>
+public class AdoptionEligibilityResolverTests
+{
+    [Theory]
+    [InlineData(false, null)]  // gate off, no claim
+    [InlineData(false, true)]  // gate off, verified
+    [InlineData(true, true)]   // gate on, verified
+    public void AdminTarget_IsAlwaysRefused(bool requireVerifiedEmail, bool? emailVerified)
+    {
+        var verdict = AdoptionEligibilityResolver.Resolve(
+            targetIsAdministrator: true,
+            new AdoptionGate(requireVerifiedEmail, emailVerified));
+
+        Assert.Equal(AdoptionVerdict.RefusePrivileged, verdict);
+    }
+
+    [Theory]
+    [InlineData(null)] // claim absent
+    [InlineData(true)] // verified
+    [InlineData(false)] // explicitly unverified
+    public void NonAdmin_GateOff_IsAlwaysAllowed(bool? emailVerified)
+    {
+        // Default posture: adoption proceeds without a verified-email requirement, preserving current
+        // AllowExistingAccountLink deployments.
+        var verdict = AdoptionEligibilityResolver.Resolve(
+            targetIsAdministrator: false,
+            new AdoptionGate(RequireVerifiedEmail: false, emailVerified));
+
+        Assert.Equal(AdoptionVerdict.Allow, verdict);
+    }
+
+    [Fact]
+    public void NonAdmin_GateOn_VerifiedTrue_IsAllowed()
+    {
+        var verdict = AdoptionEligibilityResolver.Resolve(
+            targetIsAdministrator: false,
+            new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true));
+
+        Assert.Equal(AdoptionVerdict.Allow, verdict);
+    }
+
+    [Theory]
+    [InlineData(false)] // email_verified == false
+    [InlineData(null)]  // claim absent — treated like false (fail closed)
+    public void NonAdmin_GateOn_ClaimFalseOrAbsent_IsRefused(bool? emailVerified)
+    {
+        var verdict = AdoptionEligibilityResolver.Resolve(
+            targetIsAdministrator: false,
+            new AdoptionGate(RequireVerifiedEmail: true, emailVerified));
+
+        Assert.Equal(AdoptionVerdict.RefuseUnverifiedEmail, verdict);
+    }
+
+    [Fact]
+    public void None_IsTheOpenPosture_ForANonAdminTarget()
+    {
+        // AdoptionGate.None is what SAML and the legacy call sites pass: no verified-email requirement.
+        Assert.Equal(AdoptionVerdict.Allow, AdoptionEligibilityResolver.Resolve(targetIsAdministrator: false, AdoptionGate.None));
+    }
+}

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
@@ -23,6 +25,13 @@ public class CanonicalLinkServiceTests
     private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
     private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
+
+    private static User AdminUserNamed(string name, Guid id)
+    {
+        var user = UserNamed(name, id);
+        user.SetPermission(PermissionKind.IsAdministrator, true);
+        return user;
+    }
 
     private static (CanonicalLinkService Service, PluginConfiguration Config, IUserManager Users, CapturingLogger Log) Build(Action<PluginConfiguration>? seed = null)
     {
@@ -794,5 +803,107 @@ public class CanonicalLinkServiceTests
 
         Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_AdoptionAllowed_AdminTarget_RefusedWithoutLinking()
+    {
+        // #218: an administrator account is the highest-value takeover target, so a name-based adoption
+        // of one is always refused regardless of the verified-email gate — even with adoption enabled and
+        // a fully verified login. The operator links an admin account explicitly via the admin endpoints.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "admin", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true)));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("attacker-sub"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_SamlAdoptionAllowed_AdminTarget_RefusedWithoutLinking()
+    {
+        // #218: the admin-adoption refusal is protocol-agnostic. SAML carries no email_verified claim
+        // (AdoptionGate.None), but adopting an admin account by NameID is still refused.
+        var (service, cfg, users, _) = Build(c => c.SamlConfigs["idp"] = new SamlConfig { Enabled = true });
+        users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("saml", "idp", "admin", "admin", allowExistingAccountLink: true, AdoptionGate.None));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.False(cfg.SamlConfigs["idp"].CanonicalLinks.ContainsKey("admin"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_RequireVerifiedEmail_ClaimTrue_AdoptsNonAdmin()
+    {
+        // #218: with the verified-email gate on, a non-admin login carrying email_verified == true clears
+        // it and adopts, keying the link on the stable subject as usual.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true));
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Theory]
+    [InlineData(false)] // email_verified == false
+    [InlineData(null)]  // claim absent
+    public async Task ResolveOrCreateAsync_RequireVerifiedEmail_ClaimFalseOrAbsent_RefusesWithoutLinking(bool? emailVerified)
+    {
+        // #218: with the gate on, an absent or false email_verified claim fails closed — no link, no
+        // account, and the takeover-blocking 403 (AccountLinkForbiddenException) is thrown.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: emailVerified)));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LegacyLinkToAdminAccount_RefusesInsteadOfMigrating()
+    {
+        // #218: the admin-adoption refusal also covers the #155 legacy re-key path — an attacker
+        // presenting a NEW subject with an admin's preferred_username must not migrate the admin's legacy
+        // username-keyed link onto their subject. Fail closed: no re-key, 403, legacy key untouched.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["admin"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(AdminUserNamed("admin", Existing));
+        users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "admin", allowExistingAccountLink: true));
+
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.True(links.ContainsKey("admin"));       // legacy key not re-keyed
+        Assert.False(links.ContainsKey("attacker-sub")); // attacker's subject not linked
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_RequireVerifiedEmailOff_NonAdmin_AdoptsRegardlessOfClaim()
+    {
+        // #218: the default posture (gate off) is unchanged — a non-admin adoption proceeds with no
+        // email_verified claim, so a conformant deployment already using AllowExistingAccountLink is not
+        // silently locked out on upgrade.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: false, EmailVerified: null));
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
     }
 }

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -77,6 +77,54 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void EmailVerified_Absent_IsNull()
+    {
+        // No email_verified claim (the IdP omits it, or the "email" scope was not requested) surfaces as
+        // null, which the adoption gate (#218) fails closed on when a verified email is required.
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));
+
+        Assert.Null(result.EmailVerified);
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("True", true)]   // bool.TryParse is case-insensitive
+    [InlineData("FALSE", false)]
+    public void EmailVerified_BooleanClaim_IsParsed(string claimValue, bool expected)
+    {
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("email_verified", claimValue)),
+            Config(_ => { }));
+
+        Assert.Equal(expected, result.EmailVerified);
+    }
+
+    [Theory]
+    [InlineData("yes")]
+    [InlineData("1")]
+    [InlineData("")]
+    public void EmailVerified_NonBooleanClaim_IsNull(string claimValue)
+    {
+        // A non-boolean value is treated as absent (null) rather than coerced to true — fail closed.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("email_verified", claimValue)),
+            Config(_ => { }));
+
+        Assert.Null(result.EmailVerified);
+    }
+
+    [Fact]
+    public void EmailVerified_LastBooleanClaimWins()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("email_verified", "false"), ("email_verified", "true")),
+            Config(_ => { }));
+
+        Assert.True(result.EmailVerified);
+    }
+
+    [Fact]
     public void AllowListConfigured_MatchingRole_IsValid()
     {
         var config = Config(c =>

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -574,10 +574,10 @@ public class OidcStateStoreTests
         Assert.NotNull(pending);
 
         pending.Complete(new OidcAuthorizeStateBuilder.OidcAuthorizeState(
-            Username: "alice", Subject: "sub-1", Valid: true, Admin: false,
+            Username: "alice", Subject: "sub-1", EmailVerified: null, Valid: true, Admin: false,
             EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>(), AvatarUrl: null));
         pending.Complete(new OidcAuthorizeStateBuilder.OidcAuthorizeState(
-            Username: "bob", Subject: "sub-2", Valid: true, Admin: true,
+            Username: "bob", Subject: "sub-2", EmailVerified: null, Valid: true, Admin: true,
             EnableLiveTv: true, EnableLiveTvManagement: true, Folders: new List<string> { "all" }, AvatarUrl: null));
 
         var redeemed = store.TryRedeem("tok", "p", Now, Binding);
@@ -601,6 +601,7 @@ public class OidcStateStoreTests
         pending.Complete(new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: "alice",
             Subject: "sub-1",
+            EmailVerified: null,
             Valid: true,
             Admin: true,
             EnableLiveTv: true,
@@ -657,7 +658,7 @@ public class OidcStateStoreTests
     // so TryRedeem — which requires a validated state — can exercise the per-client release.
     private static void Validate(OidcStateStore store, string token) =>
         store.PeekCurrent(token, "p", Now, Binding)!.Complete(
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", true, false, false, false, new System.Collections.Generic.List<string>(), null));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", null, true, false, false, false, new System.Collections.Generic.List<string>(), null));
 
     [Fact]
     public void TryAdd_FloodFromOneKey_DoesNotRefuseADifferentKey()

--- a/SSO-Auth/Api/AdoptionEligibilityResolver.cs
+++ b/SSO-Auth/Api/AdoptionEligibilityResolver.cs
@@ -1,0 +1,75 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The outcome of the adoption-eligibility gate: whether a name-matched pre-existing account may be
+/// adopted, or the specific reason it is refused. Closed by convention (the caller throws on an
+/// unhandled arm), so a new reason forces a new mapping rather than a silent fall-through.
+/// </summary>
+internal enum AdoptionVerdict
+{
+    /// <summary>The pre-existing account may be adopted.</summary>
+    Allow,
+
+    /// <summary>Refused: the target account is privileged (administrator) and must be linked explicitly.</summary>
+    RefusePrivileged,
+
+    /// <summary>Refused: the provider requires a verified email for adoption and the login carried none (absent or false).</summary>
+    RefuseUnverifiedEmail,
+}
+
+/// <summary>
+/// What the login can prove for a same-named adoption: whether the provider requires a verified email
+/// before adopting, and the <c>email_verified</c> claim the login actually carried (null when the claim
+/// is absent). SAML has no <c>email_verified</c> concept, so it always passes <see cref="None"/>.
+/// </summary>
+/// <param name="RequireVerifiedEmail">Whether the provider gates adoption on a verified email.</param>
+/// <param name="EmailVerified">The login's <c>email_verified</c> claim: true, false, or null when absent.</param>
+internal readonly record struct AdoptionGate(bool RequireVerifiedEmail, bool? EmailVerified)
+{
+    /// <summary>Gets the no-op gate: no verified-email requirement and no claim (the SAML and default posture).</summary>
+    internal static AdoptionGate None => new AdoptionGate(false, null);
+}
+
+/// <summary>
+/// Decides whether an SSO login may adopt the pre-existing, unlinked Jellyfin account that merely shares
+/// its name. Adoption keys on the mutable display name (<c>GetUserByName</c>), so on its own it trusts the
+/// identity provider to make usernames unique and non-reassignable (#218). Two protocol-agnostic gates
+/// raise that bar, both fail closed:
+/// <list type="bullet">
+/// <item>An administrator account is NEVER adopted by name-matching — it is the highest-value takeover
+/// target, so the operator must link it explicitly through the admin link endpoint. This holds regardless
+/// of the verified-email gate or protocol.</item>
+/// <item>When the provider sets <c>RequireVerifiedEmailForAdoption</c>, the login must additionally carry
+/// <c>email_verified == true</c>; an absent or false claim is refused. Jellyfin accounts store no email to
+/// cross-check against, so this proves the principal holds a provider-verified email rather than matching
+/// it to the target account — it does not replace the IdP's unique-username assumption, it narrows who can
+/// exploit it. Off by default so a conformant deployment that already relies on name-based adoption is not
+/// silently locked out on upgrade; opt in once the provider is confirmed to emit <c>email_verified</c>
+/// (which needs the <c>email</c> scope).</item>
+/// </list>
+/// Pure so the whole matrix is unit-testable; the caller resolves the target's admin flag and supplies the
+/// gate, then maps a refusal to <see cref="AccountLinkForbiddenException"/> (the existing 403).
+/// </summary>
+internal static class AdoptionEligibilityResolver
+{
+    /// <summary>
+    /// Decides whether the name-matched account may be adopted.
+    /// </summary>
+    /// <param name="targetIsAdministrator">Whether the account about to be adopted holds administrator rights.</param>
+    /// <param name="gate">What the login can prove (the verified-email requirement and the asserted claim).</param>
+    /// <returns>The adoption verdict.</returns>
+    internal static AdoptionVerdict Resolve(bool targetIsAdministrator, AdoptionGate gate)
+    {
+        if (targetIsAdministrator)
+        {
+            return AdoptionVerdict.RefusePrivileged;
+        }
+
+        if (gate.RequireVerifiedEmail && gate.EmailVerified != true)
+        {
+            return AdoptionVerdict.RefuseUnverifiedEmail;
+        }
+
+        return AdoptionVerdict.Allow;
+    }
+}

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;
@@ -83,8 +85,13 @@ internal sealed class CanonicalLinkService
     /// <param name="canonicalKey">The stable identity key (OpenID sub / SAML NameID).</param>
     /// <param name="username">The display name the account is provisioned/adopted under.</param>
     /// <param name="allowExistingAccountLink">Whether adopting a pre-existing unlinked account is permitted.</param>
+    /// <param name="adoptionGate">
+    /// The extra proof a same-named adoption must clear (#218): a privileged target is always refused, and
+    /// when the gate requires a verified email the login must carry <c>email_verified == true</c>. Default
+    /// (<see cref="AdoptionGate.None"/>) is the SAML/legacy posture: admin refusal only.
+    /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink)
+    internal async Task<Guid> ResolveOrCreateAsync(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -142,12 +149,31 @@ internal sealed class CanonicalLinkService
         // username key is still true same-name matching rather than handing over an account that was
         // renamed away from this name (#361). A legacy link whose target no longer holds the name is left
         // for the terminal branches to label (a fresh-account orphan, or a reject), never followed.
-        Guid? existingAccountUserId = _userManager.GetUserByName(username)?.Id;
+        var existingAccount = _userManager.GetUserByName(username);
+        Guid? existingAccountUserId = existingAccount?.Id;
         bool legacyNameStillHeldByTarget = legacyLink.HasValue && existingAccountUserId == legacyLink;
 
         var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink, legacyNameStillHeldByTarget, allowExistingAccountLink);
         if (migrateLegacy)
         {
+            // The legacy re-key is name-based account matching too (#218): migration fires only when the
+            // account currently bearing the name IS the legacy target (legacyNameStillHeldByTarget), so
+            // that target is exactly existingAccount. Apply the admin refusal here as well — an attacker
+            // presenting a new subject with a victim admin's preferred_username would otherwise re-key the
+            // admin's legacy link onto their own subject and take the account over. Admin-only gate
+            // (AdoptionGate.None): the verified-email requirement is deliberately not applied to the
+            // re-key, which continues a relationship established under the pre-#155 scheme rather than
+            // forming a new one. Link an admin account explicitly via the admin endpoint instead.
+            if (AdoptionEligibilityResolver.Resolve(existingAccount!.HasPermission(PermissionKind.IsAdministrator), AdoptionGate.None) != AdoptionVerdict.Allow)
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode,
+                    provider?.ReplaceLineEndings(string.Empty));
+                throw new AccountLinkForbiddenException();
+            }
+
             MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
@@ -175,6 +201,28 @@ internal sealed class CanonicalLinkService
 
             case AccountLinkAction.AdoptExistingAccount:
             {
+                // Same-name adoption trusts the identity provider to make usernames unique and
+                // non-reassignable (#218): a new principal asserting an existing user's name is otherwise
+                // routed straight to that account. Before writing the link, clear the eligibility gate —
+                // an administrator target is never adopted by name (link it explicitly via the admin
+                // endpoint), and a provider that requires a verified email must have carried
+                // email_verified == true. Fail closed: a refusal writes no link and emits no adoption
+                // audit. existingAccount is non-null here (adoption is only chosen when a named account
+                // resolved), so the admin read cannot NRE.
+                var verdict = AdoptionEligibilityResolver.Resolve(
+                    existingAccount!.HasPermission(PermissionKind.IsAdministrator),
+                    adoptionGate);
+                if (verdict != AdoptionVerdict.Allow)
+                {
+                    _logger.LogWarning(
+                        "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
+                        username?.ReplaceLineEndings(string.Empty),
+                        mode,
+                        provider?.ReplaceLineEndings(string.Empty),
+                        verdict);
+                    throw new AccountLinkForbiddenException();
+                }
+
                 // Atomic check-then-link (#133): if a concurrent first-login already linked this
                 // identity, that winner is used and no second write or duplicate audit occurs.
                 var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -57,6 +57,13 @@ internal static class OidcAuthorizeStateBuilder
         // login that resolved no subject (fail closed).
         var subject = ResolveSubject(claimList);
 
+        // The provider's assertion that the login's email is verified (#218), carried to the adoption
+        // gate so a provider that requires it can refuse a name-based adoption without one. Null when the
+        // claim is absent (the IdP does not emit it, or the "email" scope was not requested); the gate
+        // treats absent exactly like false — fail closed — when the requirement is on. Independent of
+        // validity and of the username, like the subject above.
+        var emailVerified = ResolveEmailVerified(claimList);
+
         // Map the collected roles to privileges and merge (monotonic: only ever grants).
         var grants = RolePrivilegeMapper.Evaluate(roles, config);
         valid |= grants.Valid;
@@ -85,7 +92,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+        return new OidcAuthorizeState(username, subject, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -102,6 +109,25 @@ internal static class OidcAuthorizeStateBuilder
         }
 
         return subject;
+    }
+
+    // The last "email_verified" claim parsed as a boolean, or null when the claim is absent or carries a
+    // non-boolean value. OIDC serializes it as a JSON boolean, which surfaces here as the string "true"/
+    // "false"; anything else is treated as absent (null), which the adoption gate fails closed on when a
+    // verified email is required. Last wins, matching the subject/username derivations.
+    private static bool? ResolveEmailVerified(IReadOnlyList<Claim> claims)
+    {
+        bool? emailVerified = null;
+        foreach (var claim in claims)
+        {
+            if (string.Equals(claim.Type, "email_verified", StringComparison.Ordinal)
+                && bool.TryParse(claim.Value, out var parsed))
+            {
+                emailVerified = parsed;
+            }
+        }
+
+        return emailVerified;
     }
 
     // Resolves the avatar URL by substituting @{claimType} tokens in the configured format, or null
@@ -168,6 +194,7 @@ internal static class OidcAuthorizeStateBuilder
     /// </summary>
     /// <param name="Username">The resolved username (last matching preferred-username or sub claim), or null when none is present.</param>
     /// <param name="Subject">The stable subject identifier (the "sub" claim) used to key the account link, or null when absent.</param>
+    /// <param name="EmailVerified">The login's "email_verified" claim (true/false), or null when the claim is absent, used by the adoption gate (#218).</param>
     /// <param name="Valid">Whether the login is permitted (no allow-list, or a role matched the allow-list).</param>
     /// <param name="Admin">Whether the login grants administrator rights.</param>
     /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
@@ -177,6 +204,7 @@ internal static class OidcAuthorizeStateBuilder
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
+        bool? EmailVerified,
         bool Valid,
         bool Admin,
         bool EnableLiveTv,

--- a/SSO-Auth/Api/PendingState.cs
+++ b/SSO-Auth/Api/PendingState.cs
@@ -43,6 +43,7 @@ internal sealed class PendingState
     {
         _entry.Username = derived.Username;
         _entry.Subject = derived.Subject;
+        _entry.EmailVerified = derived.EmailVerified;
         _entry.Valid = derived.Valid;
         _entry.Admin = derived.Admin;
         _entry.EnableLiveTv = derived.EnableLiveTv;

--- a/SSO-Auth/Api/RedeemedState.cs
+++ b/SSO-Auth/Api/RedeemedState.cs
@@ -14,6 +14,7 @@ internal sealed class RedeemedState
     {
         Subject = claimed.Subject;
         Username = claimed.Username;
+        EmailVerified = claimed.EmailVerified;
         Admin = claimed.Admin;
         Folders = claimed.Folders;
         EnableLiveTv = claimed.EnableLiveTv;
@@ -26,6 +27,9 @@ internal sealed class RedeemedState
 
     /// <summary>Gets the username resolved by the verified login.</summary>
     internal string Username { get; }
+
+    /// <summary>Gets the login's <c>email_verified</c> claim (true/false), or null when absent (#218).</summary>
+    internal bool? EmailVerified { get; }
 
     /// <summary>Gets a value indicating whether the login grants administrator rights.</summary>
     internal bool Admin { get; }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -703,7 +703,13 @@ public class SSOController : ControllerBase
         Guid userId;
         try
         {
-            userId = await _canonicalLinks.ResolveOrCreateAsync("oid", provider, redeemed.Subject, redeemed.Username, config.AllowExistingAccountLink).ConfigureAwait(false);
+            userId = await _canonicalLinks.ResolveOrCreateAsync(
+                "oid",
+                provider,
+                redeemed.Subject,
+                redeemed.Username,
+                config.AllowExistingAccountLink,
+                new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.EmailVerified)).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {
@@ -1058,8 +1064,10 @@ public class SSOController : ControllerBase
         try
         {
             // SAML keys the link directly on the NameID, which is already the stable subject
-            // identifier — key and account name are the same value (no migration path needed).
-            userId = await _canonicalLinks.ResolveOrCreateAsync("saml", provider, nameId, nameId, config.AllowExistingAccountLink).ConfigureAwait(false);
+            // identifier — key and account name are the same value (no migration path needed). SAML has
+            // no email_verified claim, so the verified-email gate is not applicable (AdoptionGate.None);
+            // the resolver's unconditional admin-adoption refusal (#218) still applies.
+            userId = await _canonicalLinks.ResolveOrCreateAsync("saml", provider, nameId, nameId, config.AllowExistingAccountLink, AdoptionGate.None).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {

--- a/SSO-Auth/Api/TimedAuthorizeState.cs
+++ b/SSO-Auth/Api/TimedAuthorizeState.cs
@@ -88,6 +88,13 @@ internal sealed class TimedAuthorizeState
     public string Subject { get; set; }
 
     /// <summary>
+    /// Gets or sets the login's <c>email_verified</c> claim (true/false), or null when the claim is
+    /// absent. Carried to the adoption gate (#218) so a provider that requires a verified email can
+    /// refuse a name-based adoption without one. Null for SAML, which has no such claim.
+    /// </summary>
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the user is an administrator.
     /// </summary>
     public bool Admin { get; set; }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -282,6 +282,18 @@ public class OidConfig : ProviderConfigBase
     public string OidSecret { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether adopting a same-named pre-existing account additionally
+    /// requires the login to carry <c>email_verified == true</c> (#218). Only meaningful when
+    /// <see cref="ProviderConfigBase.AllowExistingAccountLink"/> is on. Off by default (fail closed for
+    /// availability, not for the takeover threat): name-based adoption of an administrator account is
+    /// always refused regardless of this flag, so the headline takeover is closed without it; this flag
+    /// hardens the residual non-admin, name-based adoption. Enabling it needs the <c>email</c> scope so
+    /// the provider actually returns <c>email_verified</c>; an absent or false claim then refuses
+    /// adoption. XML-only, like <see cref="ProviderConfigBase.AllowExistingAccountLink"/>.
+    /// </summary>
+    public bool RequireVerifiedEmailForAdoption { get; set; }
+
+    /// <summary>
     /// Gets or sets the claim to check roles against. Separated by "."s.
     /// </summary>
     public string RoleClaim { get; set; }

--- a/providers.md
+++ b/providers.md
@@ -80,6 +80,30 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   that mints a _different_ `sub` for the same user on every login (a misconfigured pairwise-subject
   setup) will work exactly once and then be refused — fix the IdP configuration; there is nothing
   safe to anchor the identity to otherwise.
+- **Adopting a same-named pre-existing account is gated (`AllowExistingAccountLink`).** When a first
+  login finds no link but a Jellyfin account already bears the SSO name, the account is adopted only if
+  the provider has `AllowExistingAccountLink` set — otherwise the login is refused (HTTP 403). Adoption
+  matches on the mutable display name (`preferred_username` / SAML NameID), so enabling it trusts the
+  identity provider to make usernames **unique and non-reassignable**; a provider that lets a new
+  principal assert an existing user's name would otherwise hand that account over. Two fail-closed gates
+  narrow that trust (#218):
+  - **An administrator account is never adopted by name — regardless of any setting or protocol.** An
+    admin account is the highest-value takeover target, so name-based adoption of one is always refused
+    (a `WARNING` is logged). Link an admin account to its SSO identity explicitly instead, via the admin
+    linking endpoint (`AddCanonicalLink`), which needs no name trust.
+  - **`RequireVerifiedEmailForAdoption` (OpenID only, off by default).** Set it on a provider to
+    additionally require the login to carry `email_verified == true` before adopting a same-named
+    (non-admin) account; an absent or `false` claim is refused. This raises the bar from "asserts a
+    name" to "asserts a name **and** holds a provider-verified email". Jellyfin accounts store no email
+    to cross-check against, so this does not match the email to the target account — it does not replace
+    the unique-username assumption, it narrows who can exploit it. It is **off by default** so a
+    deployment already relying on `AllowExistingAccountLink` is not silently locked out on upgrade.
+    Enabling it needs the `email` scope in the provider's `OidScopes` so the IdP actually returns
+    `email_verified`; without that scope the claim is absent and every adoption is refused. **SAML** has
+    no `email_verified` claim, so this gate is not applicable there — only the admin refusal above
+    applies, and SAML operators relying on name-based adoption should ensure their IdP issues stable,
+    non-reassignable NameIDs. Both `AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` are
+    edited in the provider's `config.xml`, not on the config page.
 - **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
   identity provider can reassign, so following such a link is name-based account matching, governed by

--- a/providers.md
+++ b/providers.md
@@ -102,7 +102,10 @@ expiry). A few provider settings must therefore match, or login is refused (fail
     `email_verified`; without that scope the claim is absent and every adoption is refused. **SAML** has
     no `email_verified` claim, so this gate is not applicable there — only the admin refusal above
     applies, and SAML operators relying on name-based adoption should ensure their IdP issues stable,
-    non-reassignable NameIDs. Both `AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` are
+    non-reassignable NameIDs. The transitional legacy re-key path below is **exempt** from the
+    verified-email requirement (it continues a relationship established under the old scheme, not a new
+    one), so on that one path the admin-takeover ceiling is still enforced but this verified-email
+    defense-in-depth is not. Both `AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` are
     edited in the provider's `config.xml`, not on the config page.
 - **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
@@ -121,6 +124,14 @@ expiry). A few provider settings must therefore match, or login is refused (fail
      password, so if your only admins sign in through OpenID they will be locked out by the 403 above
      with no way back in-band. **Before upgrading**, make sure at least one Jellyfin administrator has a
      normal password login (Dashboard → Users), or you will be left editing config on disk (next point).
+     Note the extra admin case (#218): a returning **administrator** who held a pre-#155 username-keyed
+     OpenID link is **refused on their first post-upgrade login even with `AllowExistingAccountLink` on**
+     — an admin account is never adopted or re-keyed by name — so re-link it explicitly with
+     `AddCanonicalLink` (from the break-glass admin) rather than expecting self-migration. If that admin
+     was itself originally plugin-**created** and is your _only_ admin (random password, signs in through
+     SSO), recover server-side: reset its password from the Jellyfin dashboard using another admin, or —
+     if truly locked out — link it by editing the provider's `<CanonicalLinks>` in `config.xml` to map
+     the current `sub` to that user id, then restart.
   2. **Fully locked out?** Stop Jellyfin, open the plugin's `config.xml` in its data directory, set
      `<AllowExistingAccountLink>true</AllowExistingAccountLink>` inside the affected provider's config
      block, restart, and complete the migration below; then set it back to `false`.


### PR DESCRIPTION
# What & why

Same-named account adoption resolved only on the mutable display name
(`_userManager.GetUserByName(username)`), never consulting whether the target
account is privileged or whether the login proved a verified email. With a
provider's `AllowExistingAccountLink` enabled, a new principal who asserts an
existing user's name (e.g. `admin`) is routed straight to adoption and takes
that account over on first login (account-takeover class, #218). The link is
correctly keyed on the stable `sub` (#155), but the adoption MATCH was name-only.

This adds a pure, single-responsibility gate behind the resolver, mirroring
V2's `PrivilegedAdoptionResolver` / `EmailVerifiedResolver` intent, with two
fail-closed rules:

- **An administrator target is never adopted by name, unconditional, both
  protocols.** An admin account is the highest-value takeover target, so a
  name-based bind to one is always refused. This covers BOTH name-based paths:
  the fresh adoption (`AdoptExistingAccount`) and the #155 legacy username-key
  re-key (`migrateLegacy`), whose target is the same account. Operators link an
  admin account explicitly via the admin endpoint (`AddCanonicalLink`).
- **`RequireVerifiedEmailForAdoption` (OpenID per-provider, default false).**
  When set, a non-admin adoption additionally requires `email_verified == true`;
  absent or false is refused. Jellyfin accounts store no email to cross-check, so
  this proves the principal holds a provider-verified email rather than matching
  it to the target, it narrows who can exploit the name-uniqueness assumption
  rather than replacing it. Off by default so a conformant deployment already
  using `AllowExistingAccountLink` is not silently locked out on upgrade; needs
  the `email` scope. SAML has no such claim, so it passes `AdoptionGate.None`
  (admin refusal only).

`email_verified` is threaded from `OidcAuthorizeStateBuilder` through the
authorize state and `RedeemedState` to the resolver. A refusal throws
`AccountLinkForbiddenException` (the existing 403 mapping); no link is written
and no adoption is audited. `providers.md` documents the gate, the returning-admin
upgrade case, the sole-admin recovery, and the legacy re-key exemption.

Closes #218

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

**Design decision, the adoption case matrix** (default posture in bold):

| Target / claim | Gate off (default) | `RequireVerifiedEmailForAdoption` on |
| --- | --- | --- |
| Non-admin, `email_verified` true | **Adopt** | Adopt |
| Non-admin, `email_verified` false | **Adopt** | Refuse (403) |
| Non-admin, claim absent | **Adopt** | Refuse (403) |
| Administrator (any claim) | **Refuse (403)** | Refuse (403) |
| SAML (no `email_verified`) | admin refusal only | n/a (flag is OID-only) |

The unconditional admin refusal is the fail-closed core (closes the headline
`admin` takeover by default, no config); the verified-email requirement is an
opt-in that preserves availability for IdPs that omit the claim.

**Adversarial self-review, four refute-by-default lenses, all PASS:**

- **Availability / mass-lockout, PASS.** The flag defaults false in code
  (`default(AdoptionGate)` == `None`), so a conformant `AllowExistingAccountLink`
  deployment omitting `email_verified` is unchanged. The admin refusal is the one
  deliberate behavior change; its recovery (`AddCanonicalLink`, or a config-XML /
  dashboard reset for a sole plugin-created admin) is real, reachable, and
  documented. No non-adoption path (UseExistingLink / CreateNewAccount /
  RejectNameTaken) is newly refused.
- **Security-bypass / fail-open, PASS.** Both name-based paths (fresh adopt +
  legacy re-key) are admin-gated; the subject-keyed `UseExistingLink` is
  correctly not gated. `email_verified` is parsed fail-closed (bool-only,
  last-wins, non-boolean/absent -> null -> refuse when required). The gate runs
  before the link write / audit; a refusal writes nothing.
- **Correctness, PASS.** `existingAccount` is non-null on both gated paths
  (adopt requires `existingAccountUserId.HasValue`; migrate requires
  `legacyNameStillHeldByTarget` which implies `existingAccountUserId == legacyLink`).
  Record field-ordering updated at every construction site (prod + tests).
- **Integration, PASS.** `RequireVerifiedEmailForAdoption` is a plain bool: it
  round-trips through the JSON GET/PUT the config page uses (the save fetches the
  full live config and overlays only page fields), persists to XML, and is
  correctly NOT in `ServerManagedFields`. `HasPermission(PermissionKind.IsAdministrator)`
  is the correct Jellyfin 10.11 admin contract. The 403 mapping is unchanged.

**Two documented residuals (accepted):**

1. A returning administrator with a pre-#155 username-keyed OpenID link is refused
   on first post-upgrade login (admin accounts are never re-keyed by name) and must
   be re-linked via `AddCanonicalLink`, documented in the upgrade runbook.
2. The transitional legacy re-key path is exempt from the verified-email
   requirement (passes `AdoptionGate.None`): the admin-takeover ceiling is enforced
   there, the verified-email defense-in-depth is not, a deliberate scope choice
   (it continues a pre-#155 relationship, not a new one), documented.

Tests: 33 new across `AdoptionEligibilityResolverTests` (full decision matrix),
`CanonicalLinkServiceTests` (admin refusal on adopt + legacy paths, both
protocols; verified-email true/false/absent; gate-off regression), and
`OidcAuthorizeStateBuilderTests` (`email_verified` parsing). 913 total green,
Debug + Release `--warnaserror` clean, Jellyfin compat check clean.
