### PR TITLE
Add an in-repo architecture / login-flow map

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,217 @@
+# Architecture: the login flow, end to end
+
+A map for a new contributor working from a fork, a source tarball, or offline —
+so a first change can be placed onto the flow instead of reverse-engineered
+from `SSO-Auth/Api/SSOController.cs` (currently ~1,525 lines) and its ~45
+helper types. It complements, and does not replace, the wiki
+[Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow)
+page.
+
+This page keeps two things apart on purpose:
+
+- **Current state** — what is in the tree today, verified against the code at
+  the time of writing. Every type and method named below exists.
+- **Target direction ([#318](https://github.com/iderex/jellyfin-plugin-sso/issues/318))**
+  — the unified OO architecture the codebase is migrating toward, one small
+  behaviour-preserving PR at a time. It is marked as such everywhere it
+  appears; nothing here describes the target as if it already existed.
+
+## 1. The login flow today
+
+Both protocols follow the same shape — challenge (redirect to the identity
+provider), callback (render an intermediate auth page), auth (mint the
+session) — with the SAML validation done inline rather than through a
+separate client library.
+
+### OpenID Connect
+
+```
+OidChallenge  (GET  OID/p/{provider}, OID/start/{provider})
+  -> PrepareLoginAsync (Duende OidcClient)      -- discovery + PKCE (S256) check
+  -> OidcStateStore.TryAdd                      -- registers the in-flight authorize state
+  -> AuthorizeStateBinding                      -- binds the state to the initiating browser (cookie)
+  -> redirect to the provider
+
+OidPost       (GET  OID/r/{provider}, OID/redirect/{provider})   -- the provider's callback
+  -> OidcStateStore.PeekCurrent                 -- looks up the pending state (does not consume it)
+  -> OidcClient.ProcessResponseAsync            -- token exchange + id_token signature validation
+  -> OidcResponseIssuer.IsRejected              -- RFC 9207 issuer mix-up check
+  -> OidcAuthorizeStateBuilder.Build             -- derives username/roles/admin/folders from claims
+  -> renders the intermediate auth page (WebResponse.Generator)
+
+OidAuth       (POST OID/Auth/{provider})         -- the auth page posts back here to mint the session
+  -> OidcStateStore.TryRedeem                    -- one-time atomic claim of the authorize state
+  -> CanonicalLinkService.ResolveOrCreateAsync    -- resolve/adopt/create the Jellyfin account link
+  -> SessionMinter.MintAsync                      -- permissions + avatar + AuthenticateDirect
+  -> LoginOutcome -> LoginStatusMapper.ToActionResult
+```
+
+### SAML 2.0
+
+```
+SamlChallenge (GET  SAML/p/{provider}, SAML/start/{provider})
+  -> SamlAuthnRequest                            -- hand-rolled AuthnRequest (Saml.cs)
+  -> SamlRequestCache.Register                    -- outstanding-request correlation (InResponseTo)
+  -> AuthorizeStateBinding                        -- binds the request to the initiating browser (cookie)
+  -> redirect to the IdP
+
+SamlPost      (POST SAML/p/{provider}, SAML/post/{provider})    -- the IdP's ACS callback
+  -> SamlResponseLoader.TryParse                  -- parses + validates the signed response (Saml.cs core)
+  -> SamlLoginPolicy.IsLoginAllowed                -- role allow-list check
+  -> renders the intermediate auth page (WebResponse.Generator)
+
+SamlAuth      (POST SAML/Auth/{provider})          -- the auth page posts back here to mint the session
+  -> SamlResponseLoader.TryParse + validation (again -- a caller can skip the page and POST directly)
+  -> SamlRequestCache.TryConsume                   -- InResponseTo correlation + browser-binding check
+  -> SamlReplayCache                               -- one-time-use assertion ID (replay protection)
+  -> SamlAuthorizeStateBuilder.Build                -- derives admin/roles/folders from assertion attributes
+  -> CanonicalLinkService.ResolveOrCreateAsync
+  -> SessionMinter.MintAsync
+  -> LoginOutcome -> LoginStatusMapper.ToActionResult
+```
+
+Both auth endpoints call the identical two-step tail —
+`CanonicalLinkService.ResolveOrCreateAsync` then `SessionMinter.MintAsync` —
+today as two calls repeated at each of the four login/link sites (login +
+account-linking, per protocol), not through a shared extracted method. Folding
+that tail into one shared collaborator is target-direction step 11
+(`LoginCompletionService`, #318 §3) — not yet done.
+
+### Process-wide stores
+
+A handful of state stores live as `private static readonly` fields on
+`SSOController` (not dependency-injected — there is no
+`IPluginServiceRegistrator` in source, so a `static readonly` field is today's
+only way to get one process-wide instance):
+
+| Store                 | Guards                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------ |
+| `OidcStateStore`      | in-flight OIDC authorize state; capacity cap, lifetime, throttled-sweep via `IntervalGate` |
+| `SamlReplayCache`     | one-time-use SAML assertion IDs (replay protection)                                        |
+| `SamlRequestCache`    | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                         |
+| `DiscoveryFactsCache` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL                          |
+| `SsoRateLimiter`      | opt-in per-client rate limiting on the anonymous login endpoints                           |
+
+### The uniform outcome
+
+`LoginOutcome` (`SSO-Auth/Api/LoginOutcome.cs`) is a closed, internal sum type
+with exactly three cases: `Success(AuthenticationResult)`, `Rejected(PublicReason)`,
+`Denied`. There is deliberately no `Error` case — anything unexpected
+propagates as an exception and surfaces as a genuine 500, so a client-caused
+condition can never silently become one, and a login-path helper cannot report
+an ambiguous "maybe okay" result. `LoginStatusMapper.ToActionResult` is the
+single place an outcome becomes an HTTP response; both its outer switch (over
+`LoginOutcome`) and its inner switch (over `PublicReason`) throw
+`InvalidOperationException` on anything unmapped, so a case added to either
+enum without a mapped response fails loudly (a compile-time-adjacent
+guarantee, not a silent fall-through). `AccountLinkForbiddenException`, thrown
+by `CanonicalLinkService.ResolveOrCreateAsync`, is caught at each of the four
+call sites and mapped to `Rejected(PublicReason.AccountLinkForbidden)` — a 403.
+
+## 2. The tier model and naming standard
+
+Four tiers, each discoverable by suffix or namespace, enforced as fitness
+functions in `SSO-Auth.Tests/ArchitectureConformanceTests.cs` (runs in
+`dotnet test`, so every PR is checked):
+
+| Tier                         | Suffix / shape                                                                        | Example                                          | Rule                                                            |
+| ---------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| HTTP boundary                | `*Controller`, derives `ControllerBase`                                               | `SSOController`                                  | `Controllers_DeriveFromControllerBase`                          |
+| Flow (stateful collaborator) | `*Service`, internal sealed                                                           | `CanonicalLinkService`, `SessionMinter`          | `FlowServices_AreInternalAndSealed`                             |
+| Pure leaves                  | `*Validator/*Builder/*Mapper/*Resolver/*Policy/*Extractor`, internal sealed or static | `LoginStatusMapper`, `OidcAuthorizeStateBuilder` | `SingleResponsibilityHelpers_Are…` (internal, sealed-or-static) |
+| Keyed runtime state          | `*Store/*Cache/*Gate/*Limiter`                                                        | `OidcStateStore`, `SsoRateLimiter`               | `MutableKeyedState_LivesOnlyInsideStoreLikeTypes`               |
+
+All production types live under the `Jellyfin.Plugin.SSO_Auth` root namespace
+(`EverythingLivesUnderThePluginRootNamespace`); helper types are internal by
+default, never part of the plugin's public surface
+(`SingleResponsibilityHelpers_AreInternal_NotPartOfThePublicSurface`) and
+sealed or static leaves, never an inheritance base
+(`…_AreSealedOrStatic_NotAnInheritanceBase`). Two call-level invariants are
+locked in as source scans over every controller file rather than by
+reflection: the controller touches no provider link map directly
+(`Controller_NeverTouchesProviderLinkMaps` — that stays confined to
+`CanonicalLinkService` and `ServerManagedFields.Preserve`) and no raw
+socket/DNS surface (`Controller_NeverTouchesRawSocketsOrDns`).
+
+### Target direction (#318) — not yet implemented
+
+The [#318 target-architecture design note](https://github.com/iderex/jellyfin-plugin-sso/issues/318)
+plans a further decomposition on top of the same four tiers, landed as a
+sequence of small, independently gated PRs (tracked on the
+[SSO Roadmap board](https://github.com/users/iderex/projects/1)):
+
+- **A flow-service spine per protocol** — `OidcLoginService` / `SamlLoginService`
+  under a new `Api/Flows/` namespace, each owning its protocol's process-wide
+  stores as its own `static readonly` fields (a pure relocation, not a
+  lifetime change — no service registrator exists to promote them to DI). The
+  controller shrinks to route/model-binding plus one call into a flow
+  service.
+- **`LoginCompletionService`** — the shared resolve → mint → audit → outcome
+  tail described above, extracted once so both protocols call one
+  collaborator instead of duplicating the same four call sites.
+- **`VerifiedIdentity`** — a protocol-agnostic record only the two protocol
+  validators can construct (private constructor + factory), generalizing the
+  existing OIDC `RedeemedState`. `LoginCompletionService` accepts only a
+  `VerifiedIdentity`, so reaching account-resolution with an unvalidated
+  response becomes a compile error rather than something a review has to
+  catch — the fail-closed keystone of the migration.
+
+None of the three exist in the tree yet. The ordered step list, the
+parallelization map, and the maintainer decisions still open are in the
+#318 design-note comment; this page is deliberately step 0 of that plan — a
+map of the current shape so later migration PRs and their reviews do not have
+to reconstruct it from scratch.
+
+## 3. Security invariants a change must not regress
+
+- **Fail closed by construction, not by convention.** A missing signature, an
+  out-of-bounds time window, a wrong audience, a replayed assertion, an
+  unresolved identity, or an unmapped `LoginOutcome`/`PublicReason` case is
+  rejected or throws — never defaults to success. `LoginStatusMapper`'s two
+  exhaustive switches are the enforcement point; see §1.
+- **A throwing accessor turned into a guarded `Try*` accessor is a fail-open
+  hazard.** Replacing a throw with a miss-branch (`is not { } x`) on the login
+  path silently converts implicit fail-closed into fail-open unless the new
+  miss-branch is explicitly re-decided as a rejection, with a reject-path
+  test covering it. Every store lookup on this page (`PeekCurrent`,
+  `TryRedeem`, `TryConsume`, `FindOidConfig`/`FindSamlConfig`) already follows
+  this pattern — preserve it when extracting or refactoring around them.
+- **Guard order is a preserved invariant.** For example, the disabled-provider
+  check in `OidAuth`/`SamlAuth` runs _before_ the state/replay consume, so a
+  disabled provider cannot be used to burn a legitimate user's in-flight
+  state. Reordering guards during a refactor is a behaviour change, not a
+  pure move — it needs the same review a semantics change gets.
+- **Log-forging sanitization is inline, not delegated.** A value that reaches
+  a log call and originated from the request (provider name, claims,
+  `relayState`, roles) is sanitized at the call site
+  (`x?.ReplaceLineEndings(string.Empty)`), because CodeQL's `cs/log-forging`
+  sanitizers are not propagated across a helper-method boundary. Wrapping the
+  sanitization in a shared helper defeats the analysis, not just the style.
+- **Secrets are never logged and never round-tripped.** `OidSecret` and
+  signing keys are write-only: a config read never returns the stored secret,
+  and no log line carries one.
+
+## What lives where
+
+| Concern                                                     | File(s)                                                                                                                  |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| HTTP endpoints, provider admin CRUD                         | `SSO-Auth/Api/SSOController.cs`                                                                                          |
+| OIDC state / discovery caching                              | `OidcStateStore.cs`, `PendingState.cs`, `RedeemedState.cs`, `TimedAuthorizeState.cs`                                     |
+| OIDC claim/role derivation                                  | `OidcAuthorizeStateBuilder.cs`, `OidcRoleExtractor.cs`, `OidcResponseIssuer.cs`, `OidcIdTokenValidator.cs`               |
+| SAML core (parsing, signature, XML hardening)               | `Saml.cs`, `SamlResponseLoader.cs`, `SamlCertificate.cs`, `SamlRecipientValidator.cs`                                    |
+| SAML request/replay correlation                             | `SamlRequestCache.cs`, `SamlReplayCache.cs`, `SamlAuthorizeStateBuilder.cs`, `SamlLoginPolicy.cs`                        |
+| Account linking (resolve/adopt/create/revoke)               | `Linking/CanonicalLinkService.cs`, `AccountLinkResolver.cs`, `AdoptionEligibilityResolver.cs`, `CanonicalLinkRevoker.cs` |
+| Session minting (permissions, avatar, `AuthenticateDirect`) | `SessionMinter.cs`, `SessionParameters.cs`, `AvatarService.cs`                                                           |
+| The uniform outcome / HTTP mapping                          | `LoginOutcome.cs`, `LoginStatusMapper.cs`, `PublicReason.cs`                                                             |
+| Rate limiting / browser binding                             | `SsoRateLimiter.cs`, `AuthorizeStateBinding.cs`, `IntervalGate.cs`                                                       |
+| Config persistence                                          | `Config/PluginConfiguration.cs`, `ProviderConfigStore` (see `Config/`)                                                   |
+| Structural rules (fitness functions)                        | `SSO-Auth.Tests/ArchitectureConformanceTests.cs`                                                                         |
+
+## See also
+
+- [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) —
+  the wiki walkthrough this page complements.
+- [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) —
+  the fuller threat-model-level writeup.
+- [#318](https://github.com/iderex/jellyfin-plugin-sso/issues/318) — the
+  target-architecture design note this page's §2 target section summarizes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
-**Getting oriented.** Before diving into `SSOController.cs` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) wiki page — it walks an OpenID and a SAML sign-in from challenge to session, so you can map a change onto the flow instead of reverse-engineering it.
+**Getting oriented.** Before diving into `SSOController.cs` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) wiki page and the in-tree [ARCHITECTURE.md](ARCHITECTURE.md) — together they walk an OpenID and a SAML sign-in from challenge to session and map the code layout, so you can place a change onto the flow instead of reverse-engineering it. ARCHITECTURE.md also separates that current shape from the [#318](https://github.com/iderex/jellyfin-plugin-sso/issues/318) target architecture the codebase is migrating toward.
 
 **Building and testing.** CI runs these on every pull request and they must pass:
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 
 - [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Per-identity-provider setup: [Provider Guides](providers.md)
+- In-tree contributor map of the login flow and code layout: [ARCHITECTURE.md](ARCHITECTURE.md)
 
 ## Security
 


### PR DESCRIPTION
# What & why

`SSO-Auth/Api/SSOController.cs` is ~1,525 lines with ~45 helper types under
`SSO-Auth/Api/`, and until now the only walkthrough of how the OpenID and SAML
login flows connect end to end was the external GitHub wiki "Login Flow" page
 - unusable when working from a fork, a source tarball, or offline. This is
step 0 of the #318 unified-architecture migration plan: a map of the login
path's *current* shape, so every later #318 extraction PR (and its review)
does not have to reconstruct that shape from scratch.

Adds `ARCHITECTURE.md` at the repo root and links it from `CONTRIBUTING.md`'s
existing "Getting oriented" paragraph (next to the wiki reference, as the
issue asks) and from the README Documentation section.

**Note on location:** the issue's own text flags that `docs/` is entirely
git-ignored (`.gitignore`: local process docs only) and asks for "a top-level
`ARCHITECTURE.md`, or a README section" instead, verified against
`.gitignore` before writing, so the file lives at the repo root, not under
`docs/`.

What the page covers:

- Both protocols traced endpoint by endpoint through their real helper types
 , `OidChallenge`/`OidPost`/`OidAuth` and `SamlChallenge`/`SamlPost`/`SamlAuth`
 , down to the shared `LoginOutcome`/`LoginStatusMapper` tail, plus the five
  process-wide stores (`OidcStateStore`, `SamlReplayCache`, `SamlRequestCache`,
  the discovery-facts cache, `SsoRateLimiter`).
- The four-tier naming standard (`*Controller` → `*Service` → pure leaves →
  `*Store/*Cache/*Gate/*Limiter`) and the `ArchitectureConformanceTests`
  fitness functions that enforce it today.
- The #318 target direction (flow-service spine, `LoginCompletionService`,
  the `VerifiedIdentity` keystone) in its own clearly labelled, explicitly
  "not yet implemented" section, linking back to the #318 design note.
- The security invariants a change on this path must not regress: fail-closed
  by construction, the throwing-accessor→guarded-`Try*` fail-open hazard,
  guard-order preservation, inline log-forging sanitization, and secrets never
  logged/round-tripped.
- A "what lives where" file-map table.

Closes #451

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, documentation only, no change to the login path, crypto,
config persistence, or the release pipeline. No security review needed (also
the issue's own acceptance criterion).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (N/A — no code, but the doc itself avoids duplicating the
      wiki: it complements, not replaces, the Login Flow / Security Model pages.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). (The page
      itself keeps current vs. target strictly separated, per #318's own
      "residual idiom coexistence" mitigation.)
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No structural property changes — docs only, no `.cs` file touched.)

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. (Not run - no `.cs`
      file changed; nothing to build.)
- [ ] `dotnet test` is green. (Not run, same reason.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`npx prettier --check ARCHITECTURE.md README.md CONTRIBUTING.md` —
      clean; the repo-wide check shows only pre-existing warnings on files
      this PR does not touch.)

## Notes

- **Current vs. target separation:** §1 and the "What lives where" table
  describe only what exists in the tree today (every named type/method was
  verified against `origin/main` via `Grep`/`Read`, not written from memory);
  §2's "Target direction (#318), not yet implemented" subsection is the only
  place the target architecture appears, explicitly marked as not yet built,
  with a pointer to the #318 design-note comment for the full plan.
- **Verified types/methods** (all read from source, not recalled): `OidChallenge`,
  `OidPost`, `OidAuth`, `SamlChallenge`, `SamlPost`, `SamlAuth` (routes and
  bodies read in full); `OidcStateStore.{TryAdd,PeekCurrent,TryRedeem}`;
  `SamlRequestCache.{Register,TryConsume}`; `SamlReplayCache`;
  `CanonicalLinkService.ResolveOrCreateAsync`/`IsIdentityStillLinked`;
  `SessionMinter.MintAsync`; `LoginOutcome` (closed 3-case record, no `Error`
  case); `LoginStatusMapper.ToActionResult` (both exhaustive switches, throw
  on unmapped); `AccountLinkForbiddenException` → 403;
  `ArchitectureConformanceTests` rule names (`FlowServices_AreInternalAndSealed`,
  `MutableKeyedState_LivesOnlyInsideStoreLikeTypes`, etc.); `ProviderConfigStore`.
- Out of scope, not filed as a separate issue: nothing found needing one - 
  the doc-location deviation above is the only discrepancy from the literal
  task brief, and it is resolved in favor of the issue's own explicit
  constraint plus the verified `.gitignore` state.
