### PR TITLE
Throttle the pending-legacy-link warning through a shared IntervalGate

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -185,6 +185,24 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void CanonicalLinkService_ThrottlesTheLegacyLinkWarningThroughAStaticIntervalGate()
+    {
+        // Locked in by #362 (CWE-400, log-volume): the terminal pending-legacy-link warnings live in a
+        // service the controller constructs PER REQUEST, so the once-per-interval throttle must be a
+        // PROCESS-WIDE (static) IntervalGate — an instance field would reset every login and throttle
+        // nothing, letting a hot login loop for a not-yet-migrated user flood the log. Pin the static gate
+        // so a later refactor cannot silently demote it to an instance field (which compiles and passes the
+        // unit tests, because those inject a fresh gate) and reopen the flood.
+        var staticGate = typeof(CanonicalLinkService)
+            .GetFields(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly)
+            .Any(f => f.FieldType == typeof(IntervalGate));
+
+        Assert.True(
+            staticGate,
+            "CanonicalLinkService must throttle its pending-legacy-link warning through a static IntervalGate (#362), because the service is constructed per request and an instance gate would throttle nothing.");
+    }
+
+    [Fact]
     public void AuthorizeStates_AreImmutableVariants()
     {
         // Locked in by #341: the in-flight OpenID authorize state is a CLOSED, IMMUTABLE sum — an

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -40,7 +40,12 @@ public class CanonicalLinkServiceTests
         var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
         var users = Substitute.For<IUserManager>();
         var log = new CapturingLogger();
-        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, log);
+
+        // Inject a FRESH legacy-link-warning gate per service so the process-wide static gate (#362) never
+        // leaks its cursor across cases: a fresh gate starts at MinValue, so the single warning each of the
+        // legacy-link tests provokes always enters. The dedicated throttle test below drives its own gate +
+        // fake clock to pin the once-per-interval bound.
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, log, new IntervalGate(TimeSpan.FromMinutes(1)));
         return (service, cfg, users, log);
     }
 
@@ -209,6 +214,60 @@ public class CanonicalLinkServiceTests
         Assert.Single(warnings);
         Assert.Contains("orphaned", warnings[0].Message, StringComparison.Ordinal);
         Assert.DoesNotContain("refused", warnings[0].Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_PendingLegacyLinkWarning_IsThrottledToOncePerInterval()
+    {
+        // #362 (CWE-400, log-volume): the terminal pending-legacy-link warning must be bounded to one line
+        // per interval so a hot login loop for a not-yet-migrated user cannot flood the log. The reject
+        // branch is idempotent (it throws and writes nothing), so repeating the same login re-enters the
+        // warning site every time — exactly the loop the gate must throttle. A fresh gate + a fake clock the
+        // test advances pins the once-per-interval bound deterministically, and the refusal must still throw
+        // on every attempt regardless of whether the line is emitted.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        };
+        var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        var log = new CapturingLogger();
+
+        var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var service = new CanonicalLinkService(
+            users,
+            new FakeCryptoProvider(),
+            store,
+            log,
+            new IntervalGate(TimeSpan.FromMinutes(1)),
+            () => now);
+
+        async Task AttemptRefusedLogin() =>
+            await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+                service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "alice", allowExistingAccountLink: false));
+
+        int LegacyWarnings() => log.Entries
+            .FindAll(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning
+                && e.Message.Contains("legacy username-keyed link", StringComparison.Ordinal))
+            .Count;
+
+        // Three refused logins inside one interval: the first enters the gate, the next two are throttled.
+        await AttemptRefusedLogin();
+        now = now.AddSeconds(10);
+        await AttemptRefusedLogin();
+        now = now.AddSeconds(49); // t0 + 59s, still within the 1-minute interval
+        await AttemptRefusedLogin();
+        Assert.Equal(1, LegacyWarnings());
+
+        // Past the interval, one more login re-opens the gate: a second line, so the signal still surfaces
+        // periodically for triage rather than being suppressed forever.
+        now = now.AddSeconds(2); // t0 + 61s
+        await AttemptRefusedLogin();
+        Assert.Equal(2, LegacyWarnings());
     }
 
     [Fact]

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -58,21 +58,41 @@ internal enum CanonicalLinkRemoveResult
 /// </summary>
 internal sealed class CanonicalLinkService
 {
+    // The once-per-interval throttle for the two terminal pending-legacy-link warnings (the
+    // CreateNewAccount-orphan and RejectNameTaken-migratable branches). It is PROCESS-WIDE (static) on
+    // purpose: this service is constructed per request by the controller, so an instance field would
+    // reset every login and throttle nothing. During an upgrade window a hot login loop for a
+    // not-yet-migrated user would otherwise re-emit the same warning on every attempt (CWE-400,
+    // log-volume — #362/#358); the shared gate bounds that to one line per interval across all requests.
+    // A one-minute interval matches the sibling cap-warn gates (OidcStateStore / SamlRequestCache, #246).
+    // Tests inject a fresh gate + a fake clock so the throttle is deterministic and never leaks its cursor
+    // across cases.
+    private static readonly IntervalGate SharedLegacyLinkWarnGate = new(TimeSpan.FromMinutes(1));
+
     private readonly IUserManager _userManager;
     private readonly ICryptoProvider _cryptoProvider;
     private readonly ProviderConfigStore _configStore;
     private readonly ILogger _logger;
+    private readonly IntervalGate _legacyLinkWarnGate;
+    private readonly Func<DateTime> _clock;
 
     internal CanonicalLinkService(
         IUserManager userManager,
         ICryptoProvider cryptoProvider,
         ProviderConfigStore configStore,
-        ILogger logger)
+        ILogger logger,
+        IntervalGate legacyLinkWarnGate = null,
+        Func<DateTime> clock = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
         _cryptoProvider = cryptoProvider ?? throw new ArgumentNullException(nameof(cryptoProvider));
         _configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // Production leaves both null and gets the process-wide gate + wall clock; tests pass a fresh gate
+        // and a fake clock so the throttle stays deterministic and isolated per case.
+        _legacyLinkWarnGate = legacyLinkWarnGate ?? SharedLegacyLinkWarnGate;
+        _clock = clock ?? (() => DateTime.UtcNow);
     }
 
     /// <summary>
@@ -195,10 +215,11 @@ internal sealed class CanonicalLinkService
         // fresh-account creation (the name was freed by a rename), and only the outcome
         // branch below can label it accurately — the fresh-account case is a SUCCESSFUL login that
         // silently orphans the original account, not a "refused" one, so a single pre-gate line would
-        // mislabel exactly the event an operator most needs to see. Each terminal branch emits one
-        // line (not deduplicated: a cross-request throttle would need process-wide state on this
-        // per-request service, which would leak across tests), so during an upgrade window it is a
-        // stream — enough to identify who still needs migrating, scanned expecting volume.
+        // mislabel exactly the event an operator most needs to see. Each terminal branch emits its one
+        // line through the shared once-per-interval gate (#362): a hot login loop for a not-yet-migrated
+        // user is bounded to one warning per interval instead of one per attempt, so an upgrade window is
+        // a heartbeat naming who still needs migrating rather than a flood. Only the WARNING FREQUENCY is
+        // throttled — the refusal throw and the fresh-account creation still run on every login.
 
         // Adoption of a pre-existing unlinked account still matches on the display name resolved above.
         var decision = AccountLinkResolver.Resolve(linkedUserId, existingAccountUserId, allowExistingAccountLink);
@@ -244,7 +265,7 @@ internal sealed class CanonicalLinkService
 
             case AccountLinkAction.CreateNewAccount:
             {
-                if (legacyLink.HasValue)
+                if (legacyLink.HasValue && _legacyLinkWarnGate.TryEnter(_clock()))
                 {
                     // The dangerous, previously-silent case (#354/#361): a legacy username-keyed link
                     // exists and its target still exists, but no live account bears the name anymore (the
@@ -254,7 +275,9 @@ internal sealed class CanonicalLinkService
                     // provision a FRESH account under this subject, leaving the original — the one the
                     // legacy key points at — orphaned from this identity. This warning is the single
                     // observable signal of that outcome; recover by linking the original account to this
-                    // subject via the admin endpoints. See the upgrade runbook in providers.md.
+                    // subject via the admin endpoints. See the upgrade runbook in providers.md. Throttled
+                    // through the shared once-per-interval gate (#362) so a login loop cannot flood it; the
+                    // account is still provisioned on every login regardless of whether the line is emitted.
                     _logger.LogWarning(
                         "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
                         username?.ReplaceLineEndings(string.Empty),
@@ -280,12 +303,17 @@ internal sealed class CanonicalLinkService
                 {
                     // Refused, but specifically because a legacy username-keyed link (#354) is pending
                     // and a live account still bears the name — the migratable case, distinct from an
-                    // ordinary #95 name collision. One line, so the reject path is not double-logged.
-                    _logger.LogWarning(
-                        "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
-                        username?.ReplaceLineEndings(string.Empty),
-                        mode.ToToken(),
-                        provider?.ReplaceLineEndings(string.Empty));
+                    // ordinary #95 name collision. Throttled through the shared once-per-interval gate
+                    // (#362) so a login loop for a not-yet-migrated user cannot flood it; the refusal below
+                    // still throws on every login regardless of whether this line is emitted.
+                    if (_legacyLinkWarnGate.TryEnter(_clock()))
+                    {
+                        _logger.LogWarning(
+                            "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
+                            username?.ReplaceLineEndings(string.Empty),
+                            mode.ToToken(),
+                            provider?.ReplaceLineEndings(string.Empty));
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
# What & why

The two terminal pending-legacy-link warnings in `CanonicalLinkService` - the
`CreateNewAccount`-orphan branch and the `RejectNameTaken`-migratable branch - 
were emitted once per matching login. During a migration/upgrade window a hot
login loop for a not-yet-migrated user re-emits the same line on every attempt,
so the log volume is bounded only by the anonymous-endpoint rate limiter
(CWE-400, log-volume; raised by CodeRabbit and the availability lens on #358).

We route both warnings through the repo's sanctioned once-per-interval log-flood
primitive (`IntervalGate`, #246/#195), so a login loop is bounded to one line per
interval instead of one per attempt. The gate is a **process-wide static** field
with a one-minute interval matching the sibling cap-warn gates
(`OidcStateStore` / `SamlRequestCache`): the service is constructed per request
by the controller, so an instance gate would reset every login and throttle
nothing. Both the gate and the clock are injectable, so the throttle is
unit-testable with a fake clock and stays isolated per test case.

Only the warning FREQUENCY changes. The refusal throw and the fresh-account
creation still run on every login, the migration/adoption resolution is
untouched, and the inline log-forging sanitizer (`ReplaceLineEndings`) stays at
each call site.

Closes #362

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

(Hardening of a login-path log signal; no behaviour change beyond log frequency.)

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the `RejectNameTaken` throw and the account
      resolution are unconditional; the gate wraps only the `LogWarning` call.
- [x] No secrets logged; secrets are redacted on config export. (Unchanged - the
      warnings log only username/provider, already sanitized.)
- [x] A security review was performed - the four-lens adversarial gate, results
      under Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call
      (`username?.ReplaceLineEndings(...)`, `provider?.ReplaceLineEndings(...)`
      unchanged, inside the gated block).

## Quality checklist

- [x] No duplicated logic; the throttle reuses the existing `IntervalGate`
      primitive.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the new static-gate property is locked
      in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0 warnings).
- [x] `dotnet test` is green (1042 passed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (none touched).
- [x] `scripts/check-jellyfin-compat.sh` consistent.

## Notes

**Scope.** Only `CanonicalLinkService.cs` (+ its tests + one conformance rule).
The ordinary #95 name-collision warning (the non-legacy `else` arm of
`RejectNameTaken`) is deliberately left unthrottled, it is a different signal
and out of this issue's scope.

**Adversarial self-review (login-path linking), four refute-by-default lenses:**

- **Availability / mass-lockout, PASS.** The gate changes log frequency only; no
  login is newly blocked or allowed, so there is no lockout. The first occurrence
  always enters (fresh cursor), and a second line surfaces each interval
  (pinned by the test), so detection of the first event and periodic triage are
  preserved. Documented residual: with a single shared gate, when several
  distinct users are pending in the same minute only one is named per interval - 
  a triage-completeness reduction the issue explicitly accepts ("as far as the
  primitive allows") and the task specifies ("emitted at most once per
  interval"). The bounded-cardinality "who is still pending" counter the issue
  floats as the richer alternative can be a later opportunistic follow-up.
- **Security-bypass / fail-open, PASS.** The gate wraps only `LogWarning`. The
  `throw new AccountLinkForbiddenException()` and the account provisioning sit
  outside the gated block and run on every login; the `&&` short-circuit in the
  orphan branch skips only the log, never a side effect. Migration/adoption,
  config locking, and the admin/adoption refusal audit lines are untouched. The
  throttle strictly improves posture (removes a log-flood DoS) without weakening
  the 403.
- **Correctness, PASS.** `IntervalGate.TryEnter` enters on the first call
  (cursor `MinValue`), throttles within the interval, and re-anchors past it. The
  clock is consulted only when `legacyLink.HasValue`, so no gate slot is consumed
  on the ordinary-collision path. The new test pins: three refused logins within
  one minute emit one warning; a fourth just past the interval emits the second.
- **Integration, PASS.** The static gate is process-wide, thread-safe
  (Interlocked CAS), and shared across per-request service instances via the
  4-arg production constructor (SSOController's call site is unchanged, new
  params are optional). Tests inject a fresh gate + fake clock, so the static
  cursor never leaks across cases. The inline log-forging sanitizers are intact.
  A conformance rule pins the gate as static so a refactor cannot silently demote
  it to an instance field (which would compile and pass the unit tests, since
  those inject a fresh gate) and reopen the flood.
