### PR TITLE
Extract the OpenID login flow into OidcLoginService

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -472,6 +472,46 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void Controller_DelegatesOidcFlowToTheFlowService()
+    {
+        // Locked in by the OpenID flow extraction (#160, #318 step 12): the OpenID challenge and redirect
+        // callback bodies, together with the OpenID-specific process-wide state (the in-flight authorize
+        // store and the discovery-facts cache), moved into OidcLoginService. The controller's OpenID
+        // endpoints now apply the shared rate-limit gate and hand the request to that service, so a
+        // CONTROLLER neither holds those OIDC caches nor drives the OidcClient challenge/callback protocol
+        // itself. Call-level property, so it is a source scan like the other controller rules above.
+        //
+        // The two cache tokens are nameof-derived, so a rename of either type fails to COMPILE this rule
+        // rather than passing vacuously; the two protocol tokens are the OidcClient methods the challenge
+        // (PrepareLoginAsync) and callback (ProcessResponseAsync) drive. The shared per-client rate limiter
+        // is deliberately NOT a marker — it fronts BOTH protocols, so it legitimately stays a controller
+        // static and its extraction is out of scope for this step.
+        var storeToken = nameof(OidcStateStore);
+        var cacheToken = nameof(OidcDiscoveryCache);
+        var markers = new[] { storeToken, cacheToken, "PrepareLoginAsync", "ProcessResponseAsync" };
+
+        var controllerHits = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => markers.Any(m => l.Text.Contains(m, StringComparison.Ordinal)))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            controllerHits.Count == 0,
+            "A controller must not hold the OpenID authorize/discovery caches or drive the OidcClient challenge/callback protocol; the OpenID flow lives in OidcLoginService (#160). Found: " + string.Join(" | ", controllerHits));
+
+        // Liveness against a vacuous pass: the OpenID flow must actually live in OidcLoginService — a move,
+        // not a silent removal — so the flow service's own source must contain every moved token.
+        var oidcSource = string.Join(
+            "\n",
+            SourceFilesDeclaring(new[] { typeof(OidcLoginService) }).Select(File.ReadAllText));
+        Assert.True(
+            markers.All(m => oidcSource.Contains(m, StringComparison.Ordinal)),
+            "OidcLoginService must own the OpenID challenge/callback flow and its authorize/discovery caches; otherwise the controller scan passes vacuously (#160).");
+    }
+
+    [Fact]
     public void RateLimiting_FlowsThroughLoginOutcome()
     {
         // Locked in by #474: the rate-limit rejection was the last login-path error that bypassed the single

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct unit tests of <see cref="OidcLoginService"/>, the OpenID flow extracted off the controller
+/// (#160, #318 step 12). The end-to-end challenge/callback/authenticate/link behaviour is still exercised
+/// through the thin controller endpoints in <see cref="SSOControllerOidPostTests"/>,
+/// <see cref="SSOControllerOidAuthTests"/> and <see cref="SSOControllerLinkTests"/> (each endpoint is now a
+/// one-line delegation, so a passing controller test is a passing service test); these add coverage that
+/// targets the service in isolation — the fail-closed guard branches that reject before any collaborator is
+/// touched, and the process-wide-state test hooks that moved with the flow. Uses the non-parallel
+/// <c>SSOController</c> collection because it sets the static <see cref="SSOPlugin.Instance"/>.
+/// </summary>
+[Collection("SSOController")]
+public class OidcLoginServiceTests
+{
+    [Fact]
+    public async Task ChallengeAsync_DisabledProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
+        context.Request.Path = "/sso/OID/start/kc";
+
+        // A disabled provider fails closed before any discovery fetch or authorization request, with the
+        // same uniform body the unknown-provider case gets — so the two cannot be told apart (#318).
+        var result = await service.ChallengeAsync("kc", isLinking: false, context.Request, context.Response);
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
+    }
+
+    [Fact]
+    public async Task ChallengeAsync_UnknownProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(_ => { });
+        context.Request.Path = "/sso/OID/start/nope";
+
+        var result = await service.ChallengeAsync("nope", isLinking: false, context.Request, context.Response);
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_MissingData_ReturnsBadRequest()
+    {
+        var (service, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var result = await service.AuthenticateAsync("kc", new AuthResponse(), bindingCookie: null, () => "127.0.0.1");
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_UnknownState_RejectsAsInvalidState()
+    {
+        var (service, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        // No state was seeded, so the redeem misses — a client-caused 400, the same body an expired or
+        // replayed state gets, so a replay stays indistinguishable from an expiry.
+        var result = await service.AuthenticateAsync("kc", new AuthResponse { Data = "no-such-state" }, bindingCookie: null, () => "127.0.0.1");
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Invalid or expired state", content.Content);
+    }
+
+    [Fact]
+    public void StateSummaries_ReflectSeededState_AndResetClearsThem()
+    {
+        var (service, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = "seed-1" }, "kc", isLinking: false, DateTime.Now, "binding", clientKey: null, providerInformation: null, responseIssuerRequired: false);
+        OidcLoginService.SeedOidStateForTests("seed-1", pending);
+
+        Assert.Contains(service.StateSummaries(), s => s.Provider == "kc" && !s.Valid);
+
+        // The reset hook moved with the statics; it must drop the seeded state so it cannot leak between tests.
+        OidcLoginService.ResetOidStateForTests();
+        Assert.Empty(service.StateSummaries());
+    }
+
+    // Builds an OidcLoginService over the same collaborator graph the controller constructs, against a
+    // freshly-bootstrapped SSOPlugin.Instance seeded via the configure callback and a DefaultHttpContext for
+    // the request/response the challenge reads and writes. The harness resets the process-wide OpenID state,
+    // so each test starts clean.
+    private static (OidcLoginService Service, DefaultHttpContext Context) Build(Action<PluginConfiguration> configure)
+    {
+        var harness = new SsoControllerHarness(configure);
+        var logger = Substitute.For<ILogger>();
+
+        var canonicalLinks = new CanonicalLinkService(harness.UserManager, new FakeCryptoProvider(), SSOPlugin.Instance.ConfigStore, logger);
+        var avatarService = new AvatarService(harness.UserManager, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), logger, SsoHttp.UserAgent);
+        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, Substitute.For<ISessionManager>(), logger);
+        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, logger);
+        var service = new OidcLoginService(loginCompletion, canonicalLinks, Substitute.For<IHttpClientFactory>(), Substitute.For<ILoggerFactory>(), logger);
+
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("jf.example.com");
+        return (service, context);
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Net;
 using Microsoft.AspNetCore.Http;
@@ -198,7 +199,7 @@ public class SSOControllerLinkTests
     {
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         // The OID link path redeems an authorize state the redirect leg validated; seed a redeemable one.
-        SSOController.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
 
@@ -217,7 +218,7 @@ public class SSOControllerLinkTests
         // rejection mirrors OidAuth's short-circuit order and shares the unknown-provider response, so
         // the two cases cannot be probed apart.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = false });
-        SSOController.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
 
@@ -240,7 +241,7 @@ public class SSOControllerLinkTests
         // different browser's binding cookie is refused, and — the binding check preceding the atomic
         // remove — the state is NOT consumed, so the browser that started the flow can still link.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
-        SSOController.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
         // A wrong-browser callback: overwrite the matching cookie ForCaller set with a different id.

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
@@ -153,7 +154,7 @@ public class SSOControllerOidAuthTests
             new OidcAuthorizeStateBuilder.OidcAuthorizeState(
                 Username: "alice", Subject: "sub-1", EmailVerified: null, Valid: true, Admin: false,
                 EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>(), AvatarUrl: null));
-        SSOController.SeedOidStateForTests(token, ready);
+        OidcLoginService.SeedOidStateForTests(token, ready);
 
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
         harness.UserManager.CreateUserAsync("alice").Returns(user);

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -419,7 +420,7 @@ public class SSOControllerOidPostTests
         // parameter (#210), so the callback must require iss; false is the tolerant default (the challenge
         // capture path itself is pinned end-to-end by OidChallengeToCallback_* below). Seeded as a Pending:
         // the callback derives the login and promotes it to a Ready (#341).
-        SSOController.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: responseIssuerRequired));
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: responseIssuerRequired));
 
         return harness;
     }

--- a/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
+++ b/SSO-Auth.Tests/SSOControllerScopeStringTests.cs
@@ -1,12 +1,13 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Pins <see cref="SSOController.BuildScopeString"/> — the shared OpenID scope-string builder used by
+/// Pins <see cref="OidcLoginService.BuildScopeString"/> — the shared OpenID scope-string builder used by
 /// both the challenge and the callback client. Guards #368: a provider stored without scopes leaves
 /// <see cref="OidConfig.OidScopes"/> null, which previously threw an unhandled 500 on the anonymous
 /// challenge (<c>OidScopes.Prepend</c> on null) and null-padded the callback scope string
@@ -20,7 +21,7 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = null };
 
-        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile", OidcLoginService.BuildScopeString(config));
     }
 
     [Fact]
@@ -28,7 +29,7 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = Array.Empty<string>() };
 
-        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile", OidcLoginService.BuildScopeString(config));
     }
 
     [Fact]
@@ -36,7 +37,7 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = new[] { "email", "groups" } };
 
-        Assert.Equal("openid profile email groups", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile email groups", OidcLoginService.BuildScopeString(config));
     }
 
     [Fact]
@@ -44,7 +45,7 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = new[] { "email", null } };
 
-        Assert.Equal("openid profile email", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile email", OidcLoginService.BuildScopeString(config));
     }
 
     [Fact]
@@ -52,7 +53,7 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = new[] { "", "groups" } };
 
-        Assert.Equal("openid profile groups", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile groups", OidcLoginService.BuildScopeString(config));
     }
 
     [Fact]
@@ -60,6 +61,6 @@ public class SSOControllerScopeStringTests
     {
         var config = new OidConfig { OidScopes = new[] { "", " ", null } };
 
-        Assert.Equal("openid profile", SSOController.BuildScopeString(config));
+        Assert.Equal("openid profile", OidcLoginService.BuildScopeString(config));
     }
 }

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Http;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Configuration;
@@ -45,10 +46,10 @@ internal sealed class SsoControllerHarness
         IPAddress? clientIp = null,
         Func<HttpRequestMessage, HttpResponseMessage>? httpResponder = null)
     {
-        // The controller keeps process-wide OpenID caches as private statics; clear them so a prior test
-        // that exercised the login flow cannot leak in-flight state into this one (#289). The
+        // The OpenID flow keeps process-wide caches as statics on OidcLoginService; clear them so a prior
+        // test that exercised the login flow cannot leak in-flight state into this one (#289). The
         // outstanding-SAML-request cache is the same kind of static and is cleared for the same reason (#415).
-        SSOController.ResetOidStateForTests();
+        OidcLoginService.ResetOidStateForTests();
         SSOController.ResetSamlRequestsForTests();
 
         Configuration = new PluginConfiguration();

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -1,0 +1,499 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Mime;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Providers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
+
+/// <summary>
+/// The OpenID login flow, extracted whole off <see cref="SSOController"/> (#160, #318 step 12): the
+/// challenge (redirect the browser to the authorization server), the redirect callback (exchange the code,
+/// validate the id_token, render the intermediate auth page), the session-minting authenticate leg, and the
+/// manual link redeem. The controller's OpenID endpoints are now thin adapters — they apply the shared
+/// rate-limit gate and hand the request to this service — so the OpenID-specific protocol logic lives in one
+/// flow-tier collaborator rather than inline on the controller.
+/// </summary>
+/// <remarks>
+/// The two OpenID-specific process-wide caches live here as <c>static readonly</c> fields, one instance for
+/// the whole process exactly as they were on the controller (a fresh per-request controller reconstructs the
+/// service, so an instance field would lose the in-flight state between the challenge and its callback):
+/// <list type="bullet">
+/// <item>the in-flight authorize-state store (<see cref="OidcStateStore"/>), and</item>
+/// <item>the discovery-facts cache (<see cref="OidcDiscoveryCache"/>).</item>
+/// </list>
+/// The shared per-client rate limiter is deliberately NOT here — it also fronts the SAML flow, so it stays a
+/// controller static both flows reach through the controller's rate-limit gate. Because the challenge and
+/// callback are irreducibly HTTP (cookies, query string, redirect, the intermediate page), those two methods
+/// take the request/response and, for the two response shapes the controller still owns (the security-headered
+/// auth page and the manual-link write mapping), a delegate the controller binds — rather than duplicating the
+/// controller's <c>ControllerBase</c> result construction here. The mint tail stays HttpContext-free like
+/// <see cref="LoginCompletionService"/>: the authenticate leg takes only the redeemed model, the presented
+/// binding cookie value, and the remote-endpoint resolver (#177).
+/// </remarks>
+internal sealed class OidcLoginService
+{
+    // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal all
+    // live inside; see OidcStateStore). One process-wide instance, like the discovery cache below and the
+    // SAML caches the controller keeps.
+    private static readonly OidcStateStore StateStore = new();
+
+    // The per-discovery-URL cache of the two facts the challenge reads in one fetch — PKCE-S256 support
+    // (#141) and whether the AS advertises the RFC 9207 response-`iss` parameter (#210) — plus the
+    // fetch/parse that populates it. One process-wide instance; the TTL, bounding rationale, and tolerant
+    // fail-open-only-under-RequirePkce behaviour all live inside OidcDiscoveryCache (#449).
+    private static readonly OidcDiscoveryCache DiscoveryCache = new();
+
+    // The shared login-completion tail (#160): resolve/adopt the link, build the session parameters, mint
+    // under the revocation gate, audit, map to a LoginOutcome. Both protocols funnel their verified identity
+    // into it, so it is a shared collaborator this service holds a reference to rather than owning.
+    private readonly LoginCompletionService _loginCompletion;
+
+    // The account-linking workflow (resolve/adopt/create, legacy re-key, revoke). Used here only by the OID
+    // manual-link redeem; the controller keeps the authz guards and the HTTP mapping around it (#318).
+    private readonly CanonicalLinkService _canonicalLinks;
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _logger;
+
+    internal OidcLoginService(
+        LoginCompletionService loginCompletion,
+        CanonicalLinkService canonicalLinks,
+        IHttpClientFactory httpClientFactory,
+        ILoggerFactory loggerFactory,
+        ILogger logger)
+    {
+        _loginCompletion = loginCompletion ?? throw new ArgumentNullException(nameof(loginCompletion));
+        _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>Projects the in-flight authorize states to non-secret summaries for the admin debug endpoint.</summary>
+    /// <returns>One redacted summary per in-flight state.</returns>
+    internal IEnumerable<OidcStateStore.Summary> StateSummaries() => StateStore.Summaries();
+
+    // Test-only reset of the process-wide OpenID caches this service keeps as statics: the in-flight
+    // authorize-state store and the discovery-facts cache. A test that drives the login flow mutates these,
+    // so without a reset the state leaks into a sibling test in the same non-parallel collection. Internal
+    // and reachable only through InternalsVisibleTo; it is never wired to an endpoint or DI, so it adds no
+    // runtime or security surface. Moved here with the statics from the controller (#160, #289).
+    internal static void ResetOidStateForTests()
+    {
+        StateStore.Clear();
+        DiscoveryCache.Clear();
+    }
+
+    // Test-only seed of a single authorize-state entry so a test can exercise the callback/authenticate legs
+    // (which consume an already-validated state that the browser redirect leg normally populates) without
+    // standing up the full token-exchange flow. Same test-only surface as ResetOidStateForTests (internal,
+    // InternalsVisibleTo, no endpoint/DI) — never reachable in production. Moved here with the statics (#160).
+    internal static void SeedOidStateForTests(string token, AuthorizeSession state) => StateStore.Seed(token, state);
+
+    /// <summary>
+    /// Initiates the OpenID login flow: prepares the authorization request, registers the in-flight authorize
+    /// state, binds it to the initiating browser, and redirects to the identity provider. The controller
+    /// applies the shared rate-limit gate before delegating here.
+    /// </summary>
+    /// <param name="provider">The provider name from the route.</param>
+    /// <param name="isLinking">Whether this challenge intends to link an account rather than authenticate.</param>
+    /// <param name="request">The current request; read for the base URL, the challenge route spelling, and the client IP.</param>
+    /// <param name="response">The response the browser-binding cookie is appended to on a successful registration.</param>
+    /// <returns>A redirect to the authorization server, or a fail-closed rejection/error.</returns>
+    internal async Task<ActionResult> ChallengeAsync(string provider, bool isLinking, HttpRequest request, HttpResponse response)
+    {
+        StateStore.PruneExpired(DateTime.Now);
+        var config = FindOidConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            // Unknown and disabled providers share one rejection so neither can be probed apart (no
+            // enumeration oracle), and the answer no longer depends on host middleware mapping a thrown
+            // ArgumentException — the in-process 400 is fail-closed regardless of the deployment (#318).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        // RFC 9700 §2.1.1: confirm the authorization server advertises PKCE (S256) before relying on
+        // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
+        // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
+        // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
+        // One discovery read yields both facts the challenge needs: PKCE-S256 support (gated below) and
+        // whether the AS advertises the RFC 9207 response-`iss` parameter (persisted on the state below,
+        // so the callback can require `iss` without a second fetch) (#210).
+        var discoveryFacts = await DiscoveryCache.ReadFactsAsync(config, provider, _httpClientFactory, _logger).ConfigureAwait(false);
+        var pkceSupported = discoveryFacts.PkceS256;
+        if (pkceSupported == false)
+        {
+            if (config.RequirePkce)
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
+            }
+
+            SsoAudit.PkceNotAdvertised(_logger, provider);
+        }
+        else if (pkceSupported is null && config.RequirePkce)
+        {
+            _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceUnverifiable));
+        }
+
+        var newPath = ResolveChallengeNewPath(config, isLinking, request);
+
+        string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
+
+        var oidcClient = CreateOidcClient(config, redirectUri, BuildScopeString(config));
+        var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
+
+        if (state.IsError)
+        {
+            return PlainTextError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
+        }
+
+        // Bind this authorize state to the browser that started it (#326): record a fresh random id on
+        // the state and hand the same value to the browser as a cookie. The callbacks require the cookie
+        // to match before honoring the state, so a state started in one browser cannot be completed in
+        // another (the forced-login / session-fixation defense).
+        var bindingId = AuthorizeStateBinding.NewId();
+
+        // IsLinking tracks whether this is a linking request rather than a login. The state value
+        // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
+        // always the capacity backstop under a flood, and the store throttles its warning signal.
+        // The client key bounds how much of the store one source can occupy (#327); a proxy/private
+        // source normalizes to null and is exempt.
+        var clientKey = SsoRateLimiter.NormalizeClientKey(request.HttpContext.Connection.RemoteIpAddress);
+
+        // Build the challenge's authorize state complete — the discovery metadata PrepareLoginAsync just
+        // fetched and validated against this provider's DiscoveryPolicy (reused at the callback so
+        // ProcessResponseAsync skips a second discovery + JWKS, #247), and whether that discovery
+        // advertised the RFC 9207 response-`iss` parameter (so the callback requires `iss`, its absence
+        // being a downgrade, #210). Folded in at construction so registration is one atomic insert and the
+        // stored Pending is never mutated after it enters the store (#341).
+        var pending = new AuthorizeSession.Pending(state, provider, isLinking, DateTime.Now, bindingId, clientKey, oidcClient.Options.ProviderInformation, discoveryFacts.ResponseIssuerAdvertised);
+        if (!StateStore.TryAdd(pending, out var shouldWarnCapacity))
+        {
+            if (shouldWarnCapacity)
+            {
+                _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
+            return PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+        }
+
+        // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
+        response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(OidcStateStore.DefaultLifetime));
+
+        return new RedirectResult(state.StartUrl);
+    }
+
+    /// <summary>
+    /// The OpenID redirect callback (a GET; named for consistency with the SAML sibling): validates the
+    /// browser-bound authorize state, exchanges the authorization code, validates the id_token and the RFC
+    /// 9207 response issuer, applies the role gate, promotes the state to redeemable, and renders the
+    /// intermediate auth page. The controller applies the shared rate-limit gate before delegating here and
+    /// supplies the security-headered page renderer.
+    /// </summary>
+    /// <param name="provider">The provider name from the route.</param>
+    /// <param name="state">The authorize-state token the callback presented (also the auth-page data).</param>
+    /// <param name="request">The current request; read for the base URL, the callback route, the code-exchange query string, the response `iss`, and the binding cookie.</param>
+    /// <param name="renderAuthPage">The controller's security-headered HTML auth-page renderer (nonce → body).</param>
+    /// <returns>The rendered auth page on success, or a fail-closed rejection.</returns>
+    internal async Task<ActionResult> CallbackAsync(string provider, string state, HttpRequest request, Func<Func<string, string>, ContentResult> renderAuthPage)
+    {
+        // Unknown and disabled providers share one rejection so neither can be probed apart, matching
+        // the guard-clause form the SAML sibling (SamlPost) already uses.
+        var config = FindOidConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage);
+        }
+
+        if (string.IsNullOrEmpty(state))
+        {
+            return new BadRequestObjectResult("Missing state");
+        }
+
+        if (StateStore.PeekCurrent(state, provider, DateTime.Now, request.Cookies[AuthorizeStateBinding.CookieName]) is not { } pending)
+        {
+            // Unknown, expired, minted for a different provider, or from a different browser than the
+            // one that started the flow (#326) — reject (details on PeekCurrent / AuthorizeStateBinding).
+            return new BadRequestObjectResult("Invalid or expired state");
+        }
+
+        var oidcClient = CreateCallbackOidcClient(config, provider, request, pending.ProviderInformation);
+        var result = await oidcClient.ProcessResponseAsync(request.QueryString.Value, pending.OidcState).ConfigureAwait(false);
+
+        if (result.IsError)
+        {
+            return PlainTextError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
+        }
+
+        // RFC 9207 (#125, hardened #210): the library parses the authorization-response `iss` but never
+        // checks it. When present it must match the authorization server this callback is bound to — its
+        // discovery issuer (§2.4's canonical anchor, from the reused #247 or freshly-discovered
+        // ProviderInformation) OR the redeemed id_token's issuer. Both are accepted so a provider whose
+        // issuer legitimately differs from its discovery location (DoNotValidateIssuerName / templated /
+        // multi-tenant) is not locked out — there the response iss equals the concrete id_token iss, not
+        // the templated discovery iss. A response iss matching neither is a mix-up, so reject. When the
+        // server advertised the parameter (captured at challenge), a missing iss is a downgrade and is
+        // likewise rejected; otherwise absence is tolerated so IdPs that never emit `iss` keep working.
+        if (!config.DoNotValidateResponseIssuer
+            && OidcResponseIssuer.IsRejected(request.Query["iss"], oidcClient.Options.ProviderInformation?.IssuerName, result.IdentityToken, pending.ResponseIssuerRequired))
+        {
+            _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
+        }
+
+        // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
+        // from the verified login's claims and the provider configuration.
+        var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config);
+
+        // Fail closed (#155): a valid OpenID login must resolve a stable subject to key the account
+        // link on. sub is an OIDC Core MUST and (post-#134) the id_token validator has verified the
+        // token, so a missing sub means a non-conformant provider — reject rather than fall back to
+        // keying on the mutable username.
+        if (derived.Valid && string.IsNullOrWhiteSpace(derived.Subject))
+        {
+            _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        if (!derived.Valid)
+        {
+            // The role gate did not pass: leave the Pending unpromoted (never redeemable — the redeem
+            // requires a Ready) so it simply expires. Checked before Promote so no Ready is ever created
+            // for a denied login.
+            _logger.LogWarning(
+                "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
+                derived.Username?.ReplaceLineEndings(string.Empty),
+                result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
+                config.Roles);
+
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        // Atomically swap the peeked Pending for a redeemable Ready (#341). A false return means a
+        // concurrent callback already promoted it, or it expired/was pruned since the peek — either way
+        // the browser's redeem is the real gate, which consumes the single Ready once (or cleanly rejects
+        // a state that is gone), so the auth page is returned regardless.
+        StateStore.Promote(pending, derived);
+
+        _logger.LogInformation("Is request linking: {IsLinking}", pending.IsLinking);
+        return renderAuthPage(nonce => WebResponse.Generator(data: state, provider: provider, baseUrl: RequestBaseUrl(request, config), mode: "OID", nonce: nonce, isLinking: pending.IsLinking));
+    }
+
+    /// <summary>
+    /// The session-minting authenticate leg: redeems the browser-bound authorize state once, then hands the
+    /// verified identity to the shared completion tail. The controller applies the shared rate-limit gate
+    /// before delegating and supplies the binding cookie and remote-endpoint resolver.
+    /// </summary>
+    /// <param name="provider">The provider name from the route.</param>
+    /// <param name="response">The client's auth request context (app/device) plus the state token in <c>Data</c>.</param>
+    /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#326).</param>
+    /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177).</param>
+    /// <returns>The minted session, or a fail-closed rejection.</returns>
+    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
+    {
+        if (string.IsNullOrEmpty(response?.Data))
+        {
+            return new BadRequestObjectResult("Missing data");
+        }
+
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // unifies the previously JSON unknown-provider body and the disabled provider's 500 into the
+        // one uniform 400, and a disabled provider does not consume the state (the guard precedes the
+        // redeem, as before).
+        var config = FindOidConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        // One-time atomic claim — details on OidcStateStore.TryRedeem. A miss (unknown, expired,
+        // provider-mismatched, already-redeemed, or from a different browser than started the flow, #326)
+        // is a client-caused rejection, not a server fault: one uniform body, so a replay is
+        // indistinguishable from an expiry and replay stays hidden. A binding mismatch does not consume
+        // the state (the check precedes the atomic remove), so it cannot burn a legitimate user's state.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, bindingCookie) is not { } redeemed)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
+        }
+
+        // The redeemed state carries the fully-verified identity (#473); the OpenID adoption gate applies
+        // the provider's verified-email requirement (#218). From here the OpenID and SAML paths are one.
+        return await _loginCompletion.CompleteAsync(
+            redeemed.Identity,
+            response,
+            config,
+            new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.Identity.EmailVerified),
+            remoteEndPointResolver).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The OpenID manual-link redeem: consumes the browser-bound authorize state once and creates the
+    /// canonical link on the redeemed identity's stable subject. The controller applies the caller-authz
+    /// guard before delegating and supplies the write-result-to-HTTP mapping.
+    /// </summary>
+    /// <param name="provider">The provider to link against.</param>
+    /// <param name="jellyfinUserId">The Jellyfin account to link (already authorized by the controller).</param>
+    /// <param name="response">The client information carrying the state token in <c>Data</c>.</param>
+    /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#326).</param>
+    /// <param name="mapWrite">The controller's mapping from a canonical-link write result to an HTTP response.</param>
+    /// <returns>The link-creation result, or a fail-closed rejection.</returns>
+    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, string bindingCookie, Func<CanonicalLinkWriteResult, ActionResult> mapWrite)
+    {
+        if (string.IsNullOrEmpty(response?.Data))
+        {
+            return new BadRequestObjectResult("Missing data");
+        }
+
+        // A disabled provider must neither create a link nor consume the state (#343), mirroring
+        // AuthenticateAsync's short-circuit order: an administrator disabling a provider takes effect for
+        // in-flight linking states immediately, not after their 15-minute lifetime. The unknown and
+        // disabled cases share one response, so neither can be probed apart (no enumeration oracle).
+        if (FindOidConfig(provider) is not { Enabled: true })
+        {
+            return new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage);
+        }
+
+        // One-time atomic claim (see OidcStateStore.TryRedeem): consume the state so one verified
+        // identity cannot be linked repeatedly and cannot then be reused to mint a session. A miss
+        // (unknown, expired, provider-mismatched, already-redeemed, or from a different browser than
+        // started the flow, #326) is a client-caused 400 in the same uniform body as the login path,
+        // not a 500. The linking challenge sets the same binding cookie, carried on this same-origin POST.
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, bindingCookie) is not { } redeemed)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
+        }
+
+        // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
+        // later provider-side rename does not orphan the link the user just created.
+        return mapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
+    }
+
+    // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".
+    // OidScopes is null when a provider was stored without scopes (#368, e.g. via the OID/Add API) —
+    // normalize to empty so neither the challenge nor the callback throws (an unhandled 500 on the
+    // anonymous challenge endpoint) or pads the scope string with null entries. Blank elements inside a
+    // non-null array are dropped too, so a persisted null/empty/whitespace scope cannot inject a
+    // doubled or trailing separator (#407). Shared by both sites.
+    internal static string BuildScopeString(OidConfig config)
+        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Prepend("openid profile"));
+
+    // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
+    // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
+    // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
+    // Returns null for an unknown provider so call sites branch on a null check instead of catching
+    // KeyNotFoundException as control flow (#241). An uncontended lock is nanoseconds; it is only held long
+    // during a first-login/admin persist, which is exactly when a consistent read matters.
+    private static OidConfig FindOidConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs.TryGetValue(provider, out var config) ? config : null);
+
+    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that as
+    // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
+    // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
+    // flow — which cannot know which redirect path the identity provider has registered — reuses the last
+    // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
+    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver on
+    // the controller because OidConfig and SamlConfig share no base with a NewPath setter; here the type is
+    // known, so the record is a direct assignment.
+    private static bool ResolveChallengeNewPath(OidConfig config, bool isLinking, HttpRequest request)
+    {
+        if (isLinking)
+        {
+            return config.NewPath;
+        }
+
+        var newPath = ChallengePath.IsNewPath(request.Path.Value);
+        config.NewPath = newPath;
+        return newPath;
+    }
+
+    // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
+    // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
+    // so the caller supplies them. Constructed in the same order as before the extraction, so a null
+    // OidEndpoint still fails at the same point (the Uri constructor, after the options object).
+    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope, ProviderInformation providerInformation = null)
+    {
+        var options = new OidcClientOptions
+        {
+            Authority = config.OidEndpoint?.Trim(),
+            ClientId = config.OidClientId?.Trim(),
+            ClientSecret = config.OidSecret?.Trim(),
+            RedirectUri = redirectUri,
+            Scope = scope,
+            DisablePushedAuthorization = config.DisablePushedAuthorization,
+            LoggerFactory = _loggerFactory,
+            LoadProfile = !config.DoNotLoadProfile,
+            HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory)
+        };
+        var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
+        options.Policy.Discovery.RequireHttps = !config.DisableHttps;
+        options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
+
+        // OidcClient 7.x validates nothing about the id_token unless a validator is supplied (its
+        // fallback only base64-decodes the payload). Signature validation is required and has no
+        // config toggle: an unvalidated id_token is a forgeable login (#134).
+        options.Policy.RequireIdentityTokenSignature = true;
+        options.IdentityTokenValidator = new OidcIdTokenValidator();
+
+        // Reuse the challenge's already-fetched, policy-validated discovery metadata when the callback
+        // supplies it (#247), so ProcessResponseAsync does not re-run discovery + JWKS. Pre-assigning
+        // ProviderInformation sets the client's internal _useDiscovery = false, which also disables the
+        // library's invalid_signature JWKS-refresh-and-retry. Two directions of key change, both bounded
+        // by the authorize state's ~15-minute lifetime: a key rotated IN during the window (the id_token
+        // signed by a key the challenge did not capture) fails this callback closed and self-heals on
+        // retry (the next challenge fetches fresh keys); a key rotated OUT / revoked during the window
+        // stays accepted until the state expires, since the callback validates against the captured
+        // set — a far tighter exposure than the platform-default 24-hour JWKS cache, and never wider than
+        // the state lifetime. Populated only from a validated fetch (never hand-filled), so the
+        // DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed.
+        if (providerInformation is not null)
+        {
+            options.ProviderInformation = providerInformation;
+        }
+
+        return new OidcClient(options);
+    }
+
+    // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls
+    // back on exactly the route the authorization request advertised), so the token request's
+    // redirect_uri matches the authorization request's as RFC 6749 requires (#98). The scope string
+    // is normalized the same way as the challenge side (BuildScopeString) — both tolerate a null
+    // OidScopes identically (#368).
+    private OidcClient CreateCallbackOidcClient(OidConfig config, string provider, HttpRequest request, ProviderInformation providerInformation)
+    {
+        var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(RequestBaseUrl(request, config), request.Path.Value, provider);
+        return CreateOidcClient(config, redirectUri, BuildScopeString(config), providerInformation);
+    }
+
+    // Resolves the canonical base URL from the live request and the provider's overrides — the same pure
+    // CanonicalBaseUrl.Resolve decision (#242) the controller's shared GetRequestBase feeds for SAML. Kept
+    // as a thin local read rather than a controller round-trip so this flow tier is self-contained.
+    private static string RequestBaseUrl(HttpRequest request, OidConfig config) =>
+        CanonicalBaseUrl.Resolve(config.BaseUrlOverride, request.Scheme, request.Host.Host, request.Host.Port, request.PathBase, config.SchemeOverride, config.PortOverride);
+
+    // A plain-text error result, reproducing the controller's ReturnError shape exactly (ContentResult,
+    // text/plain), so the two non-outcome OpenID errors (a PrepareLogin failure, a store-capacity refusal)
+    // stay byte-identical on the wire after the move. The SAML challenge keeps the controller's own copy for
+    // its signing-key failure; a shared home for both is deferred to the SAML extraction step (#160).
+    private static ContentResult PlainTextError(int code, string message) => new ContentResult
+    {
+        Content = message,
+        ContentType = MediaTypeNames.Text.Plain,
+        StatusCode = code,
+    };
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using Duende.IdentityModel.OidcClient;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
@@ -56,16 +55,16 @@ public class SSOController : ControllerBase
     private readonly ISessionManager _sessionManager;
     private readonly IAuthorizationContext _authContext;
     private readonly ILogger<SSOController> _logger;
-    private readonly ILoggerFactory _loggerFactory;
     private readonly ICryptoProvider _cryptoProvider;
-    private readonly IHttpClientFactory _httpClientFactory;
 
     // The account-linking workflow (resolve/adopt/create, legacy re-key, revoke); the controller keeps
     // the authz guards, the one-time-use replay/state consume, and the HTTP mapping (#318).
     private readonly CanonicalLinkService _canonicalLinks;
-    // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal
-    // all live inside; see OidcStateStore). One process-wide instance, like the SAML caches below.
-    private static readonly OidcStateStore StateStore = new();
+    // The OpenID login flow (#160, #318 step 12): challenge, redirect callback, session-minting
+    // authenticate, and manual link. It owns the OpenID-specific process-wide caches (the authorize-state
+    // store and the discovery-facts cache) as its own statics; the controller's OpenID endpoints apply the
+    // shared rate-limit gate below and delegate here. New'd per request like the other collaborators.
+    private readonly Flows.OidcLoginService _oidc;
 
     // One-time-use tracking for consumed SAML assertion IDs (replay protection).
     private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
@@ -73,15 +72,9 @@ public class SSOController : ControllerBase
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
-    // The per-discovery-URL cache of the two facts the challenge reads in one fetch — PKCE-S256 support
-    // (#141) and whether the AS advertises the RFC 9207 response-`iss` parameter (#210) — plus the
-    // fetch/parse that populates it. One process-wide instance, like the SAML caches above; the TTL,
-    // bounding rationale, and tolerant fail-open-only-under-RequirePkce behaviour all live inside
-    // OidcDiscoveryCache (#449).
-    private static readonly OidcDiscoveryCache DiscoveryCache = new();
-
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
-    // (challenge -> IdP login/MFA -> POST back -> mint), matching OidcStateStore.DefaultLifetime.
+    // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID authorize-state lifetime the
+    // flow service keeps.
     private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
 
     // Opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128).
@@ -114,13 +107,12 @@ public class SSOController : ControllerBase
         _authContext = authContext;
         _cryptoProvider = cryptoProvider;
         _logger = logger;
-        _loggerFactory = loggerFactory;
-        _httpClientFactory = httpClientFactory;
         _sessionManager = sessionManager;
         _canonicalLinks = new CanonicalLinkService(userManager, cryptoProvider, SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
         var sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
         _loginCompletion = new LoginCompletionService(_canonicalLinks, sessionMinter, logger);
+        _oidc = new Flows.OidcLoginService(_loginCompletion, _canonicalLinks, httpClientFactory, loggerFactory, logger);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -142,86 +134,10 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        // Unknown and disabled providers share one rejection so neither can be probed apart, matching
-        // the guard-clause form the SAML sibling (SamlPost) already uses.
-        var config = FindOidConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return BadRequest(NoMatchingProviderMessage);
-        }
-
-        if (string.IsNullOrEmpty(state))
-        {
-            return BadRequest("Missing state");
-        }
-
-        if (StateStore.PeekCurrent(state, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } pending)
-        {
-            // Unknown, expired, minted for a different provider, or from a different browser than the
-            // one that started the flow (#326) — reject (details on PeekCurrent / AuthorizeStateBinding).
-            return BadRequest("Invalid or expired state");
-        }
-
-        var oidcClient = CreateCallbackOidcClient(config, provider, pending.ProviderInformation);
-        var result = await oidcClient.ProcessResponseAsync(Request.QueryString.Value, pending.OidcState).ConfigureAwait(false);
-
-        if (result.IsError)
-        {
-            return ReturnError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
-        }
-
-        // RFC 9207 (#125, hardened #210): the library parses the authorization-response `iss` but never
-        // checks it. When present it must match the authorization server this callback is bound to — its
-        // discovery issuer (§2.4's canonical anchor, from the reused #247 or freshly-discovered
-        // ProviderInformation) OR the redeemed id_token's issuer. Both are accepted so a provider whose
-        // issuer legitimately differs from its discovery location (DoNotValidateIssuerName / templated /
-        // multi-tenant) is not locked out — there the response iss equals the concrete id_token iss, not
-        // the templated discovery iss. A response iss matching neither is a mix-up, so reject. When the
-        // server advertised the parameter (captured at challenge), a missing iss is a downgrade and is
-        // likewise rejected; otherwise absence is tolerated so IdPs that never emit `iss` keep working.
-        if (!config.DoNotValidateResponseIssuer
-            && OidcResponseIssuer.IsRejected(Request.Query["iss"], oidcClient.Options.ProviderInformation?.IssuerName, result.IdentityToken, pending.ResponseIssuerRequired))
-        {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
-        }
-
-        // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
-        // from the verified login's claims and the provider configuration.
-        var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config);
-
-        // Fail closed (#155): a valid OpenID login must resolve a stable subject to key the account
-        // link on. sub is an OIDC Core MUST and (post-#134) the id_token validator has verified the
-        // token, so a missing sub means a non-conformant provider — reject rather than fall back to
-        // keying on the mutable username.
-        if (derived.Valid && string.IsNullOrWhiteSpace(derived.Subject))
-        {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-        }
-
-        if (!derived.Valid)
-        {
-            // The role gate did not pass: leave the Pending unpromoted (never redeemable — the redeem
-            // requires a Ready) so it simply expires. Checked before Promote so no Ready is ever created
-            // for a denied login.
-            _logger.LogWarning(
-                "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
-                derived.Username?.ReplaceLineEndings(string.Empty),
-                result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
-                config.Roles);
-
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-        }
-
-        // Atomically swap the peeked Pending for a redeemable Ready (#341). A false return means a
-        // concurrent callback already promoted it, or it expired/was pruned since the peek — either way
-        // the browser's redeem is the real gate, which consumes the single Ready once (or cleanly rejects
-        // a state that is gone), so the auth page is returned regardless.
-        StateStore.Promote(pending, derived);
-
-        _logger.LogInformation("Is request linking: {IsLinking}", pending.IsLinking);
-        return HtmlAuthPage(nonce => WebResponse.Generator(data: state, provider: provider, baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), mode: "OID", nonce: nonce, isLinking: pending.IsLinking));
+        // The OpenID redirect callback lives in the flow service (#160, #318): it validates the
+        // browser-bound state, exchanges the code, validates the id_token and RFC 9207 response issuer,
+        // applies the role gate, and renders the security-headered intermediate auth page (passed in).
+        return await _oidc.CallbackAsync(provider, state, Request, HtmlAuthPage).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -239,116 +155,17 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        StateStore.PruneExpired(DateTime.Now);
-        var config = FindOidConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            // Unknown and disabled providers share one rejection so neither can be probed apart (no
-            // enumeration oracle), and the answer no longer depends on host middleware mapping a thrown
-            // ArgumentException — the in-process 400 is fail-closed regardless of the deployment (#318).
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
-        }
-
-        // RFC 9700 §2.1.1: confirm the authorization server advertises PKCE (S256) before relying on
-        // it. OidcClient sends code_challenge unconditionally but never checks this, so a server that
-        // ignores PKCE would silently downgrade authorization-code-injection protection (#141). Fail
-        // closed when the provider is marked RequirePkce; otherwise emit an audit warning and proceed.
-        // One discovery read yields both facts the challenge needs: PKCE-S256 support (gated below) and
-        // whether the AS advertises the RFC 9207 response-`iss` parameter (persisted on the state below,
-        // so the callback can require `iss` without a second fetch) (#210).
-        var discoveryFacts = await DiscoveryCache.ReadFactsAsync(config, provider, _httpClientFactory, _logger).ConfigureAwait(false);
-        var pkceSupported = discoveryFacts.PkceS256;
-        if (pkceSupported == false)
-        {
-            if (config.RequirePkce)
-            {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
-            }
-
-            SsoAudit.PkceNotAdvertised(_logger, provider);
-        }
-        else if (pkceSupported is null && config.RequirePkce)
-        {
-            _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the discovery document could not be read to confirm PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceUnverifiable));
-        }
-
-        bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
-
-        string redirectUri = SsoUrlBuilder.OidRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
-
-        var oidcClient = CreateOidcClient(config, redirectUri, BuildScopeString(config));
-        var state = await oidcClient.PrepareLoginAsync().ConfigureAwait(false);
-
-        if (state.IsError)
-        {
-            return ReturnError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
-        }
-
-        // Bind this authorize state to the browser that started it (#326): record a fresh random id on
-        // the state and hand the same value to the browser as a cookie. The callbacks require the cookie
-        // to match before honoring the state, so a state started in one browser cannot be completed in
-        // another (the forced-login / session-fixation defense).
-        var bindingId = AuthorizeStateBinding.NewId();
-
-        // IsLinking tracks whether this is a linking request rather than a login. The state value
-        // is a fresh CSPRNG token, so a collision is effectively impossible; a refusal is almost
-        // always the capacity backstop under a flood, and the store throttles its warning signal.
-        // The client key bounds how much of the store one source can occupy (#327); a proxy/private
-        // source normalizes to null and is exempt.
-        var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
-
-        // Build the challenge's authorize state complete — the discovery metadata PrepareLoginAsync just
-        // fetched and validated against this provider's DiscoveryPolicy (reused at the callback so
-        // ProcessResponseAsync skips a second discovery + JWKS, #247), and whether that discovery
-        // advertised the RFC 9207 response-`iss` parameter (so the callback requires `iss`, its absence
-        // being a downgrade, #210). Folded in at construction so registration is one atomic insert and the
-        // stored Pending is never mutated after it enters the store (#341).
-        var pending = new AuthorizeSession.Pending(state, provider, isLinking, DateTime.Now, bindingId, clientKey, oidcClient.Options.ProviderInformation, discoveryFacts.ResponseIssuerAdvertised);
-        if (!StateStore.TryAdd(pending, out var shouldWarnCapacity))
-        {
-            if (shouldWarnCapacity)
-            {
-                _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
-            }
-
-            return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
-        }
-
-        // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
-        Response.Cookies.Append(AuthorizeStateBinding.CookieName, bindingId, AuthorizeStateBinding.CookieOptions(OidcStateStore.DefaultLifetime));
-
-        return Redirect(state.StartUrl);
-    }
-
-    // Test-only reset of the process-wide OpenID caches this controller keeps as private statics: the
-    // in-flight authorize-state store and the discovery-facts cache. A test that drives the login flow
-    // mutates these, so without a reset the state leaks into a sibling test in the same non-parallel
-    // collection. The other static caches are deliberately not cleared here: the SAML replay/request
-    // caches key on random IDs and the rate limiter is isolated by per-test client IP, so they cannot
-    // bleed between tests. Internal and reachable only through InternalsVisibleTo; it is never wired to
-    // an endpoint or DI, so it adds no runtime or security surface. Callback/challenge coverage relies
-    // on it for isolation (#289).
-    internal static void ResetOidStateForTests()
-    {
-        StateStore.Clear();
-        DiscoveryCache.Clear();
+        // The OpenID challenge lives in the flow service (#160, #318): it reads discovery, applies the
+        // PKCE gate, prepares the authorization request, registers the browser-bound authorize state, and
+        // redirects to the identity provider (setting the binding cookie on the response).
+        return await _oidc.ChallengeAsync(provider, isLinking, Request, Response).ConfigureAwait(false);
     }
 
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
     // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
-    // into the next test. Same test-only surface as ResetOidStateForTests (internal, InternalsVisibleTo).
+    // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
+    // InternalsVisibleTo).
     internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
-
-    // Test-only seed of a single authorize-state entry so a test can exercise the OidAuth callback
-    // (which consumes an already-validated state that the browser redirect leg normally populates)
-    // without standing up the full token-exchange flow. Same test-only surface as ResetOidStateForTests
-    // (internal, InternalsVisibleTo, no endpoint/DI) — never reachable in production.
-    internal static void SeedOidStateForTests(string token, AuthorizeSession state)
-    {
-        StateStore.Seed(token, state);
-    }
 
     // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
     // binding (#415) — normally populated by the SamlChallenge redirect leg — without deriving the
@@ -362,10 +179,8 @@ public class SSOController : ControllerBase
     // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
     // Returns null for an unknown provider so call sites branch on a null check instead of catching
     // KeyNotFoundException as control flow (#241). An uncontended lock is nanoseconds; it is only held long
-    // during a first-login/admin persist, which is exactly when a consistent read matters.
-    private static OidConfig FindOidConfig(string provider) =>
-        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs.TryGetValue(provider, out var config) ? config : null);
-
+    // during a first-login/admin persist, which is exactly when a consistent read matters. (The OpenID twin
+    // moved into the flow service with the OID flow, #160.)
     private static SamlConfig FindSamlConfig(string provider) =>
         SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
 
@@ -386,77 +201,6 @@ public class SSOController : ControllerBase
         var newPath = ChallengePath.IsNewPath(Request.Path.Value);
         record(newPath);
         return newPath;
-    }
-
-    // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".
-    // OidScopes is null when a provider was stored without scopes (#368, e.g. via the OID/Add API) —
-    // normalize to empty so neither the challenge nor the callback throws (an unhandled 500 on the
-    // anonymous challenge endpoint) or pads the scope string with null entries. Blank elements inside a
-    // non-null array are dropped too, so a persisted null/empty/whitespace scope cannot inject a
-    // doubled or trailing separator (#407). Shared by both sites.
-    internal static string BuildScopeString(OidConfig config)
-        => string.Join(" ", (config.OidScopes ?? Array.Empty<string>())
-            .Where(s => !string.IsNullOrWhiteSpace(s))
-            .Prepend("openid profile"));
-
-    // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
-    // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
-    // so the caller supplies them. Constructed in the same order as before the extraction, so a null
-    // OidEndpoint still fails at the same point (the Uri constructor, after the options object).
-    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope, ProviderInformation providerInformation = null)
-    {
-        var options = new OidcClientOptions
-        {
-            Authority = config.OidEndpoint?.Trim(),
-            ClientId = config.OidClientId?.Trim(),
-            ClientSecret = config.OidSecret?.Trim(),
-            RedirectUri = redirectUri,
-            Scope = scope,
-            DisablePushedAuthorization = config.DisablePushedAuthorization,
-            LoggerFactory = _loggerFactory,
-            LoadProfile = !config.DoNotLoadProfile,
-            HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory)
-        };
-        var oidEndpointUri = new Uri(config.OidEndpoint?.Trim());
-        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
-        options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
-        options.Policy.Discovery.RequireHttps = !config.DisableHttps;
-        options.Policy.Discovery.ValidateIssuerName = !config.DoNotValidateIssuerName;
-
-        // OidcClient 7.x validates nothing about the id_token unless a validator is supplied (its
-        // fallback only base64-decodes the payload). Signature validation is required and has no
-        // config toggle: an unvalidated id_token is a forgeable login (#134).
-        options.Policy.RequireIdentityTokenSignature = true;
-        options.IdentityTokenValidator = new OidcIdTokenValidator();
-
-        // Reuse the challenge's already-fetched, policy-validated discovery metadata when the callback
-        // supplies it (#247), so ProcessResponseAsync does not re-run discovery + JWKS. Pre-assigning
-        // ProviderInformation sets the client's internal _useDiscovery = false, which also disables the
-        // library's invalid_signature JWKS-refresh-and-retry. Two directions of key change, both bounded
-        // by the authorize state's ~15-minute lifetime: a key rotated IN during the window (the id_token
-        // signed by a key the challenge did not capture) fails this callback closed and self-heals on
-        // retry (the next challenge fetches fresh keys); a key rotated OUT / revoked during the window
-        // stays accepted until the state expires, since the callback validates against the captured
-        // set — a far tighter exposure than the platform-default 24-hour JWKS cache, and never wider than
-        // the state lifetime. Populated only from a validated fetch (never hand-filled), so the
-        // DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed.
-        if (providerInformation is not null)
-        {
-            options.ProviderInformation = providerInformation;
-        }
-
-        return new OidcClient(options);
-    }
-
-    // Callback-side client: the redirect URI is rebuilt from the callback's own route (the IdP calls
-    // back on exactly the route the authorization request advertised), so the token request's
-    // redirect_uri matches the authorization request's as RFC 6749 requires (#98). The scope string
-    // is normalized the same way as the challenge side (BuildScopeString) — both tolerate a null
-    // OidScopes identically (#368).
-    private OidcClient CreateCallbackOidcClient(OidConfig config, string provider, ProviderInformation providerInformation)
-    {
-        var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), Request.Path.Value, provider);
-        return CreateOidcClient(config, redirectUri, BuildScopeString(config), providerInformation);
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
@@ -623,8 +367,8 @@ public class SSOController : ControllerBase
     [HttpGet("OID/States")]
     public ActionResult OidStates()
     {
-        // Non-secret summaries only — the redaction rationale lives on OidcStateStore.Summaries.
-        return Ok(StateStore.Summaries());
+        // Non-secret summaries only — the flow service projects the in-flight states to redacted summaries.
+        return Ok(_oidc.StateSummaries());
     }
 
     /// <summary>
@@ -643,38 +387,14 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        if (string.IsNullOrEmpty(response?.Data))
-        {
-            return BadRequest("Missing data");
-        }
-
-        // Unknown and disabled providers share one rejection so neither can be probed apart — this
-        // unifies the previously JSON unknown-provider body and the disabled provider's 500 into the
-        // one uniform 400, and a disabled provider does not consume the state (the guard precedes the
-        // redeem, as before).
-        var config = FindOidConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
-        }
-
-        // One-time atomic claim — details on OidcStateStore.TryRedeem. A miss (unknown, expired,
-        // provider-mismatched, already-redeemed, or from a different browser than started the flow, #326)
-        // is a client-caused rejection, not a server fault: one uniform body, so a replay is
-        // indistinguishable from an expiry and replay stays hidden. A binding mismatch does not consume
-        // the state (the check precedes the atomic remove), so it cannot burn a legitimate user's state.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } redeemed)
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
-        }
-
-        // The redeemed state carries the fully-verified identity (#473); the OpenID adoption gate applies
-        // the provider's verified-email requirement (#218). From here the OpenID and SAML paths are one.
-        return await _loginCompletion.CompleteAsync(
-            redeemed.Identity,
+        // The session-minting authenticate leg lives in the flow service (#160, #318): it redeems the
+        // browser-bound authorize state once and hands the verified identity to the shared completion tail.
+        // The controller passes the presented binding cookie and the HttpContext-derived remote endpoint in,
+        // keeping the flow tier HttpContext-free (#177).
+        return await _oidc.AuthenticateAsync(
+            provider,
             response,
-            config,
-            new AdoptionGate(config.RequireVerifiedEmailForAdoption, redeemed.Identity.EmailVerified),
+            Request.Cookies[AuthorizeStateBinding.CookieName],
             () => HttpContext.GetNormalizedRemoteIP().ToString()).ConfigureAwait(false);
     }
 
@@ -1277,37 +997,11 @@ public class SSOController : ControllerBase
     /// <param name="response">The data passed to the client to ensure it is the right one.</param>
     /// <returns>JSON for the client to populate information with.</returns>
     // No [Consumes]/[Produces]: inert on a private helper (see SamlLink) — AddCanonicalLink owns the
-    // content negotiation (#393).
-    private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response)
-    {
-        if (string.IsNullOrEmpty(response?.Data))
-        {
-            return BadRequest("Missing data");
-        }
-
-        // A disabled provider must neither create a link nor consume the state (#343), mirroring
-        // OidAuth's short-circuit order: an administrator disabling a provider takes effect for
-        // in-flight linking states immediately, not after their 15-minute lifetime. The unknown and
-        // disabled cases share one response, so neither can be probed apart (no enumeration oracle).
-        if (FindOidConfig(provider) is not { Enabled: true })
-        {
-            return BadRequest(NoMatchingProviderMessage);
-        }
-
-        // One-time atomic claim (see OidcStateStore.TryRedeem): consume the state so one verified
-        // identity cannot be linked repeatedly and cannot then be reused to mint a session. A miss
-        // (unknown, expired, provider-mismatched, already-redeemed, or from a different browser than
-        // started the flow, #326) is a client-caused 400 in the same uniform body as the login path,
-        // not a 500. The linking challenge sets the same binding cookie, carried on this same-origin POST.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, Request.Cookies[AuthorizeStateBinding.CookieName]) is not { } redeemed)
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
-        }
-
-        // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
-        // later provider-side rename does not orphan the link the user just created.
-        return MapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
-    }
+    // content negotiation (#393). The OID link redeem (which consumes the flow service's authorize state)
+    // lives on the flow service; the controller keeps the caller-authz guard (AddCanonicalLink) and the
+    // write-result-to-HTTP mapping it shares with SamlLink (#160).
+    private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response) =>
+        _oidc.Link(provider, jellyfinUserId, response, Request.Cookies[AuthorizeStateBinding.CookieName], MapWrite);
 
     // The HTTP boundary for a manual link creation: maps the service's closed write result to a response.
     // The empty-key and unknown-provider refusals keep distinct bodies (the service checks the empty key


### PR DESCRIPTION
# What & why

Continue thinning the `SSOController` monolith (#318 step 12): the whole OpenID
flow, the challenge, the redirect callback, the session-minting authenticate
leg, and the manual link redeem, moves out of the controller into a new
`internal sealed OidcLoginService` in the flow tier (`Api/Flows/`), matching the
shape `LoginCompletionService` already established.

- The two OpenID-specific process-wide caches (the in-flight authorize-state
  store and the discovery-facts cache) move onto the service as `static readonly`
  fields, keeping their single-process-wide instance semantics, the controller
  is per-request, so an instance field would drop in-flight state between a
  challenge and its callback. The `Reset*/Seed*ForTests` hooks move with them and
  stay `internal` via `InternalsVisibleTo`.
- The shared per-client rate limiter deliberately stays a controller static: it
  fronts **both** the OpenID and SAML flows, so both keep reaching it through the
  controller's unchanged rate-limit gate. **SAML rate-limiting is untouched.**
- The controller's OpenID endpoints become thin adapters: apply the shared
  rate-limit gate, then delegate. Challenge/callback are irreducibly HTTP, so they
  take the request/response plus a delegate for the two response shapes the
  controller still owns (the security-headered auth page and the shared
  manual-link write mapping); the authenticate leg stays HttpContext-free like the
  completion tail, taking only the model, the binding cookie, and the
  remote-endpoint resolver.

Behaviour-preserving and wire-for-wire: same redirect/authorize URLs, state
handling, callback outcomes, and 400/401/redirect bodies. The controller drops
from 1476 to 1058 lines. Refs #160.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the disabled-provider guard still precedes state
      consumption, a binding mismatch does not consume the state, a miss/expiry
      cleanly rejects, and the `VerifiedIdentity` factory still runs only after
      full OIDC validation. No throwing path became a guarded-Try that falls
      through to mint.
- [x] No secrets logged; secrets are redacted on config export. (No logging
      changed; the moved log calls keep their inline `ReplaceLineEndings`
      sanitizers.)
- [x] A security review was performed, the four-lens adversarial gate below.
- [x] Log inputs from the IdP are sanitized inline at the log call (moved
      verbatim with the code).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit (`OidcLoginService`). The one deliberate copy — a `PlainTextError`
      helper mirroring the controller's `ReturnError`, which the SAML challenge
      still uses — is noted below; a shared home is deferred to the SAML
      extraction step.
- [x] The change adds no more code than the problem requires (it is a move; the
      controller shrinks by 418 lines).
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and the new structural property is
      locked in as `Controller_DelegatesOidcFlowToTheFlowService` in
      `ArchitectureConformanceTests` (nameof-derived tokens, liveness-guarded).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0 warnings).
- [x] `dotnet test` is green (1014 passed, 0 failed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none in this PR).

## Notes

**Adversarial self-review, four refute-by-default lenses (login-path,
both-protocol-touching):**

- **Availability / mass-lockout, VERDICT: the shared rate limiter is untouched
  and still fronts both protocols (SAML `RateLimitCheck` unchanged); the OIDC
  caches keep single-process-wide lifetime (`static readonly`, not per-instance,
  so per-request service construction never re-initialises them, confirmed by
  the end-to-end challenge→callback test that persists state across two calls); no
  new lockout path. PASS.**
- **Security-bypass / fail-open, VERDICT: every fail-closed guard precedes state
  consumption exactly as before (enabled-check before TryAdd/PeekCurrent/TryRedeem
  in all four legs); the binding mismatch still does not consume the state; the
  `VerifiedIdentity` keystone is unweakened (still built inside
  `AuthorizeSession.Ready`, handed out only by the one-time atomic redeem, the
  `VerifiedIdentity_IsConstructedOnlyByProtocolValidators` conformance rule still
  passes); no throwing guard became a fall-through; no default-accept. PASS.**
- **Correctness / wire equivalence + static semantics, VERDICT: rejection bodies
  are byte-identical, preserving the `BadRequestObjectResult` vs `ContentResult`
  distinctions (callback "Missing state"/"Invalid or expired state" stay
  `BadRequestObjectResult`; challenge/auth rejections stay `ContentResult` via
  `LoginStatusMapper`; `PlainTextError` reproduces `ReturnError` exactly);
  `RedirectResult` for the challenge and text/html for the callback are unchanged;
  the base-URL argument mapping into `CanonicalBaseUrl.Resolve` is identical; the
  1014-test suite (RFC 9207, COAT, browser-binding, token-exchange-fail,
  sub-missing, end-to-end challenge→callback) passes empirically. PASS.**
- **Integration, VERDICT: the service is constructed after its collaborators in
  the controller ctor and receives the factories as ctor params; the per-request
  service / process-wide static lifetime split is sound; the test-isolation hooks
  moved to `OidcLoginService` and the harness/tests call the new location (build +
  tests green); both callbacks (redirect callback, session-mint) plus the link and
  states endpoints delegate correctly, with the CSP/security-header logic still
  owned by the controller's `HtmlAuthPage` (passed as a delegate, not duplicated).
  PASS.**

All four PASS.

**Out of scope:** `ReturnError` and the `MapWrite`/`HtmlAuthPage` helpers remain
shared with the SAML endpoints, so this PR passes the two render/mapping helpers
into the service as delegates and keeps a small `PlainTextError` twin rather than
extracting a shared home, that unification rides with the later SAML flow
extraction step (Refs #160).
