### PR TITLE
Stop offering disabled providers on the linking page and surface link rejections

### DIFF
--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -606,6 +606,28 @@ public class CanonicalLinkServiceTests
     }
 
     [Fact]
+    public void DisabledProvider_LinksStayListedAndRemovable()
+    {
+        // The linking page no longer offers a disabled provider for new links (#344), but a link the
+        // user already holds to one must stay visible and removable — disable-then-clean-up is the
+        // intended workflow. This pins the server contract the page now relies on: LinksByUser returns
+        // the disabled provider's links, and TryRemoveLink removes them (requireEnabled:false), so the
+        // enabled-only GetNames filter never strands a stale link.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var listed = service.LinksByUser(ProviderMode.Oid, Existing);
+        Assert.Equal(new[] { "sub-1" }, listed["kc"]);
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
+    }
+
+    [Fact]
     public void TryRemoveLink_OwnLink_RemovesItAndReturnsRemoved()
     {
         var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig

--- a/SSO-Auth.Tests/SSOControllerAdminTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAdminTests.cs
@@ -18,7 +18,9 @@ public class SSOControllerAdminTests
     [Fact]
     public void OidDel_RemovesTheProvider()
     {
-        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig());
+        // Enabled so the provider would appear in the enabled-only names list if it were not deleted
+        // (#344), keeping the DoesNotContain assertion a real proof of removal.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
 
         harness.Controller.OidDel("keycloak");
 
@@ -39,7 +41,8 @@ public class SSOControllerAdminTests
     [Fact]
     public void SamlDel_RemovesTheProvider_ReturnsOk()
     {
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
+        // Enabled so it would appear in the enabled-only names list if not deleted (#344).
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true });
 
         Assert.IsType<OkResult>(harness.Controller.SamlDel("adfs"));
 

--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -125,12 +125,12 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public void OidProviderNames_ReturnsSeededNames()
+    public void OidProviderNames_ReturnsEnabledNames()
     {
         var harness = new SsoControllerHarness(c =>
         {
-            c.OidConfigs["keycloak"] = new OidConfig();
-            c.OidConfigs["authelia"] = new OidConfig();
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+            c.OidConfigs["authelia"] = new OidConfig { Enabled = true };
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
@@ -141,9 +141,40 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public void SamlProviderNames_ReturnsSeededNames()
+    public void OidProviderNames_ExcludesDisabledProviders()
     {
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig());
+        // The self-service linking page must not offer a provider a user cannot link through (#344):
+        // a disabled provider is filtered out at the source so no add button is ever rendered for it.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+            c.OidConfigs["disabled-idp"] = new OidConfig { Enabled = false };
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "keycloak" }, names);
+    }
+
+    [Fact]
+    public void SamlProviderNames_ReturnsEnabledNames()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "adfs" }, names);
+    }
+
+    [Fact]
+    public void SamlProviderNames_ExcludesDisabledProviders()
+    {
+        // SAML twin of the enabled-only linking filter (#344).
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+            c.SamlConfigs["disabled-idp"] = new SamlConfig { Enabled = false };
+        });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
         var names = Assert.IsType<List<string>>(result.Value);

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -289,27 +289,37 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
-    /// Lists the OpenID providers names only.
+    /// Lists the names of the enabled OpenID providers only.
     /// </summary>
-    /// <returns>The list of OpenID configurations.</returns>
+    /// <returns>The list of enabled OpenID provider names.</returns>
     [HttpGet("OID/GetNames")]
     public ActionResult OidProviderNames()
     {
-        // Materialize the keys under the lock (#157/F-10): returning the live KeyCollection lets the
-        // JSON formatter enumerate it outside the lock, tearing against a concurrent provider add/remove.
-        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.Keys.ToList()));
+        // Only enabled providers are offered (#344): this endpoint drives the self-service linking page,
+        // and a disabled provider cannot complete a link (the link leg fail-closes on Enabled, #343), so
+        // offering it would render an add button that only ever fails. The filter is UX honesty, not the
+        // gate — the server-side rejection stays the real defense in depth.
+        // Materialize under the lock (#157/F-10): returning a live view lets the JSON formatter enumerate
+        // it outside the lock, tearing against a concurrent provider add/remove.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.OidConfigs)));
     }
 
     /// <summary>
-    /// Lists the SAML providers names only.
+    /// Lists the names of the enabled SAML providers only.
     /// </summary>
-    /// <returns>The list of SAML provider names.</returns>
+    /// <returns>The list of enabled SAML provider names.</returns>
     [HttpGet("SAML/GetNames")]
     public ActionResult SamlProviderNames()
     {
-        // Materialize under the lock (#157/F-10), as OID/GetNames does.
-        return Ok(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.Keys.ToList()));
+        // Enabled-only and materialized under the lock, as OID/GetNames does (#344, #157/F-10).
+        return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.SamlConfigs)));
     }
+
+    // Names of the enabled providers in a config map, materialized to a detached list (the caller holds
+    // the config lock). Shared by both GetNames twins so the enabled-only rule lives in one place.
+    private static List<string> EnabledProviderNames<TConfig>(SerializableDictionary<string, TConfig> configs)
+        where TConfig : ProviderConfigBase =>
+        configs.Where(kvp => kvp.Value.Enabled).Select(kvp => kvp.Key).ToList();
 
     /// <summary>
     /// This is a debug endpoint to list all running OpenID flows. Requires administrator privileges.

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -23,43 +23,16 @@ const ssoConfigLinking = {
     });
   },
   loadProviderList: (container, providers, provider_mode) => {
+    // The server only offers enabled providers for new links (#344), so every name here gets an
+    // add button. A link the user still holds to a since-disabled provider is rendered separately
+    // below, from the links feed, so it stays visible and removable.
     providers.forEach((provider_name) => {
-      // Provider and canonical names are identity-provider/admin-controlled: build the DOM with
-      // createElement/textContent (never innerHTML), and feed them into selectors and URLs only
-      // through CSS.escape / encodeURIComponent, never raw.
-      const provider_config = document.createElement("div");
-      provider_config.classList.add("sso-provider-links-container");
-      provider_config.dataset.id = provider_name;
-
-      const title = document.createElement("label");
-      title.classList.add(
-        "inputLabel",
-        "inputLabelUnfocused",
-        "sso-provider-link-title",
+      ssoConfigLinking.appendProviderContainer(
+        container,
+        provider_name,
+        provider_mode,
+        true,
       );
-      title.textContent = provider_name;
-
-      const add_provider = document.createElement("a");
-      add_provider.classList.add(
-        "fab",
-        "emby-button",
-        "sso-provider-add-link",
-        "sso-provider",
-      );
-      const add_icon = document.createElement("span");
-      add_icon.classList.add("material-icons", "add");
-      add_icon.setAttribute("aria-hidden", "true");
-      add_provider.appendChild(add_icon);
-      add_provider.href = ApiClient.getUrl(
-        `/SSO/${provider_mode}/p/${encodeURIComponent(provider_name)}?isLinking=true`,
-      );
-
-      const existing_links = document.createElement("div");
-      existing_links.classList.add("sso-provider-existing-links-container");
-      existing_links.dataset.provider = provider_name;
-
-      provider_config.append(title, add_provider, existing_links);
-      container.appendChild(provider_config);
     });
 
     const currentUserId = ApiClient.getCurrentUserId();
@@ -74,11 +47,31 @@ const ssoConfigLinking = {
       ).then((resp) => {
         resp.json().then((provider_map) => {
           Object.keys(provider_map).forEach((provider_name) => {
-            const provider_container = container.querySelector(
+            let existing_links = container.querySelector(
               `.sso-provider-existing-links-container[data-provider="${CSS.escape(provider_name)}"]`,
             );
+
+            // No container means the provider is not offered for new links because it is disabled
+            // (it is absent from the enabled-only GetNames list, #344). The server still returns
+            // such links and still lets the user delete them (LinksByUser / TryRemoveLink pass
+            // requireEnabled:false — disabling then cleaning up is the intended workflow), so render
+            // a container without an add button, marked disabled, rather than dropping it and
+            // throwing on a null container. A disabled provider the user holds no link to (empty
+            // list, nothing to remove) is skipped.
+            if (!existing_links) {
+              if (provider_map[provider_name].length === 0) {
+                return;
+              }
+              existing_links = ssoConfigLinking.appendProviderContainer(
+                container,
+                provider_name,
+                provider_mode,
+                false,
+              );
+            }
+
             ssoConfigLinking.populateExistingLinks(
-              provider_container,
+              existing_links,
               provider_mode,
               provider_name,
               provider_map[provider_name],
@@ -87,6 +80,63 @@ const ssoConfigLinking = {
         });
       });
     }
+  },
+
+  // Builds one provider row (title, optional add button, existing-links container) and appends it,
+  // returning the existing-links container so the caller can populate it. When offerLink is false the
+  // provider is disabled: no add button is drawn (it cannot accept a new link) and the title is marked,
+  // but any link the user already holds stays listed and removable.
+  appendProviderContainer: (
+    container,
+    provider_name,
+    provider_mode,
+    offerLink,
+  ) => {
+    // Provider and canonical names are identity-provider/admin-controlled: build the DOM with
+    // createElement/textContent (never innerHTML), and feed them into selectors and URLs only
+    // through CSS.escape / encodeURIComponent, never raw.
+    const provider_config = document.createElement("div");
+    provider_config.classList.add("sso-provider-links-container");
+    provider_config.dataset.id = provider_name;
+
+    const title = document.createElement("label");
+    title.classList.add(
+      "inputLabel",
+      "inputLabelUnfocused",
+      "sso-provider-link-title",
+    );
+    title.textContent = provider_name;
+
+    const existing_links = document.createElement("div");
+    existing_links.classList.add("sso-provider-existing-links-container");
+    existing_links.dataset.provider = provider_name;
+
+    if (offerLink) {
+      const add_provider = document.createElement("a");
+      add_provider.classList.add(
+        "fab",
+        "emby-button",
+        "sso-provider-add-link",
+        "sso-provider",
+      );
+      const add_icon = document.createElement("span");
+      add_icon.classList.add("material-icons", "add");
+      add_icon.setAttribute("aria-hidden", "true");
+      add_provider.appendChild(add_icon);
+      add_provider.href = ApiClient.getUrl(
+        `/SSO/${provider_mode}/p/${encodeURIComponent(provider_name)}?isLinking=true`,
+      );
+      provider_config.append(title, add_provider, existing_links);
+    } else {
+      const disabled_note = document.createElement("span");
+      disabled_note.classList.add("sso-provider-disabled-note");
+      disabled_note.textContent = " (disabled)";
+      title.appendChild(disabled_note);
+      provider_config.append(title, existing_links);
+    }
+
+    container.appendChild(provider_config);
+    return existing_links;
   },
 
   populateExistingLinks: (

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -278,7 +278,7 @@ async function link(request) {
            `MediaBrowser Client=""${request.appName}"",Device=""${request.deviceName}"",DeviceId=""${request.deviceId}"",Version=""${request.appVersion}"",Token=""${jfToken}""`)
 
        xhr.onload = function(e) {
-         resolve(xhr.response);
+         resolve(xhr.status);
        };
        xhr.onerror = function (e) {
          console.log(e);
@@ -306,7 +306,22 @@ async function main() {
 
     var request = {deviceId, appName, appVersion, deviceName, data};
 
-    if (" + $"{isLinking}".ToLower() + @") await link(request);
+    if (" + $"{isLinking}".ToLower() + @") {
+        // Surface a rejected link instead of swallowing it (#344): the link leg fail-closes with a
+        // non-2xx when the provider is disabled (#343), the caller is not allowed, or the request is
+        // throttled. Left silent, the page would fall through to the auth leg and show a misleading
+        // 'Login failed', so a rejected link stops here with its own message. A missing status
+        // (undefined: no stored credentials, or a network error) keeps the prior behavior of
+        // proceeding, since the outcome cannot be told apart from success.
+        var linkStatus = await link(request);
+        if (linkStatus !== undefined && (linkStatus < 200 || linkStatus >= 300)) {
+            document.querySelector('p').textContent =
+                linkStatus === 429
+                    ? 'Too many attempts. Please wait a moment and try again.'
+                    : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
+            return;
+        }
+    }
 
     var url = ssoBaseUrl + '/sso/' + ssoMode + '/Auth/' + encodeURIComponent(ssoProvider);
 


### PR DESCRIPTION
# What & why

Closes #344.

The self-service linking page (`/SSOViews/linking`) offered providers a user
could not actually link through, and swallowed the resulting rejection.

`OID/GetNames` and `SAML/GetNames`, the only feed for the linking page's add
buttons, listed every configured provider regardless of `Enabled`, so a
disabled provider got an active add button. Linking through it is already
rejected server-side (#343), but the served auth page threw that rejection
away: its `link()` XHR resolved the response without reading the status, so the
page fell through to the auth leg and showed a misleading "Login failed" (or
nothing), never telling the user the link did not take.

Two fixes, both UX honesty layered on top of the unchanged server-side gate:

- **Filter at the source.** `OID/GetNames` and `SAML/GetNames` now return only
  enabled providers, via a shared `EnabledProviderNames` helper materialized
  under the config read lock. The disabled provider is never offered, so no dead
  add button is drawn. `linking.js` is the only consumer of `GetNames` (the
  admin config page reads the full `OidConfigs`/`SamlConfigs` from the plugin
  config, so it still shows disabled providers for management), so filtering at
  the endpoint is safe.
- **Surface the rejection.** `WebResponse.link()` now resolves the HTTP status,
  and the auth page stops on a non-2xx link with a clear message (a distinct one
  for 429) instead of proceeding. A missing status (no stored credentials, or a
  network error) keeps the prior proceed-anyway behavior, since it cannot be
  told apart from success.

Defense in depth is unchanged: a disabled provider is still rejected by the link
leg (#343) even though the UI no longer offers it, hiding it is not the gate.

The follow-up commit keeps existing links to a since-disabled provider visible
and removable. The `links/{userId}` feed deliberately returns links for all
providers regardless of `Enabled`, and `TryRemoveLink` deletes them with
`requireEnabled:false` (disable-then-clean-up is the intended workflow). With
the add-button list now enabled-only, the existing-links display is driven off
the links feed instead: a held link whose provider is no longer offered renders
as a removable, `(disabled)`-marked row (a shared `appendProviderContainer`
builder), rather than a null container that would throw. Add buttons stay
enabled-only.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No validation touched; the disabled-provider
      link rejection in the link legs, #343, is unchanged — the UI filter is additive.)
- [x] No secrets logged; secrets are redacted on config export. (No logging or
      secret handling touched.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial review — see Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new log calls.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (`EnabledProviderNames` helper; `appendProviderContainer` builder.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property; existing conformance tests pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (1087 passed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (`linking.js`.)

## Notes

Scope note: the swallowed link rejection lives in the served auth page
(`WebResponse.cs` `link()`), not `linking.js`, `linking.js` renders the list
and handles unlink; the add button is a full navigation to the challenge, and
the actual link POST is issued by the auth page after the IdP round-trip. The
fix is applied where the swallow actually is. `WebResponse.cs` is C# (embedded
JS string), so Prettier does not apply to it. The recently-merged #251 only
touched a doc comment in that file, no collision.

Four-lens adversarial review (login/link surface):

- **security-bypass, PASS.** The server-side `Enabled` gate on both link legs
  (`OidLink`/`SamlLink`, #343) is unchanged; the UI filter is additive
  defense-in-depth and reduces the enumeration surface. No secret leak from
  surfacing the status (generic text; only 429 distinguished).
- **availability, PASS.** No legitimate login/link is blocked; the enabled-only
  filter runs under the config read lock and is materialized to a `List`; the
  `undefined`-status path preserves proceed-anyway so a network hiccup never
  false-blocks.
- **correctness, PASS.** `EnabledProviderNames` is provably equivalent to the
  old `Keys.ToList()` apart from the intended filter; the JS 2xx boundary
  (`< 200 || >= 300`) and the `undefined`-proceed path are correct.
- **integration, NEEDS_IMPROVEMENT → PASS after the follow-up.** The first
  review caught a real regression: with `GetNames` enabled-only, a held link to
  a since-disabled provider (still returned by `links/{userId}` and still
  deletable via `requireEnabled:false`) hit a null container and threw, aborting
  existing-links rendering and removing the stale-link delete path. The
  follow-up commit drives the existing-links display off the `links/{userId}`
  feed, rendering a removable `(disabled)` row for such links, and adds a service
  test (`DisabledProvider_LinksStayListedAndRemovable`) pinning the contract.
  Re-review returned PASS: no null-container throw remains, held disabled-provider
  links stay visible and removable, add buttons stay enabled-only, and the
  XSS-safety invariants (`createElement`/`textContent`/`CSS.escape`/
  `encodeURIComponent`) are intact.

Tests: OID and SAML `*_ExcludesDisabledProviders` (a disabled provider is not in
the offered names, an enabled one is); the provider-delete tests now seed
`Enabled` providers so the names-list observation still proves removal; and the
disabled-link list/remove contract test above.
