### PR TITLE
Bump NSubstitute to 6.0.0

### DIFF
--- a/SSO-Auth.Tests/SSO-Auth.Tests.csproj
+++ b/SSO-Auth.Tests/SSO-Auth.Tests.csproj
@@ -22,7 +22,7 @@
          avoiding the FsCheck.Xunit ↔ xunit-version coupling. -->
     <PackageReference Include="FsCheck" Version="3.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -23,9 +23,9 @@
       },
       "NSubstitute": {
         "type": "Direct",
-        "requested": "[5.3.0, )",
-        "resolved": "5.3.0",
-        "contentHash": "lJ47Cps5Qzr86N99lcwd+OUvQma7+fBgr8+Mn+aOC0WrlqMNkdivaYD9IvnZ5Mqo6Ky3LS7ZI+tUq1/s9ERd0Q==",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "0gvKMbiJ+/WrfbcfBfqRZZrvfLJcd3rqkqVMjjlY5dtmLRVzMY+o/K/rJUStofQ2haSr9Vd04YDfvZtVVGS3/A==",
         "dependencies": {
           "Castle.Core": "5.1.1"
         }


### PR DESCRIPTION
# What & why

Bumps NSubstitute (test-only mocking dependency, `SSO-Auth.Tests.csproj`)
from 5.3.0 to 6.0.0. Surfaced by #159's dependency-hygiene review; Dependabot
flags majors for a human look rather than auto-merging them.

Reviewed the 6.0.0 changelog against our usage. The documented breaking
changes are:

- Target-framework floor raised to net8.0 / netstandard2.0 (we target
  net9.0 with `RollForward: Major`, no effect).
- Removal of already-obsolete legacy API (grep across
  `SSO-Auth.Tests/**/*.cs` shows no usage of anything removed).
- The pre-C#7 `CompatArg` surface marked obsolete (unused here, we don't
  target old language versions).
- Nullable annotations enabled on the public API for net8.0+ TFMs (no
  nullable-warning fallout in our build, since our test project already
  runs with `Nullable enabled` + `CodeAnalysisTreatWarningsAsErrors`).

None of that touches how we use NSubstitute (`Substitute.For<T>()`,
`Received()`/`DidNotReceive()`, `Returns()`, `Arg.Any<T>()`, 11 test files).

Closes #483.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, test-only dependency, no login-path/crypto/config/release
surface touched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release,
      0 warnings both).
- [x] `dotnet test` is green, 940/940 passing on both Debug and Release.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, no
      such files touched (csproj + packages.lock.json only).

## Notes

`packages.lock.json` diff is limited to the single `NSubstitute` entry
(version + content hash); no incidental transitive-dependency drift.
