### PR TITLE
Trim redundant per-login work in the avatar fetch

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -268,6 +268,23 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void AvatarService_HoldsAStaticSharedHttpClient()
+    {
+        // Locked in by the per-login churn trim (#248): the controller builds a fresh AvatarService per
+        // request, so the outbound HTTP stack must be a STATIC shared client — one connection pool for the
+        // whole process — not a per-instance client that would open a new pool (a full TCP+TLS handshake)
+        // on every login. The reference field the constructor reads (_httpClient) points at this shared
+        // client in production; the reference-equality across two production instances is proven behaviorally
+        // in AvatarServiceTests, and this rule locks in that the shared field it points at exists at all.
+        var staticClient = typeof(AvatarService)
+            .GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Where(f => !f.Name.Contains('<', StringComparison.Ordinal))
+            .Any(f => typeof(System.Net.Http.HttpClient).IsAssignableFrom(f.FieldType));
+
+        Assert.True(staticClient, "AvatarService must hold a static HttpClient so the outbound stack is reused across the controller's per-request instances rather than rebuilt per login (#248).");
+    }
+
+    [Fact]
     public void SessionMinter_RechecksRevocationImmediatelyBeforeTheMint()
     {
         // Locked in by the in-flight revocation gate (#232): MintAsync must evaluate the caller-supplied

--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -39,7 +39,8 @@ public class AvatarServiceTests
     }
 
     // Builds a service whose HTTP fetch is served by a stub handler returning the given response, so the
-    // fetch path (content-type gate, size cap, happy path) runs without live HTTP (#385 seam).
+    // fetch path (content-type gate, size cap, happy path, conditional 304) runs without live HTTP (#385
+    // seam). The client wraps the stub and stands in for the process-wide shared client (#248).
     private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build(HttpResponseMessage response)
     {
         var users = Substitute.For<IUserManager>();
@@ -47,7 +48,7 @@ public class AvatarServiceTests
         var serverConfig = Substitute.For<IServerConfigurationManager>();
         serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
         var log = new CapturingLogger();
-        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", () => new StubHandler(response));
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", new HttpClient(new StubHandler(response)));
         return (service, providers, users, log);
     }
 
@@ -61,7 +62,7 @@ public class AvatarServiceTests
         var serverConfig = Substitute.For<IServerConfigurationManager>();
         serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
         var log = new CapturingLogger();
-        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", () => new StubHandler(new HttpResponseMessage()), userStoreLocks);
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", new HttpClient(new StubHandler(new HttpResponseMessage())), userStoreLocks);
         return (service, providers, users, log);
     }
 
@@ -81,16 +82,30 @@ public class AvatarServiceTests
         return new HttpResponseMessage(HttpStatusCode.OK) { Content = content };
     }
 
-    // Returns a single canned response for every request, standing in for the live HTTP fetch.
+    // Returns a single canned response for every request, standing in for the live HTTP fetch, and records
+    // what it was asked so a test can assert the conditional-fetch header (#248) and the reuse count.
     private sealed class StubHandler : HttpMessageHandler
     {
         private readonly HttpResponseMessage _response;
 
         public StubHandler(HttpResponseMessage response) => _response = response;
 
+        // How many requests this one handler served — proves the client/handler is reused across fetches
+        // (#248) rather than rebuilt per fetch.
+        public int Invocations { get; private set; }
+
+        // The If-Modified-Since sent on the most recent request, or null if the fetch was unconditional.
+        public DateTimeOffset? LastIfModifiedSince { get; private set; }
+
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            => Task.FromResult(_response);
+        {
+            Invocations++;
+            LastIfModifiedSince = request.Headers.IfModifiedSince;
+            return Task.FromResult(_response);
+        }
     }
+
+    private static HttpResponseMessage NotModifiedResponse() => new HttpResponseMessage(HttpStatusCode.NotModified);
 
     private static string ProfilePath(string username, string extension)
         => Path.Combine(UserDataRoot, username, "profile" + extension);
@@ -428,5 +443,113 @@ public class AvatarServiceTests
         await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
 
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    // Builds a service over a StubHandler the test keeps a handle to, so it can assert the conditional
+    // fetch header and the handler reuse count (#248). The logger is returned too, so a test can assert the
+    // 304 path took the early return rather than a swallowed error.
+    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, StubHandler Handler, CapturingLogger Log) BuildWithHandler(HttpResponseMessage response)
+    {
+        var users = Substitute.For<IUserManager>();
+        var providers = Substitute.For<IProviderManager>();
+        var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
+        var handler = new StubHandler(response);
+        var log = new CapturingLogger();
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", new HttpClient(handler));
+        return (service, providers, users, handler, log);
+    }
+
+    [Fact]
+    public async Task TrySetAsync_NotModified_KeepsExistingAvatarAndDoesNotReStore()
+    {
+        // The decided cadence (#248): when the user already has an avatar, the fetch is conditional on
+        // If-Modified-Since, and a 304 means the image is unchanged — keep the existing profile image and
+        // download/store nothing. 304 must be handled BEFORE EnsureSuccessStatusCode (which throws on it).
+        using var response = NotModifiedResponse();
+        var (service, providers, users, handler, log) = BuildWithHandler(response);
+        var user = UserNamed("alice");
+        var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        user.ProfileImage = previous;
+
+        await service.TrySetAsync(user, AllowedUrl);
+
+        // The conditional header was sent, carrying our last-store timestamp.
+        Assert.Equal(new DateTimeOffset(previous.LastModified, TimeSpan.Zero), handler.LastIfModifiedSince);
+        // Nothing re-downloaded/re-stored; the existing record is untouched.
+        Assert.Same(previous, user.ProfileImage);
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        // The 304 was handled by the early return, not by EnsureSuccessStatusCode throwing into the
+        // best-effort catch: were the early return removed, 304 would raise, be swallowed, and log an error
+        // while leaving the assertions above unchanged. Asserting no error logged is what pins the early return.
+        Assert.DoesNotContain(log.Entries, e => e.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public async Task TrySetAsync_ExistingImageChanged_SendsConditionalHeaderAndRefreshes()
+    {
+        // The 200 side of the decided cadence: the origin reports the image changed (a 200, not a 304), so
+        // the new bytes are fetched and re-stored over the same path — the conditional header was still sent.
+        using var response = ImageResponse("image/png", new byte[] { 9 });
+        var (service, providers, _, handler, _) = BuildWithHandler(response);
+        var user = UserNamed("alice");
+        user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+
+        await service.TrySetAsync(user, AllowedUrl);
+
+        Assert.NotNull(handler.LastIfModifiedSince);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public async Task TrySetAsync_NoPreviousImage_FetchesUnconditionally()
+    {
+        // First login for this user: no stored image, so no If-Modified-Since — the fetch is unconditional
+        // and the avatar is stored, exactly as before the conditional-fetch change.
+        using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
+        var (service, providers, _, handler, _) = BuildWithHandler(response);
+
+        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+
+        Assert.Null(handler.LastIfModifiedSince);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public void ProductionInstances_ShareOneHttpClient()
+    {
+        // #248 trim 1, cross-instance: the controller builds a fresh AvatarService per request (see
+        // SSOController), so reuse only helps if the client is process-wide. Two services built through the
+        // production constructor must reference the very same HttpClient instance — i.e. the static shared
+        // one — not a fresh per-instance client (which would reopen a connection pool each login).
+        var users = Substitute.For<IUserManager>();
+        var providers = Substitute.For<IProviderManager>();
+        var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
+
+        var first = new AvatarService(users, providers, serverConfig, new CapturingLogger(), "test-agent/1.0");
+        var second = new AvatarService(users, providers, serverConfig, new CapturingLogger(), "test-agent/1.0");
+
+        var clientField = typeof(AvatarService).GetField("_httpClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(clientField);
+        Assert.Same(clientField!.GetValue(first), clientField.GetValue(second));
+    }
+
+    [Fact]
+    public async Task TrySetAsync_TwoFetches_ReuseTheSameHttpStack()
+    {
+        // #248 trim 1: TrySetAsync no longer builds its own HttpClient/handler per fetch — it uses the
+        // injected (in production: process-wide shared) client. Two fetches through one service are served
+        // by the one handler instance, proving the stack is reused rather than rebuilt per login. (The
+        // static-field structural guarantee that this reuse spans the controller's per-request AvatarService
+        // instances is locked in ArchitectureConformanceTests.)
+        using var response = ImageResponse("image/png", new byte[] { 1 });
+        var (service, _, _, handler, _) = BuildWithHandler(response);
+
+        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+        await service.TrySetAsync(UserNamed("bob"), AllowedUrl);
+
+        Assert.Equal(2, handler.Invocations);
     }
 }

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -32,12 +32,22 @@ internal sealed class AvatarService
     // is exactly the profile-path determinant (Path.Combine on user.Username below).
     private static readonly KeyedLockStore SharedUserStoreLocks = new KeyedLockStore(StringComparer.Ordinal);
 
+    // One process-wide HTTP stack reused across every login (#248). Static for the same reason the store
+    // lock is: the controller builds a fresh AvatarService per request, so a per-instance client would
+    // open a new connection pool — a full TCP+TLS handshake — on every login. The single shared client
+    // keeps its pool warm across logins while the hardened handler's guards (SSRF ConnectCallback, redirect
+    // bound, proxy-off) are unchanged; PooledConnectionLifetime bounds how long a pooled connection lives
+    // so DNS changes are still eventually honored despite the reuse. Thread-safe: concurrent logins call
+    // SendAsync with their own HttpRequestMessage (User-Agent and If-Modified-Since live on the request,
+    // not on the shared client's mutable DefaultRequestHeaders).
+    private static readonly HttpClient SharedClient = CreateHardenedClient();
+
     private readonly IUserManager _userManager;
     private readonly IProviderManager _providerManager;
     private readonly IServerConfigurationManager _serverConfigurationManager;
     private readonly ILogger _logger;
     private readonly string _userAgent;
-    private readonly Func<HttpMessageHandler> _handlerFactory;
+    private readonly HttpClient _httpClient;
     private readonly KeyedLockStore _userStoreLocks;
 
     internal AvatarService(
@@ -46,22 +56,23 @@ internal sealed class AvatarService
         IServerConfigurationManager serverConfigurationManager,
         ILogger logger,
         string userAgent)
-        : this(userManager, providerManager, serverConfigurationManager, logger, userAgent, CreateHardenedHandler)
+        : this(userManager, providerManager, serverConfigurationManager, logger, userAgent, SharedClient)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AvatarService"/> class with an injected HTTP message
-    /// handler factory. This is the test seam (#385): a stub handler makes the content-type gate, the
-    /// size cap, the happy path, and the timeout reachable without live HTTP. Production uses the
-    /// five-argument constructor, which supplies the hardened SSRF-safe <see cref="SocketsHttpHandler"/>.
+    /// Initializes a new instance of the <see cref="AvatarService"/> class with an injected
+    /// <see cref="HttpClient"/>. This is the test seam (#385): a client wrapping a stub handler makes the
+    /// content-type gate, the size cap, the happy path, the conditional 304, and the timeout reachable
+    /// without live HTTP. Production uses the five-argument constructor, which supplies the process-wide
+    /// shared client built on the hardened SSRF-safe <see cref="SocketsHttpHandler"/>.
     /// </summary>
     /// <param name="userManager">The Jellyfin user manager.</param>
     /// <param name="providerManager">The Jellyfin provider manager (image saving).</param>
     /// <param name="serverConfigurationManager">The server configuration manager (user data paths).</param>
     /// <param name="logger">The logger.</param>
     /// <param name="userAgent">The outbound User-Agent.</param>
-    /// <param name="handlerFactory">Builds the message handler used for each fetch; called once per fetch and disposed after.</param>
+    /// <param name="httpClient">The client used for every fetch; reused across calls (never disposed here).</param>
     /// <param name="userStoreLocks">The per-user store lock (#400); null uses the process-wide shared one. A test injects its own so it can drive the serialization deterministically.</param>
     internal AvatarService(
         IUserManager userManager,
@@ -69,7 +80,7 @@ internal sealed class AvatarService
         IServerConfigurationManager serverConfigurationManager,
         ILogger logger,
         string userAgent,
-        Func<HttpMessageHandler> handlerFactory,
+        HttpClient httpClient,
         KeyedLockStore userStoreLocks = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
@@ -77,7 +88,7 @@ internal sealed class AvatarService
         _serverConfigurationManager = serverConfigurationManager ?? throw new ArgumentNullException(nameof(serverConfigurationManager));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _userAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
-        _handlerFactory = handlerFactory ?? throw new ArgumentNullException(nameof(handlerFactory));
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _userStoreLocks = userStoreLocks ?? SharedUserStoreLocks;
     }
 
@@ -104,21 +115,42 @@ internal sealed class AvatarService
 
         try
         {
-            using var handler = _handlerFactory();
-            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
-
-            client.DefaultRequestHeaders.UserAgent.ParseAdd(_userAgent);
-
             // One deadline for the whole fetch: with ResponseHeadersRead the client Timeout stops
             // applying once the headers arrive, so a malicious endpoint could send headers immediately
-            // then trickle the body forever. A single 10s token passed into GetAsync AND every body
+            // then trickle the body forever. A single 10s token passed into SendAsync AND every body
             // ReadAsync bounds the header wait and the streamed read together, while keeping the
             // streaming size cap (#220).
             using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
 
+            using var request = new HttpRequestMessage(HttpMethod.Get, avatarUri);
+            request.Headers.UserAgent.ParseAdd(_userAgent);
+
+            // Conditional refresh (#248): when we already hold this user's avatar, ask the origin to send
+            // fresh bytes only if the image changed since we last stored it. If-Modified-Since carries the
+            // timestamp of our last store (ProfileImage.LastModified) — exactly "when we last fetched this
+            // representation" — so an unchanged avatar answers 304 and we skip the re-download AND the
+            // re-store entirely; only a changed image (200) is fetched and re-stored. An origin that ignores
+            // the header just answers 200 as before, so this degrades safely to the old always-download.
+            // SpecifyKind(Utc) makes the DateTimeOffset construction total regardless of the stored Kind;
+            // ProfileImage.LastModified is already written as DateTime.UtcNow, so no time is shifted.
+            if (user.ProfileImage?.LastModified is { } lastStored && lastStored > DateTime.MinValue)
+            {
+                request.Headers.IfModifiedSince = new DateTimeOffset(DateTime.SpecifyKind(lastStored, DateTimeKind.Utc));
+            }
+
             // ResponseHeadersRead so the body is streamed, not fully buffered, before ReadCappedAsync
             // enforces the size limit; otherwise the cap runs only after the whole download is in memory.
-            using var avatarResponse = await client.GetAsync(avatarUri, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+            using var avatarResponse = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeout.Token).ConfigureAwait(false);
+
+            // 304: the image is unchanged since our last store — keep the existing profile image, fetch and
+            // store nothing, and deliberately do NOT advance ProfileImage.LastModified (it stays the anchor
+            // for the next login's If-Modified-Since; refreshing it here would defeat the conditional). Checked
+            // before EnsureSuccessStatusCode, which treats 304 as a non-success throw.
+            if (avatarResponse.StatusCode == HttpStatusCode.NotModified)
+            {
+                return;
+            }
+
             avatarResponse.EnsureSuccessStatusCode();
 
             // Media types are case-insensitive (RFC 7231); use the parsed type with parameters stripped.
@@ -269,11 +301,19 @@ internal sealed class AvatarService
         return string.Equals(fullCandidate, Path.Combine(fullRoot, username), comparison);
     }
 
+    // The process-wide shared client (#248): one hardened handler + one connection pool for the whole
+    // process, reused across every login instead of rebuilt per fetch. Timeout stays 10s; because the
+    // fetch uses ResponseHeadersRead the per-request CancellationTokenSource is the real end-to-end
+    // deadline (see TrySetAsync), so this Timeout bounds only connect + header wait. Never disposed —
+    // it lives for the process, the intended lifetime of a shared HttpClient.
+    private static HttpClient CreateHardenedClient() =>
+        new HttpClient(CreateHardenedHandler(), disposeHandler: true) { Timeout = TimeSpan.FromSeconds(10) };
+
     // The production handler: routes every connection (including redirect targets) through a callback
     // that rejects private/loopback addresses, closing the SSRF and DNS-rebinding vectors. Redirects
     // stay enabled (many avatar URLs redirect) but are bounded, each hop is IP-validated, and both the
-    // request and the download are bounded. A fresh handler is built per fetch and disposed by the caller.
-    private static HttpMessageHandler CreateHardenedHandler() => new SocketsHttpHandler
+    // request and the download are bounded. Built once for the shared client above.
+    private static SocketsHttpHandler CreateHardenedHandler() => new SocketsHttpHandler
     {
         AllowAutoRedirect = true,
         MaxAutomaticRedirections = 5,
@@ -282,6 +322,10 @@ internal sealed class AvatarService
         // A system proxy would be the connection target, so the connect callback would validate the
         // proxy's address rather than the avatar host's - bypassing the guard.
         UseProxy = false,
+
+        // The handler is reused across logins, so bound how long a pooled connection lives — after this
+        // the connection is recycled and the host re-resolved, so DNS changes are honored despite reuse.
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
     };
 
     // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that


### PR DESCRIPTION
# What & why

Closes #248.

`Authenticate` repeated avoidable work on every successful login. This trims two of the three items in the issue inside `AvatarService`; the third was already resolved upstream.

**1, HTTP stack churn.** The controller builds a fresh `AvatarService` per request (`SSOController.cs:121`), and `TrySetAsync` built a new `SocketsHttpHandler` + `HttpClient` per fetch, a fresh connection pool, so a full TCP+TLS handshake and zero reuse every login. We hoist one process-wide `static readonly HttpClient` (`SharedClient`) built from the same `CreateHardenedHandler()`, reused across all per-request instances. The hardening is unchanged, SSRF `ConnectCallback` (per-connection + per-redirect-hop IP validation), `MaxAutomaticRedirections = 5`, `UseProxy = false`, the 10s deadline, the `ContentLength` pre-check, and the streamed `ReadCappedAsync` byte cap all stay exactly as they were. We add `PooledConnectionLifetime = 2 min` so DNS changes are still honored despite pooling. User-Agent and the conditional header move onto the per-request `HttpRequestMessage`, so the shared client holds no mutable per-login header state (thread-safe under concurrent logins). The test seam changes from a `Func<HttpMessageHandler>` factory to an injected `HttpClient`.

**2, Unconditional re-download → conditional (the decided cadence).** Per my decision on #248, the fetch is now conditional via **`If-Modified-Since`**, not skip-on-unchanged-URL and not always-download. The header value is the user's last-store timestamp (`user.ProfileImage.LastModified`), exactly "when we last fetched this representation". A **304** keeps the existing avatar and stores nothing; a **200** refreshes it as before. First login (no stored image) sends no conditional header and fetches unconditionally. An origin that ignores the header answers 200, so the flow degrades safely to the old always-download.

Design detail on the `If-Modified-Since` value: we deliberately do **not** advance `LastModified` on a 304, so it stays the stable anchor for the next login's conditional. `new DateTimeOffset(DateTime.SpecifyKind(lastStored, DateTimeKind.Utc))` is total for any stored `Kind` (values are written as `DateTime.UtcNow`, so no time is shifted). The 304 branch is checked **before** `EnsureSuccessStatusCode`, which treats 304 as a non-success throw. Clock-skew degrades safely in both directions (a needless re-fetch, or a bounded stale window that self-corrects), never a broken login.

**3, Double user write.** Already collapsed upstream by #391 (commit `3f03475`): the mint path (`SessionMinter.MintAsync`) now performs a single `UpdateUserAsync` with `AuthenticationProviderId` set beforehand. The remaining second `UpdateUserAsync` in the codebase (`SSOController.cs:1128`) is the `Unregister` admin endpoint, not the login path. Verified empirically, no change needed here, and `SessionMinter.cs` is untouched on this branch.

Structural lock-in: `ArchitectureConformanceTests.AvatarService_HoldsAStaticSharedHttpClient` pins that the outbound stack is a static shared client (rebuild-per-login cannot regress silently); a behavioural test proves two production-built instances reference the same client.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Avatar fetch is best-effort throughout; all SSRF/content-type/size guards still fail closed — no fetch, no store.)
- [x] No secrets logged; secrets are redacted on config export. (No secret handling touched; IdP-controlled URL and content-type are still sanitized inline at the log call.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Unchanged: `avatarUrl` and `mediaType` use `ReplaceLineEndings(string.Empty)` at the call site.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires. (Net: the shared client removes the per-fetch construct; the conditional adds one header + one early return.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). (Step 15 of #318; changes confined to AvatarService.)
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (933 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None touched, C# only.)

## Notes

**Adversarial four-lens review (refute-by-default), all PASS:**

- **Availability / mass-lockout, PASS.** No new stall/deadlock/serialization vector. `SocketsHttpHandler` keeps its default `MaxConnectionsPerServer` (int.MaxValue), so concurrent logins never queue behind one another; the per-request `CancellationTokenSource(10s)` still bounds the whole fetch end to end (a trickle-body attack cannot hang a login past ~10s); the shared client is never disposed so it cannot self-brick, and a throw is swallowed by the best-effort catch. The 304 early-return is a net availability win. The per-user store lock (#400) is unchanged and never held across the network fetch.

- **Security-bypass, PASS.** Connection pooling cannot skip the per-connection SSRF `ConnectCallback`: the pool is keyed by request authority (same host only) and a pooled connection is pinned to the already-validated public IP, so a DNS rebind cannot hijack it; reaching an internal IP needs a new connection, which re-runs the callback → `IsBlockedAddress` → reject. `PooledConnectionLifetime = 2 min` tightens rebind staleness relative to the default (infinite). Moving User-Agent to the per-request message is the correct thread-safety fix, same value. A malicious 304 (even with a body) only keeps the user's existing, previously-validated avatar, no new/unvalidated content is stored (body never read). All guards intact and reachable: content-type raster allow-list (#217), ContentLength + streamed byte cap (#220), #447 username path-traversal guard, #384 dotted extension, #400 per-user lock, #448 bounded acquire. No user-write field dropped, `SessionMinter.cs` is byte-identical to `origin/main`.

- **Correctness, PASS** (was NEEDS_IMPROVEMENT, resolved). `If-Modified-Since` ordering, `DateTimeOffset` totality, the first-login guard, and shared-client thread-safety are all correct and fail-safe. The initial pass flagged that the 304 test did not distinguish the correct early-return from a regression (a deleted early-return throws on 304, is swallowed, and leaves the same observable state), fixed by asserting no `Error` was logged, which now fails on that regression (empirically, 304 → `HttpRequestException` into the Error-logging catch). Re-reviewed: PASS.

- **Integration, PASS.** Constructor seam change compiles at every call site (production 5-arg constructor unchanged at `SSOController.cs:121`; `SessionMinter` untouched). `ImageInfo.LastModified` confirmed (against the pinned Jellyfin 10.11.11 package) to be a real settable property initialized to `DateTime.UtcNow`. A never-disposed static `HttpClient` is the correct process-lifetime pattern (Jellyfin does not hot-unload plugins). The `Controller_NeverTouchesRawSocketsOrDns` liveness marker still matches AvatarService, and the new conformance rule is non-vacuous. Two low-severity best-effort notes (below).

**Out-of-scope / follow-up candidates (not addressed here):**

- The issue's "while in the area" note, `SamlAuth` evaluates `samlResponse.GetCustomAttributes("Role")` twice per login (`SSOController.cs`), is in the controller hot file (#318 serial), so it is left out of this PR. Candidate for a separate small refactor.
- Best-effort self-heal edge (integration lens): if the on-disk `profile.*` file is deleted out-of-band while the DB `ImageInfo` record survives, a 304 now skips the re-download so the avatar no longer self-heals on the next login. Low severity, best-effort path, candidate follow-up if self-heal is desired.
- The 304-vs-200 behaviour against real conditional / non-conditional avatar hosts is a browser/real-server behaviour CI cannot exercise, belongs on the manual E2E checklist, not a merge blocker.

