### PR TITLE
Revoke tokens on last-link unlink; document per-provider disable non-revoke

### DIFF
--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -585,7 +585,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "broken", "sub-1", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
+        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result.Result);
     }
 
     [Fact]
@@ -623,7 +623,7 @@ public class CanonicalLinkServiceTests
         Assert.Equal(new[] { "sub-1" }, listed["kc"]);
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
-        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
     }
 
@@ -638,7 +638,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
     }
 
@@ -655,8 +655,86 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Saml, "adfs", "alice", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
         Assert.False(cfg.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("alice"));
+    }
+
+    [Fact]
+    public void TryRemoveLink_RemovingTheUsersLastLink_ReportsNoRemainingLink()
+    {
+        // #468: removing the user's only canonical link leaves them unable to SSO at all, so the removal
+        // reports UserRetainsAnyLink=false — the signal the controller uses to revoke live tokens.
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
+        Assert.False(result.UserRetainsAnyLink);
+    }
+
+    [Fact]
+    public void TryRemoveLink_UserKeepsALinkOnAnotherProvider_ReportsRemainingLink()
+    {
+        // #468: the user still holds a link on a DIFFERENT provider (even a different protocol), so they can
+        // still SSO in — the removal reports UserRetainsAnyLink=true, and the controller must NOT revoke
+        // (avoiding a self-inflicted mass-logout of a healthy multi-link user).
+        var (service, _, _, _) = Build(c =>
+        {
+            c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            };
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+            };
+        });
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
+        Assert.True(result.UserRetainsAnyLink);
+    }
+
+    [Fact]
+    public void TryRemoveLink_UserKeepsASecondLinkOnTheSameProvider_ReportsRemainingLink()
+    {
+        // #468: two identities on the same provider point at the same user; removing one leaves the other,
+        // so the user keeps SSO access and the removal reports UserRetainsAnyLink=true.
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Existing },
+        });
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
+        Assert.True(result.UserRetainsAnyLink);
+    }
+
+    [Fact]
+    public void TryRemoveLink_AnotherUsersRemainingLink_DoesNotCountAsThisUsersRemainder()
+    {
+        // #468: the remainder is scoped to the UNLINKED user's id — a different user's surviving link on the
+        // same provider must not be read as this user retaining SSO access, or the controller would skip a
+        // required revoke (an under-revoke leaving the severed identity's tokens alive).
+        var (service, _, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-other"] = Other },
+        });
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
+        Assert.False(result.UserRetainsAnyLink);
     }
 
     [Fact]
@@ -666,7 +744,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "does-not-exist", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.NotFound, result);
+        Assert.Equal(CanonicalLinkRemoveResult.NotFound, result.Result);
     }
 
     [Fact]
@@ -680,7 +758,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Other);
 
-        Assert.Equal(CanonicalLinkRemoveResult.Mismatch, result);
+        Assert.Equal(CanonicalLinkRemoveResult.Mismatch, result.Result);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]); // untouched
     }
 
@@ -691,7 +769,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "does-not-exist", "sub-1", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result);
+        Assert.Equal(CanonicalLinkRemoveResult.UnknownProvider, result.Result);
     }
 
     [Fact]
@@ -969,7 +1047,7 @@ public class CanonicalLinkServiceTests
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
 
-        Assert.Equal(CanonicalLinkRemoveResult.Removed, result);
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
         Assert.False(cfg.OidConfigs["kc"].CanonicalLinks.ContainsKey("sub-1"));
     }
 

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -218,5 +220,28 @@ public class SSOControllerAddTests
 
         Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("kc=prod", new OidConfig()));
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("kc=prod")));
+    }
+
+    [Fact]
+    public async Task OidAdd_DisablingAProviderWithLinkedUsers_DoesNotRevokeAnyTokens()
+    {
+        // #468 documented decision — per-provider disable is intentionally NOT a token-revocation trigger.
+        // Jellyfin attributes no live session to the originating SSO provider (RevokeUserTokens is scoped to
+        // a user id, not a provider), so revoking on disable would be an unscoped mass-logout of every linked
+        // user's password and other-provider sessions too. Disabling only fails FUTURE logins closed (#343);
+        // pin that no revoke fires for the linked user when a provider is switched off via a re-add.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["keycloak"] = new OidConfig
+        {
+            Enabled = true,
+            OidClientId = "client-1",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+        });
+
+        // The config page's disable path re-adds the provider with Enabled=false; server-managed links are
+        // preserved (ServerManagedFields.Preserve), so the user stays linked but the provider is off.
+        harness.Controller.OidAdd("keycloak", new OidConfig { Enabled = false, OidClientId = "client-1" });
+
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].Enabled));
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
     }
 }

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -204,6 +204,83 @@ public class SSOControllerLinkTests
     }
 
     [Fact]
+    public async Task DeleteCanonicalLink_RemovingTheUsersLastLink_RevokesTheirActiveTokens()
+    {
+        // #468: unlinking the user's ONLY canonical link severs their SSO identity entirely (they can no
+        // longer SSO in at all), so — matching Unregister's hard-lockdown posture (#440) — their already
+        // issued tokens are revoked, scoped strictly to this one user id (null revokes all of theirs).
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target },
+            });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(Target, null);
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_LastLinkRevoke_ScopedToTarget_LeavesOtherUsersTokensAlone()
+    {
+        // The revoke is scoped strictly to the resolved target — no other user's tokens may be swept even
+        // when their link lives on the same provider.
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target, ["sub-other"] = Other },
+            });
+
+        await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        await harness.SessionManager.Received(1).RevokeUserTokens(Target, null);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Other, Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_UserKeepsAnotherLink_DoesNotRevokeTokens()
+    {
+        // #468 availability guard: a user who still holds a link on ANOTHER provider can still SSO in, so
+        // unlinking a secondary provider must NOT revoke — that would be a self-inflicted mass-logout of a
+        // healthy multi-link user for no security gain.
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target },
+            };
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = Target },
+            };
+        });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1");
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task DeleteCanonicalLink_NoOpOutcomes_DoNotRevokeTokens()
+    {
+        // Only a real removal (Removed) can trigger a last-link revoke; a NotFound canonical name changes no
+        // state, so no tokens are revoked — the revoke is gated on the durable state change, never a miss.
+        var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
+
+        var result = await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "does-not-exist");
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
+    [Fact]
     public async Task DeleteCanonicalLink_AuthorizedButUidMismatch_Returns409()
     {
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c =>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -48,6 +48,22 @@ internal enum CanonicalLinkRemoveResult
 }
 
 /// <summary>
+/// The outcome of a manual unlink, together with whether the target user still holds any other canonical
+/// SSO link after it. The remainder is meaningful only when <see cref="Result"/> is
+/// <see cref="CanonicalLinkRemoveResult.Removed"/> (the other outcomes change no state); the controller
+/// uses it to revoke the user's active tokens ONLY when the unlink removed their LAST link, matching the
+/// hard-lockdown posture of Unregister (#440/#468) without logging out a user who still has a working SSO
+/// identity.
+/// </summary>
+/// <param name="Result">The remove outcome.</param>
+/// <param name="UserRetainsAnyLink">
+/// Whether any SAML or OpenID provider still holds a canonical link pointing at the unlinked user,
+/// evaluated in the SAME transaction as the removal. Only defined when <paramref name="Result"/> is
+/// <see cref="CanonicalLinkRemoveResult.Removed"/>; false on the no-op outcomes.
+/// </param>
+internal readonly record struct CanonicalLinkRemoval(CanonicalLinkRemoveResult Result, bool UserRetainsAnyLink);
+
+/// <summary>
 /// The account-linking workflow behind the SSO login and admin endpoints: it resolves an SSO identity
 /// to a Jellyfin account (reusing an existing canonical link, adopting a pre-existing account, or
 /// creating one), migrates legacy username-keyed links to the stable subject key (#155), and revokes
@@ -379,14 +395,14 @@ internal sealed class CanonicalLinkService
     /// <param name="provider">The provider the link belongs to.</param>
     /// <param name="canonicalName">The provider-side identity key whose link is removed.</param>
     /// <param name="jellyfinUserId">The Jellyfin user the link must belong to.</param>
-    /// <returns>The remove outcome.</returns>
-    internal CanonicalLinkRemoveResult TryRemoveLink(ProviderMode mode, string provider, string canonicalName, Guid jellyfinUserId)
+    /// <returns>The remove outcome, plus whether the user retains any other link (#468).</returns>
+    internal CanonicalLinkRemoval TryRemoveLink(ProviderMode mode, string provider, string canonicalName, Guid jellyfinUserId)
     {
-        // Kept as ONE Mutate (find, ownership check, and remove cannot interleave). A no-result outcome
-        // still persists the unchanged config. For NotFound / Mismatch that already matched the old
-        // controller code (its mutate callback ran to completion and persisted a no-op); for
-        // UnknownProvider it is a deliberate small delta — the old code threw KeyNotFoundException out of
-        // the callback before the persist, so the unknown-provider DELETE did not write, whereas this
+        // Kept as ONE Mutate (find, ownership check, remove, and the last-link check cannot interleave). A
+        // no-result outcome still persists the unchanged config. For NotFound / Mismatch that already
+        // matched the old controller code (its mutate callback ran to completion and persisted a no-op);
+        // for UnknownProvider it is a deliberate small delta — the old code threw KeyNotFoundException out
+        // of the callback before the persist, so the unknown-provider DELETE did not write, whereas this
         // returns UnknownProvider normally and Mutate<T> then persists. The config content and the HTTP
         // response are byte-identical either way, it is admin-gated, and it adds no new capability (the
         // valid-provider + bogus-name DELETE already forced the same no-op write). A read-probe-then-
@@ -398,21 +414,28 @@ internal sealed class CanonicalLinkService
             // fail-open nothing while blocking exactly that cleanup (#380). Only absence is unknown here.
             if (!TryGetLinks(configuration, mode, provider, requireEnabled: false, out var links))
             {
-                return CanonicalLinkRemoveResult.UnknownProvider;
+                return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.UnknownProvider, UserRetainsAnyLink: false);
             }
 
             if (!links.TryGetValue(canonicalName, out var linkedId))
             {
-                return CanonicalLinkRemoveResult.NotFound;
+                return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.NotFound, UserRetainsAnyLink: false);
             }
 
             if (linkedId != jellyfinUserId)
             {
-                return CanonicalLinkRemoveResult.Mismatch;
+                return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.Mismatch, UserRetainsAnyLink: false);
             }
 
             links.Remove(canonicalName);
-            return CanonicalLinkRemoveResult.Removed;
+
+            // Whether the user keeps any other canonical link across ALL providers, read in the SAME
+            // transaction as the removal (#468): computing it here rather than in a second lock acquisition
+            // means a concurrent link add/remove cannot interleave between the remove and the check and
+            // mislead the controller's last-link revocation decision. Fail toward availability at the exact
+            // boundary — the user is deemed to still have SSO access unless this proves otherwise.
+            var retainsAnyLink = UserHasAnyLink(configuration, jellyfinUserId);
+            return new CanonicalLinkRemoval(CanonicalLinkRemoveResult.Removed, retainsAnyLink);
         });
     }
 
@@ -480,6 +503,25 @@ internal sealed class CanonicalLinkService
 
             return removed;
         });
+    }
+
+    // Whether any SAML or OpenID provider still holds a canonical link pointing at the user, read under the
+    // caller's already-held config lock (#468). A provider stored with a null config object (reachable via
+    // the null-body add, #350) holds no links and is skipped rather than dereferenced — the same fail-closed
+    // treatment TryGetLinks / RemoveUserEverywhere give it. Short-circuits on the first match. Static and
+    // parameterized on the live configuration so it composes inside an existing Read/Mutate transaction
+    // without taking the lock again.
+    private static bool UserHasAnyLink(PluginConfiguration configuration, Guid userId)
+    {
+        foreach (var config in configuration.SamlConfigs.Values.Concat<ProviderConfigBase>(configuration.OidConfigs.Values))
+        {
+            if (config?.CanonicalLinks is { } links && links.ContainsValue(userId))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -620,14 +620,35 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        var removeResult = _canonicalLinks.TryRemoveLink(ParseMode(mode), provider, canonicalName, jellyfinUserId);
-        return removeResult switch
+        var removal = _canonicalLinks.TryRemoveLink(ParseMode(mode), provider, canonicalName, jellyfinUserId);
+
+        // Terminate the user's already-issued tokens ONLY when this unlink removed their LAST canonical SSO
+        // link (#468) — the terminal "can no longer SSO in at all" state that matches the hard-lockdown
+        // posture of Unregister (#440). Removing the links only fails FUTURE logins closed; a token minted
+        // before the unlink stays valid until it expires, so a security-motivated unlink of a compromised
+        // identity must also kill live sessions. A user who unlinks a SECONDARY provider while still holding
+        // another link keeps a working SSO identity, so revoking there would be a self-inflicted mass-logout
+        // with no security gain — the availability-preserving choice is to revoke only at the last link
+        // (UserRetainsAnyLink evaluated atomically with the removal). Scoped strictly to this one user id;
+        // null revokes all of their tokens (including the caller's own, when an admin unlinks their own last
+        // link — the durable removal above is why that is safe). Runs AFTER the removal is persisted, so a
+        // revoke that throws leaves the unlink already complete rather than half-done. Per-provider disable
+        // deliberately does NOT revoke: Jellyfin attributes no live session to the originating SSO provider
+        // (RevokeUserTokens is per user id, not per provider), so revoking on disable would be an unscoped
+        // mass-logout of every linked user's password and other-provider sessions too (#468).
+        if (removal is { Result: CanonicalLinkRemoveResult.Removed, UserRetainsAnyLink: false })
+        {
+            await _sessionManager.RevokeUserTokens(jellyfinUserId, null).ConfigureAwait(false);
+            _logger.LogInformation("Removed the last SSO link for user {UserId} and revoked their active tokens.", jellyfinUserId);
+        }
+
+        return removal.Result switch
         {
             CanonicalLinkRemoveResult.Removed => Ok(),
             CanonicalLinkRemoveResult.NotFound => NotFound("No SSO link is registered for that canonical name."),
             CanonicalLinkRemoveResult.Mismatch => StatusCode(StatusCodes.Status409Conflict, "jellyfin UID does not match id registered to that canonical name."),
             CanonicalLinkRemoveResult.UnknownProvider => BadRequest(NoMatchingProviderMessage),
-            _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {removeResult}"),
+            _ => throw new InvalidOperationException($"Unhandled canonical-link remove result: {removal.Result}"),
         };
     }
 


### PR DESCRIPTION
# What & why

Follow-up to #440 (PR #467), which added `ISessionManager.RevokeUserTokens(userId, null)` to the admin hard-lockdown path (`POST /sso/Unregister`) so a fully-unregistered user's already-issued Jellyfin tokens are killed. Two adjacent paths that also sever an SSO identity still left live tokens valid; we evaluated both against the security-vs-availability trade-off the issue asks us to resolve and reached a documented decision for each. Closes #468.

**Single-link unlink (`DELETE /sso/{mode}/Link/...`), revoke-conditionally.** We revoke the target user's tokens ONLY when the unlink removes their LAST canonical SSO link across all providers, the terminal "can no longer SSO in at all" state that matches Unregister's posture. A user who unlinks a secondary provider while still holding another link keeps a working SSO identity, so revoking there would be a self-inflicted mass-logout with no security gain. The "does the user retain any link" check is evaluated atomically inside the same config-lock transaction as the removal, so a concurrent link add/remove cannot interleave between the remove and the check. Scoped strictly to the one user id; runs after the durable removal is persisted (a revoke that throws leaves the unlink already complete).

**Per-provider disable, intentionally NOT revoked (documented).** `ISessionManager.RevokeUserTokens(Guid userId, string currentAccessToken)` is the only revocation primitive, and its second argument is the token to KEEP, not a provider filter, revocation is per user id. Jellyfin attributes no live session to the SSO provider that minted it (an SSO login yields an ordinary user token). Revoking on disable would mean killing every linked user's ALL tokens, including their password and other-provider sessions, an unscoped mass-logout. New logins through a disabled provider are already fail-closed (#343/#380 write guards + the #232 in-flight re-check). An operator who needs to hard-sever specific users uses Unregister (#440) or removes their last link (this change).

Changes: `CanonicalLinkService.TryRemoveLink` now returns `CanonicalLinkRemoval(CanonicalLinkRemoveResult Result, bool UserRetainsAnyLink)`, the remainder computed via a new static `UserHasAnyLink` in the same `Mutate`; `SSOController.DeleteCanonicalLink` revokes when `removal is { Result: Removed, UserRetainsAnyLink: false }`, with the Ok/404/409/400 response mapping unchanged.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (The revoke runs after the durable config change; the last-link check is atomic with the removal; scoped strictly to one user id. Only a real removal can trigger it — no-op outcomes revoke nothing.)
- [x] No secrets logged; secrets are redacted on config export. (Only the user id is logged.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Adversarial 4-lens review below.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (The new log line interpolates a Guid only, no IdP-controlled strings.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (`UserHasAnyLink`, `CanonicalLinkRemoval`.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318). (Thin controller decision; the pure resolution stays in the service under the lock.)
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new structural property; existing conformance tests pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (1123 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None touched; N/A.)

## Notes

Adversarial multi-lens review (refute-by-default), all four PASS:

- Availability / mass-lockout, VERDICT: UserHasAnyLink is evaluated in the same Mutate after the removal, so a multi-link user unlinking a secondary provider (or a second same-provider identity) reports UserRetainsAnyLink=true and is not revoked; disable calls no session API; the remainder is atomic with the removal so no concurrent add/remove over-revokes another user; tests pin these, no mass-logout regression. PASS
- Security-bypass / under-revoke, VERDICT: last-link removal fires RevokeUserTokens(userId, null); ContainsValue(userId) is scoped to the unlinked user, so another user's link cannot suppress the revoke; RevokeUserTokens has no provider filter, so per-provider disable is genuinely unscopable and documented (new logins stay fail-closed #343/#380/#232); revoke runs after the durable persist, no under-revoke of a severed identity. PASS
- Correctness, VERDICT: the trigger is exactly "last link removed" (the removed entry is already gone when the remainder is computed); the default-struct footgun is unreachable and fail-safe; the switch bodies are byte-identical; live-user link presence is the right signal; dangling links do not skew it. PASS
- Integration, VERDICT: RevokeUserTokens(Guid, string) confirmed in Jellyfin.Controller 10.11.0 (2nd arg is the token to keep; null revokes all), matching #440's existing call; no per-provider revocation primitive exists; Mutate<T> returns the record struct fine; the response and rate-limit contracts are unchanged. PASS

Out of the PR (local, git-ignored process doc): the E2E checklist gains two entries, last-link unlink terminates sessions (#468), and per-provider disable does NOT (documented decision, with Unregister / last-link-unlink as the hard-sever paths).
