### PR TITLE
Surface AllowExistingAccountLink in the admin provider form

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -448,7 +448,7 @@ public class ArchitectureConformanceTests
         {
             "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",
             "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
-            "DoNotLoadProfile", "RequirePkce",
+            "DoNotLoadProfile", "RequirePkce", "AllowExistingAccountLink",
         };
         var unsaved = securityCritical.Where(p => !matchedIds.Contains(p)).ToList();
         Assert.True(

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -740,6 +740,37 @@
                   </div>
                 </div>
 
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="AllowExistingAccountLink"
+                      name="AllowExistingAccountLink"
+                      type="checkbox"
+                      class="sso-toggle"
+                    />
+                    <span>Allow Adopting Existing Accounts (Sensitive)</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Sensitive: lets a first SSO login adopt (take over) a
+                    pre-existing, unlinked Jellyfin account whose username
+                    matches the SSO name, instead of rejecting it. Off by
+                    default (fail closed). Enable only for the one-time
+                    legacy-link migration window described in the
+                    account-linking runbook on the
+                    <a
+                      is="emby-linkbutton"
+                      href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+                      class="button-link"
+                      >wiki</a
+                    >, then turn it back off. A name-matched administrator
+                    account is never adopted regardless of this setting, and
+                    each adoption is recorded as an audit event.
+                  </div>
+                </div>
+
                 <div class="inputContainer">
                   <label
                     class="inputLabel inputLabelUnfocused"


### PR DESCRIPTION
# What & why

Closes #432

`AllowExistingAccountLink` (`ProviderConfigBase`, inherited by `OidConfig`)
gates whether a first SSO login may adopt a same-named, pre-existing, unlinked
Jellyfin account, the fail-closed gate behind #354/#358. It is a real,
security-relevant toggle, but it had no field in the admin provider form:
`configPage.html` / `config.js` never referenced it, so `listArgumentsByType`
never persisted it. The only way to turn it on was hand-editing `SSO-Auth.xml`
per provider, despite the #354 legacy-link migration runbook explicitly telling
admins to enable it during the migration window.

We add an `sso-toggle` checkbox for it to `#sso-new-oidc-provider`, wired through
the existing generic save path.

**How the flag is rendered + saved (mirrors `EnableAllFolders`/`RequirePkce`):**
the checkbox carries `class="sso-toggle"` and `id="AllowExistingAccountLink"`,
spelled exactly like the `OidConfig` property. That is the entire #365 save
contract, no `config.js` change is needed because the save/load path is generic
over the marker classes:

- Load: `loadProvider` iterates `check_fields` and sets
  `#AllowExistingAccountLink.checked = Boolean(provider["AllowExistingAccountLink"])`
 , it READS the current stored value on load.
- Save: `saveProvider` overlays
  `current_config["AllowExistingAccountLink"] = checkbox.checked` onto the
  existing provider object and PUTs the whole config, it WRITES the value on
  save. The server keeps the JSON member because it is a real `OidConfig`
  property.

**Default + security posture preserved.** This surfaces the flag only; its
default (`false`, fail closed) and its semantics are unchanged. An unchecked box
persists `false`, which equals the property default, so a provider with no
explicit value stays `false` after a save. The `fieldDescription` states the
security implication (a first SSO login can adopt a same-named existing account),
points to the migration runbook, and records that a name-matched administrator
account is never adopted and that each adoption is an audit event.

**Round-trip proof.** Set in UI -> `saveProvider` writes the member -> XML
persists it (`ConfigPreservationTests` already asserts `AllowExistingAccountLink`
survives an XML round-trip) -> `loadProvider` re-reads and re-checks the box.
Other server-managed/XML-only fields are untouched: `ServerManagedFields.Preserve`
only re-injects `CanonicalLinks` and `OidSecret`, and this flag is neither, so the
overlay and server-managed preservation are intact.

The **SAML side needs no change**: there is no SAML provider form in the admin UI
at all (SAML config is entirely XML-only), so there is nothing to add the
affordance to. Building a SAML provider form is separate, out-of-scope work.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No change to auth logic; the flag's
      `false` default and semantics are untouched. An unchecked box persists
      `false`, the fail-closed value.)
- [x] No secrets logged; secrets are redacted on config export. (No logging or
      secret handling touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review
      below; config-persistence surface.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new
      logging.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the existing generic save/load path; no new JS.)
- [x] The change adds no more code than the problem requires. (One checkbox +
      one roster entry; no `config.js` or `PluginConfiguration` change.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (Added `AllowExistingAccountLink` to the security-critical reverse-pin
      roster, as that test's comment instructs.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug, 0 warnings.)
- [x] `dotnet test` is green. (937 passed, incl. the extended
      `ProviderFormFieldIds_MatchOidConfigProperties`.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`configPage.html` formatted; the local CRLF working tree flags it as a
      false positive, so verified by `prettier --write` leaving the content
      unchanged beyond the addition. CI runs on LF.)

## Notes

Adversarial self-review, four refute-by-default lenses (config-persistence + a
security-relevant flag):

- **Availability / mass-lockout, PASS.** The checkbox defaults unchecked and
  the admin page renders one more toggle; `listArgumentsByType` simply gains one
  `check_fields` entry, no iteration/limit concern. A provider with no explicit
  value loads unchecked and, if saved, persists `false` - the existing default - 
  so no adoption is silently enabled and nobody is locked out.
- **Security-bypass (does the form ever silently flip the default or wipe a
  server-managed field on save?), PASS.** The only way the save changes the
  stored flag without an explicit admin click is the pre-existing "save without
  Load Provider first" behavior shared by every toggle, and here that direction
  is `true -> false`, the fail-closed (safer) direction, and only reachable by an
  admin re-saving the same provider name without loading it. Before this change a
  stale XML `true` could never be turned off in the UI; now it can, a net
  improvement. No server-managed field is touched: `ServerManagedFields` preserves
  only `CanonicalLinks` and `OidSecret`.
- **Correctness (read-on-load / write-on-save round-trip), PASS.** `id` matches
  the `OidConfig` property exactly and `class="sso-toggle"` puts it in
  `check_fields`; `loadProvider` sets `checked = Boolean(provider[id])` and
  `saveProvider` writes `current_config[id] = checked`. Default unchecked -> `false`
  = property default. The conformance test now asserts it persists.
- **Integration (the `saveProvider` overlay + `ServerManagedFields` intact) - 
  PASS.** The checkbox is inside `#sso-new-oidc-provider` (between the RequirePkce
  and Scheme Override blocks), so the form-scoped scan picks it up; the overlay
  (seed from existing provider, overlay form fields, PUT whole object) is
  unchanged, and the added field is orthogonal to server-managed re-injection.

Out of scope: the stale-name superset residual of the flag-on arm (#361); the
`RequireVerifiedEmailForAdoption` companion flag (#218), still XML-only; a SAML
provider admin form (does not exist yet).
