### PR TITLE
Sign outgoing SAML AuthnRequests (HTTP-Redirect binding)

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -235,6 +235,93 @@ public class ConfigPreservationTests
         Assert.True(string.IsNullOrEmpty(ServerManagedFields.ResolveUpdatedSecret(incoming, live)));
     }
 
+    // --- SAML signing key: write-only secret + preserve-on-blank (#167) ---
+
+    [Fact]
+    public void SamlSigningKey_SerializedValueIsHidden_ButStaysDeserializableAndInXml()
+    {
+        var config = new SamlConfig { SamlClientId = "sp", SamlSigningKeyPfx = "pfx-secret-blob" };
+
+        // JSON responses must not leak the private-key blob; the property is emitted as null (write-only).
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("pfx-secret-blob", json, StringComparison.Ordinal);
+        Assert.Contains("\"SamlSigningKeyPfx\":null", json, StringComparison.Ordinal);
+
+        // Core serializes with a camelCase policy; the value must stay hidden there too.
+        var camel = System.Text.Json.JsonSerializer.Serialize(
+            config,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        Assert.DoesNotContain("pfx-secret-blob", camel, StringComparison.Ordinal);
+
+        // XML (on-disk config) must still persist it, so signing survives a restart.
+        var serializer = new XmlSerializer(typeof(SamlConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("SamlSigningKeyPfx", xml, StringComparison.Ordinal);
+        Assert.Contains("pfx-secret-blob", xml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlSigningKey_IsDeserializedFromJson_SoItCanBeSetAndRotated()
+    {
+        const string body = "{\"SamlClientId\":\"sp\",\"SamlSigningKeyPfx\":\"typed-pfx\"}";
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<SamlConfig>(body);
+        Assert.Equal("typed-pfx", parsed!.SamlSigningKeyPfx);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Preserve_BlankIncomingSigningKey_KeepsLiveKey(string? incomingKey)
+    {
+        // A config-page save arrives with the key blank (withheld from JSON) and must keep the stored one.
+        var live = new PluginConfiguration();
+        live.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = "live-pfx" };
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = incomingKey };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal("live-pfx", incoming.SamlConfigs["adfs"].SamlSigningKeyPfx);
+    }
+
+    [Fact]
+    public void Preserve_NonBlankIncomingSigningKey_IsKeptAsRotation()
+    {
+        var live = new PluginConfiguration();
+        live.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = "old-pfx" };
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = "rotated-pfx" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal("rotated-pfx", incoming.SamlConfigs["adfs"].SamlSigningKeyPfx);
+    }
+
+    [Fact]
+    public void Preserve_NewSamlProviderWithBlankSigningKey_StaysBlank()
+    {
+        var live = new PluginConfiguration();
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["fresh"] = new SamlConfig { SamlSigningKeyPfx = null };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.True(string.IsNullOrEmpty(incoming.SamlConfigs["fresh"].SamlSigningKeyPfx));
+    }
+
+    [Fact]
+    public void ValidateSamlSigningKey_GarbageKey_ThrowsNamingProvider()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig { SamlSigningKeyPfx = "QUJD" }; // valid base64, not a PKCS#12
+
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+    }
+
     // --- Base-URL override validation on save (#139) ---
 
     [Fact]
@@ -407,6 +494,8 @@ public class ConfigPreservationTests
             DoNotValidateAudience = true,
             ValidateRecipient = true,
             ValidateInResponseTo = true,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = "pfx-blob",
         };
 
         var back = RoundTripXml(original);
@@ -439,6 +528,8 @@ public class ConfigPreservationTests
         Assert.True(back.DoNotValidateAudience);
         Assert.True(back.ValidateRecipient);
         Assert.True(back.ValidateInResponseTo);
+        Assert.True(back.SignAuthnRequests);
+        Assert.Equal("pfx-blob", back.SamlSigningKeyPfx);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -66,6 +68,102 @@ public class SSOControllerChallengeTests
         // cookie is minted for it (#415).
         var setCookie = harness.Controller.HttpContext.Response.Headers.SetCookie.ToString();
         Assert.DoesNotContain(AuthorizeStateBinding.SamlCookieName, setCookie);
+    }
+
+    [Fact]
+    public void SamlChallenge_SigningDisabled_RedirectCarriesNoSignature()
+    {
+        // Default off (#167): existing deployments are unaffected — the redirect carries the unsigned
+        // AuthnRequest exactly as before, with no SigAlg/Signature parameters.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = EnabledProvider());
+
+        var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.Contains("SAMLRequest=", result.Url);
+        Assert.DoesNotContain("SigAlg=", result.Url);
+        Assert.DoesNotContain("Signature=", result.Url);
+    }
+
+    [Fact]
+    public void SamlChallenge_SigningEnabledWithValidKey_RedirectCarriesAVerifiableSignature()
+    {
+        var (pfx, publicKey) = SamlSigningKeyFactory.CreatePair();
+        using (publicKey)
+        {
+            var harness = new SsoControllerHarness(c =>
+            {
+                var config = EnabledProvider();
+                config.SignAuthnRequests = true;
+                config.SamlSigningKeyPfx = pfx;
+                c.SamlConfigs["adfs"] = config;
+            });
+
+            var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+            Assert.Contains("SigAlg=", result.Url);
+            Assert.Contains("Signature=", result.Url);
+            Assert.True(RedirectSignatureVerifies(result.Url, publicKey));
+        }
+    }
+
+    [Fact]
+    public void SamlChallenge_SigningEnabledButKeyMissing_FailsClosedWith500_AndNoRedirect()
+    {
+        // An operator who turned signing on but has no key must NOT get a silent unsigned request: fail
+        // closed with a 500, never a RedirectResult.
+        var harness = new SsoControllerHarness(c =>
+        {
+            var config = EnabledProvider();
+            config.SignAuthnRequests = true;
+            config.SamlSigningKeyPfx = null;
+            c.SamlConfigs["adfs"] = config;
+        });
+
+        var result = harness.Controller.SamlChallenge("adfs");
+
+        Assert.IsNotType<RedirectResult>(result);
+        Assert.Equal(500, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
+    public void SamlChallenge_SigningEnabledWithGarbageKey_FailsClosedWith500()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            var config = EnabledProvider();
+            config.SignAuthnRequests = true;
+            config.SamlSigningKeyPfx = "QUJD"; // valid base64, not a PKCS#12
+            c.SamlConfigs["adfs"] = config;
+        });
+
+        var result = harness.Controller.SamlChallenge("adfs");
+
+        Assert.IsNotType<RedirectResult>(result);
+        Assert.Equal(500, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    private static bool RedirectSignatureVerifies(string url, RSA publicKey)
+    {
+        var samlRequest = QueryValue(url, "SAMLRequest");
+        var sigAlg = QueryValue(url, "SigAlg");
+        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+
+        var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+        return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+    }
+
+    private static string QueryValue(string url, string name)
+    {
+        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -142,6 +142,26 @@ public class SSOControllerChallengeTests
         Assert.Equal(500, Assert.IsType<ContentResult>(result).StatusCode);
     }
 
+    [Fact]
+    public void SamlChallenge_SigningEnabledWithValidKeyButEmptyEndpoint_FailsClosedWith500()
+    {
+        // Signing on + a good key but a misconfigured (empty) endpoint must still fail closed with a clean
+        // handled 500, not a raw host 500 and not an unsigned request.
+        var harness = new SsoControllerHarness(c =>
+        {
+            var config = EnabledProvider();
+            config.SamlEndpoint = string.Empty;
+            config.SignAuthnRequests = true;
+            config.SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64();
+            c.SamlConfigs["adfs"] = config;
+        });
+
+        var result = harness.Controller.SamlChallenge("adfs");
+
+        Assert.IsNotType<RedirectResult>(result);
+        Assert.Equal(500, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
     private static bool RedirectSignatureVerifies(string url, RSA publicKey)
     {
         var samlRequest = QueryValue(url, "SAMLRequest");

--- a/SSO-Auth.Tests/SamlAuthnRequestTests.cs
+++ b/SSO-Auth.Tests/SamlAuthnRequestTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlAuthnRequest"/>'s two redirect builders (#167): the unsigned
+/// <see cref="SamlAuthnRequest.GetRedirectUrl"/> stays exactly as before (no signature parameters), and the
+/// opt-in <see cref="SamlAuthnRequest.GetSignedRedirectUrl"/> carries a verifiable HTTP-Redirect binding
+/// signature over the same DEFLATE/Base64 request.
+/// </summary>
+public class SamlAuthnRequestTests
+{
+    private const string Endpoint = "https://idp.example.com/sso";
+
+    [Fact]
+    public void GetRedirectUrl_Unsigned_CarriesNoSignatureParameters()
+    {
+        var request = new SamlAuthnRequest("jellyfin-sp", "https://jellyfin.example.com/sso/SAML/p/adfs");
+
+        var url = request.GetRedirectUrl(Endpoint, relayState: null);
+
+        Assert.Contains("SAMLRequest=", url);
+        Assert.DoesNotContain("SigAlg=", url);
+        Assert.DoesNotContain("Signature=", url);
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_CarriesAVerifiableSignatureOverTheRequest()
+    {
+        var request = new SamlAuthnRequest("jellyfin-sp", "https://jellyfin.example.com/sso/SAML/p/adfs");
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        using var privateKey = certificate.GetRSAPrivateKey()!;
+
+        var url = request.GetSignedRedirectUrl(Endpoint, relayState: null, privateKey);
+
+        Assert.Contains("SAMLRequest=", url);
+        Assert.Contains("SigAlg=", url);
+        Assert.Contains("Signature=", url);
+
+        using var publicKey = certificate.GetRSAPublicKey()!;
+        Assert.True(SignatureVerifies(url, publicKey));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_NullEndpoint_Throws()
+    {
+        var request = new SamlAuthnRequest("jellyfin-sp", "https://jellyfin.example.com/sso/SAML/p/adfs");
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        using var privateKey = certificate.GetRSAPrivateKey()!;
+
+        Assert.Throws<ArgumentNullException>(() => { request.GetSignedRedirectUrl(null!, null, privateKey); });
+    }
+
+    private static bool SignatureVerifies(string url, RSA publicKey)
+    {
+        var samlRequest = QueryValue(url, "SAMLRequest");
+        var sigAlg = QueryValue(url, "SigAlg");
+        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+
+        var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+        return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+    }
+
+    private static string QueryValue(string url, string name)
+    {
+        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
+    }
+}

--- a/SSO-Auth.Tests/SamlRedirectSignerTests.cs
+++ b/SSO-Auth.Tests/SamlRedirectSignerTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlRedirectSigner"/> (#167): the HTTP-Redirect binding detached signature over the
+/// URL-encoded query string. The signature is verified empirically against the signer's public key over the
+/// exact octets it must cover (SAMLRequest, then RelayState when present, then SigAlg), and the algorithm is
+/// pinned to the shared allowlist so no SHA-1 downgrade can slip in.
+/// </summary>
+public class SamlRedirectSignerTests
+{
+    private const string RsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    private const string RsaSha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    private const string Endpoint = "https://idp.example.com/sso";
+    private const string Message = "deflated+base64==/message";
+
+    [Fact]
+    public void BuildSignedRedirectUrl_EmitsSigAlgAndSignature()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, rsa);
+
+        Assert.StartsWith(Endpoint + "?SAMLRequest=", url);
+        Assert.Contains("&SigAlg=" + Uri.EscapeDataString(RsaSha256), url);
+        Assert.Contains("&Signature=", url);
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_SignatureVerifiesOverTheExactQueryOctets_NoRelayState()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, rsa);
+
+        AssertSignatureVerifies(url, rsa, expectedRelayState: null);
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_IncludesRelayStateInOrder_AndSignatureCoversIt()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: "linking", rsa);
+
+        // RelayState sits between SAMLRequest and SigAlg, the SAML Bindings 3.4.4.1 order.
+        var samlRequestIndex = url.IndexOf("SAMLRequest=", StringComparison.Ordinal);
+        var relayStateIndex = url.IndexOf("RelayState=", StringComparison.Ordinal);
+        var sigAlgIndex = url.IndexOf("SigAlg=", StringComparison.Ordinal);
+        Assert.True(samlRequestIndex < relayStateIndex && relayStateIndex < sigAlgIndex);
+        AssertSignatureVerifies(url, rsa, expectedRelayState: "linking");
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_EmptyRelayState_IsOmitted()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: string.Empty, rsa);
+
+        Assert.DoesNotContain("RelayState=", url);
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_EndpointWithQuery_UsesAmpersandSeparator()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint + "?realm=corp", "SAMLRequest", Message, relayState: null, rsa);
+
+        Assert.StartsWith(Endpoint + "?realm=corp&SAMLRequest=", url);
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_ForeignKey_DoesNotVerify()
+    {
+        using var signer = RSA.Create(2048);
+        using var attacker = RSA.Create(2048);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, signer);
+
+        // Sanity: a different key must not validate the signature — the check is real, not vacuous.
+        Assert.True(SignatureVerifies(url, signer, expectedRelayState: null));
+        Assert.False(SignatureVerifies(url, attacker, expectedRelayState: null));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BuildSignedRedirectUrl_BlankEndpoint_Throws(string? endpoint)
+    {
+        using var rsa = RSA.Create(2048);
+        Assert.Throws<ArgumentException>(() => { SamlRedirectSigner.BuildSignedRedirectUrl(endpoint!, "SAMLRequest", Message, null, rsa); });
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildSignedRedirectUrl_BlankMessage_Throws(string? message)
+    {
+        using var rsa = RSA.Create(2048);
+        Assert.Throws<ArgumentException>(() => { SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", message!, null, rsa); });
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_NullKey_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => { SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, null, null!); });
+    }
+
+    [Fact]
+    public void SignatureAlgorithm_IsOnTheInboundAllowlist_AndIsNotSha1()
+    {
+        using var rsa = RSA.Create(2048);
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, rsa);
+
+        var sigAlg = ExtractQueryValue(url, "SigAlg");
+
+        // The outgoing signer must reuse the inbound response-validator's allowlist, and never SHA-1.
+        Assert.True(SamlSignatureAlgorithms.IsSignatureMethodAllowed(sigAlg));
+        Assert.False(SamlSignatureAlgorithms.IsSignatureMethodAllowed(RsaSha1));
+        Assert.NotEqual(RsaSha1, sigAlg);
+    }
+
+    // Reconstructs the exact signed octet string (SAMLRequest[, RelayState], SigAlg — in order, URL-encoded)
+    // from the emitted URL and verifies the Signature parameter against the public key, exactly as an
+    // identity provider would.
+    private static void AssertSignatureVerifies(string url, RSA publicKey, string? expectedRelayState)
+        => Assert.True(SignatureVerifies(url, publicKey, expectedRelayState));
+
+    private static bool SignatureVerifies(string url, RSA publicKey, string? expectedRelayState)
+    {
+        var samlRequest = ExtractQueryValue(url, "SAMLRequest");
+        var sigAlg = ExtractQueryValue(url, "SigAlg");
+        var signature = Convert.FromBase64String(ExtractQueryValue(url, "Signature"));
+
+        var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest);
+        if (!string.IsNullOrEmpty(expectedRelayState))
+        {
+            signedQuery += "&RelayState=" + Uri.EscapeDataString(expectedRelayState);
+        }
+
+        signedQuery += "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+
+        return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+    }
+
+    private static string ExtractQueryValue(string url, string name)
+    {
+        var query = url[(url.IndexOf('?') + 1)..];
+        foreach (var pair in query.Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
+    }
+}

--- a/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
@@ -91,6 +91,26 @@ public class SamlSignatureAlgorithmsTests
         Assert.False(SamlSignatureAlgorithms.IsAllowed("urn:made:up", null!));
     }
 
+    // --- Signature-method allowlist shared with the outgoing-request signer (#167) ---
+
+    [Theory]
+    [InlineData(RsaSha256)]
+    [InlineData(RsaSha512)]
+    [InlineData(EcdsaSha384)]
+    public void IsSignatureMethodAllowed_StrongMethods_ReturnTrue(string method)
+    {
+        Assert.True(SamlSignatureAlgorithms.IsSignatureMethodAllowed(method));
+    }
+
+    [Theory]
+    [InlineData(RsaSha1)]
+    [InlineData("urn:made:up")]
+    [InlineData(null)]
+    public void IsSignatureMethodAllowed_WeakOrUnknownOrNull_ReturnFalse(string? method)
+    {
+        Assert.False(SamlSignatureAlgorithms.IsSignatureMethodAllowed(method!));
+    }
+
     // --- Canonicalization allowlist (#137) ---
 
     private const string ExcC14n = "http://www.w3.org/2001/10/xml-exc-c14n#";

--- a/SSO-Auth.Tests/SamlSigningKeyFactory.cs
+++ b/SSO-Auth.Tests/SamlSigningKeyFactory.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Builds throw-away service-provider signing keys for the outgoing-signing tests (#167): a Base64
+/// PKCS#12 (PFX) blob carrying an RSA keypair, the exact shape an operator supplies in
+/// <c>SamlSigningKeyPfx</c>, plus its public key for verifying the emitted signature.
+/// </summary>
+internal static class SamlSigningKeyFactory
+{
+    /// <summary>Creates a fresh self-signed RSA signing certificate.</summary>
+    internal static X509Certificate2 CreateCertificate()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Jellyfin SSO Test SP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+    }
+
+    /// <summary>Creates a signing key as the Base64 PKCS#12 blob the config stores.</summary>
+    internal static string CreatePfxBase64()
+    {
+        using var certificate = CreateCertificate();
+        return Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
+    }
+
+    /// <summary>Creates a signing key and returns both the stored blob and its public key for verification.</summary>
+    internal static (string PfxBase64, RSA PublicKey) CreatePair()
+    {
+        using var certificate = CreateCertificate();
+        var pfx = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
+
+        // A fresh public-only key so the caller can verify without holding the private cert.
+        var publicKey = RSA.Create();
+        publicKey.ImportParameters(certificate.GetRSAPublicKey()!.ExportParameters(false));
+        return (pfx, publicKey);
+    }
+}

--- a/SSO-Auth.Tests/SamlSigningKeyTests.cs
+++ b/SSO-Auth.Tests/SamlSigningKeyTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlSigningKey"/> (#167): fail-closed loading of the service-provider signing key
+/// and the admin-write-path validity check. Blank is "not configured" (valid); a set-but-unloadable or
+/// private-key-less blob is rejected, so an operator who turned signing on can never get a silent unsigned
+/// downgrade.
+/// </summary>
+public class SamlSigningKeyTests
+{
+    [Fact]
+    public void TryLoad_ValidPfx_ReturnsCertificateWithPrivateKey()
+    {
+        Assert.True(SamlSigningKey.TryLoad(SamlSigningKeyFactory.CreatePfxBase64(), out var certificate));
+        using (certificate)
+        {
+            using var privateKey = certificate.GetRSAPrivateKey();
+            Assert.NotNull(privateKey);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryLoad_Blank_ReturnsFalse(string? pfx)
+    {
+        Assert.False(SamlSigningKey.TryLoad(pfx!, out var certificate));
+        Assert.Null(certificate);
+    }
+
+    [Theory]
+    [InlineData("@@ not base64 @@")] // FormatException
+    [InlineData("QUJD")] // valid base64 ("ABC") but not a PKCS#12 -> CryptographicException
+    public void TryLoad_SetButUnloadable_ReturnsFalse(string pfx)
+    {
+        Assert.False(SamlSigningKey.TryLoad(pfx, out var certificate));
+        Assert.Null(certificate);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsInvalid_Blank_False(string? pfx)
+    {
+        Assert.False(SamlSigningKey.IsInvalid(pfx!));
+    }
+
+    [Fact]
+    public void IsInvalid_ValidPfx_False()
+    {
+        Assert.False(SamlSigningKey.IsInvalid(SamlSigningKeyFactory.CreatePfxBase64()));
+    }
+
+    [Theory]
+    [InlineData("@@ not base64 @@")]
+    [InlineData("QUJD")]
+    public void IsInvalid_Garbage_True(string pfx)
+    {
+        Assert.True(SamlSigningKey.IsInvalid(pfx));
+    }
+
+    [Fact]
+    public void IsInvalid_CertificateWithoutPrivateKey_True()
+    {
+        // A public-only PKCS#12 (no private key) cannot sign, so it must be rejected like garbage.
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        var publicOnlyPfx = Convert.ToBase64String(
+            X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert)).Export(X509ContentType.Pkcs12));
+
+        Assert.True(SamlSigningKey.IsInvalid(publicOnlyPfx));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
@@ -531,6 +532,18 @@ public class SSOController : ControllerBase
         }
     }
 
+    // Rejects a non-loadable service-provider signing key at the SAML/Add endpoint (#167), the same
+    // fail-closed door as the inbound certificate guard above: a garbage or private-key-less PKCS#12 set
+    // here would persist and then fail every signed challenge. Blank is valid (signing simply stays off,
+    // or the stored key is preserved on save).
+    internal static void RejectInvalidSamlSigningKey(string signingKeyPfx)
+    {
+        if (SamlSigningKey.IsInvalid(signingKeyPfx))
+        {
+            throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA private key, or left blank.");
+        }
+    }
+
     // Rejects a null provider body at the Add endpoints (#350). ASP.NET model binding hands a null
     // [FromBody] object for an empty or literal "null" JSON payload; storing it would put a null entry
     // in the config map that then NREs the config-page save (ServerManagedFields.Preserve). Reject at
@@ -891,7 +904,50 @@ public class SSOController : ControllerBase
                 AuthorizeStateBinding.CookieOptions(SamlRequestLifetime));
         }
 
-        return Redirect(request.GetRedirectUrl(config.SamlEndpoint.Trim(), relayState));
+        string redirectUrl;
+        try
+        {
+            redirectUrl = BuildChallengeRedirectUrl(config, request, relayState);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Signing is enabled for this provider but its signing key is missing or unusable. Fail closed
+            // with a clean 500 (never a silent unsigned request), and log the reason for the operator — the
+            // key material itself is not part of the message, so nothing sensitive is logged.
+            _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+            return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");
+        }
+
+        return Redirect(redirectUrl);
+    }
+
+    // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider
+    // opts in (#167). Fail-closed: signing enabled but the signing key missing/unloadable throws, so the
+    // caller returns an error rather than silently sending an unsigned request — an operator who turned
+    // signing on never gets a silent downgrade. Default off is byte-for-byte the previous unsigned URL.
+    private static string BuildChallengeRedirectUrl(SamlConfig config, SamlAuthnRequest request, string relayState)
+    {
+        var endpoint = config.SamlEndpoint.Trim();
+        if (!config.SignAuthnRequests)
+        {
+            return request.GetRedirectUrl(endpoint, relayState);
+        }
+
+        if (!SamlSigningKey.TryLoad(config.SamlSigningKeyPfx, out var signingCertificate))
+        {
+            throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key could not be loaded.");
+        }
+
+        using (signingCertificate)
+        using (var signingKey = signingCertificate.GetRSAPrivateKey())
+        {
+            if (signingKey is null)
+            {
+                throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key has no RSA private key.");
+            }
+
+            return request.GetSignedRedirectUrl(endpoint, relayState, signingKey);
+        }
     }
 
     /// <summary>
@@ -907,6 +963,7 @@ public class SSOController : ControllerBase
         RejectNullProviderBody(newConfig);
         RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
         RejectInvalidSamlCertificate(newConfig.SamlCertificate);
+        RejectInvalidSamlSigningKey(newConfig.SamlSigningKeyPfx);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -909,11 +909,14 @@ public class SSOController : ControllerBase
         {
             redirectUrl = BuildChallengeRedirectUrl(config, request, relayState);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or CryptographicException)
         {
-            // Signing is enabled for this provider but its signing key is missing or unusable. Fail closed
-            // with a clean 500 (never a silent unsigned request), and log the reason for the operator — the
-            // key material itself is not part of the message, so nothing sensitive is logged.
+            // Signing is enabled for this provider but the request could not be signed: the key is
+            // missing/unusable (InvalidOperationException), the endpoint is empty (ArgumentException from
+            // the signer), or the platform key store refused the signing operation (CryptographicException).
+            // ANY of these fails closed with a clean 500 — never a silent unsigned request — rather than
+            // escaping as a raw host 500. The key material is not part of the message, so nothing sensitive
+            // is logged.
             _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
             return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");
         }

--- a/SSO-Auth/Api/SamlRedirectSigner.cs
+++ b/SSO-Auth/Api/SamlRedirectSigner.cs
@@ -1,0 +1,69 @@
+#nullable enable
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Signs an outgoing SAML message for the HTTP-Redirect binding (SAML Bindings 3.4.4.1, #167). The plugin
+/// sends its AuthnRequest as a DEFLATE-compressed, Base64-encoded query parameter, so the signature is NOT
+/// an enveloped XML <c>ds:Signature</c> (identity providers ignore one on a redirect-binding message) but a
+/// detached signature over the URL-encoded query string, computed in the mandated parameter order
+/// (SAMLRequest, then RelayState when present, then SigAlg) and appended as the Signature parameter. The
+/// algorithm is RSA-SHA256, verified against the shared allowlist so this path can never sign with a weaker
+/// algorithm than the inbound path demands (no SHA-1).
+/// </summary>
+internal static class SamlRedirectSigner
+{
+    private const string RsaSha256SignatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+
+    /// <summary>
+    /// Builds the signed redirect URL for a DEFLATE/Base64-encoded SAML message.
+    /// </summary>
+    /// <param name="endpoint">The identity provider's endpoint URL.</param>
+    /// <param name="parameterName">"SAMLRequest" or "SAMLResponse".</param>
+    /// <param name="encodedMessage">The DEFLATE-compressed, Base64-encoded message.</param>
+    /// <param name="relayState">The relay state, omitted when null or empty.</param>
+    /// <param name="signingKey">The service-provider RSA private key.</param>
+    /// <returns>The full redirect URL including SigAlg and Signature.</returns>
+    /// <exception cref="ArgumentException">Thrown when the endpoint or message is null or empty.</exception>
+    internal static string BuildSignedRedirectUrl(string endpoint, string parameterName, string encodedMessage, string? relayState, RSA signingKey)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            throw new ArgumentException("Endpoint must not be empty.", nameof(endpoint));
+        }
+
+        if (string.IsNullOrEmpty(encodedMessage))
+        {
+            throw new ArgumentException("Message must not be empty.", nameof(encodedMessage));
+        }
+
+        ArgumentNullException.ThrowIfNull(signingKey);
+
+        // Defense in depth: the algorithm this signer emits must be one the inbound path would also accept,
+        // so a future edit cannot quietly introduce SHA-1 here while the response validator still rejects it.
+        if (!SamlSignatureAlgorithms.IsSignatureMethodAllowed(RsaSha256SignatureAlgorithm))
+        {
+            throw new InvalidOperationException("The outgoing SAML signing algorithm is not on the signature allowlist.");
+        }
+
+        // The signature covers these parameters URL-encoded, in exactly this order, as they will appear in
+        // the query string. Uri.EscapeDataString is used both to compute the signed octets and to emit the
+        // URL, so the identity provider verifies over the exact bytes transmitted.
+        var signedQuery = parameterName + "=" + Uri.EscapeDataString(encodedMessage);
+        if (!string.IsNullOrEmpty(relayState))
+        {
+            signedQuery += "&RelayState=" + Uri.EscapeDataString(relayState);
+        }
+
+        signedQuery += "&SigAlg=" + Uri.EscapeDataString(RsaSha256SignatureAlgorithm);
+
+        var signature = signingKey.SignData(Encoding.UTF8.GetBytes(signedQuery), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var query = signedQuery + "&Signature=" + Uri.EscapeDataString(Convert.ToBase64String(signature));
+
+        var separator = endpoint.Contains('?', StringComparison.Ordinal) ? "&" : "?";
+        return endpoint + separator + query;
+    }
+}

--- a/SSO-Auth/Api/SamlSigningKey.cs
+++ b/SSO-Auth/Api/SamlSigningKey.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Loads this service provider's SAML signing key (#167). The key is supplied by the operator as a
+/// Base64-encoded, unencrypted PKCS#12 (PFX) blob carrying the certificate and its RSA private key — the
+/// same keypair whose public certificate the identity provider is configured to trust for "signed
+/// AuthnRequest" setups. Loading is fail-closed: a blank value is "no signing key configured" (valid,
+/// signing simply stays off), and a set-but-unloadable value is rejected rather than silently ignored, so
+/// an operator who turned signing on can never get a silent unsigned downgrade.
+/// </summary>
+internal static class SamlSigningKey
+{
+    /// <summary>
+    /// Attempts to load the signing certificate (with its private key) from the stored Base64 PKCS#12 blob.
+    /// </summary>
+    /// <param name="pfxBase64">The stored Base64 PKCS#12 blob, or blank when signing is not configured.</param>
+    /// <param name="certificate">The loaded certificate with its private key, or null on failure.</param>
+    /// <returns><see langword="true"/> only when a non-blank blob loaded into a usable certificate.</returns>
+    internal static bool TryLoad(string pfxBase64, out X509Certificate2 certificate)
+    {
+        certificate = null;
+        if (string.IsNullOrWhiteSpace(pfxBase64))
+        {
+            return false;
+        }
+
+        try
+        {
+            // EphemeralKeySet keeps the imported private key in memory rather than persisting it to the
+            // per-user CNG/CAPI on-disk key store (the Windows default), avoiding SP private-key material
+            // at rest and orphaned key containers across repeated loads. It is unsupported on macOS
+            // (throws PlatformNotSupportedException), which does not use that on-disk store anyway, so fall
+            // back to the default key set there.
+            var flags = OperatingSystem.IsMacOS() ? X509KeyStorageFlags.DefaultKeySet : X509KeyStorageFlags.EphemeralKeySet;
+            certificate = X509CertificateLoader.LoadPkcs12(Convert.FromBase64String(pfxBase64), null, flags);
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or CryptographicException or ArgumentException)
+        {
+            certificate?.Dispose();
+            certificate = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether a signing-key value is set but is not a loadable PKCS#12 blob, for rejecting it at the admin
+    /// write paths (mirrors <see cref="SamlCertificate.IsInvalid"/>). Blank is valid (signing not
+    /// configured); a set-but-unloadable value is invalid.
+    /// </summary>
+    /// <param name="pfxBase64">The Base64 PKCS#12 blob.</param>
+    /// <returns><see langword="true"/> if the value is set but not a loadable signing key.</returns>
+    internal static bool IsInvalid(string pfxBase64)
+    {
+        if (string.IsNullOrWhiteSpace(pfxBase64))
+        {
+            return false;
+        }
+
+        if (!TryLoad(pfxBase64, out var certificate))
+        {
+            return true;
+        }
+
+        using (certificate)
+        {
+            // A PKCS#12 with no private key cannot sign, so it is as unusable as a garbage blob: reject it
+            // here rather than let it pass validation and then fail closed at every challenge.
+            using var privateKey = certificate.GetRSAPrivateKey();
+            return privateKey is null;
+        }
+    }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -250,6 +250,28 @@ public class SamlConfig : ProviderConfigBase
     /// enabling it rejects IdP-initiated (unsolicited) SSO, which carries no InResponseTo. Refs #156.
     /// </summary>
     public bool ValidateInResponseTo { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the outgoing AuthnRequest is signed with this service
+    /// provider's signing key, for identity providers that require signed requests (#167). Opt-in
+    /// (default off): with it off the request is sent exactly as before (unsigned), so existing
+    /// deployments are unaffected. When on, a valid <see cref="SamlSigningKeyPfx"/> must be configured —
+    /// the challenge fails closed (rather than silently sending an unsigned request) if the key is
+    /// missing or unloadable.
+    /// </summary>
+    public bool SignAuthnRequests { get; set; }
+
+    /// <summary>
+    /// Gets or sets the service-provider signing key used when <see cref="SignAuthnRequests"/> is on,
+    /// as a Base64-encoded, unencrypted PKCS#12 (PFX) blob carrying the certificate and its RSA private
+    /// key (#167). Supply the keypair whose public certificate the identity provider is configured to
+    /// trust. Treated as a secret: write-only across the JSON boundary (deserialized from a save so it
+    /// can be set and rotated, but serialized back as null so the private key never reaches the admin
+    /// browser or a config export), and preserved on a save that leaves it blank. It is still persisted
+    /// to the config XML.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
+    public string SamlSigningKeyPfx { get; set; }
 }
 
 /// <summary>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -45,6 +45,7 @@ internal static class ProviderConfigValidator
                 ValidateProviderName("SAML", kvp.Key, isNew: live?.SamlConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
                 ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
+                ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
             }
         }
     }
@@ -89,6 +90,19 @@ internal static class ProviderConfigValidator
         {
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
+        }
+    }
+
+    // A garbage service-provider signing key (#167) would be persisted and then fail every signed
+    // challenge. On the config-page save the key is withheld from JSON so it arrives blank (valid) and the
+    // stored one is re-injected afterwards; this rejects the case where a non-blank, unloadable key is
+    // posted. Same inline line-ending strip as above.
+    internal static void ValidateSamlSigningKey(string provider, string signingKeyPfx)
+    {
+        if (SamlSigningKey.IsInvalid(signingKeyPfx))
+        {
+            throw new ArgumentException(
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA private key.");
         }
     }
 }

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -18,10 +18,10 @@ internal static class ServerManagedFields
     /// so a save built from a stale client snapshot cannot clear them. Only providers present in
     /// <paramref name="incoming"/> are touched (a deleted provider stays deleted; a newly added one
     /// keeps its own empty map). Two kinds of field are preserved: the per-provider canonical links
-    /// (always server-owned, #157), and the OpenID client secret (#189) — the latter only when the
-    /// incoming value is blank, since the secret is withheld from JSON responses so a save that did
-    /// not set a new one arrives empty and must keep the stored value (a non-blank incoming value is
-    /// an intentional rotation and is left as-is).
+    /// (always server-owned, #157), and the write-only secrets (the OpenID client secret #189, the SAML
+    /// signing key #167) — the latter only when the incoming value is blank, since a secret is withheld
+    /// from JSON responses so a save that did not set a new one arrives empty and must keep the stored
+    /// value (a non-blank incoming value is an intentional rotation and is left as-is).
     /// </summary>
     /// <param name="incoming">The configuration about to be persisted.</param>
     /// <param name="live">The current live configuration to read server-managed values from.</param>
@@ -66,7 +66,9 @@ internal static class ServerManagedFields
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
 
-    // Links only: a SAML provider has no write-only secret (#157).
+    // Links + the write-only signing key: a SAML provider carries the server-managed link map (#157) and,
+    // since #167, an optional service-provider signing key that is withheld from JSON like the OpenID
+    // secret, so a save that did not rotate it arrives blank and must keep the stored value.
     internal static void Preserve(SamlConfig incoming, SamlConfig live)
     {
         if (incoming is null || live is null)
@@ -75,7 +77,22 @@ internal static class ServerManagedFields
         }
 
         incoming.CanonicalLinks = live.CanonicalLinks;
+        incoming.SamlSigningKeyPfx = ResolveUpdatedSigningKey(incoming, live);
     }
+
+    /// <summary>
+    /// Decides which service-provider signing key an updated SAML provider should keep (#167). A non-blank
+    /// incoming key is an explicit rotation and wins; a blank one keeps the stored key, so a config-page
+    /// save (which never carries the withheld key) does not wipe it. Unlike the OpenID client secret this
+    /// has no provider-identity guard: the key is never transmitted anywhere — it is used only to sign a
+    /// public AuthnRequest locally — so repointing the endpoint cannot exfiltrate it, and carrying it over
+    /// keeps a working signed-login provider from breaking on an unrelated edit.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted.</param>
+    /// <param name="live">The current live provider config.</param>
+    /// <returns>The signing key to persist for the updated provider.</returns>
+    internal static string ResolveUpdatedSigningKey(SamlConfig incoming, SamlConfig live)
+        => string.IsNullOrWhiteSpace(incoming.SamlSigningKeyPfx) ? live.SamlSigningKeyPfx : incoming.SamlSigningKeyPfx;
 
     /// <summary>
     /// Decides which OpenID client secret an updated provider should keep (#189), the single rule

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -584,4 +584,22 @@ internal sealed class SamlAuthnRequest
 
         return url;
     }
+
+    /// <summary>
+    /// Gets the redirect URL with the AuthnRequest SIGNED for the HTTP-Redirect binding (#167): the same
+    /// DEFLATE/Base64 request, carrying a detached query-string signature (SigAlg + Signature) over the
+    /// URL-encoded parameters, for identity providers that require signed AuthnRequests. Distinct from the
+    /// unsigned <see cref="GetRedirectUrl"/> — which is byte-for-byte unchanged for deployments that do not
+    /// sign — because the signed path must encode the query consistently with the octets it signs.
+    /// </summary>
+    /// <param name="samlEndpoint">The SAML endpoint.</param>
+    /// <param name="relayState">The relay state, omitted when null or empty.</param>
+    /// <param name="signingKey">The service-provider RSA private key.</param>
+    /// <returns>The signed redirect url.</returns>
+    public string GetSignedRedirectUrl(string samlEndpoint, string relayState, RSA signingKey)
+    {
+        ArgumentNullException.ThrowIfNull(samlEndpoint);
+
+        return Api.SamlRedirectSigner.BuildSignedRedirectUrl(samlEndpoint, "SAMLRequest", GetRequest(), relayState, signingKey);
+    }
 }

--- a/SSO-Auth/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/SamlSignatureAlgorithms.cs
@@ -68,13 +68,23 @@ internal static class SamlSignatureAlgorithms
         => AllOnList(AllowedTransforms, transforms);
 
     /// <summary>
+    /// Whether a signature-method URI is on the allowlist (RSA/ECDSA SHA-256 or stronger; no SHA-1).
+    /// Shared by the inbound-response check below and the outgoing-request signer, so the SP never signs
+    /// with an algorithm weaker than the one it demands of the identity provider.
+    /// </summary>
+    /// <param name="signatureMethod">The signature-method URI.</param>
+    /// <returns>True only if the method is on the allowlist.</returns>
+    internal static bool IsSignatureMethodAllowed(string signatureMethod)
+        => AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty);
+
+    /// <summary>
     /// Whether the signature method and every reference digest method are on the allowlist.
     /// </summary>
     /// <param name="signatureMethod">The SignedInfo signature-method URI.</param>
     /// <param name="digestMethods">The digest-method URI of every reference.</param>
     /// <returns>True only if the signature method is allowed and there is at least one reference, all of whose digests are allowed.</returns>
     internal static bool IsAllowed(string signatureMethod, IEnumerable<string> digestMethods)
-        => AllowedSignatureMethods.Contains(signatureMethod ?? string.Empty)
+        => IsSignatureMethodAllowed(signatureMethod)
            && AllOnList(AllowedDigestMethods, digestMethods);
 
     // The fail-closed shape both the transform chain and the reference digests require: a non-null

--- a/providers.md
+++ b/providers.md
@@ -262,6 +262,43 @@ config so a save does not reset them.
   binding cannot cover — so together they close the vector for an identity provider that can issue
   unsolicited responses.
 
+## SAML request signing (optional)
+
+Some identity providers require the service provider to **sign its outgoing `AuthnRequest`** ("signed
+authentication requests" / "client signature required"). This is **off by default** — with it off the
+request is sent exactly as before (unsigned), so existing deployments are unaffected. Enable it only
+for a provider that demands it.
+
+The plugin sends its `AuthnRequest` over the SAML **HTTP-Redirect binding**, so the signature is the
+detached query-string signature the binding mandates (SAML Bindings §3.4.4.1): the `SigAlg` and
+`Signature` parameters are appended to the redirect, computed over the URL-encoded
+`SAMLRequest`/`RelayState`/`SigAlg` string with **RSA-SHA256** (the same no-SHA-1 allowlist the inbound
+response path enforces). An enveloped XML signature is _not_ used, because identity providers ignore one
+on a redirect-binding message.
+
+Two per-provider SAML options control it (set through the `SAML/Add` API, like the other SAML options —
+there is no admin-UI toggle yet; include them whenever you re-post a provider's config so a save does
+not reset them):
+
+- **`SignAuthnRequests`** — turn request signing on for this provider.
+- **`SamlSigningKeyPfx`** — the service-provider signing key, as a **Base64-encoded, unencrypted
+  PKCS#12 (PFX)** blob containing the certificate and its RSA private key. Supply the keypair whose
+  **public certificate you have registered with the identity provider** as the SP's request-signing
+  certificate. For example, from an existing key and cert:
+  `openssl pkcs12 -export -inkey sp-key.pem -in sp-cert.pem -passout pass: -out sp.pfx`, then Base64 the
+  file (`base64 -w0 sp.pfx`). Treated as a secret: it is withheld from every config response (a `SAML`
+  provider fetch returns it as `null`) so the private key never reaches the admin browser, and a save
+  that leaves it blank keeps the stored key. It is persisted only to the server's on-disk config.
+
+**Fail-closed:** if `SignAuthnRequests` is on but the signing key is missing or unloadable, the login
+challenge is refused with an error — it never silently falls back to sending an unsigned request, so an
+operator who turned signing on cannot get a silent downgrade. A garbage key is also rejected when the
+provider is saved.
+
+> Signing with more than one certificate (primary + rollover) for zero-downtime key rotation, and
+> accepting multiple inbound IdP verification certificates during a rotation window, are tracked
+> separately and not yet implemented.
+
 ## SAML login browser binding
 
 Every SP-initiated SAML login (one started from Jellyfin, i.e. `SAML/start/...`) is bound to the


### PR DESCRIPTION
# What & why

Some identity providers require the service provider to sign its outgoing SAML `AuthnRequest` ("signed authentication requests" / "client signature required"). We add opt-in signing of the outgoing request so those providers can be used, without affecting any existing deployment.

**Design, where the signature goes.** The plugin sends its `AuthnRequest` over the **HTTP-Redirect binding** (`SamlChallenge` DEFLATE-compresses the request into the `SAMLRequest` query parameter and issues a redirect). For that binding, SAML 2.0 mandates a **detached query-string signature** (Bindings §3.4.4.1), not an enveloped `<ds:Signature>`, identity providers ignore an embedded XML signature on a redirect-binding message. So the new `SamlRedirectSigner` computes the signature over the URL-encoded `SAMLRequest`[`&RelayState`]`&SigAlg` string, in that mandated order, and appends `&Signature=`. The same `Uri.EscapeDataString` encoding is used both to compute the signed octets and to emit the URL, so the IdP verifies over exactly what is transmitted.

**Algorithm, allowlist reuse, no SHA-1.** Signing is **RSA-SHA256**. The signer pins its `SigAlg` and guards it through `SamlSignatureAlgorithms.IsSignatureMethodAllowed`, the same allowlist the inbound response validator enforces, so the outgoing path can never sign weaker than the SP demands of the IdP. A test asserts the emitted `SigAlg` is on the allowlist and is not SHA-1 (the structural "reuse the allowlist" property is locked there rather than in `ArchitectureConformanceTests`, whose rules are reflection/source-scan structural checks that a value assertion would not fit).

**Config, default off, secret handling.** Two per-provider fields on `SamlConfig`:
- `SignAuthnRequests` (bool, **default false**), off means the request is sent exactly as before (unsigned), byte-for-byte; existing deployments are unaffected.
- `SamlSigningKeyPfx`, the SP signing key as a Base64, unencrypted PKCS#12 (PFX) blob (cert + RSA private key); the operator supplies the keypair whose public certificate the IdP is configured to trust. It is a **write-only secret**: withheld from every JSON response via `WriteOnlySecretConverter` (never reaches the admin browser / a config export), preserved on a blank save via `ServerManagedFields`, validated on `SAML/Add` and on the config-page save, and persisted only to the on-disk XML. Same pattern as the OpenID `OidSecret`. It is never logged.

**Fail-closed.** With signing enabled, a missing / unloadable / private-key-less key, or an empty endpoint, or a platform key-store refusal, refuses the challenge with a clean handled 500. It never silently falls back to sending an unsigned request, so an operator who turned signing on cannot get a silent downgrade. A garbage key is also rejected at save time.

**Scope split.** This PR is single-certificate signing only. Multi-certificate rotation, SP signing-key rollover and accepting multiple inbound IdP verification certificates during an overlap window (the second half of #167's acceptance criteria), is split to #491 to keep this focused. `providers.md` documents the new options and points the rotation procedure at the follow-up.

ECDSA SP keys are not supported (the signer is RSA-SHA256); a non-RSA PFX is rejected as invalid. This is a documented limitation, not a silent failure.

Closes #167

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: signing enabled + missing/invalid key (or empty endpoint / key-store refusal) refuses the challenge with a 500; it never emits an unsigned request. Default off is unchanged behavior.
- [x] No secrets logged; the signing key is redacted on config export (write-only across JSON) and never written to a log, the 500 log message carries only the provider name (inline line-ending-stripped) and a key-free reason.
- [x] A security review was performed: the four-lens adversarial gate (availability / bypass / correctness / integration) ran on the diff, all PASS; see Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call (`provider?.ReplaceLineEndings(string.Empty)`).

## Quality checklist

- [x] No duplicated logic; the signer and key loader are small single-purpose helpers; the allowlist check is shared, not re-implemented.
- [x] The change adds no more code than the problem requires (redirect-binding signing reuses the existing transport; no new POST binding or metadata surface).
- [x] The code is self-documenting; comments explain the why (binding choice, fail-closed, secret handling).
- [x] Architecture-conformance tests pass; no new reflection/source-scan structural property is introduced (the allowlist-reuse property is locked by `SamlRedirectSignerTests`).

## Verification

- [x] `dotnet build --warnaserror` green, Debug and Release (incl. the solution).
- [x] `dotnet test` green, 988 tests, 0 failed.
- [x] Prettier clean for the `providers.md` change.
- [x] `scripts/check-jellyfin-compat.sh` green.

## Notes

**Adversarial review gate (four refute-by-default lenses, on the committed diff):**

- **Availability, PASS.** Default-off path is byte-identical (`GetRedirectUrl` untouched); only opt-in providers are affected; the write-only key cannot be wiped by a blank save (preserve-on-blank); fail-closed 500 is per-provider and bounded (request-cache is capped/#327 and self-expiring). Flagged the narrowed catch → hardened (below).
- **Security-bypass, PASS.** No SHA-1 downgrade (pinned + allowlist-guarded); no silent-unsigned path when signing is on; the private key is write-only, never logged, never transmitted (used only to sign locally, so preserve-on-blank cannot exfiltrate it, the OIDC identity-guard is not needed); the signature covers the correct octets in the mandated order.
- **Correctness, PASS.** Signed octets are the *same string* that is emitted (structurally cannot diverge); RelayState included iff non-empty and correctly ordered; separator handling correct; the round-trip tests verify via `RSA.VerifyData` with a foreign-key negative (non-vacuous); cert/key disposed strictly after signing.
- **Integration, PASS.** BCL crypto APIs exist on net9.0 and the 10.11 ABI floor (ran the abi-floor build); write-only secret round-trips XML + System.Text.Json + camelCase; `EphemeralKeySet` yields a SignData-usable key on Windows (proven by the controller test); no existing serialization/arch behavior broken; the single-file `#nullable enable` compiles clean under warnaserror + analyzers.

**Review-driven hardening (2nd commit).** Two lenses noted the challenge's `catch` was narrowed to `InvalidOperationException`, so an empty-endpoint (`ArgumentException`) or a `CryptographicException` from `SignData` would escape as a raw host 500 (still fail-closed, just not clean). Broadened the catch to cover all three and added an empty-endpoint fail-closed test.

**E2E items (outside CI's reach, for the checklist):** the macOS `DefaultKeySet` fallback branch is Mac-only; real-IdP acceptance of the detached redirect-binding signature (ADFS / Keycloak / Entra query canonicalization) is live-interop.

**Out of scope / follow-up:** multi-certificate rotation → #491.
