### PR TITLE
Add SAML service-provider metadata endpoint

### DIFF
--- a/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Xml.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the SAML SP metadata endpoint (<c>SamlMetadata</c>) via
+/// <see cref="SsoControllerHarness"/> (#162). They cover the guard branches (unknown/disabled provider),
+/// the anti-spoofing invariant — the published entity id and assertion-consumer URL come from the
+/// configured canonical Base URL and NEVER the request host, and the endpoint fails closed when that base
+/// URL is unset rather than emitting a spoofable ACS — and the signing-conditional key descriptor, which
+/// advertises only the PUBLIC certificate.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlMetadataTests
+{
+    private static readonly XNamespace Md = "urn:oasis:names:tc:SAML:2.0:metadata";
+    private static readonly XNamespace Ds = "http://www.w3.org/2000/09/xmldsig#";
+
+    // The harness always serves from this request host; the anti-spoofing tests assert it never appears in
+    // the published metadata (only the configured canonical Base URL does).
+    private const string RequestHost = "jf.example.com";
+    private const string CanonicalBaseUrl = "https://canonical.example.com";
+
+    [Fact]
+    public void SamlMetadata_UnknownProvider_RejectsAsUnknownProvider()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("nope"));
+
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("No matching provider found", result.Content);
+    }
+
+    [Fact]
+    public void SamlMetadata_DisabledProvider_RejectsAsUnknownProvider()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = false,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        // A disabled provider is refused with the uniform unknown-provider body, so this anonymous surface
+        // does not expose its entity id / signing certificate either.
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("No matching provider found", result.Content);
+    }
+
+    [Fact]
+    public void SamlMetadata_NoCanonicalBaseUrl_FailsClosed_NeverDerivingFromTheRequestHost()
+    {
+        // The anti-spoofing invariant: with no canonical Base URL configured, the endpoint refuses rather
+        // than bake the request host (which a forwarded X-Forwarded-Host could influence) into metadata an
+        // identity provider consumes. So it never emits an ACS pointing at the request host.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = null,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(409, result.StatusCode);
+        Assert.DoesNotContain(RequestHost, result.Content ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlMetadata_BlankClientId_FailsClosed()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "   ",
+            BaseUrlOverride = CanonicalBaseUrl,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(409, result.StatusCode);
+    }
+
+    [Fact]
+    public void SamlMetadata_SigningOff_UsesTheCanonicalBaseUrl_NotTheRequestHost()
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp.example.com/entity",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = false,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(200, result.StatusCode);
+        Assert.Equal("application/samlmetadata+xml", result.ContentType);
+
+        var document = XDocument.Parse(result.Content!);
+        Assert.Equal("https://sp.example.com/entity", (string?)document.Root!.Attribute("entityID"));
+
+        var spDescriptor = document.Root.Element(Md + "SPSSODescriptor");
+        Assert.Equal("false", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+        Assert.Null(spDescriptor.Element(Md + "KeyDescriptor"));
+
+        var acs = (string?)spDescriptor.Element(Md + "AssertionConsumerService")!.Attribute("Location");
+        Assert.Equal(CanonicalBaseUrl + "/sso/SAML/post/adfs", acs);
+        // The published ACS is anchored to the canonical Base URL, never the spoofable request host.
+        Assert.DoesNotContain(RequestHost, result.Content!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlMetadata_SigningOn_AdvertisesThePublicCertificate_WithoutThePrivateKey()
+    {
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        var pfxBase64 = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
+        var expectedPublicBase64 = Convert.ToBase64String(certificate.RawData);
+
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = pfxBase64,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(200, result.StatusCode);
+        var document = XDocument.Parse(result.Content!);
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+        Assert.Equal("true", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+
+        var advertised = spDescriptor
+            .Element(Md + "KeyDescriptor")!
+            .Element(Ds + "KeyInfo")!
+            .Element(Ds + "X509Data")!
+            .Element(Ds + "X509Certificate")!.Value;
+
+        // Exactly the public certificate is advertised — not the PFX/private key.
+        Assert.Equal(expectedPublicBase64, advertised);
+        using var loaded = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(advertised));
+        Assert.False(loaded.HasPrivateKey);
+        // The stored PFX (which carries the private key) never appears in the response.
+        Assert.DoesNotContain(pfxBase64, result.Content!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlMetadata_SigningOnButKeyUnloadable_FailsClosed()
+    {
+        // Request signing enabled but the key is garbage: fail closed (mirroring the signed challenge)
+        // rather than advertise AuthnRequestsSigned with no usable key.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = "not-a-valid-pfx",
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(409, result.StatusCode);
+    }
+}

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Xml.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the pure <see cref="SamlSpMetadataBuilder"/> (#162): the emitted document is well-formed SAML
+/// 2.0 SP metadata, its entity id and HTTP-POST assertion-consumer URL are the exact values it is handed, a
+/// signing <c>KeyDescriptor</c> is present precisely when (and carries exactly) the certificate given, and
+/// the builder never invents a spoofable value of its own — it only serializes its inputs.
+/// </summary>
+public class SamlSpMetadataBuilderTests
+{
+    private static readonly XNamespace Md = "urn:oasis:names:tc:SAML:2.0:metadata";
+    private static readonly XNamespace Ds = "http://www.w3.org/2000/09/xmldsig#";
+    private const string ProtocolNamespace = "urn:oasis:names:tc:SAML:2.0:protocol";
+    private const string HttpPostBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+    private const string EntityId = "https://jellyfin.example.com/sso/SAML/adfs";
+    private const string AcsUrl = "https://jellyfin.example.com/sso/SAML/post/adfs";
+
+    [Fact]
+    public void Build_WithoutSigning_IsWellFormedSpMetadataWithTheGivenEntityIdAndAcs()
+    {
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null));
+
+        var entityDescriptor = document.Root;
+        Assert.Equal(Md + "EntityDescriptor", entityDescriptor!.Name);
+        Assert.Equal(EntityId, (string?)entityDescriptor.Attribute("entityID"));
+
+        var spDescriptor = entityDescriptor.Element(Md + "SPSSODescriptor");
+        Assert.NotNull(spDescriptor);
+        Assert.Equal(ProtocolNamespace, (string?)spDescriptor.Attribute("protocolSupportEnumeration"));
+
+        var acs = spDescriptor.Element(Md + "AssertionConsumerService");
+        Assert.NotNull(acs);
+        Assert.Equal(HttpPostBinding, (string?)acs.Attribute("Binding"));
+        Assert.Equal(AcsUrl, (string?)acs.Attribute("Location"));
+        Assert.Equal("0", (string?)acs.Attribute("index"));
+        Assert.Equal("true", (string?)acs.Attribute("isDefault"));
+    }
+
+    [Fact]
+    public void Build_WithoutSigning_AdvertisesNoSigningKeyAndAuthnRequestsSignedFalse()
+    {
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null));
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+
+        Assert.Equal("false", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+        // Assertions are always signature-checked by this SP, so it truthfully requires them signed.
+        Assert.Equal("true", (string?)spDescriptor.Attribute("WantAssertionsSigned"));
+        Assert.Null(spDescriptor.Element(Md + "KeyDescriptor"));
+    }
+
+    [Fact]
+    public void Build_WithSigning_AdvertisesTheSigningCertificateAndAuthnRequestsSignedTrue()
+    {
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        var certificateBase64 = Convert.ToBase64String(certificate.RawData);
+
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, certificateBase64));
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+
+        Assert.Equal("true", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+
+        var keyDescriptor = spDescriptor.Element(Md + "KeyDescriptor");
+        Assert.NotNull(keyDescriptor);
+        Assert.Equal("signing", (string?)keyDescriptor.Attribute("use"));
+
+        var x509Certificate = keyDescriptor
+            .Element(Ds + "KeyInfo")?
+            .Element(Ds + "X509Data")?
+            .Element(Ds + "X509Certificate");
+        Assert.NotNull(x509Certificate);
+        Assert.Equal(certificateBase64, x509Certificate.Value);
+    }
+
+    [Fact]
+    public void Build_WithSigning_AdvertisedCertificateCarriesNoPrivateKey()
+    {
+        // The metadata must never leak the private key: the advertised certificate loads as a public-only
+        // certificate. (The caller exports certificate.RawData, the public DER; this pins that whatever is
+        // advertised is loadable and private-key-free.)
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        var certificateBase64 = Convert.ToBase64String(certificate.RawData);
+
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, certificateBase64));
+        var advertised = document.Root!
+            .Element(Md + "SPSSODescriptor")!
+            .Element(Md + "KeyDescriptor")!
+            .Element(Ds + "KeyInfo")!
+            .Element(Ds + "X509Data")!
+            .Element(Ds + "X509Certificate")!.Value;
+
+        using var loaded = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(advertised));
+        Assert.False(loaded.HasPrivateKey);
+    }
+
+    [Fact]
+    public void Build_DeclaresUtf8Encoding()
+    {
+        // A StringWriter is UTF-16 internally; the builder reports UTF-8 so the declaration matches the
+        // UTF-8 bytes served, rather than mislabeling the document as utf-16.
+        var xml = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null);
+        Assert.Contains("encoding=\"utf-8\"", xml, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Build_EscapesSpecialCharactersInEntityIdAndAcs()
+    {
+        // XML-significant characters in the (config-derived) inputs must be escaped so the output stays
+        // well-formed and round-trips to the exact input value.
+        const string entityId = "https://sp.example.com/meta?a=1&b=2<x>";
+        const string acs = "https://sp.example.com/acs?q=\"z\"&r=1";
+
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(entityId, acs, signingCertificateBase64: null));
+
+        Assert.Equal(entityId, (string?)document.Root!.Attribute("entityID"));
+        Assert.Equal(
+            acs,
+            (string?)document.Root.Element(Md + "SPSSODescriptor")!.Element(Md + "AssertionConsumerService")!.Attribute("Location"));
+    }
+}

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -374,6 +374,110 @@ internal sealed class SamlLoginService
     }
 
     /// <summary>
+    /// Serves this service provider's SAML 2.0 metadata for <paramref name="provider"/> (#162), so an
+    /// administrator can register the SP at the identity provider by URL rather than hand-configuring the
+    /// entity id, assertion-consumer URL and signing certificate. Anonymous by design — SP metadata is
+    /// public — and deliberately request-free: unlike the login flow, it refuses to derive the published
+    /// entity id/ACS from the request <c>Host</c>. Both are built ONLY from the provider's configured
+    /// canonical Base URL (<see cref="Config.ProviderConfigBase.BaseUrlOverride"/>, #139); if that is not
+    /// configured the endpoint fails closed rather than publish a spoofable ACS an attacker could point the
+    /// identity provider at (RFC 9700 sect. 4.1). The signing certificate is advertised only when request
+    /// signing is enabled, and only ever as the PUBLIC certificate.
+    /// </summary>
+    /// <param name="provider">The SAML provider whose metadata to serve.</param>
+    /// <returns>The SP metadata document, or a fail-closed rejection when the provider is unknown/disabled or its metadata prerequisites are unconfigured.</returns>
+    internal ActionResult Metadata(string provider)
+    {
+        // Unknown and disabled providers share the login flow's uniform rejection, so a disabled provider
+        // does not expose its entity id / signing certificate through this anonymous surface either.
+        var config = FindSamlConfig(provider);
+        if (config is not { Enabled: true })
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
+        }
+
+        // The published ACS/entity id MUST be non-spoofable: build them ONLY from the configured canonical
+        // Base URL, never the request Host (which a reverse proxy forwarding an unfiltered X-Forwarded-Host
+        // could influence). With no canonical Base URL configured, fail closed rather than bake a
+        // request-derived value into metadata an identity provider consumes to decide where to POST
+        // assertions — the login flow may fall back to the request host, but published metadata must not.
+        if (!CanonicalBaseUrl.TryNormalize(config.BaseUrlOverride, out var baseUrl))
+        {
+            return FlowResponses.PlainTextError(
+                StatusCodes.Status409Conflict,
+                "SAML metadata is unavailable: configure this provider's canonical Base URL first, so the published assertion-consumer URL cannot be derived from a spoofable request host.");
+        }
+
+        // The entity id is the value the challenge sends as the AuthnRequest Issuer (the client id); an
+        // enabled SAML provider always has one, but guard fail-closed rather than emit metadata with an
+        // empty entityID.
+        var entityId = config.SamlClientId?.Trim();
+        if (string.IsNullOrEmpty(entityId))
+        {
+            return FlowResponses.PlainTextError(
+                StatusCodes.Status409Conflict,
+                "SAML metadata is unavailable: this provider has no client id (SP entity id) configured.");
+        }
+
+        // Advertise the canonical new-path ACS spelling; the SP accepts either spelling on the way back
+        // (SsoUrlBuilder.SamlExpectedAcsUrls), so publishing one is unambiguous for the identity provider.
+        var acsUrl = SsoUrlBuilder.SamlAcsUrl(baseUrl, newPath: true, provider);
+
+        if (!TryResolveSigningCertificate(config, out var signingCertificateBase64))
+        {
+            // Request signing is enabled but the key could not be loaded — the same fail-closed posture the
+            // signed challenge takes, so metadata never advertises signing the challenge would then fail to
+            // perform.
+            return FlowResponses.PlainTextError(
+                StatusCodes.Status409Conflict,
+                "SAML metadata is unavailable: request signing is enabled but the signing key could not be loaded.");
+        }
+
+        return new ContentResult
+        {
+            Content = SamlSpMetadataBuilder.Build(entityId, acsUrl, signingCertificateBase64),
+            ContentType = "application/samlmetadata+xml",
+            StatusCode = StatusCodes.Status200OK,
+        };
+    }
+
+    // Resolves the PUBLIC signing certificate to advertise in the metadata: null when request signing is
+    // off (no KeyDescriptor is emitted), the Base64 (DER) public certificate when it is on, and false (fail
+    // closed) when it is on but the key cannot be loaded/decrypted — mirroring BuildChallengeRedirectUrl.
+    // Only the certificate's public RawData is exported; the private key never leaves this method.
+    private static bool TryResolveSigningCertificate(SamlConfig config, out string signingCertificateBase64)
+    {
+        signingCertificateBase64 = null;
+        if (!config.SignAuthnRequests)
+        {
+            return true;
+        }
+
+        string revealed;
+        try
+        {
+            // The signing key is stored encrypted at rest (#158); reveal it at the point of use. A missing
+            // or corrupt key file throws CryptographicException — fail closed here rather than surface a 500.
+            revealed = SSOPlugin.Instance.Secrets.Reveal(config.SamlSigningKeyPfx);
+        }
+        catch (CryptographicException)
+        {
+            return false;
+        }
+
+        if (!SamlSigningKey.TryLoad(revealed, out var certificate))
+        {
+            return false;
+        }
+
+        using (certificate)
+        {
+            signingCertificateBase64 = Convert.ToBase64String(certificate.RawData);
+            return true;
+        }
+    }
+
+    /// <summary>
     /// The SAML session-minting authenticate leg: validates the signed response, correlates it to an
     /// AuthnRequest this server issued (browser binding, #156/#415), enforces the login allow-list and
     /// one-time replay consume, then hands the fully-verified identity to the shared completion tail. The

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -426,6 +426,30 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Serves this service provider's SAML 2.0 metadata for <paramref name="provider"/> (#162), so an
+    /// administrator can register the SP at the identity provider by URL instead of hand-configuring the
+    /// entity id, assertion-consumer URL and signing certificate. Anonymous by design — SP metadata is
+    /// public (a real identity provider fetches it unauthenticated) — and deliberately request-free: the
+    /// published entity id and ACS URL are built only from the provider's configured canonical Base URL,
+    /// never the request Host.
+    /// </summary>
+    /// <param name="provider">The SAML provider whose metadata to serve.</param>
+    /// <returns>The SP metadata document, or a fail-closed rejection when the provider is unknown/disabled or its canonical Base URL is unconfigured.</returns>
+    [HttpGet("SAML/metadata/{provider}")]
+    public ActionResult SamlMetadata(string provider)
+    {
+        if (RateLimitCheck("metadata") is { } throttled)
+        {
+            return throttled;
+        }
+
+        // The SP metadata flow lives in the flow service (#160, #318): it resolves the entity id and
+        // assertion-consumer URL from the configured canonical Base URL (never the request Host) and emits
+        // the SPSSODescriptor, advertising the PUBLIC signing certificate only when request signing is on.
+        return _saml.Metadata(provider);
+    }
+
+    /// <summary>
     /// Adds a SAML configuration. If the provider already exists, overwrite it.
     /// </summary>
     /// <param name="provider">The provider name to add.</param>

--- a/SSO-Auth/Api/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/SamlSpMetadataBuilder.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Builds SAML 2.0 service-provider metadata — an <c>EntityDescriptor</c> carrying an
+/// <c>SPSSODescriptor</c> — that an administrator can hand to an identity provider so it registers this
+/// service provider by URL instead of by hand (#162). Pure and request-free: it emits exactly the entity
+/// id, the HTTP-POST assertion-consumer URL, and — only when request signing is enabled — the PUBLIC
+/// signing certificate it is given. It never touches a private key or any secret, and it never reads the
+/// request <c>Host</c>: the caller resolves the entity id and ACS URL from the configured canonical Base
+/// URL (#139), so a spoofed or proxy-forwarded host cannot poison the ACS the identity provider is told to
+/// POST assertions to.
+/// </summary>
+internal static class SamlSpMetadataBuilder
+{
+    private const string MetadataNamespace = "urn:oasis:names:tc:SAML:2.0:metadata";
+    private const string ProtocolNamespace = "urn:oasis:names:tc:SAML:2.0:protocol";
+    private const string DsigNamespace = "http://www.w3.org/2000/09/xmldsig#";
+    private const string HttpPostBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+    /// <summary>
+    /// Renders the service-provider metadata document.
+    /// </summary>
+    /// <param name="entityId">
+    /// The SP entity id — the same value this service provider sends as the AuthnRequest <c>Issuer</c>
+    /// (the configured client id), so the identity provider correlates the two.
+    /// </param>
+    /// <param name="assertionConsumerServiceUrl">
+    /// The absolute HTTP-POST assertion-consumer URL, built from the configured canonical Base URL (never
+    /// the request host).
+    /// </param>
+    /// <param name="signingCertificateBase64">
+    /// The Base64 (DER) PUBLIC signing certificate to advertise under a <c>KeyDescriptor use="signing"</c>
+    /// when request signing is enabled, or <see langword="null"/> to advertise no signing key. This is only
+    /// ever the public certificate — the private key must never be passed here.
+    /// </param>
+    /// <returns>The metadata document as an XML string.</returns>
+    internal static string Build(string entityId, string assertionConsumerServiceUrl, string? signingCertificateBase64)
+    {
+        // A StringWriter is UTF-16 internally, which would make XmlWriter stamp encoding="utf-16" into the
+        // XML declaration even though the bytes are served as UTF-8; report UTF-8 so the declaration matches
+        // the wire encoding a strict metadata consumer validates.
+        using var writer = new Utf8StringWriter();
+        var settings = new XmlWriterSettings
+        {
+            Indent = true,
+            Encoding = Encoding.UTF8,
+        };
+
+        using (var xml = XmlWriter.Create(writer, settings))
+        {
+            xml.WriteStartElement("md", "EntityDescriptor", MetadataNamespace);
+            xml.WriteAttributeString("entityID", entityId);
+
+            xml.WriteStartElement("md", "SPSSODescriptor", MetadataNamespace);
+
+            // Advertise request signing exactly as it is configured, and always require signed assertions:
+            // this SP rejects an unsigned assertion (Saml.cs verifies the signature on every response), so
+            // WantAssertionsSigned="true" is a truthful statement of what the IdP must send.
+            xml.WriteAttributeString("AuthnRequestsSigned", signingCertificateBase64 is null ? "false" : "true");
+            xml.WriteAttributeString("WantAssertionsSigned", "true");
+            xml.WriteAttributeString("protocolSupportEnumeration", ProtocolNamespace);
+
+            if (signingCertificateBase64 is not null)
+            {
+                xml.WriteStartElement("md", "KeyDescriptor", MetadataNamespace);
+                xml.WriteAttributeString("use", "signing");
+                xml.WriteStartElement("ds", "KeyInfo", DsigNamespace);
+                xml.WriteStartElement("ds", "X509Data", DsigNamespace);
+                xml.WriteStartElement("ds", "X509Certificate", DsigNamespace);
+                xml.WriteString(signingCertificateBase64);
+                xml.WriteEndElement(); // ds:X509Certificate
+                xml.WriteEndElement(); // ds:X509Data
+                xml.WriteEndElement(); // ds:KeyInfo
+                xml.WriteEndElement(); // md:KeyDescriptor
+            }
+
+            xml.WriteStartElement("md", "AssertionConsumerService", MetadataNamespace);
+            xml.WriteAttributeString("Binding", HttpPostBinding);
+            xml.WriteAttributeString("Location", assertionConsumerServiceUrl);
+            xml.WriteAttributeString("index", "0");
+            xml.WriteAttributeString("isDefault", "true");
+            xml.WriteEndElement(); // md:AssertionConsumerService
+
+            xml.WriteEndElement(); // md:SPSSODescriptor
+            xml.WriteEndElement(); // md:EntityDescriptor
+        }
+
+        return writer.ToString();
+    }
+
+    // A StringWriter that reports UTF-8 so XmlWriter emits encoding="utf-8" in the XML declaration (the
+    // default StringWriter reports UTF-16, which would mislabel the served UTF-8 document).
+    private sealed class Utf8StringWriter : StringWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+    }
+}

--- a/providers.md
+++ b/providers.md
@@ -382,6 +382,39 @@ provider is saved.
 > accepting multiple inbound IdP verification certificates during a rotation window, are tracked
 > separately and not yet implemented.
 
+## SAML service-provider metadata
+
+The plugin can publish standard SAML 2.0 **service-provider metadata** for a provider, so you can
+register this service provider at your identity provider by URL instead of typing the entity ID,
+assertion-consumer URL and signing certificate by hand:
+
+```
+GET <base URL>/sso/SAML/metadata/<ProviderName>
+```
+
+for example `https://jellyfin.example.com/sso/SAML/metadata/keycloak`. The response is an
+`application/samlmetadata+xml` `EntityDescriptor`/`SPSSODescriptor` carrying:
+
+- the **entityID**, which is the provider's configured client ID (`SamlClientId`) — the same value the
+  plugin sends as the `AuthnRequest` `Issuer`, so the identity provider correlates the two;
+- one **HTTP-POST `AssertionConsumerService`** at `<base URL>/sso/SAML/post/<ProviderName>`; and
+- a **`KeyDescriptor use="signing"`** carrying the SP's **public** request-signing certificate — but
+  **only when [request signing](#saml-request-signing-optional) (`SignAuthnRequests`) is enabled** for
+  that provider. Only the public certificate is published; the private key (`SamlSigningKeyPfx`) never
+  leaves the server. When signing is off, no `KeyDescriptor` is emitted and `AuthnRequestsSigned="false"`.
+
+The endpoint is **anonymous** — SP metadata is public information, and a real identity provider fetches
+it unauthenticated.
+
+**The published entity ID and ACS URL come only from the configured
+[canonical base URL](#canonical-base-url-recommended-hardening) (`BaseUrlOverride`), never from the
+request `Host` header.** This is deliberate and security-critical: metadata is consumed by the identity
+provider to decide where it POSTs assertions, so deriving the ACS from a spoofable (proxy-forwarded)
+host would let an attacker point your identity provider at an attacker-controlled endpoint. Therefore the
+endpoint **fails closed** — it returns `409 Conflict` and publishes nothing — when the provider has no
+`BaseUrlOverride` set (or no client ID, or request signing is on but the signing key cannot be loaded).
+Set the provider's `BaseUrlOverride` first, then fetch its metadata.
+
 ## SAML login browser binding
 
 Every SP-initiated SAML login (one started from Jellyfin, i.e. `SAML/start/...`) is bound to the


### PR DESCRIPTION
# What & why

Expose standard SAML 2.0 service-provider metadata so administrators can register this service provider at their identity provider by URL, instead of hand-configuring the entity id, assertion-consumer URL and signing certificate. Feature parity with the reference implementation. Closes #162.

New endpoint (anonymous, like a real IdP fetch of SP metadata):

```
GET /sso/SAML/metadata/<ProviderName>   ->   application/samlmetadata+xml
```

It emits an `EntityDescriptor`/`SPSSODescriptor` with the `entityID` (the provider's `SamlClientId`, the same value we send as the AuthnRequest `Issuer`), one HTTP-POST `AssertionConsumerService`, and, only when request signing (`SignAuthnRequests`) is enabled, a `KeyDescriptor use="signing"` carrying the SP's public signing certificate.

Design (thin controller per #318):

- `SamlSpMetadataBuilder`, a pure, request-free, `internal static` builder that serializes exactly its inputs into correctly-namespaced SAML 2.0 metadata (KeyDescriptor before AssertionConsumerService, per the metadata XSD), via `XmlWriter` (so entity id / ACS are XML-escaped). It only ever receives the public certificate (`certificate.RawData`); the private key never reaches it.
- `SamlLoginService.Metadata`, resolves the entity id and ACS **only** from the provider's configured canonical Base URL (`BaseUrlOverride`, #139), never the request `Host`, and advertises the signing certificate through `TryResolveSigningCertificate` (reveal-at-rest, load, export public DER, dispose).
- `SSOController.SamlMetadata`, a thin, anonymous endpoint behind the shared rate-limit gate that delegates to the flow service.

## The anti-spoofing decision (base URL source)

Published SP metadata is consumed by the identity provider to decide **where it POSTs assertions**. If the ACS/entityID were derived from the request `Host` (which a reverse proxy forwarding an unfiltered `X-Forwarded-Host` can influence), an attacker could serve metadata pointing the IdP at an attacker-controlled ACS. So this endpoint uses the same authoritative source as the login flow's ACS, the configured canonical Base URL (`BaseUrlOverride`, landed in #139), and, unlike the login flow, **never falls back to the request host**. When `BaseUrlOverride` is unset (or the client id is missing, or signing is on but the key cannot be loaded) it **fails closed with 409** and publishes nothing, rather than bake a spoofable value into IdP-consumed metadata. The ACS it publishes is byte-for-byte the one the login flow produces for a provider that has `BaseUrlOverride` set.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (The endpoint fails closed with 409 when the canonical base URL / client id is unset or the signing key is unloadable; it never emits spoofable or signing-implying-but-keyless metadata.)
- [x] No secrets logged; secrets are redacted on config export. (Only the public certificate `RawData` is published; the private key / stored PFX / `OidSecret` never appear. `Metadata` logs nothing.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (4-lens adversarial gate below.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A, the endpoint logs nothing.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Pure `SamlSpMetadataBuilder`; base-URL/ACS derivation reuses `CanonicalBaseUrl` + `SsoUrlBuilder`.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new structural property; the change conforms to the existing thin-controller / internal-helper rules, which pass.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release, 0 warnings.)
- [x] `dotnet test` is green. (1193 passed, 0 failed, 13 new.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (`providers.md` unchanged by `--write`.)

## Notes

Targets the `4.2` feature branch (features branch off `4.2`, fixes off `main`). Because `4.2` is not the default branch, GitHub auto-close does not fire from a merge off it, **the issue will be closed manually on merge**.

Adversarial-review gate (4 refute-by-default lenses): availability PASS, security-bypass PASS, correctness PASS, integration PASS. The bypass lens refuted both named threats (private-key/secret leakage and Host-header spoofing of the ACS); the correctness lens confirmed the SPSSODescriptor element order (KeyDescriptor before AssertionConsumerService) is XSD-conformant.

Explicitly out of scope (candidates for follow-up, not blocking):
- The metadata advertises a single index-0 ACS in the canonical new-path (`post`) spelling. A login started on the deprecated legacy `SAML/p/...` route sends the legacy-spelled ACS; a strict IdP that validates the incoming `AssertionConsumerServiceURL` against the registered metadata could reject that legacy-route login. The canonical login matches, and our own return leg accepts both spellings. If we want to fully cover the legacy route, we would add a second `AssertionConsumerService` entry, a small follow-up if it proves needed.
- No admin-UI button for the metadata URL yet; the endpoint is fetched by URL, consistent with the other SAML options being API/config-driven today.
