### PR TITLE
Shorten the avatar store-lock acquire timeout to 3s

### DIFF
--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -67,8 +67,8 @@ public class AvatarServiceTests
     }
 
     // Builds a service whose store-lock ACQUIRE WAIT is bounded by the given (short, test-only) timeout
-    // rather than the production 30s (#448), so a test can drive the abort-on-timeout branch deterministically
-    // and quickly instead of waiting out the real bound.
+    // rather than the production 3s (#448, shortened by #541), so a test can drive the abort-on-timeout
+    // branch deterministically and quickly instead of waiting out the real bound.
     private static (AvatarService Service, IProviderManager Providers, IUserManager Users, CapturingLogger Log) Build(KeyedLockStore userStoreLocks, TimeSpan storeLockAcquireTimeout)
     {
         var users = Substitute.For<IUserManager>();
@@ -286,7 +286,7 @@ public class AvatarServiceTests
         // still lets the store through exactly as before — the timeout only aborts a genuinely stalled
         // wait, it does not shrink the normal-load window.
         var locks = new KeyedLockStore(StringComparer.Ordinal);
-        var (service, providers, _, log) = Build(locks, TimeSpan.FromSeconds(30));
+        var (service, providers, _, log) = Build(locks, TimeSpan.FromSeconds(3));
         var user = UserNamed("alice");
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -27,10 +27,13 @@ internal sealed class AvatarService
 
     // Bounds the wait for the per-user store lock (#448). This flow tier is deliberately HttpContext-free
     // (see LoginCompletionService/SessionMinter), so no ambient request-abort token reaches this far — a
-    // self-contained deadline is the same pattern TrySetAsync already uses for the fetch. 30s comfortably
-    // covers several legitimate queued same-user stores (each a local disk write, occasionally a DB clear)
-    // while still bounding a truly stalled holder so it cannot park same-user logins forever.
-    private static readonly TimeSpan StoreLockAcquireTimeout = TimeSpan.FromSeconds(30);
+    // self-contained deadline is the same pattern TrySetAsync already uses for the fetch. This bound stacks
+    // with TrySetAsync's 10s fetch deadline on the synchronous login path, so it is kept well below that
+    // fetch bound rather than matching it (#541): the store step is purely local disk/DB work (SaveImage,
+    // occasionally ClearProfileImageAsync), never network I/O, so it does not need a network-sized budget.
+    // 3s comfortably covers several legitimate queued same-user stores while still bounding a truly stalled
+    // holder quickly, keeping the worst-case login stall close to the fetch's own 10s instead of ~40s.
+    private static readonly TimeSpan StoreLockAcquireTimeout = TimeSpan.FromSeconds(3);
 
     // Serializes the store step per user across ALL logins (#400). Static because the controller builds a
     // fresh AvatarService per request, so two concurrent same-user logins hold different instances — an
@@ -84,7 +87,7 @@ internal sealed class AvatarService
     /// <param name="httpClient">The client used for every fetch; reused across calls (never disposed here).</param>
     /// <param name="userStoreLocks">The per-user store lock (#400); null uses the process-wide shared one. A test injects its own so it can drive the serialization deterministically.</param>
     /// <param name="fileExists">Probe for the on-disk profile image (#480); null uses <see cref="File.Exists"/>. A test injects its own to drive the missing-file self-heal branch without touching the filesystem.</param>
-    /// <param name="storeLockAcquireTimeout">How long <see cref="StoreAsync"/> waits for the per-user store lock (#448); null uses the production 30s bound. A test injects a short timeout so the abort-on-timeout branch is reachable without a real 30s wait.</param>
+    /// <param name="storeLockAcquireTimeout">How long <see cref="StoreAsync"/> waits for the per-user store lock (#448, shortened by #541); null uses the production 3s bound. A test injects a shorter timeout so the abort-on-timeout branch is reachable without a real 3s wait.</param>
     internal AvatarService(
         IUserManager userManager,
         IProviderManager providerManager,


### PR DESCRIPTION
# What & why

PR #448 bounded `AvatarService.StoreAsync`'s per-user `KeyedLockStore` acquire
wait at 30s (previously `CancellationToken.None`, i.e. unbounded). We merged
that fix, but the availability lens flagged a follow-up (#541, LOW,
non-blocking): the 30s store-lock bound stacks with `TrySetAsync`'s existing
10s avatar-fetch deadline on the synchronous login path, `SessionMinter.
MintAsync` awaits `AvatarService.TrySetAsync` before minting the session, so
a single login could legitimately block up to ~40s under lock contention
before the server responds. Many reverse-proxy defaults sit at or below
30-60s, so a client/proxy could time out around the 30-40s mark and show the
user a failed login while the server-side login actually completed moments
later, without an avatar.

We shortened `StoreLockAcquireTimeout` from 30s to 3s. The store step is
purely local disk/DB work (`IProviderManager.SaveImage`, occasionally
`IUserManager.ClearProfileImageAsync`), never network I/O, so it does not
need a network-sized budget. 3s comfortably covers several legitimate queued
same-user stores while still bounding a truly stalled holder much sooner,
bringing the worst-case login stall down to ~13s (10s fetch + 3s store-lock)
 - well clear of typical proxy timeouts. A timed-out acquire still aborts
fail-closed exactly as before: it never reaches `SaveImage`/
`ClearProfileImageAsync` unguarded, it just skips the store and logs a
warning naming the user (sanitized inline), the same as the class's other
best-effort fail-closed branches. Only the numeric bound changed, no new
control flow.

We updated the injected timeout in the "before timeout" happy-path test to
match the new production value, and the comments that referenced the old
30s number.

Closes #541

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a timed-out acquire still never falls through to
      an unguarded store — it aborts (skips `StoreLockedAsync` entirely),
      identical to the behavior #448 already established; only the timeout
      value changed.
- [x] No secrets logged; secrets are redacted on config export. (Not touched
      — the existing warning logs a sanitized username, unchanged here.)
- [x] A security review was performed for this change (see the two-lens
      results below — this is the avatar-store path on the login critical
      path).
- [x] Log inputs from the IdP are sanitized inline at the log call
      (unchanged: `user.Username?.ReplaceLineEndings(string.Empty)`).

## Quality checklist

- [x] No duplicated logic; this is a one-constant change plus matching
      comment/doc updates.
- [x] The change adds no more code than the problem requires (a `TimeSpan`
      literal, no new branches).
- [x] The code is self-documenting and matches the target architecture
      (#318); the load-bearing "why" comment on the constant now explains
      the stacked-deadline rationale for the new value.
- [x] Architecture-conformance tests pass. No new structural property is
      established here — this is a constant-value change on an already-
      tested code path.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and
      Release).
- [x] `dotnet test` is green, 1124/1124, both Debug and Release.
- [x] Prettier, N/A, this PR only touches `.cs` files.

## Notes

We ran a focused two-lens adversarial review (availability/mass-lockout,
security-bypass/fail-open) before opening this PR, since this touches the
avatar-store timeout on the login path:

- **Availability/mass-lockout, PASS.** Re-verified `KeyedLockStore` stays
  strictly per-user (unrelated users never share a semaphore), so blast
  radius is unchanged. The store step (`SaveImage` plus, occasionally,
  `ClearProfileImageAsync`) is confirmed local-only with no reachable network
  I/O, and normally completes in well under a second even under moderate
  contention, so 3s comfortably covers legitimate same-user queuing. A
  timeout only ever drops the best-effort avatar update, it never blocks or
  fails the login itself, so the residual risk (an avatar silently skipped
  under unusually slow local/networked storage) is a minor, already-LOW-
  flagged UX cosmetic, not an availability regression. No new resource-leak
  path: the more-frequent timeout trips the same `Unclaim`-on-cancel cleanup
  that #448 already proved leak-free (`TrackedKeys == 0` after a timeout).
  The worst-case synchronous login-path total (10s fetch + 3s store-lock ≈
  13s) sits comfortably under the 30-60s reverse-proxy defaults cited in
  #541, closing the gap without introducing a new one.
- **Security-bypass/fail-open, PASS.** Re-derived `StoreAsync`'s try/catch/
  using structure directly from the code: `StoreLockedAsync` (the only call
  site that reaches `SaveImage`/`ClearProfileImageAsync`/
  `user.ProfileImage`) is still reachable only after a successful lock
  acquire; the timeout catch always returns first. Confirmed only one
  `CancellationTokenSource` exists on this path, so the
  `catch (OperationCanceledException) when (acquireTimeout.IsCancellationRequested)`
  guard is unambiguous. Confirmed the shorter bound triggering more
  frequently does not change `KeyedLockStore`'s cleanup behavior, the
  `Unclaim` decrement is per-attempt and lock-protected regardless of how
  soon cancellation fires. Confirmed the updated "before timeout" test still
  proves what it claims: it exercises the uncontended-lock path (the
  semaphore is free, so `AcquireAsync` returns near-instantly), so the
  3s value is never actually raced against real wall-clock work and the
  change introduces no flakiness. No new attacker leverage: the only
  externally observable effect is the avatar store being skipped somewhat
  more often under genuine local contention, and the warning log's only
  variable content remains the already-sanitized username.

Gates: build (Debug + Release) green, `dotnet test` green (1124/1124), both
adversarial-review lenses PASS. Out of scope: the two lenses also confirmed
this is a pure constant-tuning change with no other behavioral surface - 
nothing further was deferred.
