### PR TITLE
Extract the OpenID discovery-facts cache into OidcDiscoveryCache

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,13 +84,13 @@ A handful of state stores live as `private static readonly` fields on
 `IPluginServiceRegistrator` in source, so a `static readonly` field is today's
 only way to get one process-wide instance):
 
-| Store                 | Guards                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------ |
-| `OidcStateStore`      | in-flight OIDC authorize state; capacity cap, lifetime, throttled-sweep via `IntervalGate` |
-| `SamlReplayCache`     | one-time-use SAML assertion IDs (replay protection)                                        |
-| `SamlRequestCache`    | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                         |
-| `DiscoveryFactsCache` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL                          |
-| `SsoRateLimiter`      | opt-in per-client rate limiting on the anonymous login endpoints                           |
+| Store                | Guards                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------- |
+| `OidcStateStore`     | in-flight OIDC authorize state; capacity cap, lifetime, throttled-sweep via `IntervalGate`  |
+| `SamlReplayCache`    | one-time-use SAML assertion IDs (replay protection)                                         |
+| `SamlRequestCache`   | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                          |
+| `OidcDiscoveryCache` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL; owns the fetch/parse too |
+| `SsoRateLimiter`     | opt-in per-client rate limiting on the anonymous login endpoints                            |
 
 ### The uniform outcome
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -139,16 +139,14 @@ public class ArchitectureConformanceTests
     {
         // Locked in by the OidcStateStore consolidation (#318): a raw dictionary holding runtime state
         // outside a *Store/*Cache/*Limiter type is how the pre-consolidation controller accumulated its
-        // scattered cap/lifetime/sweep conventions. Two documented exemptions:
-        // - SSOController.DiscoveryFactsCache: the per-discovery-URL facts cache (PKCE-S256 support #141 +
-        //   the RFC 9207 response-iss advertisement #210) still lives on the controller and moves into its
-        //   own probe type in a later #318 step; naming the exact field keeps anything new from hiding
-        //   behind the exemption.
+        // scattered cap/lifetime/sweep conventions. The former SSOController.DiscoveryFactsCache exemption
+        // was retired in #449 once that cache moved into OidcDiscoveryCache (a *Cache type), so the rule now
+        // covers it structurally. One documented exemption remains:
         // - ProviderConfigBase._canonicalLinks: the persisted account-link map — serialized plugin
         //   configuration mutated only under the config lock, so a runtime store type would be the
         //   wrong home; it is config state, not in-flight state.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "SSOController.DiscoveryFactsCache", "ProviderConfigBase._canonicalLinks" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/OidcDiscoveryCacheTests.cs
+++ b/SSO-Auth.Tests/OidcDiscoveryCacheTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcDiscoveryCache"/> — the per-discovery-URL cache of the two facts the OpenID
+/// challenge reads in one fetch (PKCE-S256 support #141 and the RFC 9207 response-<c>iss</c> advertisement
+/// #210), extracted off the controller in #449. They pin the behaviour the controller relied on: a fresh
+/// fetch is parsed and cached, a second read within the TTL is served without a re-fetch, a stale entry is
+/// re-fetched, a "read but not advertised" fact is a definite false, an unusable authority never fetches,
+/// and a fetch failure returns the tolerant default WITHOUT caching it so the next login retries.
+/// </summary>
+public class OidcDiscoveryCacheTests
+{
+    private const string Authority = "https://idp-cache.example.com";
+    private const string DiscoveryUrl = Authority + "/.well-known/openid-configuration";
+
+    // Discovery that advertises PKCE S256 and the RFC 9207 response-iss parameter.
+    private static string FullDiscovery() =>
+        "{\"issuer\":\"" + Authority + "\","
+        + "\"code_challenge_methods_supported\":[\"S256\"],"
+        + "\"authorization_response_iss_parameter_supported\":true}";
+
+    private static OidConfig Config() => new OidConfig { Enabled = true, OidEndpoint = Authority };
+
+    private static ILogger Logger() => Substitute.For<ILogger>();
+
+    [Fact]
+    public async Task ReadFacts_ParsesAdvertisedFacts()
+    {
+        var http = new CountingFactory(_ => Json(FullDiscovery()));
+        var cache = new OidcDiscoveryCache();
+
+        var facts = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+
+        Assert.True(facts.PkceS256); // S256 advertised -> true
+        Assert.True(facts.ResponseIssuerAdvertised); // RFC 9207 iss advertised -> true
+    }
+
+    [Fact]
+    public async Task ReadFacts_SecondReadWithinTtl_IsServedFromCache()
+    {
+        var http = new CountingFactory(_ => Json(FullDiscovery()));
+        var cache = new OidcDiscoveryCache();
+
+        var first = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+        var second = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+
+        Assert.Equal(first, second); // identical facts round-trip out of the cache
+        Assert.Equal(1, http.DiscoveryRequests); // fetched once; the second read did not touch the network
+    }
+
+    [Fact]
+    public async Task ReadFacts_AfterTtlElapsed_ReFetches()
+    {
+        var http = new CountingFactory(_ => Json(FullDiscovery()));
+        var cache = new OidcDiscoveryCache(TimeSpan.Zero); // every entry is immediately stale
+
+        await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+        await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+
+        Assert.Equal(2, http.DiscoveryRequests); // a stale entry is re-fetched, not served
+    }
+
+    [Fact]
+    public async Task ReadFacts_DiscoveryWithoutS256_ReportsDefiniteFalse()
+    {
+        var http = new CountingFactory(_ => Json("{\"issuer\":\"" + Authority + "\"}"));
+        var cache = new OidcDiscoveryCache();
+
+        var facts = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+
+        Assert.False(facts.PkceS256); // read but not advertised -> a definite false, not null
+        Assert.False(facts.ResponseIssuerAdvertised);
+    }
+
+    [Fact]
+    public async Task ReadFacts_MissingOrInvalidEndpoint_ReturnsDefault_WithoutFetching()
+    {
+        var http = new CountingFactory(_ => Json(FullDiscovery()));
+        var cache = new OidcDiscoveryCache();
+
+        var facts = await cache.ReadFactsAsync(new OidConfig { Enabled = true, OidEndpoint = "not-a-url" }, "kc", http.Factory, Logger());
+
+        Assert.Null(facts.PkceS256); // unusable authority -> unreadable (null), caller fails closed under RequirePkce
+        Assert.False(facts.ResponseIssuerAdvertised);
+        Assert.Equal(0, http.DiscoveryRequests); // never attempted a fetch
+    }
+
+    [Fact]
+    public async Task ReadFacts_EndpointAlreadyWellKnown_DoesNotDoubleAppendThePath()
+    {
+        string? requested = null;
+        var http = new CountingFactory(req =>
+        {
+            requested = req.RequestUri!.AbsoluteUri;
+            return Json(FullDiscovery());
+        });
+        var cache = new OidcDiscoveryCache();
+
+        await cache.ReadFactsAsync(new OidConfig { Enabled = true, OidEndpoint = DiscoveryUrl }, "kc", http.Factory, Logger());
+
+        Assert.Equal(DiscoveryUrl, requested); // the well-known path is appended only when absent
+    }
+
+    [Fact]
+    public async Task ReadFacts_FetchFailure_ReturnsTolerantDefault_AndIsNotCached()
+    {
+        var http = new CountingFactory(Throw);
+        var cache = new OidcDiscoveryCache();
+
+        var failed = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+        Assert.Null(failed.PkceS256); // unreadable -> null (tolerant; caller fails closed only under RequirePkce)
+        Assert.False(failed.ResponseIssuerAdvertised);
+
+        // The failure was not cached, so a subsequent successful fetch yields the real facts — a transient
+        // outage retries on the next login rather than pinning the tolerant default for the whole TTL.
+        http.SetResponder(_ => Json(FullDiscovery()));
+        var recovered = await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+        Assert.True(recovered.PkceS256);
+        Assert.True(recovered.ResponseIssuerAdvertised);
+        Assert.Equal(2, http.DiscoveryRequests); // both the failing and the succeeding fetch actually ran
+    }
+
+    [Fact]
+    public async Task ReadFacts_Clear_DropsTheCachedEntry()
+    {
+        var http = new CountingFactory(_ => Json(FullDiscovery()));
+        var cache = new OidcDiscoveryCache();
+
+        await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+        cache.Clear();
+        await cache.ReadFactsAsync(Config(), "kc", http.Factory, Logger());
+
+        Assert.Equal(2, http.DiscoveryRequests); // a cleared cache re-fetches (test-isolation reset works)
+    }
+
+    private static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    // A fetch failure: SendAsync throws, which the cache's fetch surfaces as the tolerant default.
+    private static HttpResponseMessage Throw(HttpRequestMessage request) => throw new HttpRequestException("unreachable");
+
+    // A factory whose every client is backed by the current responder — swappable so a test can start with
+    // a failing fetch and then a succeeding one — that counts the outbound discovery requests it serves.
+    private sealed class CountingFactory
+    {
+        private Func<HttpRequestMessage, HttpResponseMessage> _responder;
+
+        internal CountingFactory(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            _responder = responder;
+            var factory = Substitute.For<IHttpClientFactory>();
+            factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new StubHttpMessageHandler(Handle)));
+            Factory = factory;
+        }
+
+        internal IHttpClientFactory Factory { get; }
+
+        internal int DiscoveryRequests { get; private set; }
+
+        internal void SetResponder(Func<HttpRequestMessage, HttpResponseMessage> responder) => _responder = responder;
+
+        private HttpResponseMessage Handle(HttpRequestMessage request)
+        {
+            DiscoveryRequests++;
+            return _responder(request);
+        }
+    }
+}

--- a/SSO-Auth/Api/DiscoveryFacts.cs
+++ b/SSO-Auth/Api/DiscoveryFacts.cs
@@ -1,0 +1,12 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The two discovery-document facts the OpenID challenge reads in one fetch: PKCE-S256 support (#141) —
+/// true when advertised, false when the document was read but does not advertise it, null when it could
+/// not be fetched/read — and whether the authorization server advertises the RFC 9207 response-<c>iss</c>
+/// parameter (#210), which is tolerant (false) whenever the document could not be read so an unreadable
+/// flag never locks out a provider that omits <c>iss</c>. Produced by <see cref="OidcDiscoveryCache"/>.
+/// </summary>
+/// <param name="PkceS256">Whether the AS advertises PKCE S256; null when discovery could not be read.</param>
+/// <param name="ResponseIssuerAdvertised">Whether the AS advertises the RFC 9207 response-<c>iss</c> parameter.</param>
+internal readonly record struct DiscoveryFacts(bool? PkceS256, bool ResponseIssuerAdvertised);

--- a/SSO-Auth/Api/OidcDiscoveryCache.cs
+++ b/SSO-Auth/Api/OidcDiscoveryCache.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Owns the per-discovery-URL cache of the two OpenID facts the challenge reads from a provider's
+/// discovery document in a single fetch — whether the authorization server advertises PKCE (S256)
+/// (#141, RFC 9700 §2.1.1) and whether it advertises the RFC 9207 response-<c>iss</c> parameter (#210) —
+/// together with the fetch/parse that populates it. Extracted off <see cref="SSOController"/> so the
+/// discovery-fetch/parse/cache logic lives in one testable place (#318, #449).
+///
+/// Bounding: the cache key is the admin-configured provider authority's resolved discovery URL, so the
+/// number of distinct keys equals the number of configured OpenID providers — a small, operator-set
+/// bound, never attacker-supplied. Unlike the anonymous-flood-facing login caches
+/// (<see cref="OidcStateStore"/>, <see cref="SamlRequestCache"/>, which key on CSPRNG tokens), it needs
+/// no hard cap or throttled expired-entry sweep: a stale entry is simply re-fetched and overwritten in
+/// place once its short TTL elapses, so the map never holds more than one entry per provider. Only a
+/// successful fetch is cached, so a transient failure retries on the next login rather than pinning a
+/// tolerant default.
+/// </summary>
+internal sealed class OidcDiscoveryCache
+{
+    // How long a cached entry is served before it is re-fetched. The discovery document changes rarely,
+    // so a login does not re-fetch it every time; the short window bounds how long a provider's changed
+    // metadata stays stale.
+    internal static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(15);
+
+    // Concurrent logins read and refresh this map, so a plain Dictionary would corrupt under the
+    // interleaving. Keyed by the resolved discovery URL with the default (ordinal) comparer — stated
+    // explicitly so the ordinal URL matching is visible. The stored FetchedAt drives the TTL check.
+    private readonly ConcurrentDictionary<string, Entry> _facts = new(StringComparer.Ordinal);
+
+    private readonly TimeSpan _ttl;
+
+    internal OidcDiscoveryCache()
+        : this(DefaultTtl)
+    {
+    }
+
+    // Test constructor: a short TTL makes the staleness/re-fetch path reachable without real time passing.
+    internal OidcDiscoveryCache(TimeSpan ttl)
+    {
+        _ttl = ttl;
+    }
+
+    /// <summary>
+    /// Returns the discovery facts for a provider, serving a still-fresh cached entry when one exists and
+    /// otherwise fetching + parsing the discovery document (the admin-configured authority + the
+    /// well-known path, the same document OidcClient uses). The fetch is bounded by a timeout and never
+    /// throws — a transient failure returns the tolerant default <c>(null, false)</c> WITHOUT caching it,
+    /// so the caller decides (PKCE fails closed only under <c>RequirePkce</c>; response-<c>iss</c> stays
+    /// optional) and the next login retries. Best-effort: it does not replace OidcClient's own discovery,
+    /// which fails the login if the provider is truly down.
+    /// </summary>
+    /// <param name="config">The provider config whose <c>OidEndpoint</c> resolves to the discovery URL.</param>
+    /// <param name="provider">The provider name, for the fetch-failure warning only.</param>
+    /// <param name="httpClientFactory">The shared HTTP client factory the outbound fetch is built over.</param>
+    /// <param name="logger">The logger for the tolerant fetch-failure warning.</param>
+    /// <returns>The discovery facts (a cache hit, a fresh fetch, or the tolerant default on failure).</returns>
+    internal async Task<DiscoveryFacts> ReadFactsAsync(OidConfig config, string provider, IHttpClientFactory httpClientFactory, ILogger logger)
+    {
+        var authority = config.OidEndpoint?.Trim();
+        if (string.IsNullOrEmpty(authority) || !Uri.TryCreate(authority, UriKind.Absolute, out _))
+        {
+            return new DiscoveryFacts(null, false);
+        }
+
+        // OidEndpoint is usually the issuer/authority, but some providers (e.g. PocketID) configure the
+        // full .well-known URL; append the discovery path only when it is not already present, matching
+        // how OidcClient resolves the same document.
+        var trimmed = authority.TrimEnd('/');
+        var discoveryUrl = trimmed.EndsWith("/.well-known/openid-configuration", StringComparison.OrdinalIgnoreCase)
+            ? trimmed
+            : trimmed + "/.well-known/openid-configuration";
+
+        if (_facts.TryGetValue(discoveryUrl, out var cached) && DateTime.UtcNow - cached.FetchedAt < _ttl)
+        {
+            return new DiscoveryFacts(cached.PkceS256, cached.ResponseIssuerAdvertised);
+        }
+
+        try
+        {
+            using var client = SsoHttp.CreateClient(httpClientFactory);
+            client.Timeout = TimeSpan.FromSeconds(10);
+            var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
+            var pkceS256 = PkceDiscovery.SupportsS256(json);
+            var responseIssuerAdvertised = OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json);
+            _facts[discoveryUrl] = new Entry(pkceS256, responseIssuerAdvertised, DateTime.UtcNow);
+            return new DiscoveryFacts(pkceS256, responseIssuerAdvertised);
+        }
+        catch (Exception e)
+        {
+            // The provider name is stripped of line endings inline at the log call so an admin-supplied
+            // value cannot forge or split the entry (the log-forging sanitizer never crosses a helper
+            // boundary).
+            logger.LogWarning(
+                e,
+                "Could not fetch the OpenID discovery document for provider {Provider} to verify PKCE support; proceeding unless RequirePkce is set.",
+                provider?.ReplaceLineEndings(string.Empty));
+            return new DiscoveryFacts(null, false);
+        }
+    }
+
+    /// <summary>Test-only: drops every cached entry so process-wide state cannot leak between tests.</summary>
+    internal void Clear() => _facts.Clear();
+
+    // One cached provider's discovery facts and when they were fetched. PkceS256 is stored non-nullable
+    // because only a definitive fetch result is ever cached — a failure returns the tolerant default and
+    // is not stored, so a cache hit always carries a real answer.
+    private readonly record struct Entry(bool PkceS256, bool ResponseIssuerAdvertised, DateTime FetchedAt);
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -74,13 +73,12 @@ public class SSOController : ControllerBase
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
-    // Cache of the two per-discovery-URL facts the challenge reads in one fetch — PKCE-S256 support (#141)
-    // and whether the AS advertises the RFC 9207 response-`iss` parameter (#210) — so a login does not
-    // fetch discovery every time (the document changes rarely). Only definitive results are cached; a
-    // fetch failure is not cached, so it retries on the next login. The short TTL bounds how long a
-    // provider's changed metadata is stale.
-    private static readonly ConcurrentDictionary<string, (bool PkceS256, bool ResponseIssuerAdvertised, DateTime FetchedAt)> DiscoveryFactsCache = new();
-    private static readonly TimeSpan DiscoveryFactsCacheTtl = TimeSpan.FromMinutes(15);
+    // The per-discovery-URL cache of the two facts the challenge reads in one fetch — PKCE-S256 support
+    // (#141) and whether the AS advertises the RFC 9207 response-`iss` parameter (#210) — plus the
+    // fetch/parse that populates it. One process-wide instance, like the SAML caches above; the TTL,
+    // bounding rationale, and tolerant fail-open-only-under-RequirePkce behaviour all live inside
+    // OidcDiscoveryCache (#449).
+    private static readonly OidcDiscoveryCache DiscoveryCache = new();
 
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
     // (challenge -> IdP login/MFA -> POST back -> mint), matching OidcStateStore.DefaultLifetime.
@@ -258,7 +256,7 @@ public class SSOController : ControllerBase
         // One discovery read yields both facts the challenge needs: PKCE-S256 support (gated below) and
         // whether the AS advertises the RFC 9207 response-`iss` parameter (persisted on the state below,
         // so the callback can require `iss` without a second fetch) (#210).
-        var discoveryFacts = await ReadDiscoveryFactsAsync(config, provider).ConfigureAwait(false);
+        var discoveryFacts = await DiscoveryCache.ReadFactsAsync(config, provider, _httpClientFactory, _logger).ConfigureAwait(false);
         var pkceSupported = discoveryFacts.PkceS256;
         if (pkceSupported == false)
         {
@@ -335,7 +333,7 @@ public class SSOController : ControllerBase
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
-        DiscoveryFactsCache.Clear();
+        DiscoveryCache.Clear();
     }
 
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
@@ -448,52 +446,6 @@ public class SSOController : ControllerBase
         }
 
         return new OidcClient(options);
-    }
-
-    // Fetches the provider's OpenID discovery document and reports the discovery facts. The discovery URL is
-    // the admin-configured authority + the well-known path (the same document OidcClient uses); the fetch
-    // is bounded by a timeout and never throws — a transient failure returns the tolerant default so the
-    // caller decides (PKCE fails closed only under RequirePkce; response-`iss` stays optional). Best-effort:
-    // this does not replace OidcClient's own discovery, which fails the login if the provider is truly down.
-    private async Task<DiscoveryFacts> ReadDiscoveryFactsAsync(OidConfig config, string provider)
-    {
-        var authority = config.OidEndpoint?.Trim();
-        if (string.IsNullOrEmpty(authority) || !Uri.TryCreate(authority, UriKind.Absolute, out _))
-        {
-            return new DiscoveryFacts(null, false);
-        }
-
-        // OidEndpoint is usually the issuer/authority, but some providers (e.g. PocketID) configure the
-        // full .well-known URL; append the discovery path only when it is not already present, matching how
-        // OidcClient resolves the same document.
-        var trimmed = authority.TrimEnd('/');
-        var discoveryUrl = trimmed.EndsWith("/.well-known/openid-configuration", StringComparison.OrdinalIgnoreCase)
-            ? trimmed
-            : trimmed + "/.well-known/openid-configuration";
-
-        if (DiscoveryFactsCache.TryGetValue(discoveryUrl, out var cached) && DateTime.UtcNow - cached.FetchedAt < DiscoveryFactsCacheTtl)
-        {
-            return new DiscoveryFacts(cached.PkceS256, cached.ResponseIssuerAdvertised);
-        }
-
-        try
-        {
-            using var client = SsoHttp.CreateClient(_httpClientFactory);
-            client.Timeout = TimeSpan.FromSeconds(10);
-            var json = await client.GetStringAsync(discoveryUrl).ConfigureAwait(false);
-            var pkceS256 = PkceDiscovery.SupportsS256(json);
-            var responseIssuerAdvertised = OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json);
-            DiscoveryFactsCache[discoveryUrl] = (pkceS256, responseIssuerAdvertised, DateTime.UtcNow);
-            return new DiscoveryFacts(pkceS256, responseIssuerAdvertised);
-        }
-        catch (Exception e)
-        {
-            _logger.LogWarning(
-                e,
-                "Could not fetch the OpenID discovery document for provider {Provider} to verify PKCE support; proceeding unless RequirePkce is set.",
-                provider?.ReplaceLineEndings(string.Empty));
-            return new DiscoveryFacts(null, false);
-        }
     }
 
     // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls
@@ -1521,11 +1473,4 @@ public class SSOController : ControllerBase
         Response.Headers.CacheControl = "no-store";
         return Content(render(nonce), MediaTypeNames.Text.Html);
     }
-
-    // The two discovery-document facts the challenge reads in one fetch: PKCE-S256 support (#141) — true
-    // when advertised, false when the document was read but does not advertise it, null when it could not
-    // be fetched/read — and whether the AS advertises the RFC 9207 response-`iss` parameter (#210), which
-    // is tolerant (false) whenever the document could not be read so an unreadable flag never locks out a
-    // provider that omits `iss`.
-    private readonly record struct DiscoveryFacts(bool? PkceS256, bool ResponseIssuerAdvertised);
 }


### PR DESCRIPTION
# What & why

Extract the OpenID discovery-facts cache out of `SSOController` into its own
internal sealed `OidcDiscoveryCache`, and retire the conformance exemption that
covered it. Closes #449 (part of the #318 thin-controller direction; coordinates
with #160/#141/#210).

The controller held a raw `ConcurrentDictionary` (`DiscoveryFactsCache`) plus a
`ReadDiscoveryFactsAsync` method that fetched a provider's discovery document and
cached the two facts the challenge reads in one fetch, PKCE-S256 support (#141,
RFC 9700 §2.1.1) and whether the AS advertises the RFC 9207 response-`iss`
parameter (#210). It lived behind a documented
`MutableKeyedState_LivesOnlyInsideStoreLikeTypes` exemption noting it would move
into its own type in a later #318 step. This is that step: now that the cache
holds two facts and owns the fetch/parse, the case to consolidate it is stronger.

What changed:

- New `OidcDiscoveryCache` (a `*Cache` type per the target layering) owns the
  keyed cache, the 15-minute TTL, the discovery-URL derivation, and the
  timeout-bounded fetch/parse. The controller keeps one process-wide
  `static readonly` instance (like the SAML caches) and delegates via
  `ReadFactsAsync(config, provider, httpClientFactory, logger)`.
- `DiscoveryFacts` moves to its own file.
- The `SSOController.DiscoveryFactsCache` exemption is removed from
  `MutableKeyedState_LivesOnlyInsideStoreLikeTypes`, so the rule now covers the
  extracted cache structurally (it ends in `Cache`) and still catches any new
  raw dictionary added to the controller.
- New focused unit tests for the cache; `ARCHITECTURE.md` updated.

Behaviour is preserved: the fetch/parse/URL-derivation/TTL logic moved verbatim,
a within-TTL read is served without a re-fetch, a stale entry re-fetches, only a
definitive result is cached (a transient failure returns the tolerant default
without caching, so the next login retries), and the #341/#247
Pending-construction reuse path is untouched.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the PKCE gate still reads the same
      `DiscoveryFacts` values, so `RequirePkce` + not-advertised (false) and
      `RequirePkce` + unreadable (null) both still reject; response-`iss` stays
      optional exactly as before.
- [x] No secrets logged; the cache holds only two booleans and a timestamp keyed
      by a discovery URL — no secrets cached or logged.
- [x] A security review was performed (adversarial 4-lens gate; see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call: the
      fetch-failure warning keeps `provider?.ReplaceLineEndings(string.Empty)`
      inline, so the sanitizer never crosses a helper boundary.

## Quality checklist

- [x] No duplicated logic; the discovery-fetch/parse/cache logic now lives in one
      small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires (a straight
      extraction plus its tests).
- [x] The code is self-documenting and matches the target architecture (#318);
      comments explain the bounding rationale and the fail-closed "why".
- [x] Architecture-conformance tests pass; the tightened
      `MutableKeyedState_LivesOnlyInsideStoreLikeTypes` (exemption removed) is
      the locked-in structural property this change establishes.

## Verification

- [x] `dotnet build --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (1004 passed, +8 new).
- [x] Prettier is clean for the `.md` change; no `.js`/`.html`/`.css` touched.
- [x] Jellyfin compatibility metadata check is consistent (no metadata changed).

## Notes

Bounding decision: the cache key is the admin-configured provider's resolved
discovery URL (reached only after `config is { Enabled: true }`), so the map
holds at most one entry per configured provider, never attacker-supplied. Unlike
the anonymous-flood-facing login caches (`OidcStateStore`, `SamlRequestCache`,
which key on CSPRNG tokens and carry a hard cap + `IntervalGate`-throttled sweep),
`OidcDiscoveryCache` needs neither: a stale entry is re-fetched and overwritten in
place. It is therefore deliberately NOT added to
`LoginPathCaches_ThrottleTheirExpiredEntrySweepThroughIntervalGate`; documented on
the type.

Adversarial self-review, four refute-by-default lenses, all PASS:

- Availability / mass-lockout, VERDICT: growth bound is unchanged (one entry per
  admin-configured provider, not attacker-supplied), the 15-min TTL still serves
  within-TTL hits without a fetch (no re-fetch storm), failures are not cached
  (retry, matching the prior tolerant behaviour), and the test-only zero-TTL
  constructor cannot reach production. PASS.
- Security-bypass, VERDICT: the PKCE gate and response-`iss` handling see the
  identical `DiscoveryFacts`; TLS trust is unchanged (same `SsoHttp.CreateClient`,
  same 10s timeout); no secrets cached/logged; the log-forging sanitizer stays
  inline. No weakened PKCE/discovery trust. PASS.
- Correctness, VERDICT: URL derivation, TTL comparison, only-definitive-caching,
  and the tolerant `(null, false)` default all moved verbatim; unit tests pin the
  cache-hit, stale-refetch, definite-false, unusable-endpoint, no-double-append,
  failure-not-cached, and clear paths. Cache key + reuse semantics identical. PASS.
- Integration, VERDICT: the #341/#247 reuse (Pending built with
  `ProviderInformation` + `ResponseIssuerAdvertised` at construction) is untouched;
  the conformance exemption removal leaves the full suite green; the harness reset
  still clears discovery state between tests. PASS.
