### PR TITLE
Surface RequireVerifiedEmailForAdoption in the admin provider form

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -488,6 +488,7 @@ public class ArchitectureConformanceTests
             "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",
             "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
             "DoNotLoadProfile", "RequirePkce", "AllowExistingAccountLink",
+            "RequireVerifiedEmailForAdoption",
         };
         var unsaved = securityCritical.Where(p => !matchedIds.Contains(p)).ToList();
         Assert.True(

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -771,6 +771,32 @@
                   </div>
                 </div>
 
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="RequireVerifiedEmailForAdoption"
+                      name="RequireVerifiedEmailForAdoption"
+                      type="checkbox"
+                      class="sso-toggle"
+                    />
+                    <span>Require Verified Email For Adoption (Sensitive)</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Sensitive: only meaningful with Allow Adopting Existing
+                    Accounts above. Additionally requires the login to carry a
+                    provider-verified email (email_verified == true) before
+                    adopting a same-named account, narrowing who can exploit the
+                    name-based match. Needs the email scope so the provider
+                    actually returns email_verified; without it, every adoption
+                    is refused. Off by default so an existing deployment relying
+                    on adoption is not silently locked out. An administrator
+                    account is never adopted regardless of this setting.
+                  </div>
+                </div>
+
                 <div class="inputContainer">
                   <label
                     class="inputLabel inputLabelUnfocused"


### PR DESCRIPTION
# What & why

Closes #486

`RequireVerifiedEmailForAdoption` (`OidConfig`, the #218 adoption-hardening
flag) additionally requires a first SSO login to carry a provider-verified
`email_verified == true` claim before adopting a same-named, pre-existing
Jellyfin account, narrowing who can exploit `AllowExistingAccountLink`'s
name-based match. It is a real, security-relevant toggle, but it was
XML-only: `configPage.html` / `config.js` never referenced it, so
`listArgumentsByType` never persisted it and the only way to set it was
hand-editing `SSO-Auth.xml` per provider. #484 (issue #432) surfaced its
sibling flag, `AllowExistingAccountLink`, the same way and flagged this one
as the follow-up (noted in that PR's Notes as out of scope), this PR closes
that gap.

We add an `sso-toggle` checkbox for it to `#sso-new-oidc-provider`, directly
below the `AllowExistingAccountLink` toggle it depends on, wired through the
existing generic save path.

**How the flag is rendered + saved (mirrors #484's `AllowExistingAccountLink`):**
the checkbox carries `class="sso-toggle"` and `id="RequireVerifiedEmailForAdoption"`,
spelled exactly like the `OidConfig` property. That is the entire #365 save
contract, no `config.js` change is needed because the save/load path is
generic over the marker classes:

- Load: `loadProvider` iterates `check_fields` and sets
  `#RequireVerifiedEmailForAdoption.checked = Boolean(provider["RequireVerifiedEmailForAdoption"])`
 , it READS the current stored value on load.
- Save: `saveProvider` overlays
  `current_config["RequireVerifiedEmailForAdoption"] = checkbox.checked` onto
  the existing provider object and PUTs the whole config, it WRITES the
  value on save. The server keeps the JSON member because it is a real
  `OidConfig` property.

**Default + security posture preserved.** This surfaces the flag only; its
default (`false`, fail closed) and its semantics are unchanged. An unchecked
box persists `false`, which equals the property default, so a provider with
no explicit value stays `false` after a save. The `fieldDescription` states
the security implication, notes it is only meaningful with
`AllowExistingAccountLink` on, that it needs the `email` scope for the
provider to actually return `email_verified`, and that an administrator
account is never adopted regardless of this setting.

**Round-trip proof.** Set in UI -> `saveProvider` writes the member -> XML
persists it -> `loadProvider` re-reads and re-checks the box. Other
server-managed/XML-only fields are untouched: `ServerManagedFields.Preserve`
only re-injects `CanonicalLinks` and `OidSecret`, and this flag is neither, so
the overlay and server-managed preservation are intact.

The **SAML side needs no change**: `RequireVerifiedEmailForAdoption` has no
`email_verified` equivalent on SAML (documented in `providers.md`) and there
is no SAML provider form in the admin UI at all (SAML config is entirely
XML-only), so there is nothing to add the affordance to there.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No change to auth/adoption logic;
      the flag's `false` default and semantics are untouched. An unchecked
      box persists `false`, the fail-closed value.)
- [x] No secrets logged; secrets are redacted on config export. (No logging
      or secret handling touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial
      self-review below; config-persistence surface.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new
      logging.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the existing generic save/load path; no new JS.)
- [x] The change adds no more code than the problem requires. (One checkbox +
      one roster entry; no `config.js` or `PluginConfiguration` change.)
- [x] The code is self-documenting (readable without comments; comments
      explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property
      this change establishes is locked in as a rule in
      `ArchitectureConformanceTests`. (Added
      `RequireVerifiedEmailForAdoption` to the security-critical reverse-pin
      roster, as that test's comment instructs.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug, 0
      warnings.)
- [x] `dotnet test` is green. (940 passed, incl. the extended
      `ProviderFormFieldIds_MatchOidConfigProperties`.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`configPage.html` formatted with `prettier --write`, confirmed clean
      with `prettier --check`. The local CRLF working tree flags the commit
      as a false positive; CI runs on LF.)

## Notes

Adversarial self-review, four refute-by-default lenses (config-persistence +
a security-relevant flag):

- **Availability / mass-lockout, PASS.** The checkbox defaults unchecked and
  the admin page renders one more toggle; `listArgumentsByType` simply gains
  one `check_fields` entry, no iteration/limit concern. A provider with no
  explicit value loads unchecked and, if saved, persists `false`, the
  existing default, so no adoption is silently gated on an unmet
  `email_verified` claim for a deployment that was not already relying on it.
- **Security-bypass (does the form ever silently flip the default or wipe a
  server-managed field on save?), PASS.** The only way the save changes the
  stored flag without an explicit admin click is the pre-existing "save
  without Load Provider first" behavior shared by every toggle, and here
  that direction is `true -> false`, which loosens a defense-in-depth check
  but does not reopen the primary gates (`AllowExistingAccountLink` off, and
  the always-on admin-account refusal, are untouched by this flag). Before
  this change a stale XML `true` could never be turned off in the UI; now it
  can. No server-managed field is touched: `ServerManagedFields` preserves
  only `CanonicalLinks` and `OidSecret`.
- **Correctness (read-on-load / write-on-save round-trip), PASS.** `id`
  matches the `OidConfig` property exactly and `class="sso-toggle"` puts it
  in `check_fields`; `loadProvider` sets `checked = Boolean(provider[id])`
  and `saveProvider` writes `current_config[id] = checked`. Default unchecked
  -> `false` = property default. The conformance test now asserts it
  persists.
- **Integration (the `saveProvider` overlay + `ServerManagedFields` intact,
  and the field sits with its dependency), PASS.** The checkbox is inside
  `#sso-new-oidc-provider`, directly below `AllowExistingAccountLink`, so the
  form-scoped scan picks it up and the UI groups the dependent flag next to
  the flag it depends on. The overlay (seed from existing provider, overlay
  form fields, PUT whole object) is unchanged, and the added field is
  orthogonal to server-managed re-injection.

Out of scope: `providers.md` line 108-109 ("Both `AllowExistingAccountLink`
and `RequireVerifiedEmailForAdoption` are edited in the provider's
`config.xml`, not on the config page") and the `RequireVerifiedEmailForAdoption`
XML-doc comment on `OidConfig` ("XML-only, like `AllowExistingAccountLink`")
are now stale, they were already stale for `AllowExistingAccountLink` after
#484 and this PR compounds it. Both are prose/doc-only, touch no runtime
behavior, and are out of the "touch only configPage.html + the conformance
test" scope given for this delivery; flagging as a follow-up doc fix rather
than widening this diff.
