### PR TITLE
Add opt-in verified-email gate for OpenID logins

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -871,7 +871,9 @@ public class ArchitectureConformanceTests
         // stop a field persisting while leaving the forward check green. For a security setting that is
         // fail-open (the server keeps the stored value; the admin can no longer harden it), so pin the
         // security-critical settings: each MUST remain a marked, correctly-typed persisting field. Extend
-        // this roster in the same PR that adds a new security toggle.
+        // this roster in the same PR that surfaces a new security toggle in the admin form; a deliberately
+        // XML-only toggle (e.g. RequireVerifiedEmailForLogin #166) is not a form field and so stays out of
+        // this roster until it is surfaced (as RequireVerifiedEmailForAdoption was, #484/#488).
         var securityCritical = new[]
         {
             "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",

--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -29,6 +29,7 @@ public class LoginStatusMapperTests
             (PublicReason.SamlResponseInvalid, 400, "SAML response validation failed"),
             (PublicReason.PkceNotSupported, 400, "The identity provider does not advertise the required PKCE (S256) support."),
             (PublicReason.PkceUnverifiable, 400, "The identity provider's PKCE (S256) support could not be verified."),
+            (PublicReason.EmailNotVerified, 403, "A verified email is required to log in."),
         };
 
         // The table itself must stay total: a new member without a row fails here.

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -143,16 +143,94 @@ public class SSOControllerOidAuthTests
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
 
+    [Fact]
+    public async Task OidAuth_RequireVerifiedEmailForLoginOff_Succeeds_RegardlessOfEmailVerified()
+    {
+        // The availability-critical property (#166): with the flag off (the default), the login succeeds
+        // even when email_verified is absent (null) — behaviour is byte-identical to before the gate, so no
+        // existing deployment or claim-omitting IdP is affected on upgrade.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+            RequireVerifiedEmailForLogin = false,
+        });
+        SeedValidState(harness, "state-token", emailVerified: null);
+        SetBindingCookie(harness, Binding);
+
+        var result = await harness.Controller.OidAuth("kc", Redeem("state-token"));
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task OidAuth_RequireVerifiedEmailForLoginOn_EmailVerifiedTrue_Succeeds()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+            RequireVerifiedEmailForLogin = true,
+        });
+        SeedValidState(harness, "state-token", emailVerified: true);
+        SetBindingCookie(harness, Binding);
+
+        var result = await harness.Controller.OidAuth("kc", Redeem("state-token"));
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Theory]
+    [InlineData(false)] // the IdP asserted the email is NOT verified
+    [InlineData(null)]  // the claim was absent or unparseable
+    public async Task OidAuth_RequireVerifiedEmailForLoginOn_EmailNotVerified_RejectsAndMintsNothing(bool? emailVerified)
+    {
+        // Fail closed (#166): with the flag on, anything other than email_verified == true rejects the whole
+        // login with the 403 gate body, and — crucially — no account is provisioned and no session minted.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+            RequireVerifiedEmailForLogin = true,
+        });
+        SeedValidState(harness, "state-token", emailVerified);
+        SetBindingCookie(harness, Binding);
+
+        var result = await harness.Controller.OidAuth("kc", Redeem("state-token"));
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(403, content.StatusCode);
+        Assert.Equal("A verified email is required to log in.", content.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    // A fully-populated redeem request; the state token is the only field these gate tests vary.
+    private static AuthResponse Redeem(string state) => new AuthResponse
+    {
+        Data = state,
+        DeviceID = "device-1",
+        DeviceName = "Test Device",
+        AppName = "Jellyfin Web",
+        AppVersion = "1.0",
+    };
+
     // Seeds a valid, redeemable login state for provider "kc" bound to a new user "alice", and mocks the
     // user provisioning + session lookup the happy path drives. BindingId records the browser-binding id
     // the challenge would have set; the redeem leg must present the matching cookie (see SetBindingCookie).
-    private static void SeedValidState(SsoControllerHarness harness, string token)
+    // emailVerified is the email_verified claim the login resolved (null = absent), so a test can exercise
+    // the verified-email login gate (#166).
+    private static void SeedValidState(SsoControllerHarness harness, string token, bool? emailVerified = null)
     {
         var pending = new AuthorizeSession.Pending(new AuthorizeState { State = token }, "kc", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false);
         var ready = new AuthorizeSession.Ready(
             pending,
             new OidcAuthorizeStateBuilder.OidcAuthorizeState(
-                Username: "alice", Subject: "sub-1", EmailVerified: null, Valid: true, Admin: false,
+                Username: "alice", Subject: "sub-1", EmailVerified: emailVerified, Valid: true, Admin: false,
                 EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>(), AvatarUrl: null));
         OidcLoginService.SeedOidStateForTests(token, ready);
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -329,6 +329,18 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
 
+        // Verified-email login gate (#166): when the provider opts in, an OpenID login must carry
+        // email_verified == true. Absent, false, or unparseable all fail this check — fail closed — reusing
+        // the single value OidcAuthorizeStateBuilder already parsed and carried on the verified identity, so
+        // there is no second, divergent parse. Off by default, so a deployment that does not set it (or an
+        // IdP that omits the claim) is unaffected. Distinct from the adoption gate below (#218), which only
+        // guards same-name account adoption; this gates every login for the provider. Needs the email scope.
+        if (config.RequireVerifiedEmailForLogin && redeemed.Identity.EmailVerified != true)
+        {
+            _logger.LogWarning("OpenID login denied for provider {Provider}: RequireVerifiedEmailForLogin is set but the login did not carry email_verified == true (absent, false, or unparseable).", provider?.ReplaceLineEndings(string.Empty));
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.EmailNotVerified));
+        }
+
         // The redeemed state carries the fully-verified identity (#473); the OpenID adoption gate applies
         // the provider's verified-email requirement (#218). From here the OpenID and SAML paths are one.
         return await _loginCompletion.CompleteAsync(

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -70,6 +70,7 @@ internal static class LoginStatusMapper
         PublicReason.SamlResponseInvalid => Emit(StatusCodes.Status400BadRequest, "SAML response validation failed"),
         PublicReason.PkceNotSupported => Emit(StatusCodes.Status400BadRequest, "The identity provider does not advertise the required PKCE (S256) support."),
         PublicReason.PkceUnverifiable => Emit(StatusCodes.Status400BadRequest, "The identity provider's PKCE (S256) support could not be verified."),
+        PublicReason.EmailNotVerified => Emit(StatusCodes.Status403Forbidden, "A verified email is required to log in."),
         // A new PublicReason member without a mapper entry fails loudly here, and the totality test
         // enumerating every member catches it before it can ship — never a fall-through.
         _ => throw new InvalidOperationException($"Unmapped public reason: {reason}"),

--- a/SSO-Auth/Api/PublicReason.cs
+++ b/SSO-Auth/Api/PublicReason.cs
@@ -28,4 +28,7 @@ internal enum PublicReason
 
     /// <summary>RequirePkce is set but the discovery document could not be read (#141). Operator-facing by design.</summary>
     PkceUnverifiable,
+
+    /// <summary>RequireVerifiedEmailForLogin is set but the login carried no verified email (absent/false/unparseable) (#166). Operator-facing by design.</summary>
+    EmailNotVerified,
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -90,7 +90,8 @@ public abstract class ProviderConfigBase
     /// <summary>
     /// Gets or sets a value indicating whether an SSO login may adopt a pre-existing, unlinked
     /// Jellyfin account whose username matches the SSO name. Off by default (fail closed): a first
-    /// login that matches an existing account is rejected rather than taking it over.
+    /// login that matches an existing account is rejected rather than taking it over. Settable in the
+    /// admin provider form as well as the config XML (#484, #488).
     /// </summary>
     public bool AllowExistingAccountLink { get; set; }
 
@@ -314,9 +315,22 @@ public class OidConfig : ProviderConfigBase
     /// always refused regardless of this flag, so the headline takeover is closed without it; this flag
     /// hardens the residual non-admin, name-based adoption. Enabling it needs the <c>email</c> scope so
     /// the provider actually returns <c>email_verified</c>; an absent or false claim then refuses
-    /// adoption. XML-only, like <see cref="ProviderConfigBase.AllowExistingAccountLink"/>.
+    /// adoption. Settable in the admin provider form as well as the config XML (#484, #488).
     /// </summary>
     public bool RequireVerifiedEmailForAdoption { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether every OpenID login for this provider must carry
+    /// <c>email_verified == true</c> (#166). Off by default (fail closed for availability, not the threat):
+    /// a deployment that does not set it — or an identity provider that omits the claim — is unaffected, so
+    /// the whole userbase sees no change on upgrade. When on, a login whose <c>email_verified</c> is not
+    /// exactly <c>true</c> (absent, false, or unparseable) is refused, so an identity provider that permits
+    /// unverified emails cannot be used to sign in. Distinct from <see cref="RequireVerifiedEmailForAdoption"/>,
+    /// which only gates same-name account adoption; this gates the login itself, before any account is
+    /// resolved. Enabling it needs the <c>email</c> scope so the provider returns <c>email_verified</c>.
+    /// XML-only.
+    /// </summary>
+    public bool RequireVerifiedEmailForLogin { get; set; }
 
     /// <summary>
     /// Gets or sets the claim to check roles against. Separated by "."s.

--- a/providers.md
+++ b/providers.md
@@ -107,6 +107,18 @@ expiry). A few provider settings must therefore match, or login is refused (fail
     one), so on that one path the admin-takeover ceiling is still enforced but this verified-email
     defense-in-depth is not. Both `AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` are
     settable in the admin OpenID provider form, or by editing the provider's `config.xml` directly.
+- **Requiring a verified email for the login itself (`RequireVerifiedEmailForLogin`, OpenID only, off
+  by default).** The adoption gate above only guards the one moment a login adopts a same-named account.
+  Set `RequireVerifiedEmailForLogin` on a provider to instead require **every** OpenID login for that
+  provider to carry `email_verified == true` — whether it adopts, creates, or signs in to an
+  already-linked account. A login whose `email_verified` is not exactly `true` (absent, `false`, or
+  unparseable) is refused (HTTP 403). Use it when the provider allows unverified emails and you do not
+  want such accounts to sign in at all. It is **off by default** so a deployment that does not set it —
+  or an IdP that never emits the claim — is unaffected on upgrade; and it needs the `email` scope in the
+  provider's `OidScopes`, otherwise the claim is absent and **every** login is refused. It is
+  independent of `AllowExistingAccountLink` / `RequireVerifiedEmailForAdoption` (you can run either, both,
+  or neither). **SAML** carries no `email_verified` claim, so this gate does not apply there. This flag
+  is currently set by editing the provider's `config.xml` directly (it is not yet in the admin form).
 - **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
   identity provider can reassign, so following such a link is name-based account matching, governed by


### PR DESCRIPTION
# What & why

Closes #166.

Adds an opt-in, per-provider verified-email gate for OpenID **logins**, feature
parity with the sibling `jellyfin-plugin-sso-V2 (private)`. Some identity
providers let a principal hold an account with an unverified email address; a
deployment that wants to keep such accounts out entirely could not express that
before this change (the existing `RequireVerifiedEmailForAdoption`, #218, only
guards the one moment a login _adopts_ a same-named account).

**Design**

- **New `OidConfig` flag `RequireVerifiedEmailForLogin`, default `false`.** Default
  off is the availability-critical property: an operator who never sets it, and
  an IdP that never emits `email_verified`, sees **zero** change on upgrade. The
  guard short-circuits on the flag, so with it off no new code path is taken.
- **Fail-closed when on.** In `OidcLoginService.AuthenticateAsync`, right after the
  one-time state redeem and **before** the shared completion tail (`CompleteAsync`,
  which resolves/creates the account and mints), a login whose `email_verified` is
  not exactly `true`, absent, `false`, or unparseable all map to `!= true`, is
  refused. Because the check precedes `CompleteAsync`, a refusal provisions no
  account and mints no session.
- **Gates the login itself, not just adoption.** It applies to every OpenID login
  for the provider (adopt, create, or sign in to an already-linked account) and is
  independent of `AllowExistingAccountLink` / `RequireVerifiedEmailForAdoption`. It
  deliberately does **not** touch the manual admin-link redeem (`Link`), which is a
  separately authorized action.
- **`email_verified` is reused, not re-parsed.** The check reads the single value
  `OidcAuthorizeStateBuilder.ResolveEmailVerified` already parsed and carried on the
  redeemed `VerifiedIdentity.EmailVerified`, so the login gate and the adoption gate
  can never disagree about the same claim. The value originates from the
  signature-validated id_token claims (#134), so there is no unvalidated source.
- **Refusal surface.** A new `PublicReason.EmailNotVerified` maps to `403` with a
  fixed, operator-facing body ("A verified email is required to log in."), mirroring
  the PKCE reasons rather than the uniform role denial, the failing condition is a
  provider/IdP configuration property, not an account-enumeration oracle. Not a 500.
- **Scope requirement documented.** Enabling it needs the `email` scope in
  `OidScopes`, otherwise the claim is absent and every login is refused. The flag is
  XML-only for now (mirrors how `RequireVerifiedEmailForAdoption` shipped before it
  was surfaced in the admin form by #484/#488); `providers.md` documents it.

**Also in this PR (small, in-scope doc cleanup):** the XML-doc comments on
`AllowExistingAccountLink` and `RequireVerifiedEmailForAdoption` still described those
flags as "XML-only", which went stale when #484/#488 surfaced them in the admin
provider form. Both are corrected to note they are settable in the admin form as well
as `config.xml`.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / code quality / docs

(Feature with a security posture, a login-path gate, so the security checklist and
the adversarial-review gate below both apply.)

## Security checklist

- [x] Fail-closed preserved: with the flag on, a missing/`false`/unparseable
      `email_verified` is rejected (`!= true`), never default-accepted; the check is
      ordered before any account resolution or session mint.
- [x] No secrets logged; the refusal log line carries only the provider name,
      sanitized inline with `provider?.ReplaceLineEndings(string.Empty)`.
- [x] A security review was performed - the four-lens adversarial gate ran on the
      committed diff (verdicts under Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; the gate reuses the already-parsed `email_verified` value
      rather than re-parsing the claim.
- [x] The change adds no more code than the problem requires (one guard, one config
      flag, one `PublicReason` + mapper row).
- [x] The code is self-documenting; the comments explain _why_ (fail-closed, reuse,
      distinct from adoption), not _what_.
- [x] Architecture-conformance tests pass. The new flag is deliberately XML-only, so
      it is not added to the `securityCritical` form-field roster; the roster comment
      is clarified to say it covers form-surfaced toggles (an XML-only toggle stays out
      until it is surfaced, as `RequireVerifiedEmailForAdoption` was).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug **and** Release, 0
      warnings), on the tree rebased onto current `main`.
- [x] `dotnet test` is green (1063 passed, 0 failed).
- [x] Jellyfin compatibility metadata check (`scripts/check-jellyfin-compat.sh`) is
      consistent.
- [x] Prettier is clean for the `providers.md` change.

## Notes

**Tests** (`SSO-Auth.Tests/SSOControllerOidAuthTests.cs`, driven end-to-end through the
thin `OidAuth` endpoint):

- flag **off** (default) + `email_verified` absent → login **succeeds** (the
  behaviour-preserving pin for the whole userbase);
- flag **on** + `email_verified == true` → **succeeds**;
- flag **on** + `email_verified` `false` **and** absent (Theory) → **rejected** with
  403 "A verified email is required to log in.", and **no account provisioned**.
- `LoginStatusMapperTests` totality table extended with the `EmailNotVerified` → 403
  row (the mapper totality invariant fails a member without an entry).

**Adversarial-review gate, four refute-by-default lenses on the committed diff:**

- **Availability / mass-lockout**, VERDICT: the gate is inert by default and
  upgrade-safe, a new `bool` XML property defaults `false`, so no existing provider
  flips on; when set, the lockout is scoped to the single opting-in OpenID provider,
  with a predicate/value byte-identical to the adoption gate. No availability defect., **PASS**
- **Security-bypass / fail-open**, VERDICT: default-off takes no new path; when on,
  `!= true` rejects absent/`false`/unparseable and only exact `true` passes; the value
  is the signature-validated id_token claim reused from the verified identity (no
  divergent parse, no unvalidated source); the check precedes the mint so nothing is
  provisioned on refusal; no alternate login endpoint bypasses it., **PASS**
- **Correctness**, VERDICT: the full on/off × true/false/absent matrix behaves as
  specified and is pinned by tests; `bool?` short-circuit correct; log line sanitized;
  the XML-only flag correctly stays out of the conformance roster., **PASS**
- **Integration**, VERDICT: the bool round-trips via the same XML/JSON path as the
  sibling flag and is not wiped by config-preservation; the new `PublicReason`
  satisfies the mapper totality invariant; the adoption gate (#218) and the SAML path
  are unaffected; no fitness function requires the flag to be a form field., **PASS**

All lens findings resolved (none required a code change). Out-of-scope follow-up:
surface `RequireVerifiedEmailForLogin` in the admin OpenID provider form (and add it to
the `securityCritical` roster then), mirroring #484/#488 for the adoption flag, a
separate P4 issue.
