### PR TITLE
Surface failed loads and unlink deletes on the linking page

### DIFF
--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -46,6 +46,15 @@
               >${Help}</a
             >
           </div>
+          <div
+            id="sso-linking-error"
+            class="sso-linking-error"
+            role="alert"
+            hidden
+          >
+            Something went wrong loading or updating your links. Please reload
+            the page and try again.
+          </div>
           <p>
             Use the
             <span class="fab" aria-hidden="true">

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,5 +1,15 @@
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
+
+  // A single generic banner for a failed request on this page (existing-links load or unlink, #536).
+  // It never carries a status code or server message, so a rejection cannot leak an internal detail
+  // into the admin UI; it just tells the user the page is no longer trustworthy as shown.
+  showError: () => {
+    const banner = document.querySelector("#sso-linking-error");
+    if (banner) {
+      banner.hidden = false;
+    }
+  },
   loadProviders: (view) => {
     ["oid", "saml"].forEach((provider_mode) => {
       const container = view.querySelector(
@@ -44,8 +54,9 @@ const ssoConfigLinking = {
           url: ApiClient.getUrl(`sso/${provider_mode}/links/${currentUserId}`),
         },
         true,
-      ).then((resp) => {
-        resp.json().then((provider_map) => {
+      )
+        .then((resp) => resp.json())
+        .then((provider_map) => {
           Object.keys(provider_map).forEach((provider_name) => {
             let existing_links = container.querySelector(
               `.sso-provider-existing-links-container[data-provider="${CSS.escape(provider_name)}"]`,
@@ -77,8 +88,10 @@ const ssoConfigLinking = {
               provider_map[provider_name],
             );
           });
-        });
-      });
+        })
+        // ApiClient.fetch rejects on a non-2xx status (auth expiry, a server error, ...), so a failed
+        // existing-links load surfaces the banner instead of silently leaving the list empty (#536).
+        .catch(() => ssoConfigLinking.showError());
     }
   },
 
@@ -223,9 +236,14 @@ const ssoConfigLinking = {
         });
       });
 
-    Promise.all(delete_requests).then((values) => {
-      window.location.reload();
-    });
+    Promise.all(delete_requests)
+      .then(() => {
+        window.location.reload();
+      })
+      // ApiClient.fetch rejects on a non-2xx status, so a rejected DELETE must not fall through to
+      // the unconditional reload below it: that would show the exact same page a successful removal
+      // shows, with no indication that the link the user asked to remove is still present (#536).
+      .catch(() => ssoConfigLinking.showError());
   },
 };
 

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -35,6 +35,14 @@
   margin-top: 0.25em;
 }
 
+.sso-linking-error {
+  color: #ff8a80;
+  border: 1px solid #ff8a80;
+  border-radius: 0.25em;
+  padding: 0.75em 1em;
+  margin-bottom: 1em;
+}
+
 .sso-role-mapping-container,
 .sso-bordered-list {
   border-color: rgba(255, 255, 255, 0.135);


### PR DESCRIPTION
# What & why

linking.js discarded a non-2xx response on two of its own client XHRs, so a server-side failure there showed no error to the user, a UX-honesty gap surfaced while fixing #344 but out of that issue's scope:

1. The `links/{userId}` existing-links fetch, a non-2xx (auth expiry, a 5xx) left the existing-links list silently empty rather than surfacing that the load failed.
2. The unlink flow, `Promise.all(delete_requests).then(reload)` reloaded unconditionally, so a failed DELETE (4xx/5xx) was indistinguishable from success.

We fixed both: a small static `#sso-linking-error` banner is added to `linking.html`/`style.css`, and a `showError()` helper unhides it. Both promise chains now wire a `.catch()` to it, the existing-links load surfaces the banner instead of leaving the list empty, and the unlink flow no longer reloads unless every DELETE actually succeeded. The banner carries no status code or server detail, only a static message, so a rejection cannot leak anything into the admin UI.

This page runs without the Jellyfin dashboard shell (`linking.html`'s own head comment says "Polyfill styles that are missing when serving without dashboard"), so `Dashboard.alert(...)`, the mechanism `config.js` uses elsewhere for the dashboard-embedded config page, is not available here; a local static banner is the correct mechanism for this page specifically.

The enabled-only add-button and disabled-provider removable-row behavior from #344 (PR #535) is untouched, only the promise-chain shape around the two named XHRs changed, plus the added banner markup/CSS.

Closes #536

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (N/A — no signature/time-bound/audience
      check in this diff; this is the client-side self-service linking admin
      page, not the login/callback path.)
- [x] No secrets logged; secrets are redacted on config export. (N/A - no
      secrets touched; the error banner is static text, never interpolated
      from a server response.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (The adversarial-review
      gate ran because `linking.js`/`linking.html` sit on the flagged
      security-sensitive surface — see Notes for the 4-lens result; this
      diff touches none of SAML/OIDC validation, config persistence, or the
      release pipeline itself.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      logging in this diff.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (`showError()` is one small helper reused by both fixed
      call sites.)
- [x] The change adds no more code than the problem requires. (42 insertions
      across the two named call sites, the banner element, and its styling;
      the adjacent GetNames swallow found by review is filed separately as
      #564, not folded in here.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property — this is a client-JS-only change; the C#
      architecture-conformance suite is unaffected and still green.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings, 0 errors.)
- [x] `dotnet test` is green. (1179/1179 passed - a client-JS-only change, so
      this confirms no regression rather than exercising the fix itself.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`npx prettier --check` reports the three touched files unchanged /
      clean; the pre-existing warnings on unrelated files predate this PR.)

## Notes

This is browser JS that CI cannot exercise end to end, so the adversarial-review
gate was the primary verification here (in addition to a manual trace of both
fixed call sites). We ran all 4 lenses:

- **Availability**, PASS. The pre-change unlink code had no `.catch` at all,
  so a failed DELETE already never reloaded before this PR; this change only
  makes that existing non-reload outcome visible instead of silent. No new
  mass-lockout or hang vector; `showError()` is idempotent and guarded against
  a missing banner element.
- **Security bypass**, PASS. The banner is strictly static text (no
  interpolation of status/body/provider name). Not reloading on a failed
  DELETE only causes client-side display staleness, every DELETE is still
  independently authorized and enforced server-side per request, so stale DOM
  state cannot grant anything the server wouldn't re-check. URL encoding
  (`encodeURIComponent`) and the disabled-provider gating from #344/#535 are
  untouched.
- **Correctness**, NEEDS_IMPROVEMENT, disposition: the two named call sites
  are verified correct (including tracing the vendored
  `jellyfin-apiClient.esm.min.js` to confirm `ApiClient.fetch(..., true)`
  resolves with a real `Response` object here, so `.then(resp => resp.json())`
  is valid and a malformed-JSON rejection now correctly reaches the trailing
  `.catch()`). The lens separately flagged that `loadProviders()`'s bare
  native `fetch()` call to `GetNames` also swallows non-2xx with no `.catch` - 
  a third instance of the same bug class, but one issue #536's own acceptance
  criteria explicitly did not name (it scoped itself to "two of its own client
  XHRs"). We filed this as #564 rather than widening this diff.
- **Integration**, PASS. No `.cs` file changed; the local banner (rather than
  `Dashboard.alert`) is correct because this page is confirmed to run without
  the dashboard shell; no id/class collisions; Prettier-clean; no inline
  script added.

Follow-up filed: #564 (GetNames provider-list fetch on this same page also
needs the same treatment, deliberately out of scope here).

Forward-merge reminder: this is a fix branched off `main`; it needs to
forward-merge into `4.2` after merge, per our branching model.
