### PR TITLE
Revoke active tokens when unregistering a user

### DIFF
--- a/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
@@ -50,6 +50,69 @@ public class SSOControllerUnregisterTests
         Assert.False(links.ContainsKey("sub-alice"));
     }
 
+    [Fact]
+    public async Task Unregister_KnownUser_RevokesTheTargetUsersActiveTokens()
+    {
+        var harness = new SsoControllerHarness();
+        SeedUser(harness);
+
+        await harness.Controller.Unregister("alice", "Jellyfin");
+
+        // A hard revoke must also terminate the user's already-issued tokens, scoped to this one user; null
+        // revokes all of their tokens (#440).
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserId, null);
+    }
+
+    [Fact]
+    public async Task Unregister_DoesNotRevokeTokensForOtherUsers()
+    {
+        var harness = new SsoControllerHarness();
+        SeedUser(harness);
+        var otherUser = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+        await harness.Controller.Unregister("alice", "Jellyfin");
+
+        // The revoke is scoped strictly to the resolved target — no other user's tokens may be swept.
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(otherUser, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task Unregister_TokenRevokeNoOp_StillCompletesOk()
+    {
+        // With the mock's default (a completed no-op task) the revoke changes nothing; the unregister must
+        // still persist the provider switch and return Ok.
+        var harness = new SsoControllerHarness();
+        var user = SeedUser(harness);
+
+        var result = await harness.Controller.Unregister("alice", "Jellyfin");
+
+        Assert.IsType<OkResult>(result);
+        await harness.UserManager.Received(1).UpdateUserAsync(user);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserId, null);
+    }
+
+    [Fact]
+    public async Task Unregister_WhenTokenRevokeFails_LinksAlreadyRemovedAndProviderPersisted()
+    {
+        // The token revoke runs LAST, after the durable revoke is committed, so a failure there cannot leave
+        // the unregister half-done: the links are already dropped and the provider switch persisted (#440).
+        var harness = new SsoControllerHarness(c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = UserId },
+            });
+        var user = SeedUser(harness);
+        harness.SessionManager.RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>())
+            .Returns(Task.FromException(new InvalidOperationException("session store unavailable")));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => harness.Controller.Unregister("alice", "Jellyfin"));
+
+        var links = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks);
+        Assert.False(links.ContainsKey("sub-alice"));
+        Assert.Equal("Jellyfin", user.AuthenticationProviderId);
+        await harness.UserManager.Received(1).UpdateUserAsync(user);
+    }
+
     // Registers a user with the harness's mocked IUserManager so GetUserByName resolves it.
     private static User SeedUser(SsoControllerHarness harness)
     {

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -50,6 +50,9 @@ public class SSOController : ControllerBase
     // The session-minting flow (#318): permissions + avatar + default-provider, then AuthenticateDirect.
     // The controller passes the HttpContext-derived remote endpoint in and keeps no session/avatar field.
     private readonly SessionMinter _sessionMinter;
+    // Kept so a hard revoke (Unregister) can also terminate the user's already-issued tokens (#440); the
+    // minter takes its own reference for the login path.
+    private readonly ISessionManager _sessionManager;
     private readonly IAuthorizationContext _authContext;
     private readonly ILogger<SSOController> _logger;
     private readonly ILoggerFactory _loggerFactory;
@@ -113,6 +116,7 @@ public class SSOController : ControllerBase
         _logger = logger;
         _loggerFactory = loggerFactory;
         _httpClientFactory = httpClientFactory;
+        _sessionManager = sessionManager;
         _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
         _sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
@@ -1123,7 +1127,16 @@ public class SSOController : ControllerBase
         user.AuthenticationProviderId = provider;
         await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
-        _logger.LogInformation("Unregistered SSO for user {UserId}: removed {Count} canonical link(s).", user.Id, revoked);
+        // Terminate the user's already-established sessions so a hard revoke also invalidates tokens minted
+        // before it (#440). Removing the links only fails FUTURE logins closed; a token issued earlier stays
+        // valid until it expires. Scoped strictly to this one user's id; null revokes all of their tokens
+        // (including the caller's own, when an admin unregisters their own account — the durable revoke above
+        // is why that is safe). Runs LAST, after the link removal and provider switch are both persisted, so
+        // if the revoke throws the unregister is already complete rather than left half-done. Complement to
+        // the #232 in-flight re-check, not a substitute: this kills existing sessions, #232 closes the mint race.
+        await _sessionManager.RevokeUserTokens(user.Id, null).ConfigureAwait(false);
+
+        _logger.LogInformation("Unregistered SSO for user {UserId}: removed {Count} canonical link(s) and revoked active tokens.", user.Id, revoked);
 
         return Ok();
     }


### PR DESCRIPTION
# What & why

Closes #440.

`Unregister` removes a user's canonical SSO links so future SSO logins fail
closed (#213), and #232 closes the in-flight mint race, but neither terminates
the sessions **already established** for that user: a token minted before the
revoke stays valid until it expires or an admin kills it by hand. For a hard
revoke (a compromised account) the operator wants those sessions gone too.

This adds one step to the admin-only `Unregister`: after the canonical links are
removed and the provider switch persisted, it calls
`RevokeUserTokens(user.Id, null)` to terminate the target user's active
sessions and tokens.

Design:

- **Which endpoint revokes.** Only the admin-elevated `POST /sso/Unregister/{username}`
  (the hard "lock this account down" path) revokes. The per-link
  `DeleteCanonicalLink` unlink and per-provider disable are left as-is, before
  this change nothing on any path revoked tokens, and this strictly adds
  revocation to the hardest path. Extending revocation to the single-link unlink
  / provider-disable surfaces is a reasonable follow-up (candidate issue below),
  out of #440's scope.
- **API.** `ISessionManager.RevokeUserTokens(Guid userId, string? currentAccessToken)`
  returning `Task`; the second arg is the token to *preserve*, so `null` revokes
  all of the user's tokens. Verified empirically (metadata-reader probe) that
  this exact signature is present in **both** the ABI floor `Jellyfin.Controller`
  10.11.0 and the 10.11.11 build target, so no `MissingMethodException` risk (the
  `abi-floor` CI job also rebuilds against the floor with `--warnaserror`).
- **Scope.** Strictly the single resolved `user.Id` (an early `NotFound()` guards
  the unknown-user case), so it cannot mass-revoke other users.
- **Fail-closed + availability.** The revoke runs **last**, after the durable
  link removal (persisted synchronously under the config-store lock) and the
  awaited provider-switch persist. So if it throws, the unregister's
  security-critical part is already committed, the account fails future SSO
  logins closed, rather than being left half-done. The exception surfaces as a
  500 (the admin learns the token kill failed and can retry) instead of a false
  `Ok`. No login-path lock is held across the revoke I/O. On a self-unregister
  the admin still gets the `200` and is logged out on the next request; the
  account switches to local (`Jellyfin`) auth so password login and the
  last-admin path survive, no permanent lockout.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the durable revoke commits before the token revoke,
      so a throw over-locks (future SSO logins already fail closed) rather than
      under-locks; the revoke runs unconditionally on the resolved user.
- [x] No secrets logged; only `user.Id` (a Guid) and an int count are logged - no
      IdP-controlled string, so no sanitization needed.
- [x] A security review was performed - four refute-by-default lenses (verdicts
      under Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call - N/A, no
      user-controlled string is logged.

## Quality checklist

- [x] No duplicated logic; the change reuses the already-injected
      `ISessionManager` and adds one awaited call plus a field.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the one comment explains *why* the call is
      ordered last and why `null` is safe.
- [x] Architecture-conformance tests pass; this change establishes no new
      structural property to lock in.

## Verification

- [x] `dotnet build -c Debug --warnaserror` and `-c Release --warnaserror` are
      green (0 warnings).
- [x] `dotnet test` is green (921 tests, incl. 4 new).
- [x] Prettier, N/A, only `.cs` files changed.
- [x] `scripts/check-jellyfin-compat.sh` is green.

## Notes

**Tests** (`SSO-Auth.Tests/SSOControllerUnregisterTests.cs`):
`RevokesTheTargetUsersActiveTokens` (revoked once with `(UserId, null)`),
`DoesNotRevokeTokensForOtherUsers` (scope), `TokenRevokeNoOp_StillCompletesOk`
(no-op revoke still returns `Ok`), `WhenTokenRevokeFails_LinksAlreadyRemovedAndProviderPersisted`
(revoke-last ordering: a throw leaves the links removed and provider persisted).

**Adversarial review, four refute-by-default lenses:**

- Availability / mass-lockout, **PASS**: single-user, elevation-gated,
  last-in-sequence; password login survives, no login-path lock or cache added.
- Security bypass / fail-open, **PASS**: revoke is unconditional, ordered
  fail-closed (over-locks on failure), `null`=revoke-all is the stronger choice,
  and the #232 boundary is represented honestly.
- Correctness, **PASS**: `null` valid, awaited correctly, wiring correct, the
  ordering claim holds statement-by-statement, tests assert what they claim.
- Integration, **NEEDS_IMPROVEMENT → resolved at the process level**: the only
  finding was the missing E2E-CHECKLIST note the issue itself calls for.
  `docs/E2E-CHECKLIST.md` is a git-ignored local doc (never part of a PR) and the
  isolated worktree cannot edit the canonical copy, so the exact append text is
  handed over below for the local checklist. The code integration was verified
  clean (ABI floor + target, DI, self-unregister, WebSocket teardown expected).

**E2E-CHECKLIST note to add locally** (under "Account linking & safety"):

> - [ ] Unregister terminates active sessions (#440): with the target user signed
>   in on one or more clients, `POST /sso/Unregister/{username}` force-logs-out
>   those clients, their WebSockets drop and a previously-issued token now
>   returns 401 (mocks cannot exercise the real teardown). Scoped to the one
>   user: a second signed-in user's sessions are untouched. An admin
>   unregistering their OWN account still gets the 200 but is logged out on the
>   next request. Complement to #232 (mint race); this kills already-issued tokens.

**Out of scope / follow-up candidate:** extend token revocation to
`DeleteCanonicalLink` (single-link unlink) and per-provider disable, a
compromised-IdP-identity unlink arguably should also kill live tokens.
