### PR TITLE
Bound the avatar store-lock acquire wait with a timeout

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -66,6 +66,29 @@ public class AvatarServiceTests
         return (service, providers, users, log);
     }
 
+    // Builds a service whose store-lock ACQUIRE WAIT is bounded by the given (short, test-only) timeout
+    // rather than the production 30s (#448), so a test can drive the abort-on-timeout branch deterministically
+    // and quickly instead of waiting out the real bound.
+    private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build(KeyedLockStore userStoreLocks, TimeSpan storeLockAcquireTimeout)
+    {
+        var users = Substitute.For<IUserManager>();
+        var providers = Substitute.For<IProviderManager>();
+        var serverConfig = Substitute.For<IServerConfigurationManager>();
+        serverConfig.ApplicationPaths.UserConfigurationDirectoryPath.Returns(UserDataRoot);
+        var log = new CapturingLogger();
+        var service = new AvatarService(
+            users,
+            providers,
+            serverConfig,
+            log,
+            "test-agent/1.0",
+            new HttpClient(new StubHandler(new HttpResponseMessage())),
+            userStoreLocks,
+            fileExists: null,
+            storeLockAcquireTimeout: storeLockAcquireTimeout);
+        return (service, providers, users, log);
+    }
+
     // An allowed public URL: the stub handler answers before any connection, so the URL only needs to
     // clear the allow-list — the SSRF transport guard (ConnectCallback) is never reached here.
     private const string AllowedUrl = "https://cdn.example.com/avatar.png";
@@ -226,6 +249,52 @@ public class AvatarServiceTests
         Assert.Equal(ProfilePath("racer", ".png"), user.ProfileImage?.Path);
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
         Assert.Equal(0, locks.TrackedKeys); // both holders left; the map is collected
+    }
+
+    [Fact]
+    public async Task StoreAsync_LockAcquireTimesOut_AbortsWithoutStoringUnguarded()
+    {
+        // #448: CancellationToken.None made the same-user acquire wait unbounded, so a store step stalled
+        // while holding the gate could park every other concurrent login for that user forever. With a
+        // bounded wait, a stalled holder (stood in for here by a lock we hold and never release) times the
+        // waiter out; the store must abort — SaveImage is NEVER called (no unguarded write bypassing the
+        // lock) and the user's profile-image record is left untouched — rather than propagate an unhandled
+        // exception into the best-effort login path.
+        var locks = new KeyedLockStore(StringComparer.Ordinal);
+        var (service, providers, users, log) = Build(locks, TimeSpan.FromMilliseconds(50));
+        var user = UserNamed("racer");
+        var previous = new ImageInfo(ProfilePath("racer", ".jpg"));
+        user.ProfileImage = previous;
+
+        using (await locks.AcquireAsync(user.Username, TestContext.Current.CancellationToken))
+        {
+            // The lock is held for the whole store attempt, standing in for a stalled concurrent store.
+            await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+        }
+
+        await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
+        await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
+        Assert.Same(previous, user.ProfileImage); // record untouched — no unguarded store ran
+        Assert.Contains(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Timed out"));
+        Assert.Equal(0, locks.TrackedKeys); // the timed-out waiter left no reference behind
+    }
+
+    [Fact]
+    public async Task StoreAsync_LockAcquiredBeforeTimeout_StoresNormally()
+    {
+        // The counterpart to the timeout test: when the lock is free (the normal case), a bounded wait
+        // still lets the store through exactly as before — the timeout only aborts a genuinely stalled
+        // wait, it does not shrink the normal-load window.
+        var locks = new KeyedLockStore(StringComparer.Ordinal);
+        var (service, providers, _, log) = Build(locks, TimeSpan.FromSeconds(30));
+        var user = UserNamed("alice");
+
+        await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
+
+        await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
+        Assert.Equal(ProfilePath("alice", ".png"), user.ProfileImage?.Path);
+        Assert.DoesNotContain(log.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("Timed out"));
+        Assert.Equal(0, locks.TrackedKeys);
     }
 
     [Fact]

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -25,6 +25,13 @@ internal sealed class AvatarService
     /// <summary>The maximum avatar size accepted, enforced both against Content-Length and while streaming (#220).</summary>
     internal const long MaxAvatarBytes = 10 * 1024 * 1024;
 
+    // Bounds the wait for the per-user store lock (#448). This flow tier is deliberately HttpContext-free
+    // (see LoginCompletionService/SessionMinter), so no ambient request-abort token reaches this far — a
+    // self-contained deadline is the same pattern TrySetAsync already uses for the fetch. 30s comfortably
+    // covers several legitimate queued same-user stores (each a local disk write, occasionally a DB clear)
+    // while still bounding a truly stalled holder so it cannot park same-user logins forever.
+    private static readonly TimeSpan StoreLockAcquireTimeout = TimeSpan.FromSeconds(30);
+
     // Serializes the store step per user across ALL logins (#400). Static because the controller builds a
     // fresh AvatarService per request, so two concurrent same-user logins hold different instances — an
     // instance lock would not serialize them. Keyed by user, so unrelated users never block each other,
@@ -50,6 +57,7 @@ internal sealed class AvatarService
     private readonly HttpClient _httpClient;
     private readonly KeyedLockStore _userStoreLocks;
     private readonly Func<string, bool> _fileExists;
+    private readonly TimeSpan _storeLockAcquireTimeout;
 
     internal AvatarService(
         IUserManager userManager,
@@ -76,6 +84,7 @@ internal sealed class AvatarService
     /// <param name="httpClient">The client used for every fetch; reused across calls (never disposed here).</param>
     /// <param name="userStoreLocks">The per-user store lock (#400); null uses the process-wide shared one. A test injects its own so it can drive the serialization deterministically.</param>
     /// <param name="fileExists">Probe for the on-disk profile image (#480); null uses <see cref="File.Exists"/>. A test injects its own to drive the missing-file self-heal branch without touching the filesystem.</param>
+    /// <param name="storeLockAcquireTimeout">How long <see cref="StoreAsync"/> waits for the per-user store lock (#448); null uses the production 30s bound. A test injects a short timeout so the abort-on-timeout branch is reachable without a real 30s wait.</param>
     internal AvatarService(
         IUserManager userManager,
         IProviderManager providerManager,
@@ -84,7 +93,8 @@ internal sealed class AvatarService
         string userAgent,
         HttpClient httpClient,
         KeyedLockStore userStoreLocks = null,
-        Func<string, bool> fileExists = null)
+        Func<string, bool> fileExists = null,
+        TimeSpan? storeLockAcquireTimeout = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
         _providerManager = providerManager ?? throw new ArgumentNullException(nameof(providerManager));
@@ -94,6 +104,7 @@ internal sealed class AvatarService
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _userStoreLocks = userStoreLocks ?? SharedUserStoreLocks;
         _fileExists = fileExists ?? File.Exists;
+        _storeLockAcquireTimeout = storeLockAcquireTimeout ?? StoreLockAcquireTimeout;
     }
 
     /// <summary>
@@ -200,6 +211,8 @@ internal sealed class AvatarService
     /// at a never-written path (#377). (When the target path is unchanged the host writes the file in
     /// place, so a mid-write failure can still truncate the bytes — that is ImageSaver's contract, not
     /// ours to fix.) Throws on save failure; <see cref="TrySetAsync"/>'s best-effort catch owns the logging.
+    /// Returns silently instead, logging its own warning, if the per-user store lock cannot be acquired
+    /// within the bound (#448) — a timed-out wait skips the store entirely rather than throwing.
     /// </summary>
     /// <param name="user">The user whose profile image is set.</param>
     /// <param name="image">The fetched avatar bytes.</param>
@@ -213,7 +226,30 @@ internal sealed class AvatarService
         // can clear or overwrite the other's record. The lock spans only the store; the HTTP fetch runs
         // before this call (in TrySetAsync), so a slow endpoint never holds the per-user gate. Keyed by
         // user, so unrelated users never wait on each other.
-        using (await _userStoreLocks.AcquireAsync(user.Username, CancellationToken.None).ConfigureAwait(false))
+        //
+        // The wait itself is bounded (#448): CancellationToken.None made it unbounded, so a store step
+        // stalled while holding the gate (e.g. SaveImage blocking on disk I/O, or ClearProfileImageAsync
+        // on the host DB) could park every other concurrent login for this SAME user indefinitely.
+        // KeyedLockStore.AcquireAsync already honors cancellation and leaks no waiter/permit on it
+        // (KeyedLockStoreTests); a timed-out wait here acquires nothing, so the store below never runs
+        // unguarded — it is skipped entirely, exactly like the other best-effort fail-closed branches in
+        // this class (disallowed URL, disallowed content type, unsafe username).
+        using var acquireTimeout = new CancellationTokenSource(_storeLockAcquireTimeout);
+        IDisposable storeLock;
+        try
+        {
+            storeLock = await _userStoreLocks.AcquireAsync(user.Username, acquireTimeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (acquireTimeout.IsCancellationRequested)
+        {
+            _logger.LogWarning(
+                "Timed out after {TimeoutSeconds}s waiting for another login to finish storing the SSO avatar for user: {Username}; skipping this store.",
+                _storeLockAcquireTimeout.TotalSeconds,
+                user.Username?.ReplaceLineEndings(string.Empty));
+            return;
+        }
+
+        using (storeLock)
         {
             await StoreLockedAsync(user, image, mediaType, extension).ConfigureAwait(false);
         }


### PR DESCRIPTION
# What & why

`AvatarService.StoreAsync` acquired the per-user `KeyedLockStore` gate with
`CancellationToken.None`, so the same-user store-lock acquire wait was
unbounded. If one user's store step stalled while holding the gate (e.g.
`IProviderManager.SaveImage` blocking on disk I/O, or `ClearProfileImageAsync`
on the host DB), concurrent logins for that same user would queue behind it
forever.

We bound the wait with a 30s `CancellationTokenSource` instead. A timed-out
acquire never reaches the guarded write, it logs a warning naming the user
and returns, exactly like this class's other best-effort fail-closed branches
(disallowed URL, disallowed content type, unsafe username). The timeout is
injectable via a new optional constructor parameter, mirroring the existing
`userStoreLocks`/`fileExists` test seams, so the abort path is reachable in
tests without a real 30s wait.

`KeyedLockStore.AcquireAsync` already honored cancellation correctly (proven
by the existing `KeyedLockStoreTests`) and leaked no waiter or permit on it - 
this change only threads a bounded token into the one call site that was
passing `None`.

Closes #448.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a timed-out/cancelled acquire never falls through
      to an unguarded store — it aborts (skips `StoreLockedAsync` entirely),
      the same as the other fail-closed branches in this class.
- [x] No secrets logged; secrets are redacted on config export. (Not touched - 
      this path logs a username, already logged elsewhere in this file.)
- [x] A security review was performed for this change (see the four-lens
      results below — this is an avatar-store path that runs on every SSO
      login).
- [x] Log inputs from the IdP are sanitized inline at the log call (the new
      warning uses `user.Username?.ReplaceLineEndings(string.Empty)`, matching
      every other IdP-controlled value logged in this file).

## Quality checklist

- [x] No duplicated logic; the new logic is a single guarded `try`/`catch`
      around the existing `AcquireAsync` call, plus one test seam.
- [x] The change adds no more code than the problem requires (one bounded
      `CancellationTokenSource`, one catch branch, one constructor parameter).
- [x] The code is self-documenting and matches the target architecture (#318);
      the load-bearing "why" comments explain the bound and the fail-closed
      contract.
- [x] Architecture-conformance tests pass. No new structural property is
      established here — `_userStoreLocks.AcquireAsync` has exactly one call
      site in the whole codebase, so a dedicated fitness function would be
      premature generalization; the behavior is locked in by two direct unit
      tests instead (see below).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green, 1098/1098, both Debug and Release.
- [x] Prettier, N/A, this PR only touches `.cs` files.

New/extended tests (`SSO-Auth.Tests/AvatarServiceTests.cs`):

- `StoreAsync_LockAcquireTimesOut_AbortsWithoutStoringUnguarded`, with the
  per-user lock held for the whole call (standing in for a stalled
  concurrent store) and a short injected timeout, proves `SaveImage` and
  `ClearProfileImageAsync` are never called, the existing profile-image
  record is left untouched, a "Timed out" warning is logged, and the
  `KeyedLockStore` map is left at zero tracked keys (no leaked waiter).
- `StoreAsync_LockAcquiredBeforeTimeout_StoresNormally`, the counterpart:
  with the lock free, a bounded wait still lets a normal store through
  exactly as before.

## Notes

We ran the full four-lens adversarial review (availability/mass-lockout,
security-bypass/fail-open, correctness, integration) before opening this PR,
since the avatar store runs on the login path:

- **Availability/mass-lockout, PASS.** Blast radius stays strictly per-user
  (`KeyedLockStore` keys by username; unrelated users never share a
  semaphore). 30s comfortably covers normal same-user store queuing. No new
  leak: the `CancellationTokenSource` is a method-scoped `using var`, disposed
  on every exit path. One residual, non-blocking observation: `StoreAsync`'s
  new 30s bound stacks with `TrySetAsync`'s existing 10s fetch deadline on the
  synchronous login path, for a worst case of ~40s before the login response
  returns. We filed #541 to consider shortening the store-lock bound (the
  store step is local disk/DB work, not network I/O, so it doesn't need the
  fetch's own generous bound).
- **Security-bypass/fail-open, PASS.** Traced every exit from the
  `try`/`catch`: the only way to reach the guarded write is through a
  successfully assigned `storeLock`; the timeout catch always returns first.
  Verified `SemaphoreSlim.WaitAsync`'s "takes the permit or throws having
  taken none" contract empirically (a 200k-iteration cancel-vs-release stress
  probe, zero leaks/double-grants) rather than trusting the code comment
  alone, and confirmed `KeyedLockStore.AcquireAsync`'s existing
  `catch { Unclaim(...); throw; }` never abandons a held permit.
- **Correctness, NEEDS_IMPROVEMENT → FIXED.** Flagged that `StoreAsync`'s XML
  doc comment still read "Throws on save failure" without noting the new
  silent-return-on-timeout path. Fixed: the doc now documents both outcomes.
  (Definite-assignment, `CancellationTokenSource` disposal on every exit path,
  test determinism, and call-site compatibility were all independently
  verified and passed.)
- **Integration, NEEDS_IMPROVEMENT → FIXED.** Flagged that the new timeout
  warning omitted `user.Username`, unlike every comparable warning in this
  file (disallowed URL, disallowed content type, unsafe username all log a
  sanitized IdP-controlled value). Fixed: the warning now names the user,
  sanitized inline with `ReplaceLineEndings(string.Empty)`. Confirmed the
  fetch's 10s timeout and the store's new 30s timeout are fully independent
  tokens, and that the bound applies only to the lock *acquire*, the guarded
  `SaveImage`/`ClearProfileImageAsync` calls still receive no cancellation
  token, exactly matching the issue's scope. No architecture-conformance gap:
  the single call site doesn't warrant a new fitness function.

Gates: build (Debug + Release) green, `dotnet test` green (1098/1098), four-
lens adversarial review complete with both findings fixed in this PR before
opening it. Follow-up filed as #541 (non-blocking, LOW priority).
