### PR TITLE
Make the null-config-maps preservation contract explicit (S2699)

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -68,6 +68,9 @@ public class ConfigPreservationTests
         var exception = Record.Exception(() => ServerManagedFields.Preserve(incoming, live));
 
         Assert.Null(exception);
+        // Nothing to preserve from, so the null maps are left exactly as they arrived.
+        Assert.Null(incoming.OidConfigs);
+        Assert.Null(incoming.SamlConfigs);
     }
 
     [Fact]


### PR DESCRIPTION
# What & why

Trivial code-quality items from the #196 backlog sweep, made Sonar-independent
(the SonarCloud framing on #196 is historical, SonarCloud was removed in #463).

This PR delivers the one reproducible trivial item:

- **S2699, missing test assertion** (`SSO-Auth.Tests/ConfigPreservationTests.cs`,
  `Preserve_NullConfigMaps_DoNotThrow`). The test asserted only that `Preserve`
  did not throw (via `Record.Exception`), leaving the "nothing to preserve from"
  contract implicit. It now also asserts the null `OidConfigs`/`SamlConfigs` maps
  are left untouched, so the intent is machine-visible rather than resting on the
  absence of an exception. What the test exercises is unchanged.

The other trivial item, **S125, commented-out code in
`SSO-Auth/Api/SamlRequestCache.cs`**, is **already resolved and not reproducible**:
the file was fully rewritten after #156 (the LINQ `Prune` replaced by the throttled
`PruneExpired`, `IntervalGate` adopted, per-client budget added), and no
commented-out code remains at the current `main`, at #196's creation, or at the
#156 origin. Every `//` in the file is intention-revealing prose. Nothing to change
there, so the file is left untouched. Dispositioned in the #196 re-scope comment.

`Refs #196` (not `Closes`, three items remain on #196: the OidcIdTokenValidator
split, the value-type `[FromBody]` under-posting decision, and now the S125
already-resolved close-out).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

N/A, test-only change; no production, login-path, crypto, config-persistence, or
release-pipeline code is touched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (988 passed, 0 failed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this PR).

## Notes

- Out of scope, dispositioned on #196: **S3776 SSOController** complexity (covered
  by #160), **S3776 `OidcIdTokenValidator.cs`** (deferred until after #473, which is
  currently touching the OIDC validation path), **S6964 x2 `PluginConfiguration.cs`**
  value-type `[FromBody]` under-posting (needs a decision, annotate the
  model vs document the whole-object-replace contract).
- The S125 item is dispositioned as already-resolved by the post-#156 rewrite; #196
  stays open tracking the two remaining decisions.
