### PR TITLE
Enable TreatWarningsAsErrors as a project default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,11 @@
 <Project>
 
   <PropertyGroup>
+    <!-- CI's dotnet.yml already builds with the warnaserror flag; setting the project property too
+         makes a plain local `dotnet build` (no flag) match CI instead of silently passing on
+         warnings a contributor's machine would otherwise hide until the PR build. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
     <!-- Generate and honor a packages.lock.json per project so the restored dependency graph is
          pinned and reproducible. Locally, updating a package regenerates the lock file (or run a
          restore with the force-evaluate switch). -->

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -6,7 +6,8 @@
     <AssemblyVersion>4.0.0.4</AssemblyVersion>
     <FileVersion>4.0.0.4</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
+         build matches the CI warnaserror gate. -->
     <!-- Turns the compiler into a standing reviewer. AnalysisModeSecurity=All
          enables the disabled-by-default Security rules (CA3xxx injection/taint,
          CA53xx crypto) that Recommended leaves off. CodeAnalysisTreatWarningsAsErrors


### PR DESCRIPTION
# What & why

CI's `dotnet.yml` build job already builds with the `--warnaserror` flag, but
`SSO-Auth.csproj` explicitly set `TreatWarningsAsErrors` to `false` as a
project property. That meant a plain local `dotnet build` (no flag) could
pass on a change CI's gate would reject as a warning, local and CI drifted.

Moved `TreatWarningsAsErrors=true` into `Directory.Build.props` (already the
shared-property file for this repo, used for the lock-file settings) so it
applies to both `SSO-Auth` and `SSO-Auth.Tests`, and dropped the conflicting
`false` override in `SSO-Auth.csproj`. Verified both `dotnet build -c Debug`
and `-c Release` are 0 warnings / 0 errors with the property alone (i.e. no
warning was hiding behind the flag-only gate), the ABI-floor Release build
(`-p:JellyfinVersion=10.11.0`, mirroring the `dotnet.yml` floor job) is clean,
and the full test suite (937 tests) still passes.

Also reviewed the dependency set per the issue's second half (assessment
only, no bumps, see Notes).

Refs #159

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this change touches only build-property configuration
(`Directory.Build.props`, `SSO-Auth.csproj`), no login-path, crypto, or config
persistence code.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property introduced — a build-property change only.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (937/937).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none
      touched by this PR).
- [x] `dotnet build -c Debug` / `-c Release` **without** the flag are also
      0 warnings / 0 errors now that the property is set (the actual gap this
      PR closes).
- [x] `sh scripts/check-jellyfin-compat.sh` passes.

## Notes

**Dependency hygiene assessment (issue's second half, no version bumps
made, per policy that Dependabot owns bumps):**

- No duplicate or unused `PackageReference` entries found. Checked every
  direct reference (`Duende.IdentityModel.OidcClient`,
  `Microsoft.IdentityModel.JsonWebTokens`,
  `System.Security.Cryptography.Xml`, `Newtonsoft.Json`, the five analyzer
  packages, and the four test packages) against actual `using`/type usage in
  `SSO-Auth/` and `SSO-Auth.Tests/`, all are live.
- `dotnet list package --outdated` shows only routine minor/patch drift
  (`Meziantou.Analyzer` 3.0.122→3.0.123, `Microsoft.IdentityModel.JsonWebTokens`
  8.19.1→8.19.2, `System.Security.Cryptography.Xml` 10.0.9→10.0.10,
  `Microsoft.NET.Test.Sdk` 18.7.0→18.8.1), `.github/dependabot.yml` already
  covers the `nuget` ecosystem weekly with a 7-day cooldown, so these will
  surface as Dependabot PRs on their own; not duplicating that here.
- One **major** version is available and needs an explicit decision, not a
  routine bump: `NSubstitute` 5.3.0→6.0.0. Flagging as a candidate issue
  rather than acting on it here.
- The issue's other two acceptance criteria, the `Duende.IdentityModel.OidcClient`
  major-version move and a nullable-annotations sweep, are already tracked
  by existing, more specific issues: the OidcClient bump is bundled into the
  net10.0/Jellyfin 12 migration issue (#135, which explicitly calls out
  verifying OidcClient on net10 empirically), and analyzer/nullable backlog
  work is tracked under #104. Redoing either narrowly here would fork that
  tracking, so this PR intentionally does not touch them and keeps #159
  open, referencing rather than closing it, until those two land or #159 is
  explicitly re-scoped down to just the build-property fix.
