### PR TITLE
Correct stale config.xml-only claim for two adoption flags

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -106,7 +106,7 @@ expiry). A few provider settings must therefore match, or login is refused (fail
     verified-email requirement (it continues a relationship established under the old scheme, not a new
     one), so on that one path the admin-takeover ceiling is still enforced but this verified-email
     defense-in-depth is not. Both `AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` are
-    edited in the provider's `config.xml`, not on the config page.
+    settable in the admin OpenID provider form, or by editing the provider's `config.xml` directly.
 - **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
   identity provider can reassign, so following such a link is name-based account matching, governed by


### PR DESCRIPTION
# What & why

`providers.md` still told readers that `AllowExistingAccountLink` and
`RequireVerifiedEmailForAdoption` are edited in the provider's `config.xml`,
not on the config page. That went stale once #484 and #488 added both flags
as toggles in the admin OpenID provider form
(`SSO-Auth/Config/configPage.html`, `id="AllowExistingAccountLink"` /
`id="RequireVerifiedEmailForAdoption"`). We verified both toggles are present
in the merged form before touching the doc. Corrected the one stale passage
to say each flag is settable in the admin OpenID provider form, or by editing
`config.xml` directly, the security/behavior wording around what each flag
does is unchanged. We grepped the rest of `providers.md` for both flag names
and for other "no admin-UI toggle" claims; the three remaining ones
(`SamlAudience`/`DoNotValidateAudience`, `ValidateRecipient`/
`ValidateInResponseTo`, `DisableHttps`/`DoNotLoadProfile`) are genuinely
different flags that are still config-XML-only, so we left them alone.

Closes #489

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, docs-only change, no login path/crypto/config-persistence/
release-pipeline code touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (N/A — docs-only, no structural change.)

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. (N/A, no `.cs` touched.)
- [ ] `dotnet test` is green. (N/A, no `.cs` touched.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change
      (`npx prettier --check providers.md` passes).

## Notes

Only `providers.md` was touched. `SSO-Auth/Config/PluginConfiguration.cs`
still carries stale XML-doc comments for these two flags, that's tracked
separately and intentionally out of scope here.
