### PR TITLE
Widen SourceFilesDeclaring to match record struct and struct declarations

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -980,6 +980,27 @@ public class ArchitectureConformanceTests
             "Every persisting provider-form field (sso-text/sso-line-list/sso-toggle/sso-folder-list/sso-role-map) must have an id equal to an OidConfig property; these do not: " + string.Join(" | ", offenders));
     }
 
+    [Fact]
+    public void SourceFilesDeclaring_MatchesRecordStructAndStructAlongsideClass()
+    {
+        // #542: the helper's regex used to be "\bclass\s+{Name}\b" only, so it silently returned an empty
+        // file list for a record struct/struct type instead of finding its declaring file — a latent
+        // false-negative for any future rule that scans one by name. RouteSuffix and DiscoveryFacts
+        // ("internal readonly record struct ...") are real record structs already living in SSO-Auth/Api,
+        // so this pins the fix against actual source rather than a synthetic fixture.
+        var recordStructFiles = SourceFilesDeclaring(new[] { typeof(RouteSuffix), typeof(DiscoveryFacts) });
+        Assert.True(
+            recordStructFiles.Count == 2,
+            "SourceFilesDeclaring must find the declaring file of a record struct type (RouteSuffix, DiscoveryFacts), not just a class.");
+
+        // The class path must keep working too — the widened regex must not have narrowed the original
+        // "class Name" match.
+        var classFiles = SourceFilesDeclaring(new[] { typeof(AuthorizeSession) });
+        Assert.True(
+            classFiles.Count == 1,
+            "SourceFilesDeclaring must still find the declaring file of an ordinary class (AuthorizeSession).");
+    }
+
     // The markup of the #sso-new-oidc-provider settings form (from the opening tag's id attribute to its
     // closing </form>). Forms are not nested here, so the first </form> after the id marker closes it; the
     // preceding #sso-load-config form is left out because its </form> sits before the marker.
@@ -1042,14 +1063,21 @@ public class ArchitectureConformanceTests
         return files;
     }
 
-    // Every source file that declares any of the given types, matched by class declaration in the file
-    // body (not the file name), so a file rename still resolves via the type's own name. Shared by
-    // ControllerSourceFiles above and the raw socket/DNS liveness check (#444) — both need "which files
-    // declare these types", just for a different type set.
+    // The C# keywords a type declaration's name can immediately follow. "struct" alone also matches a
+    // "record struct" declaration (the name follows "struct", not "record", in that form); "record" alone
+    // matches a positional/reference record ("record Foo(...)"), since "record class Foo" is already
+    // covered by "class".
+    private static readonly string[] TypeDeclarationKeywords = { "class", "struct", "record" };
+
+    // Every source file that declares any of the given types, matched by class/struct/record declaration
+    // in the file body (not the file name), so a file rename still resolves via the type's own name.
+    // Shared by ControllerSourceFiles above and the raw socket/DNS liveness check (#444) — both need
+    // "which files declare these types", just for a different type set (#542).
     private static IReadOnlyList<string> SourceFilesDeclaring(IEnumerable<Type> types)
     {
         var declarations = types
-            .Select(t => new Regex($@"\bclass\s+{Regex.Escape(SimpleName(t))}\b"))
+            .SelectMany(t => TypeDeclarationKeywords.Select(keyword =>
+                new Regex($@"\b{keyword}\s+{Regex.Escape(SimpleName(t))}\b")))
             .ToList();
 
         return Directory


### PR DESCRIPTION
# What & why

`ArchitectureConformanceTests`' `SourceFilesDeclaring` helper matched source
files with the regex `\bclass\s+{Name}\b`, which never matches a `record
struct` or plain `struct` declaration (e.g. `internal readonly record struct
RouteSuffix(...)`). No current fitness-function rule calls the helper with a
struct/record-struct type, so nothing was broken today, but a future rule
scanning one of the record-struct helpers we already have in `SSO-Auth/Api`
(`DiscoveryFacts`, `RouteSuffix`, and others) by declaring-file lookup would
have silently scanned zero files instead of failing loudly, the integration
lens flagged this as a latent gap while reviewing #509.

Closes #542.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, this touches test infrastructure only, not the login path,
crypto, config persistence, or the release pipeline.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (1174/1174, including every existing
      conformance rule and the new one).
- [x] Prettier is not applicable - no `.js` / `.html` / `.md` / `.css` files
      changed.

## Notes

We widened `SourceFilesDeclaring` to match against `class`, `struct`, and
`record` keywords instead of `class` alone. `struct` alone also matches a
`record struct` declaration (the type name follows `struct`, not `record`,
in that form); `record` alone matches a positional/reference record
(`record Foo(...)`), since `record class Foo` is already covered by `class`.

We added `SourceFilesDeclaring_MatchesRecordStructAndStructAlongsideClass`,
which pins the fix against two real record structs already in the tree
(`RouteSuffix`, `DiscoveryFacts`) and re-asserts the class path still works
(`AuthorizeSession`). We ran the full suite to verify no existing conformance
rule silently depended on the old class-only behavior, all 1174 tests,
including every rule that calls `SourceFilesDeclaring` today, stayed green
with the widened regex.

Out of scope: no rule today targets a struct/record-struct type by name, so
we did not add a new fitness-function rule here, this PR only fixes the
scanning helper itself.
