### PR TITLE
Support ECDSA service-provider signing keys for outgoing SAML requests

### DIFF
--- a/SSO-Auth.Tests/SamlAuthnRequestTests.cs
+++ b/SSO-Auth.Tests/SamlAuthnRequestTests.cs
@@ -47,6 +47,20 @@ public class SamlAuthnRequestTests
     }
 
     [Fact]
+    public void GetSignedRedirectUrl_EcdsaKey_CarriesAVerifiableEcdsaSignature()
+    {
+        var request = new SamlAuthnRequest("jellyfin-sp", "https://jellyfin.example.com/sso/SAML/p/adfs");
+        using var certificate = SamlSigningKeyFactory.CreateEcdsaCertificate();
+        using var privateKey = certificate.GetECDsaPrivateKey()!;
+
+        var url = request.GetSignedRedirectUrl(Endpoint, relayState: null, privateKey);
+
+        Assert.Contains("SigAlg=" + Uri.EscapeDataString("http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"), url);
+        using var publicKey = certificate.GetECDsaPublicKey()!;
+        Assert.True(EcdsaSignatureVerifies(url, publicKey));
+    }
+
+    [Fact]
     public void GetSignedRedirectUrl_NullEndpoint_Throws()
     {
         var request = new SamlAuthnRequest("jellyfin-sp", "https://jellyfin.example.com/sso/SAML/p/adfs");
@@ -64,6 +78,16 @@ public class SamlAuthnRequestTests
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+    }
+
+    private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey)
+    {
+        var samlRequest = QueryValue(url, "SAMLRequest");
+        var sigAlg = QueryValue(url, "SigAlg");
+        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+
+        var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+        return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
     }
 
     private static string QueryValue(string url, string name)

--- a/SSO-Auth.Tests/SamlRedirectSignerTests.cs
+++ b/SSO-Auth.Tests/SamlRedirectSignerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -16,6 +17,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class SamlRedirectSignerTests
 {
     private const string RsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    private const string EcdsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
     private const string RsaSha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
     private const string Endpoint = "https://idp.example.com/sso";
     private const string Message = "deflated+base64==/message";
@@ -116,6 +118,60 @@ public class SamlRedirectSignerTests
     }
 
     [Fact]
+    public void BuildSignedRedirectUrl_EcdsaKey_EmitsEcdsaSigAlg_AndSignatureVerifiesOverTheOctets()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: "linking", ecdsa);
+
+        // An ECDSA key selects ecdsa-sha256 (#493), on the same allowlist, never SHA-1.
+        Assert.Contains("&SigAlg=" + Uri.EscapeDataString(EcdsaSha256), url);
+        Assert.True(SamlSignatureAlgorithms.IsSignatureMethodAllowed(EcdsaSha256));
+        Assert.True(EcdsaSignatureVerifies(url, ecdsa, expectedRelayState: "linking"));
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_EcdsaKey_ForeignKey_DoesNotVerify()
+    {
+        using var signer = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        using var attacker = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+
+        var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, signer);
+
+        Assert.True(EcdsaSignatureVerifies(url, signer, expectedRelayState: null));
+        Assert.False(EcdsaSignatureVerifies(url, attacker, expectedRelayState: null));
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_EcdsaCertificateFromPkcs12_RoundTripsThroughTheLoader()
+    {
+        // The full production path: an ECDSA PKCS#12 loads, the key type is detected, and the emitted
+        // signature verifies against the certificate's ECDSA public key with SigAlg=ecdsa-sha256.
+        Assert.True(SamlSigningKey.TryLoad(SamlSigningKeyFactory.CreateEcdsaPfxBase64(), out var certificate));
+        using (certificate)
+        using (var signingKey = SamlSigningKey.GetSigningKey(certificate))
+        {
+            Assert.NotNull(signingKey);
+
+            var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, signingKey);
+
+            Assert.Contains("&SigAlg=" + Uri.EscapeDataString(EcdsaSha256), url);
+            using var publicKey = certificate.GetECDsaPublicKey()!;
+            Assert.True(EcdsaSignatureVerifies(url, publicKey, expectedRelayState: null));
+        }
+    }
+
+    [Fact]
+    public void BuildSignedRedirectUrl_UnsupportedKeyType_ThrowsRatherThanSigningUnknown()
+    {
+        // A key that is neither RSA nor ECDSA is rejected, never silently left unsigned or signed weakly.
+        using var dsa = DSA.Create();
+
+        Assert.Throws<InvalidOperationException>(
+            () => { SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, dsa); });
+    }
+
+    [Fact]
     public void SignatureAlgorithm_IsOnTheInboundAllowlist_AndIsNotSha1()
     {
         using var rsa = RSA.Create(2048);
@@ -150,6 +206,25 @@ public class SamlRedirectSignerTests
         signedQuery += "&SigAlg=" + Uri.EscapeDataString(sigAlg);
 
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+    }
+
+    // The ECDSA counterpart of SignatureVerifies: the XML-DSig ecdsa-sha256 signature value is the raw
+    // IEEE P1363 r||s concatenation the signer emits, so verification must use the same format.
+    private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey, string? expectedRelayState)
+    {
+        var samlRequest = ExtractQueryValue(url, "SAMLRequest");
+        var sigAlg = ExtractQueryValue(url, "SigAlg");
+        var signature = Convert.FromBase64String(ExtractQueryValue(url, "Signature"));
+
+        var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest);
+        if (!string.IsNullOrEmpty(expectedRelayState))
+        {
+            signedQuery += "&RelayState=" + Uri.EscapeDataString(expectedRelayState);
+        }
+
+        signedQuery += "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+
+        return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
     }
 
     private static string ExtractQueryValue(string url, string name)

--- a/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/SamlSignatureAlgorithmsTests.cs
@@ -12,8 +12,10 @@ public class SamlSignatureAlgorithmsTests
 {
     private const string RsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
     private const string RsaSha512 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+    private const string EcdsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
     private const string EcdsaSha384 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384";
     private const string RsaSha1 = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+    private const string EcdsaSha1 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1";
 
     private const string DigestSha256 = "http://www.w3.org/2001/04/xmlenc#sha256";
     private const string DigestSha384 = "http://www.w3.org/2001/04/xmldsig-more#sha384";
@@ -96,6 +98,7 @@ public class SamlSignatureAlgorithmsTests
     [Theory]
     [InlineData(RsaSha256)]
     [InlineData(RsaSha512)]
+    [InlineData(EcdsaSha256)] // the algorithm the outgoing ECDSA signer emits (#493)
     [InlineData(EcdsaSha384)]
     public void IsSignatureMethodAllowed_StrongMethods_ReturnTrue(string method)
     {
@@ -104,6 +107,7 @@ public class SamlSignatureAlgorithmsTests
 
     [Theory]
     [InlineData(RsaSha1)]
+    [InlineData(EcdsaSha1)] // no SHA-1 variant is admitted, ECDSA included (#493)
     [InlineData("urn:made:up")]
     [InlineData(null)]
     public void IsSignatureMethodAllowed_WeakOrUnknownOrNull_ReturnFalse(string? method)

--- a/SSO-Auth.Tests/SamlSigningKeyFactory.cs
+++ b/SSO-Auth.Tests/SamlSigningKeyFactory.cs
@@ -5,8 +5,8 @@ using System.Security.Cryptography.X509Certificates;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Builds throw-away service-provider signing keys for the outgoing-signing tests (#167): a Base64
-/// PKCS#12 (PFX) blob carrying an RSA keypair, the exact shape an operator supplies in
+/// Builds throw-away service-provider signing keys for the outgoing-signing tests (#167, #493): a Base64
+/// PKCS#12 (PFX) blob carrying an RSA or ECDSA keypair, the exact shape an operator supplies in
 /// <c>SamlSigningKeyPfx</c>, plus its public key for verifying the emitted signature.
 /// </summary>
 internal static class SamlSigningKeyFactory
@@ -17,6 +17,21 @@ internal static class SamlSigningKeyFactory
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest("CN=Jellyfin SSO Test SP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+    }
+
+    /// <summary>Creates a fresh self-signed ECDSA (nistP256) signing certificate (#493).</summary>
+    internal static X509Certificate2 CreateEcdsaCertificate()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var request = new CertificateRequest("CN=Jellyfin SSO Test SP ECDSA", ecdsa, HashAlgorithmName.SHA256);
+        return request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+    }
+
+    /// <summary>Creates an ECDSA signing key as the Base64 PKCS#12 blob the config stores (#493).</summary>
+    internal static string CreateEcdsaPfxBase64()
+    {
+        using var certificate = CreateEcdsaCertificate();
+        return Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
     }
 
     /// <summary>Creates a signing key as the Base64 PKCS#12 blob the config stores.</summary>

--- a/SSO-Auth.Tests/SamlSigningKeyTests.cs
+++ b/SSO-Auth.Tests/SamlSigningKeyTests.cs
@@ -25,6 +25,29 @@ public class SamlSigningKeyTests
         }
     }
 
+    [Fact]
+    public void TryLoad_EcdsaPfx_ReturnsCertificateWhoseSigningKeyIsEcdsa()
+    {
+        // An ECDSA SP signing key is a first-class option (#493): it loads, and GetSigningKey surfaces it.
+        Assert.True(SamlSigningKey.TryLoad(SamlSigningKeyFactory.CreateEcdsaPfxBase64(), out var certificate));
+        using (certificate)
+        {
+            using var privateKey = SamlSigningKey.GetSigningKey(certificate);
+            Assert.IsAssignableFrom<ECDsa>(privateKey);
+        }
+    }
+
+    [Fact]
+    public void GetSigningKey_RsaCertificate_ReturnsRsaKey()
+    {
+        Assert.True(SamlSigningKey.TryLoad(SamlSigningKeyFactory.CreatePfxBase64(), out var certificate));
+        using (certificate)
+        {
+            using var privateKey = SamlSigningKey.GetSigningKey(certificate);
+            Assert.IsAssignableFrom<RSA>(privateKey);
+        }
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -57,6 +80,13 @@ public class SamlSigningKeyTests
     public void IsInvalid_ValidPfx_False()
     {
         Assert.False(SamlSigningKey.IsInvalid(SamlSigningKeyFactory.CreatePfxBase64()));
+    }
+
+    [Fact]
+    public void IsInvalid_EcdsaPfx_False()
+    {
+        // An ECDSA signing key can sign (#493), so the admin-write validity check must accept it.
+        Assert.False(SamlSigningKey.IsInvalid(SamlSigningKeyFactory.CreateEcdsaPfxBase64()));
     }
 
     [Theory]

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -462,11 +462,11 @@ internal sealed class SamlLoginService
         }
 
         using (signingCertificate)
-        using (var signingKey = signingCertificate.GetRSAPrivateKey())
+        using (var signingKey = SamlSigningKey.GetSigningKey(signingCertificate))
         {
             if (signingKey is null)
             {
-                throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key has no RSA private key.");
+                throw new InvalidOperationException("Outgoing SAML request signing is enabled but the signing key has no RSA or ECDSA private key.");
             }
 
             return request.GetSignedRedirectUrl(endpoint, relayState, signingKey);

--- a/SSO-Auth/Api/SamlRedirectSigner.cs
+++ b/SSO-Auth/Api/SamlRedirectSigner.cs
@@ -11,12 +11,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// an enveloped XML <c>ds:Signature</c> (identity providers ignore one on a redirect-binding message) but a
 /// detached signature over the URL-encoded query string, computed in the mandated parameter order
 /// (SAMLRequest, then RelayState when present, then SigAlg) and appended as the Signature parameter. The
-/// algorithm is RSA-SHA256, verified against the shared allowlist so this path can never sign with a weaker
-/// algorithm than the inbound path demands (no SHA-1).
+/// SigAlg is chosen from the service-provider key's own type — an RSA key signs rsa-sha256, an ECDSA key
+/// signs ecdsa-sha256 (#493) — and every choice is verified against the shared allowlist so this path can
+/// never sign with a weaker algorithm than the inbound path demands (no SHA-1). A key that is neither RSA
+/// nor ECDSA is rejected, never silently left unsigned.
 /// </summary>
 internal static class SamlRedirectSigner
 {
     private const string RsaSha256SignatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    private const string EcdsaSha256SignatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
 
     /// <summary>
     /// Builds the signed redirect URL for a DEFLATE/Base64-encoded SAML message.
@@ -25,10 +28,11 @@ internal static class SamlRedirectSigner
     /// <param name="parameterName">"SAMLRequest" or "SAMLResponse".</param>
     /// <param name="encodedMessage">The DEFLATE-compressed, Base64-encoded message.</param>
     /// <param name="relayState">The relay state, omitted when null or empty.</param>
-    /// <param name="signingKey">The service-provider RSA private key.</param>
+    /// <param name="signingKey">The service-provider private key — RSA or ECDSA.</param>
     /// <returns>The full redirect URL including SigAlg and Signature.</returns>
     /// <exception cref="ArgumentException">Thrown when the endpoint or message is null or empty.</exception>
-    internal static string BuildSignedRedirectUrl(string endpoint, string parameterName, string encodedMessage, string? relayState, RSA signingKey)
+    /// <exception cref="InvalidOperationException">Thrown when the key is neither RSA nor ECDSA, or its algorithm is not on the allowlist.</exception>
+    internal static string BuildSignedRedirectUrl(string endpoint, string parameterName, string encodedMessage, string? relayState, AsymmetricAlgorithm signingKey)
     {
         if (string.IsNullOrWhiteSpace(endpoint))
         {
@@ -42,9 +46,13 @@ internal static class SamlRedirectSigner
 
         ArgumentNullException.ThrowIfNull(signingKey);
 
+        // The SigAlg is derived from the key's own type: an RSA key can only sign rsa-sha256, an ECDSA key
+        // only ecdsa-sha256. Any other key type is rejected here rather than silently left unsigned.
+        var signatureAlgorithm = ResolveSignatureAlgorithm(signingKey);
+
         // Defense in depth: the algorithm this signer emits must be one the inbound path would also accept,
         // so a future edit cannot quietly introduce SHA-1 here while the response validator still rejects it.
-        if (!SamlSignatureAlgorithms.IsSignatureMethodAllowed(RsaSha256SignatureAlgorithm))
+        if (!SamlSignatureAlgorithms.IsSignatureMethodAllowed(signatureAlgorithm))
         {
             throw new InvalidOperationException("The outgoing SAML signing algorithm is not on the signature allowlist.");
         }
@@ -58,12 +66,32 @@ internal static class SamlRedirectSigner
             signedQuery += "&RelayState=" + Uri.EscapeDataString(relayState);
         }
 
-        signedQuery += "&SigAlg=" + Uri.EscapeDataString(RsaSha256SignatureAlgorithm);
+        signedQuery += "&SigAlg=" + Uri.EscapeDataString(signatureAlgorithm);
 
-        var signature = signingKey.SignData(Encoding.UTF8.GetBytes(signedQuery), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var signature = Sign(signingKey, Encoding.UTF8.GetBytes(signedQuery));
         var query = signedQuery + "&Signature=" + Uri.EscapeDataString(Convert.ToBase64String(signature));
 
         var separator = endpoint.Contains('?', StringComparison.Ordinal) ? "&" : "?";
         return endpoint + separator + query;
     }
+
+    private static string ResolveSignatureAlgorithm(AsymmetricAlgorithm signingKey) => signingKey switch
+    {
+        RSA => RsaSha256SignatureAlgorithm,
+        ECDsa => EcdsaSha256SignatureAlgorithm,
+        _ => throw Unsupported(signingKey),
+    };
+
+    private static byte[] Sign(AsymmetricAlgorithm signingKey, byte[] data) => signingKey switch
+    {
+        RSA rsa => rsa.SignData(data, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+
+        // XML-DSig ecdsa-sha256 signature values are the raw IEEE P1363 r||s concatenation, not the ASN.1/DER
+        // sequence .NET emits by default, so the identity provider verifies the exact fixed-size octets.
+        ECDsa ecdsa => ecdsa.SignData(data, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation),
+        _ => throw Unsupported(signingKey),
+    };
+
+    private static InvalidOperationException Unsupported(AsymmetricAlgorithm signingKey)
+        => new InvalidOperationException($"Unsupported SAML signing key type '{signingKey.GetType().Name}'; only RSA and ECDSA are supported.");
 }

--- a/SSO-Auth/Api/SamlSigningKey.cs
+++ b/SSO-Auth/Api/SamlSigningKey.cs
@@ -6,11 +6,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
 /// Loads this service provider's SAML signing key (#167). The key is supplied by the operator as a
-/// Base64-encoded, unencrypted PKCS#12 (PFX) blob carrying the certificate and its RSA private key — the
-/// same keypair whose public certificate the identity provider is configured to trust for "signed
-/// AuthnRequest" setups. Loading is fail-closed: a blank value is "no signing key configured" (valid,
-/// signing simply stays off), and a set-but-unloadable value is rejected rather than silently ignored, so
-/// an operator who turned signing on can never get a silent unsigned downgrade.
+/// Base64-encoded, unencrypted PKCS#12 (PFX) blob carrying the certificate and its private key — an RSA or
+/// ECDSA key (#493) — the same keypair whose public certificate the identity provider is configured to
+/// trust for "signed AuthnRequest" setups. Loading is fail-closed: a blank value is "no signing key
+/// configured" (valid, signing simply stays off), and a set-but-unloadable value is rejected rather than
+/// silently ignored, so an operator who turned signing on can never get a silent unsigned downgrade.
 /// </summary>
 internal static class SamlSigningKey
 {
@@ -68,10 +68,26 @@ internal static class SamlSigningKey
 
         using (certificate)
         {
-            // A PKCS#12 with no private key cannot sign, so it is as unusable as a garbage blob: reject it
-            // here rather than let it pass validation and then fail closed at every challenge.
-            using var privateKey = certificate.GetRSAPrivateKey();
+            // A PKCS#12 with no usable private key cannot sign, so it is as unusable as a garbage blob:
+            // reject it here rather than let it pass validation and then fail closed at every challenge.
+            using var privateKey = GetSigningKey(certificate);
             return privateKey is null;
         }
+    }
+
+    /// <summary>
+    /// Returns the service-provider signing key from the certificate — its RSA or ECDSA private key,
+    /// whichever it carries (#493) — or null when it has neither and so cannot sign. The caller owns the
+    /// returned key and must dispose it.
+    /// </summary>
+    /// <param name="certificate">The loaded signing certificate.</param>
+    /// <returns>The RSA or ECDSA private key, or null when the certificate cannot sign.</returns>
+    internal static AsymmetricAlgorithm GetSigningKey(X509Certificate2 certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        // Prefer RSA (the common case and the byte-identical existing path); fall back to ECDSA. Any other
+        // key type returns null, which the callers treat as "unusable" and fail closed on.
+        return (AsymmetricAlgorithm)certificate.GetRSAPrivateKey() ?? certificate.GetECDsaPrivateKey();
     }
 }

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -583,9 +583,9 @@ internal sealed class SamlAuthnRequest
     /// </summary>
     /// <param name="samlEndpoint">The SAML endpoint.</param>
     /// <param name="relayState">The relay state, omitted when null or empty.</param>
-    /// <param name="signingKey">The service-provider RSA private key.</param>
+    /// <param name="signingKey">The service-provider private key — RSA or ECDSA (#493).</param>
     /// <returns>The signed redirect url.</returns>
-    public string GetSignedRedirectUrl(string samlEndpoint, string relayState, RSA signingKey)
+    public string GetSignedRedirectUrl(string samlEndpoint, string relayState, AsymmetricAlgorithm signingKey)
     {
         ArgumentNullException.ThrowIfNull(samlEndpoint);
 


### PR DESCRIPTION
# What & why

The outgoing SAML AuthnRequest redirect-binding signer (#167) was RSA-only: an
operator who supplied an ECDSA PKCS#12 as the service-provider signing key had
it rejected as invalid at the admin write path rather than used to sign. This
extends the signer to detect the SP key type and sign with the matching,
already-allowlisted algorithm, an additive change that leaves the RSA path
byte-identical.

- `SamlRedirectSigner.BuildSignedRedirectUrl` now takes the SP private key as
  `AsymmetricAlgorithm` and derives the `SigAlg` from the key's own runtime
  type: RSA → `rsa-sha256` (the exact prior call, byte-identical), ECDSA →
  `ecdsa-sha256`. A key that is neither is rejected with an
  `InvalidOperationException`, never silently left unsigned or signed weakly.
- The emitted `SigAlg` is still re-checked against the shared inbound/outbound
  allowlist (`SamlSignatureAlgorithms.IsSignatureMethodAllowed`) before signing,
  so no SHA-1 can slip in, the check now validates the *actual* emitted value.
- ECDSA signs with the IEEE P1363 (r‖s) signature format XML-DSig mandates for
  the redirect binding, not .NET's default DER sequence, so the identity
  provider verifies over the exact octets transmitted.
- `SamlSigningKey.GetSigningKey` surfaces the RSA-or-ECDSA private key from the
  certificate (RSA-preferred, ECDSA fallback, null otherwise); `IsInvalid` now
  accepts an ECDSA key so an operator can save one.
- `ecdsa-sha256` was already on the `SamlSignatureAlgorithms` allowlist (added
  with the inbound hardening), so no allowlist source change was needed.

Closes #493

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Signing-on with an unusable or
      unsupported key still throws; the only unsigned path is the unchanged
      opt-out `SignAuthnRequests = false`.)
- [x] No secrets logged; secrets are redacted on config export. (The signer has
      no logging; the sole diagnostic string emits a key *type* name, never key
      material.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review
      below — all PASS.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      logging added.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Key-type → SigAlg and key-type → signing are two small
      switch expressions sharing one `Unsupported` factory.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property; existing rules pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings.)
- [x] `dotnet test` is green. (1050/1050 passing, including a full ECDSA
      PKCS#12 load → key-detect → IEEE-P1363 sign → verify round-trip.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A - 
      only `.cs` files changed.)

## Notes

**Scope.** The core change is in `SamlRedirectSigner.cs` and `SamlSigningKey.cs`.
Two thin plumbing edits were unavoidable for the feature to reach production
rather than be dead code: the outbound wrapper `SamlAuthnRequest.GetSignedRedirectUrl`
(`Saml.cs`) and the challenge builder `SamlLoginService.BuildChallengeRedirectUrl`
widen the key parameter from `RSA` to `AsymmetricAlgorithm` and select the key
via `GetSigningKey`. Neither is the inbound SAML validator; both are outbound-only
signing code. `SamlSignatureAlgorithms.cs` needed no change (the ECDSA entries
already exist).

**RSA byte-identical.** For an RSA key the resolved `SigAlg` is the same constant,
the signed octets are the same, and the signing call is `rsa.SignData(data,
SHA256, Pkcs1)` as before. The existing #167 RSA tests are untouched and pass.

**Adversarial review, four refute-by-default lenses, all PASS:**

- **Availability / mass-lockout, PASS.** Purely additive, monotonic widening.
  RSA path byte-identical; signing stays strictly opt-in; the only behavior
  change is *accepting* ECDSA keys that were previously unpersistable, so no
  existing RSA deployment can regress or be locked out.
- **Security-bypass / fail-open, PASS.** `SigAlg` is derived from the key type
  (two hard-coded constants), re-checked against the allowlist; no code path
  yields a `*-sha1` URI; unsupported/keyless input throws (never silent
  degrade); signed octets equal transmitted bytes; ECDSA uses IEEE P1363; no key
  material leaked.
- **Correctness, PASS.** ECDSA format is IEEE P1363 (empirically pinned, the
  verifier uses the same format, so a DER signer would fail the positive
  assert); RSA branch statement-for-statement identical; `GetSigningKey`
  null-safe RSA-then-ECDSA fallback with correct caller-owned disposal
  (key-before-cert); exhaustive fail-closed switches; tests are non-vacuous.
- **Integration, PASS.** `ECDsa.SignData(…, DSASignatureFormat)` and
  `IeeeP1363FixedFieldConcatenation` are BCL APIs present on net9.0 (TFM-bound,
  unrelated to the 10.11 ABI floor); the widened `AsymmetricAlgorithm` signature
  is source-compatible for all existing RSA callers; the admin-write path
  accepts ECDSA with no change to the forbidden `SSOController`; build + full
  suite pass empirically on Windows.

**Out-of-scope follow-up.** The operator-facing validation error strings in
`ProviderConfigValidator.cs` and `SSOController.cs` still say "RSA private key"
though an ECDSA key is now accepted. Cosmetic; one lives in `SSOController` (owned
by a parallel PR), so both are left for a small follow-up rather than partially
fixed here.
