### PR TITLE
Add Kanidm to the tested-providers index in providers.md

### DIFF
--- a/providers.md
+++ b/providers.md
@@ -17,6 +17,7 @@ This section is broken into providers that support Role-Based Access Control (RB
 - ✅ [Keycloak](#keycloak-oidc)
   - Both [OIDC](#keycloak-oidc) & [SAML](#keycloak-saml)
 - ✅ [Pocket ID](#pocket-id)
+- ✅ [Kanidm](#kanidm)
 
 ### No RBAC Support
 


### PR DESCRIPTION
# What & why

`providers.md` carries a full `## Kanidm` configuration section, but Kanidm was missing from the "TOC / Tested Providers" index at the top of the file, so the section was unreachable from the index and the provider list read as incomplete. Kanidm supports RBAC (its example maps `groups` to `RoleClaim`/`AdminRoles`/`Roles` with `EnableAuthorization: true`), so we list it under **Providers that support RBAC**, alongside Authelia, authentik, Keycloak, and Pocket ID.

Documentation only, one index line, no code or behaviour change. The note-only `✅ Google OIDC` entry under "No RBAC Support" is intentional plain text (not a broken anchor) and is left untouched.

Closes #510

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this change does not touch the login path, crypto (SAML/OIDC), config persistence, or the release pipeline. It edits a single Markdown index line.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (no source touched).
- [x] `dotnet test` is green (no source touched).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (`prettier --check providers.md` passes).

## Notes

Out of scope: adding a full Google OIDC configuration section (the entry is a deliberate note-only line inherited from upstream). Converging the provider index otherwise now complete.