### PR TITLE
Split OidcIdTokenValidator into named validation sub-checks

### DIFF
--- a/SSO-Auth/Api/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/OidcIdTokenValidator.cs
@@ -44,52 +44,31 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
         var ephemeralKeys = new List<IDisposable>();
         try
         {
-            var parameters = new TokenValidationParameters
-            {
-                ValidIssuer = options.ProviderInformation.IssuerName,
-                ValidAudience = options.ClientId,
-                IssuerSigningKeys = ConvertSigningKeys(options.ProviderInformation.KeySet, ephemeralKeys),
-                ValidAlgorithms = AllowedSignatureAlgorithms,
-                ClockSkew = options.ClockSkew,
-                RequireSignedTokens = true,
-                RequireExpirationTime = true,
-                // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
-                // legitimately differs from the discovery location; it relaxes ONLY the issuer match.
-                // Signature, audience and lifetime validation have no off switch.
-                ValidateIssuer = options.Policy.Discovery.ValidateIssuerName,
-                // The downstream claim scan compares raw JWT claim names ordinally ("preferred_username",
-                // "sub", the configured role-claim path), so the principal must carry the payload names
-                // verbatim — these two only name the identity's Name/Role accessors.
-                NameClaimType = "name",
-                RoleClaimType = "role",
-            };
-
-            // MapInboundClaims=false keeps the raw JWT claim types; the default mapping would rename
-            // "sub" and friends to SOAP-style URIs and break every ordinal claim comparison downstream.
+            // Signature (against the discovery JWKS, under the asymmetric-only allowlist), issuer,
+            // audience and lifetime are enforced atomically by the handler from the parameters built
+            // below; any failure rejects (fail closed). MapInboundClaims=false keeps the raw JWT claim
+            // types — the default mapping would rename "sub" and friends to SOAP-style URIs and break
+            // every ordinal claim comparison downstream.
             var handler = new JsonWebTokenHandler { MapInboundClaims = false };
-            var result = await handler.ValidateTokenAsync(identityToken, parameters).ConfigureAwait(false);
+            var result = await handler.ValidateTokenAsync(identityToken, BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
             if (!result.IsValid)
             {
-                return new IdentityTokenValidationResult { Error = MapError(result.Exception) };
+                return Reject(MapError(result.Exception));
             }
 
             var token = (JsonWebToken)result.SecurityToken;
             var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
 
-            // azp (OIDC Core 3.1.3.7 rule 5): optional, but when present it MUST equal this client's id —
-            // a token authorized for a different party must not log in here.
-            if (azp != null && !string.Equals(azp, options.ClientId, StringComparison.Ordinal))
+            var authorizedPartyError = CheckAuthorizedParty(azp, options.ClientId);
+            if (authorizedPartyError != null)
             {
-                return new IdentityTokenValidationResult { Error = "Identity token validation failed: azp mismatch" };
+                return Reject(authorizedPartyError);
             }
 
-            // rules 3-4: with more than one audience the token MUST carry an azp (already pinned to this
-            // client above). A multi-audience token WITHOUT azp is rejected — it may have been minted for
-            // a different party that merely lists this client as a co-audience. ValidateAudience only
-            // checks that our id is among the audiences, so this closes the "additional audiences" clause.
-            if (azp == null && token.Audiences.Count() > 1)
+            var audienceError = CheckAudienceRestriction(azp, token);
+            if (audienceError != null)
             {
-                return new IdentityTokenValidationResult { Error = "Identity token validation failed: multiple audiences without azp" };
+                return Reject(audienceError);
             }
 
             return new IdentityTokenValidationResult
@@ -106,6 +85,50 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
             }
         }
     }
+
+    // Signature / issuer / audience / lifetime configuration for the handler: the discovery JWKS as the
+    // only signing keys, the asymmetric-only algorithm allowlist, the discovery issuer, the client id as
+    // the audience, and the client's clock skew. Signed + expiring tokens are required (fail closed).
+    private static TokenValidationParameters BuildValidationParameters(OidcClientOptions options, List<IDisposable> ephemeralKeys) =>
+        new()
+        {
+            ValidIssuer = options.ProviderInformation.IssuerName,
+            ValidAudience = options.ClientId,
+            IssuerSigningKeys = ConvertSigningKeys(options.ProviderInformation.KeySet, ephemeralKeys),
+            ValidAlgorithms = AllowedSignatureAlgorithms,
+            ClockSkew = options.ClockSkew,
+            RequireSignedTokens = true,
+            RequireExpirationTime = true,
+            // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
+            // legitimately differs from the discovery location; it relaxes ONLY the issuer match.
+            // Signature, audience and lifetime validation have no off switch.
+            ValidateIssuer = options.Policy.Discovery.ValidateIssuerName,
+            // The downstream claim scan compares raw JWT claim names ordinally ("preferred_username",
+            // "sub", the configured role-claim path), so the principal must carry the payload names
+            // verbatim — these two only name the identity's Name/Role accessors.
+            NameClaimType = "name",
+            RoleClaimType = "role",
+        };
+
+    // azp (OIDC Core 3.1.3.7 rule 5): optional, but when present it MUST equal this client's id —
+    // a token authorized for a different party must not log in here. Returns the rejection reason, or
+    // null when the check passes.
+    private static string? CheckAuthorizedParty(string? azp, string clientId) =>
+        azp != null && !string.Equals(azp, clientId, StringComparison.Ordinal)
+            ? "Identity token validation failed: azp mismatch"
+            : null;
+
+    // rules 3-4: with more than one audience the token MUST carry an azp (already pinned to this client
+    // by CheckAuthorizedParty). A multi-audience token WITHOUT azp is rejected — it may have been minted
+    // for a different party that merely lists this client as a co-audience. ValidateAudience only checks
+    // that our id is among the audiences, so this closes the "additional audiences" clause. Returns the
+    // rejection reason, or null when the check passes.
+    private static string? CheckAudienceRestriction(string? azp, JsonWebToken token) =>
+        azp == null && token.Audiences.Count() > 1
+            ? "Identity token validation failed: multiple audiences without azp"
+            : null;
+
+    private static IdentityTokenValidationResult Reject(string error) => new() { Error = error };
 
     // The exact string "invalid_signature" is the OidcClient contract: its response processor reacts
     // to it by refreshing the discovery JWKS and retrying once, which is what heals a signing-key


### PR DESCRIPTION
# What & why

Refs #196 (item 4). Split the OIDC `id_token` validator's `ValidateAsync` into small, named, single-responsibility sub-checks so the top-level method reads as a linear sequence of named checks, mirroring the SAML validator decomposition. This clears the S3776 cognitive-complexity finding on `OidcIdTokenValidator.cs` that was deferred until #473 landed (VerifiedIdentity merged 2026-07-17, so the OIDC validation path is free again).

This is a **behaviour-preserving readability refactor of a security validator**, check-for-check identical to `main`. No validation is added, dropped, weakened, or reordered; every reject/accept outcome and error string is byte-for-byte preserved.

**Sub-checks extracted (order + outcomes identical to before):**

1. `BuildValidationParameters(options, ephemeralKeys)`, the **signature / issuer / audience / lifetime** configuration handed to `JsonWebTokenHandler` (verbatim move of the `TokenValidationParameters` initializer: JWKS signing keys, the asymmetric-only algorithm allowlist, issuer, audience, clock skew, `RequireSignedTokens`, `RequireExpirationTime`, `ValidateIssuer`, name/role claim types). `ConvertSigningKeys(...)` still runs against the same `ephemeralKeys` list, populating it before the validation call, so the `finally` disposal path is unchanged.
2. The handler call performs signature/iss/aud/exp **atomically** (the platform library validates them in one operation, they cannot be split into separate sequential method calls without changing behaviour, so they stay one call, configured by the extracted parameters). A failure rejects via `Reject(MapError(...))`.
3. `CheckAuthorizedParty(azp, clientId)`, the **azp-mismatch** rule (OIDC Core 3.1.3.7 rule 5): `azp != null && !Equals(azp, clientId, Ordinal)`.
4. `CheckAudienceRestriction(azp, token)`, the **multi-audience-without-azp** rule (rules 3-4): `azp == null && token.Audiences.Count() > 1`.
5. `Reject(error)`, a small factory removing the repeated `new IdentityTokenValidationResult { Error = ... }` construction (DRY).

**Proof of check-for-check equivalence:** the two boolean predicates and both error strings are transcribed verbatim; the azp-mismatch check is still evaluated *before* the multi-audience check (same short-circuit: `Audiences.Count()` only runs when `azp == null`); the success path constructs the same `IdentityTokenValidationResult`; `MapError`, `ConvertSigningKeys`, `TryGetCurve`, and the algorithm allowlist are untouched. The existing `OidcIdTokenValidatorTests` suite is unmodified and passes unchanged.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Every reject path is preserved verbatim; no check became a guarded-Try that falls through.)
- [x] No secrets logged; secrets are redacted on config export. (No logging changed; `MapError` unchanged.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review, all PASS â€” see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Unchanged; no new log calls.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new structural property; existing rules still pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug + Release, 0 warnings.)
- [x] `dotnet test` is green. (1040 tests, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None changed, C# only.)

## Notes

Delivers **item 4** of #196. **#196 stays open** for item 5 (the S6964 value-type `[FromBody]` under-posting decision, which I still need to decide), this PR uses `Refs #196`, not `Closes`.

**Adversarial four-lens review (refute-by-default), all PASS:**

- **Availability / mass-lockout:** PASS, verbatim helper-extraction; `ephemeralKeys` disposal in `finally` intact, keys still populated before `ValidateTokenAsync`, no token that validated before is rejected now, no new exception path.
- **Security-bypass:** PASS, no validation dropped/weakened/reordered-to-change-outcome; boolean conditions and short-circuit order preserved; algorithm allowlist and signature verification untouched; no reject-path turned fail-open; both error strings byte-identical.
- **Correctness (check-for-check equivalence):** PASS, every `TokenValidationParameters` property reproduced with identical value; both predicates and error strings verbatim; azp-before-audience ordering and `&&` short-circuit preserved; success path and `MapError`/`ConvertSigningKeys`/`TryGetCurve` unchanged.
- **Integration:** PASS, public `ValidateAsync` signature and `IIdentityTokenValidator` contract unchanged; sole caller `OidcLoginService.cs` (`new OidcIdTokenValidator()`) needs no change; all new helpers `private static`, no surface leak; unmodified test suite compiles and covers the same paths; no `ArchitectureConformanceTests` rule affected.
