### PR TITLE
Rate-limit the Unregister admin endpoint

### DIFF
--- a/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Net;
+using System.Reflection;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
@@ -111,6 +116,76 @@ public class SSOControllerUnregisterTests
         Assert.False(links.ContainsKey("sub-alice"));
         Assert.Equal("Jellyfin", user.AuthenticationProviderId);
         await harness.UserManager.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task Unregister_AuthorizedOverRateLimit_Returns429()
+    {
+        // #516: the admin SSO-revoke is throttled by the shared gate under its own "unregister" class. A burst
+        // past the configured budget is refused with the same 429 the login path renders, before any work runs.
+        var harness = new SsoControllerHarness(
+            c =>
+            {
+                c.EnableRateLimit = true;
+                c.RateLimitMaxAttempts = 1;
+                c.RateLimitWindowSeconds = 60;
+            },
+            // A dedicated public address so the process-static limiter counter is this test's alone.
+            clientIp: IPAddress.Parse("8.8.4.20"));
+        var user = SeedUser(harness);
+
+        // The first call passes the limiter, spends the single-attempt budget, and completes the revoke (Ok).
+        Assert.IsType<OkResult>(await harness.Controller.Unregister("alice", "Jellyfin"));
+
+        // The second is over budget and throttled before any work: a 429 from LoginOutcome.Throttled via the
+        // single mapper (#474), carrying the machine-readable Retry-After.
+        var throttled = Assert.IsType<ContentResult>(await harness.Controller.Unregister("alice", "Jellyfin"));
+        Assert.Equal(429, throttled.StatusCode);
+        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+
+        var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
+        Assert.True(
+            int.TryParse(retryAfter, out var seconds) && seconds >= 1 && seconds <= 60,
+            $"Retry-After must be whole seconds within the 60s window; was '{retryAfter}'.");
+
+        // The throttled call did no work: only the first revoke touched the session manager (#440 untouched by the 429).
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserId, null);
+    }
+
+    [Fact]
+    public async Task Unregister_AuthorizedUnderRateLimit_NotThrottled()
+    {
+        // With rate limiting enabled but the budget generous (the default 30/60s), a normal admin unregister is
+        // unaffected: it revokes SSO and returns Ok, never a 429, and the #440 session revocation still fires.
+        var harness = new SsoControllerHarness(
+            c =>
+            {
+                c.EnableRateLimit = true;
+                c.RateLimitMaxAttempts = 30;
+                c.RateLimitWindowSeconds = 60;
+            },
+            clientIp: IPAddress.Parse("8.8.4.21"));
+        SeedUser(harness);
+
+        var result = await harness.Controller.Unregister("alice", "Jellyfin");
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserId, null);
+    }
+
+    [Fact]
+    public void Unregister_IsGuardedByTheElevationPolicy_SoUnauthorizedNeverReachesTheLimiter()
+    {
+        // The in-process harness calls the action directly, bypassing MVC's authorization filters, so the
+        // "unauthorized never 429" property is pinned structurally instead: the [Authorize(RequiresElevation)]
+        // filter rejects a non-elevated caller (401/403) BEFORE the action body — and thus before the
+        // RateLimitCheck the body fronts itself with — runs. So no 429 can ever precede the auth rejection: a
+        // hammering unauthorized caller is refused, never throttled, and never consumes the "unregister" budget.
+        var authorize = typeof(SSOController).GetMethod(nameof(SSOController.Unregister))!
+            .GetCustomAttribute<AuthorizeAttribute>();
+
+        Assert.NotNull(authorize);
+        Assert.Equal(Policies.RequiresElevation, authorize!.Policy);
     }
 
     // Registers a user with the harness's mocked IUserManager so GetUserByName resolves it.

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -502,6 +502,18 @@ public class SSOController : ControllerBase
     [HttpPost("Unregister/{username}")]
     public async Task<ActionResult> Unregister(string username, [FromBody] string provider)
     {
+        // Throttle after the elevation guard, before any work (#516): the [Authorize] filter rejects a
+        // non-elevated caller before the body runs, so an unauthorized request is refused (401/403) and never
+        // reaches — or is judged by — the limiter (no rate-limit oracle). Once past it, the shared gate caps
+        // how fast an authorized admin can drive this heavy revoke, which removes the user's canonical links
+        // everywhere, persists a provider switch, and revokes the user's active sessions (#440). Its own
+        // "unregister" class carries an independent budget, so it neither starves nor is starved by the
+        // link/unlink write surface's "link" bucket (#382) or the anonymous login flows.
+        if (RateLimitCheck("unregister") is { } throttled)
+        {
+            return throttled;
+        }
+
         var user = _userManager.GetUserByName(username);
         if (user is null)
         {
@@ -706,10 +718,11 @@ public class SSOController : ControllerBase
             ? parsed
             : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
 
-    // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382): null when the request
-    // may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login endpoints
-    // pass their class (challenge/callback/auth); the authenticated link/unlink write surface passes "link"
-    // after its own authz guard. The gate owns the one process-wide limiter and the whole check (config read,
+    // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382, #516): null when the
+    // request may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login
+    // endpoints pass their class (challenge/callback/auth); the authenticated link/unlink write surface passes
+    // "link" after its own authz guard, and the admin SSO-revoke passes "unregister" after its elevation
+    // guard. The gate owns the one process-wide limiter and the whole check (config read,
     // IP classifier, endpoint-class keying, the #195 observability signal); this wrapper only supplies the
     // three request-scoped inputs it needs — the endpoint class, the connection's remote address, and the
     // response the retry-delay header is set on — so the controller keeps no rate-limit state of its own.

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>
 /// The shared per-client rate-limit gate over the SSO flow endpoints (#128, #160): the anonymous login
-/// endpoints and, since #382, the authenticated link/unlink admin write surface. It owns the ONE
+/// endpoints, the authenticated link/unlink admin write surface (#382) and the admin SSO-revoke (#516). It owns the ONE
 /// process-wide <see cref="SsoRateLimiter"/> instance and the opt-in check every rate-limited endpoint
 /// fronts itself with — the last mutable process-wide static that lived on <see cref="SSOController"/> (#318).
 /// Relocating it into the shared tier leaves the controller a stateless request dispatcher (every store,
@@ -24,7 +24,8 @@ internal static class SsoRateLimitGate
     // The opt-in per-client rate limiter over the SSO flow endpoints (#128). One process-wide instance
     // (static readonly), exactly as it was on the controller: every rate-limited endpoint reaches it through
     // this gate, so a single shared window per client is preserved across the OpenID and SAML login endpoints
-    // (and now the link/unlink admin surface, #382, under its own class) rather than split into separate limiters.
+    // (and now the link/unlink admin surface, #382, and the admin SSO-revoke, #516, each under its own class)
+    // rather than split into separate limiters.
     private static readonly SsoRateLimiter RateLimiter = new SsoRateLimiter();
 
     /// <summary>
@@ -34,12 +35,12 @@ internal static class SsoRateLimitGate
     /// availability over throttling). Keys on the connection's remote address only — proxy attribution is the
     /// host's job (Jellyfin's "Known proxies" setting resolves the real client into it); see
     /// <see cref="SsoRateLimiter.NormalizeClientKey"/>. The endpoint class (challenge/callback/auth for the
-    /// anonymous login flows, "link" for the authenticated link/unlink write surface, #382) is part of the
-    /// key, so each class carries an independent budget: one login — which hits all three login classes — gets
-    /// the full budget at each stage rather than a third of it, keeping the default generous for shared egress
-    /// addresses (NAT/CGNAT).
+    /// anonymous login flows, "link" for the authenticated link/unlink write surface, #382, and "unregister"
+    /// for the admin SSO-revoke write, #516) is part of the key, so each class carries an independent budget:
+    /// one login — which hits all three login classes — gets the full budget at each stage rather than a third
+    /// of it, keeping the default generous for shared egress addresses (NAT/CGNAT).
     /// </summary>
-    /// <param name="endpointClass">The endpoint class folded into the rate-limit key (e.g. challenge/callback/auth/link).</param>
+    /// <param name="endpointClass">The endpoint class folded into the rate-limit key (e.g. challenge/callback/auth/link/unregister).</param>
     /// <param name="remoteIp">The connection's remote address, the sole attribution input (proxy resolution is the host's job).</param>
     /// <param name="logger">The caller's logger, for the bounded throttle-engaged observability signal (#195).</param>
     /// <param name="response">The response whose Retry-After header a throttled outcome sets (#474).</param>


### PR DESCRIPTION
# What & why

Follow-up to #382, which rate-limited the admin link/unlink write surface. The
admin `Unregister` endpoint was the last heavy admin write left un-throttled: it
removes a user's canonical links from every provider, persists a provider
switch, and revokes the user's active sessions (#440). An authorized-but-hostile
or scripted admin could drive it in a tight loop, so we front it with the shared
`SsoRateLimitGate` under a new `"unregister"` endpoint class, mirroring #382.

- The `RateLimitCheck("unregister")` call is the first statement in the method
  body, after the `[Authorize(Policy = RequiresElevation)]` filter (which runs
  before the body). A non-elevated caller is rejected 401/403 before the limiter
  is ever consulted, so there is no rate-limit-versus-auth enumeration oracle and
  no 429 can precede the auth rejection. Placing it before the user lookup also
  means a throttled request does no work at all.
- Bucket choice: a NEW `"unregister"` class rather than reusing `"link"`.
  Justification: unregister is a distinct, heavier operation (it also revokes
  sessions, #440), so its own class carries an independent per-client budget, it
  neither starves nor is starved by the `"link"` write surface (#382) or the
  anonymous login classes. No gate code changed (the class key is a free string);
  only its doc comments were extended to name the new class.
- Over-limit renders the same `LoginOutcome.Throttled` 429 + `Retry-After`
  through the single mapper (#474); the gate still fails open for unattributable
  or non-public clients.

Rate limiting stays off by default; when enabled the default 30/60s budget leaves
normal admin use unaffected. The #440 session revocation and the link/unlink and
login rate-limit classes are byte-for-byte unchanged.

Closes #516

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (N/A to this diff; the throttle is
      additive and the auth guard fires first.)
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review,
      all PASS — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new log
      call takes IdP input.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the shared gate; no new limiter or state.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property; the existing `RateLimiting_FlowsThroughLoginOutcome`
      and `Controller_HoldsNoMutableStaticState` rules already cover the new call
      site and stay green.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (1059 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None in this diff.)

## Notes

**Design.** Bucket choice justified above (new `"unregister"` class for an
independent budget on a heavier operation). Auth-before-throttle is structural:
the `[Authorize]` MVC filter runs before the action body, and the throttle is the
first body statement, so an unauthorized caller never reaches the limiter. The
over-limit response is the shared 429 + `Retry-After` from `LoginStatusMapper`
(#474). Tests cover over-limit burst → 429 (with the throttled call doing no
work), a normal admin unregister under a generous budget → Ok with the #440
revoke still firing, and a reflection pin that the elevation policy guards the
endpoint (the only honest in-process proxy for "unauthorized never 429", since
the harness bypasses MVC filters).

**Adversarial four-lens review, all PASS:**

- **Availability (mass-lockout):** PASS. Off by default; the independent
  `"unregister"` bucket cannot cross-starve login/link budgets; the gate fails
  open for LAN/private/unattributable admins; the default 30/60s budget leaves
  real admin use unaffected. No lockout path.
- **Security-bypass:** PASS. The declarative `[Authorize(RequiresElevation)]`
  filter provably precedes the in-body throttle, no unauthorized-throttle or
  enumeration oracle; the throttle precedes the user lookup so there is no
  user-existence leak; the class key is disjoint from the other classes.
- **Correctness:** PASS. `maxAttempts=1` first-Ok / second-429 verified; the
  shared-mapper 429 body and `Retry-After` bound checked against
  `LoginStatusMapper`; the `AuthorizeAttribute.Policy` reflection pin is correct;
  the work-skipping throttle path (session revoke not called on the 429) is sound
  with proper test isolation (dedicated public client IPs).
- **Integration:** PASS. The shared gate is reused (no second limiter, no new
  state); the other rate-limit classes and the #440 revoke are byte-identical;
  both conformance rules (`RateLimiting_FlowsThroughLoginOutcome`,
  `Controller_HoldsNoMutableStaticState`) stay green.

**Out of scope:** none noted during this delivery.
