### PR TITLE
Widen dotnet/prettier pull_request triggers to all branches

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 # Read-only: build/test/scan only, no job here writes to the repo or a release.
 permissions:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 # Read-only: the lint only inspects tracked files, it never writes.
 permissions:


### PR DESCRIPTION
# What & why

The "Protect main and 4.2" ruleset (18802863) requires the `build`,
`prettier`, and `dependency-review` status checks on both `refs/heads/main`
and `refs/heads/4.2`, but `.github/workflows/dotnet.yml` and
`.github/workflows/prettier.yml` had their `pull_request` trigger hard-scoped
to `branches: [main]`. Neither workflow fired for a PR whose base was `4.2`,
so `build` and `prettier` never posted a status there, GitHub treats a
missing required check as blocking, so every PR into `4.2` sat permanently at
`mergeStateStatus: BLOCKED`, with no green path other than an admin bypass.
This blocked every PR into `4.2`, confirmed empirically on PR #558 (commit
078a935: `dependency-review`, zizmor, and opengrep posted checks; `build` and
`prettier` did not).

Widens the `pull_request` branch filter on both workflows from
`branches: [main]` to `branches: ["**"]`, matching the convention
`opengrep.yml` and `zizmor.yml` already use for the identical reason
(`dependency-review.yml` has no branch filter at all, so it was already
unaffected). `push` triggers stay scoped to `main` on both files, same as
those two reference workflows, the gap was specifically in the
PR-triggered required check, not the post-merge push build.

Closes #560

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable, this touches only CI trigger scoping (`on:` branch filters),
not the login path, crypto, config persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Two-line YAML diff, no logic added.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (Workflow-only change; no new structural property to lock in.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green (1175/1175, including
      `ArchitectureConformanceTests`).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change (no
      such files touched).

## Self-review (inline, workflow-only change)

**Correctness:** `branches: ["**"]` on `pull_request` matches any base
branch a PR targets, including `main` and `4.2` (and any future feature
branch), so `build` and `prettier` now fire regardless of PR base, the same
glob pattern already proven working in `opengrep.yml` and `zizmor.yml`. The
`push` trigger is untouched (`branches: [main]`); the ruleset gap was
specifically the PR-triggered check, not the post-merge push build. Job ids
(`build`, `prettier`) are unchanged, so the ruleset's required-check names
still match, the load-bearing "no `name:`" comment in each file is
unaffected.

**Integration:** the ruleset requires `build`, `prettier`, and
`dependency-review` on both protected refs. `dependency-review.yml` already
has no branch filter and was unaffected. After this change all three
required checks fire on a 4.2-base PR the same way they do on a main-base
PR. No new `uses:`, permissions, or secrets access were introduced, so no new
zizmor/CodeQL finding is expected from this diff, verified against `git
diff` (only the two `branches:` lines changed).

## Notes

Workflow-only change; nothing to sync in README/providers.md/wiki. This PR is
delivered off `main` per the branching model, the fix reaches `4.2` only
after `main` is forward-merged into `4.2`, which still needs to happen for
open/future `4.2` PRs to actually unblock.
