### PR TITLE
Extract the SAML login flow into SamlLoginService

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -260,8 +260,9 @@ public class ArchitectureConformanceTests
         // Sentinel + call-site pins. The factory NAMES are the contract; require both to exist (a rename
         // must consciously update this rule), then confine each factory's invocation to the file(s) that own
         // its protocol's validation. AuthorizeSession is where the OpenID identity is built (from the
-        // role-gate result); the SAML factory is invoked from the controller's SAML endpoint until a later
-        // #318 step extracts a dedicated SAML validator — at which point this allow-list moves with it.
+        // role-gate result); the SAML factory is invoked from the SAML flow service's session-minting leg
+        // (SamlLoginService), where it moved with the SAML flow extraction (#160, #318 step 13) — off the
+        // controller, as the earlier comment anticipated.
         const string oidcFactory = "FromOidcRedemption";
         const string samlFactory = "FromValidatedSaml";
         var factoryMethods = typeof(VerifiedIdentity)
@@ -274,9 +275,9 @@ public class ArchitectureConformanceTests
             $"VerifiedIdentity must expose the two named validation factories ({oidcFactory}, {samlFactory}); one was renamed, so update this rule and the source-scan allow-list with it (#473).");
 
         var oidcHome = SourceFilesDeclaring(new[] { typeof(AuthorizeSession) });
-        var samlHome = ControllerSourceFiles();
+        var samlHome = SourceFilesDeclaring(new[] { typeof(SamlLoginService) });
         AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + oidcFactory + "(", oidcHome, "the OpenID redeem path (AuthorizeSession.Ready)");
-        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + samlFactory + "(", samlHome, "the SAML session-minting endpoint");
+        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + samlFactory + "(", samlHome, "the SAML session-minting leg (SamlLoginService)");
     }
 
     // Fails if the given factory-invocation token appears in any SSO-Auth source file outside the allowed
@@ -509,6 +510,81 @@ public class ArchitectureConformanceTests
         Assert.True(
             markers.All(m => oidcSource.Contains(m, StringComparison.Ordinal)),
             "OidcLoginService must own the OpenID challenge/callback flow and its authorize/discovery caches; otherwise the controller scan passes vacuously (#160).");
+    }
+
+    [Fact]
+    public void Controller_DelegatesSamlFlowToTheFlowService()
+    {
+        // Locked in by the SAML flow extraction (#160, #318 step 13), the mirror of the OpenID rule above:
+        // the SAML challenge, assertion-consumer callback, session-minting authenticate and manual-link
+        // bodies, together with the SAML-specific process-wide state (the replay cache and the
+        // outstanding-AuthnRequest cache), moved into SamlLoginService. The controller's SAML endpoints now
+        // apply the shared rate-limit gate and hand the request to that service, so a CONTROLLER neither
+        // holds those SAML caches nor drives the SAML challenge/validation protocol itself. Call-level
+        // property, so it is a source scan like the other controller rules above.
+        //
+        // The two cache tokens are nameof-derived, so a rename of either type fails to COMPILE this rule
+        // rather than passing vacuously; the two protocol tokens are the outgoing-request builder
+        // (SamlAuthnRequest, which the challenge constructs and signs) and the response validator
+        // (ValidateSaml). The shared per-client rate limiter is deliberately NOT a marker — it fronts BOTH
+        // protocols, so it legitimately stays a controller static, exactly as in the OpenID rule.
+        var replayToken = nameof(SamlReplayCache);
+        var requestToken = nameof(SamlRequestCache);
+        var markers = new[] { replayToken, requestToken, "SamlAuthnRequest", "ValidateSaml" };
+
+        var controllerHits = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => markers.Any(m => l.Text.Contains(m, StringComparison.Ordinal)))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            controllerHits.Count == 0,
+            "A controller must not hold the SAML replay/request caches or drive the SAML challenge/validation protocol; the SAML flow lives in SamlLoginService (#160). Found: " + string.Join(" | ", controllerHits));
+
+        // Liveness against a vacuous pass: the SAML flow must actually live in SamlLoginService — a move,
+        // not a silent removal — so the flow service's own source must contain every moved token.
+        var samlSource = string.Join(
+            "\n",
+            SourceFilesDeclaring(new[] { typeof(SamlLoginService) }).Select(File.ReadAllText));
+        Assert.True(
+            markers.All(m => samlSource.Contains(m, StringComparison.Ordinal)),
+            "SamlLoginService must own the SAML challenge/callback/authenticate/link flow and its replay/request caches; otherwise the controller scan passes vacuously (#160).");
+    }
+
+    [Fact]
+    public void SharedFlowResponses_OwnTheAuthPageErrorAndLinkWriteResults()
+    {
+        // Locked in by the shared-helper consolidation (#160, #500): the three HTTP result shapes both flow
+        // services need — the security-headered intermediate auth page (the CSP build), the plain-text flow
+        // error, and the manual-link write mapping — were duplicated (the controller's HtmlAuthPage +
+        // ReturnError, and the OpenID service's PlainTextError twin). They now live once in FlowResponses,
+        // which both flow services call, so a CONTROLLER neither builds the CSP auth page nor sets its
+        // defensive headers itself. Call-level property, so it is a source scan like the other controller
+        // rules above. Markers are the emission tokens: the CSP builder (AuthPageCsp.Build) and the two
+        // clickjacking/sniffing headers the auth page sets.
+        var markers = new[] { "AuthPageCsp.Build", "X-Frame-Options", "X-Content-Type-Options" };
+        var offenders = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => markers.Any(m => l.Text.Contains(m, StringComparison.Ordinal)))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "A controller must not build the CSP auth page or set its defensive headers directly; the shared flow-result shapes live in FlowResponses (#160). Found: " + string.Join(" | ", offenders));
+
+        // Liveness against a vacuous pass: the auth page must actually live in FlowResponses — a move, not a
+        // silent removal — so its own source must build the CSP and set the frame-options header.
+        var sharedSource = string.Join(
+            "\n",
+            Directory.EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Shared"), "*.cs", SearchOption.AllDirectories)
+                .Select(File.ReadAllText));
+        Assert.True(
+            sharedSource.Contains("AuthPageCsp.Build", StringComparison.Ordinal) && sharedSource.Contains("X-Frame-Options", StringComparison.Ordinal),
+            "FlowResponses must own the CSP auth-page render (AuthPageCsp.Build + the defensive headers); otherwise the controller scan passes vacuously (#160).");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
@@ -164,7 +165,7 @@ public class SSOControllerSamlAuthTests
         var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(UserId).Returns(user);
-        SSOController.SeedSamlRequestForTests("adfs", AuthnRequestId, bindingId, DateTime.UtcNow.AddMinutes(15));
+        SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, bindingId, DateTime.UtcNow.AddMinutes(15));
         return harness;
     }
 

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct unit tests of <see cref="SamlLoginService"/>, the SAML flow extracted off the controller
+/// (#160, #318 step 13), the mirror of <see cref="OidcLoginServiceTests"/>. The end-to-end
+/// challenge/callback/authenticate/link behaviour is still exercised through the thin controller endpoints
+/// in <see cref="SSOControllerSamlPostTests"/>, <see cref="SSOControllerSamlAuthTests"/> and
+/// <see cref="SSOControllerLinkTests"/> (each endpoint is now a one-line delegation, so a passing controller
+/// test is a passing service test); these add coverage that targets the service in isolation — the
+/// fail-closed guard branches that reject before any collaborator is touched, and the process-wide-state test
+/// hook that moved with the flow. Uses the non-parallel <c>SSOController</c> collection because it sets the
+/// static <see cref="SSOPlugin.Instance"/>.
+/// </summary>
+[Collection("SSOController")]
+public class SamlLoginServiceTests
+{
+    [Fact]
+    public void Challenge_DisabledProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+        context.Request.Path = "/sso/SAML/start/adfs";
+
+        // A disabled provider fails closed before any AuthnRequest is built, with the same uniform body the
+        // unknown-provider case gets — so the two cannot be told apart (#318).
+        var result = service.Challenge("adfs", isLinking: false, context.Request, context.Response);
+
+        AssertUnknownProvider(result);
+    }
+
+    [Fact]
+    public void Challenge_UnknownProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(_ => { });
+        context.Request.Path = "/sso/SAML/start/nope";
+
+        var result = service.Challenge("nope", isLinking: false, context.Request, context.Response);
+
+        AssertUnknownProvider(result);
+    }
+
+    [Fact]
+    public void Post_DisabledProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+
+        var result = service.Post("adfs", relayState: null, formSamlResponse: null, context.Request, context.Response);
+
+        AssertUnknownProvider(result);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_DisabledProvider_RejectsAsUnknownProvider()
+    {
+        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+
+        // Guard precedes the state consume, so a disabled provider is rejected without touching any
+        // collaborator — the same uniform body an unknown provider gets.
+        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "irrelevant" }, bindingCookie: null, context.Request, () => "127.0.0.1");
+
+        AssertUnknownProvider(result);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_MalformedResponse_RejectsAsInvalid()
+    {
+        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, DoNotValidateAudience = true });
+
+        // A non-base64 / malformed response fails TryParse and is rejected the same way an invalid one is —
+        // a clean 4xx in the uniform SAML body, never an unhandled 500 (#199).
+        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "not-a-saml-response" }, bindingCookie: null, context.Request, () => "127.0.0.1");
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("SAML response validation failed", content.Content);
+    }
+
+    [Fact]
+    public void Link_DisabledProvider_ReturnsBadRequest()
+    {
+        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+
+        // A disabled provider must neither create a link nor consume the assertion (#343); the unknown and
+        // disabled cases share one 400 response so neither can be probed apart.
+        var result = service.Link("adfs", Guid.NewGuid(), new AuthResponse { Data = "irrelevant" }, context.Request);
+
+        var content = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal("No matching provider found", content.Value);
+    }
+
+    [Fact]
+    public void SeedAndReset_AreProcessWideHooksThatMovedWithTheFlow()
+    {
+        // The seed and reset test hooks moved off the controller onto the flow service with the SAML statics
+        // (#160). They are process-wide and must not throw when driven directly; the reset makes each test
+        // start from a clean outstanding-request cache (the harness calls it for exactly this reason).
+        SamlLoginService.SeedSamlRequestForTests("adfs", "req-1", "binding-1", DateTime.UtcNow.AddMinutes(15));
+        SamlLoginService.ResetSamlRequestsForTests();
+    }
+
+    private static void AssertUnknownProvider(ActionResult result)
+    {
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("No matching provider found", content.Content);
+    }
+
+    // Builds a SamlLoginService over the same collaborator graph the controller constructs, against a
+    // freshly-bootstrapped SSOPlugin.Instance seeded via the configure callback and a DefaultHttpContext for
+    // the request/response the flow reads and writes. The harness resets the process-wide SAML state, so
+    // each test starts clean.
+    private static (SamlLoginService Service, DefaultHttpContext Context) Build(Action<PluginConfiguration> configure)
+    {
+        var harness = new SsoControllerHarness(configure);
+        var logger = Substitute.For<ILogger>();
+
+        var canonicalLinks = new CanonicalLinkService(harness.UserManager, new FakeCryptoProvider(), SSOPlugin.Instance.ConfigStore, logger);
+        var avatarService = new AvatarService(harness.UserManager, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), logger, SsoHttp.UserAgent);
+        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, Substitute.For<ISessionManager>(), logger);
+        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, logger);
+        var service = new SamlLoginService(loginCompletion, canonicalLinks, logger);
+
+        var context = new DefaultHttpContext();
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("jf.example.com");
+        return (service, context);
+    }
+}

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -50,7 +50,7 @@ internal sealed class SsoControllerHarness
         // test that exercised the login flow cannot leak in-flight state into this one (#289). The
         // outstanding-SAML-request cache is the same kind of static and is cleared for the same reason (#415).
         OidcLoginService.ResetOidStateForTests();
-        SSOController.ResetSamlRequestsForTests();
+        SamlLoginService.ResetSamlRequestsForTests();
 
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);

--- a/SSO-Auth.Tests/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/ValidateSamlTests.cs
@@ -1,12 +1,13 @@
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for the controller's ValidateSaml helper: how the expected audience is derived
+/// Tests for the SAML flow service's ValidateSaml helper: how the expected audience is derived
 /// (SamlAudience, falling back to SamlClientId, both trimmed) and the DoNotValidateAudience opt-out.
 /// </summary>
 public class ValidateSamlTests
@@ -24,15 +25,15 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor("whatever");
         var config = new SamlConfig { DoNotValidateAudience = true, SamlClientId = "unrelated" };
-        Assert.True(SSOController.ValidateSaml(response, config));
+        Assert.True(SamlLoginService.ValidateSaml(response, config));
     }
 
     [Fact]
     public void SamlClientId_UsedAsAudienceWhenNoSamlAudience()
     {
         var response = SignedResponseFor(Audience);
-        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = Audience }));
-        Assert.False(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = "https://other" }));
+        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = Audience }));
+        Assert.False(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = "https://other" }));
     }
 
     [Fact]
@@ -40,7 +41,7 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor(Audience);
         var config = new SamlConfig { SamlAudience = Audience, SamlClientId = "https://other" };
-        Assert.True(SSOController.ValidateSaml(response, config));
+        Assert.True(SamlLoginService.ValidateSaml(response, config));
     }
 
     [Fact]
@@ -48,21 +49,21 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor(Audience);
         var config = new SamlConfig { SamlAudience = "", SamlClientId = Audience };
-        Assert.True(SSOController.ValidateSaml(response, config));
+        Assert.True(SamlLoginService.ValidateSaml(response, config));
     }
 
     [Fact]
     public void ExpectedAudienceIsTrimmed()
     {
         var response = SignedResponseFor(Audience);
-        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlClientId = "  " + Audience + "  " }));
-        Assert.True(SSOController.ValidateSaml(response, new SamlConfig { SamlAudience = " " + Audience + " ", SamlClientId = "x" }));
+        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = "  " + Audience + "  " }));
+        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlAudience = " " + Audience + " ", SamlClientId = "x" }));
     }
 
     [Fact]
     public void NoExpectedAudienceConfigured_FailsClosed()
     {
         var response = SignedResponseFor(Audience);
-        Assert.False(SSOController.ValidateSaml(response, new SamlConfig()));
+        Assert.False(SamlLoginService.ValidateSaml(response, new SamlConfig()));
     }
 }

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Mime;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Providers;
 using Microsoft.AspNetCore.Http;
@@ -156,7 +156,7 @@ internal sealed class OidcLoginService
 
         if (state.IsError)
         {
-            return PlainTextError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
+            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
         }
 
         // Bind this authorize state to the browser that started it (#326): record a fresh random id on
@@ -186,7 +186,7 @@ internal sealed class OidcLoginService
                 _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
             }
 
-            return PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+            return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
         }
 
         // Set the cookie only after the state is registered, so a refused challenge leaves no cookie.
@@ -199,15 +199,14 @@ internal sealed class OidcLoginService
     /// The OpenID redirect callback (a GET; named for consistency with the SAML sibling): validates the
     /// browser-bound authorize state, exchanges the authorization code, validates the id_token and the RFC
     /// 9207 response issuer, applies the role gate, promotes the state to redeemable, and renders the
-    /// intermediate auth page. The controller applies the shared rate-limit gate before delegating here and
-    /// supplies the security-headered page renderer.
+    /// intermediate auth page. The controller applies the shared rate-limit gate before delegating here.
     /// </summary>
     /// <param name="provider">The provider name from the route.</param>
     /// <param name="state">The authorize-state token the callback presented (also the auth-page data).</param>
     /// <param name="request">The current request; read for the base URL, the callback route, the code-exchange query string, the response `iss`, and the binding cookie.</param>
-    /// <param name="renderAuthPage">The controller's security-headered HTML auth-page renderer (nonce → body).</param>
+    /// <param name="response">The response the auth page's defensive headers are written to.</param>
     /// <returns>The rendered auth page on success, or a fail-closed rejection.</returns>
-    internal async Task<ActionResult> CallbackAsync(string provider, string state, HttpRequest request, Func<Func<string, string>, ContentResult> renderAuthPage)
+    internal async Task<ActionResult> CallbackAsync(string provider, string state, HttpRequest request, HttpResponse response)
     {
         // Unknown and disabled providers share one rejection so neither can be probed apart, matching
         // the guard-clause form the SAML sibling (SamlPost) already uses.
@@ -234,7 +233,7 @@ internal sealed class OidcLoginService
 
         if (result.IsError)
         {
-            return PlainTextError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
+            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
         }
 
         // RFC 9207 (#125, hardened #210): the library parses the authorization-response `iss` but never
@@ -288,7 +287,7 @@ internal sealed class OidcLoginService
         StateStore.Promote(pending, derived);
 
         _logger.LogInformation("Is request linking: {IsLinking}", pending.IsLinking);
-        return renderAuthPage(nonce => WebResponse.Generator(data: state, provider: provider, baseUrl: RequestBaseUrl(request, config), mode: "OID", nonce: nonce, isLinking: pending.IsLinking));
+        return FlowResponses.AuthPage(response, nonce => WebResponse.Generator(data: state, provider: provider, baseUrl: RequestBaseUrl(request, config), mode: "OID", nonce: nonce, isLinking: pending.IsLinking));
     }
 
     /// <summary>
@@ -347,9 +346,8 @@ internal sealed class OidcLoginService
     /// <param name="jellyfinUserId">The Jellyfin account to link (already authorized by the controller).</param>
     /// <param name="response">The client information carrying the state token in <c>Data</c>.</param>
     /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#326).</param>
-    /// <param name="mapWrite">The controller's mapping from a canonical-link write result to an HTTP response.</param>
     /// <returns>The link-creation result, or a fail-closed rejection.</returns>
-    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, string bindingCookie, Func<CanonicalLinkWriteResult, ActionResult> mapWrite)
+    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, string bindingCookie)
     {
         if (string.IsNullOrEmpty(response?.Data))
         {
@@ -377,7 +375,7 @@ internal sealed class OidcLoginService
 
         // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
         // later provider-side rename does not orphan the link the user just created.
-        return mapWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
     }
 
     // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".
@@ -481,19 +479,8 @@ internal sealed class OidcLoginService
     }
 
     // Resolves the canonical base URL from the live request and the provider's overrides — the same pure
-    // CanonicalBaseUrl.Resolve decision (#242) the controller's shared GetRequestBase feeds for SAML. Kept
-    // as a thin local read rather than a controller round-trip so this flow tier is self-contained.
+    // CanonicalBaseUrl.Resolve decision (#242) SamlLoginService.GetRequestBase feeds for SAML. Kept as a
+    // thin local read so this flow tier is self-contained.
     private static string RequestBaseUrl(HttpRequest request, OidConfig config) =>
         CanonicalBaseUrl.Resolve(config.BaseUrlOverride, request.Scheme, request.Host.Host, request.Host.Port, request.PathBase, config.SchemeOverride, config.PortOverride);
-
-    // A plain-text error result, reproducing the controller's ReturnError shape exactly (ContentResult,
-    // text/plain), so the two non-outcome OpenID errors (a PrepareLogin failure, a store-capacity refusal)
-    // stay byte-identical on the wire after the move. The SAML challenge keeps the controller's own copy for
-    // its signing-key failure; a shared home for both is deferred to the SAML extraction step (#160).
-    private static ContentResult PlainTextError(int code, string message) => new ContentResult
-    {
-        Content = message,
-        ContentType = MediaTypeNames.Text.Plain,
-        StatusCode = code,
-    };
 }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -1,0 +1,553 @@
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
+
+/// <summary>
+/// The SAML login flow, extracted whole off <see cref="SSOController"/> (#160, #318 step 13), symmetric to
+/// <see cref="OidcLoginService"/>: the challenge (redirect the browser to the identity provider with an
+/// optionally-signed AuthnRequest, #167), the assertion-consumer callback (validate the signed response and
+/// render the intermediate auth page), the session-minting authenticate leg, and the manual link redeem. The
+/// controller's SAML endpoints are now thin adapters — they apply the shared rate-limit gate and hand the
+/// request to this service — so the SAML-specific protocol logic lives in one flow-tier collaborator rather
+/// than inline on the controller.
+/// </summary>
+/// <remarks>
+/// The two SAML-specific process-wide caches live here as <c>static readonly</c> fields, one instance for the
+/// whole process exactly as they were on the controller (a fresh per-request controller reconstructs the
+/// service, so an instance field would lose the in-flight state between the challenge and its callback):
+/// <list type="bullet">
+/// <item>the one-time-use replay cache of consumed assertion IDs (<see cref="SamlReplayCache"/>), and</item>
+/// <item>the outstanding-AuthnRequest cache for InResponseTo correlation and the browser binding (<see cref="SamlRequestCache"/>, #156/#415).</item>
+/// </list>
+/// The shared per-client rate limiter is deliberately NOT here — it also fronts the OpenID flow, so it stays a
+/// controller static both flows reach through the controller's rate-limit gate. The methods take the
+/// request/response because SAML is irreducibly HTTP (the redirect, the ACS POST form, the binding cookie, the
+/// security-headered page, and the request-host-derived assertion-consumer URL the Recipient is bound to); the
+/// two response shapes both flows share — the security-headered auth page and the manual-link write mapping —
+/// are rendered from the shared <see cref="FlowResponses"/> home rather than a controller delegate (#160).
+/// </remarks>
+internal sealed class SamlLoginService
+{
+    // One-time-use tracking for consumed SAML assertion IDs (replay protection). One process-wide instance,
+    // like the outstanding-request cache below and the OpenID caches the sibling flow service keeps.
+    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
+
+    // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156) and the
+    // browser binding (#415). One process-wide instance.
+    private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
+
+    // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
+    // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID authorize-state lifetime the
+    // sibling flow service keeps.
+    private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
+
+    // The shared login-completion tail (#160): resolve/adopt the link, build the session parameters, mint
+    // under the revocation gate, audit, map to a LoginOutcome. Both protocols funnel their verified identity
+    // into it, so it is a shared collaborator this service holds a reference to rather than owning.
+    private readonly LoginCompletionService _loginCompletion;
+
+    // The account-linking workflow (resolve/adopt/create, legacy re-key, revoke). Used here only by the SAML
+    // manual-link redeem; the controller keeps the caller-authz guard and the one-time-use consume around it.
+    private readonly CanonicalLinkService _canonicalLinks;
+
+    private readonly ILogger _logger;
+
+    internal SamlLoginService(
+        LoginCompletionService loginCompletion,
+        CanonicalLinkService canonicalLinks,
+        ILogger logger)
+    {
+        _loginCompletion = loginCompletion ?? throw new ArgumentNullException(nameof(loginCompletion));
+        _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
+    // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
+    // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
+    // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160).
+    internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
+
+    // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
+    // binding (#415) — normally populated by the challenge redirect leg — without deriving the random
+    // request id from the emitted AuthnRequest. Same test-only surface as SeedOidStateForTests
+    // (internal, InternalsVisibleTo, no endpoint/DI); never reachable in production. Moved here (#160).
+    internal static void SeedSamlRequestForTests(string provider, string requestId, string bindingId, DateTime expiryUtc) =>
+        SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow, clientKey: null, out _);
+
+    /// <summary>
+    /// The SAML assertion-consumer callback: validates the signed response and, on a passing role gate,
+    /// renders the intermediate auth page. The controller applies the shared rate-limit gate before
+    /// delegating here.
+    /// </summary>
+    /// <param name="provider">The provider that is calling back.</param>
+    /// <param name="relayState">The RelayState from the original SAML request; "linking" marks a link request.</param>
+    /// <param name="formSamlResponse">The SAMLResponse form field (model-bound, so a non-form POST binds null and is rejected).</param>
+    /// <param name="request">The current request; read for the assertion-consumer base URL.</param>
+    /// <param name="response">The response the auth page's defensive headers are written to.</param>
+    /// <returns>The rendered auth page on success, or a fail-closed rejection.</returns>
+    internal ActionResult Post(string provider, string relayState, string formSamlResponse, HttpRequest request, HttpResponse response)
+    {
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // retires the unique "No active providers found" wording that distinguished the disabled case
+        // (a disabled provider now short-circuits before the relayState log line).
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        bool isLinking = string.Equals(relayState, "linking", StringComparison.Ordinal);
+
+        // relayState is attacker-controllable; strip line endings inline at the log call to prevent
+        // log forging (structured logging alone does not sanitize a newline-bearing value).
+        _logger.LogInformation(
+            "SAML request has relayState of {RelayState}",
+            relayState?.ReplaceLineEndings(string.Empty));
+
+        // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
+        // content-type binds null (the form value provider is skipped, so Request.Form is never
+        // touched and cannot throw the InvalidOperationException that escaped as a 500, #206), and a
+        // null body is rejected the same way as any other malformed response — a clean 400.
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, formSamlResponse, out var samlResponse)
+            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        {
+            // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
+            // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
+        {
+            return FlowResponses.AuthPage(response, nonce =>
+                WebResponse.Generator(
+                    data: Convert.ToBase64String(Encoding.UTF8.GetBytes(samlResponse.Xml)),
+                    provider: provider,
+                    baseUrl: GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
+                    mode: "SAML",
+                    nonce: nonce,
+                    isLinking: isLinking));
+        }
+
+        _logger.LogWarning(
+            "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
+            samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
+            samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
+            config.Roles);
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+    }
+
+    /// <summary>
+    /// Initiates the SAML login flow: builds the AuthnRequest, binds it to the initiating browser, and
+    /// redirects to the identity provider (signing the request when the provider opts in, #167). The
+    /// controller applies the shared rate-limit gate before delegating here.
+    /// </summary>
+    /// <param name="provider">The provider to begin the flow with.</param>
+    /// <param name="isLinking">Whether this flow intends to link an account rather than authenticate.</param>
+    /// <param name="request">The current request; read for the assertion-consumer base URL, the challenge route spelling, and the client IP.</param>
+    /// <param name="response">The response the browser-binding cookie is appended to on a login challenge.</param>
+    /// <returns>A redirect to the SAML provider's auth page, or a fail-closed rejection/error.</returns>
+    internal ActionResult Challenge(string provider, bool isLinking, HttpRequest request, HttpResponse response)
+    {
+        // Unknown and disabled providers share one rejection so neither can be probed apart, and the
+        // answer no longer depends on host middleware mapping a thrown ArgumentException (#318).
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        bool newPath = ResolveChallengeNewPath(config, isLinking, request);
+
+        string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
+        string relayState = null;
+        if (isLinking)
+        {
+            relayState = "linking";
+        }
+
+        var samlRequest = new SamlAuthnRequest(
+            config.SamlClientId.Trim(),
+            redirectUri);
+
+        // Bind this login to the initiating browser (#415): mint a binding id, set it as a cookie, and
+        // record it against the request id so the session-mint endpoint (Authenticate) can require the
+        // response's browser to be the one that started the flow — closing the SP-initiated forced-login
+        // / session-fixation vector, the SAML analogue of #326. Only for login flows: the linking
+        // callback (Link) is a separate flow that does not consume the outstanding request, so a
+        // linking registration would only leave an id to expire unused. Registration now happens for
+        // every login challenge (not only under ValidateInResponseTo), so the binding is enforced for
+        // every SOLICITED login this plugin initiated — the case ValidateInResponseTo alone left open.
+        // It does NOT bind an unsolicited (IdP-initiated) response, which carries no matching request;
+        // fully closing forced login for an IdP that issues unsolicited responses additionally requires
+        // ValidateInResponseTo (which refuses them). Because the cookie is __Host-/Secure, the browser
+        // only returns it over HTTPS — SP-initiated SAML now needs HTTPS at the browser edge, as OIDC
+        // already does.
+        if (!isLinking)
+        {
+            var bindingId = AuthorizeStateBinding.NewId();
+
+            // The client key bounds how much of the request cache one source can occupy (#327); a
+            // proxy/private source normalizes to null and is exempt.
+            var clientKey = SsoRateLimiter.NormalizeClientKey(request.HttpContext.Connection.RemoteIpAddress);
+            if (!SamlRequests.Register(
+                    ProviderScopedKey.For(provider, samlRequest.Id),
+                    bindingId,
+                    DateTime.UtcNow + SamlRequestLifetime,
+                    DateTime.UtcNow,
+                    clientKey,
+                    out var shouldWarnCapacity))
+            {
+                // The per-client sub-cap or the global cap refused this login's outstanding-request
+                // entry (#327). Fail closed HERE rather than redirect to the IdP for a login that could
+                // then only be refused at the callback (no correlation entry). The store throttles the
+                // capacity warning to one signal per interval so a flood cannot amplify into log volume
+                // (CWE-400) — parity with the OpenID challenge refusal.
+                if (shouldWarnCapacity)
+                {
+                    _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                }
+
+                return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+            }
+
+            response.Cookies.Append(
+                AuthorizeStateBinding.SamlCookieName,
+                bindingId,
+                AuthorizeStateBinding.CookieOptions(SamlRequestLifetime));
+        }
+
+        string redirectUrl;
+        try
+        {
+            redirectUrl = BuildChallengeRedirectUrl(config, samlRequest, relayState);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or CryptographicException)
+        {
+            // Signing is enabled for this provider but the request could not be signed: the key is
+            // missing/unusable (InvalidOperationException), the endpoint is empty (ArgumentException from
+            // the signer), or the platform key store refused the signing operation (CryptographicException).
+            // ANY of these fails closed with a clean 500 — never a silent unsigned request — rather than
+            // escaping as a raw host 500. The key material is not part of the message, so nothing sensitive
+            // is logged.
+            _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+            return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");
+        }
+
+        return new RedirectResult(redirectUrl);
+    }
+
+    /// <summary>
+    /// The SAML session-minting authenticate leg: validates the signed response, correlates it to an
+    /// AuthnRequest this server issued (browser binding, #156/#415), enforces the login allow-list and
+    /// one-time replay consume, then hands the fully-verified identity to the shared completion tail. The
+    /// controller applies the shared rate-limit gate before delegating and supplies the binding cookie and
+    /// remote-endpoint resolver.
+    /// </summary>
+    /// <param name="provider">The provider to authenticate against.</param>
+    /// <param name="response">The client's auth request context (app/device) plus the SAML response in <c>Data</c>.</param>
+    /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#415).</param>
+    /// <param name="request">The current request; read for the assertion-consumer base URL (recipient binding).</param>
+    /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177).</param>
+    /// <returns>The minted session, or a fail-closed rejection.</returns>
+    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, HttpRequest request, Func<string> remoteEndPointResolver)
+    {
+        // Unknown and disabled providers share one rejection so neither can be probed apart — this
+        // unifies the previously JSON unknown-provider body and the disabled provider's 500.
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
+            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        {
+            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Correlate the response to an AuthnRequest this server issued (#156, #415), and enforce the
+        // browser binding for a solicited login. A NON-EMPTY InResponseTo means the response claims to
+        // answer a request this server issued, so it must actually correlate to a live outstanding
+        // request AND carry that request's binding cookie — anything less fails closed. Crucially, a
+        // non-empty InResponseTo whose entry is gone (expired past the 15-minute window, evicted at the
+        // cap, lost to a restart or a non-sticky multi-node hop) is a LOST correlation, not an
+        // unsolicited response: treating it as unsolicited would let a signature-valid response mint a
+        // session with no binding check when ValidateInResponseTo is off, which is exactly the
+        // forced-login bypass the binding exists to close (login validity must never default to true).
+        //
+        // The binding is checked AFTER the atomic claim (unlike the OpenID state, #326) and that is safe:
+        // the response already passed signature validation above and the InResponseTo is read from that
+        // validated document, so an attacker cannot mint a signature-valid response carrying a victim's
+        // request id to burn their outstanding entry. The cookie is checked here (the same-origin auth
+        // endpoint), not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
+        var inResponseTo = samlResponse.GetInResponseTo();
+        if (!string.IsNullOrEmpty(inResponseTo))
+        {
+            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
+            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId)
+                || !AuthorizeStateBinding.Matches(storedBindingId, bindingCookie))
+            {
+                _logger.LogWarning("SAML login denied: a solicited response did not correlate to a live outstanding request from the initiating browser (binding mismatch, expiry, or lost correlation).");
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+            }
+        }
+        else if (config.ValidateInResponseTo)
+        {
+            // No InResponseTo at all: a genuinely unsolicited (IdP-initiated) response. It is refused
+            // only when the opt-in solicited-only mode is on; otherwise it proceeds — unchanged and
+            // non-breaking for IdP-initiated deployments. The rejection is a client-caused 400 in the
+            // uniform SAML body, never a 500, and the diagnosis stays in the warning log.
+            _logger.LogWarning("SAML login denied: the response was not solicited by this server (no InResponseTo).");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
+        // can POST an assertion straight to this session-minting endpoint and skip the page, so
+        // checking it only there would be fail-open.
+        if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
+        {
+            _logger.LogWarning(
+                "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
+                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
+        // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
+        // renders the intermediate page, so the two-step post-then-auth flow consumes the id once. A
+        // replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
+        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
+        if (!TryConsumeSamlReplay(samlResponse, provider))
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
+        // the assertion's roles and the provider configuration. Login validity was already decided
+        // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
+        // here.
+        var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
+
+        // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
+        // reject it as an invalid login instead of failing downstream on a null canonical name.
+        // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
+        var nameId = samlResponse.GetNameID();
+        if (string.IsNullOrWhiteSpace(nameId))
+        {
+            _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        // All SAML validation has now passed — signature, time bounds, audience, recipient, InResponseTo
+        // correlation, the login allow-list, replay one-time-use, and the non-empty-NameID guard — so this
+        // is the point at which the response becomes a fully-verified SAML identity (#473). SAML keys the
+        // link directly on the NameID (subject and username are the same value; no migration path needed)
+        // and carries no email_verified claim, so the verified-email gate is not applicable
+        // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
+        // From here the SAML and OpenID paths are one.
+        return await _loginCompletion.CompleteAsync(
+            VerifiedIdentity.FromValidatedSaml(provider, nameId, derived),
+            response,
+            config,
+            AdoptionGate.None,
+            remoteEndPointResolver).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// The SAML manual-link redeem: validates the signed response, consumes its one-time-use assertion id,
+    /// and creates the canonical link on the assertion's NameID. The controller applies the caller-authz
+    /// guard before delegating.
+    /// </summary>
+    /// <param name="provider">The provider to link against.</param>
+    /// <param name="jellyfinUserId">The Jellyfin account to link (already authorized by the controller).</param>
+    /// <param name="response">The client information carrying the SAML response in <c>Data</c>.</param>
+    /// <param name="request">The current request; read for the assertion-consumer base URL (recipient binding).</param>
+    /// <returns>The link-creation result, or a fail-closed rejection.</returns>
+    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, HttpRequest request)
+    {
+        // A disabled provider must neither create a link nor consume the assertion's one-time-use ID
+        // (#343): an administrator disabling a provider takes effect immediately for linking, and the
+        // unknown and disabled cases share one response so neither can be probed apart.
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage);
+        }
+
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
+            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        {
+            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        // Enforce one-time use here too (#219): without it, a captured, still-valid assertion could be
+        // replayed to bind its NameID to the caller's account. The linking flow issues no AuthnRequest,
+        // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use
+        // control. A replay is a client-caused 400 in the uniform SAML body, never a 500, and no longer
+        // discloses the replay cache to the attacker who replayed.
+        if (!TryConsumeSamlReplay(samlResponse, provider))
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+        }
+
+        string providerUserId = samlResponse.GetNameID();
+
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink("saml", provider, providerUserId, jellyfinUserId));
+    }
+
+    // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
+    // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
+    // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
+    // Returns null for an unknown provider so call sites branch on a null check instead of catching
+    // KeyNotFoundException as control flow (#241). An uncontended lock is nanoseconds; it is only held long
+    // during a first-login/admin persist, which is exactly when a consistent read matters. Moved off the
+    // controller with the SAML flow (#160); the OpenID twin lives on OidcLoginService.
+    private static SamlConfig FindSamlConfig(string provider) =>
+        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
+
+    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that as
+    // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
+    // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
+    // flow — which cannot know which redirect path the identity provider has registered — reuses the last
+    // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
+    // reason this value is remembered across requests.) Mirrors OidcLoginService.ResolveChallengeNewPath —
+    // the type is known here, so the record is a direct assignment.
+    private static bool ResolveChallengeNewPath(SamlConfig config, bool isLinking, HttpRequest request)
+    {
+        if (isLinking)
+        {
+            return config.NewPath;
+        }
+
+        var newPath = ChallengePath.IsNewPath(request.Path.Value);
+        config.NewPath = newPath;
+        return newPath;
+    }
+
+    // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider
+    // opts in (#167). Fail-closed: signing enabled but the signing key missing/unloadable throws, so the
+    // caller returns an error rather than silently sending an unsigned request — an operator who turned
+    // signing on never gets a silent downgrade. Default off is byte-for-byte the previous unsigned URL.
+    private static string BuildChallengeRedirectUrl(SamlConfig config, SamlAuthnRequest request, string relayState)
+    {
+        var endpoint = config.SamlEndpoint.Trim();
+        if (!config.SignAuthnRequests)
+        {
+            return request.GetRedirectUrl(endpoint, relayState);
+        }
+
+        if (!SamlSigningKey.TryLoad(config.SamlSigningKeyPfx, out var signingCertificate))
+        {
+            throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key could not be loaded.");
+        }
+
+        using (signingCertificate)
+        using (var signingKey = signingCertificate.GetRSAPrivateKey())
+        {
+            if (signingKey is null)
+            {
+                throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key has no RSA private key.");
+            }
+
+            return request.GetSignedRedirectUrl(endpoint, relayState, signingKey);
+        }
+    }
+
+    // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.
+    // Returns false when the assertion was already used (or carries no ID — a missing ID stays empty,
+    // so TryConsume fails closed). The key is scoped by provider so two IdPs emitting the same assertion
+    // ID cannot block each other. Shared by the session mint and the account linking (#219).
+    private static bool TryConsumeSamlReplay(SamlResponse samlResponse, string provider)
+    {
+        var samlNow = DateTime.UtcNow;
+        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
+        var assertionId = samlResponse.GetAssertionId();
+        var replayKey = ProviderScopedKey.For(provider, assertionId);
+        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
+    }
+
+    // Validates the SAML response and, on failure, logs the declared signature algorithm plus the
+    // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
+    // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
+    // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
+    private bool IsSamlResponseValid(HttpRequest request, SamlResponse samlResponse, SamlConfig config, string provider)
+    {
+        if (!ValidateSaml(samlResponse, config))
+        {
+            // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
+            // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
+            _logger.LogWarning(
+                "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
+                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
+            return false;
+        }
+
+        // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service
+        // provider's assertion-consumer URL, so an assertion minted for a different endpoint (or a
+        // different SP sharing the identity provider) cannot be presented here.
+        if (config.ValidateRecipient
+            && !SamlRecipientValidator.IsBound(samlResponse.GetRecipient(), samlResponse.GetDestination(), ExpectedAcsUrls(request, config, provider)))
+        {
+            _logger.LogWarning("SAML response rejected: the assertion Recipient or Response Destination does not match this server's assertion-consumer URL.");
+            return false;
+        }
+
+        return true;
+    }
+
+    // The assertion-consumer URLs this service provider advertises for the provider — the same value
+    // Challenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
+    // Destination) must equal one. Both the new ("post") and legacy ("p") path spellings are returned:
+    // config.NewPath is process-wide mutable state a concurrent challenge can flip, and the Recipient
+    // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids
+    // rejecting a valid login on a path-form flip; both are this provider's own ACS URLs.
+    //
+    // The host comes from GetRequestBase. With BaseUrlOverride set (#139) it is the pinned canonical
+    // host, so this binding is exact regardless of the request Host. Without it the host is the request
+    // Host, so the binding is only as strong as host resolution: behind a reverse proxy, configure
+    // Jellyfin's Known/Trusted Proxies (or set BaseUrlOverride) so the Host cannot be spoofed, or an
+    // attacker controlling the Host can make the expected URL match a captured assertion's Recipient
+    // (defense-in-depth, not a hard guarantee).
+    private static string[] ExpectedAcsUrls(HttpRequest request, SamlConfig config, string provider) =>
+        SsoUrlBuilder.SamlExpectedAcsUrls(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), provider);
+
+    // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
+    // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
+    // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
+    // Issuer sent in the AuthnRequest, and an empty SamlAudience falls through to the client id.
+    internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
+    {
+        if (config.DoNotValidateAudience)
+        {
+            return samlResponse.IsValid();
+        }
+
+        var expected = config.SamlAudience?.Trim();
+        if (string.IsNullOrEmpty(expected))
+        {
+            expected = config.SamlClientId?.Trim();
+        }
+
+        return samlResponse.IsValid(expected);
+    }
+
+    // Thin adapter feeding the live request values into the pure CanonicalBaseUrl.Resolve decision (#242) —
+    // the same decision OidcLoginService.RequestBaseUrl feeds for OpenID, kept as a local read so this flow
+    // tier is self-contained.
+    private static string GetRequestBase(HttpRequest request, string schemeOverride, int? portOverride, string baseUrlOverride) =>
+        CanonicalBaseUrl.Resolve(baseUrlOverride, request.Scheme, request.Host.Host, request.Host.Port, request.PathBase, schemeOverride, portOverride);
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -4,9 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -65,17 +62,11 @@ public class SSOController : ControllerBase
     // store and the discovery-facts cache) as its own statics; the controller's OpenID endpoints apply the
     // shared rate-limit gate below and delegate here. New'd per request like the other collaborators.
     private readonly Flows.OidcLoginService _oidc;
-
-    // One-time-use tracking for consumed SAML assertion IDs (replay protection).
-    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
-
-    // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156).
-    private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
-
-    // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
-    // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID authorize-state lifetime the
-    // flow service keeps.
-    private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
+    // The SAML login flow (#160, #318 step 13): challenge, assertion-consumer callback, session-minting
+    // authenticate, and manual link. It owns the SAML-specific process-wide caches (the replay cache and
+    // the outstanding-AuthnRequest cache) as its own statics; the controller's SAML endpoints apply the
+    // shared rate-limit gate below and delegate here. New'd per request like the other collaborators.
+    private readonly Flows.SamlLoginService _saml;
 
     // Opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128).
     private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
@@ -113,6 +104,7 @@ public class SSOController : ControllerBase
         var sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
         _loginCompletion = new LoginCompletionService(_canonicalLinks, sessionMinter, logger);
         _oidc = new Flows.OidcLoginService(_loginCompletion, _canonicalLinks, httpClientFactory, loggerFactory, logger);
+        _saml = new Flows.SamlLoginService(_loginCompletion, _canonicalLinks, logger);
         _logger.LogInformation("SSO Controller initialized");
     }
 
@@ -136,8 +128,8 @@ public class SSOController : ControllerBase
 
         // The OpenID redirect callback lives in the flow service (#160, #318): it validates the
         // browser-bound state, exchanges the code, validates the id_token and RFC 9207 response issuer,
-        // applies the role gate, and renders the security-headered intermediate auth page (passed in).
-        return await _oidc.CallbackAsync(provider, state, Request, HtmlAuthPage).ConfigureAwait(false);
+        // applies the role gate, and renders the security-headered intermediate auth page on the response.
+        return await _oidc.CallbackAsync(provider, state, Request, Response).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -159,48 +151,6 @@ public class SSOController : ControllerBase
         // PKCE gate, prepares the authorization request, registers the browser-bound authorize state, and
         // redirects to the identity provider (setting the binding cookie on the response).
         return await _oidc.ChallengeAsync(provider, isLinking, Request, Response).ConfigureAwait(false);
-    }
-
-    // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
-    // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
-    // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
-    // InternalsVisibleTo).
-    internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
-
-    // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
-    // binding (#415) — normally populated by the SamlChallenge redirect leg — without deriving the
-    // random request id from the emitted AuthnRequest. Same test-only surface as SeedOidStateForTests
-    // (internal, InternalsVisibleTo, no endpoint/DI); never reachable in production.
-    internal static void SeedSamlRequestForTests(string provider, string requestId, string bindingId, DateTime expiryUtc) =>
-        SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow, clientKey: null, out _);
-
-    // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an
-    // admin Add/Del mutating the live provider dictionary in place — a Dictionary read-during-write is
-    // undefined behaviour in .NET (throw, misread, or a spin on a corrupted chain during a resize) (#252).
-    // Returns null for an unknown provider so call sites branch on a null check instead of catching
-    // KeyNotFoundException as control flow (#241). An uncontended lock is nanoseconds; it is only held long
-    // during a first-login/admin persist, which is exactly when a consistent read matters. (The OpenID twin
-    // moved into the flow service with the OID flow, #160.)
-    private static SamlConfig FindSamlConfig(string provider) =>
-        SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
-
-    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that
-    // as server-managed runtime state on the provider config. A non-linking challenge derives the
-    // spelling from the request path (a `.../start/...` route means the new path) and stores it through
-    // `record`, so a later linking flow — which cannot know which redirect path the identity provider
-    // has registered — reuses the last login's spelling. A linking challenge only reads the stored
-    // value and records nothing. `record` is passed because OidConfig and SamlConfig do not share a
-    // base type. (See ExpectedAcsUrls for the same reason this value is remembered across requests.)
-    private bool ResolveChallengeNewPath(bool currentNewPath, bool isLinking, Action<bool> record)
-    {
-        if (isLinking)
-        {
-            return currentNewPath;
-        }
-
-        var newPath = ChallengePath.IsNewPath(Request.Path.Value);
-        record(newPath);
-        return newPath;
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
@@ -420,53 +370,10 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        // Unknown and disabled providers share one rejection so neither can be probed apart — this
-        // retires the unique "No active providers found" wording that distinguished the disabled case
-        // (a disabled provider now short-circuits before the relayState log line).
-        var config = FindSamlConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
-        }
-
-        bool isLinking = string.Equals(relayState, "linking", StringComparison.Ordinal);
-
-        // relayState is attacker-controllable; strip line endings inline at the log call to prevent
-        // log forging (structured logging alone does not sanitize a newline-bearing value).
-        _logger.LogInformation(
-            "SAML request has relayState of {RelayState}",
-            relayState?.ReplaceLineEndings(string.Empty));
-
-        // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
-        // content-type binds null (the form value provider is skipped, so Request.Form is never
-        // touched and cannot throw the InvalidOperationException that escaped as a 500, #206), and a
-        // null body is rejected the same way as any other malformed response — a clean 400.
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, formSamlResponse, out var samlResponse)
-            || !IsSamlResponseValid(samlResponse, config, provider))
-        {
-            // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
-            // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
-        {
-            return HtmlAuthPage(nonce =>
-                WebResponse.Generator(
-                    data: Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(samlResponse.Xml)),
-                    provider: provider,
-                    baseUrl: GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
-                    mode: "SAML",
-                    nonce: nonce,
-                    isLinking: isLinking));
-        }
-
-        _logger.LogWarning(
-            "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-            samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-            samlResponse.GetCustomAttributes("Role").Select(r => r?.ReplaceLineEndings(string.Empty)),
-            config.Roles);
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        // The SAML assertion-consumer callback lives in the flow service (#160, #318): it validates the
+        // signed response and, on a passing role gate, renders the security-headered intermediate auth
+        // page on the response.
+        return _saml.Post(provider, relayState, formSamlResponse, Request, Response);
     }
 
     /// <summary>
@@ -484,121 +391,10 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        // Unknown and disabled providers share one rejection so neither can be probed apart, and the
-        // answer no longer depends on host middleware mapping a thrown ArgumentException (#318).
-        var config = FindSamlConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
-        }
-
-        bool newPath = ResolveChallengeNewPath(config.NewPath, isLinking, value => config.NewPath = value);
-
-        string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
-        string relayState = null;
-        if (isLinking)
-        {
-            relayState = "linking";
-        }
-
-        var request = new SamlAuthnRequest(
-            config.SamlClientId.Trim(),
-            redirectUri);
-
-        // Bind this login to the initiating browser (#415): mint a binding id, set it as a cookie, and
-        // record it against the request id so the session-mint endpoint (SamlAuth) can require the
-        // response's browser to be the one that started the flow — closing the SP-initiated forced-login
-        // / session-fixation vector, the SAML analogue of #326. Only for login flows: the linking
-        // callback (SamlLink) is a separate flow that does not consume the outstanding request, so a
-        // linking registration would only leave an id to expire unused. Registration now happens for
-        // every login challenge (not only under ValidateInResponseTo), so the binding is enforced for
-        // every SOLICITED login this plugin initiated — the case ValidateInResponseTo alone left open.
-        // It does NOT bind an unsolicited (IdP-initiated) response, which carries no matching request;
-        // fully closing forced login for an IdP that issues unsolicited responses additionally requires
-        // ValidateInResponseTo (which refuses them). Because the cookie is __Host-/Secure, the browser
-        // only returns it over HTTPS — SP-initiated SAML now needs HTTPS at the browser edge, as OIDC
-        // already does.
-        if (!isLinking)
-        {
-            var bindingId = AuthorizeStateBinding.NewId();
-
-            // The client key bounds how much of the request cache one source can occupy (#327); a
-            // proxy/private source normalizes to null and is exempt.
-            var clientKey = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
-            if (!SamlRequests.Register(
-                    ProviderScopedKey.For(provider, request.Id),
-                    bindingId,
-                    DateTime.UtcNow + SamlRequestLifetime,
-                    DateTime.UtcNow,
-                    clientKey,
-                    out var shouldWarnCapacity))
-            {
-                // The per-client sub-cap or the global cap refused this login's outstanding-request
-                // entry (#327). Fail closed HERE rather than redirect to the IdP for a login that could
-                // then only be refused at the callback (no correlation entry). The store throttles the
-                // capacity warning to one signal per interval so a flood cannot amplify into log volume
-                // (CWE-400) — parity with the OpenID challenge refusal.
-                if (shouldWarnCapacity)
-                {
-                    _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
-                }
-
-                return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
-            }
-
-            Response.Cookies.Append(
-                AuthorizeStateBinding.SamlCookieName,
-                bindingId,
-                AuthorizeStateBinding.CookieOptions(SamlRequestLifetime));
-        }
-
-        string redirectUrl;
-        try
-        {
-            redirectUrl = BuildChallengeRedirectUrl(config, request, relayState);
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or CryptographicException)
-        {
-            // Signing is enabled for this provider but the request could not be signed: the key is
-            // missing/unusable (InvalidOperationException), the endpoint is empty (ArgumentException from
-            // the signer), or the platform key store refused the signing operation (CryptographicException).
-            // ANY of these fails closed with a clean 500 — never a silent unsigned request — rather than
-            // escaping as a raw host 500. The key material is not part of the message, so nothing sensitive
-            // is logged.
-            _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
-            return ReturnError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");
-        }
-
-        return Redirect(redirectUrl);
-    }
-
-    // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider
-    // opts in (#167). Fail-closed: signing enabled but the signing key missing/unloadable throws, so the
-    // caller returns an error rather than silently sending an unsigned request — an operator who turned
-    // signing on never gets a silent downgrade. Default off is byte-for-byte the previous unsigned URL.
-    private static string BuildChallengeRedirectUrl(SamlConfig config, SamlAuthnRequest request, string relayState)
-    {
-        var endpoint = config.SamlEndpoint.Trim();
-        if (!config.SignAuthnRequests)
-        {
-            return request.GetRedirectUrl(endpoint, relayState);
-        }
-
-        if (!SamlSigningKey.TryLoad(config.SamlSigningKeyPfx, out var signingCertificate))
-        {
-            throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key could not be loaded.");
-        }
-
-        using (signingCertificate)
-        using (var signingKey = signingCertificate.GetRSAPrivateKey())
-        {
-            if (signingKey is null)
-            {
-                throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key has no RSA private key.");
-            }
-
-            return request.GetSignedRedirectUrl(endpoint, relayState, signingKey);
-        }
+        // The SAML challenge lives in the flow service (#160, #318): it builds the AuthnRequest, binds it
+        // to the initiating browser (setting the binding cookie on the response), signs it when the
+        // provider opts in (#167), and redirects to the identity provider.
+        return _saml.Challenge(provider, isLinking, Request, Response);
     }
 
     /// <summary>
@@ -681,106 +477,16 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        // Unknown and disabled providers share one rejection so neither can be probed apart — this
-        // unifies the previously JSON unknown-provider body and the disabled provider's 500.
-        var config = FindSamlConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
-        }
-
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
-            || !IsSamlResponseValid(samlResponse, config, provider))
-        {
-            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        // Correlate the response to an AuthnRequest this server issued (#156, #415), and enforce the
-        // browser binding for a solicited login. A NON-EMPTY InResponseTo means the response claims to
-        // answer a request this server issued, so it must actually correlate to a live outstanding
-        // request AND carry that request's binding cookie — anything less fails closed. Crucially, a
-        // non-empty InResponseTo whose entry is gone (expired past the 15-minute window, evicted at the
-        // cap, lost to a restart or a non-sticky multi-node hop) is a LOST correlation, not an
-        // unsolicited response: treating it as unsolicited would let a signature-valid response mint a
-        // session with no binding check when ValidateInResponseTo is off, which is exactly the
-        // forced-login bypass the binding exists to close (login validity must never default to true).
-        //
-        // The binding is checked AFTER the atomic claim (unlike the OpenID state, #326) and that is safe:
-        // the response already passed signature validation above and the InResponseTo is read from that
-        // validated document, so an attacker cannot mint a signature-valid response carrying a victim's
-        // request id to burn their outstanding entry. The cookie is checked here (the same-origin auth
-        // endpoint), not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
-        var inResponseTo = samlResponse.GetInResponseTo();
-        if (!string.IsNullOrEmpty(inResponseTo))
-        {
-            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
-            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId)
-                || !AuthorizeStateBinding.Matches(storedBindingId, Request.Cookies[AuthorizeStateBinding.SamlCookieName]))
-            {
-                _logger.LogWarning("SAML login denied: a solicited response did not correlate to a live outstanding request from the initiating browser (binding mismatch, expiry, or lost correlation).");
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-            }
-        }
-        else if (config.ValidateInResponseTo)
-        {
-            // No InResponseTo at all: a genuinely unsolicited (IdP-initiated) response. It is refused
-            // only when the opt-in solicited-only mode is on; otherwise it proceeds — unchanged and
-            // non-breaking for IdP-initiated deployments. The rejection is a client-caused 400 in the
-            // uniform SAML body, never a 500, and the diagnosis stays in the warning log.
-            _logger.LogWarning("SAML login denied: the response was not solicited by this server (no InResponseTo).");
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
-        // can POST an assertion straight to this session-minting endpoint and skip the page, so
-        // checking it only there would be fail-open.
-        if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes("Role"), config.Roles))
-        {
-            _logger.LogWarning(
-                "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
-                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-        }
-
-        // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
-        // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
-        // renders the intermediate page, so the two-step post-then-auth flow consumes the id once. A
-        // replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
-        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
-        if (!TryConsumeSamlReplay(samlResponse, provider))
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
-        // the assertion's roles and the provider configuration. Login validity was already decided
-        // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
-        // here.
-        var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes("Role"), config);
-
-        // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
-        // reject it as an invalid login instead of failing downstream on a null canonical name.
-        // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
-        var nameId = samlResponse.GetNameID();
-        if (string.IsNullOrWhiteSpace(nameId))
-        {
-            _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-        }
-
-        // All SAML validation has now passed — signature, time bounds, audience, recipient, InResponseTo
-        // correlation, the login allow-list, replay one-time-use, and the non-empty-NameID guard — so this
-        // is the point at which the response becomes a fully-verified SAML identity (#473). SAML keys the
-        // link directly on the NameID (subject and username are the same value; no migration path needed)
-        // and carries no email_verified claim, so the verified-email gate is not applicable
-        // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
-        // From here the SAML and OpenID paths are one.
-        return await _loginCompletion.CompleteAsync(
-            VerifiedIdentity.FromValidatedSaml(provider, nameId, derived),
+        // The SAML session-minting authenticate leg lives in the flow service (#160, #318): it validates
+        // the signed response, correlates it to an AuthnRequest this server issued (browser binding),
+        // enforces the login allow-list and one-time replay consume, and hands the verified identity to the
+        // shared completion tail. The controller passes the presented binding cookie and the
+        // HttpContext-derived remote endpoint in, keeping the flow tier HttpContext-free (#177).
+        return await _saml.AuthenticateAsync(
+            provider,
             response,
-            config,
-            AdoptionGate.None,
+            Request.Cookies[AuthorizeStateBinding.SamlCookieName],
+            Request,
             () => HttpContext.GetNormalizedRemoteIP().ToString()).ConfigureAwait(false);
     }
 
@@ -950,41 +656,12 @@ public class SSOController : ControllerBase
     /// </param>
     /// <param name="response">The data passed to the client to ensure it is the right one.</param>
     /// <returns>JSON for the client to populate information with.</returns>
-    // No [Consumes]/[Produces]: ASP.NET Core honors content-negotiation filters only on public action
-    // methods, and this is a private helper invoked directly from AddCanonicalLink, which carries its
-    // own. The attributes were inert metadata here (#393).
-    private ActionResult SamlLink(string provider, Guid jellyfinUserId, AuthResponse response)
-    {
-        // A disabled provider must neither create a link nor consume the assertion's one-time-use ID
-        // (#343): an administrator disabling a provider takes effect immediately for linking, and the
-        // unknown and disabled cases share one response so neither can be probed apart.
-        var config = FindSamlConfig(provider);
-        if (config is not { Enabled: true })
-        {
-            return BadRequest(NoMatchingProviderMessage);
-        }
-
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
-            || !IsSamlResponseValid(samlResponse, config, provider))
-        {
-            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        // Enforce one-time use here too (#219): without it, a captured, still-valid assertion could be
-        // replayed to bind its NameID to the caller's account. The linking flow issues no AuthnRequest,
-        // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use
-        // control. A replay is a client-caused 400 in the uniform SAML body, never a 500, and no longer
-        // discloses the replay cache to the attacker who replayed.
-        if (!TryConsumeSamlReplay(samlResponse, provider))
-        {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        string providerUserId = samlResponse.GetNameID();
-
-        return MapWrite(_canonicalLinks.TryCreateLink("saml", provider, providerUserId, jellyfinUserId));
-    }
+    // The SAML manual-link redeem (validate the signed response, consume its one-time-use assertion id,
+    // create the link on the NameID) lives on the flow service; the controller keeps the caller-authz
+    // guard (AddCanonicalLink) and hands the request in (#160). The former [Consumes]/[Produces] on this
+    // private helper were inert (AddCanonicalLink owns the content negotiation, #393).
+    private ActionResult SamlLink(string provider, Guid jellyfinUserId, AuthResponse response) =>
+        _saml.Link(provider, jellyfinUserId, response, Request);
 
     /// <summary>
     /// Validate an OIDC link request and create the link if it is valid.
@@ -996,23 +673,12 @@ public class SSOController : ControllerBase
     /// </param>
     /// <param name="response">The data passed to the client to ensure it is the right one.</param>
     /// <returns>JSON for the client to populate information with.</returns>
-    // No [Consumes]/[Produces]: inert on a private helper (see SamlLink) — AddCanonicalLink owns the
-    // content negotiation (#393). The OID link redeem (which consumes the flow service's authorize state)
-    // lives on the flow service; the controller keeps the caller-authz guard (AddCanonicalLink) and the
-    // write-result-to-HTTP mapping it shares with SamlLink (#160).
+    // The OID link redeem (which consumes the flow service's authorize state) lives on the flow service;
+    // the controller keeps the caller-authz guard (AddCanonicalLink) and hands the binding cookie in. Both
+    // flow services now map the write result through the shared FlowResponses home (#160). The former
+    // [Consumes]/[Produces] were inert on this private helper (#393).
     private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response) =>
-        _oidc.Link(provider, jellyfinUserId, response, Request.Cookies[AuthorizeStateBinding.CookieName], MapWrite);
-
-    // The HTTP boundary for a manual link creation: maps the service's closed write result to a response.
-    // The empty-key and unknown-provider refusals keep distinct bodies (the service checks the empty key
-    // first), and an unhandled result throws rather than silently returning a wrong status.
-    private ActionResult MapWrite(CanonicalLinkWriteResult result) => result switch
-    {
-        CanonicalLinkWriteResult.Created => NoContent(),
-        CanonicalLinkWriteResult.EmptyKey => BadRequest("The SSO login did not resolve an identity."),
-        CanonicalLinkWriteResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
-        _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
-    };
+        _oidc.Link(provider, jellyfinUserId, response, Request.Cookies[AuthorizeStateBinding.CookieName]);
 
     // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
     // request may proceed, else the throttled outcome rendered by the single mapper (#474). Reads the
@@ -1058,112 +724,5 @@ public class SSOController : ControllerBase
         // status, plain-text body and the retry-delay header all originate there, so the controller no
         // longer emits a bare rate-limit ContentResult or sets the delay header itself.
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(retryAfterSeconds), Response);
-    }
-
-    // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.
-    // Returns false when the assertion was already used (or carries no ID — a missing ID stays empty,
-    // so TryConsume fails closed). The key is scoped by provider so two IdPs emitting the same assertion
-    // ID cannot block each other. Shared by SamlAuth (session mint) and SamlLink (account linking, #219).
-    private bool TryConsumeSamlReplay(SamlResponse samlResponse, string provider)
-    {
-        var samlNow = DateTime.UtcNow;
-        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
-        var assertionId = samlResponse.GetAssertionId();
-        var replayKey = ProviderScopedKey.For(provider, assertionId);
-        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
-    }
-
-    // Validates the SAML response and, on failure, logs the declared signature algorithm plus the
-    // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
-    // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
-    // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
-    private bool IsSamlResponseValid(SamlResponse samlResponse, SamlConfig config, string provider)
-    {
-        if (!ValidateSaml(samlResponse, config))
-        {
-            // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
-            // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
-            _logger.LogWarning(
-                "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
-                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
-            return false;
-        }
-
-        // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service
-        // provider's assertion-consumer URL, so an assertion minted for a different endpoint (or a
-        // different SP sharing the identity provider) cannot be presented here.
-        if (config.ValidateRecipient
-            && !SamlRecipientValidator.IsBound(samlResponse.GetRecipient(), samlResponse.GetDestination(), ExpectedAcsUrls(config, provider)))
-        {
-            _logger.LogWarning("SAML response rejected: the assertion Recipient or Response Destination does not match this server's assertion-consumer URL.");
-            return false;
-        }
-
-        return true;
-    }
-
-    // The assertion-consumer URLs this service provider advertises for the provider — the same value
-    // SamlChallenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
-    // Destination) must equal one. Both the new ("post") and legacy ("p") path spellings are returned:
-    // config.NewPath is process-wide mutable state a concurrent challenge can flip, and the Recipient
-    // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids
-    // rejecting a valid login on a path-form flip; both are this provider's own ACS URLs.
-    //
-    // The host comes from GetRequestBase. With BaseUrlOverride set (#139) it is the pinned canonical
-    // host, so this binding is exact regardless of the request Host. Without it the host is the request
-    // Host, so the binding is only as strong as host resolution: behind a reverse proxy, configure
-    // Jellyfin's Known/Trusted Proxies (or set BaseUrlOverride) so the Host cannot be spoofed, or an
-    // attacker controlling the Host can make the expected URL match a captured assertion's Recipient
-    // (defense-in-depth, not a hard guarantee).
-    private string[] ExpectedAcsUrls(SamlConfig config, string provider) =>
-        SsoUrlBuilder.SamlExpectedAcsUrls(GetRequestBase(config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), provider);
-
-    // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
-    // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
-    // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
-    // Issuer sent in the AuthnRequest, and an empty SamlAudience falls through to the client id.
-    internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
-    {
-        if (config.DoNotValidateAudience)
-        {
-            return samlResponse.IsValid();
-        }
-
-        var expected = config.SamlAudience?.Trim();
-        if (string.IsNullOrEmpty(expected))
-        {
-            expected = config.SamlClientId?.Trim();
-        }
-
-        return samlResponse.IsValid(expected);
-    }
-
-    // Thin wrapper feeding the live request values into the pure CanonicalBaseUrl.Resolve decision (#242).
-    private string GetRequestBase(string schemeOverride = null, int? portOverride = null, string baseUrlOverride = null) =>
-        CanonicalBaseUrl.Resolve(baseUrlOverride, Request.Scheme, Request.Host.Host, Request.Host.Port, Request.PathBase, schemeOverride, portOverride);
-
-    private static ContentResult ReturnError(int code, string message)
-    {
-        var errorResult = new ContentResult();
-        errorResult.Content = message;
-        errorResult.ContentType = MediaTypeNames.Text.Plain;
-        errorResult.StatusCode = code;
-        return errorResult;
-    }
-
-    // Returns the rendered auth page as HTML with defensive response headers. The page carries the
-    // one-time state token / signed assertion and completes the login from an inline script, so it
-    // must not be framed (clickjacking), MIME-sniffed, cached, or leak its URL via Referer. A strict
-    // Content-Security-Policy locks it to a single nonce'd inline script and style and same-origin
-    // fetch/frame; the same per-response nonce is threaded into the rendered page via the delegate.
-    private ContentResult HtmlAuthPage(Func<string, string> render)
-    {
-        var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
-        Response.Headers.ContentSecurityPolicy = AuthPageCsp.Build(nonce);
-        Response.Headers["X-Frame-Options"] = "DENY";
-        Response.Headers["X-Content-Type-Options"] = "nosniff";
-        Response.Headers["Referrer-Policy"] = "no-referrer";
-        Response.Headers.CacheControl = "no-store";
-        return Content(render(nonce), MediaTypeNames.Text.Html);
     }
 }

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net.Mime;
+using System.Security.Cryptography;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
+
+/// <summary>
+/// The HTTP result shapes shared by both login-flow services (#160): the plain-text error, the
+/// security-headered intermediate auth page, and the manual-link write mapping. These were controller
+/// helpers (<c>ReturnError</c> + the OpenID service's <c>PlainTextError</c> twin, <c>HtmlAuthPage</c>,
+/// <c>MapWrite</c>) that both the OpenID and SAML flows need; consolidating them into one shared home
+/// removes the duplication the OpenID extraction (#500) flagged, so the two flow services render identical
+/// results from one definition rather than from a passed-in controller delegate. Pure static builders — they
+/// construct <see cref="ActionResult"/>s directly (never touching <c>ControllerBase</c>), and the only side
+/// effect is setting the defensive headers on the caller's response for the auth page.
+/// </summary>
+internal static class FlowResponses
+{
+    /// <summary>
+    /// A plain-text error result (<c>text/plain</c> with the given status), reproducing the controller's
+    /// former <c>ReturnError</c> shape exactly so the non-outcome flow errors — a SAML signing-key failure,
+    /// an OpenID PrepareLogin failure, a store-capacity refusal — stay byte-identical on the wire.
+    /// </summary>
+    /// <param name="code">The HTTP status code.</param>
+    /// <param name="message">The plain-text body.</param>
+    /// <returns>A <see cref="ContentResult"/> carrying the message as <c>text/plain</c>.</returns>
+    internal static ContentResult PlainTextError(int code, string message) => new ContentResult
+    {
+        Content = message,
+        ContentType = MediaTypeNames.Text.Plain,
+        StatusCode = code,
+    };
+
+    /// <summary>
+    /// Renders the intermediate auth page as HTML with defensive response headers. The page carries the
+    /// one-time state token / signed assertion and completes the login from an inline script, so it must not
+    /// be framed (clickjacking), MIME-sniffed, cached, or leak its URL via Referer. A strict
+    /// Content-Security-Policy locks it to a single nonce'd inline script and style and same-origin
+    /// fetch/frame; the same per-response nonce is threaded into the rendered page via the delegate.
+    /// </summary>
+    /// <param name="response">The response the defensive headers are written to.</param>
+    /// <param name="render">The page renderer, taking the per-response CSP nonce and returning the HTML body.</param>
+    /// <returns>A <see cref="ContentResult"/> carrying the rendered page as <c>text/html</c>.</returns>
+    internal static ContentResult AuthPage(HttpResponse response, Func<string, string> render)
+    {
+        var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+        response.Headers.ContentSecurityPolicy = AuthPageCsp.Build(nonce);
+        response.Headers["X-Frame-Options"] = "DENY";
+        response.Headers["X-Content-Type-Options"] = "nosniff";
+        response.Headers["Referrer-Policy"] = "no-referrer";
+        response.Headers.CacheControl = "no-store";
+        return new ContentResult
+        {
+            Content = render(nonce),
+            ContentType = MediaTypeNames.Text.Html,
+        };
+    }
+
+    /// <summary>
+    /// The HTTP boundary for a manual link creation: maps the link service's closed write result to a
+    /// response. The empty-key and unknown-provider refusals keep distinct bodies (the service checks the
+    /// empty key first), and an unhandled result throws rather than silently returning a wrong status.
+    /// </summary>
+    /// <param name="result">The closed write-result variant from <c>CanonicalLinkService.TryCreateLink</c>.</param>
+    /// <returns>The mapped <see cref="ActionResult"/>.</returns>
+    internal static ActionResult MapCanonicalLinkWrite(CanonicalLinkWriteResult result) => result switch
+    {
+        CanonicalLinkWriteResult.Created => new NoContentResult(),
+        CanonicalLinkWriteResult.EmptyKey => new BadRequestObjectResult("The SSO login did not resolve an identity."),
+        CanonicalLinkWriteResult.UnknownProvider => new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage),
+        _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
+    };
+}


### PR DESCRIPTION
# What & why

Extract the SAML login flow off the `SSOController` monolith into a new
`internal sealed SamlLoginService`, symmetric to the just-merged
`OidcLoginService` (#318 step 13). The controller's SAML endpoints become thin
rate-limit + delegate adapters, so the SAML protocol logic now lives in one
flow-tier collaborator instead of inline on the controller.

We also close the duplication PR #500 flagged: the HTTP result shapes both flow
services share, the CSP-hardened intermediate auth page, the plain-text flow
error, and the manual-link write mapping, are consolidated into one shared
`SSO-Auth/Api/Shared/FlowResponses.cs`, and `OidcLoginService` is switched to
call it instead of the passed-in controller delegates and its `PlainTextError`
twin.

Refs #160

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. The full SAML validation chain
      (signature/time/audience/recipient -> InResponseTo correlation + browser
      binding -> allow-list -> one-time replay consume -> non-empty NameID) still
      runs, in the same order, before `VerifiedIdentity.FromValidatedSaml`.
- [x] No secrets logged; secrets are redacted on config export. The signing-key
      failure path logs only `ex.Message`, never key material -- moved verbatim.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Four-lens adversarial gate
      below -- all PASS.
- [x] Log inputs from the IdP are sanitized inline at the log call
      (`?.ReplaceLineEndings(string.Empty)` at every SAML log site -- moved
      verbatim, not routed through a helper boundary).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. This removes duplication rather than adding it: the shared
      auth-page/error/write shapes now have one home in `FlowResponses`.
- [x] The change adds no more code than the problem requires. `SSOController`
      drops from 1169 to 728 lines (-441); the moved code is relocated, not
      rewritten.
- [x] The code is self-documenting and matches the target architecture (#318):
      thin controller + pure/flow-tier collaborators, mirroring the OpenID flow.
- [x] Architecture-conformance tests pass, and the new structural properties are
      locked in: `Controller_DelegatesSamlFlowToTheFlowService`,
      `SharedFlowResponses_OwnTheAuthPageErrorAndLinkWriteResults`, and the
      relocated `VerifiedIdentity` SAML-factory home in
      `VerifiedIdentity_IsConstructedOnlyByProtocolValidators`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release,
      0 warnings, 0 errors).
- [x] `dotnet test` is green (1023 passed, 0 failed) -- includes the new
      `SamlLoginServiceTests` and the extended conformance rules.
- [x] Prettier is clean -- this change touches only `.cs` files.

## Notes

**What moved into `SamlLoginService`** (`SSO-Auth/Api/Flows/SamlLoginService.cs`):
the SAML challenge (`Challenge`), the assertion-consumer callback (`Post`), the
session-minting authenticate leg (`AuthenticateAsync`), the manual link
(`Link`), and the SAML-only helpers (`FindSamlConfig`, `ResolveChallengeNewPath`,
`BuildChallengeRedirectUrl`, `TryConsumeSamlReplay`, `IsSamlResponseValid`,
`ExpectedAcsUrls`, `ValidateSaml`, `GetRequestBase`). The two SAML-only statics
-- the replay cache and the outstanding-AuthnRequest cache -- moved onto the
service as `static readonly`, so the single process-wide instance is preserved
(the service is `new`'d per request; instance fields would have lost the
in-flight state between challenge and callback and locked out every solicited
login). Their `Reset*/Seed*ForTests` hooks moved with them (internal via
`InternalsVisibleTo`).

**Shared-helper consolidation:** `ReturnError`/`PlainTextError`, the CSP
`HtmlAuthPage`, and `MapWrite` became `FlowResponses.PlainTextError`,
`FlowResponses.AuthPage`, and `FlowResponses.MapCanonicalLinkWrite`. Both flow
services call them; `OidcLoginService.CallbackAsync` now takes the `HttpResponse`
and its `Link` dropped the `mapWrite` delegate. The five defensive auth-page
headers (CSP via `AuthPageCsp.Build`, `X-Frame-Options: DENY`,
`X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`,
`Cache-Control: no-store`) are set identically for both the OIDC callback and the
SAML ACS page.

**Preserved wire-for-wire:** same AuthnRequest incl. the #167 optional signing
(default-off is byte-identical unsigned), same ACS handling, same responses
(403/400/redirect/auth-page), same CSP headers, same `VerifiedIdentity` keystone
and one-time replay consume. The shared per-client rate limiter stays a
controller static both flows reach through `RateLimitCheck` -- OIDC rate-limiting
is untouched.

### Adversarial-review gate (four lenses, refute-by-default)

- **Availability / mass-lockout** -- VERDICT: rate-limit gates remain on all six
  anonymous endpoints, the SAML replay/request caches stay process-wide statics
  so no login loses correlation, and the recipient/base-URL derivation is
  byte-for-byte the old controller path -- no mass-lockout or newly-rejected
  config. **PASS**
- **Security-bypass / fail-open** -- VERDICT: all SAML validation gates,
  ordering, replay one-time-use, fail-closed provider guards, and the shared
  response/header shapes are preserved wire-for-wire; `FromValidatedSaml` has a
  single call site (`SamlLoginService`); no bypass introduced. **PASS**
- **Correctness** -- VERDICT: a statement-by-statement equivalent extraction with
  identical response shapes, ordering, exception types, and static-cache
  semantics (incl. the `request`->`samlRequest` rename and the #167 signing
  path), confirmed by a green `--warnaserror` build. **PASS**
- **Integration** -- VERDICT: endpoint route attributes/signatures, delegation
  wiring, moved test hooks (no dangling `SSOController.` references), and the
  non-vacuous conformance rules all verified; host/ABI/packaging surface
  untouched; green build + full 1023-test pass. **PASS**

Out of scope: the pre-existing reverse-proxy / multi-instance-HA caveat (the
host-derived ACS URL and in-process caches) is carried forward verbatim in the
moved comments -- not introduced or worsened here.
