### PR TITLE
Bind OpenID canonical links to the discovered issuer

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -154,12 +154,14 @@ public class ArchitectureConformanceTests
         // scattered cap/lifetime/sweep conventions. The former SSOController.DiscoveryFactsCache moved into a
         // *Cache type in #449 and was then removed entirely in #450 (discovery is now read once per challenge
         // and fed to the login, with nothing cached), so no discovery-facts dictionary remains to exempt.
-        // One documented exemption remains:
+        // Two documented exemptions remain, both persisted account-link config state:
         // - ProviderConfigBase._canonicalLinks: the persisted account-link map — serialized plugin
         //   configuration mutated only under the config lock, so a runtime store type would be the
         //   wrong home; it is config state, not in-flight state.
+        // - OidConfig._canonicalLinkIssuers: the per-link issuer binding (#186), the exact parallel of
+        //   _canonicalLinks — serialized config mutated only under the config lock, same rationale.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))
@@ -410,25 +412,37 @@ public class ArchitectureConformanceTests
         // the "call-level invariants stay with CodeQL" note in the class summary).
         //
         // Sentinel against a vacuous pass (#388): a zero-occurrence scan only means something while its
-        // target token still names the link map. A property rename (CanonicalLinks -> anything) would make
-        // the scan match nothing and pass for the wrong reason, so pin the property by reflection — a rename
-        // fails HERE and forces a conscious update of `linkMapProperty` (and the scanned token with it).
-        const string linkMapProperty = "CanonicalLinks";
-        Assert.True(
-            typeof(ProviderConfigBase).GetProperty(linkMapProperty, BindingFlags.Public | BindingFlags.Instance) is not null,
-            $"ProviderConfigBase.{linkMapProperty} was renamed or removed; point this rule at the new provider link-map property so the scan keeps guarding it (#388).");
+        // target token still names a link map. A property rename (CanonicalLinks -> anything) would make
+        // the scan match nothing and pass for the wrong reason, so pin each property by reflection — a
+        // rename fails HERE and forces a conscious update of the roster (and the scanned token with it).
+        // BOTH server-managed link maps are guarded: the account-link map (ProviderConfigBase.CanonicalLinks,
+        // #157) and its per-link issuer binding (OidConfig.CanonicalLinkIssuers, #186). Both are owned by
+        // CanonicalLinkService and ServerManagedFields.Preserve; a controller must touch neither directly.
+        var linkMapProperties = new[]
+        {
+            (Declaring: typeof(ProviderConfigBase), Name: "CanonicalLinks"),
+            (Declaring: typeof(OidConfig), Name: "CanonicalLinkIssuers"),
+        };
+        foreach (var (declaring, name) in linkMapProperties)
+        {
+            Assert.True(
+                declaring.GetProperty(name, BindingFlags.Public | BindingFlags.Instance) is not null,
+                $"{declaring.Name}.{name} was renamed or removed; point this rule at the new provider link-map property so the scan keeps guarding it (#388).");
+        }
 
-        var token = "." + linkMapProperty;
+        // The two tokens are disjoint substrings (".CanonicalLinkIssuers" does not contain ".CanonicalLinks"
+        // — the char after "Link" is "I", not "s"), so scanning for both cannot cross-match.
+        var tokens = linkMapProperties.Select(p => "." + p.Name).ToList();
         var linkMapLines = ControllerSourceFiles()
             .SelectMany(path => File.ReadAllLines(path)
                 .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
-            .Where(l => l.Text.Contains(token, StringComparison.Ordinal))
+            .Where(l => tokens.Any(t => l.Text.Contains(t, StringComparison.Ordinal)))
             .Select(l => $"{l.File} line {l.Number}: {l.Text}")
             .ToList();
 
         Assert.True(
             linkMapLines.Count == 0,
-            "A controller must not access a provider CanonicalLinks map directly; route link-map access through CanonicalLinkService and server-managed re-injection through ServerManagedFields.Preserve. Found: " + string.Join(" | ", linkMapLines));
+            "A controller must not access a provider link map (CanonicalLinks / CanonicalLinkIssuers) directly; route link-map access through CanonicalLinkService and server-managed re-injection through ServerManagedFields.Preserve. Found: " + string.Join(" | ", linkMapLines));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -1137,6 +1137,263 @@ public class CanonicalLinkServiceTests
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
 
+    // --- OpenID canonical-link issuer binding (#186) ---
+
+    private const string OldIssuer = "https://old-idp.example";
+    private const string NewIssuer = "https://new-idp.example";
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_SubjectLinkStampedWithADifferentIssuer_RefusesFailClosed()
+    {
+        // The non-inert proof (#186, acceptance criterion 1): a subject-keyed link minted under one issuer
+        // must NOT resolve when the login presents a different one (the provider was repointed at another
+        // IdP behind the same discovery URL). The check FIRES at runtime and refuses — the prior review
+        // rejected an inert take, so this is the load-bearing test. No takeover: the old account is not
+        // handed to the new-IdP identity, and the stale link/issuer are left untouched for the admin.
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["1"] = OldIssuer },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "1", "mallory", allowExistingAccountLink: false, issuer: NewIssuer));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["1"]); // stale link untouched
+        Assert.Equal(OldIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["1"]); // stored issuer untouched
+
+        var warnings = log.Entries.FindAll(e => e.Level == Microsoft.Extensions.Logging.LogLevel.Warning);
+        Assert.Single(warnings);
+        Assert.Contains("issuer", warnings[0].Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_SubjectLinkStampedWithTheSameIssuer_ReusesItWithoutWriting()
+    {
+        // The hot path stays pure (#186): a login whose issuer matches the stored one reuses the link and
+        // writes nothing — the issuer binding adds no per-login persist once a link is stamped.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer },
+        };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        var persists = 0;
+        var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: OldIssuer);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(0, persists); // matched binding = pure read, no write
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_UnstampedSubjectLink_TrustOnFirstUse_StampsAndProceeds()
+    {
+        // Transparent migration (#186, acceptance criterion 3): an existing link with NO stored issuer
+        // (minted before this store) keeps working while the provider is unchanged AND gets stamped with the
+        // current issuer on its first login — no lockout on upgrade, and the binding is in force from then on.
+        var cfg = new PluginConfiguration();
+        cfg.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        };
+        var users = Substitute.For<IUserManager>();
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        var persists = 0;
+        var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
+        var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: OldIssuer);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(OldIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["sub-1"]); // stamped on first use
+        Assert.Equal(1, persists); // exactly one write for the stamp
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_UnstampedSubjectLink_ThenRepointedIssuer_IsRefused()
+    {
+        // The end-to-end story: after trust-on-first-use stamps a link, a later login from a DIFFERENT issuer
+        // is refused. Proves the stamp is what arms the binding (the same-URL-repoint case the belt cannot see).
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        // First login stamps the current issuer.
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: OldIssuer);
+        Assert.Equal(OldIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["sub-1"]);
+
+        // A later login from a swapped IdP (same URL) is now refused.
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: NewIssuer));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_StampedSubjectLink_LoginWithNoIssuer_IsRefused()
+    {
+        // Bypass closed (#186): a token that omits `iss` (issuer resolves to null) must NOT slip past a
+        // stamped binding — a null current issuer against a stored one is a mismatch, so the login is refused
+        // rather than mapping onto the stamped account.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: null));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_CreateNewAccount_StampsTheLoginIssuer()
+    {
+        // A newly created account's link is issuer-bound at creation (#186), so it is protected from the
+        // first login onward, not only after a later trust-on-first-use pass.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = UserNamed("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: NewIssuer);
+
+        Assert.Equal(Other, resolved);
+        Assert.Equal(NewIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_AdoptExistingAccount_StampsTheLoginIssuer()
+    {
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, issuer: NewIssuer);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(NewIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_LegacyMigration_StampsIssuerOnTheSubjectKey()
+    {
+        // The re-keyed link (#155 legacy migration) is a fresh subject-keyed link written under this login,
+        // so it is stamped with the login's issuer (#186) — the migrated link is issuer-bound like any other.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, issuer: NewIssuer);
+
+        Assert.Equal(Existing, resolved);
+        var issuers = cfg.OidConfigs["kc"].CanonicalLinkIssuers;
+        Assert.Equal(NewIssuer, issuers["sub-1"]);
+        Assert.False(issuers.ContainsKey("alice")); // no issuer under the retired legacy key
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_NullIssuerOnUnstampedLink_LeavesItUnstamped_AndProceeds()
+    {
+        // A login that carries no issuer (SAML, or a non-conformant token) never stamps a blank value — the
+        // link stays un-stamped rather than binding to nothing, and the login proceeds unchanged (#186).
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: null);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Empty(cfg.OidConfigs["kc"].CanonicalLinkIssuers);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_Saml_IgnoresIssuerBinding()
+    {
+        // SAML is out of scope (#186): a SAML login resolves normally regardless of any issuer argument, and
+        // SamlConfig carries no issuer map at all — the binding is OpenID only.
+        var (service, cfg, users, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Saml, "adfs", "alice", "alice", allowExistingAccountLink: false, issuer: NewIssuer);
+
+        Assert.Equal(Existing, resolved);
+        Assert.Equal(Existing, cfg.SamlConfigs["adfs"].CanonicalLinks["alice"]);
+    }
+
+    [Fact]
+    public void TryCreateLink_Oid_StampsTheIssuer()
+    {
+        // A manual OpenID link (the admin/self link redeem) is issuer-bound too (#186), so it is not left an
+        // un-stamped TOFU candidate a repoint could exploit before its first login.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var result = service.TryCreateLink(ProviderMode.Oid, "kc", "sub-1", Existing, issuer: NewIssuer);
+
+        Assert.Equal(CanonicalLinkWriteResult.Created, result);
+        Assert.Equal(NewIssuer, cfg.OidConfigs["kc"].CanonicalLinkIssuers["sub-1"]);
+    }
+
+    [Fact]
+    public void TryRemoveLink_Oid_DropsTheIssuerEntry()
+    {
+        // Removing a link drops its issuer entry (#186), so a removed-then-recreated sub does not inherit a
+        // stale binding and the issuer map does not accumulate orphans.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer },
+        });
+
+        var result = service.TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", Existing);
+
+        Assert.Equal(CanonicalLinkRemoveResult.Removed, result.Result);
+        Assert.False(cfg.OidConfigs["kc"].CanonicalLinkIssuers.ContainsKey("sub-1"));
+    }
+
+    [Fact]
+    public void RemoveUserEverywhere_PrunesOrphanedIssuerEntries()
+    {
+        // Revoking a user's links also prunes any now-orphaned issuer entries (#186), so the map stays clean.
+        var (service, cfg, _, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing, ["sub-2"] = Other },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer, ["sub-2"] = NewIssuer },
+        });
+
+        service.RemoveUserEverywhere(Existing);
+
+        var issuers = cfg.OidConfigs["kc"].CanonicalLinkIssuers;
+        Assert.False(issuers.ContainsKey("sub-1")); // the revoked user's issuer entry is gone
+        Assert.Equal(NewIssuer, issuers["sub-2"]); // the other user's binding survives
+    }
+
     [Fact]
     public async Task ResolveOrCreateAsync_RequireVerifiedEmailOff_NonAdmin_AdoptsRegardlessOfClaim()
     {

--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -93,6 +93,81 @@ public class ConfigPreservationTests
         Assert.Null(exception);
     }
 
+    // --- Per-link issuer binding + repoint belt (#186) ---
+
+    [Fact]
+    public void Preserve_OidEndpointUnchanged_KeepsLinksAndIssuerBindings()
+    {
+        // Criterion 3 (#186): while the provider endpoint is unchanged, both the links and their issuer
+        // bindings are carried over verbatim, so existing links keep working across an unrelated save.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = "https://idp" },
+        };
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://idp/.well-known" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal(User, incoming.OidConfigs["idp"].CanonicalLinks["sub-1"]);
+        Assert.Equal("https://idp", incoming.OidConfigs["idp"].CanonicalLinkIssuers["sub-1"]);
+    }
+
+    [Fact]
+    public void Preserve_OidEndpointChanged_ClearsLinksAndIssuerBindings_TheRepointBelt()
+    {
+        // Criterion 1 (#186), the belt: repointing the endpoint at a (potentially) different IdP drops the
+        // accumulated sub-keyed links AND their issuer bindings rather than carrying them across, so a
+        // new-IdP user whose sub collides with an old link cannot inherit the old account — even an
+        // un-stamped legacy link (a user who had not logged in since the upgrade) is protected here.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["1"] = User },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["1"] = "https://idp" },
+        };
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://other-idp/.well-known" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Empty(incoming.OidConfigs["idp"].CanonicalLinks);
+        Assert.Empty(incoming.OidConfigs["idp"].CanonicalLinkIssuers);
+    }
+
+    [Fact]
+    public void CanonicalLinkIssuers_AreOmittedFromJson_ButKeptInXml()
+    {
+        // The issuer map is server-managed exactly like CanonicalLinks (#186/#157): withheld from JSON so it
+        // cannot be read back or set via a config PUT, but persisted in the config XML so bindings survive a
+        // restart. This also pins the SerializableDictionary&lt;string,string&gt; XML round-trip shape.
+        var config = new OidConfig
+        {
+            OidClientId = "client",
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-secret"] = "https://issuer.example" },
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("CanonicalLinkIssuers", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("issuer.example", json, StringComparison.Ordinal);
+
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("CanonicalLinkIssuers", xml, StringComparison.Ordinal);
+        Assert.Contains("sub-secret", xml, StringComparison.Ordinal);
+        Assert.Contains("https://issuer.example", xml, StringComparison.Ordinal);
+
+        // Round-trips back with the value intact.
+        var back = RoundTripXml(config);
+        Assert.Equal("https://issuer.example", back.CanonicalLinkIssuers["sub-secret"]);
+    }
+
     [Fact]
     public void CanonicalLinks_AreOmittedFromJson_ButKeptInXml()
     {

--- a/SSO-Auth.Tests/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/LoginCompletionServiceTests.cs
@@ -54,6 +54,7 @@ public class LoginCompletionServiceTests
         VerifiedIdentity.FromOidcRedemption(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: username,
             Subject: subject,
+            Issuer: null,
             EmailVerified: null,
             Valid: true,
             Admin: false,

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -48,6 +48,30 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void Issuer_PassedFromTheRawToken_IsCarriedForTheLinkBinding()
+    {
+        // #186: the validated id_token's issuer is passed in by the callback (read from the raw token, since
+        // OidcClient filters `iss` out of result.User) and carried onto the derived state so the canonical
+        // link can be issuer-bound.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "sub-1")),
+            Config(_ => { }),
+            issuer: "https://issuer.example");
+
+        Assert.Equal("https://issuer.example", result.Issuer);
+    }
+
+    [Fact]
+    public void NoIssuerPassed_ResolvesToNull_SoTheLinkStaysUnstamped()
+    {
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "sub-1")),
+            Config(_ => { }));
+
+        Assert.Null(result.Issuer);
+    }
+
+    [Fact]
     public void PreferredUsernameClaim_NoRolesConfigured_IsValid()
     {
         var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -72,11 +72,11 @@ public class OidcStateStoreTests
         string? clientKey = null)
         => new(
             Pending(provider, stateValue, created, binding, isLinking, clientKey: clientKey),
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState(username, subject, emailVerified, true, admin, enableLiveTv, enableLiveTvManagement, folders ?? new List<string>(), avatar));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState(username, subject, null, emailVerified, true, admin, enableLiveTv, enableLiveTvManagement, folders ?? new List<string>(), avatar));
 
     // A fully-populated role-gate result, so a redeemed Ready can be asserted field-for-field.
     private static OidcAuthorizeStateBuilder.OidcAuthorizeState FullDerived() =>
-        new("alice", "sub-full", null, true, true, false, false, new List<string> { "movies" }, "https://idp.example/a.png");
+        new("alice", "sub-full", "https://idp.example", null, true, true, false, false, new List<string> { "movies" }, "https://idp.example/a.png");
 
     // --- PeekCurrent (OidPost precondition): provider-bound + unexpired + still pending, non-consuming ---
 
@@ -705,7 +705,7 @@ public class OidcStateStoreTests
     private static void Validate(OidcStateStore store, string token) =>
         store.Promote(
             store.PeekCurrent(token, "p", Now, Binding),
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", null, true, false, false, false, new List<string>(), null));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", null, null, true, false, false, false, new List<string>(), null));
 
     [Fact]
     public void TryAdd_FloodFromOneKey_DoesNotRefuseADifferentKey()

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -305,7 +305,7 @@ public class SSOControllerLinkTests
         // The OID link path redeems an authorize state the redirect leg validated; seed a redeemable one.
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
 
@@ -324,7 +324,7 @@ public class SSOControllerLinkTests
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = false });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
 
@@ -347,7 +347,7 @@ public class SSOControllerLinkTests
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
             new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
-            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, true, false, false, false, new List<string>(), null)));
+            new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
         // A wrong-browser callback: overwrite the matching cookie ForCaller set with a different id.
         harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}=other-browser";
 

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -230,7 +230,7 @@ public class SSOControllerOidAuthTests
         var ready = new AuthorizeSession.Ready(
             pending,
             new OidcAuthorizeStateBuilder.OidcAuthorizeState(
-                Username: "alice", Subject: "sub-1", EmailVerified: emailVerified, Valid: true, Admin: false,
+                Username: "alice", Subject: "sub-1", Issuer: null, EmailVerified: emailVerified, Valid: true, Admin: false,
                 EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>(), AvatarUrl: null));
         OidcLoginService.SeedOidStateForTests(token, ready);
 

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -4,12 +4,14 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -55,6 +57,40 @@ public class SSOControllerOidPostTests
         var page = Assert.IsType<ContentResult>(result);
         Assert.Equal("text/html", page.ContentType);
         Assert.False(string.IsNullOrEmpty(page.Content));
+    }
+
+    [Fact]
+    public async Task OidPost_FullLogin_StampsTheRealIdTokenIssuerOntoTheCanonicalLink()
+    {
+        // End-to-end empirical proof (#186): a full callback + authenticate over a REAL signed id_token must
+        // capture that token's `iss` and stamp it onto the freshly created canonical link. This is what
+        // proves the issuer binding is sourced from the validated token (not reasoned about) — the whole
+        // chain OidcIdTokenValidator -> claims -> OidcAuthorizeStateBuilder -> VerifiedIdentity ->
+        // LoginCompletionService -> CanonicalLinkService runs against the fixture's actual token here.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1");
+        var user = new User("alice", "SSO-Auth", "Default") { Id = Guid.Parse("55555555-5555-5555-5555-555555555555") };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(user.Id).Returns(user);
+
+        // The callback promotes the state to a redeemable Ready built from the real id_token's claims.
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", "state-1")).ContentType);
+
+        // The authenticate leg redeems it and mints, resolving/creating the account and stamping the link.
+        var authed = await harness.Controller.OidAuth("kc", new AuthResponse
+        {
+            Data = "state-1",
+            DeviceID = "device-1",
+            DeviceName = "Test Device",
+            AppName = "Jellyfin Web",
+            AppVersion = "1.0",
+        });
+        Assert.IsType<OkObjectResult>(authed);
+
+        // The link is bound to the token's actual issuer (the fixture's Authority), read from the real
+        // validated id_token — not a value hand-fed by the test.
+        var issuers = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].CanonicalLinkIssuers);
+        Assert.Equal(Authority, issuers["sub-1"]);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/VerifiedIdentityTests.cs
@@ -25,6 +25,7 @@ public class VerifiedIdentityTests
         var derived = new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: "alice",
             Subject: "sub-123",
+            Issuer: "https://issuer.example",
             EmailVerified: true,
             Valid: true,
             Admin: true,
@@ -40,8 +41,10 @@ public class VerifiedIdentityTests
         Assert.Equal("OpenID", identity.AuditProtocol);
         Assert.Equal("keycloak", identity.Provider);
 
-        // OpenID keys the link on the stable subject; the username is derived independently.
+        // OpenID keys the link on the stable subject; the username is derived independently. The issuer is
+        // carried onto the identity to issuer-bind the canonical link (#186).
         Assert.Equal("sub-123", identity.Subject);
+        Assert.Equal("https://issuer.example", identity.Issuer);
         Assert.Equal("alice", identity.Username);
         Assert.Equal(true, identity.EmailVerified);
         Assert.True(identity.Admin);
@@ -70,9 +73,11 @@ public class VerifiedIdentityTests
         Assert.Equal("alice@example.com", identity.Subject);
         Assert.Equal("alice@example.com", identity.Username);
 
-        // SAML carries no email_verified claim and no avatar, so the adoption gate and avatar step are inert.
+        // SAML carries no email_verified claim, no avatar, and no issuer binding (#186), so the adoption
+        // gate, avatar step, and issuer check are all inert.
         Assert.Null(identity.EmailVerified);
         Assert.Null(identity.AvatarUrl);
+        Assert.Null(identity.Issuer);
 
         Assert.True(identity.Admin);
         Assert.Equal(new[] { "movies" }, identity.Folders);

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -68,7 +68,8 @@ internal sealed class LoginCompletionService
                 identity.Subject,
                 identity.Username,
                 config.AllowExistingAccountLink,
-                adoptionGate).ConfigureAwait(false);
+                adoptionGate,
+                identity.Issuer).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -273,8 +273,11 @@ internal sealed class OidcLoginService
         }
 
         // Derive the authorize-state values (username, validity, admin, Live TV, folders, avatar)
-        // from the verified login's claims and the provider configuration.
-        var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config);
+        // from the verified login's claims and the provider configuration. The issuer the account link is
+        // bound to (#186) is read from the RAW id_token, not result.User: OidcClient filters the standard
+        // protocol claims (iss, aud, exp, …) out of the redeemed principal, so the claim list carries no
+        // `iss` — the same reason the RFC 9207 check above re-reads it from result.IdentityToken.
+        var derived = OidcAuthorizeStateBuilder.Build(result.User.Claims, config, OidcResponseIssuer.IdTokenIssuer(result.IdentityToken));
 
         // Fail closed (#155): a valid OpenID login must resolve a stable subject to key the account
         // link on. sub is an OIDC Core MUST and (post-#134) the id_token validator has verified the
@@ -406,8 +409,9 @@ internal sealed class OidcLoginService
         }
 
         // Manual linking keys on the stable subject (#155), matching the auto-login path, so a
-        // later provider-side rename does not orphan the link the user just created.
-        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Oid, provider, redeemed.Identity.Subject, jellyfinUserId));
+        // later provider-side rename does not orphan the link the user just created. The redeemed
+        // identity's issuer stamps the link (#186), so a manual link is issuer-bound like an auto-login one.
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Oid, provider, redeemed.Identity.Subject, jellyfinUserId, redeemed.Identity.Issuer));
     }
 
     // Builds the space-delimited OpenID scope string, always leading with the base "openid profile".

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -48,6 +48,25 @@ internal enum CanonicalLinkRemoveResult
 }
 
 /// <summary>
+/// The issuer binding of a resolved subject-keyed OpenID link against the current login's issuer (#186).
+/// SAML (any non-OpenID mode) and a login with no resolved subject link are <see cref="NotBound"/>.
+/// </summary>
+internal enum IssuerBinding
+{
+    /// <summary>Issuer binding does not apply (SAML / any non-OpenID mode, or no subject link resolved).</summary>
+    NotBound,
+
+    /// <summary>The link's stored issuer ordinally equals the login's issuer — proceed, no write.</summary>
+    Match,
+
+    /// <summary>The link carries no stored issuer (a legacy/un-stamped link) — eligible for trust-on-first-use stamping.</summary>
+    Absent,
+
+    /// <summary>The link's stored issuer differs from the login's — refuse the login (fail closed).</summary>
+    Mismatch,
+}
+
+/// <summary>
 /// The outcome of a manual unlink, together with whether the target user still holds any other canonical
 /// SSO link after it. The remainder is meaningful only when <see cref="Result"/> is
 /// <see cref="CanonicalLinkRemoveResult.Removed"/> (the other outcomes change no state); the controller
@@ -126,8 +145,14 @@ internal sealed class CanonicalLinkService
     /// when the gate requires a verified email the login must carry <c>email_verified == true</c>. Default
     /// (<see cref="AdoptionGate.None"/>) is the SAML/legacy posture: admin refusal only.
     /// </param>
+    /// <param name="issuer">
+    /// The OpenID login's id_token issuer, used to issuer-bind the canonical link (#186): a resolved link
+    /// whose stored issuer does not match this value is refused (fail closed, after an apparent repoint),
+    /// and a link with no stored issuer is stamped with this value on first use (trust-on-first-use). Null
+    /// for SAML and for a token that carried no <c>iss</c>; both skip the binding.
+    /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default)
+    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string issuer = null)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -152,7 +177,7 @@ internal sealed class CanonicalLinkService
         // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
         // user off the adoption gate with a spurious 403. A link whose target user was deleted counts
         // as absent (dangling links are dead, not identities).
-        var (subjectLink, legacyLink) = _configStore.Read(configuration =>
+        var (subjectLink, legacyLink, subjectIssuer) = _configStore.Read(configuration =>
         {
             // The login callbacks resolve the provider before calling, so it is normally present and
             // enabled. If it was deleted OR DISABLED in the race between that lookup and here, fail
@@ -176,8 +201,35 @@ internal sealed class CanonicalLinkService
                 && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
                 && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
                 ? n : (Guid?)null;
-            return (bySubject, byName);
+
+            // Classify the subject link's issuer binding in the SAME locked read (#186), so the verdict
+            // cannot tear against a concurrent stamp or repoint. NotBound unless a subject link resolved
+            // for an OpenID provider.
+            var issuerVerdict = bySubject is null
+                ? IssuerBinding.NotBound
+                : ClassifyIssuer(configuration, mode, provider, canonicalKey, issuer);
+            return (bySubject, byName, issuerVerdict);
         });
+
+        // Non-inert issuer binding (#186): the subject-keyed link this identity resolves to was minted
+        // under a DIFFERENT issuer than the login now presents — an admin repointed the provider entry at
+        // another identity provider behind the same discovery URL, or (with the URL edited) the belt has
+        // not yet run. Refuse rather than map this login onto the old link's account; a colliding `sub`
+        // from a new IdP (realistic for short numeric subjects like "1") no longer inherits the old user.
+        // Fail closed, self-healing: the admin re-establishes the link, or an endpoint edit clears the
+        // stale links (ServerManagedFields belt). This is the check that MUST fire at runtime — the prior
+        // review rejected an inert take; a rejection test pins that it does. A login with no issuer while
+        // the link has one lands here too (ClassifyIssuer treats it as a mismatch), so a token omitting
+        // `iss` cannot slip past a stamped binding.
+        if (subjectLink.HasValue && subjectIssuer == IssuerBinding.Mismatch)
+        {
+            _logger.LogWarning(
+                "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+            throw new AccountLinkForbiddenException("The account link was minted under a different issuer; refusing to resolve it after an apparent provider repoint.");
+        }
 
         // The account currently bearing the display name, resolved once (outside the config lock — it is
         // a user-manager read, not a config read). It is both the same-name adoption candidate for the
@@ -218,11 +270,21 @@ internal sealed class CanonicalLinkService
             // instead of reasoning about its (previously argued-benign) safety. A concurrent winner's live
             // subject link is used as-is; the deleted-target edge resolves to null so the login falls
             // through to the create/adopt gate rather than binding to a dead account.
-            linkedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username);
+            linkedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username, issuer);
             _logger.LogInformation(
                 "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
                 mode.ToToken(),
                 provider?.ReplaceLineEndings(string.Empty));
+        }
+        else if (subjectLink.HasValue && subjectIssuer == IssuerBinding.Absent)
+        {
+            // Trust-on-first-use migration (#186): the resolved subject link carries no stored issuer — it
+            // was minted before this store existed, or by a null-issuer path. The provider is unchanged
+            // (we did not hit the mismatch refusal above), so the login's issuer IS the one the link was
+            // minted under; stamp it now so a later same-URL issuer swap is caught. No lockout on upgrade:
+            // an existing user's first post-upgrade login stamps and proceeds. Skipped when the login
+            // carries no issuer — there is nothing safe to bind to, so the link stays un-stamped.
+            StampIssuer(mode, provider, canonicalKey, issuer);
         }
 
         // A legacy link that survives here un-migrated (flag off — or flag on but the name no longer
@@ -269,8 +331,9 @@ internal sealed class CanonicalLinkService
                 }
 
                 // Atomic check-then-link (#133): if a concurrent first-login already linked this
-                // identity, that winner is used and no second write or duplicate audit occurs.
-                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId);
+                // identity, that winner is used and no second write or duplicate audit occurs. The link
+                // write also stamps the login's issuer (#186), so the adopted link is issuer-bound.
+                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId, issuer);
                 if (wrote)
                 {
                     SsoAudit.AccountAdopted(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, username);
@@ -309,8 +372,9 @@ internal sealed class CanonicalLinkService
 
                 // Atomic check-then-link (#133): if a concurrent first-login for the same identity
                 // linked meanwhile, use its account — this freshly created user is left unlinked rather
-                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login).
-                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id);
+                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
+                // link write stamps the login's issuer (#186), so the new link is issuer-bound.
+                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer);
                 return effectiveUserId;
             }
 
@@ -355,8 +419,9 @@ internal sealed class CanonicalLinkService
     /// <param name="provider">The provider the link belongs to.</param>
     /// <param name="providerUserId">The provider-side identity key (OpenID sub / SAML NameID).</param>
     /// <param name="jellyfinUserId">The Jellyfin user to link the identity to.</param>
+    /// <param name="issuer">The OpenID id_token issuer to issuer-bind the new link to (#186); null for SAML or an unauthenticated admin link, which leaves the link un-stamped (trust-on-first-use applies on its first login).</param>
     /// <returns>The write outcome.</returns>
-    internal CanonicalLinkWriteResult TryCreateLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId)
+    internal CanonicalLinkWriteResult TryCreateLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId, string issuer = null)
     {
         // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
         // create a link — an empty or whitespace key would persist a dead link no login can ever redeem.
@@ -381,6 +446,7 @@ internal sealed class CanonicalLinkService
             }
 
             links[providerUserId] = jellyfinUserId;
+            StampIssuerInPlace(configuration, mode, provider, providerUserId, issuer);
             return CanonicalLinkWriteResult.Created;
         });
     }
@@ -428,6 +494,10 @@ internal sealed class CanonicalLinkService
             }
 
             links.Remove(canonicalName);
+
+            // Drop the OpenID issuer entry alongside the link (#186), so the issuer map does not accumulate
+            // orphans and a later re-link of the same sub is not judged against a stale binding. No-op for SAML.
+            RemoveIssuer(configuration, mode, provider, canonicalName);
 
             // Whether the user keeps any other canonical link across ALL providers, read in the SAME
             // transaction as the removal (#468): computing it here rather than in a second lock acquisition
@@ -499,6 +569,17 @@ internal sealed class CanonicalLinkService
                 {
                     removed += CanonicalLinkRevoker.RemoveUser(links, userId);
                 }
+
+                // Prune orphaned OpenID issuer entries (#186): after the revoke, any issuer keyed on a sub
+                // no longer present in the links map is dead weight and must not linger to spuriously bind
+                // (or refuse) a future re-link of that sub. SAML has no issuer map.
+                if (config is OidConfig oid && oid.CanonicalLinks is { } liveLinks)
+                {
+                    foreach (var staleKey in oid.CanonicalLinkIssuers.Keys.Where(k => !liveLinks.ContainsKey(k)).ToList())
+                    {
+                        oid.CanonicalLinkIssuers.Remove(staleKey);
+                    }
+                }
             }
 
             return removed;
@@ -568,7 +649,7 @@ internal sealed class CanonicalLinkService
     // reports WroteLink=false (so the caller does not re-emit the adoption audit). The link write goes
     // straight into the config (no discarded ActionResult), so a failure to persist propagates rather
     // than falling through as a successful adoption.
-    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId)
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId, string issuer)
     {
         return _configStore.Mutate(configuration =>
         {
@@ -589,6 +670,10 @@ internal sealed class CanonicalLinkService
             if (wroteLink)
             {
                 links[canonicalKey] = effectiveUserId;
+
+                // A link written under this login carries this login's issuer (#186). The #133 race loser
+                // (wroteLink == false) uses the winner's already-stamped link, so it stamps nothing.
+                StampIssuerInPlace(configuration, mode, provider, canonicalKey, issuer);
             }
 
             return (effectiveUserId, wroteLink);
@@ -605,7 +690,7 @@ internal sealed class CanonicalLinkService
     // only a dangling one (its target user deleted), which would otherwise block the hand-off on every
     // subsequent login. Returns null only when neither key resolves a live account (the dangling edge), so
     // the login fails closed into the create/adopt gate rather than binding to a dead account.
-    private Guid? MigrateAndResolveCanonicalLink(ProviderMode mode, string provider, string canonicalKey, string legacyKey)
+    private Guid? MigrateAndResolveCanonicalLink(ProviderMode mode, string provider, string canonicalKey, string legacyKey, string issuer)
     {
         return _configStore.Mutate<Guid?>(configuration =>
         {
@@ -629,6 +714,11 @@ internal sealed class CanonicalLinkService
             {
                 links.Remove(legacyKey);
                 links[canonicalKey] = legacyUserId;
+
+                // The re-keyed link is a fresh subject-keyed link written under THIS login, so stamp its
+                // issuer (#186). The legacy key carried no issuer (it predates the store); the new key is
+                // bound to the login that migrated it, matching the create/adopt write paths.
+                StampIssuerInPlace(configuration, mode, provider, canonicalKey, issuer);
                 return legacyUserId;
             }
 
@@ -679,5 +769,84 @@ internal sealed class CanonicalLinkService
         var ok = configs.TryGetValue(provider, out var config);
         links = config?.CanonicalLinks;
         return ok && links != null && (!requireEnabled || config.Enabled);
+    }
+
+    // Classifies an OpenID subject link's issuer binding against the login's issuer, read under the caller's
+    // config lock (#186). SAML (and any non-OID mode) is NotBound — issuer binding is OpenID only. For OID:
+    // Absent when the link has no stored issuer yet (legacy/un-stamped, eligible for trust-on-first-use);
+    // Match when the stored issuer ordinally equals the login's; Mismatch otherwise. A blank stored value is
+    // treated as Absent (never written blank; defensive). The Mismatch arm INCLUDES the case where the login
+    // carries no issuer while the link has one, so a token that omits `iss` cannot slip past a stamped
+    // binding — fail closed.
+    private static IssuerBinding ClassifyIssuer(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, string issuer)
+    {
+        if (mode != ProviderMode.Oid)
+        {
+            return IssuerBinding.NotBound;
+        }
+
+        var stored = configuration.OidConfigs.TryGetValue(provider, out var config) && config?.CanonicalLinkIssuers is { } issuers
+            && issuers.TryGetValue(canonicalKey, out var storedIssuer)
+            ? storedIssuer
+            : null;
+
+        if (string.IsNullOrWhiteSpace(stored))
+        {
+            return IssuerBinding.Absent;
+        }
+
+        return string.Equals(stored, issuer, StringComparison.Ordinal) ? IssuerBinding.Match : IssuerBinding.Mismatch;
+    }
+
+    // Trust-on-first-use stamp of an OpenID link that has no stored issuer yet (#186), in its own config
+    // transaction. OID-only and non-blank-issuer-only. Idempotent: writes only when the link still exists AND
+    // its issuer is still absent, so a concurrent login that already stamped is not overwritten. A no-op for
+    // SAML or a blank issuer (nothing safe to bind to) — the link stays un-stamped rather than binding to an
+    // empty value.
+    private void StampIssuer(ProviderMode mode, string provider, string canonicalKey, string issuer)
+    {
+        if (mode != ProviderMode.Oid || string.IsNullOrWhiteSpace(issuer))
+        {
+            return;
+        }
+
+        _configStore.Mutate(configuration =>
+        {
+            if (configuration.OidConfigs.TryGetValue(provider, out var config) && config?.CanonicalLinks is { } links
+                && links.ContainsKey(canonicalKey)
+                && !config.CanonicalLinkIssuers.ContainsKey(canonicalKey))
+            {
+                config.CanonicalLinkIssuers[canonicalKey] = issuer;
+            }
+        });
+    }
+
+    // Stamps (overwriting) an OpenID link's issuer within the caller's ALREADY-HELD config transaction (#186),
+    // called right after a link WRITE (adopt / create / migrate / manual link) so the fresh link carries the
+    // issuer it was minted under. Overwrites any stale value — a link just (re)written under this login belongs
+    // to this login's issuer. A no-op for SAML or a blank issuer.
+    private static void StampIssuerInPlace(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, string issuer)
+    {
+        if (mode != ProviderMode.Oid || string.IsNullOrWhiteSpace(issuer))
+        {
+            return;
+        }
+
+        if (configuration.OidConfigs.TryGetValue(provider, out var config) && config is not null)
+        {
+            config.CanonicalLinkIssuers[canonicalKey] = issuer;
+        }
+    }
+
+    // Drops an OpenID link's issuer entry within the caller's already-held config transaction (#186), called
+    // alongside a link removal so the issuer map does not accumulate orphans. A no-op for SAML.
+    private static void RemoveIssuer(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey)
+    {
+        if (mode == ProviderMode.Oid
+            && configuration.OidConfigs.TryGetValue(provider, out var config)
+            && config?.CanonicalLinkIssuers is { } issuers)
+        {
+            issuers.Remove(canonicalKey);
+        }
     }
 }

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -33,8 +33,14 @@ internal static class OidcAuthorizeStateBuilder
     /// </summary>
     /// <param name="claims">The claims of the verified OpenID login.</param>
     /// <param name="config">The OpenID provider configuration.</param>
+    /// <param name="issuer">
+    /// The validated id_token's issuer, read from the RAW token by the caller (#186). It is passed in rather
+    /// than scanned from <paramref name="claims"/> because OidcClient filters the standard protocol claims
+    /// (<c>iss</c>, <c>aud</c>, <c>exp</c>, …) out of the redeemed principal, so the claim list here never
+    /// carries <c>iss</c>. Null when the token carried none; the canonical link then stays un-stamped.
+    /// </param>
     /// <returns>The derived authorize-state values.</returns>
-    internal static OidcAuthorizeState Build(IEnumerable<Claim> claims, OidConfig config)
+    internal static OidcAuthorizeState Build(IEnumerable<Claim> claims, OidConfig config, string? issuer = null)
     {
         // Materialize so the claims can be enumerated more than once (avatar format, role claim, sub fallback).
         var claimList = claims as IReadOnlyList<Claim> ?? claims.ToList();
@@ -87,7 +93,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -189,6 +195,7 @@ internal static class OidcAuthorizeStateBuilder
     /// </summary>
     /// <param name="Username">The resolved username (last matching preferred-username or sub claim), or null when none is present.</param>
     /// <param name="Subject">The stable subject identifier (the "sub" claim) used to key the account link, or null when absent.</param>
+    /// <param name="Issuer">The id_token issuer (the "iss" claim) the account link is issuer-bound to, or null when absent (#186).</param>
     /// <param name="EmailVerified">The login's "email_verified" claim (true/false), or null when the claim is absent, used by the adoption gate (#218).</param>
     /// <param name="Valid">Whether the login is permitted (no allow-list, or a role matched the allow-list).</param>
     /// <param name="Admin">Whether the login grants administrator rights.</param>
@@ -199,6 +206,7 @@ internal static class OidcAuthorizeStateBuilder
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
+        string? Issuer,
         bool? EmailVerified,
         bool Valid,
         bool Admin,

--- a/SSO-Auth/Api/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/OidcResponseIssuer.cs
@@ -76,6 +76,17 @@ internal static class OidcResponseIssuer
         }
     }
 
+    /// <summary>
+    /// The validated id_token's issuer (its <c>iss</c> claim), or null when the token is absent/degenerate.
+    /// Read from the RAW token rather than the redeemed <c>result.User</c> claims because OidcClient filters
+    /// the standard protocol claims (<c>iss</c>, <c>aud</c>, <c>exp</c>, …) out of the principal — the same
+    /// reason the mix-up check above re-reads it here. This is the authoritative (iss, sub) issuer the
+    /// canonical link is bound to (#186).
+    /// </summary>
+    /// <param name="identityToken">The redeemed, already-validated id_token.</param>
+    /// <returns>The token's issuer; null when the token does not parse, and empty when it carries no <c>iss</c> (JsonWebToken.Issuer returns "" for an absent claim). Both are treated as "no issuer" by every consumer (IsNullOrWhiteSpace / ordinal Equals), so the link stays un-stamped.</returns>
+    internal static string? IdTokenIssuer(string? identityToken) => TokenIssuer(identityToken);
+
     // The id_token was validated by OidcIdTokenValidator before this runs, so it parses; the guard and
     // catch are defensive so a degenerate token can never turn the mix-up check itself into a 500.
     private static string? TokenIssuer(string? identityToken)

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -38,6 +38,7 @@ internal sealed record VerifiedIdentity
         string auditProtocol,
         string provider,
         string subject,
+        string? issuer,
         string username,
         bool? emailVerified,
         bool admin,
@@ -50,6 +51,7 @@ internal sealed record VerifiedIdentity
         AuditProtocol = auditProtocol;
         Provider = provider;
         Subject = subject;
+        Issuer = issuer;
         Username = username;
         EmailVerified = emailVerified;
         Admin = admin;
@@ -70,6 +72,13 @@ internal sealed record VerifiedIdentity
 
     /// <summary>Gets the stable subject identifier keying the account link (OpenID "sub"; the SAML NameID) (#155).</summary>
     internal string Subject { get; }
+
+    /// <summary>
+    /// Gets the issuer the account link is bound to — the OpenID id_token's "iss" claim, or null for SAML
+    /// (out of scope) and for a token that carried none. Used to stamp and re-check the per-link issuer
+    /// binding (#186).
+    /// </summary>
+    internal string? Issuer { get; }
 
     /// <summary>Gets the username the login resolves (the OpenID username; the SAML NameID).</summary>
     internal string Username { get; }
@@ -109,6 +118,7 @@ internal sealed record VerifiedIdentity
             "OpenID",
             provider,
             derived.Subject!,
+            derived.Issuer,
             derived.Username!,
             derived.EmailVerified,
             derived.Admin,
@@ -122,7 +132,8 @@ internal sealed record VerifiedIdentity
     /// the response has passed signature, time-bound, audience, recipient and replay validation, the login
     /// allow-list, and the non-empty-NameID guard (#95) — so a raw or unvalidated response can never reach
     /// this factory. SAML keys the link directly on the NameID (subject and username are the same value) and
-    /// carries no <c>email_verified</c> claim or avatar (both null).
+    /// carries no <c>email_verified</c> claim, avatar, or issuer binding (all null — issuer binding is
+    /// OpenID-only, #186).
     /// </summary>
     /// <param name="provider">The provider that verified the login.</param>
     /// <param name="nameId">The validated, non-empty NameID; the link key and the username.</param>
@@ -134,6 +145,7 @@ internal sealed record VerifiedIdentity
             "SAML",
             provider,
             nameId,
+            null,
             nameId,
             null,
             privileges.Admin,

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -284,10 +284,36 @@ public class SamlConfig : ProviderConfigBase
 [XmlRoot("PluginConfiguration")]
 public class OidConfig : ProviderConfigBase
 {
+    private SerializableDictionary<string, string> _canonicalLinkIssuers;
+
     /// <summary>
     /// Gets or sets the OpenID well-known information endpoint.
     /// </summary>
     public string OidEndpoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets, per canonical link, the discovered issuer the link was minted under (#186). Keyed
+    /// by the same stable subject (<c>sub</c>) as <see cref="ProviderConfigBase.CanonicalLinks"/>, the
+    /// value is the id_token issuer that asserted that subject when the link was created. At login the
+    /// resolved link's stored issuer is compared to the current login's issuer and a mismatch refuses the
+    /// login (fail closed), so an admin repointing this provider entry at a DIFFERENT identity provider
+    /// (same discovery URL, new issuer) can no longer silently map a new-IdP user whose <c>sub</c>
+    /// collides with an old link onto the old user's account. A link that carries no stored issuer (one
+    /// minted before this store existed) is stamped with the current issuer on its next successful login
+    /// (trust-on-first-use), so existing links keep working while the provider is unchanged and gain the
+    /// binding transparently — no userbase lockout on upgrade. OpenID only; SAML is out of scope.
+    /// </summary>
+    // Server-managed exactly like CanonicalLinks: persisted in the config XML but withheld from every JSON
+    // response ([JsonIgnore]) so it cannot be read back or set via a config PUT, self-healing lazy init so
+    // a direct index assignment persists, and preserved on save by ServerManagedFields.Preserve (which
+    // also CLEARS it, alongside the links, when OidEndpoint changes — the repoint belt, #186).
+    [XmlElement("CanonicalLinkIssuers")]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SerializableDictionary<string, string> CanonicalLinkIssuers
+    {
+        get => _canonicalLinkIssuers ??= new SerializableDictionary<string, string>();
+        set => _canonicalLinkIssuers = value;
+    }
 
     /// <summary>
     /// Gets or sets OpenID client ID.

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -52,7 +52,8 @@ internal static class ServerManagedFields
         }
     }
 
-    // Links + secret: an OpenID provider carries both server-managed fields (#157/#189).
+    // Links + issuer bindings + secret: an OpenID provider carries these server-managed fields
+    // (#157/#189/#186).
     internal static void Preserve(OidConfig incoming, OidConfig live)
     {
         // A null provider entry (a malformed Add before #350, or a legacy store) carries no
@@ -62,7 +63,20 @@ internal static class ServerManagedFields
             return;
         }
 
-        incoming.CanonicalLinks = live.CanonicalLinks;
+        // The repoint belt (#186): an OidEndpoint change re-identifies the provider — a different discovery
+        // URL is potentially a different identity provider — exactly as ResolveUpdatedSecret treats it when
+        // it drops the client secret on the same change. Carrying the accumulated sub-keyed links across
+        // such a change is the silent-mapping this issue closes, so DROP them (and their issuer bindings)
+        // rather than preserve them. This protects even un-stamped legacy links (a user who has not logged
+        // in since the upgrade) against a post-upgrade repoint, which the per-login issuer gate alone could
+        // not. While the endpoint is UNCHANGED (the common save), both maps are carried over verbatim so
+        // existing links keep working (issue #186 criterion 3). The complementary per-login issuer gate
+        // covers a repoint that keeps the SAME discovery URL (a swapped IdP behind it), which this string
+        // compare cannot detect.
+        var endpointUnchanged = string.Equals(incoming.OidEndpoint, live.OidEndpoint, StringComparison.Ordinal);
+        incoming.CanonicalLinks = endpointUnchanged ? live.CanonicalLinks : new SerializableDictionary<string, Guid>();
+        incoming.CanonicalLinkIssuers = endpointUnchanged ? live.CanonicalLinkIssuers : new SerializableDictionary<string, string>();
+
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
 

--- a/providers.md
+++ b/providers.md
@@ -81,6 +81,45 @@ expiry). A few provider settings must therefore match, or login is refused (fail
   that mints a _different_ `sub` for the same user on every login (a misconfigured pairwise-subject
   setup) will work exactly once and then be refused — fix the IdP configuration; there is nothing
   safe to anchor the identity to otherwise.
+- **Account links are bound to the issuer that created them (repointing protection).** Each OpenID
+  canonical link records the id_token `iss` it was minted under, so a link is the full
+  OIDC-recommended `(iss, sub)` pair, not a bare `sub`. This matters when a provider entry is
+  **repointed at a different identity provider** — because a `sub` is only unique _within_ an issuer,
+  a new IdP that mints a short numeric subject like `1` could otherwise collide with an accumulated
+  link and silently sign the new user in to the old user's account. Two independent guards close that:
+  - **Login-time issuer check.** On every login the resolved link's stored issuer is compared to the
+    login's issuer, and a mismatch **refuses the login** (fail closed). This catches a swapped IdP even
+    behind an _unchanged_ discovery URL (a DNS/backend repoint), which nothing else can see. It is
+    self-healing: re-establish the link with the admin linking endpoint (`AddCanonicalLink`), or clear
+    the stale links, and logins resume.
+  - **Clear-on-endpoint-change.** Changing a provider's `OidEndpoint` (through the admin form or
+    `OID/Add`) **drops that provider's accumulated links and their issuer bindings**, treating the URL
+    change as a provider re-identification — the same way the stored client secret is dropped on an
+    endpoint change. This also protects links that predate this feature (see migration below) against a
+    repoint. So an endpoint edit is a reconfiguration: users re-link on their next login (or via the
+    admin endpoint), just as you must re-enter the client secret. **The comparison is exact** (ordinal),
+    so even a _benign_ normalization — adding a trailing slash, changing host case — clears the links.
+    **Plan a re-link window when you change an endpoint:** with `AllowExistingAccountLink` **on**, the
+    next login wave re-adopts each account by name and re-stamps the links automatically (treat it as the
+    short, controlled window described below, then turn the flag back off); with `AllowExistingAccountLink`
+    **off**, every returning user instead hits the "an account already exists" refusal (HTTP 403) until you
+    re-link them with `AddCanonicalLink` or open that brief adoption window. If the URL edit was cosmetic
+    and you did **not** intend to re-identify the provider, prefer leaving the endpoint string untouched.
+
+  **Migration / compatibility.** Links created before this feature carry no stored issuer. They keep
+  working unchanged while the endpoint is unchanged, and are **stamped with the current issuer on the
+  next successful login** (trust-on-first-use) — no userbase lockout on upgrade. One accepted, narrow
+  residual (the issue itself calls it that, not a regression): if a provider was repointed at a new IdP
+  **before** you upgraded to a version with this feature, an un-stamped legacy link whose `sub` collides
+  is stamped with the _new_ issuer on first login rather than being caught; the clear-on-endpoint-change
+  guard covers every repoint from the upgrade onward.
+
+- **`DoNotValidateIssuerName` relaxes the issuer binding.** With this escape hatch on, the id_token's
+  `iss` is **not** cross-checked against the discovery location, so the value bound to the link is
+  whatever the signed token asserts (still signed by the discovered keyset, but not tied to the
+  configured endpoint). The binding is still enforced login-to-login; it just trusts the token's
+  self-declared issuer. Enabling it is recorded in the `[SSO Audit]` log like the other relaxations —
+  prefer it only for genuinely templated / multi-tenant providers.
 - **Adopting a same-named pre-existing account is gated (`AllowExistingAccountLink`).** When a first
   login finds no link but a Jellyfin account already bears the SSO name, the account is adopted only if
   the provider has `AllowExistingAccountLink` set — otherwise the login is refused (HTTP 403). Adoption


### PR DESCRIPTION
# What & why

Closes #186.

OpenID canonical links were keyed on `sub` within a per-provider dictionary
(`OidConfig.CanonicalLinks`). That composite equals the OIDC-recommended
`(iss, sub)` pair only while the provider entry keeps pointing at the same
identity provider. If an admin repoints an existing provider entry (same
provider name) at a **different** IdP, the accumulated `sub`-keyed links persist
across the issuer change, so a user at the new IdP whose `sub` collides with an
old link (realistic for IdPs minting short numeric subjects like `1`) is
silently mapped onto the old user's Jellyfin account.

We bind each link to the issuer it was minted under and enforce it, with two
complementary guards plus transparent migration:

- **Per-link issuer store.** A new server-managed `OidConfig.CanonicalLinkIssuers`
  (`sub -> issuer`), parallel to `CanonicalLinks`: `[JsonIgnore]` (withheld from
  every JSON response, cannot be set via a config PUT) and persisted in the
  config XML. The issuer is the **validated id_token `iss`**, read from the raw
  token, OidcClient filters the standard protocol claims (`iss`, `aud`, `exp`, …)
  out of the redeemed principal, so we read it from `result.IdentityToken` the
  same way the RFC 9207 mix-up check already does, and threaded through the
  verified identity into the link workflow.
- **Login-time issuer check (non-inert).** A resolved subject link whose stored
  issuer does not match the login's issuer **refuses the login** (fail closed).
  This catches a swapped IdP even behind an **unchanged** discovery URL (a
  DNS/backend repoint), which the endpoint-change belt cannot see.
- **Clear-on-endpoint-change belt.** Changing a provider's `OidEndpoint` (admin
  form or `OID/Add`) drops that provider's links and issuer bindings, treating
  the URL change as a provider re-identification, the same way the stored client
  secret is dropped on an endpoint change. This protects even un-stamped legacy
  links against a repoint done through the endpoint.
- **Trust-on-first-use migration.** Links minted before this store carry no
  issuer; they keep working while the endpoint is unchanged and are stamped with
  the current issuer on the next successful login. No userbase lockout on upgrade.

`DoNotValidateIssuerName` relaxes the binding to the token's self-declared issuer
(still audited). Documented in `providers.md`, including an operator note that an
endpoint edit is destructive to links and to plan a re-link/adoption window.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release, 0 warnings).
- [x] `dotnet test` is green (1173 passed, Debug and Release).
- [x] Prettier is clean for the `providers.md` change.

## Notes

### Design summary

- **Issuer captured** from the validated id_token's `iss` via
  `OidcResponseIssuer.IdTokenIssuer(result.IdentityToken)` at the OpenID callback
  (not from `result.User`, which OidcClient strips protocol claims from), carried
  on `OidcAuthorizeState.Issuer` → `VerifiedIdentity.Issuer` →
  `LoginCompletionService` → `CanonicalLinkService.ResolveOrCreateAsync(issuer)`.
- **Stored** in `OidConfig.CanonicalLinkIssuers` (`sub -> issuer`), server-managed
  exactly like `CanonicalLinks`.
- **`ClassifyIssuer` states:** `NotBound` (SAML / no subject link), `Match`
  (stored == login, ordinal), `Absent` (no stored issuer → trust-on-first-use),
  `Mismatch` (differs, including a login with no issuer against a stamped link).
- **Refuse path:** a `Mismatch` on a resolved subject link throws
  `AccountLinkForbiddenException` before any create/adopt/migrate, the identity
  is not mapped onto the old account.
- **Clear-on-repoint belt:** `ServerManagedFields.Preserve(OidConfig,…)` clears
  both maps when `OidEndpoint` changes, preserves both when unchanged.
- **`DoNotValidateIssuerName` warning:** documented in `providers.md`; the toggle
  is already recorded via `SsoAudit.InsecureOptionsEnabled` at save/`OID/Add`.

### How this resolves the prior review rejection (inert + mass-lockout)

A prior take on this issue was rejected as "inert at runtime + mass-lockout risk".
Both are resolved, and proven empirically, not asserted:

- **Non-inert.** The issuer check fires at runtime and refuses a repointed
  provider's old-issuer links. `CanonicalLinkServiceTests.ResolveOrCreateAsync_SubjectLinkStampedWithADifferentIssuer_RefusesFailClosed`
  pins the rejection, and the end-to-end
  `SSOControllerOidPostTests.OidPost_FullLogin_StampsTheRealIdTokenIssuerOntoTheCanonicalLink`
  drives a **real signed id_token** through the full callback + authenticate legs
  and asserts the token's actual `iss` reaches the stamp. That end-to-end test
  caught a genuine bug mid-implementation: the issuer was first sourced from
  `result.User.Claims`, which OidcClient strips `iss` from, so it was switched to
  the raw `result.IdentityToken`. Without the empirical test this would have
  shipped inert.
- **No mass-lockout on upgrade.** At upgrade every link is un-stamped, so
  `ClassifyIssuer` returns `Absent` → the login is stamped (trust-on-first-use)
  and proceeds; the refuse path is unreachable until a link is stamped **and** the
  issuer later changes. Pinned by
  `ResolveOrCreateAsync_UnstampedSubjectLink_TrustOnFirstUse_StampsAndProceeds`.
  The hot path (stamped, match) writes nothing (0-persist test).

### Accepted narrow residual (per the issue itself, not a regression)

A repoint that happened **before** upgrading to this version leaves an un-stamped
legacy link; on that user's first post-upgrade login (endpoint unchanged),
trust-on-first-use stamps the **new** issuer onto the old link rather than
catching it. The clear-on-endpoint-change belt covers every repoint from the
upgrade onward. This is strictly better than the current behaviour (where every
collision succeeded) and documented in `providers.md`.

### Adversarial review gate, four lenses (refute-by-default)

- **Availability, PASS.** No mass-lockout on upgrade (all links `Absent` →
  TOFU + proceed); the belt is admin-triggered and bounded, consistent with the
  existing secret-drop-on-endpoint-change; hot path writes nothing. It flagged an
  operator-doc gap (endpoint edits are destructive to links), added to
  `providers.md` (re-link / adoption-window guidance, `AllowExistingAccountLink`
  on vs off).
- **Security-bypass, PASS.** The check is non-inert; `iss` is inside the signed
  payload (not forgeable past the signature); null-issuer login against a stamped
  link is refused; create/adopt/migrate cannot reach a mismatched link; the #133
  race loser never overwrites a live stamped link; SAML unaffected. Notes the
  same-URL-swap-of-an-un-stamped-legacy-link window is the documented TOFU
  boundary above, not a regression.
- **Correctness, PASS.** Issuer capture is verbatim/ordinal-stable (same
  extraction stamps and compares); TOFU is lock-guarded and idempotent and fires
  only for a used subject link; write-path stamps only when the write happened;
  cleanup prunes only orphans (`ToList` before removal); belt handles null-vs-null.
  Two comment-accuracy nits it raised were fixed in this PR.
- **Integration, PASS (after fix).** XML round-trip, whole-config `Preserve` +
  belt, id_token issuer sourcing, discovery reuse (#450 undisturbed), and
  admin-form isolation all hold. It returned NEEDS_IMPROVEMENT for one concrete
  gap: `Controller_NeverTouchesProviderLinkMaps` scanned only `.CanonicalLinks`,
  not the new `.CanonicalLinkIssuers` map. **Fixed in this PR**, the fitness
  function now pins and scans both maps.

Out of scope: SAML (this issue is OpenID-only).
