### PR TITLE
Share the route-suffix reader between ChallengePath and OidcCallbackPath

### DIFF
--- a/SSO-Auth.Tests/RouteSuffixTests.cs
+++ b/SSO-Auth.Tests/RouteSuffixTests.cs
@@ -1,0 +1,69 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="RouteSuffix.TryRead"/> — the trim/split/anchor mechanics shared by
+/// <see cref="ChallengePath.IsNewPath"/> and <see cref="OidcCallbackPath.RedirectSegment"/> (#509).
+/// <see cref="ChallengePathTests"/> and <see cref="OidcCallbackPathTests"/> already cover the two
+/// callers' terminal comparisons end to end; these tests cover the reader itself in isolation.
+/// </summary>
+public class RouteSuffixTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryRead_EmptyOrNullPath_ReturnsFalse(string? path)
+    {
+        Assert.False(RouteSuffix.TryRead(path, out _));
+    }
+
+    [Theory]
+    [InlineData("/sso")]
+    [InlineData("/sso/OID")]
+    [InlineData("sso/OID")]
+    public void TryRead_FewerThanThreeSegments_ReturnsFalse(string path)
+    {
+        Assert.False(RouteSuffix.TryRead(path, out _));
+    }
+
+    [Fact]
+    public void TryRead_ThreeOrMoreSegments_ReadsTheLastThreeAsTheSuffix()
+    {
+        Assert.True(RouteSuffix.TryRead("/sso/OID/start/keycloak", out var suffix));
+        Assert.Equal("OID", suffix.Protocol);
+        Assert.Equal("start", suffix.PathKind);
+    }
+
+    [Fact]
+    public void TryRead_TrimsOnlyBoundarySlashes()
+    {
+        // Leading/trailing slashes are trimmed, but the segment count is otherwise untouched.
+        Assert.True(RouteSuffix.TryRead("sso/OID/start/keycloak/", out var suffix));
+        Assert.Equal("OID", suffix.Protocol);
+        Assert.Equal("start", suffix.PathKind);
+    }
+
+    [Fact]
+    public void TryRead_InternalDoubledSlash_ShiftsTheSuffixInsteadOfCollapsing()
+    {
+        // The doubled slash inserts an empty segment, so the suffix read off the END of the path no
+        // longer names the real protocol/path-kind pair — it must not be silently collapsed away.
+        Assert.True(RouteSuffix.TryRead("/sso/OID//start/keycloak", out var suffix));
+        Assert.Equal(string.Empty, suffix.Protocol);
+        Assert.Equal("start", suffix.PathKind);
+    }
+
+    [Fact]
+    public void TryRead_IgnoresPrefixSegmentsBeforeTheSuffix()
+    {
+        // A protocol-like reverse-proxy prefix earlier in the path must not be picked up: only the
+        // last three segments count.
+        Assert.True(RouteSuffix.TryRead("/OID/start/proxy/sso/SAML/redirect/keycloak", out var suffix));
+        Assert.Equal("SAML", suffix.Protocol);
+        Assert.Equal("redirect", suffix.PathKind);
+    }
+}

--- a/SSO-Auth/Api/ChallengePath.cs
+++ b/SSO-Auth/Api/ChallengePath.cs
@@ -12,7 +12,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <c>Contains("/start/")</c> substring test, which a provider literally named <c>start</c> on the
 /// legacy route (<c>.../OID/p/start/</c>) would trip, flipping the spelling and breaking the login at
 /// the IdP's redirect_uri check (#337). Same fix family as <see cref="OidcCallbackPath.RedirectSegment"/>
-/// (#98), which now shares this suffix-anchored form (#411).
+/// (#98); both now read the suffix through the shared <see cref="RouteSuffix"/> reader (#411, #509) and
+/// keep only their own terminal comparison and default.
 /// </summary>
 internal static class ChallengePath
 {
@@ -24,21 +25,13 @@ internal static class ChallengePath
     /// <returns>True for the new "start" route, false for the legacy route.</returns>
     internal static bool IsNewPath(string? path)
     {
-        // The challenge route always ends in {protocol}/{path-kind}/{provider}, so anchor to that
-        // three-segment suffix rather than the first protocol token found anywhere in the path: a
-        // protocol-like reverse-proxy prefix (e.g. /OID/start/proxy/...) must not decide the spelling.
-        // Trim only boundary slashes so an internal empty segment (a doubled slash) shifts the suffix
-        // and fails to match rather than being silently collapsed into a valid route.
-        var segments = path?.Trim('/').Split('/');
-        if (segments is null || segments.Length < 3)
+        if (!RouteSuffix.TryRead(path, out var suffix))
         {
             return false;
         }
 
-        var protocol = segments[^3];
-        var pathKind = segments[^2];
-        var isProtocol = string.Equals(protocol, "OID", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(protocol, "SAML", StringComparison.OrdinalIgnoreCase);
-        return isProtocol && string.Equals(pathKind, "start", StringComparison.OrdinalIgnoreCase);
+        var isProtocol = string.Equals(suffix.Protocol, "OID", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(suffix.Protocol, "SAML", StringComparison.OrdinalIgnoreCase);
+        return isProtocol && string.Equals(suffix.PathKind, "start", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/SSO-Auth/Api/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/OidcCallbackPath.cs
@@ -11,9 +11,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// segment is read off the callback's own path. The previous expression tested for "/start/", a
 /// challenge-route segment that never occurs on callback routes, so the new-path flow sent a
 /// mismatched redirect_uri that spec-enforcing IdPs reject (#98). The route is now read off its
-/// <c>{protocol}/{path-kind}/{provider}</c> suffix — the same robust form as
-/// <see cref="ChallengePath.IsNewPath"/> — so a protocol-like reverse-proxy prefix cannot decide
-/// the spelling (#411).
+/// <c>{protocol}/{path-kind}/{provider}</c> suffix through the shared <see cref="RouteSuffix"/> reader —
+/// the same robust form as <see cref="ChallengePath.IsNewPath"/> — so a protocol-like reverse-proxy
+/// prefix cannot decide the spelling (#411, #509).
 /// </summary>
 internal static class OidcCallbackPath
 {
@@ -24,22 +24,13 @@ internal static class OidcCallbackPath
     /// <returns>"redirect" when the route's <c>OID/{path-kind}/{provider}</c> suffix names the "redirect" path-kind, otherwise "r".</returns>
     internal static string RedirectSegment(string? path)
     {
-        // The callback route always ends in {protocol}/{path-kind}/{provider}, so anchor to that
-        // three-segment suffix rather than the first "OID" token found anywhere in the path: a
-        // protocol-like reverse-proxy prefix (e.g. /OID/redirect/proxy/...) must not decide the
-        // spelling. Trim only boundary slashes so an internal empty segment (a doubled slash) shifts
-        // the suffix and fails to match rather than being silently collapsed into a valid route.
-        // Same suffix-anchored form as ChallengePath.IsNewPath (#411).
-        var segments = path?.Trim('/').Split('/');
-        if (segments is null || segments.Length < 3)
+        if (!RouteSuffix.TryRead(path, out var suffix))
         {
             return "r";
         }
 
-        var protocol = segments[^3];
-        var pathKind = segments[^2];
-        return string.Equals(protocol, "OID", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(pathKind, "redirect", StringComparison.OrdinalIgnoreCase)
+        return string.Equals(suffix.Protocol, "OID", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(suffix.PathKind, "redirect", StringComparison.OrdinalIgnoreCase)
                 ? "redirect"
                 : "r";
     }

--- a/SSO-Auth/Api/RouteSuffix.cs
+++ b/SSO-Auth/Api/RouteSuffix.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The trailing <c>{protocol}/{path-kind}/{provider}</c> suffix that both <see cref="ChallengePath"/>
+/// and <see cref="OidcCallbackPath"/> anchor their new-vs-legacy route classification to (#411). Anchoring
+/// to the suffix — rather than the first protocol-like token found anywhere in the path — keeps a
+/// protocol-like reverse-proxy prefix (e.g. <c>/OID/start/proxy/...</c>) from deciding the spelling (#337).
+/// Each caller keeps its own terminal comparison (which protocol/path-kind values it accepts) and its own
+/// default for a missing suffix; only the trim/split/anchor mechanics live here (#509).
+/// </summary>
+/// <param name="Protocol">The suffix segment three places from the end, e.g. <c>OID</c> or <c>SAML</c>.</param>
+/// <param name="PathKind">The suffix segment two places from the end, e.g. <c>start</c> or <c>redirect</c>.</param>
+internal readonly record struct RouteSuffix(string Protocol, string PathKind)
+{
+    /// <summary>
+    /// Reads the <c>{protocol}/{path-kind}/{provider}</c> suffix off <paramref name="path"/>. Trims only
+    /// boundary slashes, so an internal doubled slash shifts the suffix and fails to match rather than
+    /// being silently collapsed into a valid route.
+    /// </summary>
+    /// <param name="path">The request path, e.g. <c>/sso/OID/start/{provider}</c>.</param>
+    /// <param name="suffix">The parsed suffix when the path has at least three segments; default otherwise.</param>
+    /// <returns>False when <paramref name="path"/> is null or has fewer than three <c>/</c>-separated segments.</returns>
+    internal static bool TryRead(string? path, out RouteSuffix suffix)
+    {
+        var segments = path?.Trim('/').Split('/');
+        if (segments is null || segments.Length < 3)
+        {
+            suffix = default;
+            return false;
+        }
+
+        suffix = new RouteSuffix(segments[^3], segments[^2]);
+        return true;
+    }
+}


### PR DESCRIPTION
# What & why

`ChallengePath.IsNewPath` and `OidcCallbackPath.RedirectSegment` carried an identical
trim/split/anchor extraction of the route's trailing `{protocol}/{path-kind}/{provider}`
suffix, the fix for #337 (a provider literally named `start` on the legacy route must not
flip the challenge's redirect_uri spelling) and #98/#411 (a protocol-like reverse-proxy
prefix earlier in the path must not decide the spelling). Only the terminal comparison and
default differed between the two. We pulled the shared mechanics into one small internal
reader, `RouteSuffix.TryRead`, that both callers now use; each keeps only its own terminal
comparison and default. Closes #509.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches the login challenge/callback routing path, so we filled this in even though
the change is behavior-preserving.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Unaffected — the extraction is a byte-for-byte
      move of the trim/split/guard/index expressions; each caller's own fail-safe default
      stayed local.)
- [x] No secrets logged; secrets are redacted on config export. (Not applicable - no
      logging or secrets in this code path.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (4-lens adversarial self-review below.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Not applicable - no
      logging in this code.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (The whole point of #509 — the duplicated trim/split/anchor now
      lives once, in `RouteSuffix`.)
- [x] The change adds no more code than the problem requires. (~30 lines for the reader
      + its doc comment; net diff removes more lines than it adds across the two callers.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new
      rule added — a 2-caller trim/split helper isn't a load-bearing structural invariant;
      the integration lens confirmed this matches how the other small internal record-struct
      helpers in this codebase, e.g. `DiscoveryFacts`, are already exempted, and that adding
      a fitness function here would be over-engineering.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (1105/1105, Debug and Release).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (Not applicable - 
      only `.cs` files touched.)

## Notes

Adversarial 4-lens self-review (this PR touches the login challenge/callback routing path):

- **Availability lens, PASS.** The extraction is index-for-index identical; both callers
  retain their own terminal comparison and fail-safe default, the `out` param is only ever
  read after a checked `true` return, and the full 1105-test suite passes, so no mass-lockout
  or availability regression is introduced.
- **Security-bypass lens, PASS.** Byte-for-byte mechanical extraction of the trim/split/index
  logic with unchanged terminal comparisons at both call sites; the null-default `out` value
  is never dereferenced on the false path; the #337/#98/#411 regression tests were carried
  forward unchanged, no suffix-anchoring bypass, spoofing, or shift.
- **Correctness lens, PASS.** Verified byte-identical trim/split/guard/index expressions
  against `origin/main`, no index shift, no null/empty divergence, no nullable-warning
  regression (`--warnaserror` clean), unchanged call sites, full 1105-test green run
  including all three touched test files.
- **Integration lens, initially NEEDS_IMPROVEMENT**, flagging that the diff under review
  was still uncommitted working-tree state (nothing on the branch yet). Not a code defect - 
  we staged and committed the four touched files (`fa980c4`) and re-ran build+test green
  against the committed state. All other integration findings (no other caller needed a
  change, `OidcLoginService.cs:430`, `SamlLoginService.cs:523`, `SsoUrlBuilder.cs:31` are
  untouched; folder placement in `Api/` not `Api/Shared/` matches precedent; no
  architecture-conformance rule needed) held and are addressed above.

Out of scope: the integration lens flagged that `ArchitectureConformanceTests`'
`SourceFilesDeclaring` helper matches on `\bclass\s+{Name}\b` and would silently return no
files for a `record struct`/`struct` type if a future rule ever tried to pin one. No current
rule does this, so nothing is broken today, filing a separate low-priority issue for
whoever eventually needs that regex to cover struct declarations.
