### PR TITLE
Generalize the shared 429 body wording

### DIFF
--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -114,7 +114,7 @@ public class LoginStatusMapperTests
         var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Throttled(42), response));
 
         Assert.Equal(429, result.StatusCode);
-        Assert.Equal("Too many login attempts. Please wait a moment and try again.", result.Content);
+        Assert.Equal("Too many attempts. Please wait a moment and try again.", result.Content);
         Assert.Equal("text/plain", result.ContentType);
         Assert.Equal("42", response.Headers.RetryAfter.ToString());
     }

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -224,7 +224,7 @@ public class SSOControllerChallengeTests
         // header whose value falls within the configured window.
         var throttled = Assert.IsType<ContentResult>(harness.Controller.SamlChallenge("does-not-exist"));
         Assert.Equal(429, throttled.StatusCode);
-        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+        Assert.Equal("Too many attempts. Please wait a moment and try again.", throttled.Content);
         Assert.Equal("text/plain", throttled.ContentType);
 
         var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -451,7 +451,7 @@ public class SSOControllerLinkTests
         var throttled = Assert.IsType<ContentResult>(
             await harness.Controller.AddCanonicalLink("oid", "does-not-exist", Target, new AuthResponse { Data = "state-token" }));
         Assert.Equal(429, throttled.StatusCode);
-        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+        Assert.Equal("Too many attempts. Please wait a moment and try again.", throttled.Content);
 
         var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
         Assert.True(

--- a/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/SSOControllerUnregisterTests.cs
@@ -141,7 +141,7 @@ public class SSOControllerUnregisterTests
         // single mapper (#474), carrying the machine-readable Retry-After.
         var throttled = Assert.IsType<ContentResult>(await harness.Controller.Unregister("alice", "Jellyfin"));
         Assert.Equal(429, throttled.StatusCode);
-        Assert.Equal("Too many login attempts. Please wait a moment and try again.", throttled.Content);
+        Assert.Equal("Too many attempts. Please wait a moment and try again.", throttled.Content);
 
         var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
         Assert.True(

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -28,10 +28,12 @@ internal static class LoginStatusMapper
     /// <summary>
     /// The rate-limit 429 body (#128, #474) — deliberately human-readable rather than a bare status, since
     /// the challenge/callback endpoints are navigated directly in the browser and a blank 429 would look
-    /// like a broken login (the XHR auth page reads the status, not this body). The Retry-After header
-    /// carries the machine-readable delay.
+    /// like a broken login (the XHR auth page reads the status, not this body). Worded generically rather
+    /// than "login attempts" because the same gate, and so the same body, also fronts the authenticated
+    /// admin link/unlink (#382) and unregister (#516) write surfaces, where nobody is logging in (#517).
+    /// The Retry-After header carries the machine-readable delay.
     /// </summary>
-    internal const string RateLimitedMessage = "Too many login attempts. Please wait a moment and try again.";
+    internal const string RateLimitedMessage = "Too many attempts. Please wait a moment and try again.";
 
     internal static ActionResult ToActionResult(LoginOutcome outcome) => outcome switch
     {


### PR DESCRIPTION
# What & why

We generalized the shared rate-limit 429 body wording. `SsoRateLimitGate` fronts
the anonymous login endpoints as well as the authenticated admin link/unlink
(#382) and unregister (#516) write surfaces, and all of them render through the
one `LoginStatusMapper.RateLimitedMessage`, which still read "Too many login
attempts" even on the admin surfaces, where nobody is logging in. We reworded it
to "Too many attempts. Please wait a moment and try again.", accurate on both
the login and the admin surfaces, and updated the doc comment on the constant to
explain why it stays generic. Updated the four pinned tests that asserted the
old body text.

The "RSA private key" half of the issue (part 2, stale wording after the
ECDSA-support addition in #493) was already fixed by #519 before we picked this
up, main no longer says "RSA private key" anywhere in the SP-signing-key
validation messages, so this PR is scoped to the 429 wording only. We left a
comment on #517 recording that.

Closes #517

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this is a strings-only change to a rejection body's wording;
no logic, status code, header, or timing changed. We did check that the new
wording discloses nothing beyond what the old one did (still generic, still no
distinction between login/admin causes and no distinction between allowed and
disabled providers).

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      (no new structural property here — the mapper's shape is unchanged).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0
      warnings).
- [x] `dotnet test` is green (1124/1124).
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (no such
      file touched).

## Notes

This is a cosmetic strings-only diff on the login/admin rejection surface, so we
skipped the full 4-lens adversarial-review gate per the CLAUDE.md carve-out for
strings-only changes, a light self-review is enough: no security-relevant
behavior changed (same status code, same header, same trigger conditions), the
new wording leaks nothing it didn't already, and it reads correctly on both the
login and the admin link/unlink/unregister surfaces we checked it against.
