### PR TITLE
Extract a dedicated SAML assertion-validator type

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -279,9 +279,9 @@ public class ArchitectureConformanceTests
         // Sentinel + call-site pins. The factory NAMES are the contract; require both to exist (a rename
         // must consciously update this rule), then confine each factory's invocation to the file(s) that own
         // its protocol's validation. AuthorizeSession is where the OpenID identity is built (from the
-        // role-gate result); the SAML factory is invoked from the SAML flow service's session-minting leg
-        // (SamlLoginService), where it moved with the SAML flow extraction (#160, #318 step 13) — off the
-        // controller, as the earlier comment anticipated.
+        // role-gate result); the SAML factory is invoked from the dedicated SamlAssertionValidator, the
+        // single home the SAML inbound validation moved into (#496) — downstream of every gate, so the
+        // "constructed only after complete validation" invariant is local to the validator.
         const string oidcFactory = "FromOidcRedemption";
         const string samlFactory = "FromValidatedSaml";
         var factoryMethods = typeof(VerifiedIdentity)
@@ -294,9 +294,9 @@ public class ArchitectureConformanceTests
             $"VerifiedIdentity must expose the two named validation factories ({oidcFactory}, {samlFactory}); one was renamed, so update this rule and the source-scan allow-list with it (#473).");
 
         var oidcHome = SourceFilesDeclaring(new[] { typeof(AuthorizeSession) });
-        var samlHome = SourceFilesDeclaring(new[] { typeof(SamlLoginService) });
+        var samlHome = SourceFilesDeclaring(new[] { typeof(SamlAssertionValidator) });
         AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + oidcFactory + "(", oidcHome, "the OpenID redeem path (AuthorizeSession.Ready)");
-        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + samlFactory + "(", samlHome, "the SAML session-minting leg (SamlLoginService)");
+        AssertFactoryInvocationsConfinedTo("VerifiedIdentity." + samlFactory + "(", samlHome, "the SAML assertion validator (SamlAssertionValidator)");
     }
 
     // Fails if the given factory-invocation token appears in any SSO-Auth source file outside the allowed
@@ -562,16 +562,19 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             controllerHits.Count == 0,
-            "A controller must not hold the SAML replay/request caches or drive the SAML challenge/validation protocol; the SAML flow lives in SamlLoginService (#160). Found: " + string.Join(" | ", controllerHits));
+            "A controller must not hold the SAML replay/request caches or drive the SAML challenge/validation protocol; the SAML flow lives in SamlLoginService and SamlAssertionValidator (#160, #496). Found: " + string.Join(" | ", controllerHits));
 
-        // Liveness against a vacuous pass: the SAML flow must actually live in SamlLoginService — a move,
-        // not a silent removal — so the flow service's own source must contain every moved token.
+        // Liveness against a vacuous pass: the SAML flow must actually live in the SAML flow tier — a move,
+        // not a silent removal — so its own source must contain every moved token. The tier is now two types:
+        // SamlLoginService owns the challenge/callback orchestration and the outstanding-request cache
+        // (SamlRequestCache, SamlAuthnRequest), and the dedicated SamlAssertionValidator owns the inbound
+        // validation and the replay cache (SamlReplayCache, ValidateSaml) it moved into (#496) — so scan both.
         var samlSource = string.Join(
             "\n",
-            SourceFilesDeclaring(new[] { typeof(SamlLoginService) }).Select(File.ReadAllText));
+            SourceFilesDeclaring(new[] { typeof(SamlLoginService), typeof(SamlAssertionValidator) }).Select(File.ReadAllText));
         Assert.True(
             markers.All(m => samlSource.Contains(m, StringComparison.Ordinal)),
-            "SamlLoginService must own the SAML challenge/callback/authenticate/link flow and its replay/request caches; otherwise the controller scan passes vacuously (#160).");
+            "The SAML flow tier (SamlLoginService + SamlAssertionValidator) must own the SAML challenge/callback/authenticate/link flow, its replay/request caches, and the inbound validation; otherwise the controller scan passes vacuously (#160, #496).");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/ValidateSamlTests.cs
@@ -1,13 +1,12 @@
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
-using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for the SAML flow service's ValidateSaml helper: how the expected audience is derived
+/// Tests for the SAML assertion validator's ValidateSaml helper: how the expected audience is derived
 /// (SamlAudience, falling back to SamlClientId, both trimmed) and the DoNotValidateAudience opt-out.
 /// </summary>
 public class ValidateSamlTests
@@ -25,15 +24,15 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor("whatever");
         var config = new SamlConfig { DoNotValidateAudience = true, SamlClientId = "unrelated" };
-        Assert.True(SamlLoginService.ValidateSaml(response, config));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, config));
     }
 
     [Fact]
     public void SamlClientId_UsedAsAudienceWhenNoSamlAudience()
     {
         var response = SignedResponseFor(Audience);
-        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = Audience }));
-        Assert.False(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = "https://other" }));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, new SamlConfig { SamlClientId = Audience }));
+        Assert.False(SamlAssertionValidator.ValidateSaml(response, new SamlConfig { SamlClientId = "https://other" }));
     }
 
     [Fact]
@@ -41,7 +40,7 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor(Audience);
         var config = new SamlConfig { SamlAudience = Audience, SamlClientId = "https://other" };
-        Assert.True(SamlLoginService.ValidateSaml(response, config));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, config));
     }
 
     [Fact]
@@ -49,21 +48,21 @@ public class ValidateSamlTests
     {
         var response = SignedResponseFor(Audience);
         var config = new SamlConfig { SamlAudience = "", SamlClientId = Audience };
-        Assert.True(SamlLoginService.ValidateSaml(response, config));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, config));
     }
 
     [Fact]
     public void ExpectedAudienceIsTrimmed()
     {
         var response = SignedResponseFor(Audience);
-        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlClientId = "  " + Audience + "  " }));
-        Assert.True(SamlLoginService.ValidateSaml(response, new SamlConfig { SamlAudience = " " + Audience + " ", SamlClientId = "x" }));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, new SamlConfig { SamlClientId = "  " + Audience + "  " }));
+        Assert.True(SamlAssertionValidator.ValidateSaml(response, new SamlConfig { SamlAudience = " " + Audience + " ", SamlClientId = "x" }));
     }
 
     [Fact]
     public void NoExpectedAudienceConfigured_FailsClosed()
     {
         var response = SignedResponseFor(Audience);
-        Assert.False(SamlLoginService.ValidateSaml(response, new SamlConfig()));
+        Assert.False(SamlAssertionValidator.ValidateSaml(response, new SamlConfig()));
     }
 }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -23,13 +23,14 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// than inline on the controller.
 /// </summary>
 /// <remarks>
-/// The two SAML-specific process-wide caches live here as <c>static readonly</c> fields, one instance for the
-/// whole process exactly as they were on the controller (a fresh per-request controller reconstructs the
-/// service, so an instance field would lose the in-flight state between the challenge and its callback):
-/// <list type="bullet">
-/// <item>the one-time-use replay cache of consumed assertion IDs (<see cref="SamlReplayCache"/>), and</item>
-/// <item>the outstanding-AuthnRequest cache for InResponseTo correlation and the browser binding (<see cref="SamlRequestCache"/>, #156/#415).</item>
-/// </list>
+/// The outstanding-AuthnRequest cache for InResponseTo correlation and the browser binding
+/// (<see cref="SamlRequestCache"/>, #156/#415) lives here as a <c>static readonly</c> field, one instance for
+/// the whole process exactly as it was on the controller (a fresh per-request controller reconstructs the
+/// service, so an instance field would lose the in-flight state between the challenge and its callback). The
+/// inbound-assertion validation — signature/time/audience/recipient, the one-time replay cache, and the sole
+/// SAML <see cref="VerifiedIdentity"/> construction — moved into the dedicated
+/// <see cref="SamlAssertionValidator"/> (#496); this service keeps the InResponseTo correlation because that
+/// is request-issued session-fixation correlation, not assertion validation.
 /// The shared per-client rate limiter is deliberately NOT here — it also fronts the OpenID flow, so it lives
 /// in the shared <see cref="SsoRateLimitGate"/> (Api/Shared) that the controller's endpoints front this
 /// service with, rather than as a per-flow static (#160). The methods take the
@@ -40,15 +41,6 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// </remarks>
 internal sealed class SamlLoginService
 {
-    // The SAML attribute name the whole RBAC design hinges on (the role allow-list check and the derived
-    // authorize-state privileges both read it). One definition site so every read agrees on the exact
-    // attribute the identity provider must send (#370).
-    private const string RoleAttributeName = "Role";
-
-    // One-time-use tracking for consumed SAML assertion IDs (replay protection). One process-wide instance,
-    // like the outstanding-request cache below and the OpenID caches the sibling flow service keeps.
-    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
-
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156) and the
     // browser binding (#415). One process-wide instance.
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
@@ -67,6 +59,12 @@ internal sealed class SamlLoginService
     // manual-link redeem; the controller keeps the caller-authz guard and the one-time-use consume around it.
     private readonly CanonicalLinkService _canonicalLinks;
 
+    // The dedicated inbound-assertion validator (#496): parse + signature/time/audience/recipient/algorithm
+    // validation, the one-time replay consume, the non-empty-NameID guard, and the sole SAML
+    // FromValidatedSaml construction site. Constructed per request with this service, but it owns the
+    // process-wide replay cache as a static, so replay state survives the two-step post-then-authenticate legs.
+    private readonly SamlAssertionValidator _validator;
+
     private readonly ILogger _logger;
 
     internal SamlLoginService(
@@ -77,6 +75,7 @@ internal sealed class SamlLoginService
         _loginCompletion = loginCompletion ?? throw new ArgumentNullException(nameof(loginCompletion));
         _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _validator = new SamlAssertionValidator(logger);
     }
 
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
@@ -126,21 +125,22 @@ internal sealed class SamlLoginService
         // content-type binds null (the form value provider is skipped, so Request.Form is never
         // touched and cannot throw the InvalidOperationException that escaped as a 500, #206), and a
         // null body is rejected the same way as any other malformed response — a clean 400.
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, formSamlResponse, out var samlResponse)
-            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        var requestBase = GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride);
+        if (!_validator.TryValidate(config, provider, requestBase, formSamlResponse, out var samlResponse))
         {
-            // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryLoad and
-            // is rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
+            // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) or a failed
+            // signature/time/audience/recipient check is rejected the same way — a clean 4xx, never an
+            // unhandled 500 (#199).
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        if (SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes(RoleAttributeName), config.Roles))
+        if (SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
         {
             return FlowResponses.AuthPage(response, nonce =>
                 WebResponse.Generator(
                     data: Convert.ToBase64String(Encoding.UTF8.GetBytes(samlResponse.Xml)),
                     provider: provider,
-                    baseUrl: GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride),
+                    baseUrl: requestBase,
                     mode: "SAML",
                     nonce: nonce,
                     isLinking: isLinking));
@@ -149,7 +149,7 @@ internal sealed class SamlLoginService
         _logger.LogWarning(
             "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
             samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-            samlResponse.GetCustomAttributes(RoleAttributeName).Select(r => r?.ReplaceLineEndings(string.Empty)),
+            SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
             config.Roles);
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
     }
@@ -277,8 +277,8 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
-            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        var requestBase = GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride);
+        if (!_validator.TryValidate(config, provider, requestBase, response?.Data, out var samlResponse))
         {
             // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
@@ -323,7 +323,7 @@ internal sealed class SamlLoginService
         // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
         // can POST an assertion straight to this session-minting endpoint and skip the page, so
         // checking it only there would be fail-open.
-        if (!SamlLoginPolicy.IsLoginAllowed(samlResponse.GetCustomAttributes(RoleAttributeName), config.Roles))
+        if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
         {
             _logger.LogWarning(
                 "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
@@ -331,41 +331,20 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 
-        // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
-        // Enforced only here (the session-minting endpoint), not at the SAML/post ACS which merely
-        // renders the intermediate page, so the two-step post-then-auth flow consumes the id once. A
-        // replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
-        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
-        if (!TryConsumeSamlReplay(samlResponse, provider))
+        // Complete the assertion validation in the dedicated validator: the one-time replay consume and the
+        // non-empty-NameID guard, then — and only then — the verified identity through FromValidatedSaml
+        // (#496). A replay fails as an invalid response and a missing NameID as a denial, the same outcomes
+        // this endpoint returned when those checks were inline. From here the SAML and OpenID paths are one:
+        // the verified identity flows into the shared completion tail (SAML keys the link on the NameID and
+        // carries no email_verified claim, so AdoptionGate.None; the resolver's admin-adoption refusal, #218,
+        // still applies).
+        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
         {
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+            return LoginStatusMapper.ToActionResult(rejection);
         }
 
-        // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from
-        // the assertion's roles and the provider configuration. Login validity was already decided
-        // above by SamlLoginPolicy and the username is the assertion's NameID, so neither is derived
-        // here.
-        var derived = SamlAuthorizeStateBuilder.Build(samlResponse.GetCustomAttributes(RoleAttributeName), config);
-
-        // Fail closed (#95): an assertion without a usable NameID carries no identity to log in —
-        // reject it as an invalid login instead of failing downstream on a null canonical name.
-        // Whitespace-only counts as unresolved (Jellyfin's username validation rejects it anyway).
-        var nameId = samlResponse.GetNameID();
-        if (string.IsNullOrWhiteSpace(nameId))
-        {
-            _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
-        }
-
-        // All SAML validation has now passed — signature, time bounds, audience, recipient, InResponseTo
-        // correlation, the login allow-list, replay one-time-use, and the non-empty-NameID guard — so this
-        // is the point at which the response becomes a fully-verified SAML identity (#473). SAML keys the
-        // link directly on the NameID (subject and username are the same value; no migration path needed)
-        // and carries no email_verified claim, so the verified-email gate is not applicable
-        // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
-        // From here the SAML and OpenID paths are one.
         return await _loginCompletion.CompleteAsync(
-            VerifiedIdentity.FromValidatedSaml(provider, nameId, derived),
+            identity,
             response,
             config,
             AdoptionGate.None,
@@ -393,8 +372,8 @@ internal sealed class SamlLoginService
             return new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage);
         }
 
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, response?.Data, out var samlResponse)
-            || !IsSamlResponseValid(request, samlResponse, config, provider))
+        var requestBase = GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride);
+        if (!_validator.TryValidate(config, provider, requestBase, response?.Data, out var samlResponse))
         {
             // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
@@ -405,7 +384,7 @@ internal sealed class SamlLoginService
         // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use
         // control. A replay is a client-caused 400 in the uniform SAML body, never a 500, and no longer
         // discloses the replay cache to the attacker who replayed.
-        if (!TryConsumeSamlReplay(samlResponse, provider))
+        if (!_validator.TryConsumeReplay(samlResponse, provider))
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
@@ -429,8 +408,9 @@ internal sealed class SamlLoginService
     // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
     // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
     // flow — which cannot know which redirect path the identity provider has registered — reuses the last
-    // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
-    // reason this value is remembered across requests.) Mirrors OidcLoginService.ResolveChallengeNewPath —
+    // login's spelling. A linking challenge only reads the stored value. (See SamlAssertionValidator's
+    // ExpectedAcsUrls for the same reason this value is remembered across requests.) Mirrors
+    // OidcLoginService.ResolveChallengeNewPath —
     // the type is known here, so the record is a direct assignment.
     private static bool ResolveChallengeNewPath(SamlConfig config, bool isLinking, HttpRequest request)
     {
@@ -471,84 +451,6 @@ internal sealed class SamlLoginService
 
             return request.GetSignedRedirectUrl(endpoint, relayState, signingKey);
         }
-    }
-
-    // Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use.
-    // Returns false when the assertion was already used (or carries no ID — a missing ID stays empty,
-    // so TryConsume fails closed). The key is scoped by provider so two IdPs emitting the same assertion
-    // ID cannot block each other. Shared by the session mint and the account linking (#219).
-    private static bool TryConsumeSamlReplay(SamlResponse samlResponse, string provider)
-    {
-        var samlNow = DateTime.UtcNow;
-        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
-        var assertionId = samlResponse.GetAssertionId();
-        var replayKey = ProviderScopedKey.For(provider, assertionId);
-        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
-    }
-
-    // Validates the SAML response and, on failure, logs the declared signature algorithm plus the
-    // weak-algorithm remediation hint. This lets an operator tell a rejected SHA-1 signature - the
-    // expected post-upgrade lockout of a legacy IdP - apart from a bad certificate, an expired
-    // assertion, or an audience mismatch, all of which otherwise surface as the same opaque error.
-    private bool IsSamlResponseValid(HttpRequest request, SamlResponse samlResponse, SamlConfig config, string provider)
-    {
-        if (!ValidateSaml(samlResponse, config))
-        {
-            // The algorithm URI is identity-provider-controlled; strip line endings inline at the log
-            // call to prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
-            _logger.LogWarning(
-                "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
-                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
-            return false;
-        }
-
-        // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service
-        // provider's assertion-consumer URL, so an assertion minted for a different endpoint (or a
-        // different SP sharing the identity provider) cannot be presented here.
-        if (config.ValidateRecipient
-            && !SamlRecipientValidator.IsBound(samlResponse.GetRecipient(), samlResponse.GetDestination(), ExpectedAcsUrls(request, config, provider)))
-        {
-            _logger.LogWarning("SAML response rejected: the assertion Recipient or Response Destination does not match this server's assertion-consumer URL.");
-            return false;
-        }
-
-        return true;
-    }
-
-    // The assertion-consumer URLs this service provider advertises for the provider — the same value
-    // Challenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
-    // Destination) must equal one. Both the new ("post") and legacy ("p") path spellings are returned:
-    // config.NewPath is process-wide mutable state a concurrent challenge can flip, and the Recipient
-    // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids
-    // rejecting a valid login on a path-form flip; both are this provider's own ACS URLs.
-    //
-    // The host comes from GetRequestBase. With BaseUrlOverride set (#139) it is the pinned canonical
-    // host, so this binding is exact regardless of the request Host. Without it the host is the request
-    // Host, so the binding is only as strong as host resolution: behind a reverse proxy, configure
-    // Jellyfin's Known/Trusted Proxies (or set BaseUrlOverride) so the Host cannot be spoofed, or an
-    // attacker controlling the Host can make the expected URL match a captured assertion's Recipient
-    // (defense-in-depth, not a hard guarantee).
-    private static string[] ExpectedAcsUrls(HttpRequest request, SamlConfig config, string provider) =>
-        SsoUrlBuilder.SamlExpectedAcsUrls(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), provider);
-
-    // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to
-    // this SP unless explicitly opted out. Expected audience is the configured SamlAudience, falling
-    // back to the SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed
-    // Issuer sent in the AuthnRequest, and an empty SamlAudience falls through to the client id.
-    internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
-    {
-        if (config.DoNotValidateAudience)
-        {
-            return samlResponse.IsValid();
-        }
-
-        var expected = config.SamlAudience?.Trim();
-        if (string.IsNullOrEmpty(expected))
-        {
-            expected = config.SamlClientId?.Trim();
-        }
-
-        return samlResponse.IsValid(expected);
     }
 
     // Thin adapter feeding the live request values into the pure CanonicalBaseUrl.Resolve decision (#242) —

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The single home for inbound SAML assertion validation (#496, #318): parse plus signature, time-bound,
+/// audience, recipient and algorithm-allowlist validation, the one-time replay consume, and the non-empty
+/// NameID guard — the whole <c>IsSamlResponseValid</c>/<c>ValidateSaml</c>/replay path that used to be
+/// spread across <see cref="Flows.SamlLoginService"/>. Consolidating it here makes the "a
+/// <see cref="VerifiedIdentity"/> is produced ONLY after complete validation" invariant local and testable:
+/// the sole SAML call to <see cref="VerifiedIdentity.FromValidatedSaml"/> lives in
+/// <see cref="TryProduceVerifiedIdentity"/>, downstream of every gate here, and is pinned there by
+/// <c>ArchitectureConformanceTests.VerifiedIdentity_IsConstructedOnlyByProtocolValidators</c>.
+/// </summary>
+/// <remarks>
+/// This validator owns the assertion-validation concerns only; the flow service keeps the concerns that are
+/// not assertion validation and must stay where the request context lives:
+/// <list type="bullet">
+/// <item>the login allow-list (<see cref="SamlLoginPolicy"/>), a policy gate enforced at BOTH the
+/// assertion-consumer page and the session-minting endpoint;</item>
+/// <item>the InResponseTo correlation and browser binding (the outstanding-request cache), which is
+/// session-fixation correlation against a request this server issued, not assertion validation.</item>
+/// </list>
+/// The one-time replay cache is a <c>static readonly</c> field so it is process-wide exactly as it was on
+/// the flow service — a fresh per-request flow service (and so a fresh validator) must not lose the consumed
+/// assertion ids between the two-step post-then-authenticate legs.
+/// </remarks>
+internal sealed class SamlAssertionValidator
+{
+    // The SAML attribute name the whole RBAC design hinges on (the role allow-list check and the derived
+    // authorize-state privileges both read it). One definition site, on the type that reads assertions, so
+    // every read agrees on the exact attribute the identity provider must send (#370); the flow service
+    // reads roles through GetAssertionRoles rather than re-declaring the name.
+    private const string RoleAttributeName = "Role";
+
+    // One-time-use tracking for consumed SAML assertion IDs (replay protection). One process-wide instance,
+    // like the outstanding-request cache the flow service keeps and the OpenID caches the sibling flow
+    // service keeps — the two-step post-then-authenticate legs run across separate per-request instances.
+    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
+
+    private readonly ILogger _logger;
+
+    internal SamlAssertionValidator(ILogger logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Reads the assertion's role values under the one role-attribute definition, so the flow service's
+    /// policy check and warning logs read the exact same attribute the derived privileges here do (#370).
+    /// </summary>
+    /// <param name="samlResponse">The (already signature-validated) assertion to read.</param>
+    /// <returns>The role values the assertion carries.</returns>
+    internal static List<string> GetAssertionRoles(SamlResponse samlResponse) =>
+        samlResponse.GetCustomAttributes(RoleAttributeName);
+
+    /// <summary>
+    /// Parses the untrusted response and runs the response-level validation shared by every SAML leg:
+    /// signature, time bounds and audience (<see cref="ValidateSaml"/>) plus the opt-in recipient binding.
+    /// On failure it logs the declared signature algorithm and the weak-algorithm remediation hint so an
+    /// operator can tell a rejected SHA-1 signature (the expected post-upgrade lockout of a legacy IdP) apart
+    /// from a bad certificate, an expired assertion, or an audience mismatch, all of which otherwise surface
+    /// as the same opaque error.
+    /// </summary>
+    /// <param name="config">The provider configuration (signing certificate, audience, recipient opt-in).</param>
+    /// <param name="provider">The provider that is calling back (for the expected assertion-consumer URLs).</param>
+    /// <param name="requestBaseUrl">The resolved assertion-consumer base URL the Recipient is bound to.</param>
+    /// <param name="rawResponse">The untrusted, Base64-encoded SAMLResponse.</param>
+    /// <param name="samlResponse">The parsed, validated response on success; otherwise null.</param>
+    /// <returns>True when the response parsed and passed response-level validation; otherwise false.</returns>
+    internal bool TryValidate(SamlConfig config, string provider, string requestBaseUrl, string rawResponse, out SamlResponse samlResponse)
+    {
+        // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryParse and is
+        // rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, rawResponse, out samlResponse)
+            || !IsResponseValid(config, provider, requestBaseUrl, samlResponse))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use. Returns
+    /// false when the assertion was already used (or carries no ID — a missing ID stays empty, so TryConsume
+    /// fails closed). The key is scoped by provider so two IdPs emitting the same assertion ID cannot block
+    /// each other. Shared by the session mint and the account linking (#219).
+    /// </summary>
+    /// <param name="samlResponse">The validated response whose assertion ID is consumed.</param>
+    /// <param name="provider">The provider the assertion ID is scoped under.</param>
+    /// <returns>True on the first use; false on a replay (or a missing assertion ID).</returns>
+    internal bool TryConsumeReplay(SamlResponse samlResponse, string provider)
+    {
+        var samlNow = DateTime.UtcNow;
+        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
+        var assertionId = samlResponse.GetAssertionId();
+        var replayKey = ProviderScopedKey.For(provider, assertionId);
+        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
+    }
+
+    /// <summary>
+    /// Completes the SAML session-minting validation on a response that already passed
+    /// <see cref="TryValidate"/>, the login allow-list, and the InResponseTo correlation: it enforces the
+    /// one-time replay consume and the non-empty NameID guard, then — and only then — produces the verified
+    /// identity through <see cref="VerifiedIdentity.FromValidatedSaml"/>. This is the sole SAML construction
+    /// site of a <see cref="VerifiedIdentity"/>, so the "produced only after complete validation" invariant
+    /// is local here.
+    /// </summary>
+    /// <param name="config">The provider configuration the privileges are derived against.</param>
+    /// <param name="provider">The provider that verified the login.</param>
+    /// <param name="samlResponse">The validated, allow-listed, correlated response.</param>
+    /// <param name="identity">The verified identity on success; otherwise null.</param>
+    /// <param name="rejection">The fail-closed outcome on failure; otherwise null.</param>
+    /// <returns>True with <paramref name="identity"/> set on success; false with <paramref name="rejection"/> set.</returns>
+    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, out VerifiedIdentity identity, out LoginOutcome rejection)
+    {
+        identity = null;
+
+        // Enforce one-time use so a captured assertion cannot be replayed to mint another session.
+        // Enforced only at the session-minting endpoint (and the link redeem), not at the SAML/post ACS
+        // which merely renders the intermediate page, so the two-step post-then-auth flow consumes the id
+        // once. A replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
+        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
+        if (!TryConsumeReplay(samlResponse, provider))
+        {
+            rejection = new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid);
+            return false;
+        }
+
+        // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from the
+        // assertion's roles and the provider configuration. Login validity was already decided by
+        // SamlLoginPolicy at the flow service and the username is the assertion's NameID, so neither is
+        // derived here.
+        var derived = SamlAuthorizeStateBuilder.Build(GetAssertionRoles(samlResponse), config);
+
+        // Fail closed (#95): an assertion without a usable NameID carries no identity to log in — reject it
+        // as an invalid login instead of failing downstream on a null canonical name. Whitespace-only counts
+        // as unresolved (Jellyfin's username validation rejects it anyway).
+        var nameId = samlResponse.GetNameID();
+        if (string.IsNullOrWhiteSpace(nameId))
+        {
+            _logger.LogWarning("SAML login denied: the assertion resolved no NameID.");
+            rejection = new LoginOutcome.Denied();
+            return false;
+        }
+
+        // All SAML validation has now passed — signature, time bounds, audience, recipient, InResponseTo
+        // correlation, the login allow-list, replay one-time-use, and the non-empty-NameID guard — so this
+        // is the point at which the response becomes a fully-verified SAML identity (#473). SAML keys the
+        // link directly on the NameID (subject and username are the same value; no migration path needed)
+        // and carries no email_verified claim, so the verified-email gate is not applicable at the caller
+        // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
+        rejection = null;
+        identity = VerifiedIdentity.FromValidatedSaml(provider, nameId, derived);
+        return true;
+    }
+
+    // Validates a SAML response: signature + time bounds always, plus AudienceRestriction binding to this SP
+    // unless explicitly opted out. Expected audience is the configured SamlAudience, falling back to the
+    // SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed Issuer sent in the
+    // AuthnRequest, and an empty SamlAudience falls through to the client id.
+    internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
+    {
+        if (config.DoNotValidateAudience)
+        {
+            return samlResponse.IsValid();
+        }
+
+        var expected = config.SamlAudience?.Trim();
+        if (string.IsNullOrEmpty(expected))
+        {
+            expected = config.SamlClientId?.Trim();
+        }
+
+        return samlResponse.IsValid(expected);
+    }
+
+    // Runs the response-level validation and, on failure, logs the declared signature algorithm plus the
+    // weak-algorithm remediation hint (see TryValidate). Split from TryValidate so the parse and the
+    // validation read as two distinct steps.
+    private bool IsResponseValid(SamlConfig config, string provider, string requestBaseUrl, SamlResponse samlResponse)
+    {
+        if (!ValidateSaml(samlResponse, config))
+        {
+            // The algorithm URI is identity-provider-controlled; strip line endings inline at the log call to
+            // prevent log forging (a helper-boundary sanitizer is not recognized by CodeQL).
+            _logger.LogWarning(
+                "SAML response validation failed (signature algorithm: {Algorithm}). SHA-1 is rejected; if that is the identity provider's algorithm, reconfigure it to sign with RSA/ECDSA-SHA-256 or stronger.",
+                samlResponse.GetSignatureAlgorithm()?.ReplaceLineEndings(string.Empty));
+            return false;
+        }
+
+        // Endpoint binding (#156, opt-in): the signed assertion must be addressed to this service provider's
+        // assertion-consumer URL, so an assertion minted for a different endpoint (or a different SP sharing
+        // the identity provider) cannot be presented here.
+        if (config.ValidateRecipient
+            && !SamlRecipientValidator.IsBound(samlResponse.GetRecipient(), samlResponse.GetDestination(), ExpectedAcsUrls(requestBaseUrl, provider)))
+        {
+            _logger.LogWarning("SAML response rejected: the assertion Recipient or Response Destination does not match this server's assertion-consumer URL.");
+            return false;
+        }
+
+        return true;
+    }
+
+    // The assertion-consumer URLs this service provider advertises for the provider — the same value the
+    // challenge puts in the AuthnRequest's AssertionConsumerServiceURL, so a signed Recipient (or
+    // Destination) must equal one. Both the new ("post") and legacy ("p") path spellings are returned:
+    // config.NewPath is process-wide mutable state a concurrent challenge can flip, and the Recipient
+    // reflects whichever the AuthnRequest advertised at challenge time, so accepting either avoids rejecting
+    // a valid login on a path-form flip; both are this provider's own ACS URLs. The base URL is resolved by
+    // the flow service (with BaseUrlOverride pinning the canonical host when set, #139) and passed in.
+    private static string[] ExpectedAcsUrls(string requestBaseUrl, string provider) =>
+        SsoUrlBuilder.SamlExpectedAcsUrls(requestBaseUrl, provider);
+}


### PR DESCRIPTION
# What & why

Consolidate the inbound SAML validation, signature / time bounds / audience / recipient / algorithm-allowlist / one-time replay / non-empty NameID, which was spread across the SAML callback path in `SamlLoginService`, into one dedicated internal sealed type, `SamlAssertionValidator`. The validator owns the full inbound validation and is the single place that yields a validated SAML result, so it is the natural home for the `VerifiedIdentity.FromValidatedSaml` factory call. This makes the "a `VerifiedIdentity` is produced only after complete validation" invariant local and testable.

This is a behaviour-preserving relocation, not a logic change: every check runs in the same order with the same reject/accept outcome and the same error surface in all three legs (callback, authenticate, link). `Saml.cs` (the XSW/algorithm-allowlist/audience-AND/recipient/time core) is untouched.

Closes #496. Part of #318 (domain-partitioned helpers).

**What moved into `SamlAssertionValidator`:**
- `ValidateSaml` (signature + time bounds + AudienceRestriction), unchanged, still `internal static`.
- The recipient binding and the algorithm-diagnostic warning log (the old `IsSamlResponseValid` / `ExpectedAcsUrls`), now `TryValidate` / `IsResponseValid`.
- The one-time replay consume (`TryConsumeReplay`) together with the process-wide `SamlReplayCache` static.
- The non-empty-NameID guard and the sole SAML `VerifiedIdentity.FromValidatedSaml` construction, in `TryProduceVerifiedIdentity`, downstream of every gate.
- The role-attribute name is one private const; the flow service reads roles through `GetAssertionRoles` so every read agrees on the attribute.

**What deliberately stayed in `SamlLoginService`:**
- The InResponseTo correlation and browser binding (the outstanding-request cache), request-issued session-fixation correlation, not assertion validation.
- The login allow-list (`SamlLoginPolicy`), a policy gate enforced at BOTH the assertion-consumer page and the session-minting endpoint.

**Check order + outcomes (authenticate leg), identical to before:** config → parse + signature/time/audience/recipient → InResponseTo/binding → login allow-list → replay consume → non-empty NameID → `FromValidatedSaml` → shared completion. `Rejected(SamlResponseInvalid)` for malformed/invalid/replay, `Denied` for role-fail and empty-NameID, unchanged.

**Conformance rules re-homed:** `VerifiedIdentity_IsConstructedOnlyByProtocolValidators` now pins the `FromValidatedSaml` call to `SamlAssertionValidator`; `Controller_DelegatesSamlFlowToTheFlowService`'s liveness scan now covers both flow-tier files (`SamlLoginService` + `SamlAssertionValidator`).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

Built Debug + Release with `--warnaserror` (0 warnings) and ran the full suite (1059 tests, all pass) on the rebased tree (branch rebased cleanly onto current `origin/main` @ eddfd26; the four files touched here are disjoint from #519/#520).

**Adversarial self-review, four refute-by-default lenses, all PASS:**
- **Availability / mass-lockout, PASS.** No new mass-lockout: the replay cache stays a single process-wide `static readonly` (survives the two-step post→authenticate legs); no validation reordered to reject a previously-passing login; the base URL passed into validation is identical to the old in-validation computation.
- **Security-bypass / fail-open, PASS.** No check dropped, weakened, or reordered-to-change-outcome; `FromValidatedSaml` is reachable only after the full gate chain; the one-time replay consume is intact and still shared by authenticate + link; `Saml.cs` (algorithm allowlist, XSW, audience-AND, recipient) untouched.
- **Correctness / check-for-check equivalence, PASS.** Line-by-line equivalence confirmed across all three legs; derived-state build, role reads, and warning logs preserved; `requestBase` computed once and reused.
- **Integration, PASS.** `SamlLoginService` constructor signature unchanged (controller wiring and test `Build` untouched); both conformance rules correctly re-homed and green; `ValidateSamlTests` updated to the new type with the now-unused `using` dropped; the new `*Validator` type satisfies the internal-and-sealed helper rules.

**Non-blocking behavioural note (availability + correctness lenses):** `GetRequestBase` is now computed eagerly before validation, so on an already-broken (unpersistable) `baseUrlOverride` config an invalid SAML response would surface as a 500 instead of a 400. This is strictly fail-closed (never fail-open) and unreachable through supported config, the config-save validation blocks a `baseUrlOverride` that would make base-URL resolution throw. Recorded here for transparency; no fix warranted.
