### PR TITLE
Harden SecretStore key handling: orphan-prevention and atomic 0600 temp key

### DIFF
--- a/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
@@ -91,6 +92,72 @@ public class ConfigSecretProtectionTests
             ConfigSecretProtection.ProtectAll(config, store);
 
             Assert.Equal(afterFirst, config.OidConfigs["a"].OidSecret);
+        });
+    }
+
+    [Fact]
+    public void ProtectAll_ExistingEnvelopeButMissingKey_FailsClosedWithoutMinting()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        try
+        {
+            // Encrypt one secret so a real envelope exists, then lose the key file (restored config, lost key).
+            var envelope = new SecretStore(path).Protect("old-secret");
+            File.Delete(path);
+
+            var config = new PluginConfiguration();
+            config.OidConfigs["a"] = new OidConfig { OidSecret = envelope };           // encrypted under the lost key
+            config.SamlConfigs["b"] = new SamlConfig { SamlSigningKeyPfx = "new-plaintext" };
+
+            // Persisting must refuse to mint a fresh key over the orphaned envelope rather than mask the loss.
+            Assert.Throws<CryptographicException>(
+                () => ConfigSecretProtection.ProtectAll(config, new SecretStore(path)));
+
+            Assert.False(File.Exists(path)); // no replacement key minted
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
+    public void ProtectAll_LegacyPlaintextOnly_NoKey_MigratesByMintingKey()
+    {
+        WithStore(store =>
+        {
+            // A legacy plaintext config with no envelopes and no key must still be migrated on first save.
+            var config = new PluginConfiguration();
+            config.OidConfigs["a"] = new OidConfig { OidSecret = "legacy-plaintext" };
+
+            ConfigSecretProtection.ProtectAll(config, store);
+
+            Assert.True(SecretEnvelope.IsProtected(config.OidConfigs["a"].OidSecret));
+            Assert.Equal("legacy-plaintext", store.Reveal(config.OidConfigs["a"].OidSecret));
+        });
+    }
+
+    [Fact]
+    public void ProtectAll_NewPlaintextAlongsideEnvelope_KeyPresent_StillEncrypts()
+    {
+        WithStore(store =>
+        {
+            var envelope = store.Protect("existing-secret"); // mints the key and encrypts
+
+            // A config that already holds an envelope, with the key present, must not be bricked when a new
+            // plaintext secret is added (adding a provider to an already-encrypted config).
+            var config = new PluginConfiguration();
+            config.OidConfigs["a"] = new OidConfig { OidSecret = envelope };
+            config.OidConfigs["b"] = new OidConfig { OidSecret = "brand-new-plaintext" };
+
+            ConfigSecretProtection.ProtectAll(config, store);
+
+            Assert.True(SecretEnvelope.IsProtected(config.OidConfigs["b"].OidSecret));
+            Assert.Equal("existing-secret", store.Reveal(config.OidConfigs["a"].OidSecret));
+            Assert.Equal("brand-new-plaintext", store.Reveal(config.OidConfigs["b"].OidSecret));
         });
     }
 

--- a/SSO-Auth.Tests/SecretStoreTests.cs
+++ b/SSO-Auth.Tests/SecretStoreTests.cs
@@ -74,6 +74,54 @@ public class SecretStoreTests
     }
 
     [Fact]
+    public void Protect_ConfigHasEnvelopes_MissingKeyFile_RefusesToMintAndFailsClosed()
+    {
+        WithTempKeyPath(path =>
+        {
+            var store = new SecretStore(path); // no key file exists
+
+            // A well-formed envelope is present in the config but the key was lost: minting a fresh key would
+            // orphan that envelope (and mask the loss), so encrypting must fail closed instead.
+            Assert.Throws<CryptographicException>(() => store.Protect("new-plaintext", configHasEnvelopes: true));
+
+            Assert.False(File.Exists(path)); // no replacement key minted
+        });
+    }
+
+    [Fact]
+    public void Protect_CleanInstall_NoEnvelopes_MintsKeyAndEncrypts()
+    {
+        WithTempKeyPath(path =>
+        {
+            var store = new SecretStore(path); // no key file exists
+
+            var protectedValue = store.Protect("client-secret", configHasEnvelopes: false);
+
+            Assert.True(File.Exists(path)); // first run legitimately mints the key
+            Assert.True(SecretEnvelope.IsProtected(protectedValue));
+            Assert.Equal("client-secret", store.Reveal(protectedValue));
+        });
+    }
+
+    [Fact]
+    public void CreateKey_KeyFile_IsOwnerOnlyOnUnix()
+    {
+        WithTempKeyPath(path =>
+        {
+            new SecretStore(path).GetOrCreateKey();
+
+            Assert.True(File.Exists(path));
+
+            // The temp file is created with the restrictive mode atomically and File.Move preserves it, so the
+            // persisted key file is owner-only with no permissive window. The mode call is a no-op on Windows.
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(path));
+            }
+        });
+    }
+
+    [Fact]
     public void Protect_PlaintextStartingWithTheEnvelopePrefix_IsStillEncrypted()
     {
         WithTempKeyPath(path =>

--- a/SSO-Auth/Api/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/ConfigSecretProtection.cs
@@ -18,8 +18,17 @@ internal static class ConfigSecretProtection
     /// </summary>
     /// <param name="configuration">The configuration about to be persisted.</param>
     /// <param name="store">The secret store providing the data-encryption key.</param>
+    /// <exception cref="System.Security.Cryptography.CryptographicException">
+    /// The configuration already holds encrypted envelopes but the key file is missing - a lost key that must
+    /// be restored deliberately rather than silently replaced (which would orphan those envelopes).
+    /// </exception>
     internal static void ProtectAll(PluginConfiguration configuration, SecretStore store)
     {
+        // Decide once, over the whole config, whether any encrypted envelope is already present. Passed into
+        // every Protect call so that minting a fresh key over a missing-key-but-envelopes-present config is
+        // refused (orphan-prevention), while a genuine first run (no envelopes anywhere) still creates a key.
+        var configHasEnvelopes = HasAnyEnvelope(configuration);
+
         if (configuration.OidConfigs != null)
         {
             foreach (var oid in configuration.OidConfigs.Values)
@@ -29,7 +38,7 @@ internal static class ConfigSecretProtection
                     continue;
                 }
 
-                oid.OidSecret = store.Protect(oid.OidSecret);
+                oid.OidSecret = store.Protect(oid.OidSecret, configHasEnvelopes);
             }
         }
 
@@ -42,8 +51,39 @@ internal static class ConfigSecretProtection
                     continue;
                 }
 
-                saml.SamlSigningKeyPfx = store.Protect(saml.SamlSigningKeyPfx);
+                saml.SamlSigningKeyPfx = store.Protect(saml.SamlSigningKeyPfx, configHasEnvelopes);
             }
         }
+    }
+
+    // True when any protected field already carries a well-formed envelope. Inspects exactly the fields
+    // ProtectAll encrypts (the OpenID client secrets and the SAML signing keys) - the only values this
+    // plugin ever writes as envelopes - so the presence signal is accurate to the data that could be
+    // orphaned.
+    private static bool HasAnyEnvelope(PluginConfiguration configuration)
+    {
+        if (configuration.OidConfigs != null)
+        {
+            foreach (var oid in configuration.OidConfigs.Values)
+            {
+                if (oid != null && SecretEnvelope.IsWellFormedEnvelope(oid.OidSecret))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (configuration.SamlConfigs != null)
+        {
+            foreach (var saml in configuration.SamlConfigs.Values)
+            {
+                if (saml != null && SecretEnvelope.IsWellFormedEnvelope(saml.SamlSigningKeyPfx))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/SSO-Auth/Api/SecretStore.cs
+++ b/SSO-Auth/Api/SecretStore.cs
@@ -9,9 +9,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <see cref="SecretEnvelope"/> envelopes. The key lives in a dedicated file in the plugin's data folder -
 /// the same volume the admin must already persist for configuration to survive - kept separate from the
 /// config XML so a leaked config alone cannot decrypt anything. The key is created once (only when a secret
-/// is first encrypted) and never rolled automatically. Two failure modes fail closed rather than orphaning
-/// every previously-encrypted secret: a wrong-length (corrupt) key file is rejected, and revealing an
-/// encrypted value when the key file is <b>missing</b> throws instead of silently generating a new key.
+/// is first encrypted) and never rolled automatically. Three failure modes fail closed rather than orphaning
+/// every previously-encrypted secret: a wrong-length (corrupt) key file is rejected; revealing an encrypted
+/// value when the key file is <b>missing</b> throws instead of silently generating a new key; and encrypting
+/// refuses to mint a replacement key when the configuration already holds envelopes but the key file is
+/// missing (that pairing proves a key existed and was lost, so a new one would orphan those envelopes and
+/// mask the loss). The key file is created with owner-only permissions atomically, never briefly readable.
 /// </summary>
 internal sealed class SecretStore
 {
@@ -34,31 +37,23 @@ internal sealed class SecretStore
     /// </summary>
     /// <returns>The 32-byte data-encryption key.</returns>
     /// <exception cref="CryptographicException">The key file exists but is not the expected length.</exception>
-    internal byte[] GetOrCreateKey()
-    {
-        lock (_lock)
-        {
-            if (_cachedKey != null)
-            {
-                return _cachedKey;
-            }
-
-            if (File.Exists(_keyFilePath))
-            {
-                return LoadKeyLocked();
-            }
-
-            return CreateKeyLocked();
-        }
-    }
+    internal byte[] GetOrCreateKey() => GetOrCreateKeyForEncrypt(configHasEnvelopes: false);
 
     /// <summary>
     /// Encrypts a plaintext secret for storage. An empty value or an already-encrypted value is returned
     /// unchanged, so the method is safe to apply to a whole config on every save.
     /// </summary>
     /// <param name="storedValue">The secret as currently held.</param>
+    /// <param name="configHasEnvelopes">
+    /// True when the configuration being persisted already holds at least one encrypted envelope. When set,
+    /// a missing key file is fail-closed (throws) instead of minting a new key, so a lost key surfaces rather
+    /// than orphaning those envelopes. Callers that protect a lone value with no config context pass false.
+    /// </param>
     /// <returns>The value in encrypted-at-rest form.</returns>
-    internal string Protect(string storedValue)
+    /// <exception cref="CryptographicException">
+    /// <paramref name="configHasEnvelopes"/> is true and the key file is missing (a key existed and was lost).
+    /// </exception>
+    internal string Protect(string storedValue, bool configHasEnvelopes = false)
     {
         // Skip only a genuinely-encrypted value (idempotency); a plaintext that merely starts with the
         // envelope prefix is not a well-formed envelope and is still encrypted here rather than stored raw.
@@ -67,7 +62,7 @@ internal sealed class SecretStore
             return storedValue;
         }
 
-        return SecretEnvelope.Protect(GetOrCreateKey(), storedValue);
+        return SecretEnvelope.Protect(GetOrCreateKeyForEncrypt(configHasEnvelopes), storedValue);
     }
 
     /// <summary>
@@ -86,6 +81,35 @@ internal sealed class SecretStore
         }
 
         return SecretEnvelope.Unprotect(GetKey(), storedValue);
+    }
+
+    // The key to encrypt a plaintext secret under. Mirrors the load-or-create of GetOrCreateKey, but when the
+    // key file is missing it only mints a fresh key on a genuine first run (no envelopes exist yet to
+    // orphan). If the configuration already carries envelopes the missing key was lost, not absent, so it
+    // fails closed exactly as the reveal path does: minting here would re-encrypt this value under a new key
+    // while the pre-existing envelopes stay unrecoverable, masking the loss.
+    private byte[] GetOrCreateKeyForEncrypt(bool configHasEnvelopes)
+    {
+        lock (_lock)
+        {
+            if (_cachedKey != null)
+            {
+                return _cachedKey;
+            }
+
+            if (File.Exists(_keyFilePath))
+            {
+                return LoadKeyLocked();
+            }
+
+            if (configHasEnvelopes)
+            {
+                throw new CryptographicException(
+                    $"The SSO secret key file '{_keyFilePath}' is missing while encrypted secrets are present. Restore it from a backup - do not delete it or let it be regenerated, or every encrypted secret becomes permanently unrecoverable.");
+            }
+
+            return CreateKeyLocked();
+        }
     }
 
     // Reads the existing key without ever creating one. Fails closed when the file is missing: reaching here
@@ -135,10 +159,10 @@ internal sealed class SecretStore
         // Write to a temp file, then move it into place. The two-argument File.Move fails if the target
         // already exists, so a concurrent writer (another process/instance sharing the volume) that won the
         // race cannot be clobbered - we discard our key and adopt theirs instead. This also makes the write
-        // atomic: a crash mid-write leaves the temp file, never a truncated key file.
+        // atomic: a crash mid-write leaves the temp file, never a truncated key file. The move preserves the
+        // temp file's mode, so the key file is owner-only from the instant it exists.
         var tempPath = _keyFilePath + "." + Guid.NewGuid().ToString("N") + ".tmp";
-        File.WriteAllBytes(tempPath, key);
-        TryRestrictToOwner(tempPath);
+        WriteKeyOwnerOnly(tempPath, key);
 
         try
         {
@@ -166,23 +190,26 @@ internal sealed class SecretStore
         }
     }
 
-    private static void TryRestrictToOwner(string path)
+    // Writes the key material to a brand-new file that is owner-only from the instant it exists. On Unix the
+    // restrictive mode is supplied to open() at creation time (UnixCreateMode), so - unlike a write followed
+    // by a chmod - there is no sub-millisecond window where the freshly-created key sits at the umask default
+    // (potentially group/world-readable). umask can only clear bits, never add them, so a create mode of
+    // UserRead|UserWrite is never widened. On Windows there is no portable owner-only chmod, so the file
+    // inherits the (already access-controlled) Jellyfin data directory's NTFS ACLs, as before.
+    private static void WriteKeyOwnerOnly(string path, byte[] key)
     {
-        if (OperatingSystem.IsWindows())
+        var options = new FileStreamOptions
         {
-            // NTFS inherits ACLs from the (already access-controlled) Jellyfin data directory; there is
-            // no portable owner-only chmod equivalent to apply here without pulling in Windows ACL APIs.
-            return;
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+        };
+
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
         }
 
-        try
-        {
-            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
-        }
-        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException or PlatformNotSupportedException)
-        {
-            // Best effort: the key is still separated from the config, so a failure to tighten the mode is
-            // not fatal.
-        }
+        using var stream = new FileStream(path, options);
+        stream.Write(key, 0, key.Length);
     }
 }


### PR DESCRIPTION
# What & why

Follow-up hardening from the adversarial review of #158 (secrets encrypted at
rest). Both notes were rated non-blocking by the 4-lens gate on #158 - the
current behavior is safe, these make it safer. Scope is confined to
`SSO-Auth/Api/SecretStore.cs` and `SSO-Auth/Api/ConfigSecretProtection.cs`.

**1. Refuse to mint a new data-encryption key when the config already holds
envelopes (orphan-prevention).** `ConfigSecretProtection.ProtectAll` now decides
once, over the whole configuration, whether any well-formed `ssoenc:` envelope
is already present - `HasAnyEnvelope` inspects exactly the fields it encrypts
(the OpenID client secrets and the SAML signing keys), the only values this
plugin ever writes as envelopes - and threads that as `configHasEnvelopes` into
every `SecretStore.Protect` call. When encrypting a plaintext secret while the
key file is missing, the store mints a fresh key only on a genuine first run
(no envelopes to orphan). If envelopes already exist the missing key was lost,
not absent, so it fails closed with the same restore-from-backup guidance as
the reveal path rather than regenerating - which would orphan every
previously-encrypted secret and mask the loss by re-encrypting the plaintext
under a new key. A clean install and a legacy plaintext-only upgrade still mint
a key exactly as before.

**2. Create the temp key file with owner-only mode atomically.**
`CreateKeyLocked` previously did `File.WriteAllBytes` then chmod 0600, leaving a
sub-millisecond window where the temp key sat at the umask default (potentially
group/world-readable). It now creates the file with `UnixCreateMode`
`UserRead|UserWrite` at `open()` time, so the key is owner-only from the instant
it exists (umask can only clear bits, never widen them); `File.Move` preserves
the mode onto the final key file. Windows keeps inheriting the data directory's
NTFS ACLs, as before. The now-redundant post-write chmod helper was removed.

Closes #550

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (This change adds a third fail-closed
      mode: encrypting refuses to mint over a missing key when envelopes exist.)
- [x] No secrets logged; secrets are redacted on config export. (The
      key-missing exception names the key file path, never key material.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (4-lens gate below.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      new logging.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (`HasAnyEnvelope` and `GetOrCreateKeyForEncrypt`;
      `GetOrCreateKey` now delegates to the latter with `configHasEnvelopes:
      false`, removing the prior duplicate load-or-create body.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property; the existing conformance suite passes.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings.)
- [x] `dotnet test` is green. (1154 passed, 0 failed, 0 skipped; +6 new tests.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A -
      only `.cs` files touched.)

## Notes

Adversarial-review gate (crypto key handling - refute-by-default, 4 lenses,
free-text verdicts). All four PASS.

- **Bypass** - VERDICT: The two hardenings are sound - orphan-prevention cannot
  be bypassed to mint over existing envelopes on any production path (single
  flagged chokepoint via `ProtectAll`, cache-safe, complete field coverage),
  and the temp key is never briefly world/group-readable (atomic
  `UnixCreateMode`, umask cannot widen, rename preserves mode). PASS
- **Availability** - VERDICT: The orphan-prevention throw is correctly gated on
  genuine key loss (envelopes present AND key file missing AND uncached), leaves
  clean installs, legacy-plaintext upgrades, and key-present steady state fully
  working with test coverage, and converts a prior silent-orphan into a clear
  fail-closed on an already-broken disaster state rather than a new mass-lockout;
  the atomic 0600 create introduces no read-back risk under any realistic umask.
  PASS
- **Correctness** - VERDICT: The orphan-prevention flag is accurate and
  consistent with the idempotency predicate, the fail-closed throw is correctly
  gated (cached/existing key still succeeds, clean first run still mints), the
  parameterless overload is provably equivalent, and the atomic owner-only key
  creation preserves 0600 across the rename - no correctness defect found. PASS
- **Integration** - VERDICT: The change threads orphan-prevention and atomic
  owner-only key creation without regressing #158's lifecycle - all callers
  compile and behave, the reveal path and public `GetOrCreateKey` are unchanged,
  no half-mutated config can persist (the throw aborts `ProtectAll` before
  `base.UpdateConfiguration`), and the one new login-path throw is intended
  fail-closed hardening in an already-broken deployment. PASS

Follow-up noted by the availability/integration lenses (not in scope here): on a
real Linux server, add an E2E-checklist verification that the key file is 0600
and that the lost-key path surfaces the restore-from-backup message rather than
regenerating. Tracked for the E2E checklist, no code change required.
