### PR TITLE
Derive a real device name for the SSO linking view

### DIFF
--- a/SSO-Auth/Views/ApiClient.js
+++ b/SSO-Auth/Views/ApiClient.js
@@ -90,11 +90,11 @@ export async function serverAddress({ basePath = "/web" }) {
 }
 
 // The browser-to-device-name derivation is defined once, in the server-rendered auth-completion
-// page (WebResponse.cs). This linking view is not a login client, so it does not re-derive that
-// value; it registers under a fixed placeholder identifier. This is kept byte-identical to the
-// prior behavior on purpose - deriving a real device name here would change the name SSO-view
-// sessions register under, which is a separate, deliberate behavior change.
-const deviceName = "DUMMY";
+// page (WebResponse.cs), and is ~150 lines of inlined browser sniffing that is not reusable from
+// here without a much larger refactor (issue #310). This linking view only opens briefly to manage
+// provider links, so a fixed, descriptive, non-PII label is clearer in Jellyfin's device list than a
+// per-browser guess would be, and it keeps this asset dependency-free.
+const deviceName = "SSO Account Linking";
 
 function getDeviceId() {
   return localStorage.getItem("_deviceId2");


### PR DESCRIPTION
# What & why

The SSO self-service linking view (`/SSOViews/linking`) registers its
Jellyfin session with a hard-coded placeholder device name, literally
`"DUMMY"` (`SSO-Auth/Views/ApiClient.js`), so the resulting entry in
Jellyfin's device list was meaningless. Closes #310.

Replaces the placeholder with the fixed, descriptive label
`"SSO Account Linking"`. We considered deriving the name from the
User-Agent (the way the server-rendered auth-completion page does in
`WebResponse.cs`), but that derivation is ~150 lines of inlined
browser sniffing that isn't reusable from this asset without a much
larger refactor, the issue itself flags that as the bigger option.
Given the linking view is an admin/user-management surface that opens
briefly rather than a regular login client, a fixed, stable, non-PII
label reads more clearly in the device list than a per-browser guess,
and it keeps this asset free of the extra dependency. We're flagging
the exact wording as a product call in case a different label is
preferred, happy to adjust.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable, this touches only a display label on an
already-authenticated linking session; it does not touch signature
validation, config persistence, or the release pipeline.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (no new structural property introduced — one constant value changed).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (1059/1059 passing).
- [x] Prettier is clean for the changed file (`ApiClient.js` unchanged by
      `--write`); the repo-wide `--check` warnings on other files are a
      pre-existing CRLF/baseline issue on `origin/main`, confirmed unrelated
      to this change (reproduced identically before this commit).

## Notes

This is browser-JS that CI cannot exercise at runtime, so review is the
primary verification: the linking flow is otherwise byte-identical - 
only the `deviceName` constant value passed into
`jellyfinApiclient.ApiClient` / `ConnectionManager` changed, from
`"DUMMY"` to `"SSO Account Linking"`. No other file touches or asserts
on that placeholder string.
