### PR TITLE
Document remaining OpenID config keys and multi-restriction SAML audience semantics

### DIFF
--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -152,7 +152,10 @@ public abstract class ProviderConfigBase
     public List<FolderRoleMap> FolderRoleMapping { get; set; }
 
     /// <summary>
-    /// Gets or sets the default provider the user after logging in with SSO.
+    /// Gets or sets the authentication provider id written to the user's Jellyfin account
+    /// (<c>User.AuthenticationProviderId</c>) after a successful SSO login. This is a Jellyfin-native
+    /// user attribute; SSO logins themselves always resolve through the per-provider canonical-link maps,
+    /// not this field. Blank leaves the account's existing provider id untouched.
     /// </summary>
     public string DefaultProvider { get; set; }
 

--- a/providers.md
+++ b/providers.md
@@ -225,6 +225,14 @@ Both are set through the SAML provider configuration (the `SAML/Add` API, like t
 options — there is no admin-UI toggle yet); include them whenever you re-post a provider's config so
 a save does not reset them.
 
+**Multiple `AudienceRestriction` blocks:** SAML 2.0 core §2.5.1.4 permits an assertion to carry more
+than one `<AudienceRestriction>` element, and the plugin requires this service provider's audience to
+be named in **every** block (AND across blocks), while a single matching `Audience` anywhere inside
+one block is enough for that block (OR within a block). An assertion whose first restriction names a
+different service provider and whose second names this one is therefore rejected, even though it
+matched one of the blocks — it is not strictly addressed to this service provider. An assertion
+carrying no `AudienceRestriction` at all fails closed the same way (rejected).
+
 ## SAML response binding (optional hardening)
 
 Two per-provider SAML options, both **off by default**, tie a response more tightly to this service
@@ -303,6 +311,27 @@ It is automatic, with no configuration. Two consequences worth knowing:
 - **Serve the whole flow from one origin.** If `BaseUrlOverride` points at a host your users do not
   actually browse, the binding cookie will not travel with them; keep the challenge and callback on the
   same origin (which a working setup already does).
+
+## Other OpenID options
+
+A few remaining per-provider OpenID settings, set through the config XML (no admin-UI toggle yet):
+
+- **`DisableHttps`** (off by default) turns off the requirement that the discovery document — and the
+  endpoints it points at (JWKS, token) — be fetched over HTTPS
+  (`options.Policy.Discovery.RequireHttps` in `SSOController.cs`). With it on, the id_token's signing
+  keys are fetched over a channel a network attacker can intercept, so only turn it on for a
+  local/testing identity provider that genuinely has no TLS — never for a production deployment.
+  Enabling it is recorded in the `[SSO Audit]` log alongside the other insecure toggles (see
+  [OpenID Connect id_token requirements](#openid-connect-id_token-requirements)).
+- **`DoNotLoadProfile`** (off by default) skips the UserInfo endpoint call after token exchange
+  (`LoadProfile` on the `OidcClient`). Some providers only return certain claims from UserInfo, not
+  the id_token, so turning this on can leave role/username/avatar mapping without data it expects —
+  set it only for a provider whose id_token alone already carries every claim you map.
+- **`DefaultProvider`** sets the value the plugin writes into Jellyfin's own `AuthenticationProviderId`
+  field on the user record after a successful login through this provider (`SessionMinter`). This is a
+  Jellyfin-native user attribute, not something the SSO plugin reads back to resolve SSO logins —
+  those always resolve through the per-provider canonical-link maps regardless of this value. Leave it
+  blank to leave the field untouched.
 
 ## In-flight login capacity (per-client)
 


### PR DESCRIPTION
# What & why

`OidConfig`/`ProviderConfigBase` (`SSO-Auth/Config/PluginConfiguration.cs`) carried three config
keys with no coverage in any user-facing doc: `DisableHttps`, `DoNotLoadProfile`, and
`DefaultProvider`. We add an "Other OpenID options" section to providers.md documenting each - 
name, purpose, default, and the security caveat on `DisableHttps` (it drops the HTTPS requirement
on discovery/JWKS/token, exposing the id_token signing keys to a MITM). We also fix the garbled
XML-doc comment on `OidConfig.DefaultProvider` in `PluginConfiguration.cs` (it read "Gets or sets the
default provider the user after logging in with SSO.", ungrammatical and inaccurate), correcting it
to describe what the field actually does: the value is written to the account's Jellyfin-native
`User.AuthenticationProviderId` on a successful login and is not read back to resolve SSO logins
(those go through the per-provider canonical-link maps). Comment-only change. Closes #455.

Separately, the existing "SAML audience validation" section described the single-`AudienceRestriction`
case but not what happens when an assertion carries several blocks. #238 made that check AND-across-blocks
(this service provider must be named in every block) / OR-within-block. We add one paragraph making that
explicit. Closes #460.

Both issues touch the same file (providers.md), so we deliver them together to avoid a merge conflict
between two separate PRs. The `PluginConfiguration.cs` edit is the one-line comment fix that fully
closes #455.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Documentation + one XML-doc comment. The `PluginConfiguration.cs` change is comment-only and alters no
behavior, control flow, or persisted value; no login-path, crypto, config-persistence, or
release-pipeline logic is touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. (N/A — docs +
      comment only, no structural change.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - confirmed for both `-c Debug` and
      `-c Release`, 0 warnings / 0 errors.
- [ ] `dotnet test` is green. (N/A - the only `.cs` change is a comment; behavior documented was
      verified by reading `Saml.cs`'s `IsAddressedTo` and the existing `SamlAttackShapeTests` coverage
      for #238, and `SSOController.cs`/`SessionMinter.cs` for the three OpenID keys.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (`npx prettier --check` on the
      committed providers.md blob; a local working-tree CRLF-conversion warning from `core.autocrlf` is
      not in the commit).

## Notes

Verified `DefaultProvider` semantics against the code before both documenting and rewriting the comment.
`SessionMinter.cs` writes `config.DefaultProvider` into Jellyfin's own `user.AuthenticationProviderId`
after a successful login; `SSOController.cs`'s `Unregister` endpoint comment confirms SSO login itself
resolves through the per-provider canonical-link maps, not this field.

For #460, the exact code path verified is `Saml.cs`'s `IsAddressedTo`:

```csharp
foreach (XmlNode restriction in restrictions)
{
    var audiences = restriction.SelectNodes("saml:Audience", _xmlNameSpaceManager);
    var present = audiences != null && audiences.Cast<XmlNode>()
        .Any(node => string.Equals(node?.InnerText?.Trim(), expectedAudience, StringComparison.Ordinal));
    if (!present)
    {
        return false;
    }
}

return true;
```

 - every restriction block must contain a matching `Audience` (AND across blocks; the `.Any` inside
the loop is the OR within one block), and zero restrictions fails closed. Cross-checked against
`SamlAttackShapeTests.IsValidAudience_PresentInEveryRestriction_ReturnsTrue` and
`IsValidAudience_PresentInOnlyOneOfTwoRestrictions_ReturnsFalse`.
