### PR TITLE
Compact admin-UI JS in linking.js and config.js

### DIFF
--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -274,12 +274,9 @@ const ssoConfigurationPage = {
     ) {
       return;
     }
-    return new Promise((resolve) => {
-      ApiClient.getPluginConfiguration(
-        ssoConfigurationPage.pluginUniqueId,
-      ).then((config) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
         if (!config.OidConfigs.hasOwnProperty(provider_name)) {
-          resolve();
           return;
         }
 
@@ -293,8 +290,6 @@ const ssoConfigurationPage = {
             ssoConfigurationPage.loadConfiguration(page);
 
             Dashboard.alert("Provider removed");
-
-            resolve();
           },
           // Report a genuine save failure rather than swallowing it. The delete
           // re-posts the whole configuration, so the server can now reject it for
@@ -308,11 +303,10 @@ const ssoConfigurationPage = {
               message:
                 "Could not remove the provider. The saved configuration was rejected by the server; reload the page and try again.",
             });
-            resolve();
           },
         );
-      });
-    });
+      },
+    );
   },
   saveProvider: (page, provider_name) => {
     return new Promise((resolve, reject) => {
@@ -327,12 +321,7 @@ const ssoConfigurationPage = {
         }
 
         form_elements.text_fields.forEach((id) => {
-          const value = page.querySelector("#" + id).value;
-          if (value) {
-            current_config[id] = page.querySelector("#" + id).value;
-          } else {
-            current_config[id] = null;
-          }
+          current_config[id] = page.querySelector("#" + id).value || null;
         });
 
         form_elements.check_fields.forEach((id) => {

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,31 +1,24 @@
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
   loadProviders: (view) => {
-    const provider_list_id = "sso-provider-list";
-    const provider_list_saml_id = `${provider_list_id}-saml`;
-    const provider_list_oid_id = `${provider_list_id}-oid`;
+    ["oid", "saml"].forEach((provider_mode) => {
+      const container = view.querySelector(
+        `#sso-provider-list-${provider_mode}`,
+      );
+      container.innerHTML = "";
 
-    const provider_list_saml = view.querySelector(`#${provider_list_saml_id}`);
-    const provider_list_oid = view.querySelector(`#${provider_list_oid_id}`);
-    provider_list_saml.innerHTML = "";
-    provider_list_oid.innerHTML = "";
-
-    fetch(new Request(ApiClient.getUrl("sso/OID/GetNames"))).then((resp) => {
-      resp.json().then((config_names) => {
-        ssoConfigLinking.loadProviderList(
-          provider_list_oid,
-          config_names,
-          "oid",
-        );
-      });
-    });
-    fetch(new Request(ApiClient.getUrl("sso/SAML/GetNames"))).then((resp) => {
-      resp.json().then((config_names) => {
-        ssoConfigLinking.loadProviderList(
-          provider_list_saml,
-          config_names,
-          "saml",
-        );
+      fetch(
+        new Request(
+          ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
+        ),
+      ).then((resp) => {
+        resp.json().then((config_names) => {
+          ssoConfigLinking.loadProviderList(
+            container,
+            config_names,
+            provider_mode,
+          );
+        });
       });
     });
   },


### PR DESCRIPTION
# What & why

Compacts the embedded admin-UI JavaScript in `SSO-Auth/Config/linking.js`
and `SSO-Auth/Config/config.js` per the P3 code-quality sweep. Three
behaviour-preserving reductions, each verified against `origin/main` and the
actual HTML templates / controller routes before landing:

1. **`linking.js`, `loadProviders`**: collapsed the near-identical OID/SAML
   fetch blocks into a single loop over `["oid", "saml"]`. Same two
   containers cleared, same two endpoints (`sso/OID/GetNames`,
   `sso/SAML/GetNames`) fetched in the same order, same lowercase
   `provider_mode` string handed to `loadProviderList`.
2. **`config.js`, `saveProvider`**: the `text_fields` loop's
   `querySelector` + `if/else` collapsed to
   `current_config[id] = page.querySelector("#" + id).value || null;`. A
   form control's `.value` is always a string, whose only falsy form is
   `""`, so this is truth-table identical to the removed if/else for every
   field on the form (including the security-relevant secret/endpoint/issuer
   fields listed at config.js:169-175).
3. **`config.js`, `deleteProvider`**: dropped the `new Promise((resolve) =>
   {...})` wrapper and its three `resolve()` calls. The sole caller (the
   `#DeleteProvider` click handler) has never chained `.then`/`.catch` or
   awaited the return value, in this diff or before it, the wrapper resolved
   a promise nobody held a reference to.

Closes #457

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Not applicable — this diff touches
      no signature/time-bound/audience check; it is admin-UI JS only.)
- [x] No secrets logged; secrets are redacted on config export. (Unchanged - 
      no logging statement touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (4-lens adversarial
      review run against the full diff — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Not
      applicable — no log call touched.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments
      explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property
      this change establishes is locked in as a rule in
      `ArchitectureConformanceTests`. (No new structural property — pure
      in-place JS compaction, no new C# types.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (927/927).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

These are browser-JS files CI cannot exercise at runtime, so review is the
primary verification. Walked the diff through the 4 refute-by-default
adversarial lenses (availability, security-bypass, correctness,
integration), all returned `PASS`, each verified against the committed
HTML templates (`linking.html`, `configPage.html`) and the controller route
attributes (`SSOController.cs`), not just the diff text.

Explicitly confirmed unchanged: no endpoint URL, no request shape/method, no
field name, and, most load-bearing, the `saveProvider` overlay that seeds
`current_config` from the existing loaded provider object before applying
form values, preserving server-managed and XML-only fields on save. That
loop's body is the only thing touched, and only its right-hand-side
expression changed, not the seeding/overwrite structure around it.

No `.cs` file touched.
