### PR TITLE
Surface a throttled cap-refusal capacity warning from SamlReplayCache

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -51,6 +51,17 @@ public class ArchitectureConformanceTests
         "Validator", "Cache", "Builder", "Mapper", "Policy", "Probe", "Store", "Revoker", "Extractor", "Gate", "State", "Resolver",
     };
 
+    // The login-path caches that converged on the shared bounding pattern — a hard global cap plus TWO
+    // distinct IntervalGates: "_pruneGate" (throttled expired-entry sweep, #452) and "_capWarnGate"
+    // (throttled cap-refusal capacity warning, #246/#327/#470). ONE canonical list, consumed by both the
+    // prune-gate rule and the cap-warn rule below, so a cache can never fall out of one rule's list but not
+    // the other's (which is exactly how SamlOutcomeStore was missed on first draft). A new cap-bounded
+    // login-path cache is added here once, and both fitness functions guard it.
+    private static readonly Type[] LoginPathCapWarnCaches =
+    {
+        typeof(SamlReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore), typeof(SamlOutcomeStore),
+    };
+
     // Every production type, compiler-generated ones excluded — the base sequence for structural rules
     // that must cover interfaces/enums/structs/delegates too (e.g. the namespace boundary).
     private static IEnumerable<Type> AllPluginTypes =>
@@ -171,9 +182,10 @@ public class ArchitectureConformanceTests
         // "_pruneGate"), not merely some IntervalGate: the siblings also carry a "_capWarnGate", so keying
         // on the field type alone would miss a sibling that dropped its prune gate but kept cap-warn.
         // SamlRequestCache and OidcStateStore already had it (#246, #327); SamlReplayCache adopted it (#452).
+        // The cache set is the shared LoginPathCapWarnCaches list, so this rule and the cap-warn rule below
+        // can never disagree on which caches are login-path caches.
         const string pruneGateField = "_pruneGate";
-        var caches = new[] { typeof(SamlReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore) };
-        var missing = caches
+        var missing = LoginPathCapWarnCaches
             .Where(t => !t.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly)
                 .Any(f => f.FieldType == typeof(IntervalGate) && f.Name == pruneGateField))
             .Select(SimpleName)
@@ -182,6 +194,35 @@ public class ArchitectureConformanceTests
         Assert.True(
             missing.Count == 0,
             "Every login-path cache must throttle its expired-entry sweep through an IntervalGate field (#452): " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void LoginPathCaches_ThrottleTheirCapacityWarningThroughItsOwnIntervalGate()
+    {
+        // Locked in by #470: every login-path cache that refuses fail-closed at its hard cap surfaces that
+        // refusal to the caller through a SEPARATE cap-warn IntervalGate ("_capWarnGate"), distinct from the
+        // prune gate ("_pruneGate"), so a full cache is observable to operators yet a flood of refusals
+        // cannot amplify into log volume (CWE-400). SamlRequestCache, OidcStateStore and SamlOutcomeStore
+        // already carried it (#246, #327, #251); SamlReplayCache adopted it here (#470). Require BOTH gates as
+        // distinct named fields so a later refactor cannot collapse the cap-warn signal onto the prune gate
+        // (which would re-couple the two intervals) or drop it and regress a cache to a silent cap refusal.
+        // The cache set is the shared LoginPathCapWarnCaches list, so it can never drift from the prune-gate
+        // rule above.
+        var missing = LoginPathCapWarnCaches
+            .Where(t =>
+            {
+                var gates = t.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                    .Where(f => f.FieldType == typeof(IntervalGate))
+                    .Select(f => f.Name)
+                    .ToList();
+                return !gates.Contains("_pruneGate") || !gates.Contains("_capWarnGate");
+            })
+            .Select(SimpleName)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "Every login-path cache must carry BOTH a _pruneGate and a distinct _capWarnGate IntervalGate (#470): " + string.Join(", ", missing));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -45,7 +45,7 @@ public class ProviderScopedKeyTests
         var replayKey = ProviderScopedKey.For("kc", string.Empty);
         var requestKey = ProviderScopedKey.For("kc", null);
 
-        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now));
+        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now, out _));
 
         var requests = new SamlRequestCache();
         requests.Register(requestKey!, "binding", now.AddMinutes(15), now, clientKey: null, out _);

--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -6,12 +6,15 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for <see cref="SamlReplayCache"/> — one-time-use of SAML assertion IDs, and the retention
-/// window that keeps a consumed id long enough that it cannot be replayed while still acceptable.
+/// Tests for <see cref="SamlReplayCache"/> — one-time-use of SAML assertion IDs, the retention
+/// window that keeps a consumed id long enough that it cannot be replayed while still acceptable, and
+/// the throttled cap-refusal capacity-warning signal (#470).
 /// </summary>
 public class SamlReplayCacheTests
 {
     private static readonly DateTime Now = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+
+    private static readonly TimeSpan PruneInterval = TimeSpan.FromMinutes(1);
 
     [Fact]
     public void TryConsume_FirstUse_Succeeds_SecondUse_IsReplay()
@@ -19,8 +22,8 @@ public class SamlReplayCacheTests
         var cache = new SamlReplayCache();
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_assertion-1", expiry, Now));
-        Assert.False(cache.TryConsume("_assertion-1", expiry, Now));
+        Assert.True(cache.TryConsume("_assertion-1", expiry, Now, out _));
+        Assert.False(cache.TryConsume("_assertion-1", expiry, Now, out _));
     }
 
     [Fact]
@@ -29,8 +32,8 @@ public class SamlReplayCacheTests
         var cache = new SamlReplayCache();
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_a", expiry, Now));
-        Assert.True(cache.TryConsume("_b", expiry, Now));
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _));
     }
 
     [Theory]
@@ -39,7 +42,7 @@ public class SamlReplayCacheTests
     public void TryConsume_MissingId_FailsClosed(string? id)
     {
         var cache = new SamlReplayCache();
-        Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now));
+        Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now, out _));
     }
 
     [Fact]
@@ -48,16 +51,16 @@ public class SamlReplayCacheTests
         // Once retention has elapsed the entry is evicted; a fresh assertion reusing the id (a new
         // login, not a replay of the same still-valid assertion) is accepted again.
         var cache = new SamlReplayCache();
-        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now));
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now, out _));
 
         var later = Now.AddMinutes(20);
-        Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_a", later.AddMinutes(10), later, out _));
     }
 
     // --- Hard cap + throttled prune (#452) ---
 
     // A cache whose cap is small and reachable (production 100k is not).
-    private static SamlReplayCache SmallCache(int cap = 3) => new SamlReplayCache(cap, TimeSpan.FromMinutes(1));
+    private static SamlReplayCache SmallCache(int cap = 3) => new SamlReplayCache(cap, PruneInterval);
 
     [Fact]
     public void TryConsume_ReplayStillRejected_UnderCapPressure()
@@ -69,12 +72,12 @@ public class SamlReplayCacheTests
         var cache = SmallCache(cap: 3);
         var expiry = Now.AddMinutes(10);
 
-        Assert.True(cache.TryConsume("_x", expiry, Now));
-        Assert.True(cache.TryConsume("_f1", expiry, Now));
-        Assert.True(cache.TryConsume("_f2", expiry, Now)); // cache now full of live entries
+        Assert.True(cache.TryConsume("_x", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_f1", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_f2", expiry, Now, out _)); // cache now full of live entries
 
-        Assert.False(cache.TryConsume("_new", expiry, Now)); // fail closed: no live entry evicted
-        Assert.False(cache.TryConsume("_x", expiry, Now)); // X still recorded -> replay still caught
+        Assert.False(cache.TryConsume("_new", expiry, Now, out _)); // fail closed: no live entry evicted
+        Assert.False(cache.TryConsume("_x", expiry, Now, out _)); // X still recorded -> replay still caught
     }
 
     [Fact]
@@ -82,10 +85,10 @@ public class SamlReplayCacheTests
     {
         var cache = SmallCache(cap: 2);
         var expiry = Now.AddMinutes(10);
-        Assert.True(cache.TryConsume("_a", expiry, Now));
-        Assert.True(cache.TryConsume("_b", expiry, Now)); // at cap with live entries
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _)); // at cap with live entries
 
-        Assert.False(cache.TryConsume("_c", expiry, Now));
+        Assert.False(cache.TryConsume("_c", expiry, Now, out _));
         Assert.Equal(2, cache.Count); // the refusal did not grow or evict
     }
 
@@ -96,14 +99,14 @@ public class SamlReplayCacheTests
         // the slots and the fresh login is admitted, even though the routine sweep is still throttled.
         var cache = SmallCache(cap: 3);
         var shortExpiry = Now.AddSeconds(30);
-        Assert.True(cache.TryConsume("_a", shortExpiry, Now)); // first call enters the prune gate
-        Assert.True(cache.TryConsume("_b", shortExpiry, Now));
-        Assert.True(cache.TryConsume("_c", shortExpiry, Now)); // at cap
+        Assert.True(cache.TryConsume("_a", shortExpiry, Now, out _)); // first call enters the prune gate
+        Assert.True(cache.TryConsume("_b", shortExpiry, Now, out _));
+        Assert.True(cache.TryConsume("_c", shortExpiry, Now, out _)); // at cap
 
         // 40s later: past the entries' expiry but within the 1-minute prune interval, so the routine sweep
         // is throttled. The cap path must still reclaim the expired entries and admit the new login.
         var later = Now.AddSeconds(40);
-        Assert.True(cache.TryConsume("_d", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_d", later.AddMinutes(10), later, out _));
         Assert.Equal(1, cache.Count); // only _d remains
     }
 
@@ -114,14 +117,14 @@ public class SamlReplayCacheTests
         // WITHIN the prune interval must leave the expired entry in place (an unthrottled sweep would drop
         // it) — proving the IntervalGate throttle is in effect.
         var cache = new SamlReplayCache(); // production cap: the cap path never fires here
-        Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now)); // enters the gate
+        Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now, out _)); // enters the gate
 
         var within = Now.AddSeconds(40); // past _a's expiry, within the 1-minute interval
-        Assert.True(cache.TryConsume("_b", within.AddMinutes(10), within));
+        Assert.True(cache.TryConsume("_b", within.AddMinutes(10), within, out _));
         Assert.Equal(2, cache.Count); // _a NOT swept -> prune is throttled
 
         var beyond = Now.AddSeconds(80); // past the interval: the sweep runs and reclaims _a
-        Assert.True(cache.TryConsume("_c", beyond.AddMinutes(10), beyond));
+        Assert.True(cache.TryConsume("_c", beyond.AddMinutes(10), beyond, out _));
         Assert.Equal(2, cache.Count); // _a reclaimed; _b and _c remain
     }
 
@@ -129,12 +132,81 @@ public class SamlReplayCacheTests
     public void TryConsume_ExpiredEntry_ReclaimedByThrottledPrune()
     {
         var cache = new SamlReplayCache();
-        Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now));
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now, out _));
 
         // A later consume past the prune interval sweeps the expired _a.
         var later = Now.AddMinutes(2);
-        Assert.True(cache.TryConsume("_b", later.AddMinutes(10), later));
+        Assert.True(cache.TryConsume("_b", later.AddMinutes(10), later, out _));
         Assert.Equal(1, cache.Count); // _a reclaimed, only _b remains
+    }
+
+    // --- Throttled cap-refusal capacity warning (#470) ---
+
+    [Fact]
+    public void TryConsume_FirstUse_DoesNotSignalCapacityWarning()
+    {
+        // Normal below-cap operation must stay silent: the signal is for a full cache under pressure only.
+        var cache = SmallCache(cap: 2);
+        Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now, out var warn));
+        Assert.False(warn);
+    }
+
+    [Fact]
+    public void TryConsume_ReplayRejection_DoesNotSignalCapacityWarning()
+    {
+        // A replay returns false but is NOT a capacity refusal, so it must not raise the capacity signal —
+        // only a genuine cap refusal does. This keeps the warning a true capacity signal, not a replay tally.
+        var cache = SmallCache(cap: 3);
+        var expiry = Now.AddMinutes(10);
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+
+        Assert.False(cache.TryConsume("_a", expiry, Now, out var warn)); // replay, well below the cap
+        Assert.False(warn);
+    }
+
+    [Fact]
+    public void TryConsume_MissingId_DoesNotSignalCapacityWarning()
+    {
+        var cache = SmallCache(cap: 2);
+        Assert.False(cache.TryConsume(string.Empty, Now.AddMinutes(10), Now, out var warn));
+        Assert.False(warn);
+    }
+
+    [Fact]
+    public void TryConsume_AtCap_Refused_SignalsCapacityWarningOncePerInterval()
+    {
+        // The warning is bounded exactly like the sweeps: the first refusal signals, further refusals inside
+        // the interval stay silent (so a compromised IdP replaying at the cap cannot amplify into log
+        // volume), and the next interval signals again. The gate is the cache's OWN cap-warn gate, driven by
+        // nowUtc — distinct from the prune gate.
+        var cache = SmallCache(cap: 2);
+        var expiry = Now.AddHours(2); // live well past every nowUtc below, so the cache stays full
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _));
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _)); // at cap with live entries
+
+        Assert.False(cache.TryConsume("_c", expiry, Now, out var firstWarn));
+        Assert.True(firstWarn); // first cap refusal signals
+
+        Assert.False(cache.TryConsume("_d", expiry, Now.AddSeconds(1), out var secondWarn));
+        Assert.False(secondWarn); // within the interval: throttled
+
+        Assert.False(cache.TryConsume("_e", expiry, Now + PruneInterval, out var nextIntervalWarn));
+        Assert.True(nextIntervalWarn); // a full interval later: signals again
+    }
+
+    [Fact]
+    public void TryConsume_CapWarnGate_IsIndependentOfThePruneGate()
+    {
+        // The cap-warn signal must ride its OWN gate, not the prune gate: exercising the prune gate (a
+        // below-cap consume that enters it) must not consume the cap-warn interval, so the first genuine cap
+        // refusal still signals.
+        var cache = SmallCache(cap: 2);
+        var expiry = Now.AddHours(2);
+        Assert.True(cache.TryConsume("_a", expiry, Now, out _)); // enters the prune gate for this interval
+        Assert.True(cache.TryConsume("_b", expiry, Now, out _)); // at cap
+
+        Assert.False(cache.TryConsume("_c", expiry, Now, out var warn)); // same interval as the prune entry
+        Assert.True(warn); // the cap-warn gate was untouched by the prune gate -> still signals
     }
 
     [Fact]

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -105,7 +105,23 @@ internal sealed class SamlAssertionValidator
         var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
         var assertionId = samlResponse.GetAssertionId();
         var replayKey = ProviderScopedKey.For(provider, assertionId);
-        return SamlReplays.TryConsume(replayKey, replayRetention, samlNow);
+        var consumed = SamlReplays.TryConsume(replayKey, replayRetention, samlNow, out var shouldWarnCapacity);
+        if (shouldWarnCapacity)
+        {
+            // The replay cache turned away a NEW assertion at its hard cap: the login already failed closed
+            // (consumed is false). This is the single observation point for every replay consume — the login
+            // mint, the deprecation-window mint leg, and the manual link redeem all funnel through here — so
+            // surfacing it here covers them all, throttled once per interval by the cache's own gate. A full
+            // replay cache is only reachable under extreme login volume or a compromised identity provider
+            // replaying signed assertions, so it is a genuine operator signal (#470). provider is
+            // identity-provider-routed input; strip line endings inline at the log call to prevent log forging
+            // (a helper-boundary sanitizer is not recognized by CodeQL).
+            _logger.LogWarning(
+                "SAML assertion replay cache refused a new assertion for provider {Provider}: the cache is at capacity (warning throttled). This indicates extreme login volume or an identity provider replaying signed assertions.",
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
+        return consumed;
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -8,7 +8,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
 /// reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
 /// bound (#452). It mirrors the sibling login-path caches (<see cref="SamlRequestCache"/>,
-/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap.
+/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and a
+/// second <see cref="IntervalGate"/>-throttled signal that surfaces a cap refusal to the caller so a full
+/// replay cache is observable rather than silent (#470).
 ///
 /// The cap is applied differently from the siblings, on purpose. Recording a consumed assertion is what
 /// makes a replay detectable, so this cache must never drop a still-valid entry to free a slot — that
@@ -43,6 +45,15 @@ internal sealed class SamlReplayCache
     // backward wall-clock step of at least the interval (#334). See PruneExpired.
     private readonly IntervalGate _pruneGate;
 
+    // Throttles the cap-refusal capacity warning to one signal per interval (CWE-400): its OWN gate,
+    // distinct from the prune gate, so a full cache signals at most once per interval rather than once per
+    // refused assertion — a compromised identity provider replaying signed assertions at the cap cannot
+    // amplify the refusal into unbounded log volume. Mirrors the sibling caches (OidcStateStore,
+    // SamlRequestCache) so the SAML replay refusal has the same operator visibility (#470). The warning
+    // LINE itself stays at the caller, which owns the logger, so the log-forging inline sanitizer never
+    // crosses a helper boundary; this cache only decides WHETHER to warn.
+    private readonly IntervalGate _capWarnGate;
+
     internal SamlReplayCache()
         : this(DefaultMaxEntries, DefaultPruneInterval)
     {
@@ -54,6 +65,7 @@ internal sealed class SamlReplayCache
     {
         _maxEntries = maxEntries;
         _pruneGate = new IntervalGate(pruneInterval);
+        _capWarnGate = new IntervalGate(pruneInterval);
     }
 
     /// <summary>Gets the live entry count. Test-only, so the cap and sweep paths can be asserted.</summary>
@@ -96,10 +108,12 @@ internal sealed class SamlReplayCache
     /// <param name="assertionId">The assertion ID.</param>
     /// <param name="expiryUtc">When the entry may be evicted (the assertion's retention horizon).</param>
     /// <param name="nowUtc">The current time.</param>
+    /// <param name="shouldWarnCapacity">True for at most one caller per interval when a fail-closed cap refusal occurred, so the caller can log it once; false on any other outcome (first use, replay, missing ID).</param>
     /// <returns>True if this is the first use; false on replay, a missing ID, or a fail-closed cap refusal.</returns>
-    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc)
+    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc, out bool shouldWarnCapacity)
     {
         PruneExpired(nowUtc);
+        shouldWarnCapacity = false;
 
         // Fail closed: without an ID we cannot enforce one-time use.
         if (string.IsNullOrEmpty(assertionId))
@@ -117,6 +131,11 @@ internal sealed class SamlReplayCache
             SweepExpired(nowUtc);
             if (_consumed.Count >= _maxEntries && !_consumed.ContainsKey(assertionId))
             {
+                // A genuine fail-closed cap refusal: the cache is full of still-live consumed assertions and
+                // this new one is turned away (the login fails closed). Signal it once per interval — its own
+                // gate, so a flood of refusals cannot amplify into log volume — so an operator can see the
+                // replay cache is under real pressure (#470). The refusal itself is unchanged.
+                shouldWarnCapacity = _capWarnGate.TryEnter(nowUtc);
                 return false;
             }
         }


### PR DESCRIPTION
# What & why

Closes #470. Follow-up to #452.

`SamlReplayCache` (the SAML assertion one-time-replay cache) hard-caps consumed
IDs at 100k and refuses a new assertion fail-closed at the cap, but did so
**silently**. Its sibling login-path caches (`OidcStateStore`,
`SamlRequestCache`, `SamlOutcomeStore`) each surface a throttled
capacity-warning signal so an operator can see the cache is under genuine
pressure; the replay cache did not, so a full replay cache - only reachable
under extreme login volume or a compromised IdP replaying signed assertions - 
was invisible.

This mirrors the siblings' pattern. It is a pure observability addition:

- `SamlReplayCache` gains its **own** `_capWarnGate` `IntervalGate` (distinct
  from the prune gate), and `TryConsume` now yields `out bool
  shouldWarnCapacity`, set true for at most one caller per interval **only** on
  the fail-closed cap-refusal branch. The cap refusal, the one-time replay
  consume, and all validation are byte-for-byte unchanged.
- `SamlAssertionValidator.TryConsumeReplay`, the single consume site shared by
  the login mint (`TryProduceVerifiedIdentity`), the #251 deprecation-window
  mint leg, and the manual link redeem, logs one throttled `LogWarning` when
  the signal is set, with the IdP-routed `provider` value sanitized inline at
  the log call.

This is built on current `main` (post-#251 one-time-outcome-token flow and
post-#496 `SamlAssertionValidator` extraction). It supersedes the earlier
attempt (PR #529, closed) which predated the #251 SAML refactor.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

(Hardening/quality: an observability signal on a security-critical login-path
cache; no behavioural change to the security controls.)

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: the cap refusal still returns false (login fails
      closed); the replay reject and every validation gate are unchanged. The
      new signal has no effect on any return value.
- [x] No secrets logged; the warning logs only the provider name and a static
      message — no assertion, key, or token.
- [x] A security review was performed (four adversarial lenses; see Notes).
- [x] Log inputs from the IdP are sanitized inline at the log call
      (`provider?.ReplaceLineEndings(string.Empty)`), not via a helper.

## Quality checklist

- [x] No duplicated logic; the cap-warn signal reuses the shared `IntervalGate`
      primitive and the caller-logs / cache-decides split the siblings use.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (comments explain the why - the fail-closed
      invariant and the throttle rationale) and matches the sibling caches.
- [x] Architecture-conformance tests pass; the new structural property (every
      login-path cache carries a distinct `_capWarnGate`) is locked in, and the
      two cache lists were hoisted into one shared canonical list so they cannot
      drift.

## Verification

- [x] `dotnet build --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (1093/1093).
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A - 
      only `.cs` files changed.)

## Notes

**Adversarial self-review, four refute-by-default lenses:**

- **Availability / mass-lockout: PASS.** The signal is throttled by its own
  gate (cannot amplify a flood into log volume), cannot suppress a real signal,
  and the login return path is unchanged (no new lockout).
- **Security-bypass / fail-open: PASS.** `shouldWarnCapacity` is a pure
  side-signal; every `TryConsume` return is behaviourally identical to before,
  the replay guard and cap are not weakened, and no secret is logged.
- **Correctness: PASS.** The warning fires only on a genuine cap refusal (not a
  first use, a replay rejection, or a missing ID), is throttled once per
  interval via an atomic CAS gate, and the tests pin the throttle and the
  gate-independence.
- **Integration: NEEDS_IMPROVEMENT → resolved.** The lens found the new
  conformance rule listed only three caches and omitted a fourth login-path
  cap-warn cache, `SamlOutcomeStore` (#251), which carries the identical
  `_pruneGate`/`_capWarnGate` pattern, so a future refactor could drop its
  `_capWarnGate` uncaught. Resolved by (a) adding `SamlOutcomeStore` to the
  guarded set, and (b) hoisting a single shared canonical `LoginPathCapWarnCaches`
  list consumed by both the prune-gate rule (#452) and the cap-warn rule (#470),
  so a cache can never fall out of one rule's list but not the other's. Both
  rules pass with the widened set.

**Out of scope / follow-ups:** none. Deliberately untouched: the linking view /
`SSOViewsController` / `OidcLoginService` (owned by parallel PRs).
