### PR TITLE
Parse the oid/saml mode token once at the controller boundary

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -712,6 +712,48 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void ProviderMode_IsThreadedTyped_NotAsARawStringToken()
+    {
+        // Locked in by #369: the route's {mode} token is parsed ONCE at the controller boundary into the
+        // ProviderMode enum, and the typed value is threaded inward — so no linking-tier method re-accepts
+        // the raw string to re-parse or re-compare it (the two former divergent dispatches, a
+        // culture-sensitive ToLower() switch and an invariant-lowercase one, that had to agree). Pin it
+        // structurally on the two types the token flows through:
+        //
+        // 1. CanonicalLinkService — the linking workflow: NO method (public or private) may take a parameter
+        //    named "mode" typed as string; it must be the ProviderMode enum. A revert to a string mode
+        //    parameter (reopening the re-parse-inward hole) fails HERE.
+        // 2. VerifiedIdentity.LinkMode — the identity the login path carries: must expose the protocol as the
+        //    typed ProviderMode, not a "oid"/"saml" string the mint path would have to re-compare.
+        const BindingFlags anyMethod = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        var methods = typeof(CanonicalLinkService).GetMethods(anyMethod);
+
+        var stringModeParams = methods
+            .SelectMany(m => m.GetParameters().Select(p => (Method: m.Name, Param: p)))
+            .Where(x => x.Param.Name == "mode" && x.Param.ParameterType == typeof(string))
+            .Select(x => $"{x.Method}(string mode)")
+            .ToList();
+        Assert.True(
+            stringModeParams.Count == 0,
+            "CanonicalLinkService must take the parsed ProviderMode, never a raw string mode token, so the {mode} route string is parsed once at the boundary and threaded typed inward (#369): " + string.Join(", ", stringModeParams));
+
+        // Sentinel against a vacuous pass: a ProviderMode-typed mode parameter must actually exist on the
+        // surface, so a rename that dropped the parameter entirely does not pass for the wrong reason.
+        var typedModeExists = methods
+            .SelectMany(m => m.GetParameters())
+            .Any(p => p.Name == "mode" && p.ParameterType == typeof(ProviderMode));
+        Assert.True(
+            typedModeExists,
+            "No ProviderMode-typed \"mode\" parameter was found on CanonicalLinkService; the linking surface was renamed, so point this rule at the new shape so the typed-mode invariant keeps guarding #369.");
+
+        var linkMode = typeof(VerifiedIdentity).GetProperty("LinkMode", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.True(linkMode is not null, "VerifiedIdentity.LinkMode was renamed or removed; point this rule at the new property so the typed-mode invariant keeps guarding #369.");
+        Assert.True(
+            linkMode!.PropertyType == typeof(ProviderMode),
+            "VerifiedIdentity.LinkMode must be the typed ProviderMode, not a raw \"oid\"/\"saml\" string the mint path would re-compare (#369).");
+    }
+
+    [Fact]
     public void SSOPlugin_DeclaresNoConfigurationLogicBeyondTheStoreFacade()
     {
         // Locked in by the ProviderConfigStore extraction (#318): SSOPlugin is bootstrap + page

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -54,7 +54,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
 
         Assert.Equal(Existing, resolved);
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
@@ -69,7 +69,7 @@ public class CanonicalLinkServiceTests
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
 
         Assert.Equal(Other, resolved);
         await users.Received(1).CreateUserAsync("alice");
@@ -83,7 +83,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
         Assert.Equal(Existing, resolved);
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
@@ -100,7 +100,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -118,7 +118,7 @@ public class CanonicalLinkServiceTests
         var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", canonicalKey, username, allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", canonicalKey, username, allowExistingAccountLink: true));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
@@ -137,7 +137,7 @@ public class CanonicalLinkServiceTests
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
         Assert.Equal(Existing, resolved);
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
@@ -161,7 +161,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "alice", allowExistingAccountLink: false));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "alice", allowExistingAccountLink: false));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
@@ -194,7 +194,7 @@ public class CanonicalLinkServiceTests
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "alice", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "alice", allowExistingAccountLink: false);
 
         Assert.Equal(Other, resolved);
         await users.Received(1).CreateUserAsync("alice");
@@ -231,7 +231,7 @@ public class CanonicalLinkServiceTests
         users.CreateUserAsync("oldname").Returns(created);
         users.GetUserById(Other).Returns(created);
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
 
         Assert.Equal(Other, resolved); // a fresh account, NOT the renamed victim (Existing)
         await users.Received(1).CreateUserAsync("oldname");
@@ -262,7 +262,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("oldname").Returns(UserNamed("oldname", Other)); // a different account now holds the name
         users.GetUserById(Other).Returns(UserNamed("oldname", Other));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
 
         Assert.Equal(Other, resolved); // adopts the current name-holder, NOT the renamed victim (Existing)
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
@@ -285,7 +285,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "opaque-sub-123", "opaque-sub-123", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "opaque-sub-123", "opaque-sub-123", allowExistingAccountLink: false);
 
         Assert.Equal(Existing, resolved);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["opaque-sub-123"]); // untouched, not re-keyed
@@ -303,7 +303,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns((User?)null); // name is free -> the create arm would fire
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "deleted-provider", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "deleted-provider", "sub-1", "alice", allowExistingAccountLink: true));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
@@ -339,7 +339,7 @@ public class CanonicalLinkServiceTests
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
 
         var ex = await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
 
         // Pin the MIGRATE guard specifically, not just any fail-closed throw: the three login-path guards
         // carry distinct messages, so if the provider were dropped during the wrong transaction the test
@@ -363,7 +363,7 @@ public class CanonicalLinkServiceTests
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
 
         Assert.Equal(Existing, resolved);
         Assert.Equal(0, persists); // no write on the hot path
@@ -384,7 +384,7 @@ public class CanonicalLinkServiceTests
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
         Assert.Equal(Existing, resolved);
         Assert.Equal(1, persists); // one mutation for the migration, not two
@@ -427,7 +427,7 @@ public class CanonicalLinkServiceTests
             new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true);
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
         Assert.Equal(Existing, resolved); // bound to the winner's live subject link
         var final = cfg.OidConfigs["kc"].CanonicalLinks;
@@ -442,7 +442,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryCreateLink("oid", "kc", "sub-1", Existing);
+        var result = service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkWriteResult.Created, result);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
@@ -455,7 +455,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryCreateLink("oid", "kc", providerUserId, Existing);
+        var result = service.TryCreateLink(ProviderMode.Oid, "kc", providerUserId, Existing);
 
         Assert.Equal(CanonicalLinkWriteResult.EmptyKey, result);
         Assert.Empty(cfg.OidConfigs["kc"].CanonicalLinks);
@@ -466,7 +466,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryCreateLink("oid", "does-not-exist", "sub-1", Existing);
+        var result = service.TryCreateLink(ProviderMode.Oid, "does-not-exist", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkWriteResult.UnknownProvider, result);
     }
@@ -479,7 +479,7 @@ public class CanonicalLinkServiceTests
         // runs first). Locks the check ordering the controller's distinct 400 bodies depend on.
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryCreateLink("oid", "does-not-exist", "   ", Existing);
+        var result = service.TryCreateLink(ProviderMode.Oid, "does-not-exist", "   ", Existing);
 
         Assert.Equal(CanonicalLinkWriteResult.EmptyKey, result);
     }
@@ -496,7 +496,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
-        var result = service.TryCreateLink("oid", "kc", "sub-1", Other);
+        var result = service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Other);
 
         Assert.Equal(CanonicalLinkWriteResult.Created, result);
         Assert.Equal(Other, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // rebound to the new user
@@ -512,7 +512,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns((User?)null); // name is free -> the create arm would fire if it fell through
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "broken", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "broken", "sub-1", "alice", allowExistingAccountLink: true));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
@@ -524,7 +524,7 @@ public class CanonicalLinkServiceTests
         // as absent, not dereferenced into a 500 — same fail-closed treatment as a missing provider.
         var (service, _, _, _) = Build(c => c.OidConfigs["broken"] = null);
 
-        var result = service.TryRemoveLink("oid", "broken", "sub-1", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "broken", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
     }
@@ -540,7 +540,7 @@ public class CanonicalLinkServiceTests
             c.OidConfigs["broken"] = null;
         });
 
-        var oid = service.LinksByUser("oid", Existing);
+        var oid = service.LinksByUser(ProviderMode.Oid, Existing);
 
         Assert.Equal(new[] { "sub-1" }, oid["kc"]);
         Assert.DoesNotContain("broken", oid.Keys); // the null-config provider is skipped, not thrown on
@@ -555,7 +555,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
-        var result = service.TryRemoveLink("oid", "kc", "sub-1", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -572,7 +572,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
 
-        var result = service.TryRemoveLink("saml", "adfs", "alice", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Saml, "adfs", "alice", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
         Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
@@ -583,7 +583,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryRemoveLink("oid", "kc", "does-not-exist", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "does-not-exist", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.NotFound, result);
     }
@@ -597,7 +597,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
-        var result = service.TryRemoveLink("oid", "kc", "sub-1", Other);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Other);
 
         Assert.Equal(CanonicalLinkRemoveResult.Mismatch, result);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // untouched
@@ -608,7 +608,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var result = service.TryRemoveLink("oid", "does-not-exist", "sub-1", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "does-not-exist", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
     }
@@ -623,7 +623,7 @@ public class CanonicalLinkServiceTests
             c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         });
 
-        var oid = service.LinksByUser("oid", Existing);
+        var oid = service.LinksByUser(ProviderMode.Oid, Existing);
 
         Assert.Equal(new[] { "sub-1" }, oid["kc"]); // the other user's sub-2 is excluded
         Assert.Equal(new[] { "sub-3" }, oid["authelia"]);
@@ -647,7 +647,7 @@ public class CanonicalLinkServiceTests
             c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
         });
 
-        var saml = service.LinksByUser("saml", Existing);
+        var saml = service.LinksByUser(ProviderMode.Saml, Existing);
 
         Assert.Equal(new[] { "alice" }, saml["adfs"]); // the other user's "bob" is excluded
         Assert.DoesNotContain("kc", saml.Keys); // OID provider is not in the SAML projection
@@ -682,7 +682,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        Assert.True(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+        Assert.True(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
 
     [Fact]
@@ -696,7 +696,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        Assert.True(service.IsIdentityStillLinked("saml", "adfs", "alice", Existing));
+        Assert.True(service.IsIdentityStillLinked(ProviderMode.Saml, "adfs", "alice", Existing));
     }
 
     [Fact]
@@ -713,7 +713,7 @@ public class CanonicalLinkServiceTests
 
         service.RemoveUserEverywhere(Existing);
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
 
     [Fact]
@@ -729,7 +729,7 @@ public class CanonicalLinkServiceTests
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
         cfg.OidConfigs["kc"].Enabled = false;
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
 
     [Fact]
@@ -737,7 +737,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        Assert.False(service.IsIdentityStillLinked("oid", "does-not-exist", "sub-1", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "does-not-exist", "sub-1", Existing));
     }
 
     [Fact]
@@ -749,7 +749,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-unknown", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-unknown", Existing));
     }
 
     [Fact]
@@ -764,7 +764,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Other).Returns(UserNamed("bob", Other));
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
 
     [Fact]
@@ -778,7 +778,7 @@ public class CanonicalLinkServiceTests
         });
         users.GetUserById(Existing).Returns((User?)null);
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", "sub-1", Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
 
     [Theory]
@@ -789,7 +789,7 @@ public class CanonicalLinkServiceTests
     {
         var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        Assert.False(service.IsIdentityStillLinked("oid", "kc", canonicalKey, Existing));
+        Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", canonicalKey, Existing));
     }
 
     [Fact]
@@ -806,7 +806,7 @@ public class CanonicalLinkServiceTests
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // link untouched
@@ -827,7 +827,7 @@ public class CanonicalLinkServiceTests
         });
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
 
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1")); // no link written
     }
@@ -855,7 +855,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
 
         Assert.True(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("alice")); // not re-keyed
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -869,7 +869,7 @@ public class CanonicalLinkServiceTests
         // gate and this transaction must not gain a dormant link that would mint on re-enable.
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = false });
 
-        var result = service.TryCreateLink("oid", "kc", "sub-1", Existing);
+        var result = service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkWriteResult.UnknownProvider, result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -886,7 +886,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
 
-        var result = service.TryRemoveLink("oid", "kc", "sub-1", Existing);
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
         Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -902,7 +902,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "admin", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true)));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "admin", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true)));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("attacker-sub"));
@@ -917,7 +917,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("saml", "idp", "admin", "admin", allowExistingAccountLink: true, AdoptionGate.None));
+            service.ResolveOrCreateAsync(ProviderMode.Saml, "idp", "admin", "admin", allowExistingAccountLink: true, AdoptionGate.None));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.False(cfg.SamlConfigs["idp"].CanonicalLinks.ContainsKey("admin"));
@@ -932,7 +932,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true));
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true));
 
         Assert.Equal(Existing, resolved);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
@@ -949,7 +949,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: emailVerified)));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: emailVerified)));
 
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
@@ -970,7 +970,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("admin").Returns(AdminUserNamed("admin", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
-            service.ResolveOrCreateAsync("oid", "kc", "attacker-sub", "admin", allowExistingAccountLink: true));
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "admin", allowExistingAccountLink: true));
 
         var links = cfg.OidConfigs["kc"].CanonicalLinks;
         Assert.True(links.ContainsKey("admin"));       // legacy key not re-keyed
@@ -988,7 +988,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
         users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
 
-        var resolved = await service.ResolveOrCreateAsync("oid", "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: false, EmailVerified: null));
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: false, EmailVerified: null));
 
         Assert.Equal(Existing, resolved);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);

--- a/SSO-Auth.Tests/ProviderModeTests.cs
+++ b/SSO-Auth.Tests/ProviderModeTests.cs
@@ -1,0 +1,52 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Unit tests for the single <see cref="ProviderMode"/> ↔ token mapping parsed once at the controller
+/// boundary (#369): the route's <c>{mode}</c> string is turned into the typed enum exactly here, an unknown
+/// token is rejected fail-closed (never defaulting to a protocol), and the two accepted protocols round-trip
+/// through the lowercase link-namespace token used in operator logs. The theories key on token strings (not
+/// the internal enum) so the public test methods stay accessible; the enum is asserted inside the body.
+/// </summary>
+public class ProviderModeTests
+{
+    [Theory]
+    [InlineData("oid")]
+    [InlineData("saml")]
+    [InlineData("OID")]  // case-insensitive, so both former divergent dispatches agree
+    [InlineData("SAML")]
+    [InlineData("Oid")]
+    [InlineData("Saml")]
+    public void TryParse_KnownToken_ParsesAndRoundTripsThroughTheLowercaseToken(string token)
+    {
+        Assert.True(ProviderModeParser.TryParse(token, out var mode));
+        // The parse is case-insensitive but the rendered token is always the canonical lowercase form.
+        Assert.Equal(token.ToLowerInvariant(), mode.ToToken());
+    }
+
+    [Fact]
+    public void TryParse_DistinguishesTheTwoProtocols()
+    {
+        Assert.True(ProviderModeParser.TryParse("oid", out var oid));
+        Assert.True(ProviderModeParser.TryParse("saml", out var saml));
+        Assert.Equal(ProviderMode.Oid, oid);
+        Assert.Equal(ProviderMode.Saml, saml);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("ldap")]
+    [InlineData("oidc")]     // near-miss: only the exact tokens are accepted
+    [InlineData("sam l")]
+    public void TryParse_UnknownToken_FailsClosedWithoutDefaultingToAProtocol(string? token)
+    {
+        Assert.False(ProviderModeParser.TryParse(token, out var mode));
+        // The out value is the default and must not be mistaken for a resolved protocol: callers gate on the
+        // bool, never the out on a false return.
+        Assert.Equal(default, mode);
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -92,6 +92,32 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedButInvalidMode_Throws()
+    {
+        // #369: the DELETE route parses {mode} at the same boundary as the add route, so an unknown mode is
+        // rejected there once — fail closed, exactly like AddCanonicalLink — rather than being forwarded raw
+        // to the service to throw deep inside TryGetLinks. Pins the previously-untested DELETE invalid-mode path.
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            harness.Controller.DeleteCanonicalLink("ldap", "keycloak", Target, "sub-1"));
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_MixedCaseMode_RoutesToTheRightFlow()
+    {
+        // #369: the single boundary parse is case-insensitive and culture-independent, so a mixed-case token
+        // routes to the same protocol the lowercase one does — the two former divergent dispatches (one
+        // culture-sensitive) can no longer disagree. "SAML" routes to the SAML link path, proven by its
+        // clean unknown-provider 400 (SamlLink checks the provider before touching the response).
+        var harness = ForCaller(isAdmin: true, callerId: Target);
+
+        var result = await harness.Controller.AddCanonicalLink("SAML", "does-not-exist", Target, new AuthResponse { Data = "irrelevant" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
     public async Task DeleteCanonicalLink_AuthorizedButUnknownCanonicalName_ReturnsNotFound()
     {
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>

--- a/SSO-Auth.Tests/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/VerifiedIdentityTests.cs
@@ -36,7 +36,7 @@ public class VerifiedIdentityTests
         var identity = VerifiedIdentity.FromOidcRedemption("keycloak", derived);
 
         // The two protocol-facing labels drive the link namespace and the audit line.
-        Assert.Equal("oid", identity.LinkMode);
+        Assert.Equal(ProviderMode.Oid, identity.LinkMode);
         Assert.Equal("OpenID", identity.AuditProtocol);
         Assert.Equal("keycloak", identity.Provider);
 
@@ -62,7 +62,7 @@ public class VerifiedIdentityTests
 
         var identity = VerifiedIdentity.FromValidatedSaml("okta", "alice@example.com", privileges);
 
-        Assert.Equal("saml", identity.LinkMode);
+        Assert.Equal(ProviderMode.Saml, identity.LinkMode);
         Assert.Equal("SAML", identity.AuditProtocol);
         Assert.Equal("okta", identity.Provider);
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -376,7 +376,7 @@ internal sealed class OidcLoginService
 
         // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
         // later provider-side rename does not orphan the link the user just created.
-        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink("oid", provider, redeemed.Identity.Subject, jellyfinUserId));
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Oid, provider, redeemed.Identity.Subject, jellyfinUserId));
     }
 
     // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -407,7 +407,7 @@ internal sealed class SamlLoginService
 
         string providerUserId = samlResponse.GetNameID();
 
-        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink("saml", provider, providerUserId, jellyfinUserId));
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Saml, provider, providerUserId, jellyfinUserId));
     }
 
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -80,7 +80,7 @@ internal sealed class CanonicalLinkService
     /// the provider's policy, and returns its id. Throws <see cref="AccountLinkForbiddenException"/> when
     /// the login must be refused (no identity resolved, or a pre-existing account may not be adopted).
     /// </summary>
-    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
     /// <param name="provider">The provider the login authenticated against.</param>
     /// <param name="canonicalKey">The stable identity key (OpenID sub / SAML NameID).</param>
     /// <param name="username">The display name the account is provisioned/adopted under.</param>
@@ -91,7 +91,7 @@ internal sealed class CanonicalLinkService
     /// (<see cref="AdoptionGate.None"/>) is the SAML/legacy posture: admin refusal only.
     /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(string mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default)
+    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -169,7 +169,7 @@ internal sealed class CanonicalLinkService
                 _logger.LogWarning(
                     "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
                     username?.ReplaceLineEndings(string.Empty),
-                    mode,
+                    mode.ToToken(),
                     provider?.ReplaceLineEndings(string.Empty));
                 throw new AccountLinkForbiddenException();
             }
@@ -185,7 +185,7 @@ internal sealed class CanonicalLinkService
             linkedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username);
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
-                mode,
+                mode.ToToken(),
                 provider?.ReplaceLineEndings(string.Empty));
         }
 
@@ -225,7 +225,7 @@ internal sealed class CanonicalLinkService
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
                         username?.ReplaceLineEndings(string.Empty),
-                        mode,
+                        mode.ToToken(),
                         provider?.ReplaceLineEndings(string.Empty),
                         verdict);
                     throw new AccountLinkForbiddenException();
@@ -236,7 +236,7 @@ internal sealed class CanonicalLinkService
                 var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
                 if (wrote)
                 {
-                    SsoAudit.AccountAdopted(_logger, string.Equals(mode, "oid", StringComparison.Ordinal) ? "OpenID" : "SAML", provider, username);
+                    SsoAudit.AccountAdopted(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, username);
                 }
 
                 return adoptedUserId;
@@ -258,7 +258,7 @@ internal sealed class CanonicalLinkService
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
                         username?.ReplaceLineEndings(string.Empty),
-                        mode,
+                        mode.ToToken(),
                         provider?.ReplaceLineEndings(string.Empty));
                 }
 
@@ -284,7 +284,7 @@ internal sealed class CanonicalLinkService
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
                         username?.ReplaceLineEndings(string.Empty),
-                        mode,
+                        mode.ToToken(),
                         provider?.ReplaceLineEndings(string.Empty));
                 }
                 else
@@ -292,7 +292,7 @@ internal sealed class CanonicalLinkService
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
                         username?.ReplaceLineEndings(string.Empty),
-                        mode,
+                        mode.ToToken(),
                         provider?.ReplaceLineEndings(string.Empty));
                 }
 
@@ -307,12 +307,12 @@ internal sealed class CanonicalLinkService
     /// Creates a manual canonical link (admin/self linking) from a provider-side identity to a Jellyfin
     /// user, under the config lock. HTTP-free: the controller maps the returned result to a response.
     /// </summary>
-    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
     /// <param name="provider">The provider the link belongs to.</param>
     /// <param name="providerUserId">The provider-side identity key (OpenID sub / SAML NameID).</param>
     /// <param name="jellyfinUserId">The Jellyfin user to link the identity to.</param>
     /// <returns>The write outcome.</returns>
-    internal CanonicalLinkWriteResult TryCreateLink(string mode, string provider, string providerUserId, Guid jellyfinUserId)
+    internal CanonicalLinkWriteResult TryCreateLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId)
     {
         // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
         // create a link — an empty or whitespace key would persist a dead link no login can ever redeem.
@@ -347,12 +347,12 @@ internal sealed class CanonicalLinkService
     /// ownership check, and removal are one read-modify-write so they cannot interleave with a concurrent
     /// write to the same map.
     /// </summary>
-    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
     /// <param name="provider">The provider the link belongs to.</param>
     /// <param name="canonicalName">The provider-side identity key whose link is removed.</param>
     /// <param name="jellyfinUserId">The Jellyfin user the link must belong to.</param>
     /// <returns>The remove outcome.</returns>
-    internal CanonicalLinkRemoveResult TryRemoveLink(string mode, string provider, string canonicalName, Guid jellyfinUserId)
+    internal CanonicalLinkRemoveResult TryRemoveLink(ProviderMode mode, string provider, string canonicalName, Guid jellyfinUserId)
     {
         // Kept as ONE Mutate (find, ownership check, and remove cannot interleave). A no-result outcome
         // still persists the unchanged config. For NotFound / Mismatch that already matched the old
@@ -394,10 +394,10 @@ internal sealed class CanonicalLinkService
     /// result is a detached snapshot that cannot tear against a concurrent login writing a link during
     /// JSON serialization.
     /// </summary>
-    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
     /// <param name="jellyfinUserId">The Jellyfin user whose links are listed.</param>
     /// <returns>A provider -> link-key-list map.</returns>
-    internal SerializableDictionary<string, IEnumerable<string>> LinksByUser(string mode, Guid jellyfinUserId)
+    internal SerializableDictionary<string, IEnumerable<string>> LinksByUser(ProviderMode mode, Guid jellyfinUserId)
     {
         return _configStore.Read(configuration =>
         {
@@ -406,7 +406,7 @@ internal sealed class CanonicalLinkService
             // today via #350's null-body add) yields null links and is skipped rather than dereferenced —
             // same fail-closed treatment TryGetLinks gives it, so the read side cannot NRE into a 500 on
             // a state the write side can produce.
-            var providerLinks = string.Equals(mode, "saml", StringComparison.Ordinal)
+            var providerLinks = mode == ProviderMode.Saml
                 ? configuration.SamlConfigs.Select(p => (p.Key, p.Value?.CanonicalLinks))
                 : configuration.OidConfigs.Select(p => (p.Key, p.Value?.CanonicalLinks));
 
@@ -473,12 +473,12 @@ internal sealed class CanonicalLinkService
     /// resolves to false (missing/whitespace key, missing or disabled provider, missing/mismatched link,
     /// deleted target), so it is fail closed.
     /// </remarks>
-    /// <param name="mode">The protocol mode token, "oid" or "saml".</param>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
     /// <param name="provider">The provider the login authenticated against.</param>
     /// <param name="canonicalKey">The stable identity key the link is stored under (OpenID sub / SAML NameID).</param>
     /// <param name="userId">The Jellyfin user the login resolved to.</param>
     /// <returns>True only when a live, enabled link for this identity still points at the user.</returns>
-    internal bool IsIdentityStillLinked(string mode, string provider, string canonicalKey, Guid userId)
+    internal bool IsIdentityStillLinked(ProviderMode mode, string provider, string canonicalKey, Guid userId)
     {
         if (string.IsNullOrWhiteSpace(canonicalKey))
         {
@@ -498,7 +498,7 @@ internal sealed class CanonicalLinkService
     // reports WroteLink=false (so the caller does not re-emit the adoption audit). The link write goes
     // straight into the config (no discarded ActionResult), so a failure to persist propagates rather
     // than falling through as a successful adoption.
-    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(string mode, string provider, string canonicalKey, Guid candidateUserId)
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId)
     {
         return _configStore.Mutate(configuration =>
         {
@@ -535,7 +535,7 @@ internal sealed class CanonicalLinkService
     // only a dangling one (its target user deleted), which would otherwise block the hand-off on every
     // subsequent login. Returns null only when neither key resolves a live account (the dangling edge), so
     // the login fails closed into the create/adopt gate rather than binding to a dead account.
-    private Guid? MigrateAndResolveCanonicalLink(string mode, string provider, string canonicalKey, string legacyKey)
+    private Guid? MigrateAndResolveCanonicalLink(ProviderMode mode, string provider, string canonicalKey, string legacyKey)
     {
         return _configStore.Mutate<Guid?>(configuration =>
         {
@@ -581,22 +581,21 @@ internal sealed class CanonicalLinkService
     // like a deleted one (#380), while removal passes false because revoking must keep working on a
     // disabled provider (disable-then-clean-up). The map is
     // self-healing (CanonicalLinks lazily creates and stores it), so mutating the returned map persists
-    // directly; callers must hold the config lock (Read / Mutate) while touching it. An unrecognized mode
-    // is not an unknown provider but a caller contract violation, so it throws — note the DELETE route
-    // forwards mode unvalidated (unlike the AddCanonicalLink dispatch), so that throw is reachable there;
-    // #369 tracks parsing mode once at the HTTP boundary into an internal enum.
-    private static bool TryGetLinks(PluginConfiguration configuration, string mode, string provider, bool requireEnabled, out SerializableDictionary<string, Guid> links)
+    // directly; callers must hold the config lock (Read / Mutate) while touching it. The mode is the typed
+    // ProviderMode the controller parsed once at the HTTP boundary (#369), so both dispatch arms are reached
+    // only with a validated value; the default throw stays as a belt against an out-of-range enum value.
+    private static bool TryGetLinks(PluginConfiguration configuration, ProviderMode mode, string provider, bool requireEnabled, out SerializableDictionary<string, Guid> links)
     {
-        switch (mode.ToLowerInvariant())
+        switch (mode)
         {
-            case "saml":
+            case ProviderMode.Saml:
                 return TryGetLinks(configuration.SamlConfigs, provider, requireEnabled, out links);
 
-            case "oid":
+            case ProviderMode.Oid:
                 return TryGetLinks(configuration.OidConfigs, provider, requireEnabled, out links);
 
             default:
-                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
+                throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown provider mode.");
         }
     }
 

--- a/SSO-Auth/Api/ProviderMode.cs
+++ b/SSO-Auth/Api/ProviderMode.cs
@@ -1,0 +1,71 @@
+using System;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The SSO protocol a canonical-link operation applies to. The route's <c>{mode}</c> token is parsed into
+/// this typed value once, at the controller boundary (<see cref="ProviderModeParser.TryParse"/>), and the
+/// enum is threaded inward from there (#369) — so no inner layer re-parses or re-compares the raw string,
+/// and an unknown token is rejected exactly once, fail-closed, before any protocol is chosen.
+/// </summary>
+internal enum ProviderMode
+{
+    /// <summary>SAML.</summary>
+    Saml,
+
+    /// <summary>OpenID Connect.</summary>
+    Oid,
+}
+
+/// <summary>
+/// The single home for the <see cref="ProviderMode"/> ↔ string-token mapping (#369): parsing the route
+/// token into the enum at the boundary, and rendering the enum back to its lowercase link-namespace token
+/// for operator log lines. Nothing else in the linking surface touches the raw <c>"oid"</c>/<c>"saml"</c>
+/// strings — they thread the typed enum instead.
+/// </summary>
+internal static class ProviderModeParser
+{
+    /// <summary>
+    /// Parses the route's <c>{mode}</c> token into a <see cref="ProviderMode"/>. Case-insensitive and
+    /// culture-independent (ordinal), so the two protocols the plugin exposes are accepted in any casing
+    /// while an unknown token fails closed — the caller rejects it rather than defaulting to a protocol.
+    /// This replaces the two former divergent dispatches (a culture-sensitive <c>ToLower()</c> switch and an
+    /// invariant-lowercase one) with one parse whose result every layer shares.
+    /// </summary>
+    /// <param name="value">The raw route token (<c>"oid"</c> / <c>"saml"</c>, any casing).</param>
+    /// <param name="mode">The parsed mode when the token is recognized.</param>
+    /// <returns><c>true</c> when the token names a known protocol; otherwise <c>false</c>.</returns>
+    internal static bool TryParse(string? value, out ProviderMode mode)
+    {
+        if (string.Equals(value, "saml", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = ProviderMode.Saml;
+            return true;
+        }
+
+        if (string.Equals(value, "oid", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = ProviderMode.Oid;
+            return true;
+        }
+
+        mode = default;
+        return false;
+    }
+
+    /// <summary>
+    /// The lowercase link-namespace token (<c>"oid"</c> / <c>"saml"</c>) the canonical-link store keys under,
+    /// used only to render the mode into operator-facing log lines. The exhaustive switch throws on an
+    /// undefined enum value so a future third mode cannot slip through unlabelled.
+    /// </summary>
+    /// <param name="mode">The typed mode to render.</param>
+    /// <returns>The lowercase protocol token.</returns>
+    internal static string ToToken(this ProviderMode mode) => mode switch
+    {
+        ProviderMode.Saml => "saml",
+        ProviderMode.Oid => "oid",
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown provider mode."),
+    };
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -554,15 +554,12 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to link SSO providers.");
         }
 
-        switch (mode.ToLower())
+        return ParseMode(mode) switch
         {
-            case "saml":
-                return SamlLink(provider, jellyfinUserId, authResponse);
-            case "oid":
-                return OidLink(provider, jellyfinUserId, authResponse);
-            default:
-                throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
-        }
+            ProviderMode.Saml => SamlLink(provider, jellyfinUserId, authResponse),
+            ProviderMode.Oid => OidLink(provider, jellyfinUserId, authResponse),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode)),
+        };
     }
 
     /// <summary>
@@ -584,7 +581,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
         }
 
-        var removeResult = _canonicalLinks.TryRemoveLink(mode, provider, canonicalName, jellyfinUserId);
+        var removeResult = _canonicalLinks.TryRemoveLink(ParseMode(mode), provider, canonicalName, jellyfinUserId);
         return removeResult switch
         {
             CanonicalLinkRemoveResult.Removed => Ok(),
@@ -610,7 +607,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        return _canonicalLinks.LinksByUser("saml", jellyfinUserId);
+        return _canonicalLinks.LinksByUser(ProviderMode.Saml, jellyfinUserId);
     }
 
     /// <summary>
@@ -628,7 +625,7 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "Non-admin is not allowed to query other user's mappings.");
         }
 
-        return _canonicalLinks.LinksByUser("oid", jellyfinUserId);
+        return _canonicalLinks.LinksByUser(ProviderMode.Oid, jellyfinUserId);
     }
 
     // A shallow copy of a provider map, taken under the config lock so the admin list endpoints
@@ -681,6 +678,16 @@ public class SSOController : ControllerBase
     // [Consumes]/[Produces] were inert on this private helper (#393).
     private ActionResult OidLink(string provider, Guid jellyfinUserId, AuthResponse response) =>
         _oidc.Link(provider, jellyfinUserId, response, Request.Cookies[AuthorizeStateBinding.CookieName]);
+
+    // Parse the {mode} route token once, at the HTTP boundary (#369): every link endpoint routes its raw
+    // route string through here, so the protocol is validated in exactly one place and the typed
+    // ProviderMode is threaded inward — no inner layer re-parses or re-compares the string. Fail closed: an
+    // unknown token throws (an ArgumentException, surfacing as the same rejection the two former divergent
+    // ToLower()/ToLowerInvariant() dispatches produced), never defaulting to a protocol.
+    private static ProviderMode ParseMode(string mode) =>
+        ProviderModeParser.TryParse(mode, out var parsed)
+            ? parsed
+            : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
 
     // Fronts an anonymous flow endpoint with the shared per-client rate-limit gate (#128, #160): null when
     // the request may proceed, else the throttled outcome the single mapper renders (#474). The gate owns the

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -34,7 +34,7 @@ internal sealed record VerifiedIdentity
     // the sole construction sites, and each stands for a completed protocol validation. Anything that
     // holds a VerifiedIdentity therefore holds proof the login was verified (#473).
     private VerifiedIdentity(
-        string linkMode,
+        ProviderMode linkMode,
         string auditProtocol,
         string provider,
         string subject,
@@ -59,8 +59,8 @@ internal sealed record VerifiedIdentity
         AvatarUrl = avatarUrl;
     }
 
-    /// <summary>Gets the account-link namespace ("oid"/"saml") the canonical-link store keys this identity under.</summary>
-    internal string LinkMode { get; }
+    /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
+    internal ProviderMode LinkMode { get; }
 
     /// <summary>Gets the protocol label ("OpenID"/"SAML") recorded in the login audit line.</summary>
     internal string AuditProtocol { get; }
@@ -105,7 +105,7 @@ internal sealed record VerifiedIdentity
     /// <returns>The verified OpenID identity.</returns>
     internal static VerifiedIdentity FromOidcRedemption(string provider, OidcAuthorizeStateBuilder.OidcAuthorizeState derived) =>
         new(
-            "oid",
+            ProviderMode.Oid,
             "OpenID",
             provider,
             derived.Subject!,
@@ -130,7 +130,7 @@ internal sealed record VerifiedIdentity
     /// <returns>The verified SAML identity.</returns>
     internal static VerifiedIdentity FromValidatedSaml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
         new(
-            "saml",
+            ProviderMode.Saml,
             "SAML",
             provider,
             nameId,


### PR DESCRIPTION
# What & why

Closes #369. The route's `{mode}` token (`oid`/`saml`) travelled inward as a raw
string and was parsed/compared in several places that all had to agree:

- two independent switches that had to stay in lock-step, the controller's
  culture-sensitive `mode.ToLower()` dispatch in `AddCanonicalLink`, and
  `CanonicalLinkService.TryGetLinks`' invariant-lowercase `mode.ToLowerInvariant()`
  switch;
- per-site `string.Equals(mode, "saml"/"oid", …)` comparisons for the link
  projection (`LinksByUser`) and the adoption audit line;
- the DELETE link route forwarded the raw, unvalidated string all the way into
  the service, where the invalid-mode throw was reachable deep inside a config
  transaction.

A typo or a culture-sensitive lowercasing edge (e.g. an uppercase `OID` under a
Turkish locale) could make the two dispatches disagree.

This sequences after the flow extractions (#500/#501), so the boundary is now
its final shape. The change introduces a typed `ProviderMode` enum (`Saml`/`Oid`)
parsed exactly once, at the HTTP boundary, through a single
`ProviderModeParser.TryParse`, and threads the typed value inward:

- **Single parse at the boundary.** `SSOController.ParseMode` turns the `{mode}`
  route string into `ProviderMode` once, for both the add and delete link routes.
  An unknown token is rejected there, an `ArgumentException` with the same
  message the old dispatch produced, and never defaults to a protocol. No inner
  layer re-parses or re-compares the raw string.
- **Typed value threaded inward.** `CanonicalLinkService` takes `ProviderMode` on
  every mode-bearing method (`ResolveOrCreateAsync`, `TryCreateLink`,
  `TryRemoveLink`, `LinksByUser`, `IsIdentityStillLinked`, and the private
  helpers); the dispatch is an enum `switch`, and the link projection and adoption
  audit compare the enum. `VerifiedIdentity.LinkMode` carries the protocol as the
  typed `ProviderMode`, and the flow services pass the enum literal to
  `TryCreateLink`.
- **Log output unchanged.** The lowercase link-namespace token still renders in
  operator log lines via `ProviderMode.ToToken()`, the single string↔mode
  mapping home, so `{Mode}` log output is byte-identical.

Removed: the second (`TryGetLinks`) dispatch's string lowercasing, the two
`string.Equals(mode, …)` comparisons, and the controller's culture-sensitive
`ToLower()` switch.

Behaviour-preserving: same routes, same accepted modes (now case-insensitive and
culture-independent, so the two former dispatches can no longer disagree), same
fail-closed rejection of an unknown mode (same `ArgumentException`), same
downstream behaviour and log output.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Touches the login path, so filled in even though it is security-neutral:

- [x] Fail-closed preserved: an unknown/unparseable mode is still rejected once,
      at the boundary, and never defaults to a protocol (the internal
      `TryGetLinks` default arm keeps a belt throw against an out-of-range enum).
- [x] No secrets logged; secrets are redacted on config export. (No logging
      change beyond rendering the same lowercase mode token.)
- [x] A security review was performed - the four-lens adversarial-review gate;
      results under Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged;
      `ReplaceLineEndings` on provider/username stays inline).

## Quality checklist

- [x] No duplicated logic; the single string↔mode mapping lives once in
      `ProviderModeParser`, and the dispatch lives once behind the boundary parse.
- [x] The change adds no more code than the problem requires (net removes the
      second dispatch and the per-site comparisons).
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the new structural property (the
      linking surface threads the typed `ProviderMode`, never a raw string mode)
      is locked in as `ProviderMode_IsThreadedTyped_NotAsARawStringToken`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (1040 tests).
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed.

## Notes

New tests: `ProviderModeTests` (parse case-insensitivity, fail-closed rejection,
token round-trip), a delete-route invalid-mode pin and a mixed-case routing pin
in `SSOControllerLinkTests`, and the conformance rule above.

Minor deliberate behaviour delta, an improvement not a regression: the parse is
now culture-independent (`OrdinalIgnoreCase`), so a mixed-case token like `OID`
is accepted consistently on both routes instead of depending on the server
locale. Real traffic sends lowercase `oid`/`saml` (see `Config/linking.js`), so
it is unaffected.

Pre-merge review, the four-lens adversarial gate ran on the diff; verdicts are
posted as a follow-up comment. Ready for approval once green.
