### PR TITLE
Publish the release from a version-tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,15 @@
 name: Publish Release
 
+# A four-part version tag push (e.g. v4.1.0.0) is the ONLY publish trigger, per
+# docs/RELEASE-POLICY.md. The upload job below CREATES and publishes the GitHub
+# release from that tag in CI (action-gh-release creates the release when none
+# exists) — the release is never minted out of band, because a deleted immutable
+# release permanently burns its tag. The glob matches only our numeric four-part
+# tags, never the branch-triggered rolling `nightly` prerelease.
 on:
-  release:
-    types:
-      - released
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 # Default to read-only; the jobs that create the release and update the
@@ -41,11 +47,16 @@ jobs:
         ls -l
     - name: Publish output artifacts
       id: publish-assets
-      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58 # unreleased commit between v3.0.1 and v3.0.2
+      # Creates the release for the pushed tag if it does not exist yet, then
+      # uploads the assets. tag_name defaults to github.ref_name; set explicitly
+      # so intent is obvious. fail_on_unmatched_files stays true so a missing
+      # build asset fails the run rather than publishing an empty release.
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
+          name: ${{ github.ref_name }}
           prerelease: false
           fail_on_unmatched_files: true
-          tag_name:  ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.ref_name }}
           files: ./*
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What & why

`publish.yml` triggered on `release: [released]` and attached assets to an
already-published release (`github.event.release.tag_name`). It was not
triggered by a tag push and did not create the release itself, which
contradicts our documented process (RELEASE-POLICY / CLAUDE.md: a tag push is
the only publish trigger; never `gh release create`, because a deleted
immutable release permanently burns its tag). This blocked the 4.1.0.0 release.

We align the pipeline with the docs:

- Trigger on a four-part version-tag push (`v[0-9]+.[0-9]+.[0-9]+.[0-9]+`),
  keeping `workflow_dispatch`. The glob matches only our numeric four-part tags,
  never the branch-triggered rolling `nightly` prerelease, and a tag push does
  not fire the branch-triggered build/format workflows.
- Create the release atomically in CI from the pushed tag:
  `action-gh-release` creates the release when none exists. We set
  `tag_name`/`name` to `github.ref_name`; keep `prerelease: false` and
  `fail_on_unmatched_files: true` so a missing build asset fails the run rather
  than publishing an empty release.
- Re-pin `action-gh-release` from an unreleased commit between v3.0.1 and v3.0.2
  (`132dbbba`) to the released v3.0.2 commit (`3d0d9888`). v3.0.2 is a strict
  descendant of the old pin (ahead by 10, behind by 0), so it is purely forward,
  and the pin is now auditable against a published version.

The load-bearing `.md5`/`.sha256` sidecar step is unchanged (the manifest
checksum is MD5 read from the `.md5`). The manifest job (`needs: upload`) still
runs after the release exists and is non-prerelease, so `ignorePrereleases`
picks it up. Least-privilege permissions preserved (`contents: write` only on
the jobs that create the release and push the manifest branch).

Closes #556

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Notes on the checklist for this release-pipeline change: there is no signature /
secret / IdP-log surface in a workflow file. "Fail-closed" here means the
pipeline never publishes a partial release, `if-no-files-found: error` in the
build and `fail_on_unmatched_files: true` in the upload step make a missing
asset fail the run. The adversarial review below is the primary verification,
since CI cannot exercise a release-only workflow.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Build: Debug `--warnaserror`, 0 warnings / 0 errors. Tests: 1173 passed, 0
failed (Debug). Prettier: not applicable, the diff is a single `.yml` file,
outside Prettier's `js/html/md/css` glob. The change touches no C#; the build
and tests are confirmed unaffected.

## Notes

### Traced tag-push -> published-release sequence

I push `v4.1.0.0` (gated locally by the `SSO_RELEASE_GO` guard
hook, which is unchanged, the workflow trigger is server-side):

1. GitHub creates `refs/tags/v4.1.0.0`. `github.ref_name = v4.1.0.0` matches the
   `v[0-9]+.[0-9]+.[0-9]+.[0-9]+` glob, so `publish.yml` runs. Branch-triggered
   workflows (dotnet, prettier, publish-nightly) do not run on a tag push.
2. `build` (reusable `build.yml`, read-only): checks out the tagged commit, JPRM
   builds the plugin zip from `build.yaml` version 4.1.0.0, uploads it as
   `build-artifact` (`if-no-files-found: error`).
3. `upload` (`needs: build`, `contents: write`): downloads the artifact,
   generates the `.md5` and `.sha256` sidecars (step unchanged), then
   `action-gh-release` (v3.0.2) creates the non-prerelease release for tag
   `v4.1.0.0` (none exists yet) and uploads `./*` (zip + md5 + sha256).
   `fail_on_unmatched_files: true` fails the run if no asset matched.
4. `generate` (`needs: upload`, `contents: write`): the Kevinjil manifest action
   enumerates the repo's releases via the API (it does not consume the trigger
   event), sees the new non-prerelease release, reads the MD5 sidecar for the
   checksum, and updates `manifest.json` on the `manifest-release` branch.

One atomic run off the tag. No double-publish (only `publish.yml` fires; we
never `gh release create`). No fail-open path: every step that could yield an
empty or partial release fails the run visibly.

### Adversarial review (4 lenses, refute-by-default)

- Availability - VERDICT: the release is created and published, or the run fails
  visibly; no silent no-op or empty release. `if-no-files-found: error` +
  `fail_on_unmatched_files: true` + `needs:` ordering are all fail-closed. The
  one caveat: `action-gh-release` creates the release then uploads, so a
  mid-step upload failure could leave an empty release with a red run (visible,
  actioned by me), this is pre-existing behavior (identical to the nightly
  job) and not fail-open. PASS.
- Security-bypass - VERDICT: pushing a matching tag requires repo write access
  (same trust boundary as the old flow and as creating a release); external
  actors cannot trigger it. The specific four-part glob prevents accidental
  publishes from typo/partial tags. `github.ref_name` is used only as an action
  input (`name`/`tag_name`), never interpolated into a `run:` block, so there is
  no script-injection vector; the only `run:` block (sidecars) uses no `${{ }}`.
  Permissions are least-privilege (default read; `contents: write` only where
  needed). The pin moves to a released, auditable commit. PASS.
- Correctness - VERDICT: the glob matches `v4.1.0.0` and rejects `nightly`,
  `v4.1`, `v4.1.0`, and suffixed tags; `nightly` is branch-triggered and a
  prerelease, so no cross-fire. `action-gh-release` create-on-missing is
  confirmed from its README (`tag_name` defaults to `github.ref_name`). Job
  ordering build -> upload -> generate holds via `needs`. The MD5 sidecar hunk
  is byte-for-byte unchanged. PASS.
- Integration - VERDICT: the Kevinjil action reads releases via the API, not the
  workflow event, so switching the trigger does not break it; it only needs the
  release to exist (guaranteed by `needs: upload`) and be non-prerelease
  (`prerelease: false` + `ignorePrereleases: true`). `GITHUB_TOKEN` with
  `contents: write` is sufficient because the tag already exists at trigger time
  (the action creates the release object, not the tag ref). The
  `manifest-release` branch exists. PASS.

### For myself before the tag

- `build.yaml` and `SSO-Auth.csproj` are already at `4.1.0.0` on `main`; the tag
  must be `v4.1.0.0` to match both the glob and the JPRM-built version.
- Push the tag with the guard marker: `$env:SSO_RELEASE_GO='1'; git push origin v4.1.0.0`.
- The local `guard-git.ps1` hook (git-ignored, unchanged) still gates the tag
  push and the manual `workflow run publish` dispatch behind `SSO_RELEASE_GO`.
  Its inline comment still says the workflow "triggers on release:released", a
  cosmetic staleness only; the gate logic (version-tag push + workflow_dispatch)
  is unaffected and remains correct. Not touched here per scope.

