### PR TITLE
Address zizmor pedantic workflow code-smells

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,14 @@ on:
         description: "The .NET target to set for JPRM"
         type: string
 
+# Read-only: this reusable workflow only builds the plugin and uploads the
+# resulting artifact, no job here needs write access.
 permissions:
   contents: read
 
 jobs:
   build:
+    name: Build package
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,8 @@ name: Dependency review
 on:
   pull_request:
 
+# Read-only: the dependency-review action only inspects the PR diff against the
+# advisory database, it never writes to the repo.
 permissions:
   contents: read
 
@@ -11,6 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # No `name:` on this job: the "Protect main" ruleset's required status check
+  # matches the literal check-run name, which defaults to the job id
+  # ("dependency-review") when no `name:` is set. Overriding it here would
+  # rename the check run and silently break the required-status-check gate.
   dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main ]
 
+# Read-only: build/test/scan only, no job here writes to the repo or a release.
 permissions:
   contents: read
 
@@ -16,6 +17,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # No `name:` on this job: the "Protect main" ruleset's required status check
+  # matches the literal check-run name, which defaults to the job id ("build")
+  # when no `name:` is set. Overriding it here would rename the check run and
+  # silently break the required-status-check gate.
   build:
 
     runs-on: ubuntu-latest
@@ -59,6 +64,7 @@ jobs:
   # member added after the floor would compile against the SDK but throw MissingMethodException at
   # login on an older 10.11 server (#142). Builds SSO-Auth against Jellyfin.* pinned to that floor.
   abi-floor:
+    name: ABI floor build
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -85,6 +91,7 @@ jobs:
   # Verify the plugin actually packages as a loadable Jellyfin plugin (JPRM builds it against the
   # targeted ABI and produces the manifest) on every PR, not only at release time.
   package:
+    name: Package (JPRM)
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.x"

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -18,6 +18,8 @@ on:
   pull_request:
     branches: ["**"]
 
+# Explicit deny-all at workflow level; the job below grants only the read
+# access it needs to check out the tree.
 permissions: {}
 
 # Cancel a superseded run on the same ref so a new push / PR update does not
@@ -31,6 +33,7 @@ jobs:
     name: Enforce greppable invariants
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Only needs to read the checkout; the rule set is local and the scan is offline.
     permissions:
       contents: read
     env:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main ]
 
+# Read-only: the lint only inspects tracked files, it never writes.
 permissions:
   contents: read
 
@@ -14,6 +15,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # No `name:` on this job: the "Protect main" ruleset's required status check
+  # matches the literal check-run name, which defaults to the job id
+  # ("prettier") when no `name:` is set. Overriding it here would rename the
+  # check run and silently break the required-status-check gate.
   prettier:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -5,10 +5,13 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Explicit deny-all at workflow level; the job below opts into write access
+# explicitly rather than granting it workflow-wide.
 permissions: {}
 
 jobs:
   build:
+    name: Build & publish nightly
 
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -63,7 +66,7 @@ jobs:
         popd
     - name: Publish output artifacts
       id: publish-assets
-      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58
+      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58 # unreleased commit between v3.0.1 and v3.0.2
       with:
           # Mark the nightly as a prerelease so the manifest step's ignorePrereleases
           # filter keeps 0.0.0.9000 out of the production manifest.json every plugin-repo
@@ -79,7 +82,7 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish Plugin Manifest
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485
+      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
       with:
         ignorePrereleases: true
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,16 @@ permissions:
 
 jobs:
   build:
+    name: Build package
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.*"
       dotnet-target:  "net9.0"
   upload:
+    name: Upload release assets
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Publishes the GitHub release asset, so needs write access.
     permissions:
       contents: write
     needs:
@@ -38,7 +41,7 @@ jobs:
         ls -l
     - name: Publish output artifacts
       id: publish-assets
-      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58
+      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58 # unreleased commit between v3.0.1 and v3.0.2
       with:
           prerelease: false
           fail_on_unmatched_files: true
@@ -47,15 +50,17 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   generate:
+    name: Publish plugin manifest
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Publishes the plugin manifest to the pages branch, so needs write access.
     permissions:
       contents: write
     needs:
     - upload
     steps:
     - name: Publish Plugin Manifest
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485
+      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
       with:
         ignorePrereleases: true
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only: the guard only greps the tracked tree, it never writes.
 permissions:
   contents: read
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,15 +26,24 @@ on:
   pull_request:
     branches: [ "**" ]
 
+# Explicit deny-all at workflow level; the job below grants only what it needs.
 permissions: {}
+
+# Cancel a superseded run on the same ref so a new push / PR update does not
+# queue behind an obsolete scan. This is an audit job, not a publish, so
+# cancelling a superseded run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   zizmor:
+    name: Audit workflows (zizmor)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       security-events: write # upload the SARIF into the code-scanning tab
-      contents: read
+      contents: read # checkout the workflows to scan
     env:
       ZIZMOR_VERSION: "1.26.1"
     steps:


### PR DESCRIPTION
# What & why

zizmor's regular persona gates the workflow-security check (`.github/workflows/zizmor.yml`)
on actionable findings; its pedantic persona additionally surfaces low-severity
hygiene findings that are deliberately non-gating (see the header comment in
`zizmor.yml`). This addresses that pedantic backlog without touching the
release pipeline's trigger logic, artifact steps, or the MD5 sidecar. Closes #263.

## Per-finding disposition

| zizmor pedantic finding | Disposition |
|---|---|
| `undocumented-permissions` (×4 in the issue, all workflow/job `permissions:` blocks swept) | **Fixed**, added a one-line rationale comment above/near every `permissions:` block across all nine workflow files that lacked one. No permission scope was changed, only comments added. |
| `ref-version-mismatch` / `stale-action-refs` (×4: `softprops/action-gh-release` and `Kevinjil/jellyfin-plugin-repo-action`, each pinned twice) | **Fixed**, appended a trailing version comment to both pins in `publish.yml` and `publish-nightly.yml`. `Kevinjil/jellyfin-plugin-repo-action@2968503...` resolves to tag `v0.4.3`. `softprops/action-gh-release@132dbbba...` does not resolve to any tag, it sits between `v3.0.1` (2026-06-19) and `v3.0.2` (2026-07-13), so it is documented as `# unreleased commit between v3.0.1 and v3.0.2` rather than guessing a version. The pinned SHAs themselves are unchanged (bumping the pin is a separate decision, tracked by Dependabot PR #226). |
| `concurrency-limits` (×3 in the issue) | **Partially fixed, two accepted-with-reason.** Added a `concurrency:` (cancel-in-progress) block to `zizmor.yml`, a non-release audit workflow, same pattern already used by `dotnet.yml`/`prettier.yml`/`opengrep.yml`/`unicode-guard.yml`/`dependency-review.yml`. `publish.yml` and `publish-nightly.yml` are intentionally left without one: the release path must never be run-cancelled mid-publish, exactly as the issue and `zizmor.yml`'s own header comment already call out. `build.yml` is also intentionally left without one, it's a reusable `workflow_call` workflow invoked from two different callers (`dotnet.yml`'s `package` job and `publish.yml`'s `build` job), and a shared concurrency group there could cancel one caller's build because of another; that's a correctness/availability risk on the release path, not a hygiene fix, so it's declined. |
| `anonymous-definition` (×8 in the issue) | **Fixed for all but three, with a documented reason for those three.** Added `name:` to every previously-unnamed job in `build.yml`, `dotnet.yml` (`abi-floor`, `package`), `publish-nightly.yml`, `publish.yml` (`build`, `upload`, `generate`), and `zizmor.yml`. **Declined for `dotnet.yml`'s `build` job, `prettier.yml`'s `prettier` job, and `dependency-review.yml`'s `dependency-review` job**: the `Protect main` ruleset's required status checks (`gh api repos/iderex/jellyfin-plugin-sso/rulesets/18802863`) are the literal contexts `build`, `prettier`, `dependency-review`, GitHub uses the job id as the check-run name when no `name:` override is set. Adding a `name:` to those three would rename their check runs and silently break the required-status-check gate on every subsequent PR. This was caught empirically by two of the four adversarial-review lenses (availability, integration) against the live ruleset before this PR was opened, and reverted; each of the three jobs now carries a comment explaining why it stays anonymous. |
| `superfluous-actions` (×2, info) | **Deferred, untouched**, `softprops/action-gh-release` duplicates the runner's built-in `gh release`. Replacing it is a release-pipeline change touching both publish workflows, the MD5-sidecar/manifest flow, and the action Dependabot PR #226 already tracks a version bump for. Left for a separate, explicitly-scoped follow-up once that's decided, exactly as #263 asks. |

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches the release pipeline surface (`publish.yml`, `publish-nightly.yml`),
so it goes through the checklist even though every change in those two files
is a comment or a job `name:` field, no trigger, `if:` guard, permission
scope, pinned SHA, or artifact/manifest step was altered.

- [x] Fail-closed preserved: no validation logic touched (workflow metadata only).
- [x] No secrets logged; secrets are redacted on config export (unaffected - no
      step handling secrets was changed).
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline — ran the four-lens
      adversarial-review gate against this diff (availability, security-bypass,
      correctness, integration). Availability and integration both failed on
      the first pass over the required-status-check-name risk described above;
      that finding was fixed and independently corroborated by our own
      `gh api` check against the live ruleset before this PR was opened.
      Security-bypass and correctness passed clean.
- [x] Log inputs from the IdP are sanitized inline at the log call (unaffected, no logging changed).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit (N/A — no application code, workflow YAML only).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318) (N/A — workflow YAML).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (N/A — no `.cs` touched).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (N/A, no `.cs` changed; not run).
- [x] `dotnet test` is green (N/A, no `.cs` changed; not run).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (N/A, no such file changed).
- All nine touched workflow files were re-validated as syntactically valid
      YAML (`npx js-yaml`) after every edit, including the required-check fix.

## Notes

- `scorecard.yml` was read but not touched, it already carries named jobs,
  documented `permissions:` blocks, and a `concurrency:` block, so it already
  satisfies #263's acceptance criteria.
- The `Protect main` ruleset's required-status-check contexts were not changed
  in this PR, the safer fix was to leave those three job ids anonymous
  rather than touch branch-protection configuration in a hygiene PR.
