### PR TITLE
Harden IntervalGate against stale-sample re-admission

### DIFF
--- a/SSO-Auth.Tests/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/IntervalGateTests.cs
@@ -10,8 +10,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// Characterization tests pinning IntervalGate's once-per-interval semantics — the shared throttle the
 /// anonymous-path sweeps and log signals rely on to not amplify a flood into CPU or log volume (#246,
 /// #195). The wall-clock cases (boundary, backward step) are the primary evidence for the #318 step 2b
-/// unification because CI cannot move real time, and each adopting site's Interlocked original had exactly
-/// these semantics: guard on a non-negative sub-interval span, then a single CAS winner per interval.
+/// unification because CI cannot move real time. The guard suppresses a sub-interval span in either
+/// direction (|now - last| &lt; interval), then a single CAS winner enters per interval: a genuine
+/// correction (backward span &ge; interval) self-heals, while a stale sub-interval sample is suppressed
+/// rather than re-admitted (#334), closing the original fail-open residual without opening a stall.
 /// </summary>
 public class IntervalGateTests
 {
@@ -63,34 +65,62 @@ public class IntervalGateTests
     }
 
     [Fact]
-    public void TryEnter_BackwardClockStep_EntersAndReAnchors()
+    public void TryEnter_BackwardClockStepOfAtLeastTheInterval_EntersAndReAnchors()
     {
-        // #246 self-heal: a wall-clock correction (now earlier than the last entry) must not stall the
-        // gate. It enters and re-anchors to the earlier time, so throttling then resumes from there.
+        // #246 self-heal: a genuine wall-clock correction — a backward span of at least the interval (DST
+        // fall-back, NTP step) — must not stall the gate. It enters and re-anchors to the earlier time, so
+        // throttling then resumes from there. Only sub-interval backward spans are treated as stale (#334).
         var gate = new IntervalGate(Interval);
         Assert.True(gate.TryEnter(At(12, 0)));
 
-        var backward = At(11, 30);
-        Assert.True(gate.TryEnter(backward));                     // backward step enters (self-heal)
+        var backward = At(11, 30);                                // 30 min back, well over the 1-min interval
+        Assert.True(gate.TryEnter(backward));                     // large correction enters (self-heal)
         Assert.False(gate.TryEnter(backward.AddSeconds(30)));     // re-anchored to 11:30: throttled again
         Assert.True(gate.TryEnter(backward + Interval));          // a full interval past the new anchor: enters
     }
 
     [Fact]
-    public void TryEnter_StaleOlderSample_AdmitsAndReAnchors_TheDocumentedFailOpenResidual()
+    public void TryEnter_BackwardStepOfExactlyTheInterval_EntersAndReAnchors()
     {
-        // A caller whose captured 'now' is older than the cursor (a thread descheduled between reading the
-        // clock and entering) is indistinguishable from a wall-clock correction, so it enters and re-anchors
-        // — one extra admission, with the next interval measured from the older time. This is the documented
-        // residual of the self-heal guard, bounded to fail-open noise (an extra sweep or log line); the
-        // dangerous direction, a stall, cannot occur because a backward re-anchor only shortens the wait.
+        // The suppression guard is strict (|span| < interval), so a backward span of exactly one interval is
+        // a correction, not a stale sample: it enters and re-anchors — the backward mirror of the forward
+        // exactly-the-interval case, keeping the self-heal boundary symmetric.
         var gate = new IntervalGate(Interval);
-        Assert.True(gate.TryEnter(At(12, 0)));
+        var t0 = At(12, 0);
+        Assert.True(gate.TryEnter(t0));
+        Assert.True(gate.TryEnter(t0 - Interval));                // exactly one interval back: self-heals
+    }
+
+    [Fact]
+    public void TryEnter_StaleSubIntervalOlderSample_IsSuppressed()
+    {
+        // A caller whose captured 'now' is merely stale — descheduled between reading the clock and entering,
+        // so it lands just behind the cursor (a sub-interval backward span) — is now suppressed, closing the
+        // #334 fail-open second admission. The cursor is left untouched, so throttling still lifts exactly one
+        // interval after the real entry; a stale blip can neither re-admit nor stall the gate.
+        var gate = new IntervalGate(Interval);
+        var t0 = At(12, 0);
+        Assert.True(gate.TryEnter(t0));
 
         var stale = At(11, 59, 59);
-        Assert.True(gate.TryEnter(stale));                        // stale sample admits (the residual)
-        Assert.False(gate.TryEnter(At(12, 0, 58)));               // re-anchored to 11:59:59: still throttled
-        Assert.True(gate.TryEnter(stale + Interval));             // and open again one interval after the anchor
+        Assert.False(gate.TryEnter(stale));                       // stale sub-interval sample is suppressed
+        Assert.False(gate.TryEnter(At(12, 0, 58)));               // cursor stayed at 12:00: still throttled
+        Assert.True(gate.TryEnter(t0 + Interval));                // and opens exactly one interval after the entry
+    }
+
+    [Fact]
+    public void TryEnter_RepeatedSubIntervalBackwardBlips_NeverStallBeyondOneInterval()
+    {
+        // The dangerous direction is a stall — a capped store refusing forever. Suppressing sub-interval
+        // backward blips leaves the cursor untouched, so admission is still guaranteed one interval after the
+        // last real entry no matter how many stale blips arrive; the wait can never exceed one interval.
+        var gate = new IntervalGate(Interval);
+        var t0 = At(12, 0);
+        Assert.True(gate.TryEnter(t0));
+
+        Assert.False(gate.TryEnter(At(11, 59, 30)));              // sub-interval backward blip: suppressed, no re-anchor
+        Assert.False(gate.TryEnter(At(11, 59, 45)));              // another blip: still suppressed, cursor still 12:00
+        Assert.True(gate.TryEnter(t0 + Interval));                // guaranteed open one interval after the real entry
     }
 
     [Fact]

--- a/SSO-Auth/Api/IntervalGate.cs
+++ b/SSO-Auth/Api/IntervalGate.cs
@@ -38,10 +38,15 @@ internal sealed class IntervalGate
         var nowTicks = now.Ticks;
         var last = Interlocked.Read(ref _cursor);
 
-        // Suppress only when a non-negative, sub-interval span has elapsed. A backward wall-clock step
-        // (nowTicks < last) fails the first term, so it does NOT suppress — it enters and re-anchors the
-        // cursor below, so a clock correction can never stall the gate and leave a capped store refusing.
-        if (nowTicks >= last && nowTicks - last < _intervalTicks)
+        // Suppress a sub-interval span in EITHER direction: |now - last| < interval. A forward span shorter
+        // than the interval is the normal throttle. A backward span shorter than the interval is a stale
+        // sample — a thread descheduled between reading the clock and entering, landing just behind the
+        // cursor — and must NOT re-admit (#334): leaving the cursor untouched keeps the next admission at
+        // last + interval, so a stale blip opens no second admission yet can never stall the gate either
+        // (the wait is capped at one interval from the real entry). A backward span of at least the interval
+        // is a genuine wall-clock correction (DST fall-back, NTP step): it fails the guard, so it enters and
+        // re-anchors below, preserving the #246 self-heal that stops a correction from stranding a capped store.
+        if (Math.Abs(nowTicks - last) < _intervalTicks)
         {
             return false;
         }

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -43,7 +43,9 @@ internal sealed class OidcStateStore
 
     // Throttles the capacity-full warning (#246, CWE-400) to one signal per interval: under a flood
     // every refused challenge would otherwise emit a warning, amplifying the flood into unbounded log
-    // volume. The gate self-heals a backward wall-clock step.
+    // volume. The gate self-heals a backward wall-clock step of at least the interval (re-anchors); a
+    // sub-interval backward step is a stale sample, suppressed with the cursor untouched (#334) — still
+    // without stalling like the hand-rolled predecessor.
     private readonly IntervalGate _capWarnGate;
 
     // Per-client occupancy sub-cap (#327): bounds how much of the global budget one client key can hold,

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -31,8 +31,9 @@ internal sealed class SamlRequestCache
     private readonly ConcurrentDictionary<string, Entry> _outstanding = new(StringComparer.Ordinal);
 
     // Throttles the sweep to one run per prune interval; the gate owns the atomic cursor and self-heals
-    // a backward wall-clock step (the hand-rolled predecessor stalled until the clock re-passed its
-    // cursor). See PruneExpired.
+    // a backward wall-clock step of at least the interval (re-anchors), while a sub-interval backward step
+    // is a stale sample suppressed with the cursor untouched (#334) — either way it never stalls until the
+    // clock re-passes its cursor the way the hand-rolled predecessor did. See PruneExpired.
     private readonly IntervalGate _pruneGate;
 
     // Throttles the capacity-full warning to one signal per interval (CWE-400): under a flood every

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -44,8 +44,9 @@ internal sealed class SsoRateLimiter
     private readonly IntervalGate _signalGate = new(SignalInterval);
 
     // Throttles the stale-counter sweep to one run per PruneInterval; the gate owns the atomic cursor
-    // and self-heals a backward wall-clock step (the hand-rolled predecessor stalled until the clock
-    // re-passed its cursor). See PruneStale.
+    // and self-heals a backward wall-clock step of at least the interval (re-anchors), while a sub-interval
+    // backward step is a stale sample suppressed with the cursor untouched (#334) — either way it never
+    // stalls until the clock re-passes its cursor the way the hand-rolled predecessor did. See PruneStale.
     private readonly IntervalGate _pruneGate = new(PruneInterval);
 
     // Bounded observability signal (#195). Every refusal increments the tally; RecordThrottledHit drains it
@@ -221,8 +222,9 @@ internal sealed class SsoRateLimiter
         // Only the gate's single winner per interval drains the tally; everyone else returns 0 (suppressed).
         // An increment racing with the winner's drain lands either in that drain's returned count or in the
         // tally for a later drain — never erased, since increment and exchange on one location are serialized
-        // atomic operations (pinned by the conservation test). The gate self-heals a backward clock, so a
-        // correction cannot stall the signal; the first refusal (cursor at MinValue) signals the onset at once.
+        // atomic operations (pinned by the conservation test). The gate self-heals a backward clock step of
+        // at least the interval and suppresses a sub-interval stale sample (#334), so neither a correction nor
+        // a stale blip can stall the signal; the first refusal (cursor at MinValue) signals the onset at once.
         return _signalGate.TryEnter(nowUtc) ? Interlocked.Exchange(ref _throttledHits, 0) : 0;
     }
 


### PR DESCRIPTION
# What & why

`IntervalGate.TryEnter` treated every sample older than the cursor as a wall-clock correction and re-anchored (the #246 self-heal). A caller whose captured `now` was merely *stale*, descheduled between reading the clock and entering, landing just behind the cursor, was indistinguishable from a correction, so it CASed the cursor backward and was admitted: a second admission inside one interval. This is the fail-open residual the old characterization test pinned deliberately (the throttles guard anonymous-path DoS amplification, so an extra sweep/log line per race is bounded, but it is still a fail-open we can now close cleanly).

We replace the one-directional guard with a **symmetric** one: suppress when `|now - last| < interval`.

- **Stale sub-interval sample (the bug):** a backward span shorter than the interval is now suppressed *without* re-anchoring. No second admission; the cursor is left untouched so the next admission stays capped at one interval after the real entry.
- **Genuine large correction (DST fall-back, NTP step ≥ interval):** still fails the guard, so it enters and re-anchors, the #246 self-heal is preserved, and no capped store can be stranded.
- **Forward direction / first call / exactly-the-interval boundary:** bit-identical to before.

We picked the symmetric guard over the monotonic-clock alternative (issue candidate 2) because it is one line, keeps each caller's wall-clock `now` shared with the throttled action's expiry math (a `TickCount64` gate would decouple the two), keeps the injectable clock the characterization tests rely on, and moves only in the safe direction: it can never lengthen the wait beyond one interval, so it opens no stall.

Closes #334
Refs #318, #331

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. *(N/A to this diff; the change closes a fail-open in a DoS-guard throttle without touching any accept/reject decision.)*
- [x] No secrets logged; secrets are redacted on config export. *(Unchanged; the gate carries no request data.)*
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. *(Four-lens adversarial gate — see Notes.)*
- [x] Log inputs from the IdP are sanitized inline at the log call. *(Unchanged; no log inputs touched.)*

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. *(The change lands once in `IntervalGate`, shared by all 5 throttle sites.)*
- [x] The change adds no more code than the problem requires. *(One-line guard; comment + test updates.)*
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. *(No new structural property; the existing `no-inline-interval-throttle-cursor` opengrep rule stays accurate — confirmed by the integration lens.)*

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. *(Debug + Release, 0 warnings.)*
- [x] `dotnet test` is green. *(889 passed, 0 failed.)*
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. *(No such files changed.)*

## Notes

### Behavior: before → after

| Case | Before | After |
| --- | --- | --- |
| Forward, ≥ interval elapsed | enters, re-anchors | unchanged |
| Forward, < interval elapsed | throttled | unchanged |
| Exactly interval (forward) | enters | unchanged |
| First call (cursor at MinValue) | enters | unchanged |
| **Stale sample, < interval behind cursor** | **enters + re-anchors backward (2nd admission)** | **suppressed, cursor untouched (no 2nd admission)** |
| Genuine correction, ≥ interval behind cursor | enters + re-anchors | unchanged (self-heals) |

Across all five sites (OidcStateStore prune + cap-warn, SamlRequestCache prune + cap-warn, SsoRateLimiter signal + prune) this only changes the stale-sample row; the DoS-amplification protection (single CAS winner per interval) is intact.

### Adversarial self-review (four refute-by-default lenses)

- **Availability / mass-lockout, VERDICT: PASS.** No new stall at any site. Suppressing a sub-interval backward blip leaves the cursor put, so admission is still guaranteed one interval after the last real entry regardless of how many stale blips arrive; a capped store's prune can never stop running into a cap-fill lockout. Genuine ≥-interval corrections still self-heal; no first-call regression.
- **Security-bypass / fail-open, VERDICT: PASS.** The fail-open race is actually closed: no stale sub-interval sample can produce a second admission, and boundary-straddling timing cannot amplify the throttled action beyond one action per interval. The single-CAS-winner property holds. No `Math.Abs(long.MinValue)` overflow, the tick difference for real `DateTime` values is bounded well below `long` range.
- **Correctness, VERDICT: PASS.** Forward/first-call/exactly-the-interval semantics are bit-identical; backward-exactly-the-interval enters + re-anchors, sub-interval-back is suppressed without re-anchor. The updated/added tests' arithmetic assertions hold.
- **Integration, VERDICT: NEEDS_IMPROVEMENT → resolved.** The lens found documentation drift: four downstream call-site comments still described the gate as an unconditional backward self-heal. **Resolved** in commit `64e1cd1`, each comment now qualifies the self-heal with "≥ interval (re-anchors)" and notes the sub-interval case is suppressed with the cursor untouched, while preserving the "never stalls like the hand-rolled predecessor" property. The opengrep `no-inline-interval-throttle-cursor` rule needs no change (confirmed accurate). No behavior change from the reconciliation.

### Tests

Re-pinned the stale-sample characterization test from the fail-open residual to the new suppressed behavior, and added: exactly-one-interval-backward self-heals (boundary), and no-stall-under-repeated-sub-interval-blips (admission still opens one interval after the real entry). The genuine large-correction self-heal test is unchanged (30 min back ≫ 1 min interval).
