### PR TITLE
Replace the SAML assertion browser round-trip with a one-time outcome token

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -242,6 +242,39 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void SamlLoginOutcome_IsImmutable()
+    {
+        // Locked in by the SAML one-time outcome token (#251): the login outcome stored between the ACS
+        // callback and the mint leg is redeemed by an atomic remove of the WHOLE record, so a redeemer never
+        // observes a torn outcome. A settable property or writable instance field would reopen an in-place
+        // mutation window on a value that IS the proof the assertion passed every gate, so pin it structurally
+        // exactly as AuthorizeSession's variants are (#341). A get-only auto-property / positional record
+        // parameter compiles to a readonly (initonly) backing field and passes; a `{ get; set; }` or a plain
+        // writable field would be flagged.
+        var outcome = typeof(SamlLoginOutcome);
+        Assert.True(outcome.IsSealed, "SamlLoginOutcome must be a sealed leaf.");
+
+        const BindingFlags members = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        var mutable = outcome.GetProperties(members)
+            .Where(p => p.SetMethod is not null && !IsInitOnlySetter(p.SetMethod))
+            .Select(p => $"{SimpleName(outcome)}.{p.Name} (settable property)")
+            .Concat(outcome.GetFields(members)
+                .Where(f => !f.IsInitOnly && !f.IsLiteral && !f.Name.Contains('<', StringComparison.Ordinal))
+                .Select(f => $"{SimpleName(outcome)}.{f.Name} (writable field)"))
+            .ToList();
+
+        Assert.True(
+            mutable.Count == 0,
+            "SamlLoginOutcome must be immutable (no settable property or writable instance field) so the store's one-time redeem stays torn-read-free (#251): " + string.Join(", ", mutable));
+    }
+
+    // A record's positional properties expose an `init` setter (SetMethod is non-null) but are immutable
+    // after construction; treat an init-only setter as read-only so a record's own positional members are
+    // not mis-flagged as mutable. An init-only setter carries the IsExternalInit modreq on its return type.
+    private static bool IsInitOnlySetter(MethodInfo setter) =>
+        setter.ReturnParameter.GetRequiredCustomModifiers().Any(m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+    [Fact]
     public void VerifiedIdentity_IsConstructedOnlyByProtocolValidators()
     {
         // Locked in by #473: VerifiedIdentity is the keystone the session-minting path is keyed on, and it

--- a/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// End-to-end tests of the SAML one-time login-outcome token (#251): the assertion-consumer callback
+/// validates the signed assertion ONCE and renders the intermediate page carrying only an opaque token
+/// (never the assertion); posting that token to SAML/Auth redeems the already-verified outcome and mints
+/// the session without re-parsing or re-validating the assertion. They pin the token is single-use, an
+/// unknown/expired token is refused, the one-time replay guard fires exactly once (at the callback), the
+/// browser binding still gates a solicited login on the token path, and the pre-#251 deprecation shape
+/// (the full assertion posted to SAML/Auth) still fully validates and logs in during the window.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlTokenTests
+{
+    private static readonly Guid UserId = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+    // Extracts the one-time token the auth page carries: WebResponse renders it as `var data = "<hex>";`.
+    private static string ExtractToken(ActionResult callbackResult)
+    {
+        var page = Assert.IsType<ContentResult>(callbackResult);
+        var match = Regex.Match(page.Content!, "var data = \"([0-9A-F]{64})\"");
+        Assert.True(match.Success, "the login auth page must carry a 64-hex one-time token, not the assertion");
+        return match.Groups[1].Value;
+    }
+
+    private static SsoControllerHarness ProvisioningHarness(SamlFixture fixture, out User user)
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        var provisioned = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(provisioned);
+        harness.UserManager.GetUserById(UserId).Returns(provisioned);
+        user = provisioned;
+        return harness;
+    }
+
+    [Fact]
+    public async Task LoginRoundTrip_CallbackRendersToken_TokenMintsSession()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+
+        // The callback validates the assertion once and hands the page a token, not the base64 assertion.
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+
+        // Posting the token (never the assertion) mints the session — no re-parse, no second validation.
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task Token_IsSingleUse_ReplayRejectsWithoutSecondMint()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+
+        // The atomic redeem removed the outcome, so a replay of the token finds nothing and is refused —
+        // a client-caused 400 in the uniform SAML body, and no second session is minted.
+        var replay = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        Assert.Equal(400, replay.StatusCode);
+        Assert.Equal("SAML response validation failed", replay.Content);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task UnknownToken_Rejects()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+
+        // A token that was never issued misses the store and falls through to the deprecation validation,
+        // which fails closed: its decoded bytes are not a SAML response, so the XML parse rejects it — a
+        // clean fail-closed 400, nothing minted.
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = SamlOutcomeStore.NewToken() }));
+        Assert.Equal(400, result.StatusCode);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ExpiredToken_Rejects()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+
+        // Seed an outcome whose lifetime has already elapsed (Created well in the past): the redeem rejects
+        // it as out of its window, so it cannot mint even though its token is otherwise well-formed.
+        var identity = VerifiedIdentity.FromValidatedSaml("adfs", "alice", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
+        var token = SamlOutcomeStore.NewToken();
+        SamlLoginService.SeedSamlOutcomeForTests(new SamlLoginOutcome(token, "adfs", identity, string.Empty, null, DateTime.UtcNow.AddHours(-1)));
+
+        var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        Assert.Equal(400, result.StatusCode);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ReplayGuard_FiresExactlyOnce_AtTheCallback()
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+        var assertion = fixture.EncodeResponse();
+
+        // The first callback validates and consumes the assertion's one-time id, minting a token.
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+
+        // Re-posting the SAME assertion to the callback is refused by the replay guard (its id was already
+        // consumed at the first callback) — the token round-trip did not skip the one-time-use control.
+        var replayCallback = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        Assert.Equal(400, replayCallback.StatusCode);
+
+        // The token from the first, valid callback still mints exactly once.
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task DeprecationWindow_FullAssertionPostedToAuth_StillValidatesAndLogsIn()
+    {
+        // The pre-#251 intermediate page embeds the full assertion and posts it straight to SAML/Auth. For
+        // the deprecation window that legacy shape must still FULLY validate and mint, so an admin upgrading
+        // mid-login does not break a user's in-flight login. (No prior callback ran, so nothing consumed the
+        // assertion's one-time id — the deprecation branch validates and consumes it here.)
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.IsType<OkObjectResult>(result);
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    private const string AuthnRequestId = "_authnreq-251";
+    private const string Binding = "251251251251251251251251251251251251251251251251251251251251251A";
+
+    [Fact]
+    public async Task SolicitedTokenFlow_MatchingBindingCookie_Mints()
+    {
+        // A solicited login (the assertion carries an InResponseTo for a request this server issued): the
+        // browser binding still gates the token path, and it is enforced at SAML/Auth — the same-origin leg
+        // where the cookie is sent — not at the cross-site callback. The stored outcome carries the
+        // InResponseTo so the mint leg can correlate it without the assertion.
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
+        var harness = ProvisioningHarness(fixture, out _);
+        SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
+
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.SamlCookieName}={Binding}";
+
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task SolicitedTokenFlow_MissingBindingCookie_RejectsWithoutMint()
+    {
+        // The forced-login shape on the token path: the token is redeemed in a browser that never started
+        // the flow, so it carries no binding cookie. Fail closed; nothing is minted.
+        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
+        var harness = ProvisioningHarness(fixture, out _);
+        SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
+
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        // No binding cookie set.
+
+        var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+}

--- a/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlOutcomeStore"/> — the one-time SAML login-outcome store (#251): an outcome
+/// registered at the ACS callback is redeemable exactly once at the mint leg, is scoped to its own
+/// provider so a token cannot be replayed against another's endpoint, expires with its lifetime, and
+/// bounds per-client occupancy so one source cannot fill it. This is the SAML analogue of the OpenID
+/// authorize-state store's one-time redeem; the properties mirror <see cref="SamlRequestCache"/>'s.
+/// </summary>
+public class SamlOutcomeStoreTests
+{
+    private static readonly DateTime Now = new DateTime(2026, 7, 18, 12, 0, 0, DateTimeKind.Utc);
+
+    // A store whose per-key sub-cap is small and reachable (global 200 -> per-key 2).
+    private static SamlOutcomeStore SmallStore() => new SamlOutcomeStore(200, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
+
+    // A verified identity is opaque to the store; any real one will do. Built through the SAML factory so
+    // the test does not forge one (its constructor is private).
+    private static VerifiedIdentity Identity(string provider = "adfs") =>
+        VerifiedIdentity.FromValidatedSaml(provider, "alice", SamlAuthorizeStateBuilder.Build(new List<string>(), new SamlConfig()));
+
+    private static SamlLoginOutcome Outcome(string token, string provider = "adfs", string inResponseTo = "", string? clientKey = null, DateTime? created = null) =>
+        new SamlLoginOutcome(token, provider, Identity(provider), inResponseTo, clientKey, created ?? Now);
+
+    [Fact]
+    public void Add_ThenRedeem_SucceedsOnce_ThenReplayReturnsNull()
+    {
+        var store = new SamlOutcomeStore();
+        Assert.True(store.TryAdd(Outcome("tok-1"), out _));
+
+        var redeemed = store.TryRedeem("tok-1", "adfs", Now);
+        Assert.NotNull(redeemed);
+        Assert.Equal("alice", redeemed!.Identity.Username);
+
+        // Single-use: a replay of the same token finds nothing (the atomic redeem removed it).
+        Assert.Null(store.TryRedeem("tok-1", "adfs", Now));
+    }
+
+    [Fact]
+    public void Redeem_UnknownToken_ReturnsNull()
+    {
+        var store = new SamlOutcomeStore();
+        Assert.Null(store.TryRedeem("never-issued", "adfs", Now));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void Redeem_BlankToken_ReturnsNull(string? token)
+    {
+        var store = new SamlOutcomeStore();
+        Assert.Null(store.TryRedeem(token!, "adfs", Now));
+    }
+
+    [Fact]
+    public void Redeem_WrongProvider_ReturnsNull_AndDoesNotConsumeTheOutcome()
+    {
+        // Cross-provider replay guard: an outcome verified for one provider is not redeemable on another's
+        // mint endpoint, and the failed attempt must NOT consume it — the correct provider still redeems.
+        var store = new SamlOutcomeStore();
+        store.TryAdd(Outcome("tok-1", provider: "adfs"), out _);
+
+        Assert.Null(store.TryRedeem("tok-1", "other", Now));
+        Assert.NotNull(store.TryRedeem("tok-1", "adfs", Now));
+    }
+
+    [Fact]
+    public void Redeem_AfterExpiry_ReturnsNull()
+    {
+        var store = new SamlOutcomeStore(200, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
+        store.TryAdd(Outcome("tok-1", created: Now), out _);
+
+        // Past the lifetime the outcome is no longer redeemable, even though the sweep may not have run.
+        Assert.Null(store.TryRedeem("tok-1", "adfs", Now.AddMinutes(16)));
+    }
+
+    [Fact]
+    public void Redeem_NegativeAge_ReturnsNull()
+    {
+        // A backward clock step (Created in the future relative to now) must not make an outcome
+        // effectively never expire — it is rejected as out of its window.
+        var store = new SamlOutcomeStore();
+        store.TryAdd(Outcome("tok-1", created: Now.AddMinutes(5)), out _);
+
+        Assert.Null(store.TryRedeem("tok-1", "adfs", Now));
+    }
+
+    [Fact]
+    public void PruneExpired_RemovesExpired_KeepsLive()
+    {
+        var store = new SamlOutcomeStore(200, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
+        store.TryAdd(Outcome("old", created: Now), out _);
+        store.TryAdd(Outcome("fresh", created: Now.AddMinutes(20)), out _);
+
+        store.PruneExpired(Now.AddMinutes(20));
+
+        Assert.Null(store.TryRedeem("old", "adfs", Now.AddMinutes(20)));
+        Assert.NotNull(store.TryRedeem("fresh", "adfs", Now.AddMinutes(20)));
+    }
+
+    [Fact]
+    public void Add_FloodFromOneKey_DoesNotRefuseADifferentKey()
+    {
+        // Fairness: filling client "A" to its per-key share must not deny a login from client "B".
+        var store = SmallStore(); // per-key cap 2
+        Assert.True(store.TryAdd(Outcome("a1", clientKey: "A"), out _));
+        Assert.True(store.TryAdd(Outcome("a2", clientKey: "A"), out _));
+        Assert.False(store.TryAdd(Outcome("a3", clientKey: "A"), out var warn)); // A at its share
+        Assert.True(warn); // the throttled capacity warning fires for the first refusal in the interval
+
+        Assert.True(store.TryAdd(Outcome("b1", clientKey: "B"), out _)); // B is unaffected
+    }
+
+    [Fact]
+    public void Add_ReleaseOnRedeem_ReadmitsTheSameKey()
+    {
+        var store = SmallStore(); // per-key cap 2
+        store.TryAdd(Outcome("a1", clientKey: "A"), out _);
+        store.TryAdd(Outcome("a2", clientKey: "A"), out _);
+        Assert.False(store.TryAdd(Outcome("a3", clientKey: "A"), out _)); // full
+
+        Assert.NotNull(store.TryRedeem("a1", "adfs", Now)); // frees one A slot
+        Assert.True(store.TryAdd(Outcome("a3", clientKey: "A"), out _));
+    }
+
+    [Fact]
+    public void Add_OverflowCap_DoesNotThrow_AndPreservesInFlightOutcome()
+    {
+        // At the cap a fresh outcome is refused rather than evicting an in-flight one; a flood cannot
+        // displace a user mid-login, and registration never throws under the overflow path.
+        var store = new SamlOutcomeStore();
+        store.TryAdd(Outcome("_inflight", clientKey: null), out _);
+
+        var exception = Record.Exception(() =>
+        {
+            for (var i = 0; i < 100_050; i++)
+            {
+                store.TryAdd(Outcome("_flood-" + i.ToString(CultureInfo.InvariantCulture), clientKey: null), out _);
+            }
+        });
+
+        Assert.Null(exception);
+        Assert.NotNull(store.TryRedeem("_inflight", "adfs", Now));
+    }
+
+    [Fact]
+    public void NewToken_IsUnguessableAndDistinct()
+    {
+        // A CSPRNG token: two mints never collide. A token that misses the store falls through to the
+        // deprecation validation, which fails closed either way — the hex may Base64-decode, but its bytes
+        // are not a SAML response, so the XML parse rejects it (covered end-to-end by UnknownToken_Rejects).
+        var a = SamlOutcomeStore.NewToken();
+        var b = SamlOutcomeStore.NewToken();
+        Assert.NotEqual(a, b);
+        Assert.Equal(64, a.Length); // 32 CSPRNG bytes, hex-encoded
+    }
+}

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -51,6 +51,10 @@ internal sealed class SsoControllerHarness
         // outstanding-SAML-request cache is the same kind of static and is cleared for the same reason (#415).
         OidcLoginService.ResetOidStateForTests();
         SamlLoginService.ResetSamlRequestsForTests();
+        // The one-time SAML login-outcome store (#251) and the one-time replay cache are process-wide
+        // statics too; clear them so a prior test's stored outcome or consumed assertion id cannot leak in.
+        SamlLoginService.ResetSamlOutcomesForTests();
+        SamlAssertionValidator.ResetReplaysForTests();
 
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -45,6 +45,13 @@ internal sealed class SamlLoginService
     // browser binding (#415). One process-wide instance.
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
+    // The in-flight login-outcome store (#251): the ACS callback validates the assertion ONCE, stores the
+    // resulting verified outcome keyed by a CSPRNG token, and hands the intermediate page only that token;
+    // the session-mint leg redeems the token instead of re-parsing and re-validating the assertion. One
+    // process-wide instance, like the outstanding-request cache above — the callback and the mint leg run
+    // across separate per-request flow-service instances.
+    private static readonly SamlOutcomeStore Outcomes = new SamlOutcomeStore();
+
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
     // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID authorize-state lifetime the
     // sibling flow service keeps.
@@ -83,6 +90,14 @@ internal sealed class SamlLoginService
     // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
     // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160).
     internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
+
+    // Test-only: clears the in-flight login-outcome store (#251) between tests, the same process-wide-static
+    // reset reason as ResetSamlRequestsForTests. Internal, InternalsVisibleTo, never wired to an endpoint/DI.
+    internal static void ResetSamlOutcomesForTests() => Outcomes.Clear();
+
+    // Test-only: seeds a single login outcome so a test can drive the token-redeem mint leg without first
+    // running the callback that normally populates the store. Same test-only surface as the resets above.
+    internal static void SeedSamlOutcomeForTests(SamlLoginOutcome outcome) => Outcomes.Seed(outcome);
 
     // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
     // binding (#415) — normally populated by the challenge redirect leg — without deriving the random
@@ -134,7 +149,22 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        if (SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
+        if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
+        {
+            _logger.LogWarning(
+                "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
+                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
+                SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
+                config.Roles);
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        }
+
+        // Linking keeps the assertion-embedded page (#251 is scoped to the login round-trip): the page JS
+        // posts its data to BOTH SAML/Link and SAML/Auth, and the one-time outcome token is single-use, so a
+        // token would satisfy only the first of the two posts. The link redeem (SamlLoginService.Link)
+        // consumes the assertion's one-time-use id on its own leg, and the follow-on SAML/Auth post then
+        // falls to the fully-validating deprecation branch below — byte-for-byte the pre-#251 linking flow.
+        if (isLinking)
         {
             return FlowResponses.AuthPage(response, nonce =>
                 WebResponse.Generator(
@@ -143,15 +173,52 @@ internal sealed class SamlLoginService
                     baseUrl: requestBase,
                     mode: "SAML",
                     nonce: nonce,
-                    isLinking: isLinking));
+                    isLinking: true));
         }
 
-        _logger.LogWarning(
-            "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-            samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-            SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
-            config.Roles);
-        return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+        // Login path (#251): validate the assertion exactly ONCE here — the one-time replay consume, the
+        // non-empty-NameID guard, and the sole SAML VerifiedIdentity construction — then store the verified
+        // outcome server-side keyed by a CSPRNG token and hand the page only that token. The signed XML never
+        // crosses to the browser, so SAML/Auth redeems the outcome instead of parsing and validating a second
+        // copy. The InResponseTo correlation and browser binding are NOT enforced here: the ACS POST is
+        // cross-site and would not carry the SameSite=Lax binding cookie, so that check stays at the
+        // same-origin mint leg (below), where the cookie is present — the assertion's InResponseTo is carried
+        // in the stored outcome so the mint leg can correlate it without the XML.
+        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
+        {
+            return LoginStatusMapper.ToActionResult(rejection);
+        }
+
+        var clientKey = SsoRateLimiter.NormalizeClientKey(request.HttpContext.Connection.RemoteIpAddress);
+        Outcomes.PruneExpired(DateTime.UtcNow);
+        var outcome = new SamlLoginOutcome(
+            SamlOutcomeStore.NewToken(),
+            provider,
+            identity,
+            samlResponse.GetInResponseTo() ?? string.Empty,
+            clientKey,
+            DateTime.UtcNow);
+        if (!Outcomes.TryAdd(outcome, out var shouldWarnCapacity))
+        {
+            // A CSPRNG-token collision (effectively impossible) or the store is at capacity — fail closed
+            // rather than render a page whose token could never redeem. The store throttles the capacity
+            // warning to one signal per interval so a flood cannot amplify into log volume (CWE-400).
+            if (shouldWarnCapacity)
+            {
+                _logger.LogWarning("SAML login outcome refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the outcome store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
+            return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+        }
+
+        return FlowResponses.AuthPage(response, nonce =>
+            WebResponse.Generator(
+                data: outcome.Token,
+                provider: provider,
+                baseUrl: requestBase,
+                mode: "SAML",
+                nonce: nonce,
+                isLinking: false));
     }
 
     /// <summary>
@@ -277,52 +344,54 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
+        // The one-time outcome-token path (#251): the plugin now renders a token (not the assertion) for
+        // login flows. Redeem it once — an atomic claim, so a replayed token misses and a token minted for
+        // another provider is refused (details on SamlOutcomeStore.TryRedeem). The assertion was already
+        // fully validated at the ACS callback (signature, time, audience, recipient, role gate, the one-time
+        // replay consume and the verified-identity construction), so NOTHING is re-parsed or re-validated
+        // here: only the browser binding remains, checked at this same-origin leg where the SameSite=Lax
+        // cookie is sent (the cross-site ACS POST could not carry it). A miss falls through to the
+        // deprecation branch below, so an unknown/expired/replayed token is rejected there rather than minting.
+        if (Outcomes.TryRedeem(response?.Data, provider, DateTime.UtcNow) is { } outcome)
+        {
+            if (!CorrelateAndBind(provider, outcome.InResponseTo, bindingCookie, config.ValidateInResponseTo))
+            {
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
+            }
+
+            // From here the SAML and OpenID paths are one: the verified identity flows into the shared
+            // completion tail. SAML keys the link on the NameID and carries no email_verified claim, so
+            // AdoptionGate.None; the resolver's admin-adoption refusal (#218) still applies.
+            return await _loginCompletion.CompleteAsync(
+                outcome.Identity,
+                response,
+                config,
+                AdoptionGate.None,
+                remoteEndPointResolver).ConfigureAwait(false);
+        }
+
+        // DEPRECATION WINDOW (#251, drop scheduled by #528): a page rendered by a PRE-#251
+        // plugin still embeds the full base64 assertion and posts it here. For one release SAML/Auth also
+        // accepts that legacy shape and FULLY validates it — signature/time/audience/recipient, the
+        // InResponseTo correlation + browser binding, the login allow-list, and the one-time replay consume —
+        // exactly as before #251, so an admin upgrading mid-login does not break a user's in-flight login.
+        // The plugin itself renders only tokens going forward; this branch is removed once the window closes.
         var requestBase = GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride);
         if (!_validator.TryValidate(config, provider, requestBase, response?.Data, out var samlResponse))
         {
-            // Malformed input is rejected the same way an invalid response is — clean 4xx, not 500 (#199).
+            // A malformed body, an unknown/expired/replayed token that reached this fallback, or a failed
+            // signature/time/audience/recipient check is rejected the same way — a clean 4xx, never a 500 (#199).
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Correlate the response to an AuthnRequest this server issued (#156, #415), and enforce the
-        // browser binding for a solicited login. A NON-EMPTY InResponseTo means the response claims to
-        // answer a request this server issued, so it must actually correlate to a live outstanding
-        // request AND carry that request's binding cookie — anything less fails closed. Crucially, a
-        // non-empty InResponseTo whose entry is gone (expired past the 15-minute window, evicted at the
-        // cap, lost to a restart or a non-sticky multi-node hop) is a LOST correlation, not an
-        // unsolicited response: treating it as unsolicited would let a signature-valid response mint a
-        // session with no binding check when ValidateInResponseTo is off, which is exactly the
-        // forced-login bypass the binding exists to close (login validity must never default to true).
-        //
-        // The binding is checked AFTER the atomic claim (unlike the OpenID state, #326) and that is safe:
-        // the response already passed signature validation above and the InResponseTo is read from that
-        // validated document, so an attacker cannot mint a signature-valid response carrying a victim's
-        // request id to burn their outstanding entry. The cookie is checked here (the same-origin auth
-        // endpoint), not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
-        var inResponseTo = samlResponse.GetInResponseTo();
-        if (!string.IsNullOrEmpty(inResponseTo))
+        if (!CorrelateAndBind(provider, samlResponse.GetInResponseTo(), bindingCookie, config.ValidateInResponseTo))
         {
-            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
-            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId)
-                || !AuthorizeStateBinding.Matches(storedBindingId, bindingCookie))
-            {
-                _logger.LogWarning("SAML login denied: a solicited response did not correlate to a live outstanding request from the initiating browser (binding mismatch, expiry, or lost correlation).");
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-            }
-        }
-        else if (config.ValidateInResponseTo)
-        {
-            // No InResponseTo at all: a genuinely unsolicited (IdP-initiated) response. It is refused
-            // only when the opt-in solicited-only mode is on; otherwise it proceeds — unchanged and
-            // non-breaking for IdP-initiated deployments. The rejection is a client-caused 400 in the
-            // uniform SAML body, never a 500, and the diagnosis stays in the warning log.
-            _logger.LogWarning("SAML login denied: the response was not solicited by this server (no InResponseTo).");
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Enforce the login allow-list here too, not only at the assertion-consumer page: a caller
-        // can POST an assertion straight to this session-minting endpoint and skip the page, so
-        // checking it only there would be fail-open.
+        // Enforce the login allow-list here too, not only at the assertion-consumer page: a legacy caller
+        // can POST an assertion straight to this session-minting endpoint and skip the page, so checking it
+        // only there would be fail-open.
         if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
         {
             _logger.LogWarning(
@@ -333,11 +402,7 @@ internal sealed class SamlLoginService
 
         // Complete the assertion validation in the dedicated validator: the one-time replay consume and the
         // non-empty-NameID guard, then — and only then — the verified identity through FromValidatedSaml
-        // (#496). A replay fails as an invalid response and a missing NameID as a denial, the same outcomes
-        // this endpoint returned when those checks were inline. From here the SAML and OpenID paths are one:
-        // the verified identity flows into the shared completion tail (SAML keys the link on the NameID and
-        // carries no email_verified claim, so AdoptionGate.None; the resolver's admin-adoption refusal, #218,
-        // still applies).
+        // (#496). A replay fails as an invalid response and a missing NameID as a denial.
         if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
         {
             return LoginStatusMapper.ToActionResult(rejection);
@@ -349,6 +414,42 @@ internal sealed class SamlLoginService
             config,
             AdoptionGate.None,
             remoteEndPointResolver).ConfigureAwait(false);
+    }
+
+    // Correlates a response to an AuthnRequest this server issued (#156, #415) and enforces the browser
+    // binding for a solicited login. A NON-EMPTY InResponseTo means the response claims to answer a request
+    // this server issued, so it must actually correlate to a live outstanding request AND carry that
+    // request's binding cookie — anything less fails closed. Crucially, a non-empty InResponseTo whose entry
+    // is gone (expired past the 15-minute window, evicted at the cap, lost to a restart or a non-sticky
+    // multi-node hop) is a LOST correlation, not an unsolicited response: treating it as unsolicited would
+    // let a validated response complete a login with no binding check when ValidateInResponseTo is off, which
+    // is exactly the forced-login bypass the binding exists to close (login validity must never default to
+    // true). The consume is the atomic claim of the outstanding request; the cookie match is checked at this
+    // same-origin auth endpoint, not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
+    // Shared by the token-redeem mint path (on the stored outcome's InResponseTo) and the deprecation branch
+    // (on the freshly parsed response), so both enforce the identical correlation.
+    private bool CorrelateAndBind(string provider, string inResponseTo, string bindingCookie, bool validateInResponseTo)
+    {
+        if (!string.IsNullOrEmpty(inResponseTo))
+        {
+            var requestKey = ProviderScopedKey.For(provider, inResponseTo);
+            if (!SamlRequests.TryConsume(requestKey, DateTime.UtcNow, out var storedBindingId)
+                || !AuthorizeStateBinding.Matches(storedBindingId, bindingCookie))
+            {
+                _logger.LogWarning("SAML login denied: a solicited response did not correlate to a live outstanding request from the initiating browser (binding mismatch, expiry, or lost correlation).");
+                return false;
+            }
+        }
+        else if (validateInResponseTo)
+        {
+            // No InResponseTo at all: a genuinely unsolicited (IdP-initiated) response. It is refused only
+            // when the opt-in solicited-only mode is on; otherwise it proceeds — unchanged and non-breaking
+            // for IdP-initiated deployments.
+            _logger.LogWarning("SAML login denied: the response was not solicited by this server (no InResponseTo).");
+            return false;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -48,6 +48,12 @@ internal sealed class SamlAssertionValidator
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    // Test-only: clears the process-wide one-time replay cache between tests, the same static-state reset
+    // reason as the flow service's request/outcome resets — a test that consumed an assertion id must not
+    // leak it into a sibling test. Internal, reachable only through InternalsVisibleTo; never wired to an
+    // endpoint or DI, so it adds no runtime or security surface.
+    internal static void ResetReplaysForTests() => SamlReplays.Clear();
+
     /// <summary>
     /// Reads the assertion's role values under the one role-attribute definition, so the flow service's
     /// policy check and warning logs read the exact same attribute the derived privileges here do (#370).

--- a/SSO-Auth/Api/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/SamlOutcomeStore.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The in-flight SAML login-outcome store (#251): the assertion-consumer callback validates the signed
+/// assertion ONCE, then stores the resulting <see cref="SamlLoginOutcome"/> here keyed by a fresh CSPRNG
+/// token and hands the intermediate auth page only that token — never the assertion. The same-origin
+/// session-mint leg redeems the token once and completes the login from the stored outcome, so the signed
+/// XML no longer round-trips through the browser and is not parsed or validated a second time. This is the
+/// SAML analogue of <see cref="OidcStateStore"/>'s one-time authorize-state redeem: cap-bounded
+/// registration, an atomic one-time claim, and an <see cref="IntervalGate"/>-throttled expired-entry sweep.
+/// </summary>
+/// <remarks>
+/// A single stored variant, not the OpenID two-phase Pending -> Ready swap: a SAML login is FULLY verified
+/// at the callback (signature, time, audience, recipient, role gate, one-time replay consume and the
+/// verified-identity construction all complete there), so what is stored is already the redeemable outcome.
+/// Holding a <see cref="SamlLoginOutcome"/> is therefore proof the assertion passed every gate, and the
+/// redeem is the sole one-time claim — a token is redeemable at most once even under concurrent posts.
+/// </remarks>
+internal sealed class SamlOutcomeStore
+{
+    // An approximate ceiling on outstanding login outcomes, so a flood of validated callbacks cannot grow
+    // the store without bound (mirrors OidcStateStore / SamlRequestCache). At the cap a fresh outcome is
+    // refused rather than evicting an in-flight one; the callback path is reached only after full signature
+    // validation, so it is not anonymously floodable, and rate-limiting at the edge (#128) is the primary
+    // defense.
+    internal const int DefaultMaxEntries = 100_000;
+
+    // How long a stored login outcome may live before it is rejected/pruned. It bounds the gap between the
+    // ACS callback rendering the page and the browser posting the token back — a fast same-origin round
+    // trip — so it matches the sibling in-flight lifetimes (the outstanding-request/authorize-state window).
+    internal static readonly TimeSpan DefaultLifetime = TimeSpan.FromMinutes(15);
+
+    // The expired-entry sweep is an O(n) scan; throttling it to at most once per this interval keeps it off
+    // the hot path (mirrors the siblings). Throttling only defers memory reclamation — the redeem predicate
+    // rejects an expired outcome independently, so a not-yet-swept entry never completes a login.
+    internal static readonly TimeSpan DefaultPruneInterval = TimeSpan.FromMinutes(1);
+
+    private readonly int _maxEntries;
+    private readonly TimeSpan _lifetime;
+
+    // Concurrent requests add to, redeem from, and prune this map; a plain Dictionary corrupts or throws
+    // under that interleaving. The redeem is a single atomic TryRemove, so one outcome completes at most one
+    // login even under concurrent posts. Ordinal matches the CSPRNG token's exact-byte comparison.
+    private readonly ConcurrentDictionary<string, SamlLoginOutcome> _outcomes = new(StringComparer.Ordinal);
+
+    // Throttles the sweep to one run per interval; the gate owns the atomic cursor. See PruneExpired.
+    private readonly IntervalGate _pruneGate;
+
+    // Throttles the capacity-full warning (CWE-400) to one signal per interval, so a flood of refused
+    // registrations cannot amplify into unbounded log volume (parity with the siblings).
+    private readonly IntervalGate _capWarnGate;
+
+    // Per-client occupancy sub-cap (#327): bounds how much of the global budget one client key can hold, so
+    // a single source cannot fill the store and lock out everyone else's logins.
+    private readonly PerClientBudgetLimiter _perClient;
+
+    internal SamlOutcomeStore()
+        : this(DefaultMaxEntries, DefaultLifetime, DefaultPruneInterval)
+    {
+    }
+
+    // Test constructor: small caps and lifetimes make the cap and expiry paths reachable in unit tests (the
+    // production values are unreachable there). IntervalGate rejects a non-positive interval.
+    internal SamlOutcomeStore(int maxEntries, TimeSpan lifetime, TimeSpan pruneInterval)
+    {
+        _maxEntries = maxEntries;
+        _lifetime = lifetime;
+        _pruneGate = new IntervalGate(pruneInterval);
+        _capWarnGate = new IntervalGate(pruneInterval);
+        _perClient = PerClientBudgetLimiter.FromGlobalCap(maxEntries);
+    }
+
+    /// <summary>Gets the live entry count. Test-only, like Clear.</summary>
+    internal int Count => _outcomes.Count;
+
+    /// <summary>
+    /// A fresh 256-bit CSPRNG token, hex-encoded. A token that misses the store falls through to the
+    /// deprecation branch's assertion validation, which fails closed regardless: the hex string may be
+    /// Base64-decodable, but its decoded bytes are not a SAML response, so the XML parse rejects it.
+    /// </summary>
+    /// <returns>The new one-time outcome token.</returns>
+    internal static string NewToken() => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+
+    /// <summary>
+    /// Registers a fully-verified login outcome under its CSPRNG token. At the cap a NEW token is refused
+    /// (that one login fails closed) rather than evicting an in-flight outcome — evicting would drop a user
+    /// already mid-login. On refusal, <paramref name="shouldWarnCapacity"/> is true for at most one caller
+    /// per interval; the warning line stays at the call site so the log-forging inline sanitizer never
+    /// crosses a helper boundary.
+    /// </summary>
+    /// <param name="outcome">The verified outcome; its token keys the entry and its Created drives the throttled warning.</param>
+    /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
+    /// <returns>True if the outcome was registered; false if refused (per-client sub-cap, global cap, or token collision).</returns>
+    internal bool TryAdd(SamlLoginOutcome outcome, out bool shouldWarnCapacity)
+    {
+        // Per-client sub-cap (#327): reserve this client's slot BEFORE the global insert so one source
+        // cannot fill the whole budget and lock out every other login. A null key is exempt.
+        if (!_perClient.TryReserve(outcome.ClientKey))
+        {
+            shouldWarnCapacity = _capWarnGate.TryEnter(outcome.Created);
+            return false;
+        }
+
+        if ((_outcomes.Count >= _maxEntries && !_outcomes.ContainsKey(outcome.Token))
+            || !_outcomes.TryAdd(outcome.Token, outcome))
+        {
+            // The entry never entered the store (global cap, or a CSPRNG-token collision losing the atomic
+            // add) — release the reservation so the client's bucket does not leak a slot.
+            _perClient.Release(outcome.ClientKey);
+            shouldWarnCapacity = _capWarnGate.TryEnter(outcome.Created);
+            return false;
+        }
+
+        shouldWarnCapacity = false;
+        return true;
+    }
+
+    /// <summary>
+    /// The one-time atomic claim: the store is keyed by the outcome token, which is exactly the value the
+    /// mint leg presents, so this is an O(1) lookup plus an atomic TryRemove — only the request that wins the
+    /// removal proceeds, so one outcome completes at most one login even under concurrent posts. Redeemable
+    /// only while the outcome still belongs to the route provider (so a token cannot be replayed against
+    /// another provider's endpoint) and is within its lifetime; an unknown, expired, provider-mismatched or
+    /// already-claimed token returns null (fail closed).
+    /// </summary>
+    /// <param name="token">The outcome token the mint leg presented.</param>
+    /// <param name="provider">The provider named in the consuming request's route.</param>
+    /// <param name="now">The current time.</param>
+    /// <returns>The redeemed outcome, or null when not redeemable.</returns>
+    internal SamlLoginOutcome TryRedeem(string token, string provider, DateTime now)
+    {
+        if (string.IsNullOrEmpty(token)
+            || !_outcomes.TryGetValue(token, out var outcome)
+            || !IsCurrentFor(outcome, provider, now)
+            || !_outcomes.TryRemove(new KeyValuePair<string, SamlLoginOutcome>(token, outcome)))
+        {
+            return null;
+        }
+
+        // Only the winner of the atomic TryRemove reaches here, so the client's slot is released exactly once.
+        _perClient.Release(outcome.ClientKey);
+        return outcome;
+    }
+
+    /// <summary>
+    /// Removes every outcome whose lifetime has elapsed, at most once per prune interval so a flood does not
+    /// amplify the O(n) scan into CPU load. Safe concurrently with additions and redeems because it operates
+    /// on a <see cref="ConcurrentDictionary{TKey,TValue}"/>.
+    /// </summary>
+    /// <param name="now">The reference time driving both the gate and the expiry evaluation.</param>
+    internal void PruneExpired(DateTime now)
+    {
+        if (!_pruneGate.TryEnter(now))
+        {
+            return;
+        }
+
+        foreach (var kvp in _outcomes.Where(kvp => now.Subtract(kvp.Value.Created) > _lifetime))
+        {
+            // Release only on the winning removal so a concurrent redeem does not double-release the slot.
+            if (_outcomes.TryRemove(kvp.Key, out var removed))
+            {
+                _perClient.Release(removed.ClientKey);
+            }
+        }
+    }
+
+    /// <summary>Test-only: drops every entry, restoring a fresh store between tests.</summary>
+    internal void Clear()
+    {
+        _outcomes.Clear();
+        _perClient.Clear();
+    }
+
+    /// <summary>Test-only: seeds one outcome directly, bypassing the callback leg.</summary>
+    /// <param name="outcome">The outcome to store under its own token.</param>
+    internal void Seed(SamlLoginOutcome outcome) => _outcomes[outcome.Token] = outcome;
+
+    // Whether a stored outcome still belongs to the route provider and has not expired. The provider check
+    // is the token-scoping guard: without it, an outcome verified at a low-trust provider could be replayed
+    // against a higher-trust provider's mint endpoint. A negative age (Created in the future, e.g. a
+    // backward clock step) is rejected too, so a clock anomaly cannot make an outcome effectively never
+    // expire.
+    private bool IsCurrentFor(SamlLoginOutcome outcome, string provider, DateTime now)
+    {
+        if (!string.Equals(outcome.Provider, provider, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var age = now.Subtract(outcome.Created);
+        return age >= TimeSpan.Zero && age <= _lifetime;
+    }
+}
+
+/// <summary>
+/// One fully-verified SAML login, held server-side between the assertion-consumer callback (which builds it
+/// after complete validation) and the same-origin session-mint leg (which redeems it once). Immutable: the
+/// redeem is an atomic remove of the whole record, so a redeemer never observes a torn outcome. It carries
+/// the protocol-agnostic <see cref="VerifiedIdentity"/> the mint path needs plus the correlation facts the
+/// mint leg still enforces there (the assertion's <c>InResponseTo</c>, matched against the browser-binding
+/// cookie that the cross-site ACS POST could not carry).
+/// </summary>
+/// <param name="Token">The CSPRNG token keying the entry — the only value that crosses to the browser.</param>
+/// <param name="Provider">The provider that verified the login; a token is redeemable only on its own provider's endpoint.</param>
+/// <param name="Identity">The verified identity and privileges the mint path is keyed on (#473).</param>
+/// <param name="InResponseTo">The assertion's <c>InResponseTo</c> (empty for an unsolicited response), correlated + browser-bound at the mint leg (#415).</param>
+/// <param name="ClientKey">The normalized client key that reserved this outcome's per-client budget slot (#327), or null for an exempt source.</param>
+/// <param name="Created">When the outcome was created, used to time it out.</param>
+internal sealed record SamlLoginOutcome(
+    string Token,
+    string Provider,
+    VerifiedIdentity Identity,
+    string InResponseTo,
+    string ClientKey,
+    DateTime Created);

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -59,6 +59,9 @@ internal sealed class SamlReplayCache
     /// <summary>Gets the live entry count. Test-only, so the cap and sweep paths can be asserted.</summary>
     internal int Count => _consumed.Count;
 
+    /// <summary>Test-only: drops all consumed-assertion entries so process-wide state cannot leak between tests.</summary>
+    internal void Clear() => _consumed.Clear();
+
     /// <summary>
     /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
     /// window it would still be accepted - its NotOnOrAfter plus the validation clock skew - with a

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -226,7 +226,7 @@ const sleep = (milliseconds) => {
     /// <summary>
     /// A generator for the web response that incorporates the data from the server.
     /// </summary>
-    /// <param name="data">The data of the auth flow. Is signed XML for SAML and a state ID for OpenID.</param>
+    /// <param name="data">The opaque value the page posts back to the mint leg: a one-time state token for OpenID and, since #251, a one-time login-outcome token for a SAML login (a base64 assertion only on the SAML linking / pre-#251 deprecation path).</param>
     /// <param name="provider">The name of the provider to callback to.</param>
     /// <param name="baseUrl">The base URL of the Jellyfin installation.</param>
     /// <param name="mode">The mode of the function; SAML or OID.</param>


### PR DESCRIPTION
# What & why

The SAML login flow validated the same signed assertion **twice**. The ACS
callback (`SAML/post`) parsed and validated the response, re-serialized the whole
document, and embedded it base64 in the intermediate auth page; the page then
posted that assertion back to `SAML/Auth`, which parsed and fully validated it
again. Per login the base64-decode / DOM-parse / C14N + RSA-verify pipeline ran
twice, the document was copied ~4 times to embed it, and the signed assertion
crossed the untrusted client. The OpenID flow already uses the better shape - 
only a state token crosses the page.

This validates the assertion **once** at the callback and stores the verified
outcome server-side in a one-time, CSPRNG-keyed store, mirroring the OpenID
authorize-state redeem. The page carries only an opaque token; the assertion
never crosses the browser again.

Closes #251.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

(Security-relevant: it touches the SAML login path, so the adversarial gate was run, see Notes.)

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

### Design

- **One-time outcome store + atomic redeem.** New `SamlOutcomeStore` (a `*Store`
  under the flow tier) keyed by a 256-bit CSPRNG token: cap-bounded registration
  with a per-client sub-cap (1/100), an `IntervalGate`-throttled expired-entry
  sweep, provider- and lifetime-scoping on redeem, and a single atomic
  `TryRemove` claim, so a token mints at most one session even under concurrent
  posts. `SamlLoginOutcome` is an immutable record, so the redeem is never a torn
  read; the store faithfully mirrors `OidcStateStore` (cap / release / prune /
  negative-age guard). A new fitness function `SamlLoginOutcome_IsImmutable`
  locks in that immutability.
- **Once-only validation + replay consume.** The callback runs the full
  validation exactly once - signature/time/audience/recipient, the role gate, the
  one-time replay consume, and the sole SAML `VerifiedIdentity` construction - 
  then stores the verified outcome and hands the page only the token. `SAML/Auth`
  redeems the token and completes the login through the shared completion tail
  with no re-parse. The `InResponseTo` correlation + browser binding (#415) stay
  at the same-origin mint leg, where the `SameSite=Lax` cookie is sent, which
  the cross-site ACS POST could not carry, via a shared `CorrelateAndBind` that
  operates on the outcome's stored `InResponseTo`. The one-time replay id is
  consumed exactly once (at the callback on the token path, at `SAML/Auth` on the
  deprecation path); never double-consumed, never skipped.
- **Deprecation-window dual-accept.** For one release, `SAML/Auth` also accepts
  and FULLY validates the pre-#251 assertion-embedded shape (byte-equivalent to
  the old full validation), so a login already in flight when an admin upgrades
  does not break. Linking keeps the assertion page (its own leg consumes the
  one-time id; the follow-on `SAML/Auth` post lands on the deprecation branch),
  so linking is unchanged. Follow-up #528 tracks dropping the deprecated path in
  a later (breaking) release.
- **Fail-closed token handling.** An unknown / expired / provider-mismatched /
  replayed token misses the store and falls through to the deprecation
  validation, which rejects it (its decoded bytes are not a SAML response), a
  clean 400, never a mint.

### Adversarial self-review, all four lenses PASS

- **Availability**, PASS. In-flight logins survive the upgrade via the
  deprecation window; the store refuses-at-cap (never evicts) with a per-client
  sub-cap, and the callback is reached only after full signature validation (not
  anonymously floodable); no mass-lockout.
- **Security-bypass**, PASS. Token is 256-bit CSPRNG, single-use via the atomic
  `TryRemove` winner, provider- and lifetime-scoped; the deprecation path is
  byte-equivalent full validation (not a bypass); replay is consumed exactly
  once; the browser binding / lost-correlation fail-closed is preserved.
- **Correctness**, PASS. Assertion validated exactly once; outcome identical to
  today (same `VerifiedIdentity`, `AdoptionGate.None`); token consumed once; the
  re-ordering across the two legs opens no observable edge case; store
  release/prune shapes match the siblings.
- **Integration**, PASS. The auth-page JS posts `data` opaquely and is unchanged
  (token for login, assertion for linking); the store reuses
  `PerClientBudgetLimiter` / `IntervalGate` / `ProviderScopedKey`; the harness
  resets the new process-wide statics; conformance rules still hold; the
  controller / admin UI / config persistence are untouched.

### E2E checklist

- SAML login, including IdP-initiated, now requires session affinity in
  multi-instance deployments (extends the existing OIDC `OidcStateStore`
  constraint, the outcome, like the OpenID authorize state, lives in-process
  between the callback and the mint leg).
