### PR TITLE
Extract the shared login-completion tail into a flow service

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
 using Microsoft.AspNetCore.Mvc;
@@ -432,6 +433,44 @@ public class ArchitectureConformanceTests
         Assert.False(
             interveningMutation,
             "No user-mutating side effect may sit between the final #232 revocation re-check and AuthenticateDirect — the re-check must be the last gate before the mint.");
+    }
+
+    [Fact]
+    public void Controller_DelegatesLoginCompletionToTheFlowService()
+    {
+        // Locked in by the login-completion extraction (#160, #318 step 11): the one shared completion tail —
+        // resolve/adopt the link, build the SessionParameters, mint the session under the revocation gate,
+        // audit, map to a LoginOutcome — moved wholesale into LoginCompletionService. The controller's two
+        // callbacks now hand a VerifiedIdentity to that service and return its result, so a CONTROLLER neither
+        // builds SessionParameters nor mints a session itself. Call-level property, so it is a source scan
+        // like the other controller rules above.
+        //
+        // The scanned tokens are derived from the moved types via nameof, so a rename of SessionParameters or
+        // SessionMinter.MintAsync fails to COMPILE this rule (the strongest pin) rather than passing
+        // vacuously. Constructing the minter to inject it (new SessionMinter(...)) is wiring, not the tail, so
+        // it is deliberately not a scanned token — only building the parameters and minting are.
+        var paramsToken = "new " + nameof(SessionParameters);
+        var mintToken = nameof(SessionMinter.MintAsync) + "(";
+
+        var controllerHits = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => l.Text.Contains(paramsToken, StringComparison.Ordinal) || l.Text.Contains(mintToken, StringComparison.Ordinal))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            controllerHits.Count == 0,
+            "A controller must not build SessionParameters or mint a session directly; the shared login-completion tail lives in LoginCompletionService (#160). Found: " + string.Join(" | ", controllerHits));
+
+        // Liveness against a vacuous pass: the tail must actually live in the flow service — a move, not a
+        // silent removal — so LoginCompletionService's own source must contain both moved tokens.
+        var completionSource = string.Join(
+            "\n",
+            SourceFilesDeclaring(new[] { typeof(LoginCompletionService) }).Select(File.ReadAllText));
+        Assert.True(
+            completionSource.Contains(paramsToken, StringComparison.Ordinal) && completionSource.Contains(mintToken, StringComparison.Ordinal),
+            "LoginCompletionService must own the login-completion tail (build SessionParameters and mint the session); otherwise the controller scan passes vacuously (#160).");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/LoginCompletionServiceTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct tests of <see cref="LoginCompletionService"/> — the shared login-completion tail extracted from
+/// the controller (#160, #318 step 11). They pin that both protocols funnel their <see cref="VerifiedIdentity"/>
+/// into the identical mint (an OpenID and a SAML identity complete the same way, carrying the
+/// controller-supplied remote endpoint through), and that a refusal from the account-linking workflow still
+/// surfaces as a <c>Rejected</c> 403 with no session minted — the fail-closed behavior that must survive the
+/// move verbatim. The controller suites keep proving the wire behavior end to end; these pin the tail in
+/// isolation.
+/// </summary>
+public class LoginCompletionServiceTests
+{
+    private static readonly Guid Created = Guid.Parse("33333333-3333-3333-3333-333333333333");
+    private static readonly Guid Existing = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
+
+    private static (LoginCompletionService Service, PluginConfiguration Config, IUserManager Users, ISessionManager Sessions) Build(Action<PluginConfiguration> seed)
+    {
+        var cfg = new PluginConfiguration();
+        seed(cfg);
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+        // A real AvatarService (its deps stubbed): a null AvatarUrl early-returns, so no network is reached.
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, new CapturingLogger()), cfg, users, sessions);
+    }
+
+    private static AuthResponse Response() =>
+        new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity OidcIdentity(string provider, string subject, string username) =>
+        VerifiedIdentity.FromOidcRedemption(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: username,
+            Subject: subject,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null));
+
+    private static VerifiedIdentity SamlIdentity(string provider, string nameId) =>
+        VerifiedIdentity.FromValidatedSaml(provider, nameId, new SamlAuthorizeStateBuilder.SamlAuthorizeState(
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>()));
+
+    [Fact]
+    public async Task CompleteAsync_OidcIdentity_ResolvesTheAccountAndMintsWithTheSuppliedRemoteEndPoint()
+    {
+        var config = new OidConfig { Enabled = true };
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
+        var created = UserNamed("alice", Created);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Created).Returns(created);
+        AuthenticationRequest? captured = null;
+        sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.NotNull(captured);
+        Assert.Equal(Created, captured!.UserId);
+        Assert.Equal("203.0.113.9", captured.RemoteEndPoint);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_SamlIdentity_CompletesIdenticallyToTheOidcPath()
+    {
+        // The keystone's whole point (#473): a SAML VerifiedIdentity funnels into the same tail — resolve the
+        // account, mint the session, carry the supplied remote endpoint — indistinguishable from OpenID.
+        var config = new SamlConfig { Enabled = true };
+        var (service, _, users, sessions) = Build(c => c.SamlConfigs["okta"] = config);
+        var created = UserNamed("bob", Created);
+        users.GetUserByName("bob").Returns((User?)null);
+        users.CreateUserAsync("bob").Returns(created);
+        users.GetUserById(Created).Returns(created);
+        AuthenticationRequest? captured = null;
+        sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            SamlIdentity("okta", "bob"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.NotNull(captured);
+        Assert.Equal(Created, captured!.UserId);
+        Assert.Equal("203.0.113.9", captured.RemoteEndPoint);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_AccountLinkRefused_ReturnsRejectedWithoutMinting()
+    {
+        // Fail closed, moved verbatim: a login whose name matches a pre-existing unlinked account with
+        // adoption off is refused (#95). ResolveOrCreateAsync throws AccountLinkForbiddenException, which the
+        // tail must catch and turn into a Rejected 403 — and crucially NO session may be minted. The catch is
+        // moved as a whole unit, so a refusal cannot fall through to the mint.
+        var config = new OidConfig { Enabled = true, AllowExistingAccountLink = false };
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        var result = await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(403, content.StatusCode);
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
+
+/// <summary>
+/// The one shared completion path both protocols funnel into once their validation has produced a
+/// <see cref="VerifiedIdentity"/> (#473): resolve-or-create the account, build the session parameters, and
+/// mint the session under the in-flight revocation gate, then audit and map to a <see cref="LoginOutcome"/>.
+/// Extracting it here (#160, #318 step 11) leaves the controller's two callbacks a single delegation each,
+/// and keeps the whole tail — every decision from a resolved identity to a minted session — in one flow-tier
+/// collaborator rather than inline on the controller.
+/// </summary>
+/// <remarks>
+/// The entrypoint takes a <see cref="VerifiedIdentity"/> and nothing rawer, so the compile-time "no mint
+/// without validation" property the keystone establishes is preserved across the extraction: there is no
+/// overload that accepts an unvalidated response. This flow tier holds no <c>HttpContext</c> dependency —
+/// the controller passes the normalized client remote endpoint in as a resolver (#177), exactly as it does
+/// for <see cref="SessionMinter"/>.
+/// </remarks>
+internal sealed class LoginCompletionService
+{
+    private readonly CanonicalLinkService _canonicalLinks;
+    private readonly SessionMinter _sessionMinter;
+    private readonly ILogger _logger;
+
+    internal LoginCompletionService(CanonicalLinkService canonicalLinks, SessionMinter sessionMinter, ILogger logger)
+    {
+        _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
+        _sessionMinter = sessionMinter ?? throw new ArgumentNullException(nameof(sessionMinter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Completes a login from its fully-verified identity: resolve-or-create the account, build the session
+    /// parameters, and mint the session under the in-flight revocation gate. Taking a
+    /// <see cref="VerifiedIdentity"/> — the only type either protocol can produce, and only after full
+    /// validation — is what makes minting from a raw, unvalidated response a compile error: there is no
+    /// overload that accepts anything else. The only per-protocol input left is the adoption gate (OpenID may
+    /// require a verified email #218; SAML passes <see cref="AdoptionGate.None"/>), so it is a parameter;
+    /// every other divergence collapsed into the identity's own fields (its link namespace, audit label,
+    /// subject, username, privileges).
+    /// </summary>
+    /// <param name="identity">The fully-verified login identity and privileges (#473).</param>
+    /// <param name="response">The client's auth request context (app/device), carried into the session mint.</param>
+    /// <param name="config">The provider configuration governing authorization/folder/default-provider grants.</param>
+    /// <param name="adoptionGate">The extra proof a same-named adoption must clear (#218).</param>
+    /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177); the controller reads it from <c>HttpContext</c> and passes it in so this tier stays HttpContext-free. Evaluated at the original point inside the minter — after avatar/persistence, and not at all on the fail-closed path.</param>
+    /// <returns>The HTTP result for the completed (or refused) login.</returns>
+    internal async Task<ActionResult> CompleteAsync(
+        VerifiedIdentity identity,
+        AuthResponse response,
+        ProviderConfigBase config,
+        AdoptionGate adoptionGate,
+        Func<string> remoteEndPointResolver)
+    {
+        Guid userId;
+        try
+        {
+            userId = await _canonicalLinks.ResolveOrCreateAsync(
+                identity.LinkMode,
+                identity.Provider,
+                identity.Subject,
+                identity.Username,
+                config.AllowExistingAccountLink,
+                adoptionGate).ConfigureAwait(false);
+        }
+        catch (AccountLinkForbiddenException)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
+        }
+
+        var sessionParameters = new SessionParameters
+        {
+            UserId = userId,
+            IsAdmin = identity.Admin,
+            EnableAuthorization = config.EnableAuthorization,
+            EnableAllFolders = config.EnableAllFolders,
+            EnabledFolders = identity.Folders.ToArray(),
+            EnableLiveTv = identity.EnableLiveTv,
+            EnableLiveTvManagement = identity.EnableLiveTvManagement,
+            AuthResponse = response,
+            DefaultProvider = config.DefaultProvider?.Trim(),
+            AvatarUrl = identity.AvatarUrl,
+        };
+
+        // Mint under the in-flight revocation gate (#232): the minter re-checks the link is still live both
+        // before any user side effect and again as the last act before AuthenticateDirect. The remote-endpoint
+        // resolver is passed rather than the value so the minter evaluates it at the exact original point.
+        var authenticationResult = await _sessionMinter.MintAsync(
+            sessionParameters,
+            remoteEndPointResolver,
+            () => _canonicalLinks.IsIdentityStillLinked(identity.LinkMode, identity.Provider, identity.Subject, userId)).ConfigureAwait(false);
+        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, identity.Username, identity.Admin);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -13,11 +13,11 @@ using Duende.IdentityModel.OidcClient;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Helpers;
 using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Extensions;
-using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Net;
@@ -48,9 +48,10 @@ public class SSOController : ControllerBase
     private const string SamlProtocol = "SAML";
 
     private readonly IUserManager _userManager;
-    // The session-minting flow (#318): permissions + avatar + default-provider, then AuthenticateDirect.
-    // The controller passes the HttpContext-derived remote endpoint in and keeps no session/avatar field.
-    private readonly SessionMinter _sessionMinter;
+    // The shared login-completion tail (#160, #318): resolve/adopt the link, build the session parameters,
+    // mint under the revocation gate, audit, map to a LoginOutcome. The controller passes the
+    // HttpContext-derived remote endpoint in and keeps no session/avatar field.
+    private readonly LoginCompletionService _loginCompletion;
     // Kept so a hard revoke (Unregister) can also terminate the user's already-issued tokens (#440); the
     // minter takes its own reference for the login path.
     private readonly ISessionManager _sessionManager;
@@ -120,7 +121,8 @@ public class SSOController : ControllerBase
         _sessionManager = sessionManager;
         _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
-        _sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
+        var sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
+        _loginCompletion = new LoginCompletionService(_canonicalLinks, sessionMinter, logger);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -716,11 +718,12 @@ public class SSOController : ControllerBase
 
         // The redeemed state carries the fully-verified identity (#473); the OpenID adoption gate applies
         // the provider's verified-email requirement (#218). From here the OpenID and SAML paths are one.
-        return await CompleteLoginAsync(
+        return await _loginCompletion.CompleteAsync(
             redeemed.Identity,
             response,
             config,
-            new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.Identity.EmailVerified)).ConfigureAwait(false);
+            new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.Identity.EmailVerified),
+            () => HttpContext.GetNormalizedRemoteIP().ToString()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1101,11 +1104,12 @@ public class SSOController : ControllerBase
         // and carries no email_verified claim, so the verified-email gate is not applicable
         // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
         // From here the SAML and OpenID paths are one.
-        return await CompleteLoginAsync(
+        return await _loginCompletion.CompleteAsync(
             VerifiedIdentity.FromValidatedSaml(provider, nameId, derived),
             response,
             config,
-            AdoptionGate.None).ConfigureAwait(false);
+            AdoptionGate.None,
+            () => HttpContext.GetNormalizedRemoteIP().ToString()).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -1363,64 +1367,6 @@ public class SSOController : ControllerBase
         CanonicalLinkWriteResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
-
-    // The one shared completion path both protocols funnel into once their validation has produced a
-    // VerifiedIdentity (#473): resolve-or-create the account, build the session parameters, and mint the
-    // session under the in-flight revocation gate. Taking a VerifiedIdentity — the only type either
-    // protocol can produce, and only after full validation — is what makes minting from a raw, unvalidated
-    // response a compile error: there is no overload that accepts anything else. The only per-protocol
-    // input left is the adoption gate (OpenID may require a verified email #218; SAML passes
-    // AdoptionGate.None), so it is a parameter; every other divergence collapsed into the identity's own
-    // fields (its link namespace, audit label, subject, username, privileges).
-    private async Task<ActionResult> CompleteLoginAsync(
-        VerifiedIdentity identity,
-        AuthResponse response,
-        ProviderConfigBase config,
-        AdoptionGate adoptionGate)
-    {
-        Guid userId;
-        try
-        {
-            userId = await _canonicalLinks.ResolveOrCreateAsync(
-                identity.LinkMode,
-                identity.Provider,
-                identity.Subject,
-                identity.Username,
-                config.AllowExistingAccountLink,
-                adoptionGate).ConfigureAwait(false);
-        }
-        catch (AccountLinkForbiddenException)
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
-        }
-
-        var sessionParameters = new SessionParameters
-        {
-            UserId = userId,
-            IsAdmin = identity.Admin,
-            EnableAuthorization = config.EnableAuthorization,
-            EnableAllFolders = config.EnableAllFolders,
-            EnabledFolders = identity.Folders.ToArray(),
-            EnableLiveTv = identity.EnableLiveTv,
-            EnableLiveTvManagement = identity.EnableLiveTvManagement,
-            AuthResponse = response,
-            DefaultProvider = config.DefaultProvider?.Trim(),
-            AvatarUrl = identity.AvatarUrl,
-        };
-        var authenticationResult = await Authenticate(
-            sessionParameters,
-            () => _canonicalLinks.IsIdentityStillLinked(identity.LinkMode, identity.Provider, identity.Subject, userId)).ConfigureAwait(false);
-        SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, identity.Username, identity.Admin);
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
-    }
-
-    // The HTTP boundary for session minting: hand the resolved parameters and a resolver for the client's
-    // normalized remote IP (#177 — Jellyfin's own GetNormalizedRemoteIP, so the plugin adds no proxy-trust
-    // logic of its own) to the SessionMinter flow. The resolver is passed rather than the value so the
-    // flow evaluates it at the exact original point (after avatar/persistence, and NOT at all on the
-    // fail-closed deleted-user path) — the pre-extraction Authenticate read it inline there.
-    private Task<AuthenticationResult> Authenticate(SessionParameters parameters, Func<bool> identityStillLinked) =>
-        _sessionMinter.MintAsync(parameters, () => HttpContext.GetNormalizedRemoteIP().ToString(), identityStillLinked);
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
     // request may proceed, else a 429 carrying Retry-After. Reads the settings under the config


### PR DESCRIPTION
# What & why

Closes #160 (login-completion tail), the next step of the #318 controller
thinning. #473 landed `SSOController.CompleteLoginAsync`, the one shared path
both OIDC and SAML funnel into once their validation has produced a
`VerifiedIdentity`. This change lifts that whole tail out of the controller and
into a dedicated flow-tier collaborator so the controller's two callbacks are a
single delegation each.

**What moved.** `CompleteLoginAsync` plus the private `Authenticate` helper it
solely owned move into a new `internal sealed class LoginCompletionService`
(`SSO-Auth/Api/Flows/LoginCompletionService.cs`, namespace
`Jellyfin.Plugin.SSO_Auth.Api.Flows`). Its collaborators are injected: the
`CanonicalLinkService` (resolve/adopt the link, re-check the revocation gate),
the `SessionMinter` (mint the session), and the `ILogger` (the success audit).
The controller `new`s the service in its constructor exactly as it does
`_canonicalLinks`, and both callbacks call `_loginCompletion.CompleteAsync(...)`.

**What stays.** The controller keeps the HTTP boundary, provider lookup,
state/replay consume, and the per-protocol identity construction, the two
`VerifiedIdentity.From…` factory calls stay at their callbacks (their
conformance allow-list is unchanged), and the OIDC/SAML `AdoptionGate` is still
decided at the call site and passed in.

**Behaviour-preserving, field-for-field.**

- The `AccountLinkForbiddenException` catch → `LoginOutcome.Rejected(AccountLinkForbidden)`
  moves as a **whole unit**, still scoped to `ResolveOrCreateAsync` only, so a
  refusal fails closed and cannot fall through to the mint. `SessionMinter`'s
  deleted-user / revoked-in-flight `throw`s are untouched and the `MintAsync`
  call sits outside the try, so they still propagate, never a guarded `Try`
  that reaches `AuthenticateDirect`.
- `LoginOutcome` keeps its no-`Error`-case shape, so an unexpected condition
  still surfaces as a genuine 500, never a default-accept.
- The completion entrypoint takes **only** a `VerifiedIdentity` (nothing rawer),
  so the compile-time "no mint without validation" property (#473) is preserved.
- The service holds **no `HttpContext`**: the controller passes the normalized
  client remote endpoint (#177) in as a `Func<string>` resolver, exactly as it
  already does for `SessionMinter`. With the resolver now a parameter, the
  former one-line `Authenticate` wrapper collapses into the direct `MintAsync`
  call, same three arguments, same order, same lazy evaluation point.

**Controller shrinks** by ~53 net lines; the `_sessionMinter` field becomes a
constructor local injected into the new service, and the now-unused
`using MediaBrowser.Controller.Authentication;` is dropped.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Behaviour-preserving move; the
      `AccountLinkForbidden` catch and the `SessionMinter` fail-closed throws
      are unchanged and still cannot reach the mint.)
- [x] No secrets logged; secrets are redacted on config export. (No new logging;
      the success audit logs provider/username/admin only.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial gate,
      see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No log call
      moved or added; the sanitized SAML sites stay in the controller.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (`Controller_DelegatesLoginCompletionToTheFlowService`).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0 warnings).
- [x] `dotnet test` is green (996 passed, 0 failed).
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A, C# only.)

## Notes

**Tests.** A focused `LoginCompletionServiceTests` suite pins that an OpenID and
a SAML `VerifiedIdentity` complete identically (same resolve→mint, same
controller-supplied remote endpoint reaching the `AuthenticationRequest`), and
that an account-link refusal yields `Rejected`/403 with **no** session minted
and no user created. The existing completion/mint tests (`SessionMinterTests`,
the controller OID/SAML auth suites) now exercise the service through the
controller and stay green. New conformance rule
`Controller_DelegatesLoginCompletionToTheFlowService` locks in that the
controller no longer builds `SessionParameters` or mints, its scanned tokens
are `nameof`-derived (a rename fails to compile, not silently) with a liveness
assert that the tail actually lives in the flow service.

**Adversarial-review gate, four lenses, all PASS.**

- **Availability / mass-lockout, PASS.** The `AccountLinkForbidden`→`Rejected`
  catch is byte-identical and still specific (not broadened); the remote-endpoint
  resolver stays a lazily-evaluated `Func`, so the fail-closed deleted-user /
  revoked paths add no eager `HttpContext` access. No login that previously
  succeeded is newly rejected.
- **Security-bypass / fail-open, PASS.** No throwing path became a guarded
  `Try` that falls through to the mint; the `MintAsync` call is outside the try
  and both callbacks call it with no surrounding catch. The `VerifiedIdentity`
  compile-time gate and its factory-home allow-list are intact; no gate dropped,
  no secret logged.
- **Correctness, PASS.** Statement-by-statement equivalence: all 10
  `SessionParameters` fields, the `MintAsync` argument triple and order, the
  `IsIdentityStillLinked` revocation closure, the audit args, and both call
  sites' `AdoptionGate` are identical to `origin/main`; no `ConfigureAwait`
  omission or evaluation-order change.
- **Integration / wiring, PASS.** DI/lifetime correct (single
  `SessionMinter`/`CanonicalLinkService` instances injected, `_sessionMinter`
  field removed with no dangling refs); both callbacks wired with the resolver;
  the new type is `internal sealed` under `…Api.Flows` and covered by
  `FlowServices_AreInternalAndSealed`; the removed `using` is genuinely unused.
  Empirically re-verified: plugin + tests build clean, 996/996 pass.

Out of scope: no further controller decomposition, no behaviour change, a pure
structural move continuing #318 step by step.
