### PR TITLE
Introduce VerifiedIdentity as the session-mint keystone

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -224,6 +224,87 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void VerifiedIdentity_IsConstructedOnlyByProtocolValidators()
+    {
+        // Locked in by #473: VerifiedIdentity is the keystone the session-minting path is keyed on, and it
+        // is unforgeable — its constructor is PRIVATE, so the only way to obtain one is a named factory that
+        // stands for "this protocol's validation has completed". Two properties are pinned:
+        //
+        // 1. Reflection: NO declared instance constructor is reachable from outside the type — none is
+        //    public, internal, or protected-internal. A sealed record's own compiler-generated copy
+        //    constructor is emitted PRIVATE (protected only for unsealed records), so it too is excluded by
+        //    this filter; the accessibility test is written to also exclude a plain `protected` ctor, which
+        //    is unreachable on a sealed type anyway (no derived type could invoke it). The C# compiler
+        //    guarantees such a constructor cannot be invoked outside the declaring type, so this alone
+        //    proves `new VerifiedIdentity(...)` can appear only inside VerifiedIdentity.cs (the two
+        //    factories) — no third construction path can compile. (An empty `with { }` on an existing
+        //    instance clones a valid identity verbatim; every property is get-only, so it can neither
+        //    mutate nor forge one.) A future `public`/`internal` ctor added to the type would reopen that
+        //    hole and fail HERE.
+        // 2. Source scan: each factory is INVOKED only from its protocol's validator. FromOidcRedemption
+        //    belongs to the OpenID redeem path — built inside AuthorizeSession.Ready, which the store hands
+        //    out only through the one-time atomic redeem — and FromValidatedSaml only at the SAML
+        //    session-minting endpoint after full response validation. A call from anywhere else (a link
+        //    endpoint, a new controller action) would mean an identity minted from something other than a
+        //    completed validation, so it fails the scan.
+        var ctors = typeof(VerifiedIdentity)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+        Assert.True(ctors.Length > 0, "VerifiedIdentity must declare an instance constructor to pin (it was removed or the type was renamed).");
+        var reachable = ctors
+            .Where(c => c.IsPublic || c.IsAssembly || c.IsFamilyOrAssembly)
+            .Select(c => c.ToString())
+            .ToList();
+        Assert.True(
+            reachable.Count == 0,
+            "VerifiedIdentity's constructor(s) must not be reachable from outside the type (no public/internal/protected-internal ctor) so it is constructible only through its validation factories (#473): " + string.Join(", ", reachable));
+
+        // Sentinel + call-site pins. The factory NAMES are the contract; require both to exist (a rename
+        // must consciously update this rule), then confine each factory's invocation to the file(s) that own
+        // its protocol's validation. AuthorizeSession is where the OpenID identity is built (from the
+        // role-gate result); the SAML factory is invoked from the controller's SAML endpoint until a later
+        // #318 step extracts a dedicated SAML validator — at which point this allow-list moves with it.
+        const string oidcFactory = "FromOidcRedemption";
+        const string samlFactory = "FromValidatedSaml";
+        var factoryMethods = typeof(VerifiedIdentity)
+            .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Where(m => m.ReturnType == typeof(VerifiedIdentity))
+            .Select(m => m.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        Assert.True(
+            factoryMethods.Contains(oidcFactory) && factoryMethods.Contains(samlFactory),
+            $"VerifiedIdentity must expose the two named validation factories ({oidcFactory}, {samlFactory}); one was renamed, so update this rule and the source-scan allow-list with it (#473).");
+
+        var oidcHome = SourceFilesDeclaring(new[] { typeof(AuthorizeSession) });
+        var samlHome = ControllerSourceFiles();
+        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + oidcFactory + "(", oidcHome, "the OpenID redeem path (AuthorizeSession.Ready)");
+        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + samlFactory + "(", samlHome, "the SAML session-minting endpoint");
+    }
+
+    // Fails if the given factory-invocation token appears in any SSO-Auth source file outside the allowed
+    // homes. Shared by the two #473 call-site pins; the allowed set is matched by absolute path so a file
+    // rename that the reflection-driven home discovery already tracks flows through unchanged. This is a
+    // qualified-call substring scan (belt-and-braces): the AIRTIGHT construction lock is the private-ctor
+    // reflection assertion above — nothing outside VerifiedIdentity.cs can construct one at all, so a call
+    // that this scan's substring might miss (a `using static` unqualified spelling, a line-split call) still
+    // cannot forge an identity; this scan adds the sharper "constructed only by the RIGHT validator" signal
+    // on top, keying on the qualified spelling the codebase actually uses.
+    private static void AssertFactoryInvocationsConfinedTo(string invocationToken, IEnumerable<string> allowedFiles, string homeDescription)
+    {
+        var allowed = allowedFiles.Select(Path.GetFullPath).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var strays = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path => !allowed.Contains(Path.GetFullPath(path)))
+            .Where(path => File.ReadAllText(path).Contains(invocationToken, StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.True(
+            strays.Count == 0,
+            $"{invocationToken}...) may be invoked only from {homeDescription}; found outside it in: " + string.Join(", ", strays));
+    }
+
+    [Fact]
     public void Controller_NeverTouchesProviderLinkMaps()
     {
         // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: the two

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -260,11 +260,11 @@ public class OidcStateStoreTests
 
         var redeemed = store.TryRedeem("tok", "p", Now, Binding);
         Assert.NotNull(redeemed);
-        Assert.Equal("alice", redeemed.Username);
-        Assert.Equal("sub-full", redeemed.Subject);
-        Assert.True(redeemed.Admin);
-        Assert.Equal(new[] { "movies" }, redeemed.Folders);
-        Assert.Equal("https://idp.example/a.png", redeemed.AvatarUrl);
+        Assert.Equal("alice", redeemed.Identity.Username);
+        Assert.Equal("sub-full", redeemed.Identity.Subject);
+        Assert.True(redeemed.Identity.Admin);
+        Assert.Equal(new[] { "movies" }, redeemed.Identity.Folders);
+        Assert.Equal("https://idp.example/a.png", redeemed.Identity.AvatarUrl);
     }
 
     [Fact]
@@ -340,11 +340,11 @@ public class OidcStateStoreTests
             var redeemed = await redeem;
             if (redeemed != null)
             {
-                Assert.Equal("alice", redeemed.Username);
-                Assert.Equal("sub-full", redeemed.Subject);
-                Assert.True(redeemed.Admin);
-                Assert.Equal(new[] { "movies" }, redeemed.Folders);
-                Assert.Equal("https://idp.example/a.png", redeemed.AvatarUrl);
+                Assert.Equal("alice", redeemed.Identity.Username);
+                Assert.Equal("sub-full", redeemed.Identity.Subject);
+                Assert.True(redeemed.Identity.Admin);
+                Assert.Equal(new[] { "movies" }, redeemed.Identity.Folders);
+                Assert.Equal("https://idp.example/a.png", redeemed.Identity.AvatarUrl);
             }
         }
     }
@@ -364,13 +364,13 @@ public class OidcStateStoreTests
         var redeemed = store.TryRedeem("tok", "p", Now, Binding);
 
         Assert.NotNull(redeemed);
-        Assert.Equal("sub-1", redeemed.Subject);
-        Assert.Equal("alice", redeemed.Username);
-        Assert.True(redeemed.Admin);
-        Assert.Equal(new[] { "movies" }, redeemed.Folders);
-        Assert.True(redeemed.EnableLiveTv);
-        Assert.False(redeemed.EnableLiveTvManagement);
-        Assert.Equal("https://idp.example.com/a.png", redeemed.AvatarUrl);
+        Assert.Equal("sub-1", redeemed.Identity.Subject);
+        Assert.Equal("alice", redeemed.Identity.Username);
+        Assert.True(redeemed.Identity.Admin);
+        Assert.Equal(new[] { "movies" }, redeemed.Identity.Folders);
+        Assert.True(redeemed.Identity.EnableLiveTv);
+        Assert.False(redeemed.Identity.EnableLiveTvManagement);
+        Assert.Equal("https://idp.example.com/a.png", redeemed.Identity.AvatarUrl);
     }
 
     [Theory]

--- a/SSO-Auth.Tests/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/VerifiedIdentityTests.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Unit tests for the <see cref="VerifiedIdentity"/> keystone (#473): both protocols must funnel their
+/// validated result into the identical shape the shared mint path consumes, and the type must be
+/// unforgeable — obtainable only through the two validation factories. The behavioral proof that a raw or
+/// unvalidated response cannot reach the mint lives in the controller suites (an invalid SAML signature or
+/// an unredeemed OpenID state is rejected before any provisioning: e.g.
+/// <c>SamlAuth_SignedByAnotherCertificate_Returns400</c>, <c>OidAuth</c>'s invalid-state rejections); the
+/// structural proof that no third construction path can even compile lives in
+/// <c>ArchitectureConformanceTests.VerifiedIdentity_IsConstructedOnlyByProtocolValidators</c>. These tests
+/// pin the field mapping each factory performs so the two protocols stay in lock-step.
+/// </summary>
+public class VerifiedIdentityTests
+{
+    [Fact]
+    public void FromOidcRedemption_MapsEveryFieldFromTheRoleGateResult()
+    {
+        var derived = new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: "sub-123",
+            EmailVerified: true,
+            Valid: true,
+            Admin: true,
+            EnableLiveTv: true,
+            EnableLiveTvManagement: false,
+            Folders: new List<string> { "movies", "shows" },
+            AvatarUrl: "https://idp.example/a.png");
+
+        var identity = VerifiedIdentity.FromOidcRedemption("keycloak", derived);
+
+        // The two protocol-facing labels drive the link namespace and the audit line.
+        Assert.Equal("oid", identity.LinkMode);
+        Assert.Equal("OpenID", identity.AuditProtocol);
+        Assert.Equal("keycloak", identity.Provider);
+
+        // OpenID keys the link on the stable subject; the username is derived independently.
+        Assert.Equal("sub-123", identity.Subject);
+        Assert.Equal("alice", identity.Username);
+        Assert.Equal(true, identity.EmailVerified);
+        Assert.True(identity.Admin);
+        Assert.Equal(new[] { "movies", "shows" }, identity.Folders);
+        Assert.True(identity.EnableLiveTv);
+        Assert.False(identity.EnableLiveTvManagement);
+        Assert.Equal("https://idp.example/a.png", identity.AvatarUrl);
+    }
+
+    [Fact]
+    public void FromValidatedSaml_KeysSubjectAndUsernameOnTheNameId_AndCarriesNoEmailOrAvatar()
+    {
+        var privileges = new SamlAuthorizeStateBuilder.SamlAuthorizeState(
+            Admin: true,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: true,
+            Folders: new List<string> { "movies" });
+
+        var identity = VerifiedIdentity.FromValidatedSaml("okta", "alice@example.com", privileges);
+
+        Assert.Equal("saml", identity.LinkMode);
+        Assert.Equal("SAML", identity.AuditProtocol);
+        Assert.Equal("okta", identity.Provider);
+
+        // SAML keys the link directly on the NameID: subject and username are the same value.
+        Assert.Equal("alice@example.com", identity.Subject);
+        Assert.Equal("alice@example.com", identity.Username);
+
+        // SAML carries no email_verified claim and no avatar, so the adoption gate and avatar step are inert.
+        Assert.Null(identity.EmailVerified);
+        Assert.Null(identity.AvatarUrl);
+
+        Assert.True(identity.Admin);
+        Assert.Equal(new[] { "movies" }, identity.Folders);
+        Assert.False(identity.EnableLiveTv);
+        Assert.True(identity.EnableLiveTvManagement);
+    }
+
+    [Fact]
+    public void Constructor_IsNotReachableFromOutside_SoTheTypeIsUnforgeable()
+    {
+        // The security contract at the unit level: nothing outside VerifiedIdentity can construct one, so a
+        // caller must go through a validation factory. No declared instance constructor is public, internal,
+        // or protected-internal (a sealed record's own copy constructor is unreachable and ignored).
+        var reachable = typeof(VerifiedIdentity)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Where(c => c.IsPublic || c.IsAssembly || c.IsFamilyOrAssembly)
+            .ToList();
+
+        Assert.Empty(reachable);
+    }
+}

--- a/SSO-Auth/Api/AuthorizeSession.cs
+++ b/SSO-Auth/Api/AuthorizeSession.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Duende.IdentityModel.OidcClient;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
@@ -106,38 +105,19 @@ internal abstract class AuthorizeSession
         internal Ready(Pending pending, OidcAuthorizeStateBuilder.OidcAuthorizeState derived)
             : base(pending.Token, pending.Provider, pending.IsLinking, pending.BindingId, pending.ClientKey, pending.Created)
         {
-            Subject = derived.Subject;
-            Username = derived.Username;
-            EmailVerified = derived.EmailVerified;
-            Admin = derived.Admin;
-            Folders = derived.Folders;
-            EnableLiveTv = derived.EnableLiveTv;
-            EnableLiveTvManagement = derived.EnableLiveTvManagement;
-            AvatarUrl = derived.AvatarUrl;
+            // The role gate has passed, so this is exactly the point at which an OpenID login becomes a
+            // fully-verified identity (#473): fold the derived result into the one protocol-agnostic
+            // VerifiedIdentity the mint path is keyed on. Building it here — inside the variant the store
+            // only ever produces for a promoted state and only hands out through the one-time atomic
+            // redeem — is what makes this the OpenID construction site the keystone's contract names.
+            Identity = VerifiedIdentity.FromOidcRedemption(pending.Provider, derived);
         }
 
-        /// <summary>Gets the stable subject identifier keying the account link (#155).</summary>
-        internal string Subject { get; }
-
-        /// <summary>Gets the username resolved by the verified login.</summary>
-        internal string Username { get; }
-
-        /// <summary>Gets the login's <c>email_verified</c> claim (true/false), or null when absent (#218).</summary>
-        internal bool? EmailVerified { get; }
-
-        /// <summary>Gets a value indicating whether the login grants administrator rights.</summary>
-        internal bool Admin { get; }
-
-        /// <summary>Gets the folders the login grants access to.</summary>
-        internal List<string> Folders { get; }
-
-        /// <summary>Gets a value indicating whether the login may view live TV.</summary>
-        internal bool EnableLiveTv { get; }
-
-        /// <summary>Gets a value indicating whether the login may manage live TV.</summary>
-        internal bool EnableLiveTvManagement { get; }
-
-        /// <summary>Gets the avatar URL resolved by the verified login.</summary>
-        internal string AvatarUrl { get; }
+        /// <summary>
+        /// Gets the fully-verified identity and privileges of the redeemed OpenID login (#473). This is
+        /// the sole payload of a <see cref="Ready"/>: holding one is the evidence the login passed the role
+        /// gate, and it is what <see cref="OidcStateStore.TryRedeem"/> feeds into the shared mint path.
+        /// </summary>
+        internal VerifiedIdentity Identity { get; }
     }
 }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -714,40 +714,13 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
 
-        Guid userId;
-        try
-        {
-            userId = await _canonicalLinks.ResolveOrCreateAsync(
-                "oid",
-                provider,
-                redeemed.Subject,
-                redeemed.Username,
-                config.AllowExistingAccountLink,
-                new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.EmailVerified)).ConfigureAwait(false);
-        }
-        catch (AccountLinkForbiddenException)
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
-        }
-
-        var sessionParameters = new SessionParameters
-        {
-            UserId = userId,
-            IsAdmin = redeemed.Admin,
-            EnableAuthorization = config.EnableAuthorization,
-            EnableAllFolders = config.EnableAllFolders,
-            EnabledFolders = redeemed.Folders.ToArray(),
-            EnableLiveTv = redeemed.EnableLiveTv,
-            EnableLiveTvManagement = redeemed.EnableLiveTvManagement,
-            AuthResponse = response,
-            DefaultProvider = config.DefaultProvider?.Trim(),
-            AvatarUrl = redeemed.AvatarUrl,
-        };
-        var authenticationResult = await Authenticate(
-            sessionParameters,
-            () => _canonicalLinks.IsIdentityStillLinked("oid", provider, redeemed.Subject, userId)).ConfigureAwait(false);
-        SsoAudit.LoginSucceeded(_logger, OpenIdProtocol, provider, redeemed.Username, redeemed.Admin);
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+        // The redeemed state carries the fully-verified identity (#473); the OpenID adoption gate applies
+        // the provider's verified-email requirement (#218). From here the OpenID and SAML paths are one.
+        return await CompleteLoginAsync(
+            redeemed.Identity,
+            response,
+            config,
+            new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.Identity.EmailVerified)).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1121,38 +1094,18 @@ public class SSOController : ControllerBase
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 
-        Guid userId;
-        try
-        {
-            // SAML keys the link directly on the NameID, which is already the stable subject
-            // identifier — key and account name are the same value (no migration path needed). SAML has
-            // no email_verified claim, so the verified-email gate is not applicable (AdoptionGate.None);
-            // the resolver's unconditional admin-adoption refusal (#218) still applies.
-            userId = await _canonicalLinks.ResolveOrCreateAsync("saml", provider, nameId, nameId, config.AllowExistingAccountLink, AdoptionGate.None).ConfigureAwait(false);
-        }
-        catch (AccountLinkForbiddenException)
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
-        }
-
-        var sessionParameters = new SessionParameters
-        {
-            UserId = userId,
-            IsAdmin = derived.Admin,
-            EnableAuthorization = config.EnableAuthorization,
-            EnableAllFolders = config.EnableAllFolders,
-            EnabledFolders = derived.Folders.ToArray(),
-            EnableLiveTv = derived.EnableLiveTv,
-            EnableLiveTvManagement = derived.EnableLiveTvManagement,
-            AuthResponse = response,
-            DefaultProvider = config.DefaultProvider?.Trim(),
-            AvatarUrl = null,
-        };
-        var authenticationResult = await Authenticate(
-            sessionParameters,
-            () => _canonicalLinks.IsIdentityStillLinked("saml", provider, nameId, userId)).ConfigureAwait(false);
-        SsoAudit.LoginSucceeded(_logger, SamlProtocol, provider, nameId, derived.Admin);
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+        // All SAML validation has now passed — signature, time bounds, audience, recipient, InResponseTo
+        // correlation, the login allow-list, replay one-time-use, and the non-empty-NameID guard — so this
+        // is the point at which the response becomes a fully-verified SAML identity (#473). SAML keys the
+        // link directly on the NameID (subject and username are the same value; no migration path needed)
+        // and carries no email_verified claim, so the verified-email gate is not applicable
+        // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
+        // From here the SAML and OpenID paths are one.
+        return await CompleteLoginAsync(
+            VerifiedIdentity.FromValidatedSaml(provider, nameId, derived),
+            response,
+            config,
+            AdoptionGate.None).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1397,7 +1350,7 @@ public class SSOController : ControllerBase
 
         // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
         // later provider-side rename does not orphan the link the user just created.
-        return MapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Subject, jellyfinUserId));
+        return MapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
     }
 
     // The HTTP boundary for a manual link creation: maps the service's closed write result to a response.
@@ -1410,6 +1363,56 @@ public class SSOController : ControllerBase
         CanonicalLinkWriteResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
+
+    // The one shared completion path both protocols funnel into once their validation has produced a
+    // VerifiedIdentity (#473): resolve-or-create the account, build the session parameters, and mint the
+    // session under the in-flight revocation gate. Taking a VerifiedIdentity — the only type either
+    // protocol can produce, and only after full validation — is what makes minting from a raw, unvalidated
+    // response a compile error: there is no overload that accepts anything else. The only per-protocol
+    // input left is the adoption gate (OpenID may require a verified email #218; SAML passes
+    // AdoptionGate.None), so it is a parameter; every other divergence collapsed into the identity's own
+    // fields (its link namespace, audit label, subject, username, privileges).
+    private async Task<ActionResult> CompleteLoginAsync(
+        VerifiedIdentity identity,
+        AuthResponse response,
+        ProviderConfigBase config,
+        AdoptionGate adoptionGate)
+    {
+        Guid userId;
+        try
+        {
+            userId = await _canonicalLinks.ResolveOrCreateAsync(
+                identity.LinkMode,
+                identity.Provider,
+                identity.Subject,
+                identity.Username,
+                config.AllowExistingAccountLink,
+                adoptionGate).ConfigureAwait(false);
+        }
+        catch (AccountLinkForbiddenException)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
+        }
+
+        var sessionParameters = new SessionParameters
+        {
+            UserId = userId,
+            IsAdmin = identity.Admin,
+            EnableAuthorization = config.EnableAuthorization,
+            EnableAllFolders = config.EnableAllFolders,
+            EnabledFolders = identity.Folders.ToArray(),
+            EnableLiveTv = identity.EnableLiveTv,
+            EnableLiveTvManagement = identity.EnableLiveTvManagement,
+            AuthResponse = response,
+            DefaultProvider = config.DefaultProvider?.Trim(),
+            AvatarUrl = identity.AvatarUrl,
+        };
+        var authenticationResult = await Authenticate(
+            sessionParameters,
+            () => _canonicalLinks.IsIdentityStillLinked(identity.LinkMode, identity.Provider, identity.Subject, userId)).ConfigureAwait(false);
+        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, identity.Username, identity.Admin);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+    }
 
     // The HTTP boundary for session minting: hand the resolved parameters and a resolver for the client's
     // normalized remote IP (#177 — Jellyfin's own GetNormalizedRemoteIP, so the plugin adds no proxy-trust

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The protocol-agnostic keystone the session-minting path is keyed on (#473): the fully-verified
+/// identity and privileges that an OpenID or SAML login resolves, once — and only once — all of that
+/// protocol's validation has passed. Both protocols funnel their result into this one shape, so the
+/// shared completion path (<c>ResolveOrCreateAsync -&gt; SessionParameters -&gt; SessionMinter</c>)
+/// takes a <see cref="VerifiedIdentity"/> and nothing else; a caller cannot reach the mint with a raw,
+/// unvalidated response because there is no other way to obtain one.
+/// </summary>
+/// <remarks>
+/// The constructor is PRIVATE, so the type is unforgeable from outside: the only way to obtain an
+/// instance is one of the two named factories, each of which represents a completed protocol validation.
+/// <list type="bullet">
+/// <item><see cref="FromOidcRedemption"/>, built inside <see cref="AuthorizeSession.Ready"/> and handed
+/// out only by <see cref="OidcStateStore.TryRedeem"/> after the atomic one-time claim of a promoted
+/// (role-gate-passed) state.</item>
+/// <item><see cref="FromValidatedSaml"/>, called only at the SAML session-minting endpoint after the
+/// response has passed signature, time-bound, audience, recipient and replay validation.</item>
+/// </list>
+/// This construction lock is pinned as a fitness function
+/// (<c>ArchitectureConformanceTests.VerifiedIdentity_IsConstructedOnlyByProtocolValidators</c>). The two
+/// protocol-facing labels (<see cref="LinkMode"/>, <see cref="AuditProtocol"/>) are the only branch the
+/// completion path needs; a richer protocol abstraction is deferred to a later #318 step rather than
+/// pre-empted here.
+/// </remarks>
+internal sealed record VerifiedIdentity
+{
+    // Private so the type cannot be constructed from unvalidated data: the two static factories below are
+    // the sole construction sites, and each stands for a completed protocol validation. Anything that
+    // holds a VerifiedIdentity therefore holds proof the login was verified (#473).
+    private VerifiedIdentity(
+        string linkMode,
+        string auditProtocol,
+        string provider,
+        string subject,
+        string username,
+        bool? emailVerified,
+        bool admin,
+        IReadOnlyList<string> folders,
+        bool enableLiveTv,
+        bool enableLiveTvManagement,
+        string? avatarUrl)
+    {
+        LinkMode = linkMode;
+        AuditProtocol = auditProtocol;
+        Provider = provider;
+        Subject = subject;
+        Username = username;
+        EmailVerified = emailVerified;
+        Admin = admin;
+        Folders = folders;
+        EnableLiveTv = enableLiveTv;
+        EnableLiveTvManagement = enableLiveTvManagement;
+        AvatarUrl = avatarUrl;
+    }
+
+    /// <summary>Gets the account-link namespace ("oid"/"saml") the canonical-link store keys this identity under.</summary>
+    internal string LinkMode { get; }
+
+    /// <summary>Gets the protocol label ("OpenID"/"SAML") recorded in the login audit line.</summary>
+    internal string AuditProtocol { get; }
+
+    /// <summary>Gets the provider that verified this login.</summary>
+    internal string Provider { get; }
+
+    /// <summary>Gets the stable subject identifier keying the account link (OpenID "sub"; the SAML NameID) (#155).</summary>
+    internal string Subject { get; }
+
+    /// <summary>Gets the username the login resolves (the OpenID username; the SAML NameID).</summary>
+    internal string Username { get; }
+
+    /// <summary>Gets the login's <c>email_verified</c> claim (true/false), or null when absent — SAML always null (#218).</summary>
+    internal bool? EmailVerified { get; }
+
+    /// <summary>Gets a value indicating whether the login grants administrator rights.</summary>
+    internal bool Admin { get; }
+
+    /// <summary>Gets the folders the login grants access to (statically enabled plus role-granted).</summary>
+    internal IReadOnlyList<string> Folders { get; }
+
+    /// <summary>Gets a value indicating whether the login may view live TV.</summary>
+    internal bool EnableLiveTv { get; }
+
+    /// <summary>Gets a value indicating whether the login may manage live TV.</summary>
+    internal bool EnableLiveTvManagement { get; }
+
+    /// <summary>Gets the avatar URL the login resolves, or null when none — SAML always null.</summary>
+    internal string? AvatarUrl { get; }
+
+    /// <summary>
+    /// Builds the verified identity of an OpenID login from the role-gate result. Called from inside
+    /// <see cref="AuthorizeSession.Ready"/>, which the store produces only for a promoted (role-gate-passed)
+    /// state and hands out only through the one-time atomic redeem — so this can never run before that claim.
+    /// The subject and username are non-null by that point: the callback rejects a valid login that resolved
+    /// no subject (#155) and no username (#95) before the state is promoted, so the null-forgiving reads
+    /// preserve that upstream fail-closed guarantee rather than re-deciding it here.
+    /// </summary>
+    /// <param name="provider">The provider that verified the login.</param>
+    /// <param name="derived">The passed role-gate result carrying the resolved identity and privileges.</param>
+    /// <returns>The verified OpenID identity.</returns>
+    internal static VerifiedIdentity FromOidcRedemption(string provider, OidcAuthorizeStateBuilder.OidcAuthorizeState derived) =>
+        new(
+            "oid",
+            "OpenID",
+            provider,
+            derived.Subject!,
+            derived.Username!,
+            derived.EmailVerified,
+            derived.Admin,
+            derived.Folders,
+            derived.EnableLiveTv,
+            derived.EnableLiveTvManagement,
+            derived.AvatarUrl);
+
+    /// <summary>
+    /// Builds the verified identity of a SAML login. Called only at the SAML session-minting endpoint after
+    /// the response has passed signature, time-bound, audience, recipient and replay validation, the login
+    /// allow-list, and the non-empty-NameID guard (#95) — so a raw or unvalidated response can never reach
+    /// this factory. SAML keys the link directly on the NameID (subject and username are the same value) and
+    /// carries no <c>email_verified</c> claim or avatar (both null).
+    /// </summary>
+    /// <param name="provider">The provider that verified the login.</param>
+    /// <param name="nameId">The validated, non-empty NameID; the link key and the username.</param>
+    /// <param name="privileges">The privileges derived from the assertion's roles and the provider configuration.</param>
+    /// <returns>The verified SAML identity.</returns>
+    internal static VerifiedIdentity FromValidatedSaml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
+        new(
+            "saml",
+            "SAML",
+            provider,
+            nameId,
+            nameId,
+            null,
+            privileges.Admin,
+            privileges.Folders,
+            privileges.EnableLiveTv,
+            privileges.EnableLiveTvManagement,
+            null);
+}


### PR DESCRIPTION
# What & why

Both the OpenID and SAML login paths resolve the same identity and privilege values, then each built its own `SessionParameters` inline before minting the session. Nothing at the type level stopped a future caller from reaching the mint with values that had not been through full protocol validation.

This introduces **`VerifiedIdentity`**, a sealed record with a **private constructor** and two factories, each of which represents a completed protocol validation:

- **`FromOidcRedemption`**, built inside `AuthorizeSession.Ready`, which the store produces only for a promoted (role-gate-passed) state and hands out only through the one-time atomic redeem; and
- **`FromValidatedSaml`**, called only at the SAML session-minting endpoint after the response has passed signature, time-bound, audience, recipient, `InResponseTo`/binding, the login allow-list, replay one-time-use, and the non-empty-NameID guard.

The shared completion path, `CompleteLoginAsync` (`ResolveOrCreateAsync → SessionParameters → SessionMinter`), now accepts a `VerifiedIdentity` **and nothing else**, so minting from a raw, unvalidated response is a **compile error**: there is no overload that takes anything else, and the private constructor makes the type unforgeable from outside. The two protocols' divergent `SessionParameters` construction collapses into this one path; the only per-protocol input left is the adoption gate (OpenID may require a verified email #218; SAML passes `AdoptionGate.None`), passed as a parameter.

Behaviour is preserved field-for-field: HTTP response shapes, audit labels (`OpenID`/`SAML`), config reads, the ten `SessionParameters` members, and the fail-closed subject/username guards are all unchanged.

Closes #473

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

(Hardening-flavoured refactor: it tightens a login-path type invariant, but ships no behaviour change.)

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

### Design

- **Unforgeable keystone.** `VerifiedIdentity` has a private constructor; the only two construction sites are the two factories, each named for the validation it presupposes. Nothing outside `VerifiedIdentity.cs` can `new` one, so holding a `VerifiedIdentity` is proof the login was verified.
- **Type-level mint lock.** `CompleteLoginAsync` and `SessionMinter.MintAsync` are reachable only with a `VerifiedIdentity`; there is no path that mints from a raw response.
- **Protocol asymmetry, deliberately documented.** For OpenID the guarantee is structural (the store only produces `Ready` for a promoted state and only hands it out through the atomic redeem). For SAML the factory call sits after the full validation chain in the endpoint, pinned by the existing controller characterization tests plus the new conformance call-site scan. A dedicated SAML validator type is a later #318 step; the factory's allow-list moves with it.
- **No premature `SsoProtocol` abstraction.** The identity carries just the two protocol-facing labels the completion path branches on (`LinkMode` "oid"/"saml", `AuditProtocol` "OpenID"/"SAML"); the richer protocol type is deferred to its own #318 step.
- **Minimal churn.** `AuthorizeSession.Ready`'s constructor signature is unchanged (it now builds the identity internally), so existing `Ready(...)` construction in tests is untouched.

### Conformance rule (locked in)

`VerifiedIdentity_IsConstructedOnlyByProtocolValidators`: (1) reflection, no externally-reachable constructor (public/internal/protected-internal); (2) the two named factories exist; (3) source scan, each factory is invoked only from its protocol's validator (`FromOidcRedemption` → `AuthorizeSession.cs`; `FromValidatedSaml` → the controller's SAML endpoint). The private-ctor reflection assertion is the airtight lock; the call-site scan is the sharper "constructed only by the RIGHT validator" signal on top.

### Adversarial-review gate, four lenses, all PASS

- **Availability / mass-lockout, PASS.** Field-for-field equivalence against `origin/main`: link keys, adoption gates (SAML still `AdoptionGate.None`; OpenID still keyed on `EmailVerified`), session parameters, audit labels and the fail-closed subject/username guards all preserved. The null-forgiving `derived.Subject!`/`derived.Username!` is safe, `OidCallback` guarantees non-null subject and (via `Valid`) non-null username before promotion, so no new NRE/crash path.
- **Security-bypass / fail-open, PASS.** `CompleteLoginAsync` has exactly two callers (both post-validation); the SAML factory sits after every reject gate with no reordering; the link paths gain no mint capability; empirically refuted the `with`-expression/copy-ctor escape (`with { Admin = true }` fails to compile, all properties get-only; the sealed record's copy ctor is private).
- **Correctness, PASS.** Factory field mapping verified against the removed inline code (no swapped Subject/Username, correct label strings, `Folders` aliased not copied). Conformance helper verified: the qualified token does not match the method definition, path normalization is consistent, the reflection ctor check ignores the private copy ctor and is non-vacuous. One non-blocking residual (the substring scan would miss a `using static`/line-split spelling), dispositioned: the airtight lock is the private ctor; the scan is documented as belt-and-braces.
- **Integration, PASS.** HTTP response shapes and status codes unchanged for success and every rejection; the four `ProviderConfigBase` reads are genuinely base-class (no per-subtype shadow); the admin debug `Summaries()` reads only base members; no existing conformance rule trips on the new type; `InternalsVisibleTo` reaches the internal type/factories; all ten `required` `SessionParameters` members still set. Empirically green: build `--warnaserror` clean, 992/992 tests pass.

Two lens observations were addressed by tightening comments (the copy-ctor accessibility note; the substring-scan defense-in-depth note). CI still green after.

### Gates

- `dotnet build -c Debug --warnaserror` and `-c Release --warnaserror`: 0 warnings, 0 errors.
- `dotnet test`: 992 passed / 0 failed (989 prior + 3 new).
- No `.js`/`.html`/`.md`/`.css` touched, so Prettier is a no-op.

### Out of scope

- Extracting a dedicated SAML validator type (a later #318 step) that would become the natural home for the `FromValidatedSaml` call and the conformance allow-list.
