### PR TITLE
Surface a throttled capacity warning from SamlReplayCache

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -185,6 +185,29 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void LoginPathCaches_SurfaceAThrottledCapacityWarningThroughACapWarnGate()
+    {
+        // Locked in by #470: every login-path cache surfaces its cap-refusal as a throttled capacity
+        // warning through a DEDICATED IntervalGate field named "_capWarnGate", separate from the prune
+        // gate — so a full cache is observable to operators instead of a silent fail-closed reject, and a
+        // refusal burst cannot amplify into log volume. SamlRequestCache and OidcStateStore already had it
+        // (#246, #327); SamlReplayCache adopted it here so the parity holds for all three, and a later
+        // refactor cannot drop one cache's warning signal and re-open the silent-refusal gap. Keyed on the
+        // field NAME (not merely the IntervalGate type) so the prune gate cannot satisfy it vacuously.
+        const string capWarnGateField = "_capWarnGate";
+        var caches = new[] { typeof(SamlReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore) };
+        var missing = caches
+            .Where(t => !t.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                .Any(f => f.FieldType == typeof(IntervalGate) && f.Name == capWarnGateField))
+            .Select(SimpleName)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "Every login-path cache must surface a throttled cap-refusal capacity warning through a dedicated IntervalGate field (#470): " + string.Join(", ", missing));
+    }
+
+    [Fact]
     public void CanonicalLinkService_ThrottlesTheLegacyLinkWarningThroughAStaticIntervalGate()
     {
         // Locked in by #362 (CWE-400, log-volume): the terminal pending-legacy-link warnings live in a

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -45,7 +45,7 @@ public class ProviderScopedKeyTests
         var replayKey = ProviderScopedKey.For("kc", string.Empty);
         var requestKey = ProviderScopedKey.For("kc", null);
 
-        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now));
+        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now, out _));
 
         var requests = new SamlRequestCache();
         requests.Register(requestKey!, "binding", now.AddMinutes(15), now, clientKey: null, out _);

--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -19,8 +19,8 @@ public class SamlReplayCacheTests
         var cache = new SamlReplayCache();
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_assertion-1", expiry, Now));
-        Assert.False(cache.TryConsume("_assertion-1", expiry, Now));
+        Assert.True(cache.TryConsume("_assertion-1", expiry, Now, out _));
+        Assert.False(cache.TryConsume("_assertion-1", expiry, Now, out _));
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class SamlReplayCacheTests
         var cache = new SamlReplayCache();
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_a", expiry, Now));
-        Assert.True(cache.TryConsume("_b", expiry, Now));
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _));
     }
 
     [Theory]
@@ -39,7 +39,7 @@ public class SamlReplayCacheTests
     public void TryConsume_MissingId_FailsClosed(string? id)
     {
         var cache = new SamlReplayCache();
-        Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now));
+        Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now, out _));
     }
 
     [Fact]
@@ -48,13 +48,13 @@ public class SamlReplayCacheTests
         // Once retention has elapsed the entry is evicted; a fresh assertion reusing the id (a new
         // login, not a replay of the same still-valid assertion) is accepted again.
         var cache = new SamlReplayCache();
-        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now));
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now, out _));
 
         var later = Now.AddMinutes(20);
-        Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later, out _));
     }
 
-    // --- Hard cap + throttled prune (#452) ---
+    // --- Hard cap + throttled prune + throttled cap-refusal warning (#452, #470) ---
 
     // A cache whose cap is small and reachable (production 100k is not).
     private static SamlReplayCache SmallCache(int cap = 3) => new SamlReplayCache(cap, TimeSpan.FromMinutes(1));
@@ -69,12 +69,12 @@ public class SamlReplayCacheTests
         var cache = SmallCache(cap: 3);
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_x", expiry, Now));
-        Assert.True(cache.TryConsume("_f1", expiry, Now));
-        Assert.True(cache.TryConsume("_f2", expiry, Now)); // cache now full of live entries
+        Assert.True(cache.TryConsume("_x", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_f1", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_f2", expiry, Now, out _)); // cache now full of live entries
 
-        Assert.False(cache.TryConsume("_new", expiry, Now)); // fail closed: no live entry evicted
-        Assert.False(cache.TryConsume("_x", expiry, Now)); // X still recorded -> replay still caught
+        Assert.False(cache.TryConsume("_new", expiry, Now, out _)); // fail closed: no live entry evicted
+        Assert.False(cache.TryConsume("_x", expiry, Now, out _)); // X still recorded -> replay still caught
     }
 
     [Fact]
@@ -82,11 +82,57 @@ public class SamlReplayCacheTests
     {
         var cache = SmallCache(cap: 2);
         var expiry = Now.AddMinutes(10);
-        Assert.True(cache.TryConsume("_a", expiry, Now));
-        Assert.True(cache.TryConsume("_b", expiry, Now)); // at cap with live entries
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _)); // at cap with live entries
 
-        Assert.False(cache.TryConsume("_c", expiry, Now));
+        Assert.False(cache.TryConsume("_c", expiry, Now, out _));
         Assert.Equal(2, cache.Count); // the refusal did not grow or evict
+    }
+
+    [Fact]
+    public void TryConsume_Refused_SignalsTheCapacityWarningOncePerInterval()
+    {
+        // The cap-refusal warning is bounded exactly like the sweeps and the sibling caches (#470): the
+        // first refusal in an interval signals, further refusals inside the interval stay silent (so a
+        // burst of refusals cannot amplify into log volume), and the next interval signals again. It rides
+        // its OWN gate, so filling the cache and refusing never touches the prune gate.
+        var cache = SmallCache(cap: 1);
+        var expiry = Now.AddMinutes(10);
+
+        Assert.True(cache.TryConsume("_a", expiry, Now, out var admitWarn));
+        Assert.False(admitWarn); // an admitted consume never warns
+
+        Assert.False(cache.TryConsume("_b", expiry, Now, out var firstWarn));
+        Assert.True(firstWarn); // first cap refusal in the interval signals
+
+        Assert.False(cache.TryConsume("_c", expiry, Now.AddSeconds(1), out var secondWarn));
+        Assert.False(secondWarn); // a second refusal within the interval stays silent
+
+        var nextInterval = Now.AddMinutes(1);
+        Assert.False(cache.TryConsume("_d", nextInterval.AddMinutes(10), nextInterval, out var nextWarn));
+        Assert.True(nextWarn); // the next interval signals again
+    }
+
+    [Fact]
+    public void TryConsume_ReplayAndMissingId_DoNotSignalCapacityWarning()
+    {
+        // The warning is scoped to genuine capacity pressure only. A replay refusal and a missing-id
+        // refusal both still fail closed (the reject semantics are byte-identical to #452), but neither is
+        // capacity pressure, so neither signals — a hot replay attempt or a stream of id-less assertions
+        // cannot masquerade as a full cache. Production cap here, so the cap path never fires.
+        var cache = new SamlReplayCache();
+        var expiry = Now.AddMinutes(10);
+
+        Assert.True(cache.TryConsume("_a", expiry, Now, out var firstWarn));
+        Assert.False(firstWarn);
+
+        // A replay: rejected, but not a capacity signal.
+        Assert.False(cache.TryConsume("_a", expiry, Now, out var replayWarn));
+        Assert.False(replayWarn);
+
+        // A missing id: fails closed, and not a capacity signal.
+        Assert.False(cache.TryConsume(string.Empty, expiry, Now, out var missingWarn));
+        Assert.False(missingWarn);
     }
 
     [Fact]
@@ -96,14 +142,14 @@ public class SamlReplayCacheTests
         // the slots and the fresh login is admitted, even though the routine sweep is still throttled.
         var cache = SmallCache(cap: 3);
         var shortExpiry = Now.AddSeconds(30);
-        Assert.True(cache.TryConsume("_a", shortExpiry, Now)); // first call enters the prune gate
-        Assert.True(cache.TryConsume("_b", shortExpiry, Now));
-        Assert.True(cache.TryConsume("_c", shortExpiry, Now)); // at cap
+        Assert.True(cache.TryConsume("_a", shortExpiry, Now, out _)); // first call enters the prune gate
+        Assert.True(cache.TryConsume("_b", shortExpiry, Now, out _));
+        Assert.True(cache.TryConsume("_c", shortExpiry, Now, out _)); // at cap
 
         // 40s later: past the entries' expiry but within the 1-minute prune interval, so the routine sweep
         // is throttled. The cap path must still reclaim the expired entries and admit the new login.
         var later = Now.AddSeconds(40);
-        Assert.True(cache.TryConsume("_d", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_d", later.AddMinutes(10), later, out _));
         Assert.Equal(1, cache.Count); // only _d remains
     }
 
@@ -114,14 +160,14 @@ public class SamlReplayCacheTests
         // WITHIN the prune interval must leave the expired entry in place (an unthrottled sweep would drop
         // it) — proving the IntervalGate throttle is in effect.
         var cache = new SamlReplayCache(); // production cap: the cap path never fires here
-        Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now)); // enters the gate
+        Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now, out _)); // enters the gate
 
         var within = Now.AddSeconds(40); // past _a's expiry, within the 1-minute interval
-        Assert.True(cache.TryConsume("_b", within.AddMinutes(10), within));
+        Assert.True(cache.TryConsume("_b", within.AddMinutes(10), within, out _));
         Assert.Equal(2, cache.Count); // _a NOT swept -> prune is throttled
 
         var beyond = Now.AddSeconds(80); // past the interval: the sweep runs and reclaims _a
-        Assert.True(cache.TryConsume("_c", beyond.AddMinutes(10), beyond));
+        Assert.True(cache.TryConsume("_c", beyond.AddMinutes(10), beyond, out _));
         Assert.Equal(2, cache.Count); // _a reclaimed; _b and _c remain
     }
 
@@ -129,11 +175,11 @@ public class SamlReplayCacheTests
     public void TryConsume_ExpiredEntry_ReclaimedByThrottledPrune()
     {
         var cache = new SamlReplayCache();
-        Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now));
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now, out _));
 
         // A later consume past the prune interval sweeps the expired _a.
         var later = Now.AddMinutes(2);
-        Assert.True(cache.TryConsume("_b", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_b", later.AddMinutes(10), later, out _));
         Assert.Equal(1, cache.Count); // _a reclaimed, only _b remains
     }
 

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -338,8 +338,19 @@ internal sealed class SamlLoginService
         // the verified identity flows into the shared completion tail (SAML keys the link on the NameID and
         // carries no email_verified claim, so AdoptionGate.None; the resolver's admin-adoption refusal, #218,
         // still applies).
-        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
+        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection, out var shouldWarnCapacity))
         {
+            // A cap refusal — the process-wide replay cache is full of still-valid consumed assertions —
+            // is surfaced once per interval so operators see the replay cache under genuine pressure
+            // (extreme volume or a compromised IdP replaying signed assertions) instead of a silent
+            // fail-closed reject. The validator throttles the signal via its own cap-warn gate; the line
+            // stays here so the log-forging inline sanitizer never crosses a helper boundary (#470). A
+            // plain replay or a missing NameID leaves shouldWarnCapacity false, so only capacity is logged.
+            if (shouldWarnCapacity)
+            {
+                _logger.LogWarning("SAML login refused for provider {Provider}: the assertion replay cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(rejection);
         }
 
@@ -384,8 +395,17 @@ internal sealed class SamlLoginService
         // so InResponseTo is not correlated here — the replay cache is the applicable one-time-use
         // control. A replay is a client-caused 400 in the uniform SAML body, never a 500, and no longer
         // discloses the replay cache to the attacker who replayed.
-        if (!_validator.TryConsumeReplay(samlResponse, provider))
+        if (!_validator.TryConsumeReplay(samlResponse, provider, out var shouldWarnCapacity))
         {
+            // Same cap-refusal observability as the session-minting leg: a full replay cache is surfaced
+            // once per interval (throttled by the validator's cap-warn gate) rather than failing closed
+            // silently. The line stays here so the log-forging inline sanitizer never crosses a helper
+            // boundary (#470); a plain replay leaves shouldWarnCapacity false and is not logged.
+            if (shouldWarnCapacity)
+            {
+                _logger.LogWarning("SAML link refused for provider {Provider}: the assertion replay cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -88,18 +88,21 @@ internal sealed class SamlAssertionValidator
     /// Consumes the SAML assertion's ID against the provider-scoped replay cache for one-time use. Returns
     /// false when the assertion was already used (or carries no ID — a missing ID stays empty, so TryConsume
     /// fails closed). The key is scoped by provider so two IdPs emitting the same assertion ID cannot block
-    /// each other. Shared by the session mint and the account linking (#219).
+    /// each other. Shared by the session mint and the account linking (#219). Surfaces the cache's throttled
+    /// cap-refusal signal so the flow can log a full replay cache once per interval (#470); the warning line
+    /// stays at the flow so the log-forging inline sanitizer never crosses a helper boundary.
     /// </summary>
     /// <param name="samlResponse">The validated response whose assertion ID is consumed.</param>
     /// <param name="provider">The provider the assertion ID is scoped under.</param>
+    /// <param name="shouldWarnCapacity">True when the flow should emit the throttled capacity warning (a cap refusal, at most once per interval).</param>
     /// <returns>True on the first use; false on a replay (or a missing assertion ID).</returns>
-    internal bool TryConsumeReplay(SamlResponse samlResponse, string provider)
+    internal bool TryConsumeReplay(SamlResponse samlResponse, string provider, out bool shouldWarnCapacity)
     {
         var samlNow = DateTime.UtcNow;
         var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
         var assertionId = samlResponse.GetAssertionId();
         var replayKey = ProviderScopedKey.For(provider, assertionId);
-        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
+        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow, out shouldWarnCapacity);
     }
 
     /// <summary>
@@ -115,8 +118,9 @@ internal sealed class SamlAssertionValidator
     /// <param name="samlResponse">The validated, allow-listed, correlated response.</param>
     /// <param name="identity">The verified identity on success; otherwise null.</param>
     /// <param name="rejection">The fail-closed outcome on failure; otherwise null.</param>
+    /// <param name="shouldWarnCapacity">True when the flow should emit the throttled capacity warning — set from the replay consume, so it is true only on a cap refusal (never a replay or a missing NameID).</param>
     /// <returns>True with <paramref name="identity"/> set on success; false with <paramref name="rejection"/> set.</returns>
-    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, out VerifiedIdentity identity, out LoginOutcome rejection)
+    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, out VerifiedIdentity identity, out LoginOutcome rejection, out bool shouldWarnCapacity)
     {
         identity = null;
 
@@ -124,8 +128,10 @@ internal sealed class SamlAssertionValidator
         // Enforced only at the session-minting endpoint (and the link redeem), not at the SAML/post ACS
         // which merely renders the intermediate page, so the two-step post-then-auth flow consumes the id
         // once. A replay is a client-caused 400 in the uniform SAML body — it no longer discloses the replay
-        // cache to the attacker who replayed, and the log-side diagnosis is unchanged.
-        if (!TryConsumeReplay(samlResponse, provider))
+        // cache to the attacker who replayed, and the log-side diagnosis is unchanged. The consume also sets
+        // shouldWarnCapacity (true only on a cap refusal), so a full replay cache is surfaced to the flow;
+        // every later exit path here leaves it at the consume's value (false, since the consume succeeded).
+        if (!TryConsumeReplay(samlResponse, provider, out shouldWarnCapacity))
         {
             rejection = new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid);
             return false;

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -8,7 +8,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
 /// reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
 /// bound (#452). It mirrors the sibling login-path caches (<see cref="SamlRequestCache"/>,
-/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap.
+/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and —
+/// at the cap — a throttled cap-refusal capacity-warning signal surfaced to the flow so a full replay
+/// cache is observable rather than silent (#470).
 ///
 /// The cap is applied differently from the siblings, on purpose. Recording a consumed assertion is what
 /// makes a replay detectable, so this cache must never drop a still-valid entry to free a slot — that
@@ -43,6 +45,16 @@ internal sealed class SamlReplayCache
     // backward wall-clock step of at least the interval (#334). See PruneExpired.
     private readonly IntervalGate _pruneGate;
 
+    // Throttles the cap-refusal capacity warning to one signal per interval (#470, CWE-400): its OWN gate,
+    // separate from the prune gate, so the sweep cadence and the warning cadence never interfere. Under a
+    // burst of cap refusals (extreme login volume, or a compromised identity provider replaying signed
+    // assertions) every refusal would otherwise emit a warning, amplifying into unbounded log volume. The
+    // gate self-heals a backward wall-clock step of at least the interval (#334). Mirrors the siblings so
+    // the SAML replay refusal has the same operator visibility the OpenID/SAML-request caches already give
+    // (#246, #327); the warning line itself stays at the flow so the log-forging inline sanitizer never
+    // crosses a helper boundary.
+    private readonly IntervalGate _capWarnGate;
+
     internal SamlReplayCache()
         : this(DefaultMaxEntries, DefaultPruneInterval)
     {
@@ -54,6 +66,7 @@ internal sealed class SamlReplayCache
     {
         _maxEntries = maxEntries;
         _pruneGate = new IntervalGate(pruneInterval);
+        _capWarnGate = new IntervalGate(pruneInterval);
     }
 
     /// <summary>Gets the live entry count. Test-only, so the cap and sweep paths can be asserted.</summary>
@@ -88,14 +101,19 @@ internal sealed class SamlReplayCache
     /// Records the assertion ID as consumed. Returns false when the assertion has no usable ID, has
     /// already been consumed within its validity window (a replay), or the cache is full of still-valid
     /// entries (a fail-closed cap refusal). A false return always rejects the login, so refusing at the
-    /// cap never reopens the replay window.
+    /// cap never reopens the replay window. Adding the capacity signal did not change this reject behavior:
+    /// the boolean outcome and the no-live-entry-eviction rule are byte-identical to #452 (#470).
     /// </summary>
     /// <param name="assertionId">The assertion ID.</param>
     /// <param name="expiryUtc">When the entry may be evicted (the assertion's retention horizon).</param>
     /// <param name="nowUtc">The current time.</param>
+    /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning — a
+    /// cap refusal only, at most once per interval. A replay or a missing ID leaves it false, so only genuine
+    /// capacity pressure is surfaced.</param>
     /// <returns>True if this is the first use; false on replay, a missing ID, or a fail-closed cap refusal.</returns>
-    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc)
+    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc, out bool shouldWarnCapacity)
     {
+        shouldWarnCapacity = false;
         PruneExpired(nowUtc);
 
         // Fail closed: without an ID we cannot enforce one-time use.
@@ -114,6 +132,10 @@ internal sealed class SamlReplayCache
             SweepExpired(nowUtc);
             if (_consumed.Count >= _maxEntries && !_consumed.ContainsKey(assertionId))
             {
+                // Fail-closed cap refusal: the cache is genuinely full of still-valid entries. Signal the
+                // operator (throttled to one per interval by the dedicated cap-warn gate) that the replay
+                // cache is under real pressure — observability only, the refusal itself is unchanged (#470).
+                shouldWarnCapacity = _capWarnGate.TryEnter(nowUtc);
                 return false;
             }
         }


### PR DESCRIPTION
# What & why

The 100k cap on `SamlReplayCache` (#452) refuses a new SAML assertion fail-closed at the cap, but did so **silently**, unlike its sibling login-path caches (`OidcStateStore`, `SamlRequestCache`) it exposed no capacity signal. A full replay cache is reached only under extreme volume or a compromised identity provider replaying signed assertions, and until now that condition was invisible to operators.

This mirrors the sibling pattern to make the refusal observable. It is pure observability parity, the replay and fail-closed semantics are untouched.

- `SamlReplayCache.TryConsume` surfaces a throttled `shouldWarnCapacity` out of its cap-refusal path, gated by its **own** cap-warn `IntervalGate` (separate from the prune gate) so a refusal burst cannot amplify into log volume (CWE-400).
- `SamlAssertionValidator` threads the signal out through `TryConsumeReplay` and `TryProduceVerifiedIdentity`.
- `SamlLoginService` logs it **once per interval at the flow boundary** on both the session-mint (`AuthenticateAsync`) and manual-link (`Link`) legs, with the provider inline-sanitized (`provider?.ReplaceLineEndings(string.Empty)`) so the log-forging sanitizer never crosses a helper boundary.

The reject behaviour is byte-identical: `TryConsume`'s boolean outcomes and the never-evict-a-live-entry rule (#32) are unchanged; the signal only decides whether to log. A replay or a missing assertion id fails closed and does **not** warn, only genuine cap pressure is surfaced, so the signal cannot be read as a per-assertion oracle.

Closes #470

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Observability parity on the SAML login path; no behaviour change. Quality milestone P3.

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted. `TryConsume` still refuses a new assertion at the cap and rejects a replay/missing-id, byte-identical to #452 (confirmed by the review gate and the retained cap/replay tests).
- [x] No secrets logged; secrets are redacted on config export. The new warning logs only the route-derived, already-validated provider name, no assertion id, NameID, or signature material.
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. Full adversarial four-lens review plus the SAML domain reviewer; results under Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call. `provider?.ReplaceLineEndings(string.Empty)` inline at both `LogWarning` sites.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. Reuses the existing `IntervalGate`; the signal is one out-param threaded through the tiers.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318). Comments cover the throttle rationale, the own-gate separation, and the byte-identical semantics.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`. New rule `LoginPathCaches_SurfaceAThrottledCapacityWarningThroughACapWarnGate` pins the `_capWarnGate` parity across all three login-path caches.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Debug and Release, both projects, 0 warnings.
- [x] `dotnet test` is green. 1066 passed, 0 failed (+3 new tests over the base).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. n/a, no such files touched.

## Notes

Adversarial review gate, five refute-by-default lenses, each reading the full touched files plus their callers:

- availability / mass-lockout, PASS. No new false-reject; the added `LogWarning` is null-safe and the gate is lock-free; nothing evicts a live entry.
- security-bypass / fail-open, PASS. The boolean return that gates login is byte-identical; `shouldWarnCapacity` is read only to decide whether to log, never to admit.
- correctness, PASS. `shouldWarnCapacity` is definitely-assigned on every path (false on success/replay/missing-id, true only on a cap refusal); the once-per-interval throttle test timeline is valid to the exact interval boundary; the `_capWarnGate` CAS is thread-safe.
- integration, PASS. Both flow call sites updated; log wording matches the sibling pattern; the sibling `SamlRequestCache.TryConsume` is untouched; the new conformance rule is non-vacuous.
- SAML domain, PASS. The #32 no-eviction invariant is intact; the warning fires only on new-id capacity pressure (silent on a replay) and is never surfaced in the HTTP body, so it is not an oracle; replay is enforced identically at both legs.

The three required confirmations were affirmed by every lens: (a) the fail-closed replay semantics are byte-identical; (b) the warning path is throttled by the dedicated cap-warn gate and cannot be abused (no log-flood, no oracle); (c) there is no cross-interaction with the prune gate, independent `IntervalGate` instances with independent cursors.

Out of scope: none.
