### PR TITLE
Rate-limit the authenticated link/unlink admin endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ only way to get one process-wide instance):
 | `SamlReplayCache`    | `SamlLoginService` | one-time-use SAML assertion IDs (replay protection)                                         |
 | `SamlRequestCache`   | `SamlLoginService` | outstanding SAML `AuthnRequest` IDs for `InResponseTo` correlation                          |
 | `OidcDiscoveryCache` | `OidcLoginService` | per-discovery-URL PKCE-S256 / RFC 9207 `iss` facts, 15-minute TTL; owns the fetch/parse too |
-| `SsoRateLimiter`     | `SsoRateLimitGate` | opt-in per-client rate limiting on the anonymous login endpoints                            |
+| `SsoRateLimiter`     | `SsoRateLimitGate` | opt-in per-client rate limiting on the login endpoints and the link/unlink admin surface    |
 
 The controller itself now holds **no mutable static state** — every store above
 lives in a flow service or the Shared tier, pinned by

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Data;
@@ -351,12 +352,106 @@ public class SSOControllerLinkTests
         Assert.Contains("nameid-1", map["adfs"]);
     }
 
+    [Fact]
+    public async Task AddCanonicalLink_AuthorizedOverRateLimit_Returns429()
+    {
+        // #382: the authenticated link write surface is now throttled by the shared gate under its own "link"
+        // class. A burst past the configured budget is refused with the same 429 the login path renders.
+        var harness = ForCaller(isAdmin: true, callerId: Target, clientIp: IPAddress.Parse("8.8.4.10"), configure: c =>
+        {
+            c.EnableRateLimit = true;
+            c.RateLimitMaxAttempts = 1;
+            c.RateLimitWindowSeconds = 60;
+        });
+
+        // The first authorized call passes the limiter and spends the single-attempt budget; the unknown
+        // provider then rejects with the uniform 400 — but the budget is already spent.
+        Assert.IsType<BadRequestObjectResult>(
+            await harness.Controller.AddCanonicalLink("oid", "does-not-exist", Target, new AuthResponse { Data = "state-token" }));
+
+        // The second authorized call is over budget and is throttled before the provider is looked up: a 429
+        // from LoginOutcome.Throttled via the single mapper (#474), with the machine-readable Retry-After.
+        var throttled = Assert.IsType<ContentResult>(
+            await harness.Controller.AddCanonicalLink("oid", "does-not-exist", Target, new AuthResponse { Data = "state-token" }));
+        Assert.Equal(429, throttled.StatusCode);
+        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+
+        var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
+        Assert.True(
+            int.TryParse(retryAfter, out var seconds) && seconds >= 1 && seconds <= 60,
+            $"Retry-After must be whole seconds within the 60s window; was '{retryAfter}'.");
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedOverRateLimit_Returns429()
+    {
+        // #382: the DELETE arm is throttled too — a name-miss DELETE still runs a full persist under the
+        // config lock, so it shares the "link" budget with the add arm.
+        var harness = ForCaller(isAdmin: true, callerId: Target, clientIp: IPAddress.Parse("8.8.4.11"), configure: c =>
+        {
+            c.EnableRateLimit = true;
+            c.RateLimitMaxAttempts = 1;
+            c.RateLimitWindowSeconds = 60;
+        });
+
+        // First call spends the single-attempt budget (unknown provider → 400).
+        Assert.IsType<BadRequestObjectResult>(
+            await harness.Controller.DeleteCanonicalLink("oid", "does-not-exist", Target, "sub-1"));
+
+        // Second call is over budget and throttled.
+        var throttled = Assert.IsType<ContentResult>(
+            await harness.Controller.DeleteCanonicalLink("oid", "does-not-exist", Target, "sub-1"));
+        Assert.Equal(429, throttled.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddCanonicalLink_UnauthorizedOverRateLimit_Returns403NotThrottled()
+    {
+        // The caller-authz guard runs before the limiter (#382 keeps the 403 first), so an unauthorized caller
+        // is refused with 403 and never consumes or is judged by the rate-limit budget — even hammering past
+        // the configured max of one. This pins the ordering: no 429 can precede the 403 (no rate-limit oracle).
+        var harness = ForCaller(isAdmin: false, callerId: Other, clientIp: IPAddress.Parse("8.8.4.12"), configure: c =>
+        {
+            c.EnableRateLimit = true;
+            c.RateLimitMaxAttempts = 1;
+            c.RateLimitWindowSeconds = 60;
+        });
+
+        for (var i = 0; i < 3; i++)
+        {
+            var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse());
+            Assert.Equal(403, Assert.IsType<ObjectResult>(result).StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_AuthorizedUnderRateLimit_NotThrottled()
+    {
+        // With rate limiting enabled but the budget generous (the default 30/60s), a normal admin unlink is
+        // unaffected: it removes the caller's own link and returns Ok, never a 429.
+        var harness = ForCaller(isAdmin: true, callerId: Target, clientIp: IPAddress.Parse("8.8.4.13"), configure: c =>
+        {
+            c.EnableRateLimit = true;
+            c.RateLimitMaxAttempts = 30;
+            c.RateLimitWindowSeconds = 60;
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target },
+            };
+        });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+    }
+
     // Builds a harness whose mocked IAuthorizationContext resolves the request to the given caller. An
     // admin (or the target user themselves) with preference access passes AssertCanUpdateUser; a
-    // non-admin editing another user, or any caller without EnableUserPreferenceAccess, is refused.
-    private static SsoControllerHarness ForCaller(bool isAdmin, Guid callerId, Action<PluginConfiguration>? configure = null, bool enableUserPreferenceAccess = true)
+    // non-admin editing another user, or any caller without EnableUserPreferenceAccess, is refused. A
+    // dedicated clientIp lets a throttling test isolate its process-static limiter counter (#382).
+    private static SsoControllerHarness ForCaller(bool isAdmin, Guid callerId, Action<PluginConfiguration>? configure = null, bool enableUserPreferenceAccess = true, IPAddress? clientIp = null)
     {
-        var harness = new SsoControllerHarness(configure);
+        var harness = new SsoControllerHarness(configure, clientIp);
 
         var user = new User("caller", "SSO-Auth", "Default") { Id = callerId, EnableUserPreferenceAccess = enableUserPreferenceAccess };
         user.SetPermission(PermissionKind.IsAdministrator, isAdmin);

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -554,6 +554,15 @@ public class SSOController : ControllerBase
             return StatusCode(StatusCodes.Status403Forbidden, "User is not allowed to link SSO providers.");
         }
 
+        // Throttle after the caller-authz guard (#382): the 403 stays first so an unauthorized caller is
+        // refused before the limiter is consulted (no rate-limit oracle), then the shared gate caps how fast
+        // an authorized caller can drive the config-XML disk writes this write surface performs. "link" is a
+        // distinct endpoint class, so its budget is independent of the anonymous login flows.
+        if (RateLimitCheck("link") is { } throttled)
+        {
+            return throttled;
+        }
+
         return ParseMode(mode) switch
         {
             ProviderMode.Saml => SamlLink(provider, jellyfinUserId, authResponse),
@@ -579,6 +588,14 @@ public class SSOController : ControllerBase
         if (!await RequestHelpers.AssertCanUpdateUser(_authContext, HttpContext.Request, jellyfinUserId).ConfigureAwait(false))
         {
             return StatusCode(StatusCodes.Status403Forbidden, "Current user is not allowed to unlink SSO providers for user ID.");
+        }
+
+        // Throttle after the caller-authz guard (#382): a name-miss DELETE still runs a full persist under the
+        // global config lock, so this endpoint is capped too. It shares the "link" budget with AddCanonicalLink
+        // — one bucket per client for the whole link/unlink write surface — while the 403 stays first.
+        if (RateLimitCheck("link") is { } throttled)
+        {
+            return throttled;
         }
 
         var removeResult = _canonicalLinks.TryRemoveLink(ParseMode(mode), provider, canonicalName, jellyfinUserId);
@@ -689,12 +706,13 @@ public class SSOController : ControllerBase
             ? parsed
             : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
 
-    // Fronts an anonymous flow endpoint with the shared per-client rate-limit gate (#128, #160): null when
-    // the request may proceed, else the throttled outcome the single mapper renders (#474). The gate owns the
-    // one process-wide limiter and the whole check (config read, IP classifier, endpoint-class keying, the
-    // #195 observability signal); this wrapper only supplies the three request-scoped inputs it needs — the
-    // endpoint class, the connection's remote address, and the response the retry-delay header is set on — so
-    // the controller keeps no rate-limit state of its own.
+    // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382): null when the request
+    // may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login endpoints
+    // pass their class (challenge/callback/auth); the authenticated link/unlink write surface passes "link"
+    // after its own authz guard. The gate owns the one process-wide limiter and the whole check (config read,
+    // IP classifier, endpoint-class keying, the #195 observability signal); this wrapper only supplies the
+    // three request-scoped inputs it needs — the endpoint class, the connection's remote address, and the
+    // response the retry-delay header is set on — so the controller keeps no rate-limit state of its own.
     private ActionResult RateLimitCheck(string endpointClass) =>
         SsoRateLimitGate.Check(endpointClass, HttpContext.Connection.RemoteIpAddress, _logger, Response);
 }

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -8,35 +8,38 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>
-/// The shared per-client rate-limit gate over the anonymous SSO flow endpoints (#128, #160). It owns the ONE
-/// process-wide <see cref="SsoRateLimiter"/> instance and the opt-in check both login flows front their
-/// endpoints with — the last mutable process-wide static that lived on <see cref="SSOController"/> (#318).
+/// The shared per-client rate-limit gate over the SSO flow endpoints (#128, #160): the anonymous login
+/// endpoints and, since #382, the authenticated link/unlink admin write surface. It owns the ONE
+/// process-wide <see cref="SsoRateLimiter"/> instance and the opt-in check every rate-limited endpoint
+/// fronts itself with — the last mutable process-wide static that lived on <see cref="SSOController"/> (#318).
 /// Relocating it into the shared tier leaves the controller a stateless request dispatcher (every store,
 /// cache and limiter now lives in a flow service or here) while keeping the gate byte-for-byte identical: the
 /// same fire points, the same fail-open classifier, and the same <see cref="LoginOutcome.Throttled"/> 429
 /// rendered by the single mapper (#474). Pure static home — one shared instance, no per-request allocation,
-/// and no <c>ControllerBase</c> coupling, so both flows (and any admin endpoint that ever needs throttling)
-/// call the one gate rather than a controller-owned static.
+/// and no <c>ControllerBase</c> coupling, so both login flows and the admin link endpoints call the one gate
+/// rather than a controller-owned static, each under its own endpoint-class budget.
 /// </summary>
 internal static class SsoRateLimitGate
 {
-    // The opt-in per-client rate limiter over the anonymous SSO flow endpoints (#128). One process-wide
-    // instance (static readonly), exactly as it was on the controller: both login flows reach it through this
-    // gate, so a single shared window per client is preserved across the OpenID and SAML endpoints rather
-    // than split into two separate limiters.
+    // The opt-in per-client rate limiter over the SSO flow endpoints (#128). One process-wide instance
+    // (static readonly), exactly as it was on the controller: every rate-limited endpoint reaches it through
+    // this gate, so a single shared window per client is preserved across the OpenID and SAML login endpoints
+    // (and now the link/unlink admin surface, #382, under its own class) rather than split into separate limiters.
     private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
 
     /// <summary>
-    /// Applies the opt-in per-client rate limit (#128) to one anonymous flow endpoint: returns null when the
+    /// Applies the opt-in per-client rate limit (#128) to one rate-limited endpoint: returns null when the
     /// request may proceed, else the throttled outcome rendered by the single mapper (#474). Reads the
     /// settings under the config lock; an unattributable or non-public client is never throttled (fail open,
     /// availability over throttling). Keys on the connection's remote address only — proxy attribution is the
     /// host's job (Jellyfin's "Known proxies" setting resolves the real client into it); see
-    /// <see cref="SsoRateLimiter.NormalizeClientKey"/>. The endpoint class (challenge/callback/auth) is part
-    /// of the key so one login — which hits all three — gets the full budget at each stage rather than a
-    /// third of it, keeping the default generous for shared egress addresses (NAT/CGNAT).
+    /// <see cref="SsoRateLimiter.NormalizeClientKey"/>. The endpoint class (challenge/callback/auth for the
+    /// anonymous login flows, "link" for the authenticated link/unlink write surface, #382) is part of the
+    /// key, so each class carries an independent budget: one login — which hits all three login classes — gets
+    /// the full budget at each stage rather than a third of it, keeping the default generous for shared egress
+    /// addresses (NAT/CGNAT).
     /// </summary>
-    /// <param name="endpointClass">The endpoint class (challenge/callback/auth) folded into the rate-limit key.</param>
+    /// <param name="endpointClass">The endpoint class folded into the rate-limit key (e.g. challenge/callback/auth/link).</param>
     /// <param name="remoteIp">The connection's remote address, the sole attribution input (proxy resolution is the host's job).</param>
     /// <param name="logger">The caller's logger, for the bounded throttle-engaged observability signal (#195).</param>
     /// <param name="response">The response whose Retry-After header a throttled outcome sets (#474).</param>
@@ -70,7 +73,7 @@ internal static class SsoRateLimitGate
         var throttledCount = RateLimiter.RecordThrottledHit(now);
         if (throttledCount > 0)
         {
-            logger.LogWarning("SSO rate limit engaged on the anonymous login endpoints: {Count} request(s) throttled since the last notice; further notices are suppressed for at least a minute.", throttledCount);
+            logger.LogWarning("SSO rate limit engaged: {Count} request(s) throttled since the last notice; further notices are suppressed for at least a minute.", throttledCount);
         }
 
         // The rejection is expressed as a LoginOutcome and rendered by the single mapper (#474): the status,


### PR DESCRIPTION
# What & why

The authenticated link/unlink admin write surface, `AddCanonicalLink` (POST
`{mode}/Link/{provider}/{jellyfinUserId}`) and `DeleteCanonicalLink` (DELETE
`{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}`), was
`AssertCanUpdateUser`-gated but had no rate limit. An authorized caller could
force serialized config-XML disk writes at will: each name-miss DELETE still
runs a full persist under the global config lock. It was the one write surface
with no throttle (raised by review on #373).

We front both endpoints with the shared per-client gate `SsoRateLimitGate.Check`
under a distinct `"link"` endpoint class, placed **after** the
`AssertCanUpdateUser` 403 guard so the auth decision stays first (no rate-limit
enumeration oracle) and the `"link"` budget is independent of the anonymous
login classes (`challenge`/`callback`/`auth`), which are byte-for-byte
unaffected. Over-limit renders the same `LoginOutcome.Throttled` 429 +
`Retry-After` the login path uses (#474). Rate limiting stays opt-in (default
off); the default 30/60s budget does not throttle real interactive admin use,
and the fail-open IP classifier still exempts private/proxied peers, so a
reverse-proxy deployment cannot be mass-locked. The gate's log line and doc
comments (and the ARCHITECTURE.md store table) were generalized from "anonymous
login endpoints" to cover the admin link surface too.

Closes #382

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the auth check (403) runs before the limiter, and
      the limiter's fail-open is availability-only, after authorization — no auth
      is ever default-accepted. Over-limit yields 429; the mapper throws rather
      than default-accepting on a wiring fault.
- [x] No secrets logged; the throttle signal carries only an aggregate count, no
      client key.
- [x] A security review was performed (four adversarial lenses, see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new IdP
      input is logged; the added log line carries only an integer count.)

## Quality checklist

- [x] No duplicated logic; the existing shared gate is reused, no new limiter.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318):
      the controller keeps no rate-limit state; the gate owns the whole check.
- [x] Architecture-conformance tests pass. No new structural property is
      established (the gate and its no-mutable-static-on-controller rule already
      exist); the reuse conforms to them.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug + Release, 0 warnings).
- [x] `dotnet test` is green (1044 passed, +4 new).
- [x] Prettier is clean for the `.md` change.

## Notes

Adversarial-review gate, four refute-by-default lenses, all resolved:

- **Availability / mass-lockout, PASS.** Default-off; `"link"` is a distinctly
  keyed bucket that cannot steal the login budgets; the fail-open classifier
  (private/proxy/CGNAT → null) keeps reverse-proxy deployments un-throttled; the
  403 guard runs first so only authorized callers are ever throttled.
- **Security-bypass / fail-open, PASS.** The `AssertCanUpdateUser` 403 fires
  before the limiter on both endpoints (unauthorized → 403, never 429), the
  `"link"` bucket is key-isolated from the login classes, and every limiter
  fail-open path is availability-only after authorization, no auth bypass, no
  enumeration oracle, no cross-bucket exhaustion.
- **Correctness, PASS.** The `is { } throttled` null-pattern proceeds on null
  and returns the 429 otherwise; over-limit → 429, under-limit → normal; the new
  tests use genuinely public (throttleable) IPs unique to the file and fail for
  the right reason under a regression.
- **Integration, NEEDS_IMPROVEMENT, resolved.** The lens flagged an incomplete
  reword: the gate's class summary + field comment and the ARCHITECTURE.md store
  row still said "anonymous". Fixed in this PR (all three generalized). The
  shared gate is reused with an unchanged signature; the login buckets are
  byte-for-byte unaffected; both endpoints are covered.

Out of scope (one line each, not addressed here):

- The `Unregister` endpoint (a heavier, admin-elevation-only config write) is
  also un-throttled; worth a follow-up hardening pass, outside #382's link/unlink
  scope.
- The throttled body reuses the shared "Too many login attempts…" wording on a
  non-login admin surface, cosmetic, inherited from the single mapper (#474),
  not a leak; a copy tweak could follow.
