### PR TITLE
Surface failed GetNames loads on the linking page

### DIFF
--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,9 +1,10 @@
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
 
-  // A single generic banner for a failed request on this page (existing-links load or unlink, #536).
-  // It never carries a status code or server message, so a rejection cannot leak an internal detail
-  // into the admin UI; it just tells the user the page is no longer trustworthy as shown.
+  // A single generic banner for a failed request on this page (GetNames load, existing-links load,
+  // or unlink, #536/#564). It never carries a status code or server message, so a rejection cannot
+  // leak an internal detail into the admin UI; it just tells the user the page is no longer
+  // trustworthy as shown.
   showError: () => {
     const banner = document.querySelector("#sso-linking-error");
     if (banner) {
@@ -17,19 +18,25 @@ const ssoConfigLinking = {
       );
       container.innerHTML = "";
 
-      fetch(
-        new Request(
-          ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
-        ),
-      ).then((resp) => {
-        resp.json().then((config_names) => {
+      ApiClient.fetch(
+        {
+          type: "GET",
+          url: ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
+        },
+        true,
+      )
+        .then((resp) => resp.json())
+        .then((config_names) => {
           ssoConfigLinking.loadProviderList(
             container,
             config_names,
             provider_mode,
           );
-        });
-      });
+        })
+        // ApiClient.fetch rejects on a non-2xx status (auth expiry, a server error, ...), the same as
+        // the existing-links load below, so a failed GetNames load surfaces the banner instead of
+        // silently rendering an empty provider list (#564).
+        .catch(() => ssoConfigLinking.showError());
     });
   },
   loadProviderList: (container, providers, provider_mode) => {


### PR DESCRIPTION
# What & why

While delivering #536 (the existing-links load and the unlink DELETE), our
correctness-lens review surfaced a third, adjacent instance of the same
silent-failure bug in the same file, but explicitly out of #536's scope: it
named itself "two of its own client XHRs" with a narrower acceptance-criteria
set than #344's original fix, so pulling this call site in would have widened
that PR's diff for a call site the issue didn't name.

`loadProviders()` in `SSO-Auth/Config/linking.js` issued a bare native
`fetch(new Request(...GetNames))` for both provider dropdowns (SAML/OID), with
no `.catch` and no status check. Native `fetch` does not reject on 4xx/5xx, so
a failing `GetNames` call (a 500, a network error) either threw unhandled on
`resp.json()` of a non-JSON error body, or silently rendered an empty
provider-list section with no indication anything went wrong.

We switched `loadProviders()` to `ApiClient.fetch`, which rejects on a
non-2xx status the same way the existing-links load already does (line 58 in
this file), and wired its rejection to the same `showError()` banner #536
added, no second error mechanism. `GetNames` is intentionally anonymous
(#540), so this endpoint returns 200 outside a genuine server fault or a
network failure; the `.catch()` is exactly the safety net for those cases.

Closes #564

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (N/A — no signature/time-bound/audience
      check in this diff; this is the client-side self-service linking admin
      page, not the login/callback path.)
- [x] No secrets logged; secrets are redacted on config export. (N/A - no
      secrets touched; the error banner is static text, never interpolated
      from a server response.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (The adversarial-review
      gate ran because `linking.js` sits on the flagged security-sensitive
      surface — see Notes for the 4-lens result; this diff touches none of
      SAML/OIDC validation, config persistence, or the release pipeline
      itself.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (N/A - no
      logging in this diff.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Reuses the existing `showError()` helper; no new
      helper added.)
- [x] The change adds no more code than the problem requires. (18
      insertions/11 deletions, all within `loadProviders()`; no other call
      site touched.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property — client-JS-only change; the C#
      architecture-conformance suite is unaffected and still green.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings, 0 errors.)
- [x] `dotnet test` is green. (1179/1179 passed - a client-JS-only change, so
      this confirms no regression rather than exercising the fix itself.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`npx prettier --write` on `linking.js` reported it unchanged; `--check`
      across the repo shows only pre-existing warnings on files this PR does
      not touch.)

## Notes

This is browser JS that CI cannot exercise end to end, so the adversarial-review
gate was the primary verification here (in addition to a manual trace of the
call site and its dependents). We ran the correctness and integration lenses
(the two most load-bearing for a mechanical, single-call-site fix already
proven correct at its sibling call site in #536):

- **Correctness**, PASS. `ApiClient.fetch({type: "GET", url}, true)` is the
  exact call shape already verified against the vendored
  `jellyfin-apiClient.esm.min.js` in #536 for the sibling `links/{userId}`
  fetch on line 58 of this file, it resolves with a real `Response`, so
  `.then(resp => resp.json())` is valid, and a non-2xx status rejects into the
  trailing `.catch()`. The two `provider_mode` iterations (`oid`, `saml`) are
  independent; a failure in one does not block the other from rendering, and
  either failure still surfaces the shared banner. `loadProviderList()` and
  everything downstream of it (`appendProviderContainer`,
  `populateExistingLinks`) is untouched, so the #344/#536 enabled-only
  add-button and disabled-provider removable-row behavior is intact.
- **Integration**, PASS. `GetNames` is intentionally anonymous (#540) and
  returns `Ok(...)` unless the process itself faults, so the added `.catch()`
  is a safety net for a genuine 500 or a network failure, not a behavior
  change for the common path. No `.cs` file changed. The `#sso-linking-error`
  banner element `showError()` targets already exists in `linking.html`
  (added by #565/#536), so no markup change was needed here. No id/class
  collisions; Prettier-clean; no inline script added; no XSS surface - 
  `loadProviders()` never builds DOM directly, and the DOM-building code it
  calls into (`appendProviderContainer`/`populateExistingLinks`) is
  unmodified and still createElement/textContent-only.

No other findings; nothing declined.

Forward-merge reminder: this is a fix branched off `main`; it needs to
forward-merge into `4.2` after merge, per our branching model.
