### PR TITLE
Forward-merge main into 4.2

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 # Read-only: build/test/scan only, no job here writes to the repo or a release.
 permissions:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ "**" ]
 
 # Read-only: the lint only inspects tracked files, it never writes.
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,15 @@
 name: Publish Release
 
+# A four-part version tag push (e.g. v4.1.0.0) is the ONLY publish trigger, per
+# docs/RELEASE-POLICY.md. The upload job below CREATES and publishes the GitHub
+# release from that tag in CI (action-gh-release creates the release when none
+# exists) — the release is never minted out of band, because a deleted immutable
+# release permanently burns its tag. The glob matches only our numeric four-part
+# tags, never the branch-triggered rolling `nightly` prerelease.
 on:
-  release:
-    types:
-      - released
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+.[0-9]+"
   workflow_dispatch:
 
 # Default to read-only; the jobs that create the release and update the
@@ -41,11 +47,16 @@ jobs:
         ls -l
     - name: Publish output artifacts
       id: publish-assets
-      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58 # unreleased commit between v3.0.1 and v3.0.2
+      # Creates the release for the pushed tag if it does not exist yet, then
+      # uploads the assets. tag_name defaults to github.ref_name; set explicitly
+      # so intent is obvious. fail_on_unmatched_files stays true so a missing
+      # build asset fails the run rather than publishing an empty release.
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
+          name: ${{ github.ref_name }}
           prerelease: false
           fail_on_unmatched_files: true
-          tag_name:  ${{ github.event.release.tag_name }}
+          tag_name: ${{ github.ref_name }}
           files: ./*
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SSO-Auth.Tests/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/SSOControllerEndpointTests.cs
@@ -159,6 +159,22 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
+    public void OidProviderNames_SkipsNullValuedEntry()
+    {
+        // A null-valued entry must not NRE the anonymous GetNames endpoint into a 500 (#538) — it is
+        // skipped, the same fail-closed treatment CanonicalLinkService already applies to these maps.
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+            c.OidConfigs["broken"] = null;
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "keycloak" }, names);
+    }
+
+    [Fact]
     public void SamlProviderNames_ReturnsEnabledNames()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true });
@@ -176,6 +192,21 @@ public class SSOControllerEndpointTests
         {
             c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
             c.SamlConfigs["disabled-idp"] = new SamlConfig { Enabled = false };
+        });
+
+        var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());
+        var names = Assert.IsType<List<string>>(result.Value);
+        Assert.Equal(new[] { "adfs" }, names);
+    }
+
+    [Fact]
+    public void SamlProviderNames_SkipsNullValuedEntry()
+    {
+        // SAML twin of OidProviderNames_SkipsNullValuedEntry (#538).
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+            c.SamlConfigs["broken"] = null;
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());

--- a/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
@@ -152,6 +152,45 @@ public class SSOControllerSamlTokenTests
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
 
+    [Fact]
+    public async Task CallbackRefusedAtOutcomeStoreCap_DoesNotBurnTheAssertion_RetrySucceeds_ReplayStillRejected()
+    {
+        // #539: in the token flow the ACS callback consumes the assertion's one-time replay id and then stores
+        // the outcome. If the store refused AFTER the consume, a cap refusal would burn the assertion for a
+        // login that never completed and permanently lock out the legitimate user. Reserving the store slot
+        // BEFORE the consume fixes that: a cap refusal leaves the assertion untouched and the login retryable,
+        // while a genuine replay is still rejected.
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = ProvisioningHarness(fixture, out _);
+        var assertion = fixture.EncodeResponse();
+
+        // Install a cap-1 outcome store (the production 100k ceiling is unreachable in a unit test) and fill
+        // its single global slot with an unrelated in-flight outcome, so the next callback's reservation is
+        // refused. The filler uses a null (exempt) client key so it occupies the GLOBAL slot.
+        var store = new SamlOutcomeStore(1, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
+        SamlLoginService.SetSamlOutcomeStoreForTests(store);
+        var filler = SamlOutcomeStore.NewToken();
+        var fillerIdentity = VerifiedIdentity.FromValidatedSaml("adfs", "filler", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
+        Assert.True(store.TryAdd(new SamlLoginOutcome(filler, "adfs", fillerIdentity, string.Empty, null, DateTime.UtcNow), out _));
+
+        // The callback is refused at the store cap — a fail-closed 500 — and the assertion's one-time replay
+        // id is NOT consumed, because the reservation is checked ahead of the consume.
+        var refused = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        Assert.Equal(500, refused.StatusCode);
+
+        // Drain the store (redeem the filler), then re-POST the SAME assertion. Because it was never burned,
+        // the retry now validates, consumes the id, and renders a real token — the login was not lost.
+        Assert.NotNull(store.TryRedeem(filler, "adfs", DateTime.UtcNow));
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+
+        // Replay protection is intact: re-POSTing the same assertion a third time (the store now has room) is
+        // refused by the one-time replay guard, since the retry above consumed the id.
+        var replay = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        Assert.Equal(400, replay.StatusCode);
+    }
+
     private const string AuthnRequestId = "_authnreq-251";
     private const string Binding = "251251251251251251251251251251251251251251251251251251251251251A";
 

--- a/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
@@ -151,6 +151,47 @@ public class SamlOutcomeStoreTests
     }
 
     [Fact]
+    public void Reserve_ThenCommit_StoresARedeemableOutcome()
+    {
+        // The two-phase path the ACS callback uses (#539): reserve capacity first, then commit the built
+        // outcome once the assertion is consumed. The committed outcome redeems exactly like a TryAdd one.
+        var store = SmallStore();
+        Assert.True(store.TryReserve(clientKey: "A", Now, out var warn));
+        Assert.False(warn);
+        Assert.True(store.CommitReserved(Outcome("tok-1", clientKey: "A")));
+
+        Assert.NotNull(store.TryRedeem("tok-1", "adfs", Now));
+    }
+
+    [Fact]
+    public void Reserve_AtGlobalCap_Refuses_SoTheCallerNeverConsumesTheAssertion()
+    {
+        // #539: a full store refuses the reservation BEFORE the caller would consume the one-time replay
+        // cache, so a capacity refusal never burns the assertion. A null (exempt) key isolates the GLOBAL cap
+        // from the per-client sub-cap, so this proves the global-cap branch, not the per-client one.
+        var store = new SamlOutcomeStore(1, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
+        Assert.True(store.TryAdd(Outcome("filler", clientKey: null), out _)); // occupies the one global slot
+
+        Assert.False(store.TryReserve(clientKey: null, Now, out var warn));
+        Assert.True(warn); // the throttled capacity warning fires for the first refusal in the interval
+    }
+
+    [Fact]
+    public void Release_AfterReserveWithoutCommit_FreesThePerClientSlot()
+    {
+        // A reservation that is not committed — a replayed or otherwise invalid assertion at the callback —
+        // must release its per-client slot, or the sub-cap would leak on every refused login and eventually
+        // lock the client out for real.
+        var store = SmallStore(); // per-key cap 2
+        Assert.True(store.TryReserve("A", Now, out _));
+        Assert.True(store.TryReserve("A", Now, out _)); // A holds its full share, all uncommitted
+        Assert.False(store.TryReserve("A", Now, out _)); // at the sub-cap
+
+        store.ReleaseReservation("A"); // abandon one reservation
+        Assert.True(store.TryReserve("A", Now, out _)); // the freed slot readmits A
+    }
+
+    [Fact]
     public void NewToken_IsUnguessableAndDistinct()
     {
         // A CSPRNG token: two mints never collide. A token that misses the store falls through to the

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -45,17 +45,19 @@ internal sealed class SamlLoginService
     // browser binding (#415). One process-wide instance.
     private static readonly SamlRequestCache SamlRequests = new SamlRequestCache();
 
-    // The in-flight login-outcome store (#251): the ACS callback validates the assertion ONCE, stores the
-    // resulting verified outcome keyed by a CSPRNG token, and hands the intermediate page only that token;
-    // the session-mint leg redeems the token instead of re-parsing and re-validating the assertion. One
-    // process-wide instance, like the outstanding-request cache above — the callback and the mint leg run
-    // across separate per-request flow-service instances.
-    private static readonly SamlOutcomeStore Outcomes = new SamlOutcomeStore();
-
     // How long an issued SAML AuthnRequest ID stays valid for correlation — the interactive leg
     // (challenge -> IdP login/MFA -> POST back -> mint), matching the OpenID authorize-state lifetime the
     // sibling flow service keeps.
     private static readonly TimeSpan SamlRequestLifetime = TimeSpan.FromMinutes(15);
+
+    // The in-flight login-outcome store (#251): the ACS callback validates the assertion ONCE, stores the
+    // resulting verified outcome keyed by a CSPRNG token, and hands the intermediate page only that token;
+    // the session-mint leg redeems the token instead of re-parsing and re-validating the assertion. One
+    // process-wide instance, like the outstanding-request cache above — the callback and the mint leg run
+    // across separate per-request flow-service instances. Reassigned only by the test-only reset/swap hooks
+    // below (production sets it once); the field is not readonly solely so those hooks can install a
+    // small-cap store to exercise the cap path that the production ceiling makes unreachable.
+    private static SamlOutcomeStore _outcomes = new SamlOutcomeStore();
 
     // The shared login-completion tail (#160): resolve/adopt the link, build the session parameters, mint
     // under the revocation gate, audit, map to a LoginOutcome. Both protocols funnel their verified identity
@@ -91,13 +93,20 @@ internal sealed class SamlLoginService
     // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160).
     internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
 
-    // Test-only: clears the in-flight login-outcome store (#251) between tests, the same process-wide-static
-    // reset reason as ResetSamlRequestsForTests. Internal, InternalsVisibleTo, never wired to an endpoint/DI.
-    internal static void ResetSamlOutcomesForTests() => Outcomes.Clear();
+    // Test-only: restores a fresh default in-flight login-outcome store (#251) between tests, the same
+    // process-wide-static reset reason as ResetSamlRequestsForTests. Installing a new instance (rather than
+    // Clear) also un-swaps any small-cap store a prior test installed via SetSamlOutcomeStoreForTests, so cap
+    // state cannot leak across tests. Internal, InternalsVisibleTo, never wired to an endpoint/DI.
+    internal static void ResetSamlOutcomesForTests() => _outcomes = new SamlOutcomeStore();
+
+    // Test-only: swaps in a specific outcome store so a test can drive the cap path the production ceiling
+    // (100k) makes unreachable — e.g. proving a cap refusal at the ACS callback no longer burns the assertion
+    // (#539). Un-swapped by the next ResetSamlOutcomesForTests. Internal, InternalsVisibleTo, no endpoint/DI.
+    internal static void SetSamlOutcomeStoreForTests(SamlOutcomeStore store) => _outcomes = store;
 
     // Test-only: seeds a single login outcome so a test can drive the token-redeem mint leg without first
     // running the callback that normally populates the store. Same test-only surface as the resets above.
-    internal static void SeedSamlOutcomeForTests(SamlLoginOutcome outcome) => Outcomes.Seed(outcome);
+    internal static void SeedSamlOutcomeForTests(SamlLoginOutcome outcome) => _outcomes.Seed(outcome);
 
     // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
     // binding (#415) — normally populated by the challenge redirect leg — without deriving the random
@@ -184,41 +193,83 @@ internal sealed class SamlLoginService
         // cross-site and would not carry the SameSite=Lax binding cookie, so that check stays at the
         // same-origin mint leg (below), where the cookie is present — the assertion's InResponseTo is carried
         // in the stored outcome so the mint leg can correlate it without the XML.
-        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
-        {
-            return LoginStatusMapper.ToActionResult(rejection);
-        }
-
+        //
+        // Reserve the outcome-store slot BEFORE the replay consume (#539). The consume is one-time: an
+        // assertion recorded as used can never be presented again. So if the store refused AFTER the consume,
+        // a cap refusal would burn the assertion for a login that never completed and permanently lock the
+        // legitimate user out even though nothing malicious happened. Reserving first means a capacity refusal
+        // fails closed here with the assertion untouched, so the user can retry once the store drains. Replay
+        // protection is unchanged: the consume below is still the atomic one-time claim, it now runs only once
+        // a slot is secured, and any failure between reserve and commit releases the reservation — so a
+        // committed login always consumed the assertion and a consumed assertion always completed (or was a
+        // genuine replay/invalid assertion, which still fails closed without minting).
         var clientKey = SsoRateLimiter.NormalizeClientKey(request.HttpContext.Connection.RemoteIpAddress);
-        Outcomes.PruneExpired(DateTime.UtcNow);
-        var outcome = new SamlLoginOutcome(
-            SamlOutcomeStore.NewToken(),
-            provider,
-            identity,
-            samlResponse.GetInResponseTo() ?? string.Empty,
-            clientKey,
-            DateTime.UtcNow);
-        if (!Outcomes.TryAdd(outcome, out var shouldWarnCapacity))
+        _outcomes.PruneExpired(DateTime.UtcNow);
+        if (!_outcomes.TryReserve(clientKey, DateTime.UtcNow, out var shouldWarnCapacity))
         {
-            // A CSPRNG-token collision (effectively impossible) or the store is at capacity — fail closed
-            // rather than render a page whose token could never redeem. The store throttles the capacity
-            // warning to one signal per interval so a flood cannot amplify into log volume (CWE-400).
+            // The per-client sub-cap or the global cap refused this login's outcome slot — fail closed BEFORE
+            // the replay consume, so the assertion is not recorded as used and the login can be retried once
+            // the store drains. The store throttles the capacity warning to one signal per interval so a flood
+            // cannot amplify into log volume (CWE-400).
             if (shouldWarnCapacity)
             {
-                _logger.LogWarning("SAML login outcome refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the outcome store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                _logger.LogWarning("SAML login outcome refused for provider {Provider}: the per-client sub-cap or the outcome store is at capacity (warning throttled); the assertion was not consumed, so the login can be retried.", provider?.ReplaceLineEndings(string.Empty));
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
         }
 
-        return FlowResponses.AuthPage(response, nonce =>
-            WebResponse.Generator(
-                data: outcome.Token,
-                provider: provider,
-                baseUrl: requestBase,
-                mode: "SAML",
-                nonce: nonce,
-                isLinking: false));
+        // Slot secured: now consume the one-time replay cache and build the verified identity. Everything from
+        // here until the outcome is committed runs under a finally that releases the reservation unless it was
+        // handed to a committed outcome — so "exactly one release per reservation" is structural, covering both
+        // the fail-closed returns (a genuine replay or a NameID-less assertion, which mint nothing) AND any
+        // unexpected throw between reserve and commit; a per-client slot can never leak.
+        bool committed = false;
+        try
+        {
+            if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
+            {
+                // A genuine replay (or an assertion with no usable NameID) still fails closed here, minting
+                // nothing — so moving the capacity check ahead of the consume never lets a replayed assertion
+                // through. The reserved slot is freed by the finally.
+                return LoginStatusMapper.ToActionResult(rejection);
+            }
+
+            var outcome = new SamlLoginOutcome(
+                SamlOutcomeStore.NewToken(),
+                provider,
+                identity,
+                samlResponse.GetInResponseTo() ?? string.Empty,
+                clientKey,
+                DateTime.UtcNow);
+            if (!_outcomes.CommitReserved(outcome))
+            {
+                // Only reachable on an effectively-impossible CSPRNG-token collision — the capacity was already
+                // reserved, so this is not a cap refusal. The assertion is one-time and already consumed here,
+                // so this ~2^-256 event fails closed (unretryable) rather than rendering a token that could
+                // never redeem. The finally frees the reserved slot.
+                return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
+            }
+
+            // The committed outcome now owns the reserved slot (released on its redeem or prune), so the finally
+            // must NOT free it. AuthPage renders the token eagerly, so it is read before the finally runs.
+            committed = true;
+            return FlowResponses.AuthPage(response, nonce =>
+                WebResponse.Generator(
+                    data: outcome.Token,
+                    provider: provider,
+                    baseUrl: requestBase,
+                    mode: "SAML",
+                    nonce: nonce,
+                    isLinking: false));
+        }
+        finally
+        {
+            if (!committed)
+            {
+                _outcomes.ReleaseReservation(clientKey);
+            }
+        }
     }
 
     /// <summary>
@@ -353,7 +404,7 @@ internal sealed class SamlLoginService
         // here: only the browser binding remains, checked at this same-origin leg where the SameSite=Lax
         // cookie is sent (the cross-site ACS POST could not carry it). A miss falls through to the
         // deprecation branch below, so an unknown/expired/replayed token is rejected there rather than minting.
-        if (Outcomes.TryRedeem(response?.Data, provider, DateTime.UtcNow) is { } outcome)
+        if (_outcomes.TryRedeem(response?.Data, provider, DateTime.UtcNow) is { } outcome)
         {
             if (!CorrelateAndBind(provider, outcome.InResponseTo, bindingCookie, config.ValidateInResponseTo))
             {

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -330,10 +330,12 @@ public class SSOController : ControllerBase
     }
 
     // Names of the enabled providers in a config map, materialized to a detached list (the caller holds
-    // the config lock). Shared by both GetNames twins so the enabled-only rule lives in one place.
+    // the config lock). Shared by both GetNames twins so the enabled-only rule lives in one place. A
+    // null-valued entry is skipped rather than dereferenced (#538) — the same fail-closed convention
+    // CanonicalLinkService already applies to these maps.
     private static List<string> EnabledProviderNames<TConfig>(SerializableDictionary<string, TConfig> configs)
         where TConfig : ProviderConfigBase =>
-        configs.Where(kvp => kvp.Value.Enabled).Select(kvp => kvp.Key).ToList();
+        configs.Where(kvp => kvp.Value is { Enabled: true }).Select(kvp => kvp.Key).ToList();
 
     /// <summary>
     /// This is a debug endpoint to list all running OpenID flows. Requires administrator privileges.

--- a/SSO-Auth/Api/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/SamlOutcomeStore.cs
@@ -88,36 +88,90 @@ internal sealed class SamlOutcomeStore
     internal static string NewToken() => Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
 
     /// <summary>
-    /// Registers a fully-verified login outcome under its CSPRNG token. At the cap a NEW token is refused
-    /// (that one login fails closed) rather than evicting an in-flight outcome — evicting would drop a user
-    /// already mid-login. On refusal, <paramref name="shouldWarnCapacity"/> is true for at most one caller
-    /// per interval; the warning line stays at the call site so the log-forging inline sanitizer never
-    /// crosses a helper boundary.
+    /// Reserves capacity for one outcome BEFORE its caller consumes the one-time SAML replay cache, so an
+    /// at-cap refusal fails closed WITHOUT the assertion having been burned — the login the store cannot yet
+    /// hold can be retried once the store drains, rather than being permanently lost to a replay-cache entry
+    /// recorded for an authentication that never completed (#539). Reserves the per-client sub-cap (#327) and
+    /// checks the global cap; on a true return the caller MUST pair it with exactly one <see cref="CommitReserved"/>
+    /// or <see cref="ReleaseReservation"/>. At the cap a fresh reservation is refused rather than evicting an
+    /// in-flight outcome — evicting would drop a user already mid-login. On refusal,
+    /// <paramref name="shouldWarnCapacity"/> is true for at most one caller per interval; the warning line stays
+    /// at the call site so the log-forging inline sanitizer never crosses a helper boundary.
+    /// </summary>
+    /// <param name="clientKey">The normalized client key whose sub-cap slot is reserved, or null for an exempt source.</param>
+    /// <param name="now">The reference time driving the throttled capacity warning.</param>
+    /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
+    /// <returns>True if a slot was reserved; false if refused (per-client sub-cap or global cap).</returns>
+    internal bool TryReserve(string clientKey, DateTime now, out bool shouldWarnCapacity)
+    {
+        // Per-client sub-cap (#327): reserve this client's slot BEFORE the global check so one source cannot
+        // fill the whole budget and lock out every other login. A null key is exempt.
+        if (!_perClient.TryReserve(clientKey))
+        {
+            shouldWarnCapacity = _capWarnGate.TryEnter(now);
+            return false;
+        }
+
+        // Global cap: at capacity a fresh reservation is refused, never an in-flight one evicted. The reserve
+        // holds only the per-client slot, so the global cap stays the store's documented APPROXIMATE ceiling —
+        // between this check and the paired CommitReserved a concurrent commit can transiently overshoot by at
+        // most the in-flight thread count, immaterial for a defense-in-depth memory bound (the per-client cap,
+        // the actual availability defense, remains exact via its CAS).
+        if (_outcomes.Count >= _maxEntries)
+        {
+            _perClient.Release(clientKey);
+            shouldWarnCapacity = _capWarnGate.TryEnter(now);
+            return false;
+        }
+
+        shouldWarnCapacity = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Commits a reserved outcome into the store under its token. Reachable only after a successful
+    /// <see cref="TryReserve"/> for the same client key, so the capacity is already accounted; this can fail
+    /// only on the effectively-impossible CSPRNG-token collision losing the atomic add, in which case the
+    /// caller releases the reservation and fails closed.
+    /// </summary>
+    /// <param name="outcome">The verified outcome whose token keys the entry.</param>
+    /// <returns>True if the outcome was stored; false on the ~impossible token collision.</returns>
+    internal bool CommitReserved(SamlLoginOutcome outcome) => _outcomes.TryAdd(outcome.Token, outcome);
+
+    /// <summary>
+    /// Releases a reservation taken by <see cref="TryReserve"/> that is not being committed — a replayed or
+    /// otherwise invalid assertion, an assertion with no NameID, or the ~impossible token collision — so the
+    /// client's sub-cap slot does not leak. A null/exempt key reserved nothing, so it releases nothing.
+    /// </summary>
+    /// <param name="clientKey">The client key whose reserved slot is freed, or null (a no-op).</param>
+    internal void ReleaseReservation(string clientKey) => _perClient.Release(clientKey);
+
+    /// <summary>
+    /// Registers a fully-verified login outcome under its CSPRNG token in one atomic step — a convenience for
+    /// callers that need no work between the capacity reservation and the store insert; the ACS callback uses
+    /// the <see cref="TryReserve"/>/<see cref="CommitReserved"/> primitives directly so it can consume the
+    /// one-time replay cache between them (#539). At the cap a NEW token is refused (that one login fails
+    /// closed) rather than evicting an in-flight outcome.
     /// </summary>
     /// <param name="outcome">The verified outcome; its token keys the entry and its Created drives the throttled warning.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
     /// <returns>True if the outcome was registered; false if refused (per-client sub-cap, global cap, or token collision).</returns>
     internal bool TryAdd(SamlLoginOutcome outcome, out bool shouldWarnCapacity)
     {
-        // Per-client sub-cap (#327): reserve this client's slot BEFORE the global insert so one source
-        // cannot fill the whole budget and lock out every other login. A null key is exempt.
-        if (!_perClient.TryReserve(outcome.ClientKey))
+        if (!TryReserve(outcome.ClientKey, outcome.Created, out shouldWarnCapacity))
         {
+            return false;
+        }
+
+        if (!CommitReserved(outcome))
+        {
+            // The entry never entered the store (a CSPRNG-token collision losing the atomic add) — release the
+            // reservation so the client's bucket does not leak a slot, and warn as for any other refusal.
+            ReleaseReservation(outcome.ClientKey);
             shouldWarnCapacity = _capWarnGate.TryEnter(outcome.Created);
             return false;
         }
 
-        if ((_outcomes.Count >= _maxEntries && !_outcomes.ContainsKey(outcome.Token))
-            || !_outcomes.TryAdd(outcome.Token, outcome))
-        {
-            // The entry never entered the store (global cap, or a CSPRNG-token collision losing the atomic
-            // add) — release the reservation so the client's bucket does not leak a slot.
-            _perClient.Release(outcome.ClientKey);
-            shouldWarnCapacity = _capWarnGate.TryEnter(outcome.Created);
-            return false;
-        }
-
-        shouldWarnCapacity = false;
         return true;
     }
 


### PR DESCRIPTION
Forward-merge per docs/BRANCHING.md: brings the released-line fixes and the release infrastructure into the 4.2 feature-dev branch so the next feature release never regresses them. Carries: the 4.1.0.0 version bump + CHANGELOG (#555), the tag-push publish pipeline (#556/#557), the GetNames null-safety fix (#538/#559), and the CI branch-filter widening (#560/#561) that unblocks required checks on 4.2 pull requests. No 4.2-only commits exist yet, so this is a clean fast-forward-shaped merge.