### PR TITLE
Bound SamlReplayCache with a hard cap and throttled prune

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -162,6 +162,29 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void LoginPathCaches_ThrottleTheirExpiredEntrySweepThroughIntervalGate()
+    {
+        // Locked in by #452: the login-path caches converged on one bounding pattern — an
+        // IntervalGate-throttled expired-entry sweep plus a hard global cap — so none can regress to the
+        // unthrottled full-dictionary sweep (or the unbounded set) SamlReplayCache carried before #452.
+        // Each named cache must declare the PRUNE gate specifically (an IntervalGate field named
+        // "_pruneGate"), not merely some IntervalGate: the siblings also carry a "_capWarnGate", so keying
+        // on the field type alone would miss a sibling that dropped its prune gate but kept cap-warn.
+        // SamlRequestCache and OidcStateStore already had it (#246, #327); SamlReplayCache adopted it (#452).
+        const string pruneGateField = "_pruneGate";
+        var caches = new[] { typeof(SamlReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore) };
+        var missing = caches
+            .Where(t => !t.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Any(f => f.FieldType == typeof(IntervalGate) && f.Name == pruneGateField))
+            .Select(SimpleName)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "Every login-path cache must throttle its expired-entry sweep through an IntervalGate field (#452): " + string.Join(", ", missing));
+    }
+
+    [Fact]
     public void Controller_NeverTouchesProviderLinkMaps()
     {
         // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: the two

--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -54,6 +54,89 @@ public class SamlReplayCacheTests
         Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later));
     }
 
+    // --- Hard cap + throttled prune (#452) ---
+
+    // A cache whose cap is small and reachable (production 100k is not).
+    private static SamlReplayCache SmallCache(int cap = 3) => new SamlReplayCache(cap, TimeSpan.FromMinutes(1));
+
+    [Fact]
+    public void TryConsume_ReplayStillRejected_UnderCapPressure()
+    {
+        // The security regression: a live consumed assertion must NEVER be evicted to make room, or its
+        // replay would be re-admitted. Record X (live), fill the rest of the cap with other live logins,
+        // then push a new distinct login (refused fail-closed), then replay X — X must still be rejected,
+        // proving its live entry survived the cap pressure.
+        var cache = SmallCache(cap: 3);
+        var expiry = Now.AddMinutes(10);
+
+        Assert.True(cache.TryConsume("_x", expiry, Now));
+        Assert.True(cache.TryConsume("_f1", expiry, Now));
+        Assert.True(cache.TryConsume("_f2", expiry, Now)); // cache now full of live entries
+
+        Assert.False(cache.TryConsume("_new", expiry, Now)); // fail closed: no live entry evicted
+        Assert.False(cache.TryConsume("_x", expiry, Now)); // X still recorded -> replay still caught
+    }
+
+    [Fact]
+    public void TryConsume_AtCap_NewDistinctLogin_IsRejectedFailClosed()
+    {
+        var cache = SmallCache(cap: 2);
+        var expiry = Now.AddMinutes(10);
+        Assert.True(cache.TryConsume("_a", expiry, Now));
+        Assert.True(cache.TryConsume("_b", expiry, Now)); // at cap with live entries
+
+        Assert.False(cache.TryConsume("_c", expiry, Now));
+        Assert.Equal(2, cache.Count); // the refusal did not grow or evict
+    }
+
+    [Fact]
+    public void TryConsume_AtCap_WithExpiredEntries_ReclaimsThenAdmits()
+    {
+        // At the cap but full of EXPIRED (not yet swept) entries: the unthrottled reclaim at the cap frees
+        // the slots and the fresh login is admitted, even though the routine sweep is still throttled.
+        var cache = SmallCache(cap: 3);
+        var shortExpiry = Now.AddSeconds(30);
+        Assert.True(cache.TryConsume("_a", shortExpiry, Now)); // first call enters the prune gate
+        Assert.True(cache.TryConsume("_b", shortExpiry, Now));
+        Assert.True(cache.TryConsume("_c", shortExpiry, Now)); // at cap
+
+        // 40s later: past the entries' expiry but within the 1-minute prune interval, so the routine sweep
+        // is throttled. The cap path must still reclaim the expired entries and admit the new login.
+        var later = Now.AddSeconds(40);
+        Assert.True(cache.TryConsume("_d", later.AddMinutes(10), later));
+        Assert.Equal(1, cache.Count); // only _d remains
+    }
+
+    [Fact]
+    public void PruneExpired_IsIntervalGateThrottled_NotRunEveryCall()
+    {
+        // The sweep must be throttled, not run on every consume. Add an entry that expires, then a consume
+        // WITHIN the prune interval must leave the expired entry in place (an unthrottled sweep would drop
+        // it) — proving the IntervalGate throttle is in effect.
+        var cache = new SamlReplayCache(); // production cap: the cap path never fires here
+        Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now)); // enters the gate
+
+        var within = Now.AddSeconds(40); // past _a's expiry, within the 1-minute interval
+        Assert.True(cache.TryConsume("_b", within.AddMinutes(10), within));
+        Assert.Equal(2, cache.Count); // _a NOT swept -> prune is throttled
+
+        var beyond = Now.AddSeconds(80); // past the interval: the sweep runs and reclaims _a
+        Assert.True(cache.TryConsume("_c", beyond.AddMinutes(10), beyond));
+        Assert.Equal(2, cache.Count); // _a reclaimed; _b and _c remain
+    }
+
+    [Fact]
+    public void TryConsume_ExpiredEntry_ReclaimedByThrottledPrune()
+    {
+        var cache = new SamlReplayCache();
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now));
+
+        // A later consume past the prune interval sweeps the expired _a.
+        var later = Now.AddMinutes(2);
+        Assert.True(cache.TryConsume("_b", later.AddMinutes(10), later));
+        Assert.Equal(1, cache.Count); // _a reclaimed, only _b remains
+    }
+
     [Fact]
     public void ComputeRetention_NoExpiry_UsesOneHourFloor()
     {

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -6,11 +6,58 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <summary>
 /// Tracks SAML assertion IDs that have already been used to mint a session, so a captured assertion
 /// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
-/// evicted opportunistically.
+/// reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
+/// bound (#452). It mirrors the sibling login-path caches (<see cref="SamlRequestCache"/>,
+/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap.
+///
+/// The cap is applied differently from the siblings, on purpose. Recording a consumed assertion is what
+/// makes a replay detectable, so this cache must never drop a still-valid entry to free a slot — that
+/// would reopen the replay window for exactly that assertion (#32). Eviction is therefore tied strictly
+/// to expiry: an entry is removed only once the assertion it guards can no longer be validly presented.
+/// At the cap, a NEW distinct login is refused (returns false, so the login fails closed) rather than
+/// evicting a live entry — a bounded DoS backstop that never trades away replay protection. This path is
+/// reached only after full XML-DSig signature validation, so it is not anonymously floodable; filling the
+/// cap requires a large volume of legitimately signed, rate-limited assertions.
 /// </summary>
 internal sealed class SamlReplayCache
 {
+    // An approximate ceiling on retained consumed-assertion IDs, bounding memory (CWE-400 parity with the
+    // siblings). Unlike the siblings this is not an anti-flood cap on an anonymous endpoint — TryConsume
+    // runs only after signature validation — but a defense-in-depth memory bound. The check-then-insert is
+    // not serialized, so concurrent consumes can transiently overshoot by at most the number of in-flight
+    // threads; immaterial against a best-effort backstop.
+    internal const int DefaultMaxEntries = 100_000;
+
+    // The expired-entry sweep is an O(n) scan; throttling it to at most once per this interval matches the
+    // siblings and keeps the sweep off every consume. Throttling is safe because it is only memory
+    // reclamation — TryConsume rejects a live entry independently (see the replay check), and at the cap it
+    // forces an unthrottled reclaim before refusing, so a not-yet-swept expired entry neither grants a
+    // replay nor false-rejects a fresh login.
+    private static readonly TimeSpan DefaultPruneInterval = TimeSpan.FromMinutes(1);
+
+    private readonly int _maxEntries;
+
     private readonly ConcurrentDictionary<string, DateTime> _consumed = new(StringComparer.Ordinal);
+
+    // Throttles the sweep to one run per interval; the gate owns the atomic cursor and self-heals a
+    // backward wall-clock step of at least the interval (#334). See PruneExpired.
+    private readonly IntervalGate _pruneGate;
+
+    internal SamlReplayCache()
+        : this(DefaultMaxEntries, DefaultPruneInterval)
+    {
+    }
+
+    // Test constructor: a small cap and short interval make the cap and prune-throttle paths reachable in
+    // unit tests (the production values are unreachable there). IntervalGate rejects a non-positive interval.
+    internal SamlReplayCache(int maxEntries, TimeSpan pruneInterval)
+    {
+        _maxEntries = maxEntries;
+        _pruneGate = new IntervalGate(pruneInterval);
+    }
+
+    /// <summary>Gets the live entry count. Test-only, so the cap and sweep paths can be asserted.</summary>
+    internal int Count => _consumed.Count;
 
     /// <summary>
     /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
@@ -38,22 +85,18 @@ internal sealed class SamlReplayCache
     }
 
     /// <summary>
-    /// Records the assertion ID as consumed. Returns false when the assertion has no usable ID or has
-    /// already been consumed within its validity window (a replay).
+    /// Records the assertion ID as consumed. Returns false when the assertion has no usable ID, has
+    /// already been consumed within its validity window (a replay), or the cache is full of still-valid
+    /// entries (a fail-closed cap refusal). A false return always rejects the login, so refusing at the
+    /// cap never reopens the replay window.
     /// </summary>
     /// <param name="assertionId">The assertion ID.</param>
-    /// <param name="expiryUtc">When the entry may be evicted (typically the assertion's NotOnOrAfter).</param>
+    /// <param name="expiryUtc">When the entry may be evicted (the assertion's retention horizon).</param>
     /// <param name="nowUtc">The current time.</param>
-    /// <returns>True if this is the first use; false on replay or a missing ID.</returns>
+    /// <returns>True if this is the first use; false on replay, a missing ID, or a fail-closed cap refusal.</returns>
     internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc)
     {
-        foreach (var kvp in _consumed)
-        {
-            if (kvp.Value <= nowUtc)
-            {
-                _consumed.TryRemove(kvp.Key, out _);
-            }
-        }
+        PruneExpired(nowUtc);
 
         // Fail closed: without an ID we cannot enforce one-time use.
         if (string.IsNullOrEmpty(assertionId))
@@ -61,6 +104,75 @@ internal sealed class SamlReplayCache
             return false;
         }
 
-        return _consumed.TryAdd(assertionId, expiryUtc);
+        // Global cap. Only a NEW id would grow the set (an id already present is either a replay we reject
+        // below or an expired entry we replace in place, neither of which grows it). At the cap, reclaim
+        // expired entries the throttled sweep may have skipped, and only if the cache is STILL full of
+        // unexpired entries refuse the login (return false) — never evict a live entry, which would drop a
+        // within-window consumed assertion and reopen its replay window (#32).
+        if (_consumed.Count >= _maxEntries && !_consumed.ContainsKey(assertionId))
+        {
+            SweepExpired(nowUtc);
+            if (_consumed.Count >= _maxEntries && !_consumed.ContainsKey(assertionId))
+            {
+                return false;
+            }
+        }
+
+        while (true)
+        {
+            // Atomic first-use claim: the single winner of TryAdd is the first use, so two concurrent
+            // presentations of the same assertion cannot both succeed.
+            if (_consumed.TryAdd(assertionId, expiryUtc))
+            {
+                return true;
+            }
+
+            // An entry for this id already exists. Re-read it (it may have just been swept away).
+            if (!_consumed.TryGetValue(assertionId, out var existing))
+            {
+                continue;
+            }
+
+            // A still-valid entry is a replay: reject, and never refresh its expiry (refreshing would
+            // extend the replay window it guards).
+            if (existing > nowUtc)
+            {
+                return false;
+            }
+
+            // Present but expired: a reused xsd:ID from a genuinely new login (assertion IDs are unique in
+            // practice, so this is a correctness belt, not a hot path). It must not false-reject the new
+            // login, so replace it — but only if it is still the exact stale value we read, so a racing
+            // consumer of the same id cannot also win. A lost race loops and re-evaluates (the value is now
+            // fresh, so it is treated as a replay).
+            if (_consumed.TryUpdate(assertionId, expiryUtc, existing))
+            {
+                return true;
+            }
+        }
+    }
+
+    // Drops expired entries, at most once per prune interval. Enumerating a ConcurrentDictionary yields a
+    // safe moving snapshot and the KeyValuePair TryRemove overload is atomic, so this is correct under
+    // concurrent TryConsume — the size is bounded by the cap in TryConsume, not by this sweep.
+    private void PruneExpired(DateTime nowUtc)
+    {
+        if (_pruneGate.TryEnter(nowUtc))
+        {
+            SweepExpired(nowUtc);
+        }
+    }
+
+    // Removes every entry whose retention has elapsed. Uses the KeyValuePair overload so an entry a
+    // concurrent consume refreshed to a live expiry between the read and the remove is not dropped.
+    private void SweepExpired(DateTime nowUtc)
+    {
+        foreach (var kvp in _consumed)
+        {
+            if (kvp.Value <= nowUtc)
+            {
+                _consumed.TryRemove(kvp);
+            }
+        }
     }
 }


### PR DESCRIPTION
# What & why

Bring `SamlReplayCache` (`SSO-Auth/Api/SamlReplayCache.cs`), the SAML
assertion-ID replay cache, in line with the sibling login-path caches
(`SamlRequestCache`, `OidcStateStore`): an `IntervalGate`-throttled
expired-entry sweep plus a hard 100k global cap, replacing the unthrottled
full-dictionary sweep on every consume and the unbounded set it carried
before. This is the last cache in the family that diverged from the pattern
the other three converged on, a consistency / defense-in-depth item
(directives 1 and 4), not a performance fix.

## Design (current vs sibling structure, cap + eviction semantics)

**Before:** `TryConsume` walked the whole `_consumed` dictionary on every
call (unthrottled O(n) sweep) and the set had no size bound.

**After:** the sweep is throttled through a `_pruneGate` `IntervalGate`
(1-minute interval), and a `DefaultMaxEntries = 100_000` cap bounds the set - 
the same cap value and interval the siblings use.

The cap had to go through the security-review gate because a replay cache is
the opposite of the siblings at capacity:

- The sibling caches refuse-at-cap because refusing fails **one login
  closed**. For a replay cache, *failing to record* a consumed assertion
  would fail the replay check **open** (the assertion is never marked used, so
  it stays replayable). A naive LRU/oldest-first eviction of a *live* entry
  reopens the replay window for exactly that assertion (#32).
- Rejecting the *login* at the cap is fail-closed, but a blind reject is an
  availability hazard.

**Resolution, eviction is tied strictly to expiry; the cap fails the login
closed, never a live entry:**

- `SweepExpired` removes only entries whose recorded retention has elapsed
  (`value <= nowUtc`), using the value-matched `TryRemove(KeyValuePair)`
  overload so a concurrently-refreshed entry is never dropped.
- At the cap, only a **new** id would grow the set. The cap block first runs
  an unthrottled reclaim of expired entries (so a cache full of
  expired-but-unswept entries never false-rejects a fresh login, strictly
  *more* available than the siblings), and only if the cache is **still full
  of unexpired entries** does `TryConsume` return `false`, which the caller
  treats as a rejected login (fail closed). No live entry is ever evicted.
- The one-time claim is an atomic `TryAdd`, so two concurrent presentations of
  the same assertion cannot both succeed. A lingering **expired** entry with a
  reused xsd:ID is replaced in place via a value-matched `TryUpdate` (moot in
  practice, assertion IDs are unique, but correct once the sweep is
  throttled).

**Why replay is not re-opened:** the only removals are (a) expired entries and
(b) an in-place replace of an already-expired entry. A within-window
(unexpired) consumed id is never dropped, overwritten, or refreshed. So a
replay of any assertion still inside its validity window always finds its
entry and is rejected. `ComputeRetention` (unchanged) retains until
`max(NotOnOrAfter + skew, now + 1h)`, i.e. at least the whole window the
assertion is still acceptable, so an entry never expires while the assertion
is still replayable.

The caller (`SSOController.TryConsumeSamlReplay`) is unchanged, the
`internal bool TryConsume(string, DateTime, DateTime)` signature is
byte-identical, and `false` still rejects the login.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Here: a missing assertion ID and a
      cap refusal both return `false` → login rejected; a live entry is never
      evicted, so replay is never re-admitted.)
- [x] No secrets logged; secrets are redacted on config export. (No logging in
      this type.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      log calls.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug + Release, 0 warnings.)
- [x] `dotnet test` is green. (923 tests, Debug + Release.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None touched.)

## Notes

**Adversarial self-review (4 refute-by-default lenses), all PASS.**

- **Security-bypass**, PASS. No cap path ever evicts or refreshes a *live*
  entry; `SweepExpired` and the `TryUpdate` replace touch only entries with
  `value <= nowUtc`; `ComputeRetention` retains until `max(bounds)+skew >=` the
  acceptance window, so replay is never re-opened. Concurrent identical-id
  presentations cannot both win (atomic `TryAdd`). A cap refusal is fail-closed
  (caller rejects the login), not fail-open.
- **Availability / mass-lockout**, PASS. The 100k live-entry cap is
  unreachable by legitimate post-signature, rate-limited traffic; the
  unthrottled cap-path reclaim makes this cache *more* available than the
  siblings; no livelock in the claim loop; less hot-path work than the code it
  replaces.
- **Correctness**, PASS. The `while` loop terminates and returns the right
  result under concurrency; `TryRemove(KeyValuePair)` value-match is safe;
  boundaries (`value <= nowUtc`, `Count >= _maxEntries`) are consistent; the
  new tests exercise what they claim (accounting for `IntervalGate` entering on
  its first call).
- **Integration**, PASS. Caller signature byte-identical; the single static
  instance and the parameterless ctor surface are intact; blast radius is 3
  files; the conformance rule is non-vacuous.

**Conformance-rule tightening (from the integration lens):** the new rule
`LoginPathCaches_ThrottleTheirExpiredEntrySweepThroughIntervalGate` originally
asserted only that each cache declares *some* `IntervalGate` field, but the
siblings carry two (`_pruneGate` + `_capWarnGate`), so that would not catch a
sibling that dropped its prune gate while keeping cap-warn. Tightened to key on
the `_pruneGate` field specifically (the field name is uniform across all three
caches), so it tracks the prune throttle the rule's name promises.

**Out of scope / follow-up:** the siblings emit a throttled capacity warning at
their cap for observability. This change keeps the `TryConsume` signature
byte-identical and does not wire an equivalent signal, because doing so would
require touching `SSOController` (a parallel PR owns that file). The security
property does not depend on the warning. A follow-up can plumb a throttled
cap-refusal signal from `SamlReplayCache` through the controller once that PR
lands.

Closes #452
