### PR TITLE
Surface RequireVerifiedEmailForLogin in the admin provider form

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -872,14 +872,14 @@ public class ArchitectureConformanceTests
         // fail-open (the server keeps the stored value; the admin can no longer harden it), so pin the
         // security-critical settings: each MUST remain a marked, correctly-typed persisting field. Extend
         // this roster in the same PR that surfaces a new security toggle in the admin form; a deliberately
-        // XML-only toggle (e.g. RequireVerifiedEmailForLogin #166) is not a form field and so stays out of
-        // this roster until it is surfaced (as RequireVerifiedEmailForAdoption was, #484/#488).
+        // XML-only toggle is not a form field and so stays out of this roster until it is surfaced (as
+        // RequireVerifiedEmailForAdoption was, #484/#488, and RequireVerifiedEmailForLogin was, #524).
         var securityCritical = new[]
         {
             "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",
             "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
             "DoNotLoadProfile", "RequirePkce", "AllowExistingAccountLink",
-            "RequireVerifiedEmailForAdoption",
+            "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
         };
         var unsaved = securityCritical.Where(p => !matchedIds.Contains(p)).ToList();
         Assert.True(

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -797,6 +797,35 @@
                   </div>
                 </div>
 
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="RequireVerifiedEmailForLogin"
+                      name="RequireVerifiedEmailForLogin"
+                      type="checkbox"
+                      class="sso-toggle"
+                    />
+                    <span>Require Verified Email For Login (Sensitive)</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    ⚠ Sensitive: requires every OpenID login for this provider
+                    to carry a provider-verified email (email_verified == true)
+                    — whether it adopts, creates, or signs in to an
+                    already-linked account — not only the adoption moment above.
+                    A login whose email_verified is not exactly true (absent,
+                    false, or unparseable) is refused. Needs the email scope so
+                    the provider actually returns email_verified; without it,
+                    every login is refused. Off by default so a deployment that
+                    does not set it, or an IdP that never emits the claim, is
+                    unaffected. Independent of Allow Adopting Existing Accounts
+                    and Require Verified Email For Adoption above (run either,
+                    both, or neither).
+                  </div>
+                </div>
+
                 <div class="inputContainer">
                   <label
                     class="inputLabel inputLabelUnfocused"


### PR DESCRIPTION
# What & why

Closes #524

`RequireVerifiedEmailForLogin` (`OidConfig`, #166, PR #522) requires every
OpenID login for a provider to carry a provider-verified `email_verified ==
true` claim, not only the one moment an adoption happens, but every login:
adopt, create, or sign-in to an already-linked account. It is a real,
security-relevant toggle, but it was XML-only: `configPage.html` /
`config.js` never referenced it, so `listArgumentsByType` never persisted it
and the only way to set it was hand-editing `SSO-Auth.xml` per provider.
#484/#488 surfaced its siblings, `AllowExistingAccountLink` and
`RequireVerifiedEmailForAdoption`, the same way; this closes the same gap for
the login-time flag.

We add an `sso-toggle` checkbox for it to `#sso-new-oidc-provider`, directly
below the two adoption-related toggles, wired through the existing generic
save path.

**How the flag is rendered + saved (mirrors #484/#488):** the checkbox
carries `class="sso-toggle"` and `id="RequireVerifiedEmailForLogin"`, spelled
exactly like the `OidConfig` property. That is the entire #365 save contract
 - no `config.js` change is needed because the save/load path is generic over
the marker classes:

- Load: `loadProvider` iterates `check_fields` and sets
  `#RequireVerifiedEmailForLogin.checked = Boolean(provider["RequireVerifiedEmailForLogin"])`
 , it READS the current stored value on load.
- Save: `saveProvider` overlays
  `current_config["RequireVerifiedEmailForLogin"] = checkbox.checked` onto the
  existing provider object and PUTs the whole config, it WRITES the value on
  save. The server keeps the JSON member because it is a real `OidConfig`
  property.

**Default + security posture preserved.** This surfaces the flag only; its
default (`false`, fail closed) and its semantics are unchanged. An unchecked
box persists `false`, which equals the property default, so a provider with
no explicit value stays `false` after a save. The `fieldDescription` states
the security implication, notes it needs the `email` scope for the provider
to actually return `email_verified`, and that it is independent of
`AllowExistingAccountLink` / `RequireVerifiedEmailForAdoption` (run either,
both, or neither).

**Round-trip proof.** Set in UI -> `saveProvider` writes the member -> XML
persists it -> `loadProvider` re-reads and re-checks the box. Other
server-managed/XML-only fields are untouched: `ServerManagedFields.Preserve`
only re-injects `CanonicalLinks` and `OidSecret`, and this flag is neither, so
the overlay and server-managed preservation are intact.

The **SAML side needs no change**: `RequireVerifiedEmailForLogin` has no
`email_verified` equivalent on SAML (documented in `providers.md`) and there
is no SAML provider form in the admin UI at all (SAML config is entirely
XML-only), so there is nothing to add the affordance to there.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No change to auth/login logic; the
      flag's `false` default and semantics are untouched. An unchecked box
      persists `false`, the fail-closed value.)
- [x] No secrets logged; secrets are redacted on config export. (No logging
      or secret handling touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial
      self-review below; config-persistence surface.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new
      logging.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the existing generic save/load path; no new JS.)
- [x] The change adds no more code than the problem requires. (One checkbox +
      one roster entry; no `config.js` or `PluginConfiguration` change.)
- [x] The code is self-documenting (readable without comments; comments
      explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property
      this change establishes is locked in as a rule in
      `ArchitectureConformanceTests`. (Added `RequireVerifiedEmailForLogin`
      to the security-critical reverse-pin roster, and updated the roster's
      comment, as that test's comment instructs.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug, 0
      warnings.)
- [x] `dotnet test` is green. (1063 passed, incl. the extended
      `ProviderFormFieldIds_MatchOidConfigProperties`.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`configPage.html` formatted with `prettier --write`, confirmed clean
      with `prettier --check`; verified the committed blob is LF-only, not
      the CRLF working-tree false positive.)

## Notes

Adversarial self-review, four refute-by-default lenses (config-persistence +
a security-relevant flag):

- **Availability / mass-lockout, PASS.** The checkbox defaults unchecked and
  the admin page renders one more toggle; `listArgumentsByType` simply gains
  one `check_fields` entry, no iteration/limit concern. A provider with no
  explicit value loads unchecked and, if saved, persists `false`, the
  existing default, so no login is silently gated on an unmet
  `email_verified` claim for a deployment that was not already relying on it.
- **Security-bypass (does the form ever silently flip the default or wipe a
  server-managed field on save?), PASS.** The only way the save changes the
  stored flag without an explicit admin click is the pre-existing "save
  without Load Provider first" behavior shared by every toggle, and here
  that direction is `true -> false`, which loosens a defense-in-depth check
  but does not touch the primary auth gates (signature/issuer/audience/expiry
  validation is untouched by this flag). Before this change a stale XML
  `true` could never be turned off in the UI; now it can. No server-managed
  field is touched: `ServerManagedFields` preserves only `CanonicalLinks` and
  `OidSecret`.
- **Correctness (read-on-load / write-on-save round-trip), PASS.** `id`
  matches the `OidConfig` property exactly and `class="sso-toggle"` puts it
  in `check_fields`; `loadProvider` sets `checked = Boolean(provider[id])` and
  `saveProvider` writes `current_config[id] = checked`. Default unchecked ->
  `false` = property default. The conformance test now asserts it persists.
- **Integration (the `saveProvider` overlay + `ServerManagedFields` intact,
  and the field sits with the flags it is independent of), PASS.** The
  checkbox is inside `#sso-new-oidc-provider`, directly below
  `RequireVerifiedEmailForAdoption`, so the form-scoped scan picks it up and
  the UI groups the three email/adoption-related flags together. The overlay
  (seed from existing provider, overlay form fields, PUT whole object) is
  unchanged, and the added field is orthogonal to server-managed
  re-injection.

Out of scope: `providers.md`'s closing line for this flag ("This flag is
currently set by editing the provider's `config.xml` directly (it is not yet
in the admin form)") and the `RequireVerifiedEmailForLogin` XML-doc comment
on `OidConfig` ("XML-only") are now stale, the same way #484 made the
`providers.md` claim for `AllowExistingAccountLink` stale until #489 (a
separate follow-up PR) corrected it. Both are prose/doc-only, touch no
runtime behavior, and are out of the "touch only configPage.html + the
conformance test" scope given for this delivery; flagging as a follow-up doc
fix rather than widening this diff.
