### PR TITLE
Correct stale config.xml-only claim for RequireVerifiedEmailForLogin

### DIFF
--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -328,7 +328,7 @@ public class OidConfig : ProviderConfigBase
     /// unverified emails cannot be used to sign in. Distinct from <see cref="RequireVerifiedEmailForAdoption"/>,
     /// which only gates same-name account adoption; this gates the login itself, before any account is
     /// resolved. Enabling it needs the <c>email</c> scope so the provider returns <c>email_verified</c>.
-    /// XML-only.
+    /// Settable in the admin provider form as well as the config XML (#524, #525).
     /// </summary>
     public bool RequireVerifiedEmailForLogin { get; set; }
 

--- a/providers.md
+++ b/providers.md
@@ -118,8 +118,9 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   or an IdP that never emits the claim — is unaffected on upgrade; and it needs the `email` scope in the
   provider's `OidScopes`, otherwise the claim is absent and **every** login is refused. It is
   independent of `AllowExistingAccountLink` / `RequireVerifiedEmailForAdoption` (you can run either, both,
-  or neither). **SAML** carries no `email_verified` claim, so this gate does not apply there. This flag
-  is currently set by editing the provider's `config.xml` directly (it is not yet in the admin form).
+  or neither). **SAML** carries no `email_verified` claim, so this gate does not apply there.
+  `RequireVerifiedEmailForLogin` is settable in the admin OpenID provider form, or by editing the
+  provider's `config.xml` directly.
 - **Upgrading from a username-keyed version — read this before you upgrade.** Links created by older
   plugin versions (up to and including 4.0.0.4) are keyed on the username. A username is something the
   identity provider can reassign, so following such a link is name-based account matching, governed by


### PR DESCRIPTION
# What & why

`RequireVerifiedEmailForLogin` gained an admin OpenID provider form toggle in #525 (issue #524), but two spots still described it as settable only via `config.xml`, the same doc drift #489 (commit 744832f) fixed for the `AllowExistingAccountLink` / `RequireVerifiedEmailForAdoption` adoption flags after #484/#488 surfaced them.

This corrects both stale claims:

1. **`providers.md`**, the "Requiring a verified email for the login itself" bullet no longer says the flag "is currently set by editing the provider's `config.xml` directly (it is not yet in the admin form)"; it now mirrors the adoption-flags phrasing ("settable in the admin OpenID provider form, or by editing the provider's `config.xml` directly").
2. **`SSO-Auth/Config/PluginConfiguration.cs`**, the `RequireVerifiedEmailForLogin` XML-doc comment no longer ends with "XML-only."; it now reads "Settable in the admin provider form as well as the config XML (#524, #525)."

Docs/comment-only. No behavior change. Verified against `origin/main` that the checkbox exists in `configPage.html` (lines 806-807), so the corrected text is truthful.

Closes #532

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, no code logic, login path, crypto, config persistence, or release-pipeline behavior changes. The only edit under `SSO-Auth/Config/` is an XML-doc comment on an existing property; no runtime surface is touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (1087 passed).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (`providers.md` checked).

## Notes

Docs/comment-only follow-up to #525, exactly analogous to the #489 follow-up to #484/#488. Out of scope: any behavior or UI change, the admin-form checkbox itself already shipped in #525.