### PR TITLE
Name ECDSA in the two SP signing-key rejection messages

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -190,7 +190,7 @@ public class SSOController : ControllerBase
     {
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
-            throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA private key, or left blank.");
+            throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key, or left blank.");
         }
     }
 

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -102,7 +102,7 @@ internal static class ProviderConfigValidator
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA private key.");
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.");
         }
     }
 }


### PR DESCRIPTION
# What & why

Since #493 (shipped in #515) the outgoing SAML service-provider signing key accepts an ECDSA key as well as an RSA one, `SamlSigningKey.GetSigningKey` surfaces either private key and `SamlSigningKey.IsInvalid` admits both at the admin write path. Two operator-facing rejection messages still told the operator the PKCS#12 (PFX) blob must contain "an RSA private key", which now misleads anyone who supplies a valid ECDSA key.

This widens both strings to "an RSA or ECDSA private key", matching the wording the signer itself already uses (`SamlLoginService`: "has no RSA or ECDSA private key"):

- `SSO-Auth/Config/ProviderConfigValidator.cs`, `ValidateSamlSigningKey`
- `SSO-Auth/Api/SSOController.cs`, `RejectInvalidSamlSigningKey`

Message text only; no validation or control-flow change.

Closes #518

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted. (Unchanged, no validation logic touched; `SamlSigningKey.IsInvalid` still gates the write path.)
- [x] No secrets logged; secrets are redacted on config export. (Unchanged.)
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. (Reviewed: the diff is two string literals in already-existing rejection messages; no control flow, no validation predicate, and no persisted value changes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Unchanged, the provider echo in `ValidateSamlSigningKey` keeps its existing `ReplaceLineEndings` strip.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new structural property.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green. (1056 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (No such files touched.)

## Notes

The wording now matches what the accept path already allows (RSA or ECDSA). No behavioural change: a key that was accepted or rejected before is accepted or rejected identically; only the rejection text differs.