### PR TITLE
Prepare the 4.1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# Changelog
+
+All notable changes to this plugin are documented here. Versions follow the
+four-part `X.Y.Z.W` scheme described in the release policy (breaking / feature /
+bug-fix / security).
+
+## 4.1.0.0
+
+The first feature release of the revived plugin. It folds in a full
+security-parity pass over the SAML and OpenID login path, encrypts provider
+secrets at rest, adds outgoing SAML request signing, exposes the previously
+config-only provider flags in the admin UI, and lands a large internal rework
+that decomposes the login controller into small, testable services.
+
+### Breaking
+
+- **Provider secrets are now encrypted at rest (#158).** Client secrets and
+  signing keys are stored as an AES-256-GCM envelope (`ssoenc:` values) instead
+  of plaintext. **Upgrading is transparent** — an existing plaintext config is
+  read as-is and re-encrypted on the next save, no action required.
+  **Downgrading is breaking:** an older plugin build cannot read `ssoenc:`
+  values. Before rolling back, open each provider on the settings page and
+  re-enter its secret in plaintext (or restore the pre-upgrade config backup),
+  then install the older build. See
+  [Secrets encrypted at rest and downgrade](providers.md#secrets-encrypted-at-rest-and-downgrade).
+- **OpenID logins that relied on legacy username matching are refused until you
+  migrate (#358).** Links created by 4.0.0.4 and earlier are keyed on the
+  username, which the IdP controls. After upgrade, a login carrying such a
+  legacy link is not followed automatically — the account is adopted only when
+  the provider has `AllowExistingAccountLink` enabled (treat this as a short,
+  supervised maintenance window, not a standing setting), or when an admin links
+  the account explicitly via `AddCanonicalLink`. A returning administrator with
+  a pre-existing legacy link must be linked by an admin; self-migration is
+  refused for admins even with the flag on. Plan this before upgrading — see the
+  migration runbook under
+  [OpenID Connect id_token requirements](providers.md#openid-connect-id_token-requirements)
+  and the
+  [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model)
+  wiki page.
+
+### Security
+
+The login path was hardened end to end and now fails closed by default.
+
+- **SAML:** XXE-safe XML loading, strict single-assertion conformance, a signed
+  algorithm allowlist (SHA-1 and other weak algorithms rejected), replay
+  protection with a bounded cache, and enforced time-bound, audience, and
+  recipient checks.
+- **OpenID Connect:** PKCE S256, `state`, and `iss` / RFC 9207 response
+  validation, all sourced from the login's own discovery document rather than
+  trusting request-supplied facts; full `id_token` validation; and a verified-
+  email gate for account login and adoption.
+- **Account linking:** OpenID links are bound to the IdP issuer (#186) and to
+  the stable `sub` / `NameID`, so a renamed or re-pointed account cannot be
+  silently taken over.
+- **Abuse resistance:** rate limiting across the login, link/unlink, and
+  unregister endpoints; active session/token revocation when a user is
+  unregistered or their last link is removed; and provider-name validation that
+  rejects control characters.
+- **Transport and supply chain:** security response headers / CSP on the plugin
+  pages, SSRF-guarded avatar fetches, and a Trojan-Source (unicode) guard in CI.
+
+### Features
+
+- **Outgoing SAML AuthnRequest signing (#167),** including ECDSA signing keys
+  (#493) alongside RSA, for IdPs that require signed requests.
+- **Admin-UI toggles for provider flags** that were previously config-file only
+  (for example `AllowExistingAccountLink` and the verified-email requirement),
+  plus a real device name on linked sessions.
+- **Provider-name hardening** so invalid names are rejected at configuration
+  time.
+
+### Architecture / internal
+
+- The monolithic `SSOController` was decomposed into a thin controller over pure,
+  single-responsibility helpers and `Api/Flows/*Service` login services (#318),
+  with a fail-closed `VerifiedIdentity` keystone. Structural rules are locked in
+  as architecture-conformance tests that run in CI. This is an internal change
+  with no user-facing configuration impact.
+
+### Fixes
+
+- Login rejections consistently return their intended status codes and never
+  surface as HTTP 500.
+- Corrected avatar handling (missing-file self-heal, file-extension and path
+  handling) and disabled-provider handling across the login and linking flows.
+- Numerous smaller robustness fixes in state handling, session minting, and the
+  admin/linking pages.

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.0.0.4</AssemblyVersion>
-    <FileVersion>4.0.0.4</FileVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <FileVersion>4.1.0.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.0.0.4"
+version: "4.1.0.0"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at
@@ -45,6 +45,7 @@ artifacts:
   - "System.Security.Cryptography.Pkcs.dll"
   - "System.Formats.Asn1.dll"
 changelog: |
+  4.1.0.0: Feature (BREAKING - on-disk secret format changed; forward-transparent, downgrade requires re-entering secrets). Security-parity hardening of the SAML and OpenID login path, secrets encrypted at rest, SAML AuthnRequest signing (RSA and ECDSA), admin-UI provider toggles, and the thin-controller architecture rework. See CHANGELOG.md.
   4.0.0.4: Fix security issue in SAML
   4.0.0.0: Jellyfin 10.11
   3.5.3.0: Allow for OID-provided avatars, various bugfixes and workarounds


### PR DESCRIPTION
# What & why

Prepare the **4.1.0.0** feature release, the first feature release of the
revived plugin. `main` is 724 commits ahead of `v4.0.0.4` and carries the whole
`#318` thin-controller architecture, the P2 security-parity work, features (SAML
AuthnRequest signing `#167` + ECDSA `#493`, admin-UI provider toggles), and a
breaking on-disk change (`#158`, secrets encrypted at rest). We chose `4.1.0.0`
(feature bump, not a major) because `#158` is forward-transparent on upgrade, but
the changelog flags the breaking-ness prominently.

This is the release-bump only, version + changelog. **No tag is pushed here**;
the tag is gated on my sign-off.

Changes:

- `SSO-Auth/SSO-Auth.csproj`: `AssemblyVersion` and `FileVersion` `4.0.0.4` ->
  `4.1.0.0`.
- `build.yaml`: `version` `4.1.0.0` and a prepended changelog line in the
  existing style, flagging `BREAKING - on-disk secret format changed;
  forward-transparent, downgrade requires re-entering secrets`.
- `CHANGELOG.md` (new): a curated, user-facing 4.1.0.0 entry (not a dump of 724
  commits), grouped into **Breaking** (`#158` secrets-at-rest, `#358` OpenID
  legacy-link migration), **Security** (SAML XXE/replay/algorithm-allowlist,
  OIDC PKCE-S256 + state + iss/RFC-9207 from the login's own discovery, IdP-issuer
  link binding `#186`, verified-email gate, rate-limiting, revocation, headers/CSP,
  Trojan-Source guard), **Features** (SAML request signing `#167`/`#493`, admin-UI
  toggles, provider-name hardening), **Architecture** (`#318` thin controller),
  and **Fixes**. The Breaking entries link the `providers.md` downgrade and
  legacy-link runbooks and the Security-Model wiki page.

**Publish-pipeline verification (release-prep step 5), needs my
decision before tagging.** `publish.yml` triggers on `release: [released]`, **not
on a tag push**, and **no workflow triggers on `push: tags:`**. The MD5 `.md5`
sidecar generation is intact (`upload` job: `md5sum ... >> ${file%.*}.md5`, plus a
`.sha256`), and the manifest job reads it. But the documented process
(`docs/RELEASE-POLICY.md`, `release-prep.md`) says *"tag push is the only publish
trigger"*, with the current workflow, pushing a tag alone will **not** publish;
a GitHub release has to be published to fire the `released` event, which then runs
`publish.yml` to attach assets to that already-existing release. That contradicts
the "never `gh release create` / immutable releases burn a tag" guidance. We did
not change the pipeline (release-prep step 3 says do not touch it unless broken).
**This needs to be resolved before the tag**, see the release report.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

(Release preparation: version bump + changelog. No behavior change in this PR.)

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. — _No login-path code changed; this PR is
      version metadata + a changelog._
- [x] No secrets logged; secrets are redacted on config export. - _No code
      changed._
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. — _The pipeline was reviewed
      read-only (finding above); no pipeline change was made._
- [x] Log inputs from the IdP are sanitized inline at the log call. - _No code
      changed._

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. — _Docs/metadata only._
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      — _No new structural property; conformance tests green._

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. - _Debug and Release,
      0 warnings._
- [x] `dotnet test` is green., _1173 passed, 0 failed._
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. - 
      _`CHANGELOG.md` clean. `build.yaml` is YAML (not in the Prettier gate glob);
      its only Prettier note is pre-existing CRLF line endings, unchanged by us._

## Notes

- The tag is **not** pushed in this PR. Per policy the tag waits for my explicit go in chat, then a guarded push
  (`$env:SSO_RELEASE_GO='1'; git tag v4.1.0.0; git push origin v4.1.0.0`).
- **Blocking question for me:** the publish-pipeline trigger
  discrepancy above must be settled before the tag, either the workflow is
  changed to a tag-push trigger that creates the release atomically, or the
  documented "tag-push is the only trigger" process is corrected to match the
  current `release: [released]` reality. We did not change the pipeline in this
  release-bump PR.
- I opted to tag without a full manual E2E run for this release.

