### PR TITLE
Single-source the shared authorize-state privilege merge

### DIFF
--- a/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
@@ -310,4 +310,108 @@ public class RolePrivilegeMapperTests
         Assert.True(RolePrivilegeMapper.Evaluate(new[] { "jellyfin" }, saml).Valid);
         Assert.False(RolePrivilegeMapper.Evaluate(new[] { "other" }, saml).Valid);
     }
+
+    // --- AssemblePrivileges (#508): the shared post-Evaluate merge glue that used to be duplicated,
+    // byte-identical, in OidcAuthorizeStateBuilder and SamlAuthorizeStateBuilder. Covers both former
+    // call sites (an OidConfig and a SamlConfig) since the method is protocol-agnostic.
+
+    [Fact]
+    public void AssemblePrivileges_FolderRolesOff_CopiesEnabledFolders()
+    {
+        var config = Oid(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.EnabledFolders = new[] { "movies", "shows" };
+        });
+
+        var result = RolePrivilegeMapper.AssemblePrivileges(Array.Empty<string>(), config);
+
+        Assert.Equal(new List<string> { "movies", "shows" }, result.Folders);
+    }
+
+    [Fact]
+    public void AssemblePrivileges_FolderRolesOff_NullEnabledFolders_YieldsEmptyFolders()
+    {
+        // A null EnabledFolders (never configured) must not throw and must yield an empty, non-null list.
+        var config = Saml(c =>
+        {
+            c.EnableFolderRoles = false;
+            c.EnabledFolders = null;
+        });
+
+        var result = RolePrivilegeMapper.AssemblePrivileges(Array.Empty<string>(), config);
+
+        Assert.Empty(result.Folders);
+    }
+
+    [Fact]
+    public void AssemblePrivileges_FolderRolesOn_IgnoresStaticFolders_AppendsRoleGranted()
+    {
+        var config = Oid(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.EnabledFolders = new[] { "static" };
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = new List<string> { "movies" } },
+            };
+        });
+
+        var result = RolePrivilegeMapper.AssemblePrivileges(new[] { "media" }, config);
+
+        // Folder roles on -> the statically-enabled set is NOT copied; only role-granted folders apply.
+        Assert.Equal(new List<string> { "movies" }, result.Folders);
+    }
+
+    [Fact]
+    public void AssemblePrivileges_LiveTv_ConfigDefaultOrRoleGrant_UnionsBothSources()
+    {
+        var config = Saml(c =>
+        {
+            c.EnableLiveTv = true;
+            c.EnableLiveTvManagement = false;
+            c.EnableLiveTvRoles = true;
+            c.LiveTvManagementRoles = new[] { "tv-admin" };
+        });
+
+        var result = RolePrivilegeMapper.AssemblePrivileges(new[] { "tv-admin" }, config);
+
+        Assert.True(result.EnableLiveTv);           // from the config default
+        Assert.True(result.EnableLiveTvManagement);  // granted by the role
+    }
+
+    [Fact]
+    public void AssemblePrivileges_Admin_GrantedByRole()
+    {
+        var config = Oid(c => c.AdminRoles = new[] { "admins" });
+
+        Assert.True(RolePrivilegeMapper.AssemblePrivileges(new[] { "admins" }, config).Admin);
+        Assert.False(RolePrivilegeMapper.AssemblePrivileges(new[] { "outsiders" }, config).Admin);
+    }
+
+    [Fact]
+    public void AssemblePrivileges_Valid_ComputedForBothConfigTypes_SamlCallerIgnoresIt()
+    {
+        // Mirrors the OIDC builder's OR-merge input and the SAML builder's disregard for Valid: the
+        // assembled Valid is populated identically for both config shapes, and it is up to the caller
+        // whether to use it.
+        var oid = Oid(c => c.Roles = new[] { "jellyfin" });
+        var saml = Saml(c => c.Roles = new[] { "jellyfin" });
+
+        Assert.True(RolePrivilegeMapper.AssemblePrivileges(new[] { "jellyfin" }, oid).Valid);
+        Assert.True(RolePrivilegeMapper.AssemblePrivileges(new[] { "jellyfin" }, saml).Valid);
+        Assert.False(RolePrivilegeMapper.AssemblePrivileges(new[] { "other" }, saml).Valid);
+    }
+
+    [Fact]
+    public void AssemblePrivileges_NoRolesNoDefaults_YieldsNoPrivileges()
+    {
+        var result = RolePrivilegeMapper.AssemblePrivileges(Array.Empty<string>(), Saml(_ => { }));
+
+        Assert.False(result.Valid);
+        Assert.False(result.Admin);
+        Assert.False(result.EnableLiveTv);
+        Assert.False(result.EnableLiveTvManagement);
+        Assert.Empty(result.Folders);
+    }
 }

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -39,12 +39,6 @@ internal static class OidcAuthorizeStateBuilder
         // Materialize so the claims can be enumerated more than once (avatar format, role claim, sub fallback).
         var claimList = claims as IReadOnlyList<Claim> ?? claims.ToList();
 
-        // Folders start from the statically-enabled set only when folder roles are off; role-granted
-        // folders are appended below.
-        var folders = !config.EnableFolderRoles && config.EnabledFolders != null
-            ? new List<string>(config.EnabledFolders)
-            : new List<string>();
-
         var avatarUrl = ResolveAvatarUrl(claimList, config);
         var (username, valid, roles) = ScanClaims(claimList, config);
 
@@ -64,13 +58,14 @@ internal static class OidcAuthorizeStateBuilder
         // validity and of the username, like the subject above.
         var emailVerified = ResolveEmailVerified(claimList);
 
-        // Map the collected roles to privileges and merge (monotonic: only ever grants).
-        var grants = RolePrivilegeMapper.Evaluate(roles, config);
-        valid |= grants.Valid;
-        var admin = grants.Admin;
-        var enableLiveTv = config.EnableLiveTv || grants.EnableLiveTv;
-        var enableLiveTvManagement = config.EnableLiveTvManagement || grants.EnableLiveTvManagement;
-        folders.AddRange(grants.Folders);
+        // Assemble the role-derived privileges (folders, admin, Live TV) in the single shared home
+        // (#508); OR the assembled validity into the running validity — the SAML builder ignores it.
+        var privileges = RolePrivilegeMapper.AssemblePrivileges(roles, config);
+        valid |= privileges.Valid;
+        var admin = privileges.Admin;
+        var enableLiveTv = privileges.EnableLiveTv;
+        var enableLiveTvManagement = privileges.EnableLiveTvManagement;
+        var folders = privileges.Folders;
 
         // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
         // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning

--- a/SSO-Auth/Api/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/RolePrivilegeMapper.cs
@@ -72,6 +72,37 @@ internal static class RolePrivilegeMapper
         return new RoleGrants(valid, admin, enableLiveTv, enableLiveTvManagement, folders);
     }
 
+    /// <summary>
+    /// Assembles the full authorize-state privilege set for a login: the statically-enabled folders
+    /// (when folder roles are off) plus the role-granted folders, and the config-default-then-role-grant
+    /// merge for admin / Live TV / Live TV management. Single home for the post-<see cref="Evaluate"/>
+    /// merge that used to be duplicated, byte-identical, in the OpenID and SAML authorize-state builders
+    /// (#508). The OpenID builder OR-s the returned <see cref="AssembledPrivileges.Valid"/> into its own
+    /// running validity; the SAML builder ignores it — validity there is decided by
+    /// <see cref="SamlLoginPolicy"/>, not here.
+    /// </summary>
+    /// <param name="roles">The roles extracted from the verified login (OpenID claims or SAML attributes).</param>
+    /// <param name="config">The provider configuration.</param>
+    /// <returns>The assembled privileges, ready for the caller to fold into its authorize state.</returns>
+    internal static AssembledPrivileges AssemblePrivileges(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        // Folders start from the statically-enabled set only when folder roles are off; role-granted
+        // folders are appended below.
+        var folders = !config.EnableFolderRoles && config.EnabledFolders != null
+            ? new List<string>(config.EnabledFolders)
+            : new List<string>();
+
+        var grants = Evaluate(roles, config);
+        folders.AddRange(grants.Folders);
+
+        return new AssembledPrivileges(
+            grants.Valid,
+            grants.Admin,
+            config.EnableLiveTv || grants.EnableLiveTv,
+            config.EnableLiveTvManagement || grants.EnableLiveTvManagement,
+            folders);
+    }
+
     // Whether the login's role is on a configured allow-list. Null-safe both ways (ordinal): a null list
     // or a null entry is simply not a match — never a NullReferenceException — so an admin misconfiguration
     // or a stray null fails closed (grants nothing) instead of throwing a 500.
@@ -87,6 +118,21 @@ internal static class RolePrivilegeMapper
     /// <param name="EnableLiveTvManagement">Whether any role grants Live TV management (only when role-based Live TV is enabled).</param>
     /// <param name="Folders">The folders granted by matching folder-role mappings (only when folder roles are enabled).</param>
     internal readonly record struct RoleGrants(
+        bool Valid,
+        bool Admin,
+        bool EnableLiveTv,
+        bool EnableLiveTvManagement,
+        List<string> Folders);
+
+    /// <summary>
+    /// The assembled authorize-state privileges for a login, produced by <see cref="AssemblePrivileges"/>.
+    /// </summary>
+    /// <param name="Valid">Whether any role is on the login allow-list. Ignored by the SAML caller, whose validity is decided by <see cref="SamlLoginPolicy"/>.</param>
+    /// <param name="Admin">Whether the login grants administrator rights.</param>
+    /// <param name="EnableLiveTv">Whether the login grants Live TV access (config default OR role grant).</param>
+    /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management (config default OR role grant).</param>
+    /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
+    internal readonly record struct AssembledPrivileges(
         bool Valid,
         bool Admin,
         bool EnableLiveTv,

--- a/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
@@ -24,22 +24,12 @@ internal static class SamlAuthorizeStateBuilder
     /// <returns>The derived authorize-state privileges.</returns>
     internal static SamlAuthorizeState Build(IEnumerable<string> roles, SamlConfig config)
     {
-        // Folders start from the statically-enabled set only when folder roles are off; role-granted
-        // folders are appended below.
-        var folders = !config.EnableFolderRoles && config.EnabledFolders != null
-            ? new List<string>(config.EnabledFolders)
-            : new List<string>();
+        // Assemble the role-derived privileges (folders, admin, Live TV) in the single shared home
+        // (#508). Login validity is decided separately by SamlLoginPolicy, so the assembled Valid is
+        // ignored here.
+        var privileges = RolePrivilegeMapper.AssemblePrivileges(roles, config);
 
-        // Map the roles to privileges and merge (monotonic: only ever grants). Login validity is
-        // decided separately by SamlLoginPolicy, so grants.Valid is ignored here. Admin starts false, so
-        // its OR-merge is a plain assignment; Live TV starts from the config default and is OR-ed.
-        var grants = RolePrivilegeMapper.Evaluate(roles, config);
-        var admin = grants.Admin;
-        var enableLiveTv = config.EnableLiveTv || grants.EnableLiveTv;
-        var enableLiveTvManagement = config.EnableLiveTvManagement || grants.EnableLiveTvManagement;
-        folders.AddRange(grants.Folders);
-
-        return new SamlAuthorizeState(admin, enableLiveTv, enableLiveTvManagement, folders);
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders);
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

Closes #508.

`OidcAuthorizeStateBuilder.Build` and `SamlAuthorizeStateBuilder.Build` ran a
byte-identical post-`RolePrivilegeMapper.Evaluate` privilege merge: the
static-folders init (`EnableFolderRoles`/`EnabledFolders` → folders list), the
`Evaluate` call, `folders.AddRange(grants.Folders)`, and the
config-default-OR-role-grant merge for admin / Live TV / Live TV management.
That glue was copied across both builders, the OpenID builder differed only by
one extra `valid |= grants.Valid` line, because SAML decides validity
separately via `SamlLoginPolicy`.

We fold the shared merge into one home, `RolePrivilegeMapper.AssemblePrivileges(IEnumerable<string> roles, ProviderConfigBase config)`,
returning an `AssembledPrivileges` record (`Valid`, `Admin`, `EnableLiveTv`,
`EnableLiveTvManagement`, `Folders`) with `Folders` already holding the static
set plus the role grants. Each builder assembles its privileges there and
constructs its own state record: the OpenID builder ORs the returned `Valid`
into its running validity, the SAML builder ignores it. The privilege
derivation (admin, Live TV, folders) now lives in exactly one place instead of
being copied across two builders.

Behaviour is preserved byte-for-byte at both sites, so the derived
admin / Live-TV / folder grants are unchanged. Distinct from #367 (which
unified the mapper itself, not this builder-side assembly glue).

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

This change touches the privilege-derivation glue on the login path, so it ran
the adversarial gate (four refute-by-default lenses, each reading the full
touched files plus their two callers, `OidcLoginService` and
`SamlAssertionValidator`). All four returned PASS:

- **availability**, VERDICT: PASS. Byte-identical single-call-per-login
  extraction; a fresh folder list is allocated per call (no shared/static
  instance, no cross-login aliasing); no OR/AND polarity change; 1103 tests
  green.
- **security-bypass**, VERDICT: PASS. No OIDC-vs-SAML shape divergence papered
  over; no new grant path and no dropped restriction for either protocol; no
  reordering hazard; no fail-open on a null `FolderRoleMapping` / `EnabledFolders`
  / Live-TV role list; SAML validity still gated solely by `SamlLoginPolicy`.
- **correctness**, VERDICT: PASS. Folders init verbatim; the Live-TV OR-merge
  preserved; `AssembledPrivileges` positional field order matches the
  constructor; the evaluation-order move is safe for a pure function.
- **integration**, VERDICT: PASS. `AssembledPrivileges` does not leak past the
  builders; both callers still consume the unchanged `OidcAuthorizeState` /
  `SamlAuthorizeState` records; no Jellyfin-facing contract change;
  `RolePrivilegeMapper.Evaluate` remains internal and is now called only from
  `AssemblePrivileges`.

Verification: Debug + Release `--warnaserror` both clean (0 warnings);
`dotnet test` 1103/1103 passing (7 new `AssemblePrivileges_*` characterization
tests). No `.js`/`.html`/`.md`/`.css` touched, so Prettier is N/A. Net glue:
one shared helper replaces two duplicated inline blocks.
