### PR TITLE
Make EnabledProviderNames predicate null-safe

### DIFF
--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -159,6 +159,22 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
+    public void OidProviderNames_SkipsNullValuedEntry()
+    {
+        // A null-valued entry must not NRE the anonymous GetNames endpoint into a 500 (#538) — it is
+        // skipped, the same fail-closed treatment CanonicalLinkService already applies to these maps.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+            c.OidConfigs["broken"] = null;
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "keycloak" }, names);
+    }
+
+    [Fact]
     public void SamlProviderNames_ReturnsEnabledNames()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true });
@@ -176,6 +192,21 @@ public class SSOControllerEndpointTests
         {
             c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
             c.SamlConfigs["disabled-idp"] = new SamlConfig { Enabled = false };
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "adfs" }, names);
+    }
+
+    [Fact]
+    public void SamlProviderNames_SkipsNullValuedEntry()
+    {
+        // SAML twin of OidProviderNames_SkipsNullValuedEntry (#538).
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+            c.SamlConfigs["broken"] = null;
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -330,10 +330,12 @@ public class SSOController : ControllerBase
     }
 
     // Names of the enabled providers in a config map, materialized to a detached list (the caller holds
-    // the config lock). Shared by both GetNames twins so the enabled-only rule lives in one place.
+    // the config lock). Shared by both GetNames twins so the enabled-only rule lives in one place. A
+    // null-valued entry is skipped rather than dereferenced (#538) — the same fail-closed convention
+    // CanonicalLinkService already applies to these maps.
     private static List<string> EnabledProviderNames<TConfig>(SerializableDictionary<string, TConfig> configs)
         where TConfig : ProviderConfigBase =>
-        configs.Where(kvp => kvp.Value.Enabled).Select(kvp => kvp.Key).ToList();
+        configs.Where(kvp => kvp.Value is { Enabled: true }).Select(kvp => kvp.Key).ToList();
 
     /// <summary>
     /// This is a debug endpoint to list all running OpenID flows. Requires administrator privileges.


### PR DESCRIPTION
# What & why

`EnabledProviderNames<TConfig>` (shared by the anonymously reachable `OID/GetNames`
and `SAML/GetNames` endpoints, introduced in PR #535) dereferenced `kvp.Value.Enabled`
directly:

```csharp
configs.Where(kvp => kvp.Value.Enabled).Select(kvp => kvp.Key).ToList();
```

A null-valued entry in `OidConfigs` / `SamlConfigs` (a plain `Dictionary<TKey,TValue>`,
so a null reference-type value is legal) throws a `NullReferenceException` there, which
surfaces as a 500 on an anonymous endpoint. This diverged from the fail-closed
null-skip convention the codebase already applies to the same maps elsewhere (see
`CanonicalLinkService`, which treats a null-valued entry as unusable rather than
dereferencing it).

We switch to a null-safe property pattern so a null entry is skipped instead of
dereferenced:

```csharp
configs.Where(kvp => kvp.Value is { Enabled: true }).Select(kvp => kvp.Key).ToList();
```

Closes #538

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (A null-valued entry is now skipped —
      the same conservative outcome the endpoint already applies to a
      disabled entry — rather than crashing the request.)
- [x] No secrets logged; secrets are redacted on config export. (Unchanged - 
      this endpoint returns provider names only, never secrets.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Light correctness +
      bypass self-review run given the small, well-scoped diff on an
      already-anonymous, read-only listing endpoint; both lenses returned
      PASS — see Notes.)
- [ ] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      logging in this diff.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property introduced — this is a one-line predicate
      fix inside an existing private helper.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Both Debug and Release.)
- [x] `dotnet test` is green. (1175/1175, including two new regression tests.)
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (N/A - 
      C# only.)

## Notes

We ran a light correctness + bypass self-review (not the full four-lens gate)
given the diff is a one-line predicate change confined to a read-only,
already-anonymous listing helper with no bearing on the login/callback path:

- **Correctness lens, PASS.** Confirmed `is { Enabled: true }` is a
  non-throwing null check (verified empirically), eliminates the only
  null-dereference path in this method and its two callers, and is
  semantically equivalent to the existing fail-closed convention already
  used in `CanonicalLinkService`. The two new tests reproduce the real
  crash trigger and would catch a regression.
- **Bypass lens, PASS.** Omitting a null-valued entry is strictly
  fail-closed (a null entry was never a usable, enabled provider), adds no
  new information disclosure (a clean 200 with a shorter list discloses
  less than an unhandled 500 would), does not touch any
  authentication/authorization decision (`GetNames` is read-only), and a
  null-valued entry cannot itself be attacker-injected (only reachable via
  a malformed config file or the elevation-gated `Set` endpoints).

We record, per the issue's acceptance criteria: whether a null-valued entry
is reachable through the current persistence path is not re-derived here - 
`CanonicalLinkService`'s existing null-skip comments already document it as
a real, reachable state (not merely defensive), which this fix now handles
consistently on the `GetNames` read path too.

This targets `main` (the released line, the bug shipped in the 4.1.0.0
candidate). After merge it needs a forward-merge from `main` into `4.2`.
