### PR TITLE
Force-refresh the SSO avatar when the on-disk file is missing

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -447,8 +447,10 @@ public class AvatarServiceTests
 
     // Builds a service over a StubHandler the test keeps a handle to, so it can assert the conditional
     // fetch header and the handler reuse count (#248). The logger is returned too, so a test can assert the
-    // 304 path took the early return rather than a swallowed error.
-    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, StubHandler Handler, CapturingLogger Log) BuildWithHandler(HttpResponseMessage response)
+    // 304 path took the early return rather than a swallowed error. The on-disk probe (#480) defaults to
+    // "present" so the conditional-cadence tests exercise the normal file-present path; the missing-file
+    // self-heal tests pass their own predicate returning false.
+    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, StubHandler Handler, CapturingLogger Log) BuildWithHandler(HttpResponseMessage response, Func<string, bool>? fileExists = null)
     {
         var users = Substitute.For<IUserManager>();
         var providers = Substitute.For<IProviderManager>();
@@ -456,7 +458,7 @@ public class AvatarServiceTests
         serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
         var handler = new StubHandler(response);
         var log = new CapturingLogger();
-        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", new HttpClient(handler));
+        var service = new AvatarService(users, providers, serverConfig, log, "test-agent/1.0", new HttpClient(handler), fileExists: fileExists ?? (_ => true));
         return (service, providers, users, handler, log);
     }
 
@@ -513,6 +515,68 @@ public class AvatarServiceTests
         await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
 
         Assert.Null(handler.LastIfModifiedSince);
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public async Task TrySetAsync_ProfileFileMissingOnDisk_FetchesUnconditionallyAndReStores()
+    {
+        // #480: the ImageInfo record is live but the on-disk profile.* file was deleted out-of-band. Under the
+        // conditional-fetch cadence (#248) this login would send If-Modified-Since, get a 304, and skip the
+        // re-download — so the avatar could never self-heal from the surviving record. With the local file
+        // absent we now fetch UNCONDITIONALLY (no If-Modified-Since) and re-store, restoring the file. This is
+        // the self-heal that the always-download behaviour had before #248, back for the missing-file case only.
+        using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
+        var (service, providers, _, handler, _) = BuildWithHandler(response, fileExists: _ => false);
+        var user = UserNamed("alice");
+        user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+
+        await service.TrySetAsync(user, AllowedUrl);
+
+        Assert.Null(handler.LastIfModifiedSince); // the missing file forced a full, unconditional fetch
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+    }
+
+    [Fact]
+    public async Task TrySetAsync_ProfileFileMissingOnDisk_SuppressesConditionalEvenUnderAStubbornNotModified()
+    {
+        // #480 fail-closed edge: with the local file gone we must NOT advertise our stale last-store timestamp,
+        // so If-Modified-Since is withheld even though the record still carries a valid one — the file-existence
+        // gate overrides the timestamp-based conditional. A well-behaved origin then re-sends the image (asserted
+        // above); a non-compliant origin that answers 304 to an UNCONDITIONAL request refuses us the bytes, so
+        // the best-effort path simply keeps the existing record and, critically, never throws into the login.
+        // Pins that the header is suppressed and that the 304 short-circuit stays safe when the file is missing.
+        using var response = NotModifiedResponse();
+        var (service, providers, users, handler, log) = BuildWithHandler(response, fileExists: _ => false);
+        var user = UserNamed("alice");
+        var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
+        user.ProfileImage = previous;
+
+        await service.TrySetAsync(user, AllowedUrl);
+
+        Assert.Null(handler.LastIfModifiedSince); // the stale timestamp was deliberately withheld
+        Assert.Same(previous, user.ProfileImage); // best-effort: the record is left untouched
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        Assert.DoesNotContain(log.Entries, e => e.Level == LogLevel.Error); // never throws into login
+    }
+
+    [Fact]
+    public async Task TrySetAsync_ProfileImageWithoutRealTimestamp_FetchesUnconditionallyEvenWithFilePresent()
+    {
+        // Fail-closed edge on the re-validation anchor: a live ImageInfo whose LastModified is the sentinel
+        // DateTime.MinValue (a record with no real "when we last stored it" time) offers no basis for a 304,
+        // so even with the on-disk file present we fetch UNCONDITIONALLY rather than advertise a bogus year-0001
+        // If-Modified-Since. Pins the `lastStored > DateTime.MinValue` guard that the #480 hunk carries: a
+        // `>`->`>=` slip would send the sentinel as the conditional header, which this asserts against.
+        using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
+        var (service, providers, _, handler, _) = BuildWithHandler(response); // file present (default _ => true)
+        var user = UserNamed("alice");
+        user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = DateTime.MinValue };
+
+        await service.TrySetAsync(user, AllowedUrl);
+
+        Assert.Null(handler.LastIfModifiedSince); // no real anchor -> unconditional despite the file being present
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
     }
 

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -49,6 +49,7 @@ internal sealed class AvatarService
     private readonly string _userAgent;
     private readonly HttpClient _httpClient;
     private readonly KeyedLockStore _userStoreLocks;
+    private readonly Func<string, bool> _fileExists;
 
     internal AvatarService(
         IUserManager userManager,
@@ -74,6 +75,7 @@ internal sealed class AvatarService
     /// <param name="userAgent">The outbound User-Agent.</param>
     /// <param name="httpClient">The client used for every fetch; reused across calls (never disposed here).</param>
     /// <param name="userStoreLocks">The per-user store lock (#400); null uses the process-wide shared one. A test injects its own so it can drive the serialization deterministically.</param>
+    /// <param name="fileExists">Probe for the on-disk profile image (#480); null uses <see cref="File.Exists"/>. A test injects its own to drive the missing-file self-heal branch without touching the filesystem.</param>
     internal AvatarService(
         IUserManager userManager,
         IProviderManager providerManager,
@@ -81,7 +83,8 @@ internal sealed class AvatarService
         ILogger logger,
         string userAgent,
         HttpClient httpClient,
-        KeyedLockStore userStoreLocks = null)
+        KeyedLockStore userStoreLocks = null,
+        Func<string, bool> fileExists = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
         _providerManager = providerManager ?? throw new ArgumentNullException(nameof(providerManager));
@@ -90,6 +93,7 @@ internal sealed class AvatarService
         _userAgent = userAgent ?? throw new ArgumentNullException(nameof(userAgent));
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _userStoreLocks = userStoreLocks ?? SharedUserStoreLocks;
+        _fileExists = fileExists ?? File.Exists;
     }
 
     /// <summary>
@@ -125,15 +129,23 @@ internal sealed class AvatarService
             using var request = new HttpRequestMessage(HttpMethod.Get, avatarUri);
             request.Headers.UserAgent.ParseAdd(_userAgent);
 
-            // Conditional refresh (#248): when we already hold this user's avatar, ask the origin to send
-            // fresh bytes only if the image changed since we last stored it. If-Modified-Since carries the
-            // timestamp of our last store (ProfileImage.LastModified) — exactly "when we last fetched this
-            // representation" — so an unchanged avatar answers 304 and we skip the re-download AND the
-            // re-store entirely; only a changed image (200) is fetched and re-stored. An origin that ignores
-            // the header just answers 200 as before, so this degrades safely to the old always-download.
-            // SpecifyKind(Utc) makes the DateTimeOffset construction total regardless of the stored Kind;
-            // ProfileImage.LastModified is already written as DateTime.UtcNow, so no time is shifted.
-            if (user.ProfileImage?.LastModified is { } lastStored && lastStored > DateTime.MinValue)
+            // Conditional refresh (#248) — but only while we still hold this user's avatar ON DISK. When we
+            // have the file, ask the origin for fresh bytes only if the image changed since our last store:
+            // If-Modified-Since carries that store's timestamp (ProfileImage.LastModified) — exactly "when we
+            // last fetched this representation" — so an unchanged avatar answers 304 and we skip the
+            // re-download AND the re-store; only a changed image (200) is fetched and re-stored.
+            // Force-refresh on a missing file (#480): if the ImageInfo record is live but the profile.* file
+            // was deleted out-of-band, sending the conditional would let a 304 skip the re-download and the
+            // avatar could never self-heal from the live record — so when the local file is absent we omit
+            // If-Modified-Since and fetch unconditionally to restore it. An origin that ignores the header
+            // just answers 200 as before, so the file-present case still degrades safely to the old
+            // always-download. SpecifyKind(Utc) makes the DateTimeOffset construction total regardless of the
+            // stored Kind; ProfileImage.LastModified is already written as DateTime.UtcNow, so no time shifts.
+            var storedImage = user.ProfileImage;
+            if (storedImage?.LastModified is { } lastStored
+                && lastStored > DateTime.MinValue
+                && storedImage.Path is { } storedPath
+                && _fileExists(storedPath))
             {
                 request.Headers.IfModifiedSince = new DateTimeOffset(DateTime.SpecifyKind(lastStored, DateTimeKind.Utc));
             }


### PR DESCRIPTION
# What & why

We fix a self-heal regression in the login-time SSO avatar sync (#480). Since
the avatar fetch became conditional via `If-Modified-Since` (#248), a login
whose on-disk `profile.*` file was deleted out-of-band, while the DB
`user.ProfileImage` (`ImageInfo`) record survives, receives a **304 Not
Modified** and skips the re-download, so the avatar can no longer be restored
from the live record.

We chose **force-refresh-on-missing-file**: when the `ImageInfo` record is live
but its `profile.*` file is absent on disk, we omit `If-Modified-Since` and
fetch unconditionally so the avatar self-heals; the conditional cadence (#248)
is preserved for the normal file-present case. The on-disk probe is an injected
`Func<string,bool>` defaulting to `File.Exists`, matching the existing
test-seam idiom (the #385 `HttpClient` and #400 `KeyedLockStore` seams), so the
missing-file branch is unit-testable without touching the filesystem.

Issue #480 acceptance, a decision is recorded: **force-refresh-on-missing-file**
(not document-accept).

Closes #480

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This touches the login-time avatar sync path. The IdP-supplied avatar URL is
attacker-influenced, but the fetch path itself (the SSRF `ConnectCallback`, the
content-type allow-list, the size cap, and the 10s deadline) is unchanged, we
only gate whether the `If-Modified-Since` header is sent.

- [x] Fail-closed preserved: the change only decides whether to send
      `If-Modified-Since`; every outbound fetch still runs the unchanged
      SSRF / content-type / size guards, and the new branch fails **toward**
      re-download, never toward skipping a guard.
- [x] No secrets logged; secrets are redacted on config export. (No logging
      changed; no secrets are involved.)
- [x] A security review was performed: the adversarial correctness and
      availability lenses read the full touched files plus the caller
      (`SessionMinter.MintAsync` / `SSOController`) — results under Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call. (Unchanged;
      this change adds no new log call — the existing disallowed-URL and
      content-type warnings already strip line endings inline.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit (a one-clause extension of the existing conditional plus a
      `Func<string,bool>` seam).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. No new structural property was
      established (this is a behavioral gate, not a new architectural boundary),
      so no new `ArchitectureConformanceTests` rule was required.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green, Debug **and** Release.
- [x] `dotnet test` is green, 1066 tests (1063 baseline + 3 new), including
      `ArchitectureConformanceTests`.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - N/A,
      no such files touched (only `.cs`).

## Notes

**Adversarial review**, two refute-by-default lenses ran on the full touched
files plus the caller:

- **correctness-lens → PASS.** Ran an empirical mutation probe: reverting the
  guard fails exactly the two core new tests (so they are non-vacuous) while the
  #248 cadence tests keep passing (so the normal case is not regressed).
  Confirmed the guard reads `Path` and `LastModified` from one `ImageInfo`
  capture, short-circuits safely (no NRE, `File.Exists` never throws), and that
  the stored path equals the path the store writes, so the existence check is
  meaningful; any TOCTOU only costs one extra login of self-heal latency and
  never fails open. Flagged one optional in-diff mutation survivor on the
  pre-existing `lastStored > DateTime.MinValue` clause; we closed it with a
  third test (a `MinValue`-anchor record fetches unconditionally even with the
  file present).
- **availability-lens → PASS.** Confirmed no fetch-amplification: the
  unconditional path self-limits to a single fetch, a successful store rewrites
  the file to exactly the recorded path, so the next login's existence check
  passes and the conditional 304 cadence resumes. The path is best-effort
  (wrapped in the existing catch, so it never blocks or locks out login),
  bounded by the unchanged 10s deadline and 10MB cap, and the trigger (deleting
  the on-disk file while the DB record survives) requires host filesystem
  access, not an attacker capability. A non-compliant origin that answers 304
  to an unconditional request is handled by the early return without a throw.

**N/A:** crypto (SAML/OIDC), config persistence, and the release pipeline are
untouched.

**Out of scope:** none identified.
