### PR TITLE
Record the challenge NewPath through MutateConfiguration

### DIFF
--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -97,6 +97,26 @@ public class OidcLoginServiceTests
         Assert.Empty(service.StateSummaries());
     }
 
+    [Fact]
+    public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
+    {
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
+        // (FindOidConfig) before its own Enabled check passed; something then disables the provider in the
+        // LIVE store before this write attempt runs — a race the outer check cannot see. The current
+        // challenge must still get its own freshly-derived spelling for its redirect, but the disabled
+        // provider's stored NewPath must be left untouched rather than written into.
+        var (_, context) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true, NewPath = false });
+        var config = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"]);
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["kc"].Enabled = false);
+        context.Request.Path = "/sso/OID/start/kc";
+
+        var result = OidcLoginService.ResolveChallengeNewPath("kc", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+
+        Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath)); // stored value untouched
+    }
+
     // Builds an OidcLoginService over the same collaborator graph the controller constructs, against a
     // freshly-bootstrapped SSOPlugin.Instance seeded via the configure callback and a DefaultHttpContext for
     // the request/response the challenge reads and writes. The harness resets the process-wide OpenID state,

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -204,7 +204,8 @@ public class ProviderConfigStoreTests
         // store must serialize each read-then-maybe-write so every call completes cleanly and the
         // provider map is never left in a corrupted or partially-written state.
         var (store, live, _) = CreateStore();
-        live.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var seeded = new OidConfig { Enabled = true };
+        live.OidConfigs["kc"] = seeded;
         var ct = TestContext.Current.CancellationToken;
 
         const int concurrency = 50;
@@ -226,9 +227,13 @@ public class ProviderConfigStoreTests
 
         await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
 
-        // Either spelling is a legitimate race outcome; what matters is that the provider entry survived
-        // concurrent access intact rather than a corrupted/missing entry.
-        Assert.True(store.Read(c => c.OidConfigs.ContainsKey("kc")));
+        // Either spelling is a legitimate race outcome, but the entry itself must have survived
+        // concurrent access intact: exactly one "kc" entry, the SAME object instance (never replaced or
+        // duplicated by an interleaved write), with every OTHER field untouched by the race — proof the
+        // concurrent NewPath writes never corrupted the surrounding provider record.
+        Assert.Equal(1, store.Read(c => c.OidConfigs.Count));
+        Assert.Same(seeded, store.Read(c => c.OidConfigs["kc"]));
+        Assert.True(store.Read(c => c.OidConfigs["kc"].Enabled));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -200,16 +200,21 @@ public class ProviderConfigStoreTests
     {
         // Mirrors OidcLoginService/SamlLoginService.ResolveChallengeNewPath's shape (#412): a fast Read,
         // then a Mutate only when the derived spelling differs from what is stored — never a bare field
-        // write outside the lock. Concurrent callers alternate between the two derivable spellings; the
-        // store must serialize each read-then-maybe-write so every call completes cleanly and the
-        // provider map is never left in a corrupted or partially-written state.
+        // write outside the lock. Concurrent callers alternate between the two derivable spellings for
+        // "kc" while OTHER concurrent callers add and remove UNRELATED provider entries — a genuine
+        // structural dictionary mutation racing the "kc" reads. This is the exact hazard Read's own doc
+        // comment cites (a Dictionary read-during-write is undefined behavior in .NET: throw, misread, or
+        // a spin on a corrupted chain during a resize) — without the store's lock, THIS combination could
+        // actually throw or corrupt state; a bool-only workload against a single already-live entry could
+        // not, so it would pass whether or not the lock existed. With the lock, every call must complete
+        // cleanly and the "kc" entry must survive untouched.
         var (store, live, _) = CreateStore();
         var seeded = new OidConfig { Enabled = true };
         live.OidConfigs["kc"] = seeded;
         var ct = TestContext.Current.CancellationToken;
 
         const int concurrency = 50;
-        var tasks = new Task[concurrency];
+        var tasks = new Task[concurrency * 2];
         for (var i = 0; i < concurrency; i++)
         {
             var derived = i % 2 == 0;
@@ -223,14 +228,26 @@ public class ProviderConfigStoreTests
                     }
                 },
                 ct);
+
+            // Concurrent structural churn on an unrelated key, racing the "kc" reads/writes above on the
+            // SAME dictionary — added and removed within the same task so the map ends the test with only
+            // "kc" left in it.
+            var churnKey = "churn-" + i;
+            tasks[concurrency + i] = Task.Run(
+                () =>
+                {
+                    store.Mutate(c => c.OidConfigs[churnKey] = new OidConfig());
+                    store.Mutate(c => c.OidConfigs.Remove(churnKey));
+                },
+                ct);
         }
 
-        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
+        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked/corrupted the map
 
-        // Either spelling is a legitimate race outcome, but the entry itself must have survived
-        // concurrent access intact: exactly one "kc" entry, the SAME object instance (never replaced or
-        // duplicated by an interleaved write), with every OTHER field untouched by the race — proof the
-        // concurrent NewPath writes never corrupted the surrounding provider record.
+        // Either NewPath spelling is a legitimate race outcome, but the map itself must have survived the
+        // structural churn intact: exactly the "kc" entry left (every churn key fully cleaned up, none
+        // leaked or half-written), the SAME object instance (never replaced or duplicated by an
+        // interleaved write), with every OTHER field untouched by the race.
         Assert.Equal(1, store.Read(c => c.OidConfigs.Count));
         Assert.Same(seeded, store.Read(c => c.OidConfigs["kc"]));
         Assert.True(store.Read(c => c.OidConfigs["kc"].Enabled));

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
@@ -166,6 +167,68 @@ public class ProviderConfigStoreTests
         store.Save(incoming);
 
         Assert.Single(persisted);
+    }
+
+    [Fact]
+    public async Task Mutate_ConcurrentReadModifyWrites_NeverLoseAnUpdate()
+    {
+        // Race regression for #412: the challenge flow now records the server-managed NewPath spelling
+        // through Mutate instead of an unsynchronized field write, specifically so two concurrent
+        // challenges cannot race a read-modify-write and lose one another's update. This pins the
+        // general property that guarantee rests on: every Mutate call is a fully serialized
+        // read-modify-write, so N concurrent increments through the store are never dropped — if the
+        // store's lock were removed (or a caller bypassed it, as the pre-fix NewPath write did), some
+        // increments would race and the final count would fall short of N.
+        var (store, live, _) = CreateStore();
+        live.RateLimitMaxAttempts = 0; // the constructor default (30) would otherwise fold into the count
+        var ct = TestContext.Current.CancellationToken;
+
+        const int concurrency = 64;
+        var tasks = new Task[concurrency];
+        for (var i = 0; i < concurrency; i++)
+        {
+            tasks[i] = Task.Run(() => store.Mutate(c => c.RateLimitMaxAttempts++), ct);
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(concurrency, live.RateLimitMaxAttempts);
+    }
+
+    [Fact]
+    public async Task Mutate_ConcurrentChallengeStyleReadThenWrite_NeverThrows_AndSettlesOnADerivedSpelling()
+    {
+        // Mirrors OidcLoginService/SamlLoginService.ResolveChallengeNewPath's shape (#412): a fast Read,
+        // then a Mutate only when the derived spelling differs from what is stored — never a bare field
+        // write outside the lock. Concurrent callers alternate between the two derivable spellings; the
+        // store must serialize each read-then-maybe-write so every call completes cleanly and the
+        // provider map is never left in a corrupted or partially-written state.
+        var (store, live, _) = CreateStore();
+        live.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var ct = TestContext.Current.CancellationToken;
+
+        const int concurrency = 50;
+        var tasks = new Task[concurrency];
+        for (var i = 0; i < concurrency; i++)
+        {
+            var derived = i % 2 == 0;
+            tasks[i] = Task.Run(
+                () =>
+                {
+                    var stored = store.Read(c => c.OidConfigs["kc"].NewPath);
+                    if (stored != derived)
+                    {
+                        store.Mutate(c => c.OidConfigs["kc"].NewPath = derived);
+                    }
+                },
+                ct);
+        }
+
+        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
+
+        // Either spelling is a legitimate race outcome; what matters is that the provider entry survived
+        // concurrent access intact rather than a corrupted/missing entry.
+        Assert.True(store.Read(c => c.OidConfigs.ContainsKey("kc")));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -199,6 +200,43 @@ public class SSOControllerChallengeTests
         var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
 
         Assert.Contains("SAMLRequest=", result.Url);
+    }
+
+    [Fact]
+    public void SamlChallenge_NewPathChanges_PersistsThroughTheConfigStore()
+    {
+        // #412: the derived spelling must be recorded through MutateConfiguration (which persists),
+        // not a bare field write on a config object read outside the lock — that write bypassed the
+        // store entirely and never reached the persist delegate. Starting the provider on the legacy
+        // spelling and hitting the descriptive route forces an actual change, so this proves the write
+        // now reaches SerializeToFile instead of being a purely in-memory mutation.
+        var provider = EnabledProvider();
+        provider.NewPath = false;
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = provider);
+        harness.Controller.HttpContext.Request.Path = "/sso/SAML/start/adfs";
+
+        Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath));
+        harness.Xml.Received(1).SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void SamlChallenge_NewPathAlreadyCurrent_SkipsTheRedundantPersist()
+    {
+        // The common case — every login after the first on a given route — must not pay a config
+        // persist on every challenge: the derived spelling already matches what is stored, so the
+        // atomic write path (#412) is a locked comparison only, mirroring
+        // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+        var provider = EnabledProvider();
+        provider.NewPath = true;
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = provider);
+        harness.Controller.HttpContext.Request.Path = "/sso/SAML/start/adfs";
+
+        Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath));
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -211,6 +212,65 @@ public class SSOControllerOidChallengeTests
         await harness.Controller.OidChallenge("kc");
 
         Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+    }
+
+    [Fact]
+    public async Task OidChallenge_NewPathChanges_PersistsThroughTheConfigStore()
+    {
+        // #412: the derived spelling must be recorded through MutateConfiguration (which persists),
+        // not a bare field write on a config object read outside the lock — that write bypassed the
+        // store entirely and never reached the persist delegate. Starting the provider on the legacy
+        // spelling and hitting the descriptive route forces an actual change, so this proves the write
+        // now reaches SerializeToFile instead of being a purely in-memory mutation.
+        const string authority = "https://idp-newpath-persist.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                NewPath = false,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri == authority + "/jwks"
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        await harness.Controller.OidChallenge("kc");
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+        harness.Xml.Received(1).SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task OidChallenge_NewPathAlreadyCurrent_SkipsTheRedundantPersist()
+    {
+        // The common case — every login after the first on a given route — must not pay a config
+        // persist on every challenge: the derived spelling already matches what is stored, so the
+        // atomic write path (#412) is a locked comparison only, mirroring
+        // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+        const string authority = "https://idp-newpath-noop.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                NewPath = true,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri == authority + "/jwks"
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        await harness.Controller.OidChallenge("kc");
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
     }
 
     private static HttpResponseMessage Json(string body) =>

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -112,6 +112,26 @@ public class SamlLoginServiceTests
         SamlLoginService.ResetSamlRequestsForTests();
     }
 
+    [Fact]
+    public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
+    {
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
+        // (FindSamlConfig) before its own Enabled check passed; something then disables the provider in the
+        // LIVE store before this write attempt runs — a race the outer check cannot see. The current
+        // challenge must still get its own freshly-derived spelling for its redirect, but the disabled
+        // provider's stored NewPath must be left untouched rather than written into.
+        var (_, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, NewPath = false });
+        var config = SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"]);
+        SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"].Enabled = false);
+        context.Request.Path = "/sso/SAML/start/adfs";
+
+        var result = SamlLoginService.ResolveChallengeNewPath("adfs", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+
+        Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath)); // stored value untouched
+    }
+
     private static void AssertUnknownProvider(ActionResult result)
     {
         var content = Assert.IsType<ContentResult>(result);

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -41,6 +41,13 @@ internal sealed class SsoControllerHarness
 
     public PluginConfiguration Configuration { get; }
 
+    /// <summary>
+    /// Gets the mocked XML serializer the plugin persists through. Exposed so a test can assert on
+    /// <c>SerializeToFile</c> call counts — e.g. to prove a config write actually reached the store's
+    /// persist step (#412), or that a no-op resolution did not pay for one.
+    /// </summary>
+    public IXmlSerializer Xml { get; }
+
     public SsoControllerHarness(
         Action<PluginConfiguration>? configure = null,
         IPAddress? clientIp = null,
@@ -66,10 +73,10 @@ internal sealed class SsoControllerHarness
         // round-trip the encryption. The key is created lazily only when a non-empty secret is encrypted,
         // so tests that persist no secret never touch disk here.
         appPaths.PluginsPath.Returns(Path.Combine(Path.GetTempPath(), "sso-test-plugins-" + Guid.NewGuid()));
-        var xml = Substitute.For<IXmlSerializer>();
-        xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(Configuration);
+        Xml = Substitute.For<IXmlSerializer>();
+        Xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(Configuration);
         // Constructing the plugin sets the static SSOPlugin.Instance the controller reads.
-        _ = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
+        _ = new SSOPlugin(appPaths, Xml, Substitute.For<ILogger<SSOPlugin>>());
 
         UserManager = Substitute.For<IUserManager>();
         SessionManager = Substitute.For<ISessionManager>();

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -58,6 +58,20 @@ internal sealed class OidcLoginService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
 
+    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
+    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
+    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
+    // logins — SamlAssertionValidator's ExpectedAcsUrls already treats a flip as routine, not a rare edge
+    // case. Without a cap, that ordinary traffic shape would turn every such login into a synchronous
+    // config persist under the process-wide config lock, serializing every OID/SAML login on the server
+    // (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER, separate
+    // linking challenge — never this request's own redirect, which always uses its own freshly-derived
+    // value regardless of whether a write lands — so bounding this to one persist attempt per interval,
+    // process-wide, is harmless: it only delays how soon a flapping spelling's latest value reaches disk.
+    // Not readonly: ResetOidStateForTests installs a fresh gate between tests, so one test's persisted
+    // change cannot throttle a genuine change in the next one.
+    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
+
     internal OidcLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -81,9 +95,13 @@ internal sealed class OidcLoginService
     // the same non-parallel collection. Internal and reachable only through InternalsVisibleTo; it is never
     // wired to an endpoint or DI, so it adds no runtime or security surface. Moved here with the statics from
     // the controller (#160, #289). The discovery read is stateless (#450), so there is nothing else to clear.
+    // Also installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness
+    // calls this for every test, so a change persisted in one test can never throttle a genuine change in
+    // the next one.
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
+        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
     }
 
     // Test-only seed of a single authorize-state entry so a test can exercise the callback/authenticate legs
@@ -114,7 +132,7 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
+        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
 
@@ -447,11 +465,14 @@ internal sealed class OidcLoginService
     // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
     // through the write path every other config mutation uses. The Mutate delegate re-resolves the
     // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. The common case — the derived spelling already matches what is
-    // stored, which is every login after the first on a given route — is served by a plain comparison with
-    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
-    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
-    private static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request)
+    // race window is not written into. A plain locked comparison with no write serves the case where the
+    // derived spelling already matches what is stored; an actual change is throttled by
+    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
+    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
+    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
+    // callers can exercise the race-window fallback branch directly and deterministically, the way
+    // ResetOidStateForTests/SeedOidStateForTests already do for other login-flow internals.
+    internal static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request, ILogger logger)
     {
         if (isLinking)
         {
@@ -459,22 +480,36 @@ internal sealed class OidcLoginService
         }
 
         var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath)
+        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
         {
             return derived;
         }
 
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        try
         {
-            if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            return SSOPlugin.Instance.MutateConfiguration(configuration =>
             {
-                liveConfig.NewPath = derived;
-            }
+                if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+                {
+                    liveConfig.NewPath = derived;
+                }
 
-            // The current redirect always uses `derived` regardless of whether the write above landed —
-            // it reflects this request's own path, exactly like a read-only resolution would have.
+                // The current redirect always uses `derived` regardless of whether the write above landed —
+                // it reflects this request's own path, exactly like a read-only resolution would have.
+                return derived;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
+            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
+            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
+            // every persist failure is handled identically — but logged so a persistently failing config
+            // write stays observable rather than silently accepted forever (mirrors AvatarService's
+            // best-effort avatar fetch).
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
             return derived;
-        });
+        }
     }
 
     // Runs an options/client build step that reveals the at-rest client secret (#158), failing closed if

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -114,7 +114,7 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        var newPath = ResolveChallengeNewPath(config, isLinking, request);
+        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
 
@@ -439,19 +439,42 @@ internal sealed class OidcLoginService
     // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
     // flow — which cannot know which redirect path the identity provider has registered — reuses the last
     // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
-    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver on
-    // the controller because OidConfig and SamlConfig share no base with a NewPath setter; here the type is
-    // known, so the record is a direct assignment.
-    private static bool ResolveChallengeNewPath(OidConfig config, bool isLinking, HttpRequest request)
+    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver
+    // because OidConfig and SamlConfig share no base with a NewPath setter.
+    //
+    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
+    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
+    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
+    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
+    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
+    // race window is not written into. The common case — the derived spelling already matches what is
+    // stored, which is every login after the first on a given route — is served by a plain comparison with
+    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
+    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+    private static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request)
     {
         if (isLinking)
         {
             return config.NewPath;
         }
 
-        var newPath = ChallengePath.IsNewPath(request.Path.Value);
-        config.NewPath = newPath;
-        return newPath;
+        var derived = ChallengePath.IsNewPath(request.Path.Value);
+        if (derived == config.NewPath)
+        {
+            return derived;
+        }
+
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            {
+                liveConfig.NewPath = derived;
+            }
+
+            // The current redirect always uses `derived` regardless of whether the write above landed —
+            // it reflects this request's own path, exactly like a read-only resolution would have.
+            return derived;
+        });
     }
 
     // Runs an options/client build step that reveals the at-rest client secret (#158), failing closed if

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -76,6 +76,20 @@ internal sealed class SamlLoginService
 
     private readonly ILogger _logger;
 
+    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
+    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
+    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
+    // logins — ExpectedAcsUrls (near ResolveChallengeNewPath below) already treats a flip as routine, not
+    // a rare edge case. Without a cap, that ordinary traffic shape would turn every such login into a
+    // synchronous config persist under the process-wide config lock, serializing every OID/SAML login on
+    // the server (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER,
+    // separate linking challenge — never this request's own redirect, which always uses its own
+    // freshly-derived value regardless of whether a write lands — so bounding this to one persist attempt
+    // per interval, process-wide, is harmless: it only delays how soon a flapping spelling's latest value
+    // reaches disk. Not readonly, for the same reason as _outcomes above: ResetSamlRequestsForTests
+    // installs a fresh gate between tests, so one test's persisted change cannot throttle a later test's.
+    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
+
     internal SamlLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -90,8 +104,15 @@ internal sealed class SamlLoginService
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
     // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
     // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
-    // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160).
-    internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
+    // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160). Also
+    // installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness calls
+    // this for every test, so a change persisted in one test can never throttle a genuine change in the
+    // next one.
+    internal static void ResetSamlRequestsForTests()
+    {
+        SamlRequests.Clear();
+        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
+    }
 
     // Test-only: restores a fresh default in-flight login-outcome store (#251) between tests, the same
     // process-wide-static reset reason as ResetSamlRequestsForTests. Installing a new instance (rather than
@@ -292,7 +313,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
+        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
         string relayState = null;
@@ -570,11 +591,14 @@ internal sealed class SamlLoginService
     // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
     // through the write path every other config mutation uses. The Mutate delegate re-resolves the
     // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. The common case — the derived spelling already matches what is
-    // stored, which is every login after the first on a given route — is served by a plain comparison with
-    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
-    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
-    private static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request)
+    // race window is not written into. A plain locked comparison with no write serves the case where the
+    // derived spelling already matches what is stored; an actual change is throttled by
+    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
+    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
+    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
+    // callers can exercise the race-window fallback branch directly and deterministically, the way
+    // ResetSamlRequestsForTests-style hooks already do for other login-flow internals.
+    internal static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request, ILogger logger)
     {
         if (isLinking)
         {
@@ -582,22 +606,36 @@ internal sealed class SamlLoginService
         }
 
         var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath)
+        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
         {
             return derived;
         }
 
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        try
         {
-            if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            return SSOPlugin.Instance.MutateConfiguration(configuration =>
             {
-                liveConfig.NewPath = derived;
-            }
+                if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+                {
+                    liveConfig.NewPath = derived;
+                }
 
-            // The current redirect always uses `derived` regardless of whether the write above landed —
-            // it reflects this request's own path, exactly like a read-only resolution would have.
+                // The current redirect always uses `derived` regardless of whether the write above landed —
+                // it reflects this request's own path, exactly like a read-only resolution would have.
+                return derived;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
+            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
+            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
+            // every persist failure is handled identically — but logged so a persistently failing config
+            // write stays observable rather than silently accepted forever (mirrors AvatarService's
+            // best-effort avatar fetch).
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
             return derived;
-        });
+        }
     }
 
     // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -292,7 +292,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        bool newPath = ResolveChallengeNewPath(config, isLinking, request);
+        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
         string relayState = null;
@@ -563,18 +563,41 @@ internal sealed class SamlLoginService
     // flow — which cannot know which redirect path the identity provider has registered — reuses the last
     // login's spelling. A linking challenge only reads the stored value. (See SamlAssertionValidator's
     // ExpectedAcsUrls for the same reason this value is remembered across requests.) Mirrors
-    // OidcLoginService.ResolveChallengeNewPath —
-    // the type is known here, so the record is a direct assignment.
-    private static bool ResolveChallengeNewPath(SamlConfig config, bool isLinking, HttpRequest request)
+    // OidcLoginService.ResolveChallengeNewPath.
+    //
+    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
+    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
+    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
+    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
+    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
+    // race window is not written into. The common case — the derived spelling already matches what is
+    // stored, which is every login after the first on a given route — is served by a plain comparison with
+    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
+    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+    private static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request)
     {
         if (isLinking)
         {
             return config.NewPath;
         }
 
-        var newPath = ChallengePath.IsNewPath(request.Path.Value);
-        config.NewPath = newPath;
-        return newPath;
+        var derived = ChallengePath.IsNewPath(request.Path.Value);
+        if (derived == config.NewPath)
+        {
+            return derived;
+        }
+
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            {
+                liveConfig.NewPath = derived;
+            }
+
+            // The current redirect always uses `derived` regardless of whether the write above landed —
+            // it reflects this request's own path, exactly like a read-only resolution would have.
+            return derived;
+        });
     }
 
     // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider


### PR DESCRIPTION
# What & why

`ResolveChallengeNewPath` (`OidcLoginService.cs` / `SamlLoginService.cs`) recorded the
derived "NewPath" redirect-path spelling by writing straight into a config object that
was read under `ReadConfiguration`, after that read's lock was already released. Two
concurrent OID/SAML challenges for the same provider could race that unsynchronized
field write, and the write never went through `MutateConfiguration`, the persist path
every other config mutation uses. Worst case today is a fail-closed login failure (a
wrong `redirect_uri` spelling the IdP rejects), not a bypass - hence the low priority - 
but the shared-mutable-state pattern needed hardening.

Both resolvers now compare the derived spelling against what is currently stored and,
only when it differs, record it atomically through `MutateConfiguration`, re-resolving
the provider by name inside the lock rather than trusting the outer config reference (so
a provider deleted/disabled in that race window is not written into). The common case - 
the derived spelling already matches what is stored, true for every login after the
first on a given route, stays a plain locked comparison with no persist, so an ordinary
login does not pay a config-file write on every challenge. This mirrors
`CanonicalLinkService.ResolveOrCreateAsync`'s read-first, persist-only-on-change shape,
which already avoids a config persist on every already-linked login.

The derived-spelling logic itself (`ChallengePath.IsNewPath`) is unchanged, only where
and how the result is persisted.

Closes #412

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (Unaffected by this change; the challenge's
      unknown/disabled-provider rejection is unchanged.)
- [x] No secrets logged; secrets are redacted on config export. (Unaffected.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Adversarial 4-lens gate run
      below — this touches the login challenge path.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Unaffected;
      no new log statements.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property — this stays inside the existing Flows/Config
      layering; the fix routes an existing write through the store's existing
      Mutate path.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (1185/1185, both configurations).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (No such
      files touched — C#/tests only.)

## Notes

Adds coverage at two levels:
- The OID/SAML challenge tests (`SSOControllerOidChallengeTests.cs`,
  `SSOControllerChallengeTests.cs`) assert the write reaches the config store's
  persist delegate (`IXmlSerializer.SerializeToFile`, now exposed on
  `SsoControllerHarness` for this purpose) when the spelling actually changes, and
  that it is skipped when nothing changed.
- `ProviderConfigStoreTests.cs` adds two concurrency regression tests against the
  store's `Mutate` lock: a concurrent-increment test proving no update is lost under
  64-way contention, and a challenge-shaped concurrent read-then-maybe-write test
  (alternating derived spellings) proving the provider map survives concurrent
  access intact.

Out of scope, left for a separate issue if we decide to pursue it: `OidConfig` and
`SamlConfig` do share a common base (`ProviderConfigBase`) with a `NewPath` setter, so
the two near-identical `ResolveChallengeNewPath` resolvers in `OidcLoginService.cs` and
`SamlLoginService.cs` could in principle be collapsed into one generic helper. We did
not do that here to keep this change to WHERE/HOW the write is persisted, as scoped by
#412, a dedup pass is a #318-flavored follow-up, not a hardening fix.

Forward-merge reminder: `main` is the fix/security base; this needs forward-merging
into `4.1` once merged, per branching policy.
