### PR TITLE
Document anonymous-by-design posture of the GetNames endpoints

### DIFF
--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -188,6 +190,23 @@ public class SSOControllerEndpointTests
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.OidStates());
         Assert.Empty(Assert.IsAssignableFrom<IEnumerable>(result.Value));
+    }
+
+    [Theory]
+    [InlineData(nameof(SSOController.OidProviderNames))]
+    [InlineData(nameof(SSOController.SamlProviderNames))]
+    public void GetNames_HasNoAuthorizeAttribute(string methodName)
+    {
+        // Change detector for the documented anonymous-by-design decision (#540): OID/GetNames and
+        // SAML/GetNames carry no [Authorize] on purpose — the provider-name list they return is already
+        // rendered anonymously by SSOViewsController's linking page (see the in-code rationale on both
+        // methods), so gating them would add no confidentiality while breaking that unauthenticated
+        // render. A future [Authorize] landing here — accidental or from a reviewer expecting these
+        // gated — should fail this test and surface the decision instead of silently changing behavior.
+        var method = typeof(SSOController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+        Assert.Null(method!.GetCustomAttribute<AuthorizeAttribute>());
     }
 }
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -289,7 +289,8 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
-    /// Lists the names of the enabled OpenID providers only.
+    /// Lists the names of the enabled OpenID providers only. Intentionally anonymous — see the
+    /// in-body rationale (#540).
     /// </summary>
     /// <returns>The list of enabled OpenID provider names.</returns>
     [HttpGet("OID/GetNames")]
@@ -301,17 +302,30 @@ public class SSOController : ControllerBase
         // gate — the server-side rejection stays the real defense in depth.
         // Materialize under the lock (#157/F-10): returning a live view lets the JSON formatter enumerate
         // it outside the lock, tearing against a concurrent provider add/remove.
+        //
+        // No [Authorize] here — deliberate, not an oversight (#540). SSOViewsController, which serves the
+        // self-service linking page (linking.html/linking.js, the sole caller of this endpoint), carries no
+        // [Authorize] of its own either, so the same provider-name list this endpoint returns is already
+        // rendered into that page's visible DOM for an anonymous visitor. Gating GetNames would add no
+        // confidentiality (the list is public via the page regardless) while breaking that page's render for
+        // any caller who has not first authenticated — including the isLinking=false leg, which is how a
+        // brand-new (not-yet-Jellyfin-authenticated) user discovers which providers they can sign in with.
+        // Provider names are configuration, not secrets; the identity-provider connection itself (client
+        // secret, signing keys) stays behind the elevation-gated OID/Get and SAML/Get.
         return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.OidConfigs)));
     }
 
     /// <summary>
-    /// Lists the names of the enabled SAML providers only.
+    /// Lists the names of the enabled SAML providers only. Intentionally anonymous — see the
+    /// in-body rationale (#540).
     /// </summary>
     /// <returns>The list of enabled SAML provider names.</returns>
     [HttpGet("SAML/GetNames")]
     public ActionResult SamlProviderNames()
     {
         // Enabled-only and materialized under the lock, as OID/GetNames does (#344, #157/F-10).
+        // Anonymous by the same design as OID/GetNames above (#540) — same caller, same already-public
+        // rendering, same rationale.
         return Ok(SSOPlugin.Instance.ReadConfiguration(c => EnabledProviderNames(c.SamlConfigs)));
     }
 


### PR DESCRIPTION
# What & why

Closes #540.

`OID/GetNames` and `SAML/GetNames` carry no `[Authorize]`, so the configured
provider-name list is reachable anonymously. #535 narrowed that exposure to
enabled providers only, but the endpoints themselves stayed anonymous and we
had never written down whether that was intentional.

We evaluated gating them and concluded the anonymous posture is correct and
intentional, not an oversight. Evidence:

- `GetNames` has exactly one caller in the codebase: `linking.js`
  (`loadProviders`), which drives the self-service linking page.
- The page that calls it is itself served with no auth gate: `SSOViewsController`
  (which serves `linking.html`, `linking.js`, `ApiClient.js`, and the other
  assets for `/SSOViews/*`) carries no `[Authorize]` either. So an anonymous
  visitor who loads `/SSOViews/linking` already gets the exact same
  provider-name list rendered into the page's visible DOM (`provider_name`
  is set as `textContent` on a label), `GetNames` is not adding any new
  exposure over what the page itself already exposes.
- Gating `GetNames` would therefore add zero confidentiality, while breaking
  that page's render for a caller who has not yet authenticated to Jellyfin - 
  including the case this page exists for: a not-yet-linked user discovering
  which providers they can sign in through.
- Provider *names* are configuration, not secrets. The actual identity
  provider connection details (client secret, signing keys, endpoints) stay
  behind the elevation-gated `OID/Get` and `SAML/Get`, which are unaffected.

We recorded this as a code comment on both `GetNames` endpoints in
`SSOController.cs` and added a reflection-based xUnit test
(`GetNames_HasNoAuthorizeAttribute` in `SSOControllerEndpointTests.cs`) that
pins the no-`[Authorize]` decision, so a future accidental `[Authorize]`
landing here (or a reviewer who expects these gated) fails the test and
surfaces the documented decision instead of silently changing behavior.

`docs/THREAT-MODEL.md` is git-ignored/local and is not present in this
worktree, so we could not add the endpoint auth-posture note there; the
decision and its rationale are captured in-code instead (see the comments in
this diff), which is the durable record for this repository.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No behavior change; both endpoints
      are unauthenticated before and after this PR.)
- [x] No secrets logged; secrets are redacted on config export. (Unaffected - 
      `GetNames` only ever returned provider names, never secrets.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (This is a documentation +
      test change with no behavior change on the login path; we assessed the
      full 4-lens adversarial gate as not warranted here per our own gate
      criteria, and instead give the security rationale above and in the
      pre-merge note.)
- [x] Log inputs from the IdP are sanitized inline at the log call.
      (Unaffected.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments
      explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property
      this change establishes is locked in as a rule in
      `ArchitectureConformanceTests`. (No new structural property — the new
      test is a behavior-pinning test on `SSOController`, added alongside the
      existing `GetNames` tests in `SSOControllerEndpointTests`.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings.)
- [x] `dotnet test` is green. (1125/1125, including the 2 new
      `GetNames_HasNoAuthorizeAttribute` cases.)
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (No
      such file touched — N/A.)

## Notes

No behavior change. This PR documents an existing, already-shipped auth
posture and locks it in with a test; it does not add or remove an
`[Authorize]` attribute anywhere.
