### PR TITLE
Collapse repeated PluginPageInfo construction in SSOPlugin

### DIFF
--- a/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
+++ b/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
@@ -1,0 +1,69 @@
+using System.IO;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Model.Plugins;
+using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins the <see cref="PluginPageInfo"/> set <see cref="SSOPlugin.GetPages"/> and
+/// <see cref="SSOPlugin.GetViews"/> emit — the (name, embedded resource) contract Jellyfin resolves
+/// static assets by — so the #458 factory-collapse refactor stays behavior-preserving.
+/// </summary>
+[Collection("SSOController")]
+public class SSOPluginPageManifestTests
+{
+    private static SSOPlugin CreatePlugin()
+    {
+        var appPaths = Substitute.For<IApplicationPaths>();
+        appPaths.PluginConfigurationsPath.Returns(Path.Combine(Path.GetTempPath(), "sso-test-" + System.Guid.NewGuid()));
+        var xml = Substitute.For<IXmlSerializer>();
+        return new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
+    }
+
+    [Fact]
+    public void GetPages_EmitsTheExpectedNameAndResourcePairsInOrder()
+    {
+        var plugin = CreatePlugin();
+        const string ns = "Jellyfin.Plugin.SSO_Auth";
+
+        var actual = plugin.GetPages().Select(p => (p.Name, p.EmbeddedResourcePath)).ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                ("SSO-Auth", $"{ns}.Config.configPage.html"),
+                ("SSO-Auth.js", $"{ns}.Config.config.js"),
+                ("SSO-Auth.css", $"{ns}.Config.style.css"),
+                ("SSO-Auth-linking", $"{ns}.Config.linking.html"),
+                ("SSO-Auth-linking.js", $"{ns}.Config.linking.js"),
+            },
+            actual);
+    }
+
+    [Fact]
+    public void GetViews_EmitsTheExpectedNameAndResourcePairsInOrder()
+    {
+        var plugin = CreatePlugin();
+        const string ns = "Jellyfin.Plugin.SSO_Auth";
+
+        var actual = plugin.GetViews().Select(p => (p.Name, p.EmbeddedResourcePath)).ToArray();
+
+        Assert.Equal(
+            new[]
+            {
+                ("style.css", $"{ns}.Config.style.css"),
+                ("linking", $"{ns}.Config.linking.html"),
+                ("linking.js", $"{ns}.Config.linking.js"),
+                ("ApiClient.js", $"{ns}.Views.apiClient.js"),
+                ("emby-restyle.css", $"{ns}.Views.emby-restyle.css"),
+                ("jellyfin-apiClient.esm.min.js", $"{ns}.Views.jellyfin-apiClient.esm.min.js"),
+            },
+            actual);
+    }
+}

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -112,76 +112,34 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// Returns the available internal web pages of this plugin.
     /// </summary>
     /// <returns>A list of internal webpages in this application.</returns>
-    public IEnumerable<PluginPageInfo> GetPages()
-    {
-        return new[]
+    public IEnumerable<PluginPageInfo> GetPages() =>
+        new[]
         {
-            new PluginPageInfo
-            {
-                Name = Name,
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.configPage.html"
-            },
-            new PluginPageInfo
-            {
-                Name = Name + ".js",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.config.js"
-            },
-            new PluginPageInfo
-            {
-                Name = Name + ".css",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.style.css"
-            },
-            new PluginPageInfo
-            {
-                Name = Name + "-linking",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.linking.html"
-            },
-            new PluginPageInfo
-            {
-                Name = Name + "-linking.js",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.linking.js"
-            },
+            Page(Name, "Config.configPage.html"),
+            Page(Name + ".js", "Config.config.js"),
+            Page(Name + ".css", "Config.style.css"),
+            Page(Name + "-linking", "Config.linking.html"),
+            Page(Name + "-linking.js", "Config.linking.js"),
         };
-    }
 
     /// <summary>
     /// Returns the available user views for this plugin.
     /// </summary>
     /// <returns>A list of user views for this plugin.</returns>
-    public IEnumerable<PluginPageInfo> GetViews()
-    {
-        return new[]
+    public IEnumerable<PluginPageInfo> GetViews() =>
+        new[]
         {
-            new PluginPageInfo
-            {
-                Name = "style.css",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.style.css"
-            },
-            new PluginPageInfo
-            {
-                Name = "linking",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.linking.html"
-            },
-            new PluginPageInfo
-            {
-                Name = "linking.js",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Config.linking.js"
-            },
-            new PluginPageInfo
-            {
-                Name = "ApiClient.js",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Views.apiClient.js"
-            },
-            new PluginPageInfo
-            {
-                Name = "emby-restyle.css",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Views.emby-restyle.css"
-            },
-            new PluginPageInfo
-            {
-                Name = "jellyfin-apiClient.esm.min.js",
-                EmbeddedResourcePath = $"{GetType().Namespace}.Views.jellyfin-apiClient.esm.min.js"
-            },
+            Page("style.css", "Config.style.css"),
+            Page("linking", "Config.linking.html"),
+            Page("linking.js", "Config.linking.js"),
+            Page("ApiClient.js", "Views.apiClient.js"),
+            Page("emby-restyle.css", "Views.emby-restyle.css"),
+            Page("jellyfin-apiClient.esm.min.js", "Views.jellyfin-apiClient.esm.min.js"),
         };
-    }
+
+    // Every GetPages/GetViews entry is a (registered name, embedded resource) pair under this
+    // plugin's namespace; this factory collapses the repeated PluginPageInfo construction to one
+    // call per entry.
+    private PluginPageInfo Page(string name, string resource) =>
+        new() { Name = name, EmbeddedResourcePath = $"{GetType().Namespace}.{resource}" };
 }


### PR DESCRIPTION
# What & why

`SSOPlugin.GetPages`/`GetViews` built each `PluginPageInfo` by hand, repeating
the same `Name`/`EmbeddedResourcePath` shape 11 times (5 pages + 6 views). We
collapse each entry to a single call against a new private `Page(name,
resource)` factory. Closes #458.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this touches `SSOPlugin.cs` (flagged as a sensitive file
generally) but only its page/view manifest construction, not the login path,
crypto, or config persistence. No user input, no auth decision, no secret
handling involved; we did not run the full adversarial-review gate for this
reason, consistent with the issue's own security note ("Security: none, pure
construction refactor").

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property here — `Page` is a private helper, already
      covered by the existing `SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade`
      rule, which we confirmed still passes.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (Debug and Release, 915/915).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none
      touched — this PR is C# only).

## Notes

Self-review: the emitted `PluginPageInfo` set is byte-identical before and
after, same 5 page names/paths, same 6 view names/paths, same order, same
`{GetType().Namespace}.<resource>` interpolation. `SSOPluginPageManifestTests`
(new) asserts the exact name/resource pairs and their order for both
`GetPages()` and `GetViews()`, locking the behavior-preserving contract in.
Net: 84 lines changed, 42 fewer lines in `SSOPlugin.cs`. Scope: `SSOPlugin.cs`
plus the new test file only, nothing else touched.
