### PR TITLE
Route rate-limit rejection through LoginOutcome.Throttled

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -472,6 +472,38 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void RateLimiting_FlowsThroughLoginOutcome()
+    {
+        // Locked in by #474: the rate-limit rejection was the last login-path error that bypassed the single
+        // mapper. It now flows as LoginOutcome.Throttled through LoginStatusMapper, which is the ONE place the
+        // 429 status and its Retry-After header are emitted — so a CONTROLLER neither returns a bare rate-limit
+        // ContentResult nor sets Retry-After itself. Call-level property, so it is a source scan like the other
+        // controller rules above. Markers are the emission tokens, not prose: the 429 status constant, the
+        // typed IHeaderDictionary accessor (".RetryAfter" — the leading dot excludes the "retryAfterSeconds"
+        // local the controller still passes into the outcome), and the raw header-name literal.
+        var markers = new[] { "Status429TooManyRequests", ".RetryAfter", "Retry-After" };
+        var offenders = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => markers.Any(m => l.Text.Contains(m, StringComparison.Ordinal)))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "A controller must not emit a rate-limit 429 or set Retry-After directly; route the rejection through LoginOutcome.Throttled and LoginStatusMapper (#474). Found: " + string.Join(" | ", offenders));
+
+        // Liveness against a vacuous pass: the 429 + Retry-After must actually live in the mapper — a move,
+        // not a silent removal — so LoginStatusMapper's own source must emit both.
+        var mapperSource = string.Join(
+            "\n",
+            SourceFilesDeclaring(new[] { typeof(LoginStatusMapper) }).Select(File.ReadAllText));
+        Assert.True(
+            mapperSource.Contains("Status429TooManyRequests", StringComparison.Ordinal) && mapperSource.Contains("RetryAfter", StringComparison.Ordinal),
+            "LoginStatusMapper must own the rate-limit 429 and its Retry-After header; otherwise the controller scan passes vacuously (#474).");
+    }
+
+    [Fact]
     public void LegacyLinkMigration_ReturnsTheAuthoritativeMapping_NotAVoidReKey()
     {
         // Locked in by #363: the #155 legacy-link re-key runs as a SECOND lock acquisition after the

--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using MediaBrowser.Controller.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -99,5 +100,49 @@ public class LoginStatusMapperTests
         var result = Assert.IsType<OkObjectResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Success(session)));
 
         Assert.Same(session, result.Value);
+    }
+
+    [Fact]
+    public void Throttled_MapsToThe429WithRetryAfter_ByteIdenticalToTheFormerDirectEmission()
+    {
+        // Characterization of the pre-#474 rate-limit response, now produced only by the mapper: a 429 with
+        // the fixed plain-text body and the whole-seconds Retry-After header set to the outcome's value. A
+        // fixed retryAfterSeconds keeps the header assertion deterministic (the controller path derives the
+        // number from the clock; the exact string it emits is what this pins).
+        var response = new DefaultHttpContext().Response;
+
+        var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(42), response));
+
+        Assert.Equal(429, result.StatusCode);
+        Assert.Equal("Too many login attempts. Please wait a moment and try again.", result.Content);
+        Assert.Equal("text/plain", result.ContentType);
+        Assert.Equal("42", response.Headers.RetryAfter.ToString());
+    }
+
+    [Fact]
+    public void Throttled_ThroughThePureOverload_ThrowsInsteadOfEmittingA429WithoutRetryAfter()
+    {
+        // Fail closed: the pure overload cannot set Retry-After, so a Throttled that reaches it is a wiring
+        // fault and throws (500) rather than silently shipping a 429 with no retry hint.
+        Assert.Throws<InvalidOperationException>(() =>
+            LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(5)));
+    }
+
+    [Fact]
+    public void ResponseAwareOverload_DefersNonThrottledOutcomes_AndSetsNoRetryAfter()
+    {
+        // The response-aware overload is a superset a caller can route every outcome through: a non-Throttled
+        // outcome maps exactly as the pure overload does and leaves the response untouched (no Retry-After).
+        var response = new DefaultHttpContext().Response;
+
+        var denied = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Denied(), response));
+        Assert.Equal(401, denied.StatusCode);
+        Assert.Equal("Error. Check permissions.", denied.Content);
+
+        var session = new AuthenticationResult();
+        var success = Assert.IsType<OkObjectResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Success(session), response));
+        Assert.Same(session, success.Value);
+
+        Assert.False(response.Headers.ContainsKey("Retry-After"));
     }
 }

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -218,9 +218,19 @@ public class SSOControllerChallengeTests
         // then rejects with the uniform 400, but that is after the budget is spent.
         Assert.Equal(400, Assert.IsType<ContentResult>(harness.Controller.SamlChallenge("does-not-exist")).StatusCode);
 
-        // The second is over budget and is throttled with a 429 before the provider is even looked up.
-        var throttled = harness.Controller.SamlChallenge("does-not-exist");
-        Assert.Equal(429, Assert.IsType<ContentResult>(throttled).StatusCode);
+        // The second is over budget and is throttled before the provider is even looked up. The whole
+        // response shape is characterized here (#474): after routing through LoginOutcome.Throttled and the
+        // single mapper it must stay byte-identical — a 429, the fixed plain-text body, and a Retry-After
+        // header whose value falls within the configured window.
+        var throttled = Assert.IsType<ContentResult>(harness.Controller.SamlChallenge("does-not-exist"));
+        Assert.Equal(429, throttled.StatusCode);
+        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+        Assert.Equal("text/plain", throttled.ContentType);
+
+        var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
+        Assert.True(
+            int.TryParse(retryAfter, out var seconds) && seconds >= 1 && seconds <= 60,
+            $"Retry-After must be whole seconds within the 60s window; was '{retryAfter}'.");
     }
 
     [Fact]

--- a/SSO-Auth/Api/LoginOutcome.cs
+++ b/SSO-Auth/Api/LoginOutcome.cs
@@ -31,4 +31,13 @@ internal abstract record LoginOutcome
     /// every denial maps to the one uniform 401 body, so a cause cannot leak even by construction.
     /// </summary>
     internal sealed record Denied : LoginOutcome;
+
+    /// <summary>
+    /// The rate limiter refused an over-budget anonymous request (#128, #474). Unlike the other cases the
+    /// mapper needs the response to carry the Retry-After header, so a Throttled outcome is rendered through
+    /// <see cref="LoginStatusMapper.ToActionResult(LoginOutcome, Microsoft.AspNetCore.Http.HttpResponse)"/>;
+    /// the 429 status, plain-text body and Retry-After value are byte-identical to the pre-#474 direct emission.
+    /// </summary>
+    /// <param name="RetryAfterSeconds">Whole seconds until the client's rate-limit window resets.</param>
+    internal sealed record Throttled(int RetryAfterSeconds) : LoginOutcome;
 }

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Net.Mime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -8,8 +9,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <summary>
 /// The single translation from a <see cref="LoginOutcome"/> to an HTTP response. Rejection bodies
 /// are plain text and deliberately uniform per category, so a response does not reveal why it was
-/// rejected beyond what the category already states publicly — the server log disambiguates. The
-/// rate-limit 429 stays with the rate limiter until the filter step (Retry-After needs the response).
+/// rejected beyond what the category already states publicly — the server log disambiguates. This is
+/// also the one place the rate-limit 429 and its Retry-After header are emitted (#474): a Throttled
+/// outcome carries the delay and is rendered through the response-aware overload, which owns the header.
 /// </summary>
 internal static class LoginStatusMapper
 {
@@ -23,14 +25,40 @@ internal static class LoginStatusMapper
     /// </summary>
     internal const string NoMatchingProviderMessage = "No matching provider found";
 
+    /// <summary>
+    /// The rate-limit 429 body (#128, #474) — deliberately human-readable rather than a bare status, since
+    /// the challenge/callback endpoints are navigated directly in the browser and a blank 429 would look
+    /// like a broken login (the XHR auth page reads the status, not this body). The Retry-After header
+    /// carries the machine-readable delay.
+    /// </summary>
+    internal const string RateLimitedMessage = "Too many login attempts. Please wait a moment and try again.";
+
     internal static ActionResult ToActionResult(LoginOutcome outcome) => outcome switch
     {
         LoginOutcome.Success success => new OkObjectResult(success.Session),
         LoginOutcome.Denied => Emit(StatusCodes.Status401Unauthorized, PermissionDeniedMessage),
         LoginOutcome.Rejected rejected => ToActionResult(rejected.Reason),
+        // Throttled carries a Retry-After header this pure overload cannot set; it must be rendered through
+        // ToActionResult(outcome, response). Reaching here is a wiring fault, so it throws (500) rather than
+        // silently emitting a 429 without the header — fail closed, never a default-accept.
+        LoginOutcome.Throttled => throw new InvalidOperationException("Throttled must be mapped through the response-aware overload so Retry-After is set."),
         // Unreachable while the sum stays closed, but the compiler cannot prove it; an impossible
         // case is a genuine server fault, so it throws (500) — never a default-accept.
         _ => throw new InvalidOperationException($"Unhandled login outcome: {outcome.GetType().Name}"),
+    };
+
+    /// <summary>
+    /// Renders an outcome that may need the response. The only such case is <see cref="LoginOutcome.Throttled"/>,
+    /// whose 429 carries a Retry-After header — this is the single place that header is set. Every other outcome
+    /// defers to the pure overload unchanged, so a caller can route all outcomes through this one.
+    /// </summary>
+    /// <param name="outcome">The login outcome to translate.</param>
+    /// <param name="response">The response whose Retry-After header a Throttled outcome sets.</param>
+    /// <returns>The HTTP action result.</returns>
+    internal static ActionResult ToActionResult(LoginOutcome outcome, HttpResponse response) => outcome switch
+    {
+        LoginOutcome.Throttled throttled => Throttle(throttled.RetryAfterSeconds, response),
+        _ => ToActionResult(outcome),
     };
 
     private static ContentResult ToActionResult(PublicReason reason) => reason switch
@@ -46,6 +74,15 @@ internal static class LoginStatusMapper
         // enumerating every member catches it before it can ship — never a fall-through.
         _ => throw new InvalidOperationException($"Unmapped public reason: {reason}"),
     };
+
+    // The rate-limit 429, byte-identical to the pre-#474 direct emission at the controller: the same
+    // plain-text body via Emit plus the machine-readable Retry-After. This is the ONLY place Retry-After
+    // is set, so the single-error-emission-point invariant now covers the last login-path error too.
+    private static ContentResult Throttle(int retryAfterSeconds, HttpResponse response)
+    {
+        response.Headers.RetryAfter = retryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        return Emit(StatusCodes.Status429TooManyRequests, RateLimitedMessage);
+    }
 
     // Reproduces the controller's ReturnError shape exactly (ContentResult, text/plain), so every
     // converted call site is byte-identical on the wire.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -1321,14 +1321,14 @@ public class SSOController : ControllerBase
     };
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
-    // request may proceed, else a 429 carrying Retry-After. Reads the settings under the config
-    // lock; an unattributable or non-public client is never throttled (fail open, availability
-    // over throttling). Keys on RemoteIpAddress only — proxy attribution is the host's job
-    // (Jellyfin's "Known proxies" setting resolves the real client into it); see
+    // request may proceed, else the throttled outcome rendered by the single mapper (#474). Reads the
+    // settings under the config lock; an unattributable or non-public client is never throttled (fail
+    // open, availability over throttling). Keys on RemoteIpAddress only — proxy attribution is the
+    // host's job (Jellyfin's "Known proxies" setting resolves the real client into it); see
     // SsoRateLimiter.NormalizeClientKey. The endpoint class (challenge/callback/auth) is part of
     // the key so one login — which hits all three — gets the full budget at each stage rather
     // than a third of it, keeping the default generous for shared egress addresses (NAT/CGNAT).
-    private ContentResult RateLimitCheck(string endpointClass)
+    private ActionResult RateLimitCheck(string endpointClass)
     {
         var (enabled, maxAttempts, windowSeconds) = SSOPlugin.Instance.ReadConfiguration(
             c => (c.EnableRateLimit, c.RateLimitMaxAttempts, c.RateLimitWindowSeconds));
@@ -1360,11 +1360,10 @@ public class SSOController : ControllerBase
             _logger.LogWarning("SSO rate limit engaged on the anonymous login endpoints: {Count} request(s) throttled since the last notice; further notices are suppressed for at least a minute.", throttledCount);
         }
 
-        // A human-readable body, not a bare status: the challenge/callback endpoints are navigated
-        // directly in the browser, so a blank 429 would look like a broken login (the XHR auth page
-        // reads the status, not this body). Retry-After carries the machine-readable delay.
-        Response.Headers.RetryAfter = retryAfterSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        return ReturnError(StatusCodes.Status429TooManyRequests, "Too many login attempts. Please wait a moment and try again.");
+        // The rejection is expressed as a LoginOutcome and rendered by the single mapper (#474): the
+        // status, plain-text body and the retry-delay header all originate there, so the controller no
+        // longer emits a bare rate-limit ContentResult or sets the delay header itself.
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(retryAfterSeconds), Response);
     }
 
     // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.


### PR DESCRIPTION
# What & why

The rate-limit 429 was the last login-path error that bypassed the single
`LoginStatusMapper`: `RateLimitCheck` returned a bare `ContentResult` and set the
`Retry-After` header on the controller itself. This routes the rejection through
the outcome/mapper currency every other login result already uses, so the mapper
is the one error-emission point and `Retry-After` is set in exactly one place
(#318 step 9, first sub-issue).

- Add `LoginOutcome.Throttled(RetryAfterSeconds)`, the closed sum's own doc
  comment already reserved this case.
- Add `LoginStatusMapper.ToActionResult(LoginOutcome, HttpResponse)`: its
  `Throttled` arm sets `Retry-After` and emits the 429; every other outcome
  defers to the pure overload, so a caller can route all outcomes through it. The
  pure overload throws on `Throttled` (it cannot set the header), a mis-routed
  `Throttled` fails closed as a genuine 500, never a header-less 429. Both
  switches stay exhaustive with no default-accept arm.
- `RateLimitCheck` now returns the mapped outcome (`ActionResult`); the bare
  `ContentResult` and the direct `Retry-After` write are removed. `SsoRateLimiter`
  and the IP classifier are untouched, this changes **how** the rejection is
  expressed, not **when** it fires.
- Behaviour-preserving: the 429 status, plain-text body and `Retry-After` value
  are byte-identical to the previous direct emission.

Closes #474

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (The mapper switches are exhaustive; a
      `Throttled` reaching the pure overload throws a 500 rather than emitting a
      header-less 429 — no default-accept arm exists.)
- [x] No secrets logged; secrets are redacted on config export. (The observability
      log line is unchanged and carries only an aggregate count.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review —
      see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new log
      calls; the one existing line is unchanged.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (One `Throttle` helper; the 429 body/shape reuse the
      existing `Emit`.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (New rule `RateLimiting_FlowsThroughLoginOutcome`.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (1008 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None touched.)

## Notes

**Byte-identical proof.** Old controller emission set
`Response.Headers.RetryAfter = retryAfterSeconds.ToString(InvariantCulture)` and
returned `ReturnError(429, "Too many login attempts. Please wait a moment and try
again.")` (`ContentResult`, `text/plain`). The mapper's `Throttle` sets the same
header value/format and returns `Emit(429, RateLimitedMessage)`, where
`RateLimitedMessage` is the same literal character-for-character and `Emit`
reproduces the identical `ContentResult` shape. Pinned by
`LoginStatusMapperTests.Throttled_MapsToThe429WithRetryAfter_ByteIdenticalToTheFormerDirectEmission`
(deterministic unit characterization) and the end-to-end
`SSOControllerChallengeTests.SamlChallenge_OverRateLimit_Returns429`.

**Adversarial review, four lenses, all PASS.**

- **Availability / mass-lockout, PASS.** `SsoRateLimiter` and `NormalizeClientKey`
  are byte-for-byte unchanged (diff empty); the disabled and allowed paths still
  return null; the change only re-expresses an already-decided rejection. No new
  over-throttle or lockout risk.
- **Security-bypass / fail-open, PASS.** The `Throttled` case cannot fall through
  to a 200; the pure overload throws (fail closed) rather than emitting a
  header-less 429; both switches stay exhaustive with no default-accept arm;
  `RateLimitCheck` returns non-null exactly on refusal.
- **Correctness, PASS.** Status, body, content-type and `Retry-After`
  value/format proven byte-identical statement-by-statement; the message constant
  matches the old literal exactly; unit and integration tests pin every wire
  attribute.
- **Integration, PASS.** All six `RateLimitCheck` call sites (OIDC OidPost/
  OidChallenge/OidAuth, SAML SamlPost/SamlChallenge/SamlAuth) accept the
  `ContentResult -> ActionResult` widening; both mapper overloads are total over
  the full sum; the new conformance rule catches a controller re-introduction
  without false-positiving on the surviving `retryAfterSeconds` local, with a
  mapper-liveness guard.

**Out of scope.** The pre-existing documented fail-open in the limiter (an
unattributable/non-public client is never throttled, #128) is unchanged and not
touched here.
