### PR TITLE
Move the shared rate-limit gate off SSOController into the Shared tier

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,18 +79,24 @@ that tail into one shared collaborator is target-direction step 11
 
 ### Process-wide stores
 
-A handful of state stores live as `private static readonly` fields on
-`SSOController` (not dependency-injected — there is no
+A handful of state stores live as `private static readonly` fields — the OIDC
+and SAML caches on their owning flow service (`OidcLoginService` /
+`SamlLoginService`, #500/#501) and the shared rate limiter on the
+`SsoRateLimitGate` (Api/Shared, #160) — not dependency-injected (there is no
 `IPluginServiceRegistrator` in source, so a `static readonly` field is today's
 only way to get one process-wide instance):
 
-| Store                | Guards                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------------- |
-| `OidcStateStore`     | in-flight OIDC authorize state; capacity cap, lifetime, throttled-sweep via `IntervalGate`  |
-| `SamlReplayCache`    | one-time-use SAML assertion IDs (replay protection)                                         |
-| `SamlRequestCache`   | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                          |
-| `OidcDiscoveryCache` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL; owns the fetch/parse too |
-| `SsoRateLimiter`     | opt-in per-client rate limiting on the anonymous login endpoints                            |
+| Store                | Owner              | Guards                                                                                      |
+| -------------------- | ------------------ | ------------------------------------------------------------------------------------------- |
+| `OidcStateStore`     | `OidcLoginService` | in-flight OIDC authorize state; capacity cap, lifetime, throttled-sweep via `IntervalGate`  |
+| `SamlReplayCache`    | `SamlLoginService` | one-time-use SAML assertion IDs (replay protection)                                         |
+| `SamlRequestCache`   | `SamlLoginService` | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                          |
+| `OidcDiscoveryCache` | `OidcLoginService` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL; owns the fetch/parse too |
+| `SsoRateLimiter`     | `SsoRateLimitGate` | opt-in per-client rate limiting on the anonymous login endpoints                            |
+
+The controller itself now holds **no mutable static state** — every store above
+lives in a flow service or the Shared tier, pinned by
+`Controller_HoldsNoMutableStaticState`.
 
 ### The uniform outcome
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
 using Microsoft.AspNetCore.Mvc;
@@ -485,8 +486,9 @@ public class ArchitectureConformanceTests
         // The two cache tokens are nameof-derived, so a rename of either type fails to COMPILE this rule
         // rather than passing vacuously; the two protocol tokens are the OidcClient methods the challenge
         // (PrepareLoginAsync) and callback (ProcessResponseAsync) drive. The shared per-client rate limiter
-        // is deliberately NOT a marker — it fronts BOTH protocols, so it legitimately stays a controller
-        // static and its extraction is out of scope for this step.
+        // is deliberately NOT a marker — it fronts BOTH protocols, so rather than living on either flow
+        // service it lives in the shared SsoRateLimitGate (#160), pinned off the controller by
+        // Controller_HoldsNoMutableStaticState.
         var storeToken = nameof(OidcStateStore);
         var cacheToken = nameof(OidcDiscoveryCache);
         var markers = new[] { storeToken, cacheToken, "PrepareLoginAsync", "ProcessResponseAsync" };
@@ -527,7 +529,8 @@ public class ArchitectureConformanceTests
         // rather than passing vacuously; the two protocol tokens are the outgoing-request builder
         // (SamlAuthnRequest, which the challenge constructs and signs) and the response validator
         // (ValidateSaml). The shared per-client rate limiter is deliberately NOT a marker — it fronts BOTH
-        // protocols, so it legitimately stays a controller static, exactly as in the OpenID rule.
+        // protocols, so it lives in the shared SsoRateLimitGate (#160), pinned off the controller by
+        // Controller_HoldsNoMutableStaticState, exactly as in the OpenID rule.
         var replayToken = nameof(SamlReplayCache);
         var requestToken = nameof(SamlRequestCache);
         var markers = new[] { replayToken, requestToken, "SamlAuthnRequest", "ValidateSaml" };
@@ -617,6 +620,63 @@ public class ArchitectureConformanceTests
         Assert.True(
             mapperSource.Contains("Status429TooManyRequests", StringComparison.Ordinal) && mapperSource.Contains("RetryAfter", StringComparison.Ordinal),
             "LoginStatusMapper must own the rate-limit 429 and its Retry-After header; otherwise the controller scan passes vacuously (#474).");
+    }
+
+    [Fact]
+    public void Controller_HoldsNoMutableStaticState()
+    {
+        // Locked in by the rate-limit-gate extraction (#160, #318): after the OpenID (#500), SAML (#501) and
+        // rate-limit (#160) moves, the controller is a stateless request dispatcher — every process-wide
+        // store, cache and limiter lives in a flow service or the Shared tier. So a controller holds NO
+        // mutable process-wide state as a static field. The former SsoRateLimiter static (the last such on
+        // SSOController) moved into SsoRateLimitGate; a new cache/limiter/counter/dictionary dropped back
+        // onto ANY controller — the exact regression this rule guards — fails HERE.
+        //
+        // "Mutable state" is what is forbidden, not every static: a compile-time constant (a const, which is
+        // IsLiteral) and an immutable static readonly VALUE (e.g. SSOViewsController's version-derived asset
+        // ETag, an EntityTagHeaderValue computed once at load) are fine — they never accumulate runtime
+        // state. So a static field is an offender only when it is genuinely mutable: a WRITABLE static (not
+        // readonly, so it can be reassigned at runtime), OR a static readonly reference to a state CONTAINER
+        // — a *Store/*Cache/*Limiter type, or a raw dictionary — which is readonly-by-reference but mutates
+        // internally (exactly the shape SsoRateLimiter had on the controller). Compiler-generated backing
+        // fields ('<'-named) are excluded, the same exclusion the other reflection rules use.
+        var stateSuffixes = new[] { "Store", "Cache", "Limiter" };
+        bool IsStateContainer(Type t) =>
+            IsDictionaryLike(t)
+            || (t.Assembly == typeof(SSOPlugin).Assembly && stateSuffixes.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)));
+
+        const BindingFlags statics = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        var controllers = PluginClasses.Where(t => typeof(ControllerBase).IsAssignableFrom(t)).ToList();
+
+        // Sentinel against a vacuous pass: a controller must be found, or a rename/rebase that lost the
+        // ControllerBase base would pass this rule for the wrong reason (as ControllerSourceFiles guards the
+        // source-scan rules).
+        Assert.True(
+            controllers.Count > 0,
+            "No controller type was found to check for mutable static state; a controller was renamed or lost its ControllerBase base — update Controller_HoldsNoMutableStaticState.");
+
+        var offenders = controllers
+            .SelectMany(t => t.GetFields(statics)
+                .Where(f => !f.Name.Contains('<', StringComparison.Ordinal))
+                .Where(f => !f.IsLiteral)
+                .Where(f => !f.IsInitOnly || IsStateContainer(f.FieldType))
+                .Select(f => $"{SimpleName(t)}.{f.Name} ({SimpleName(f.FieldType)})"))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "A controller must hold no mutable static state (a writable static, or a static readonly *Store/*Cache/*Limiter or dictionary); every process-wide store/cache/limiter belongs in a flow service or a Shared gate (#160, #318). Found: " + string.Join(", ", offenders));
+
+        // Liveness against a vacuous pass: the rate limiter must actually live in its new home — a move, not
+        // a silent removal — so SsoRateLimitGate must own the process-wide SsoRateLimiter instance the
+        // controller no longer holds, and it is a state container the offender scan above would catch on a
+        // controller (so the rule is proven non-vacuous on the very type that motivated it).
+        var gateOwnsLimiter = typeof(SsoRateLimitGate)
+            .GetFields(statics)
+            .Any(f => f.FieldType == typeof(SsoRateLimiter));
+        Assert.True(
+            gateOwnsLimiter && IsStateContainer(typeof(SsoRateLimiter)),
+            "SsoRateLimitGate must own the process-wide SsoRateLimiter (a state container) that moved off the controller; otherwise the controller scan passes vacuously (#160).");
     }
 
     [Fact]

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -30,8 +30,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// <item>the in-flight authorize-state store (<see cref="OidcStateStore"/>), and</item>
 /// <item>the discovery-facts cache (<see cref="OidcDiscoveryCache"/>).</item>
 /// </list>
-/// The shared per-client rate limiter is deliberately NOT here — it also fronts the SAML flow, so it stays a
-/// controller static both flows reach through the controller's rate-limit gate. Because the challenge and
+/// The shared per-client rate limiter is deliberately NOT here — it also fronts the SAML flow, so it lives in
+/// the shared <see cref="SsoRateLimitGate"/> (Api/Shared) that the controller's endpoints front this service
+/// with, rather than as a per-flow static (#160). Because the challenge and
 /// callback are irreducibly HTTP (cookies, query string, redirect, the intermediate page), those two methods
 /// take the request/response and, for the two response shapes the controller still owns (the security-headered
 /// auth page and the manual-link write mapping), a delegate the controller binds — rather than duplicating the

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -30,8 +30,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// <item>the one-time-use replay cache of consumed assertion IDs (<see cref="SamlReplayCache"/>), and</item>
 /// <item>the outstanding-AuthnRequest cache for InResponseTo correlation and the browser binding (<see cref="SamlRequestCache"/>, #156/#415).</item>
 /// </list>
-/// The shared per-client rate limiter is deliberately NOT here — it also fronts the OpenID flow, so it stays a
-/// controller static both flows reach through the controller's rate-limit gate. The methods take the
+/// The shared per-client rate limiter is deliberately NOT here — it also fronts the OpenID flow, so it lives
+/// in the shared <see cref="SsoRateLimitGate"/> (Api/Shared) that the controller's endpoints front this
+/// service with, rather than as a per-flow static (#160). The methods take the
 /// request/response because SAML is irreducibly HTTP (the redirect, the ACS POST form, the binding cookie, the
 /// security-headered page, and the request-host-derived assertion-consumer URL the Recipient is bound to); the
 /// two response shapes both flows share — the security-headered auth page and the manual-link write mapping —

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Helpers;
 using MediaBrowser.Common.Api;
@@ -60,16 +61,17 @@ public class SSOController : ControllerBase
     // The OpenID login flow (#160, #318 step 12): challenge, redirect callback, session-minting
     // authenticate, and manual link. It owns the OpenID-specific process-wide caches (the authorize-state
     // store and the discovery-facts cache) as its own statics; the controller's OpenID endpoints apply the
-    // shared rate-limit gate below and delegate here. New'd per request like the other collaborators.
+    // shared rate-limit gate (SsoRateLimitGate) and delegate here. New'd per request like the other collaborators.
     private readonly Flows.OidcLoginService _oidc;
     // The SAML login flow (#160, #318 step 13): challenge, assertion-consumer callback, session-minting
     // authenticate, and manual link. It owns the SAML-specific process-wide caches (the replay cache and
     // the outstanding-AuthnRequest cache) as its own statics; the controller's SAML endpoints apply the
-    // shared rate-limit gate below and delegate here. New'd per request like the other collaborators.
+    // shared rate-limit gate (SsoRateLimitGate) and delegate here. New'd per request like the other collaborators.
     private readonly Flows.SamlLoginService _saml;
 
-    // Opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128).
-    private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
+    // The shared per-client rate limiter and its opt-in check live in SsoRateLimitGate (#160, #318): the last
+    // mutable process-wide static moved off the controller into the Shared tier, so the controller now holds
+    // no mutable static state. The RateLimitCheck wrapper below supplies the request-scoped inputs.
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SSOController"/> class.
@@ -680,49 +682,12 @@ public class SSOController : ControllerBase
     private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response) =>
         _oidc.Link(provider, jellyfinUserId, response, Request.Cookies[AuthorizeStateBinding.CookieName]);
 
-    // Applies the opt-in per-client rate limit (#128) on an anonymous flow endpoint: null when the
-    // request may proceed, else the throttled outcome rendered by the single mapper (#474). Reads the
-    // settings under the config lock; an unattributable or non-public client is never throttled (fail
-    // open, availability over throttling). Keys on RemoteIpAddress only — proxy attribution is the
-    // host's job (Jellyfin's "Known proxies" setting resolves the real client into it); see
-    // SsoRateLimiter.NormalizeClientKey. The endpoint class (challenge/callback/auth) is part of
-    // the key so one login — which hits all three — gets the full budget at each stage rather
-    // than a third of it, keeping the default generous for shared egress addresses (NAT/CGNAT).
-    private ActionResult RateLimitCheck(string endpointClass)
-    {
-        var (enabled, maxAttempts, windowSeconds) = SSOPlugin.Instance.ReadConfiguration(
-            c => (c.EnableRateLimit, c.RateLimitMaxAttempts, c.RateLimitWindowSeconds));
-        if (!enabled || windowSeconds < 1)
-        {
-            // maxAttempts < 1 is handled inside IsAllowed (it disables the limiter there).
-            return null;
-        }
-
-        var key = SsoRateLimiter.NormalizeClientKey(HttpContext.Connection.RemoteIpAddress);
-        if (key != null)
-        {
-            key = endpointClass + ":" + key;
-        }
-
-        var now = DateTime.UtcNow;
-        if (RateLimiter.IsAllowed(key, maxAttempts, TimeSpan.FromSeconds(windowSeconds), now, out var retryAfterSeconds))
-        {
-            return null;
-        }
-
-        // Bounded observability signal (#195): so an operator can notice a sustained brute-force or a
-        // reverse proxy misconfigured to pool every client into one bucket, without the notice itself
-        // becoming a log/CPU amplifier. The limiter emits at most one line per interval, carrying only
-        // an aggregate count (no client key — nothing to sanitize or forge); a returned 0 stays silent.
-        var throttledCount = RateLimiter.RecordThrottledHit(now);
-        if (throttledCount > 0)
-        {
-            _logger.LogWarning("SSO rate limit engaged on the anonymous login endpoints: {Count} request(s) throttled since the last notice; further notices are suppressed for at least a minute.", throttledCount);
-        }
-
-        // The rejection is expressed as a LoginOutcome and rendered by the single mapper (#474): the
-        // status, plain-text body and the retry-delay header all originate there, so the controller no
-        // longer emits a bare rate-limit ContentResult or sets the delay header itself.
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(retryAfterSeconds), Response);
-    }
+    // Fronts an anonymous flow endpoint with the shared per-client rate-limit gate (#128, #160): null when
+    // the request may proceed, else the throttled outcome the single mapper renders (#474). The gate owns the
+    // one process-wide limiter and the whole check (config read, IP classifier, endpoint-class keying, the
+    // #195 observability signal); this wrapper only supplies the three request-scoped inputs it needs — the
+    // endpoint class, the connection's remote address, and the response the retry-delay header is set on — so
+    // the controller keeps no rate-limit state of its own.
+    private ActionResult RateLimitCheck(string endpointClass) =>
+        SsoRateLimitGate.Check(endpointClass, HttpContext.Connection.RemoteIpAddress, _logger, Response);
 }

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Net;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
+
+/// <summary>
+/// The shared per-client rate-limit gate over the anonymous SSO flow endpoints (#128, #160). It owns the ONE
+/// process-wide <see cref="SsoRateLimiter"/> instance and the opt-in check both login flows front their
+/// endpoints with — the last mutable process-wide static that lived on <see cref="SSOController"/> (#318).
+/// Relocating it into the shared tier leaves the controller a stateless request dispatcher (every store,
+/// cache and limiter now lives in a flow service or here) while keeping the gate byte-for-byte identical: the
+/// same fire points, the same fail-open classifier, and the same <see cref="LoginOutcome.Throttled"/> 429
+/// rendered by the single mapper (#474). Pure static home — one shared instance, no per-request allocation,
+/// and no <c>ControllerBase</c> coupling, so both flows (and any admin endpoint that ever needs throttling)
+/// call the one gate rather than a controller-owned static.
+/// </summary>
+internal static class SsoRateLimitGate
+{
+    // The opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128). One process-wide
+    // instance (static readonly), exactly as it was on the controller: both login flows reach it through this
+    // gate, so a single shared window per client is preserved across the OpenID and SAML endpoints rather
+    // than split into two separate limiters.
+    private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
+
+    /// <summary>
+    /// Applies the opt-in per-client rate limit (#128) to one anonymous flow endpoint: returns null when the
+    /// request may proceed, else the throttled outcome rendered by the single mapper (#474). Reads the
+    /// settings under the config lock; an unattributable or non-public client is never throttled (fail open,
+    /// availability over throttling). Keys on the connection's remote address only — proxy attribution is the
+    /// host's job (Jellyfin's "Known proxies" setting resolves the real client into it); see
+    /// <see cref="SsoRateLimiter.NormalizeClientKey"/>. The endpoint class (challenge/callback/auth) is part
+    /// of the key so one login — which hits all three — gets the full budget at each stage rather than a
+    /// third of it, keeping the default generous for shared egress addresses (NAT/CGNAT).
+    /// </summary>
+    /// <param name="endpointClass">The endpoint class (challenge/callback/auth) folded into the rate-limit key.</param>
+    /// <param name="remoteIp">The connection's remote address, the sole attribution input (proxy resolution is the host's job).</param>
+    /// <param name="logger">The caller's logger, for the bounded throttle-engaged observability signal (#195).</param>
+    /// <param name="response">The response whose Retry-After header a throttled outcome sets (#474).</param>
+    /// <returns>Null when the request may proceed, or the throttled 429 outcome otherwise.</returns>
+    internal static ActionResult Check(string endpointClass, IPAddress remoteIp, ILogger logger, HttpResponse response)
+    {
+        var (enabled, maxAttempts, windowSeconds) = SSOPlugin.Instance.ReadConfiguration(
+            c => (c.EnableRateLimit, c.RateLimitMaxAttempts, c.RateLimitWindowSeconds));
+        if (!enabled || windowSeconds < 1)
+        {
+            // maxAttempts < 1 is handled inside IsAllowed (it disables the limiter there).
+            return null;
+        }
+
+        var key = SsoRateLimiter.NormalizeClientKey(remoteIp);
+        if (key != null)
+        {
+            key = endpointClass + ":" + key;
+        }
+
+        var now = DateTime.UtcNow;
+        if (RateLimiter.IsAllowed(key, maxAttempts, TimeSpan.FromSeconds(windowSeconds), now, out var retryAfterSeconds))
+        {
+            return null;
+        }
+
+        // Bounded observability signal (#195): so an operator can notice a sustained brute-force or a
+        // reverse proxy misconfigured to pool every client into one bucket, without the notice itself
+        // becoming a log/CPU amplifier. The limiter emits at most one line per interval, carrying only
+        // an aggregate count (no client key — nothing to sanitize or forge); a returned 0 stays silent.
+        var throttledCount = RateLimiter.RecordThrottledHit(now);
+        if (throttledCount > 0)
+        {
+            logger.LogWarning("SSO rate limit engaged on the anonymous login endpoints: {Count} request(s) throttled since the last notice; further notices are suppressed for at least a minute.", throttledCount);
+        }
+
+        // The rejection is expressed as a LoginOutcome and rendered by the single mapper (#474): the status,
+        // plain-text body and the retry-delay header all originate there, so the gate no longer emits a bare
+        // rate-limit ContentResult or sets the delay header itself.
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(retryAfterSeconds), response);
+    }
+}


### PR DESCRIPTION
# What & why

After the OpenID (#500) and SAML (#501) flow extractions, the only remaining mutable process-wide static on `SSOController` was the shared `SsoRateLimiter`, fronted by the controller's `RateLimitCheck` gate for both protocols' anonymous endpoints. This relocates that gate into the `Api/Shared/` tier so the controller becomes a stateless request dispatcher, the last step of the #160 static-state goal in the #318 target architecture.

- New `SsoRateLimitGate` (Api/Shared) owns the one `static readonly SsoRateLimiter` and exposes the opt-in `Check(...)`. Its body is a byte-for-byte move of the controller's former `RateLimitCheck` (config read under the lock, IP classifier, endpoint-class keying, the #195 bounded observability signal, and the `LoginOutcome.Throttled` the single mapper renders, #474).
- The controller keeps a thin `RateLimitCheck` wrapper that supplies the three request-scoped inputs (endpoint class, `HttpContext.Connection.RemoteIpAddress`, `Response`) and delegates to the gate, so every fire point stays wire-for-wire.
- Locked in by a new `Controller_HoldsNoMutableStaticState` conformance rule.
- Stale rate-limiter remarks refreshed on both flow services, the two #318 delegation-rule comments, and the ARCHITECTURE.md process-wide-stores section.

Behaviour-preserving only: no rate-limit behaviour, config, or security-posture change. The rate limit fires at the same points, same 429 + `Retry-After`, same fail-open for unattributable/non-public clients, same single process-wide instance shared across OpenID and SAML.

Closes #502, Refs #160, #318.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Unchanged — this only relocates the rate-limit gate; the limiter fails OPEN by design for unattributable/non-public clients, preserved verbatim.)
- [x] No secrets logged; secrets are redacted on config export. (The only log line is the #195 aggregate throttled-count, carrying no client key.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review below.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No IdP input reaches the moved log line; unchanged.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug + Release, 0 warnings.)
- [x] `dotnet test` is green. (1024 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (ARCHITECTURE.md checked.)

## Notes

**Design.** The shared limiter instance + the whole check live in `SsoRateLimitGate` (Api/Shared). Both login flows reach it through the controller's endpoints, which keep the thin `RateLimitCheck` wrapper, we deliberately did NOT push the gate call down into `OidcLoginService`/`SamlLoginService`, because (a) that would change fire points (the flow mint legs are intentionally HttpContext-free, #177, taking a remote-IP `Func` rather than the `IPAddress` the classifier needs), and (b) the `Link` legs are not rate-limited today, so per-method placement would risk drift. Keeping the controller as the front is the wire-for-wire-safe, minimal change, and the gate is a genuinely shared home any caller (including the future admin-endpoint throttling in #382) can call. Controller: 728 -> 693 lines, now holding no mutable static state.

**Adversarial self-review (four refute-by-default lenses).**

- **Availability / mass-lockout**, VERDICT: The gate body is a verbatim move; the disabled-limiter early-return, the `windowSeconds < 1` / `maxAttempts < 1` disables, and the null-key fail-open (unattributable/non-public/proxy) are all unchanged. One `static readonly` process-wide instance is preserved, so a client's window is still shared across all endpoints and both protocols, no new lockout, no per-flow split. The two 429 pinning tests pass. **PASS**
- **Security-bypass**, VERDICT: No path reaches a flow service without first going through the unchanged `RateLimitCheck(...) is { } throttled` guard; the gate is `internal static`, adds no public surface, and `SsoRateLimiter` itself is untouched. Throttled still maps through `LoginStatusMapper.ToActionResult(Throttled, response)` to a 429 + `Retry-After` + fixed body, characterized byte-for-byte by `SamlChallenge_OverRateLimit_Returns429`. **PASS**
- **Correctness**, VERDICT: Same instance semantics (default `maxEntries = 100_000`), same six fire points with the same endpoint-class strings, same `DateTime.UtcNow` threaded into `IsAllowed` and `RecordThrottledHit`, byte-identical log line. Nothing reordered. **PASS**
- **Integration**, VERDICT: The controller fronts the gate for its anonymous endpoints; admin endpoints (unchanged) still don't throttle. The new `Controller_HoldsNoMutableStaticState` is non-vacuous: it flags a writable static or a static readonly state-container (`*Store`/`*Cache`/`*Limiter`/dictionary) on any controller, so the former `SsoRateLimiter` static would fail it, while correctly allowing `SSOViewsController`'s immutable `static readonly` asset ETag; a controller-exists sentinel plus a liveness pin (SsoRateLimitGate owns the SsoRateLimiter, which `IsStateContainer`) guard the vacuous cases. Full suite green. **PASS**

**Out of scope (follow-up).** The ARCHITECTURE.md "Process-wide stores" section had pre-existing drift from #500/#501 (it still described the OIDC/SAML caches as living on `SSOController`); we corrected the whole table's owner column while here, but any deeper #318-narrative refresh of that doc is separate.
