### PR TITLE
Offer only enabled providers on the linking page and surface failures

### DIFF
--- a/SSO-Auth.Tests/SSOControllerAdminTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAdminTests.cs
@@ -18,7 +18,9 @@ public class SSOControllerAdminTests
     [Fact]
     public void OidDel_RemovesTheProvider()
     {
-        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig());
+        // Seed it enabled so it would otherwise appear in the names list — the assertion then proves the
+        // delete removed it, not the enabled-only linking filter (#344) hiding a still-present provider.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
 
         harness.Controller.OidDel("keycloak");
 
@@ -39,7 +41,7 @@ public class SSOControllerAdminTests
     [Fact]
     public void SamlDel_RemovesTheProvider_ReturnsOk()
     {
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true });
 
         Assert.IsType<OkResult>(harness.Controller.SamlDel("adfs"));
 

--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -125,12 +125,15 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public void OidProviderNames_ReturnsSeededNames()
+    public void OidProviderNames_ReturnsEnabledProviders_ExcludesDisabled()
     {
+        // The linking page is the sole consumer (#344): enabled providers are offered, a disabled one is
+        // withheld because linking through it is rejected (#343), so an add button for it would dead-end.
         var harness = new SsoControllerHarness(c =>
         {
-            c.OidConfigs["keycloak"] = new OidConfig();
-            c.OidConfigs["authelia"] = new OidConfig();
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+            c.OidConfigs["authelia"] = new OidConfig { Enabled = true };
+            c.OidConfigs["retired"] = new OidConfig { Enabled = false };
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
@@ -138,16 +141,83 @@ public class SSOControllerEndpointTests
         Assert.Equal(2, names.Count);
         Assert.Contains("keycloak", names);
         Assert.Contains("authelia", names);
+        Assert.DoesNotContain("retired", names);
     }
 
     [Fact]
-    public void SamlProviderNames_ReturnsSeededNames()
+    public void SamlProviderNames_ReturnsEnabledProviders_ExcludesDisabled()
     {
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+            c.SamlConfigs["retired"] = new SamlConfig { Enabled = false };
+        });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
         var names = Assert.IsType<List<string>>(result.Value);
         Assert.Equal(new[] { "adfs" }, names);
+    }
+
+    [Fact]
+    public void OidProviderNames_NullValuedEntry_SkipsItWithoutThrowing()
+    {
+        // A null provider value is reachable via a pre-#350 null-body add; GetNames must skip it (like
+        // LinksByUser) rather than NRE into a 500 on this anonymous endpoint, and still list the good one.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["broken"] = null;
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "keycloak" }, names);
+    }
+
+    [Fact]
+    public void SamlProviderNames_NullValuedEntry_SkipsItWithoutThrowing()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.SamlConfigs["broken"] = null;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "adfs" }, names);
+    }
+
+    [Fact]
+    public void ProviderNames_NoProvidersConfigured_ReturnEmpty()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.Empty(Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames()).Value));
+        Assert.Empty(Assert.IsType<List<string>>(Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames()).Value));
+    }
+
+    [Fact]
+    public void OidProviders_AdminGet_StillListsDisabledProviders()
+    {
+        // The enabled-only filter is scoped to the GetNames linking list (#344); the elevation-gated OID/Get
+        // admin surface reads the full map through SnapshotConfigs and must still expose a disabled provider
+        // so an administrator can see and re-enable it.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["retired"] = new OidConfig { Enabled = false });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviders());
+        var configs = Assert.IsType<SerializableDictionary<string, OidConfig>>(result.Value);
+        Assert.True(configs.ContainsKey("retired"));
+    }
+
+    [Fact]
+    public void SamlProviders_AdminGet_StillListsDisabledProviders()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["retired"] = new SamlConfig { Enabled = false });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviders());
+        var configs = Assert.IsType<SerializableDictionary<string, SamlConfig>>(result.Value);
+        Assert.True(configs.ContainsKey("retired"));
     }
 
     [Fact]

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -295,9 +295,11 @@ public class SSOController : ControllerBase
     [HttpGet("OID/GetNames")]
     public ActionResult OidProviderNames()
     {
-        // Materialize the keys under the lock (#157/F-10): returning the live KeyCollection lets the
-        // JSON formatter enumerate it outside the lock, tearing against a concurrent provider add/remove.
-        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.Keys.ToList()));
+        // Enabled providers only (#344): the sole consumer is the self-service linking page, and a disabled
+        // provider is rejected by both link twins (#343), so listing it would render an active add button
+        // that dead-ends in a uniform 400. Materialized under the config lock (#157/F-10): returning a live
+        // view lets the JSON formatter enumerate it outside the lock, tearing against a concurrent add/remove.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.OidConfigs)));
     }
 
     /// <summary>
@@ -307,8 +309,8 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/GetNames")]
     public ActionResult SamlProviderNames()
     {
-        // Materialize under the lock (#157/F-10), as OID/GetNames does.
-        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.Keys.ToList()));
+        // Enabled-only and materialized under the lock, as OID/GetNames does (#344, #157/F-10).
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.SamlConfigs)));
     }
 
     /// <summary>
@@ -673,6 +675,18 @@ public class SSOController : ControllerBase
 
         return copy;
     }
+
+    // The enabled provider names for the linking page (#344), materialized into a detached list under the
+    // config lock like SnapshotConfigs (#157/F-10) so the JSON formatter never enumerates the live
+    // dictionary against a concurrent add/remove. Only enabled providers are listed because a disabled one
+    // is rejected by both link twins (#343); the admin surfaces that need the full set (OID/Get, SAML/Get,
+    // the config page) read the whole map through SnapshotConfigs, not here, so they still see disabled ones.
+    // A null-valued entry (reachable via a pre-#350 null-body add) fails the property pattern and is
+    // skipped rather than dereferenced — the same fail-closed treatment LinksByUser gives it, so this
+    // anonymous endpoint cannot NRE into a 500 on a state the write side once produced.
+    private static List<string> EnabledProviderNames<TConfig>(SerializableDictionary<string, TConfig> configs)
+        where TConfig : ProviderConfigBase
+        => configs.Where(entry => entry.Value is { Enabled: true }).Select(entry => entry.Key).ToList();
 
     /// <summary>
     /// Validate a saml link request and create the link if it is valid.

--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -46,6 +46,15 @@
               >${Help}</a
             >
           </div>
+          <!-- Generic failure banner (#344): revealed by linking.js when a request on this page is
+               rejected, so a non-2xx is no longer a silent no-op. The text is deliberately generic and
+               carries no server detail. -->
+          <p id="sso-linking-error" role="alert" hidden>
+            <strong
+              >Something went wrong. Please reload the page and try
+              again.</strong
+            >
+          </p>
           <p>
             Use the
             <span class="fab" aria-hidden="true">

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -11,34 +11,62 @@ const ssoConfigLinking = {
         new Request(
           ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
         ),
-      ).then((resp) => {
-        resp.json().then((config_names) => {
+      )
+        // The global fetch resolves even on a non-2xx status, so gate on resp.ok before reading the body:
+        // a swallowed rejection would otherwise leave the section silently empty instead of telling the
+        // user something failed (#344).
+        .then((resp) => {
+          if (!resp.ok) {
+            throw new Error("provider list request failed");
+          }
+          return resp.json();
+        })
+        .then((config_names) => {
           ssoConfigLinking.loadProviderList(
             container,
             config_names,
             provider_mode,
           );
-        });
-      });
+        })
+        .catch(() => ssoConfigLinking.showError());
     });
   },
-  loadProviderList: (container, providers, provider_mode) => {
-    providers.forEach((provider_name) => {
-      // Provider and canonical names are identity-provider/admin-controlled: build the DOM with
-      // createElement/textContent (never innerHTML), and feed them into selectors and URLs only
-      // through CSS.escape / encodeURIComponent, never raw.
-      const provider_config = document.createElement("div");
-      provider_config.classList.add("sso-provider-links-container");
-      provider_config.dataset.id = provider_name;
 
-      const title = document.createElement("label");
-      title.classList.add(
-        "inputLabel",
-        "inputLabelUnfocused",
-        "sso-provider-link-title",
-      );
-      title.textContent = provider_name;
+  // A single generic banner for any failed request on this page — it never carries a status code or
+  // server message, so a rejection cannot leak an internal detail into the admin UI (#344).
+  showError: () => {
+    const banner = document.querySelector("#sso-linking-error");
+    if (banner) {
+      banner.hidden = false;
+    }
+  },
+  // Builds one provider row (title + optional add button + an empty existing-links container) and
+  // appends it, returning that container. The add button is offered only for a provider on the
+  // enabled add-list (#344): a disabled provider must not start a NEW link (the challenge/link twins
+  // reject it, #343), but a row without the button still lets its already-created links be removed —
+  // the deliberate disable-then-clean-up workflow (#380). Provider names are identity-provider/
+  // admin-controlled: the DOM is built with createElement/textContent (never innerHTML) and names reach
+  // selectors/URLs only through CSS.escape / encodeURIComponent, never raw.
+  createProviderRow: (
+    container,
+    provider_name,
+    provider_mode,
+    withAddButton,
+  ) => {
+    const provider_config = document.createElement("div");
+    provider_config.classList.add("sso-provider-links-container");
+    provider_config.dataset.id = provider_name;
 
+    const title = document.createElement("label");
+    title.classList.add(
+      "inputLabel",
+      "inputLabelUnfocused",
+      "sso-provider-link-title",
+    );
+    title.textContent = provider_name;
+    provider_config.appendChild(title);
+
+    if (withAddButton) {
       const add_provider = document.createElement("a");
       add_provider.classList.add(
         "fab",
@@ -53,13 +81,26 @@ const ssoConfigLinking = {
       add_provider.href = ApiClient.getUrl(
         `/SSO/${provider_mode}/p/${encodeURIComponent(provider_name)}?isLinking=true`,
       );
+      provider_config.appendChild(add_provider);
+    }
 
-      const existing_links = document.createElement("div");
-      existing_links.classList.add("sso-provider-existing-links-container");
-      existing_links.dataset.provider = provider_name;
+    const existing_links = document.createElement("div");
+    existing_links.classList.add("sso-provider-existing-links-container");
+    existing_links.dataset.provider = provider_name;
+    provider_config.appendChild(existing_links);
 
-      provider_config.append(title, add_provider, existing_links);
-      container.appendChild(provider_config);
+    container.appendChild(provider_config);
+    return existing_links;
+  },
+
+  loadProviderList: (container, providers, provider_mode) => {
+    providers.forEach((provider_name) => {
+      ssoConfigLinking.createProviderRow(
+        container,
+        provider_name,
+        provider_mode,
+        true,
+      );
     });
 
     const currentUserId = ApiClient.getCurrentUserId();
@@ -71,21 +112,40 @@ const ssoConfigLinking = {
           url: ApiClient.getUrl(`sso/${provider_mode}/links/${currentUserId}`),
         },
         true,
-      ).then((resp) => {
-        resp.json().then((provider_map) => {
+      )
+        .then((resp) => resp.json())
+        .then((provider_map) => {
           Object.keys(provider_map).forEach((provider_name) => {
-            const provider_container = container.querySelector(
+            const canonical_names = provider_map[provider_name];
+            let provider_container = container.querySelector(
               `.sso-provider-existing-links-container[data-provider="${CSS.escape(provider_name)}"]`,
             );
+            if (!provider_container) {
+              // The links endpoint reports every provider, including disabled ones the enabled-only
+              // add-list omitted (#344). Surface a disabled provider only when the user actually has
+              // links to remove — otherwise skip it, so a disabled provider is neither offered nor
+              // clutters the page — and render it without an add button (#380).
+              if (!canonical_names || canonical_names.length === 0) {
+                return;
+              }
+              provider_container = ssoConfigLinking.createProviderRow(
+                container,
+                provider_name,
+                provider_mode,
+                false,
+              );
+            }
             ssoConfigLinking.populateExistingLinks(
               provider_container,
               provider_mode,
               provider_name,
-              provider_map[provider_name],
+              canonical_names,
             );
           });
-        });
-      });
+        })
+        // ApiClient.fetch rejects on a non-2xx status, so a failed existing-links load surfaces the same
+        // generic banner rather than silently omitting the user's current links (#344).
+        .catch(() => ssoConfigLinking.showError());
     }
   },
 
@@ -173,9 +233,13 @@ const ssoConfigLinking = {
         });
       });
 
-    Promise.all(delete_requests).then((values) => {
-      window.location.reload();
-    });
+    Promise.all(delete_requests)
+      .then(() => {
+        window.location.reload();
+      })
+      // A rejected unlink used to reload the page anyway, presenting a failure as success; show the
+      // generic banner instead so the stale links stay visible and the user knows nothing changed (#344).
+      .catch(() => ssoConfigLinking.showError());
   },
 };
 


### PR DESCRIPTION
# What & why

`OID/GetNames` and `SAML/GetNames` listed providers regardless of `Enabled`, so
the self-service linking page rendered an active "add" button for a disabled
provider. Since #343 the server rejects a link/challenge through a disabled
provider with a uniform 400, so that button dead-ends in a rejection, and the
page's XHRs discarded non-2xx responses, so the user saw a silent no-op instead
of feedback. This is a UX-honesty fix; the server-side rejection is unchanged.

- `GetNames` (the sole consumer is the linking page) now returns only **enabled**
  provider names. A disabled provider is already rejected by both link twins
  (#343), so listing it only produced a dead-ending add button. A null-valued
  entry (reachable via a pre-#350 null-body add) is skipped rather than
  dereferenced, matching `LinksByUser`, the anonymous endpoint cannot NRE into a
  500.
- The elevation-gated admin surfaces `OID/Get` / `SAML/Get` are unchanged (they
  read the full map through `SnapshotConfigs`), so an administrator still sees and
  can re-enable a disabled provider.
- `linking.js` offers the add button only for enabled providers, but still renders
  the existing links to a disabled provider, without an add button, so the
  deliberate disable-then-clean-up unlink workflow (#380, pinned by
  `TryRemoveLink_ProviderDisabled_StillRemoves`) keeps working. A disabled
  provider the user has no links to is not shown.
- `linking.js` / `linking.html` surface a single generic failure banner when any
  of the page's requests (provider list, existing links, unlink) returns a
  non-2xx / rejects. The banner carries no status code or server detail, and the
  unlink flow no longer reloads on a rejected delete (which previously presented a
  failure as success).

Closes #344.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. _The #343 server-side disabled/unknown
      provider rejection (challenge and link twins) is untouched; hiding a
      provider from the display list is not relied on as the control — a
      hand-crafted add URL still hits the uniform 400._
- [x] No secrets logged; secrets are redacted on config export. _No logging or
      secret surface touched._
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. _Adversarial multi-lens review
      (bypass, correctness, integration) ran; results under Notes._
- [x] Log inputs from the IdP are sanitized inline at the log call. _No new log
      call sites._

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. _`EnabledProviderNames` mirrors `SnapshotConfigs`; the JS row
      builder is extracted into `createProviderRow`._
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      _No new structural rule; existing conformance tests pass._

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. _Debug and Release, 0
      warnings / 0 errors._
- [x] `dotnet test` is green. _1064 passed, 0 failed._
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      _`linking.js`, `linking.html`._

## Notes

The browser JS (`linking.js` / `linking.html`) is not exercised by CI, so the
review is its primary verification, alongside `node --check` for syntax.

Adversarial multi-lens review (refute-by-default), reading the full touched files
plus callers:

- **bypass-lens, PASS.** Confirmed the enabled-only filter cannot hide an enabled
  provider, the #343 server-side rejection is intact at every challenge/callback/
  authenticate/link sink, the generic banner leaks no internal detail, and no
  fail-open path was introduced (the delete flow is now fail-closed for display).
- **correctness-lens, first pass NEEDS_IMPROVEMENT, resolved → re-review pending.**
  Flagged that `EnabledProviderNames` dereferenced a provider value that a
  reachable null-valued entry could make null (NRE → 500 on an anonymous
  endpoint). Fixed with the `is { Enabled: true }` property pattern plus
  `*_NullValuedEntry_SkipsItWithoutThrowing` tests for both protocols.
- **integration-lens, first pass FAIL, resolved → re-review pending.** Caught that
  the enabled-only list broke a second consumer: the existing-links overlay
  null-dereferenced on disabled providers, spuriously firing the banner and
  removing the disable-then-clean-up unlink capability. Fixed by rendering
  disabled-but-linked providers without an add button and only when the user has
  links to remove.
