### PR TITLE
Add an AI-assisted, human-owned disclosure to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 > This is a **security-sensitive login path**, so every change — even a one-liner — runs the same gated flow: a GitHub **issue** first, then a short-lived work branch, an implementation with **tests** (a negative test for every fail-closed branch), an **adversarial security review** for anything touching the login path or crypto, and a pull request that must pass **CI** (build with warnings-as-errors, the full test suite, format and conformance checks) and **CodeQL** — before it merges. We review and quality-gate our own work; no external review service is a merge gate. Security work always outranks feature work, and the code stays minimal and self-documenting.
 >
 > If you contribute, please work the same way: understand and own every line you propose, and be ready to explain what it does and why. 🙂
+>
+> ### 🤝 AI-assisted, human-owned
+>
+> Development here is **AI-assisted**. Claude (Anthropic) helps with individual **process steps** — generating and analysing code, running the adversarial security reviews, and translating documentation and comments into English. It never hands over finished, unreviewed work: each step is only a proposal. **A human maintainer reviews, understands, edits where needed, and signs off on every one** — the AI proposes, a person decides, and **a human stays responsible for every line that ships, at all times.** The review discipline is modelled, as far as is practical for a volunteer project, on the change-control expected of TÜV/BSI-certified software in a critical sector such as healthcare — with **no claim to actual certification**. In short: nothing lands because a tool suggested it; it lands because a person verified it.
 
 ## Features
 


### PR DESCRIPTION
# What & why

We develop this security-sensitive login-path plugin AI-assisted, so the public README should say so plainly and honestly, transparent, but not off-putting. This adds a short **"AI-assisted, human-owned"** note under the existing "How this project is developed" section: Claude helps with individual **process steps** (generating and analysing code, running the adversarial reviews, translating documentation and comments into English) and never lands finished, unreviewed work, a human reviews, understands, edits and signs off on **every** step and stays responsible for every line that ships. It is framed on TÃœV/BSI-style critical-sector change-control, with **no claim to actual certification**.

Alongside this (as repo settings, not part of this diff) we set the repository **About** to a product-first description and added discovery **topics** (jellyfin, sso, openid-connect, saml, authentication, keycloak, dotnet, â€¦) for visibility.

Closes #471

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, documentation only. No login-path, crypto, config-persistence, or release-pipeline code is touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit., N/A (prose); the note sits in the existing development section, no duplication.
- [x] The change adds no more code than the problem requires., one short paragraph.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318)., prose is plain and honest.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`., no structural change.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green., N/A locally (docs-only, no code changed); CI confirms.
- [x] `dotnet test` is green., N/A locally (docs-only, no code changed); CI confirms.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change., `prettier --check README.md` passes.

## Notes

The public README AI note is the one deliberate, project-level AI disclosure; commit/PR/issue artifacts otherwise carry no AI markers, consistent with our conventions. No follow-ups.
