### PR TITLE
Fold legacy-link re-key into one authoritative migration transaction

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -298,6 +298,38 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void LegacyLinkMigration_ReturnsTheAuthoritativeMapping_NotAVoidReKey()
+    {
+        // Locked in by #363: the #155 legacy-link re-key runs as a SECOND lock acquisition after the
+        // candidate-resolving read, so a concurrent login could migrate the same identity between the two.
+        // The fix folds the re-key and the re-resolution into one config transaction that RETURNS the
+        // authoritative user id, and the caller binds the login to that returned id rather than the
+        // pre-migration snapshot. Structurally that means the migration helper must be a value-returning
+        // mutation (Guid?), never a fire-and-forget void re-key whose result the caller ignores — a
+        // revert to void would silently reopen the window. Reflection over the service's own private
+        // methods pins it: any migration helper (name contains "Migrate") must return Guid?.
+        var migrationHelpers = typeof(CanonicalLinkService)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Where(m => m.Name.Contains("Migrate", StringComparison.Ordinal))
+            .ToList();
+
+        // Sentinel against a vacuous pass: a rename that drops "Migrate" from the helper's name would make
+        // the scan match nothing and pass for the wrong reason, so require at least one to exist and force
+        // a conscious update of this rule if the naming changes.
+        Assert.True(
+            migrationHelpers.Count > 0,
+            "No legacy-link migration helper (a private method whose name contains \"Migrate\") was found on CanonicalLinkService; it was renamed, so point this rule at the new name so the return-type invariant keeps guarding #363.");
+
+        var voidReKeys = migrationHelpers
+            .Where(m => m.ReturnType != typeof(Guid?))
+            .Select(m => $"{m.Name} -> {m.ReturnType.Name}")
+            .ToList();
+        Assert.True(
+            voidReKeys.Count == 0,
+            "The legacy-link migration must return the authoritative mapping (Guid?) so the login binds to the post-migration state, not a pre-migration snapshot (#363); these do not: " + string.Join(", ", voidReKeys));
+    }
+
+    [Fact]
     public void SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade()
     {
         // Locked in by the ProviderConfigStore extraction (#318): SSOPlugin is bootstrap + page

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -348,6 +348,93 @@ public class CanonicalLinkServiceTests
         Assert.Contains("refusing to migrate the account link", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task ResolveOrCreateAsync_LiveSubjectLink_PersistsNothing()
+    {
+        // #363 guard: an ordinary login that resolves an existing subject-keyed link must stay a pure
+        // read. Folding the legacy migration into the resolution must NOT turn every login into a config
+        // persist — the common (no-migration) path writes nothing, so the fold cannot regress the hot
+        // path into an always-mutate.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        var persists = 0;
+        var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(0, persists); // no write on the hot path
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LegacyMigration_PersistsExactlyOnce()
+    {
+        // #363: the legacy re-key is folded into a SINGLE config transaction, so a migrating login
+        // persists exactly once — not the two write-capable lock acquisitions the pre-fold read-then-
+        // migrate pattern implied. The link ends up subject-keyed and the login binds to the migrated user.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        var persists = 0;
+        var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(1, persists); // one mutation for the migration, not two
+        var links = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, links["sub-1"]);
+        Assert.False(links.ContainsKey("alice"));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_ConcurrentLoginMigratedBeforeReKey_BindsToTheWinnerWithoutOverwriting()
+    {
+        // #363, the window the fold closes: the candidate-resolving read sees only the legacy key, but a
+        // concurrent login for the SAME identity commits its migration (subject key now live, legacy key
+        // gone) before this login's re-key transaction runs. The re-key transaction re-resolves the
+        // candidates authoritatively and binds to the winner's live subject link WITHOUT overwriting it —
+        // one winner, no double-write, and no stale pre-migration snapshot driving the outcome.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        // Access 1 is the candidate-resolving Read; access 2 is the migrate Mutate. Interposing the
+        // concurrent winner's committed migration right before the second access reproduces the race
+        // deterministically — exactly the interpose the two former separate lock acquisitions allowed.
+        var access = 0;
+        var store = new ProviderConfigStore(
+            () =>
+            {
+                if (++access == 2)
+                {
+                    var live = cfg.OidConfigs["kc"].CanonicalLinks;
+                    live.Remove("alice");
+                    live["sub-1"] = Existing; // the concurrent winner already re-keyed to the subject
+                }
+
+                return cfg;
+            },
+            _ => { },
+            new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+
+        Assert.Equal(Existing, resolved); // bound to the winner's live subject link
+        var final = cfg.OidConfigs["kc"].CanonicalLinks;
+        Assert.Equal(Existing, final["sub-1"]); // not overwritten
+        Assert.False(final.ContainsKey("alice")); // the winner's re-key stands
+    }
+
     // --- Admin surface: TryCreateLink / TryRemoveLink / LinksByUser (#372, finishing #241) ---
 
     [Fact]

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -174,7 +174,15 @@ internal sealed class CanonicalLinkService
                 throw new AccountLinkForbiddenException();
             }
 
-            MigrateCanonicalLinkKey(mode, provider, username, canonicalKey);
+            // Re-key the legacy link AND re-resolve the identity in ONE config transaction (#363), then
+            // bind the login to the value that transaction returns. The candidate resolution above was a
+            // separate lock acquisition, so a concurrent login could migrate this same identity between
+            // that snapshot and the re-key; taking the authoritative mapping from inside the re-key
+            // transaction — rather than the pre-migration snapshot's linkedUserId — closes that window
+            // instead of reasoning about its (previously argued-benign) safety. A concurrent winner's live
+            // subject link is used as-is; the deleted-target edge resolves to null so the login falls
+            // through to the create/adopt gate rather than binding to a dead account.
+            linkedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username);
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
                 mode,
@@ -517,33 +525,48 @@ internal sealed class CanonicalLinkService
         });
     }
 
-    // Re-keys a canonical link from oldKey to newKey inside the config lock (#155 legacy migration).
-    // Idempotent under concurrency: if oldKey is already gone (a concurrent login migrated first) the
-    // move is a no-op, and a LIVE newKey entry is never overwritten — only a dangling one (its target
-    // user deleted), which would otherwise block the hand-off on every subsequent login.
-    private void MigrateCanonicalLinkKey(string mode, string provider, string oldKey, string newKey)
+    // Re-keys a canonical link from the legacy username key to the stable subject key (#155) AND returns
+    // the authoritative user id the identity now resolves to, in ONE config transaction (#363). The
+    // caller resolved the candidates in an earlier lock acquisition, so folding the re-key and the
+    // re-resolution into this single transaction — and having the caller bind to the returned id rather
+    // than that earlier snapshot — removes the window a concurrent login could interpose in between the
+    // snapshot and the re-key. Idempotent under concurrency: if the legacy key is already gone (a
+    // concurrent login migrated first) the move is a no-op, and a LIVE subject key is never overwritten —
+    // only a dangling one (its target user deleted), which would otherwise block the hand-off on every
+    // subsequent login. Returns null only when neither key resolves a live account (the dangling edge), so
+    // the login fails closed into the create/adopt gate rather than binding to a dead account.
+    private Guid? MigrateAndResolveCanonicalLink(string mode, string provider, string canonicalKey, string legacyKey)
     {
-        _configStore.Mutate(configuration =>
+        return _configStore.Mutate<Guid?>(configuration =>
         {
-            // Migration is a SECOND transaction after the candidate-resolving read. If the provider was
-            // deleted or disabled in that window, fail CLOSED: throw rather than no-op, because the
-            // caller still holds the legacy user id from the pre-deletion snapshot and would otherwise
-            // return UseExistingLink, minting a session for a provider that no longer exists or was just
-            // switched off (#373, #380).
+            // The candidate-resolving read passed the provider enabled; if it was deleted or disabled in
+            // the window since, fail CLOSED: throw rather than no-op, because the caller would otherwise
+            // bind to the pre-window legacy id and mint a session for a provider that no longer exists or
+            // was just switched off (#373, #380).
             if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
                 throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to migrate the account link.");
             }
 
-            // A no-op here (unlike the throwing miss above) is the GOOD idempotent case: the provider
-            // still exists but oldKey was already re-keyed by a concurrent login, or newKey is live. The
-            // never-overwrite-a-live-newKey rule is on the method summary.
-            if (links.TryGetValue(oldKey, out var userId)
-                && (!links.TryGetValue(newKey, out var existing) || _userManager.GetUserById(existing) == null))
+            // Re-key only a legacy entry that still needs it: the subject key must be absent or dangling
+            // (never overwrite a live subject link a concurrent login already established). When we re-key,
+            // the identity now resolves subject-keyed to the legacy target, so that IS the authoritative id
+            // — returning the moved value (rather than re-reading and filtering) preserves the prior
+            // behaviour on the deleted-mid-migration race, where the caller bound to the legacy id and
+            // failed closed downstream.
+            if (links.TryGetValue(legacyKey, out var legacyUserId)
+                && (!links.TryGetValue(canonicalKey, out var subjectUserId) || _userManager.GetUserById(subjectUserId) == null))
             {
-                links.Remove(oldKey);
-                links[newKey] = userId;
+                links.Remove(legacyKey);
+                links[canonicalKey] = legacyUserId;
+                return legacyUserId;
             }
+
+            // Nothing to migrate: a concurrent login already re-keyed, or the legacy key is gone. Bind to
+            // the authoritative subject link, treating a dangling one (target deleted) as absent.
+            return links.TryGetValue(canonicalKey, out var live) && _userManager.GetUserById(live) != null
+                ? live
+                : (Guid?)null;
         });
     }
 


### PR DESCRIPTION
# What & why

Closes #363.

The #155 legacy-link (pre-#155 username-keyed) migration in
`CanonicalLinkService.ResolveOrCreateAsync` resolved the subject/legacy link
candidates in one locked `Read`, then performed the re-key in a **separate**
`Mutate`, two lock acquisitions, so a concurrent login for the same identity
could interpose between the snapshot and the re-key. The harmful outcome was
not reachable (the re-key guard is idempotent, a live subject key is never
overwritten, and the deleted-target race fails closed downstream at the #232
mint re-check), but the repo invariant is that a login-path check-then-act on
shared config state is a single atomic read-modify-write (#133 did exactly this
for link creation).

Rather than keep reasoning about the window's safety, we take the issue's
second suggested route: **have the migration mutation return the authoritative
mapping and bind the login to that.**

Current path (two acquisitions, stale-snapshot bind):
`Read` candidates -> decide migrate -> `MigrateCanonicalLinkKey` (void re-key,
second `Mutate`) -> the login keeps binding to the **pre-migration** snapshot's
`linkedUserId`.

New path:
- `void MigrateCanonicalLinkKey` becomes `Guid? MigrateAndResolveCanonicalLink`
 , the *same* idempotent re-key, inside one config transaction, that now
  **returns** the authoritative user id the identity resolves to. The caller
  binds `linkedUserId` to that return, so a concurrent winner's live subject
  link, or a since-deleted target, drives the final decision, never a stale
  read.
- The preliminary candidate `Read` stays as the fast common path: an ordinary
  login that resolves a live subject link (or needs no migration) remains a
  pure read and **persists nothing**, so the fold does not turn every login
  into a config write. The migrate transaction is entered only when a re-key is
  actually due.

Atomicity argument: the value the terminal switch acts on (`linkedUserId`) now
originates *inside* the same one-lock transaction as the re-key write. The
preliminary Read no longer supplies the bound id, it only selects the
migrate/no-migrate branch and the admin gate, both of which are re-validated
authoritatively inside the transaction (the `requireEnabled` guard and the
re-key guard itself). No stale snapshot can drive a wrong write. Concurrent
same-identity logins serialize on the one lock and resolve to exactly one
winner with no double-write.

Behaviour-preserving: the re-key guard is the old one with renamed locals
(no key-direction swap); SAML passes key == name so it never enters the migrate
path (unchanged); the #218 admin-adoption gate, the #354/#361 name-trust
guards, and the #373/#380 provider-vanished fail-closed throw all fire exactly
as before, ahead of any write. The one divergence is strictly *more*
fail-closed: in the rare concurrent-full-revoke-during-migration edge the new
code returns `null` and routes to the create/adopt gate (re-adopting through
the full eligibility gate) instead of stale-binding a just-revoked id and then
failing at the mint re-check.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

<!-- Labelled `hardening` on the issue; no behaviour change beyond a strictly
more fail-closed edge, so filed as a refactor. -->

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Adversarial review gate (login/linking path), four refute-by-default lenses:

- Availability / mass-lockout: **PASS**, migration only entered when due; hot
  path stays a pure read; no new refusal path (the migrate branch requires
  `allowExistingAccountLink == true`, so a `null` return falls through to
  adopt/create, never `RejectNameTaken`); every divergent race is equal-or-more
  available than the committed code.
- Security-bypass / fail-open: **PASS**, the #218 admin gate still throws
  before any re-key; the returned id is either the just-cleared non-admin legacy
  target or the authenticated subject's own link; the else-branch never
  overwrites a live subject link and never returns a foreign subject's id;
  deleted-target handling defers to the intact #232 re-check.
- Correctness / atomicity / concurrency: **PASS**, the re-key and authoritative
  re-resolution are one lock acquisition whose returned id (not the preliminary
  snapshot) drives the bind; guard logic preserved; concurrent same-identity
  logins resolve to exactly one winner with no double-write.
- Integration: **PASS**, public signature unchanged; both callers
  (`SSOController` OID/SAML) untouched; SAML is a genuine no-op; persist and
  locking semantics preserved; no dangling references to the removed method.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (`LegacyLinkMigration_ReturnsTheAuthoritativeMapping_NotAVoidReKey`).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0
      warnings).
- [x] `dotnet test` is green (931/931, both configs).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none
      touched).

## Notes

Scope is confined to `CanonicalLinkService` (+ tests, + conformance) per the
#318 step-2 plan; `SSOController`, `IntervalGate`, and the caches are untouched.
`ProviderConfigStore` is deliberately not modified: with only `Read` (no
persist) and `Mutate` (always persists) primitives, the fold keeps a
preliminary `Read` fast path so the hot login path stays write-free, and
escalates to a single authoritative `Mutate<Guid?>` only when a re-key is due.

The new conformance rule pins the *helper's* `Guid?` return as a proxy for
"the login binds to the authoritative value"; the caller's consumption of that
return is covered by the behavioural tests (hot-path-no-write,
migrate-persists-once, concurrent-winner-no-overwrite).
