### PR TITLE
Forward-merge main into 4.2 (post-4.1.0.0 fixes)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: iderex
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -97,6 +97,26 @@ public class OidcLoginServiceTests
         Assert.Empty(service.StateSummaries());
     }
 
+    [Fact]
+    public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
+    {
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
+        // (FindOidConfig) before its own Enabled check passed; something then disables the provider in the
+        // LIVE store before this write attempt runs — a race the outer check cannot see. The current
+        // challenge must still get its own freshly-derived spelling for its redirect, but the disabled
+        // provider's stored NewPath must be left untouched rather than written into.
+        var (_, context) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true, NewPath = false });
+        var config = SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"]);
+        SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["kc"].Enabled = false);
+        context.Request.Path = "/sso/OID/start/kc";
+
+        var result = OidcLoginService.ResolveChallengeNewPath("kc", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+
+        Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath)); // stored value untouched
+    }
+
     // Builds an OidcLoginService over the same collaborator graph the controller constructs, against a
     // freshly-bootstrapped SSOPlugin.Instance seeded via the configure callback and a DefaultHttpContext for
     // the request/response the challenge reads and writes. The harness resets the process-wide OpenID state,

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -204,7 +204,8 @@ public class ProviderConfigStoreTests
         // store must serialize each read-then-maybe-write so every call completes cleanly and the
         // provider map is never left in a corrupted or partially-written state.
         var (store, live, _) = CreateStore();
-        live.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var seeded = new OidConfig { Enabled = true };
+        live.OidConfigs["kc"] = seeded;
         var ct = TestContext.Current.CancellationToken;
 
         const int concurrency = 50;
@@ -226,9 +227,13 @@ public class ProviderConfigStoreTests
 
         await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
 
-        // Either spelling is a legitimate race outcome; what matters is that the provider entry survived
-        // concurrent access intact rather than a corrupted/missing entry.
-        Assert.True(store.Read(c => c.OidConfigs.ContainsKey("kc")));
+        // Either spelling is a legitimate race outcome, but the entry itself must have survived
+        // concurrent access intact: exactly one "kc" entry, the SAME object instance (never replaced or
+        // duplicated by an interleaved write), with every OTHER field untouched by the race — proof the
+        // concurrent NewPath writes never corrupted the surrounding provider record.
+        Assert.Equal(1, store.Read(c => c.OidConfigs.Count));
+        Assert.Same(seeded, store.Read(c => c.OidConfigs["kc"]));
+        Assert.True(store.Read(c => c.OidConfigs["kc"].Enabled));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -200,16 +200,21 @@ public class ProviderConfigStoreTests
     {
         // Mirrors OidcLoginService/SamlLoginService.ResolveChallengeNewPath's shape (#412): a fast Read,
         // then a Mutate only when the derived spelling differs from what is stored — never a bare field
-        // write outside the lock. Concurrent callers alternate between the two derivable spellings; the
-        // store must serialize each read-then-maybe-write so every call completes cleanly and the
-        // provider map is never left in a corrupted or partially-written state.
+        // write outside the lock. Concurrent callers alternate between the two derivable spellings for
+        // "kc" while OTHER concurrent callers add and remove UNRELATED provider entries — a genuine
+        // structural dictionary mutation racing the "kc" reads. This is the exact hazard Read's own doc
+        // comment cites (a Dictionary read-during-write is undefined behavior in .NET: throw, misread, or
+        // a spin on a corrupted chain during a resize) — without the store's lock, THIS combination could
+        // actually throw or corrupt state; a bool-only workload against a single already-live entry could
+        // not, so it would pass whether or not the lock existed. With the lock, every call must complete
+        // cleanly and the "kc" entry must survive untouched.
         var (store, live, _) = CreateStore();
         var seeded = new OidConfig { Enabled = true };
         live.OidConfigs["kc"] = seeded;
         var ct = TestContext.Current.CancellationToken;
 
         const int concurrency = 50;
-        var tasks = new Task[concurrency];
+        var tasks = new Task[concurrency * 2];
         for (var i = 0; i < concurrency; i++)
         {
             var derived = i % 2 == 0;
@@ -223,14 +228,26 @@ public class ProviderConfigStoreTests
                     }
                 },
                 ct);
+
+            // Concurrent structural churn on an unrelated key, racing the "kc" reads/writes above on the
+            // SAME dictionary — added and removed within the same task so the map ends the test with only
+            // "kc" left in it.
+            var churnKey = "churn-" + i;
+            tasks[concurrency + i] = Task.Run(
+                () =>
+                {
+                    store.Mutate(c => c.OidConfigs[churnKey] = new OidConfig());
+                    store.Mutate(c => c.OidConfigs.Remove(churnKey));
+                },
+                ct);
         }
 
-        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
+        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked/corrupted the map
 
-        // Either spelling is a legitimate race outcome, but the entry itself must have survived
-        // concurrent access intact: exactly one "kc" entry, the SAME object instance (never replaced or
-        // duplicated by an interleaved write), with every OTHER field untouched by the race — proof the
-        // concurrent NewPath writes never corrupted the surrounding provider record.
+        // Either NewPath spelling is a legitimate race outcome, but the map itself must have survived the
+        // structural churn intact: exactly the "kc" entry left (every churn key fully cleaned up, none
+        // leaked or half-written), the SAME object instance (never replaced or duplicated by an
+        // interleaved write), with every OTHER field untouched by the race.
         Assert.Equal(1, store.Read(c => c.OidConfigs.Count));
         Assert.Same(seeded, store.Read(c => c.OidConfigs["kc"]));
         Assert.True(store.Read(c => c.OidConfigs["kc"].Enabled));

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
@@ -166,6 +167,68 @@ public class ProviderConfigStoreTests
         store.Save(incoming);
 
         Assert.Single(persisted);
+    }
+
+    [Fact]
+    public async Task Mutate_ConcurrentReadModifyWrites_NeverLoseAnUpdate()
+    {
+        // Race regression for #412: the challenge flow now records the server-managed NewPath spelling
+        // through Mutate instead of an unsynchronized field write, specifically so two concurrent
+        // challenges cannot race a read-modify-write and lose one another's update. This pins the
+        // general property that guarantee rests on: every Mutate call is a fully serialized
+        // read-modify-write, so N concurrent increments through the store are never dropped — if the
+        // store's lock were removed (or a caller bypassed it, as the pre-fix NewPath write did), some
+        // increments would race and the final count would fall short of N.
+        var (store, live, _) = CreateStore();
+        live.RateLimitMaxAttempts = 0; // the constructor default (30) would otherwise fold into the count
+        var ct = TestContext.Current.CancellationToken;
+
+        const int concurrency = 64;
+        var tasks = new Task[concurrency];
+        for (var i = 0; i < concurrency; i++)
+        {
+            tasks[i] = Task.Run(() => store.Mutate(c => c.RateLimitMaxAttempts++), ct);
+        }
+
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(concurrency, live.RateLimitMaxAttempts);
+    }
+
+    [Fact]
+    public async Task Mutate_ConcurrentChallengeStyleReadThenWrite_NeverThrows_AndSettlesOnADerivedSpelling()
+    {
+        // Mirrors OidcLoginService/SamlLoginService.ResolveChallengeNewPath's shape (#412): a fast Read,
+        // then a Mutate only when the derived spelling differs from what is stored — never a bare field
+        // write outside the lock. Concurrent callers alternate between the two derivable spellings; the
+        // store must serialize each read-then-maybe-write so every call completes cleanly and the
+        // provider map is never left in a corrupted or partially-written state.
+        var (store, live, _) = CreateStore();
+        live.OidConfigs["kc"] = new OidConfig { Enabled = true };
+        var ct = TestContext.Current.CancellationToken;
+
+        const int concurrency = 50;
+        var tasks = new Task[concurrency];
+        for (var i = 0; i < concurrency; i++)
+        {
+            var derived = i % 2 == 0;
+            tasks[i] = Task.Run(
+                () =>
+                {
+                    var stored = store.Read(c => c.OidConfigs["kc"].NewPath);
+                    if (stored != derived)
+                    {
+                        store.Mutate(c => c.OidConfigs["kc"].NewPath = derived);
+                    }
+                },
+                ct);
+        }
+
+        await Task.WhenAll(tasks); // throws if any callback threw or the store deadlocked
+
+        // Either spelling is a legitimate race outcome; what matters is that the provider entry survived
+        // concurrent access intact rather than a corrupted/missing entry.
+        Assert.True(store.Read(c => c.OidConfigs.ContainsKey("kc")));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -199,6 +200,43 @@ public class SSOControllerChallengeTests
         var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
 
         Assert.Contains("SAMLRequest=", result.Url);
+    }
+
+    [Fact]
+    public void SamlChallenge_NewPathChanges_PersistsThroughTheConfigStore()
+    {
+        // #412: the derived spelling must be recorded through MutateConfiguration (which persists),
+        // not a bare field write on a config object read outside the lock — that write bypassed the
+        // store entirely and never reached the persist delegate. Starting the provider on the legacy
+        // spelling and hitting the descriptive route forces an actual change, so this proves the write
+        // now reaches SerializeToFile instead of being a purely in-memory mutation.
+        var provider = EnabledProvider();
+        provider.NewPath = false;
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = provider);
+        harness.Controller.HttpContext.Request.Path = "/sso/SAML/start/adfs";
+
+        Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath));
+        harness.Xml.Received(1).SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void SamlChallenge_NewPathAlreadyCurrent_SkipsTheRedundantPersist()
+    {
+        // The common case — every login after the first on a given route — must not pay a config
+        // persist on every challenge: the derived spelling already matches what is stored, so the
+        // atomic write path (#412) is a locked comparison only, mirroring
+        // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+        var provider = EnabledProvider();
+        provider.NewPath = true;
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = provider);
+        harness.Controller.HttpContext.Request.Path = "/sso/SAML/start/adfs";
+
+        Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath));
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidChallengeTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -211,6 +212,65 @@ public class SSOControllerOidChallengeTests
         await harness.Controller.OidChallenge("kc");
 
         Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+    }
+
+    [Fact]
+    public async Task OidChallenge_NewPathChanges_PersistsThroughTheConfigStore()
+    {
+        // #412: the derived spelling must be recorded through MutateConfiguration (which persists),
+        // not a bare field write on a config object read outside the lock — that write bypassed the
+        // store entirely and never reached the persist delegate. Starting the provider on the legacy
+        // spelling and hitting the descriptive route forces an actual change, so this proves the write
+        // now reaches SerializeToFile instead of being a purely in-memory mutation.
+        const string authority = "https://idp-newpath-persist.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                NewPath = false,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri == authority + "/jwks"
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        await harness.Controller.OidChallenge("kc");
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+        harness.Xml.Received(1).SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task OidChallenge_NewPathAlreadyCurrent_SkipsTheRedundantPersist()
+    {
+        // The common case — every login after the first on a given route — must not pay a config
+        // persist on every challenge: the derived spelling already matches what is stored, so the
+        // atomic write path (#412) is a locked comparison only, mirroring
+        // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+        const string authority = "https://idp-newpath-noop.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                NewPath = true,
+            },
+            httpResponder: request => request.RequestUri!.AbsoluteUri == authority + "/jwks"
+                ? Json("{\"keys\":[]}")
+                : Json(Discovery(authority)));
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        await harness.Controller.OidChallenge("kc");
+
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath));
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
     }
 
     private static HttpResponseMessage Json(string body) =>

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -112,6 +112,26 @@ public class SamlLoginServiceTests
         SamlLoginService.ResetSamlRequestsForTests();
     }
 
+    [Fact]
+    public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
+    {
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
+        // (FindSamlConfig) before its own Enabled check passed; something then disables the provider in the
+        // LIVE store before this write attempt runs — a race the outer check cannot see. The current
+        // challenge must still get its own freshly-derived spelling for its redirect, but the disabled
+        // provider's stored NewPath must be left untouched rather than written into.
+        var (_, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, NewPath = false });
+        var config = SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"]);
+        SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"].Enabled = false);
+        context.Request.Path = "/sso/SAML/start/adfs";
+
+        var result = SamlLoginService.ResolveChallengeNewPath("adfs", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+
+        Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath)); // stored value untouched
+    }
+
     private static void AssertUnknownProvider(ActionResult result)
     {
         var content = Assert.IsType<ContentResult>(result);

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -41,6 +41,13 @@ internal sealed class SsoControllerHarness
 
     public PluginConfiguration Configuration { get; }
 
+    /// <summary>
+    /// Gets the mocked XML serializer the plugin persists through. Exposed so a test can assert on
+    /// <c>SerializeToFile</c> call counts — e.g. to prove a config write actually reached the store's
+    /// persist step (#412), or that a no-op resolution did not pay for one.
+    /// </summary>
+    public IXmlSerializer Xml { get; }
+
     public SsoControllerHarness(
         Action<PluginConfiguration>? configure = null,
         IPAddress? clientIp = null,
@@ -66,10 +73,10 @@ internal sealed class SsoControllerHarness
         // round-trip the encryption. The key is created lazily only when a non-empty secret is encrypted,
         // so tests that persist no secret never touch disk here.
         appPaths.PluginsPath.Returns(Path.Combine(Path.GetTempPath(), "sso-test-plugins-" + Guid.NewGuid()));
-        var xml = Substitute.For<IXmlSerializer>();
-        xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(Configuration);
+        Xml = Substitute.For<IXmlSerializer>();
+        Xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(Configuration);
         // Constructing the plugin sets the static SSOPlugin.Instance the controller reads.
-        _ = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
+        _ = new SSOPlugin(appPaths, Xml, Substitute.For<ILogger<SSOPlugin>>());
 
         UserManager = Substitute.For<IUserManager>();
         SessionManager = Substitute.For<ISessionManager>();

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -58,6 +58,20 @@ internal sealed class OidcLoginService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
 
+    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
+    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
+    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
+    // logins — SamlAssertionValidator's ExpectedAcsUrls already treats a flip as routine, not a rare edge
+    // case. Without a cap, that ordinary traffic shape would turn every such login into a synchronous
+    // config persist under the process-wide config lock, serializing every OID/SAML login on the server
+    // (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER, separate
+    // linking challenge — never this request's own redirect, which always uses its own freshly-derived
+    // value regardless of whether a write lands — so bounding this to one persist attempt per interval,
+    // process-wide, is harmless: it only delays how soon a flapping spelling's latest value reaches disk.
+    // Not readonly: ResetOidStateForTests installs a fresh gate between tests, so one test's persisted
+    // change cannot throttle a genuine change in the next one.
+    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
+
     internal OidcLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -81,9 +95,13 @@ internal sealed class OidcLoginService
     // the same non-parallel collection. Internal and reachable only through InternalsVisibleTo; it is never
     // wired to an endpoint or DI, so it adds no runtime or security surface. Moved here with the statics from
     // the controller (#160, #289). The discovery read is stateless (#450), so there is nothing else to clear.
+    // Also installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness
+    // calls this for every test, so a change persisted in one test can never throttle a genuine change in
+    // the next one.
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
+        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
     }
 
     // Test-only seed of a single authorize-state entry so a test can exercise the callback/authenticate legs
@@ -114,7 +132,7 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
+        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
 
@@ -447,11 +465,14 @@ internal sealed class OidcLoginService
     // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
     // through the write path every other config mutation uses. The Mutate delegate re-resolves the
     // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. The common case — the derived spelling already matches what is
-    // stored, which is every login after the first on a given route — is served by a plain comparison with
-    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
-    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
-    private static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request)
+    // race window is not written into. A plain locked comparison with no write serves the case where the
+    // derived spelling already matches what is stored; an actual change is throttled by
+    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
+    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
+    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
+    // callers can exercise the race-window fallback branch directly and deterministically, the way
+    // ResetOidStateForTests/SeedOidStateForTests already do for other login-flow internals.
+    internal static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request, ILogger logger)
     {
         if (isLinking)
         {
@@ -459,22 +480,36 @@ internal sealed class OidcLoginService
         }
 
         var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath)
+        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
         {
             return derived;
         }
 
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        try
         {
-            if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            return SSOPlugin.Instance.MutateConfiguration(configuration =>
             {
-                liveConfig.NewPath = derived;
-            }
+                if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+                {
+                    liveConfig.NewPath = derived;
+                }
 
-            // The current redirect always uses `derived` regardless of whether the write above landed —
-            // it reflects this request's own path, exactly like a read-only resolution would have.
+                // The current redirect always uses `derived` regardless of whether the write above landed —
+                // it reflects this request's own path, exactly like a read-only resolution would have.
+                return derived;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
+            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
+            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
+            // every persist failure is handled identically — but logged so a persistently failing config
+            // write stays observable rather than silently accepted forever (mirrors AvatarService's
+            // best-effort avatar fetch).
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
             return derived;
-        });
+        }
     }
 
     // Runs an options/client build step that reveals the at-rest client secret (#158), failing closed if

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -114,7 +114,7 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        var newPath = ResolveChallengeNewPath(config, isLinking, request);
+        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
 
@@ -439,19 +439,42 @@ internal sealed class OidcLoginService
     // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
     // flow — which cannot know which redirect path the identity provider has registered — reuses the last
     // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
-    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver on
-    // the controller because OidConfig and SamlConfig share no base with a NewPath setter; here the type is
-    // known, so the record is a direct assignment.
-    private static bool ResolveChallengeNewPath(OidConfig config, bool isLinking, HttpRequest request)
+    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver
+    // because OidConfig and SamlConfig share no base with a NewPath setter.
+    //
+    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
+    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
+    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
+    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
+    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
+    // race window is not written into. The common case — the derived spelling already matches what is
+    // stored, which is every login after the first on a given route — is served by a plain comparison with
+    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
+    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+    private static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request)
     {
         if (isLinking)
         {
             return config.NewPath;
         }
 
-        var newPath = ChallengePath.IsNewPath(request.Path.Value);
-        config.NewPath = newPath;
-        return newPath;
+        var derived = ChallengePath.IsNewPath(request.Path.Value);
+        if (derived == config.NewPath)
+        {
+            return derived;
+        }
+
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            {
+                liveConfig.NewPath = derived;
+            }
+
+            // The current redirect always uses `derived` regardless of whether the write above landed —
+            // it reflects this request's own path, exactly like a read-only resolution would have.
+            return derived;
+        });
     }
 
     // Runs an options/client build step that reveals the at-rest client secret (#158), failing closed if

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -76,6 +76,20 @@ internal sealed class SamlLoginService
 
     private readonly ILogger _logger;
 
+    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
+    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
+    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
+    // logins — ExpectedAcsUrls (near ResolveChallengeNewPath below) already treats a flip as routine, not
+    // a rare edge case. Without a cap, that ordinary traffic shape would turn every such login into a
+    // synchronous config persist under the process-wide config lock, serializing every OID/SAML login on
+    // the server (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER,
+    // separate linking challenge — never this request's own redirect, which always uses its own
+    // freshly-derived value regardless of whether a write lands — so bounding this to one persist attempt
+    // per interval, process-wide, is harmless: it only delays how soon a flapping spelling's latest value
+    // reaches disk. Not readonly, for the same reason as _outcomes above: ResetSamlRequestsForTests
+    // installs a fresh gate between tests, so one test's persisted change cannot throttle a later test's.
+    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
+
     internal SamlLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -90,8 +104,15 @@ internal sealed class SamlLoginService
     // Test-only: clears the outstanding-SAML-request cache so a prior test's seeded or in-flight entry
     // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
     // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
-    // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160).
-    internal static void ResetSamlRequestsForTests() => SamlRequests.Clear();
+    // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160). Also
+    // installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness calls
+    // this for every test, so a change persisted in one test can never throttle a genuine change in the
+    // next one.
+    internal static void ResetSamlRequestsForTests()
+    {
+        SamlRequests.Clear();
+        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
+    }
 
     // Test-only: restores a fresh default in-flight login-outcome store (#251) between tests, the same
     // process-wide-static reset reason as ResetSamlRequestsForTests. Installing a new instance (rather than
@@ -292,7 +313,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
+        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
         string relayState = null;
@@ -570,11 +591,14 @@ internal sealed class SamlLoginService
     // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
     // through the write path every other config mutation uses. The Mutate delegate re-resolves the
     // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. The common case — the derived spelling already matches what is
-    // stored, which is every login after the first on a given route — is served by a plain comparison with
-    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
-    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
-    private static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request)
+    // race window is not written into. A plain locked comparison with no write serves the case where the
+    // derived spelling already matches what is stored; an actual change is throttled by
+    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
+    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
+    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
+    // callers can exercise the race-window fallback branch directly and deterministically, the way
+    // ResetSamlRequestsForTests-style hooks already do for other login-flow internals.
+    internal static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request, ILogger logger)
     {
         if (isLinking)
         {
@@ -582,22 +606,36 @@ internal sealed class SamlLoginService
         }
 
         var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath)
+        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
         {
             return derived;
         }
 
-        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        try
         {
-            if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            return SSOPlugin.Instance.MutateConfiguration(configuration =>
             {
-                liveConfig.NewPath = derived;
-            }
+                if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+                {
+                    liveConfig.NewPath = derived;
+                }
 
-            // The current redirect always uses `derived` regardless of whether the write above landed —
-            // it reflects this request's own path, exactly like a read-only resolution would have.
+                // The current redirect always uses `derived` regardless of whether the write above landed —
+                // it reflects this request's own path, exactly like a read-only resolution would have.
+                return derived;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
+            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
+            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
+            // every persist failure is handled identically — but logged so a persistently failing config
+            // write stays observable rather than silently accepted forever (mirrors AvatarService's
+            // best-effort avatar fetch).
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
             return derived;
-        });
+        }
     }
 
     // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -292,7 +292,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        bool newPath = ResolveChallengeNewPath(config, isLinking, request);
+        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
         string relayState = null;
@@ -563,18 +563,41 @@ internal sealed class SamlLoginService
     // flow — which cannot know which redirect path the identity provider has registered — reuses the last
     // login's spelling. A linking challenge only reads the stored value. (See SamlAssertionValidator's
     // ExpectedAcsUrls for the same reason this value is remembered across requests.) Mirrors
-    // OidcLoginService.ResolveChallengeNewPath —
-    // the type is known here, so the record is a direct assignment.
-    private static bool ResolveChallengeNewPath(SamlConfig config, bool isLinking, HttpRequest request)
+    // OidcLoginService.ResolveChallengeNewPath.
+    //
+    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
+    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
+    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
+    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
+    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
+    // race window is not written into. The common case — the derived spelling already matches what is
+    // stored, which is every login after the first on a given route — is served by a plain comparison with
+    // no write, so an ordinary login does not pay a config persist on every challenge, mirroring
+    // CanonicalLinkService.ResolveOrCreateAsync's read-first, persist-only-on-change shape.
+    private static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request)
     {
         if (isLinking)
         {
             return config.NewPath;
         }
 
-        var newPath = ChallengePath.IsNewPath(request.Path.Value);
-        config.NewPath = newPath;
-        return newPath;
+        var derived = ChallengePath.IsNewPath(request.Path.Value);
+        if (derived == config.NewPath)
+        {
+            return derived;
+        }
+
+        return SSOPlugin.Instance.MutateConfiguration(configuration =>
+        {
+            if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+            {
+                liveConfig.NewPath = derived;
+            }
+
+            // The current redirect always uses `derived` regardless of whether the write above landed —
+            // it reflects this request's own path, exactly like a read-only resolution would have.
+            return derived;
+        });
     }
 
     // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
@@ -162,74 +163,12 @@ internal sealed class CanonicalLinkService
             throw new AccountLinkForbiddenException("The SSO login did not resolve an identity; refusing to create or link an account.");
         }
 
-        // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the
-        // mutable username instead; when no subject-keyed link exists yet but a legacy one resolves,
-        // adopt and re-key it, locking it to the subject so a later provider-side rename cannot
-        // detach it. Because the legacy key is a name the identity provider controls, following it is
-        // name-based account matching, so it honors AllowExistingAccountLink exactly like same-named
-        // adoption below (#354): with the flag off, a login whose preferred_username points at another
-        // user's entry is refused by the adoption gate instead of being handed that account. Even with
-        // the flag on it is followed ONLY while the recorded target still bears the name (#361 below);
-        // a target renamed away from it is not handed over on the strength of a stale name key.
-        // Only OpenID differs key from name; SAML passes key == name.
-        // Both candidates are read in ONE pass under the config lock: with separate reads, a
-        // concurrent login's migration could commit between them, so this login would see the subject
-        // key before the re-key and the legacy key after it, resolve neither, and bounce a legitimate
-        // user off the adoption gate with a spurious 403. A link whose target user was deleted counts
-        // as absent (dangling links are dead, not identities).
-        var (subjectLink, legacyLink, subjectIssuer) = _configStore.Read(configuration =>
-        {
-            // The login callbacks resolve the provider before calling, so it is normally present and
-            // enabled. If it was deleted OR DISABLED in the race between that lookup and here, fail
-            // CLOSED: refuse rather than fall through to the adoption gate, whose create/adopt arms
-            // would otherwise mint a session with the provider's pre-delete/pre-disable settings (#373,
-            // #380 — a missing provider must never default the login to valid, and the same holds for a
-            // disabled one). Residual window, documented honestly: the mint itself always runs OUTSIDE
-            // the config lock, so a delete/disable after the LAST guarded transaction of any arm — this
-            // single read on the UseExistingLink path, the link write on adopt/create, the migration on
-            // the legacy path — still mints once. The guards move the final checkpoint later; #343's
-            // "disabling takes effect immediately" stays best-effort for an in-flight request unless the
-            // lock were held through minting.
-            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
-            {
-                throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to resolve or create an account.");
-            }
+        // Read candidates -> refuse a repoint -> maybe migrate/stamp -> resolve -> act. The two locked
+        // transactions (the candidate read and, on the legacy path, the migrate-and-resolve) stay whole
+        // inside their own helpers; each fail-closed branch keeps its verbatim log line one level down.
+        var candidates = ReadResolutionCandidates(mode, provider, canonicalKey, username, issuer);
 
-            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
-                ? s : null;
-            Guid? byName = bySubject is null
-                && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
-                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
-                ? n : (Guid?)null;
-
-            // Classify the subject link's issuer binding in the SAME locked read (#186), so the verdict
-            // cannot tear against a concurrent stamp or repoint. NotBound unless a subject link resolved
-            // for an OpenID provider.
-            var issuerVerdict = bySubject is null
-                ? IssuerBinding.NotBound
-                : ClassifyIssuer(configuration, mode, provider, canonicalKey, issuer);
-            return (bySubject, byName, issuerVerdict);
-        });
-
-        // Non-inert issuer binding (#186): the subject-keyed link this identity resolves to was minted
-        // under a DIFFERENT issuer than the login now presents — an admin repointed the provider entry at
-        // another identity provider behind the same discovery URL, or (with the URL edited) the belt has
-        // not yet run. Refuse rather than map this login onto the old link's account; a colliding `sub`
-        // from a new IdP (realistic for short numeric subjects like "1") no longer inherits the old user.
-        // Fail closed, self-healing: the admin re-establishes the link, or an endpoint edit clears the
-        // stale links (ServerManagedFields belt). This is the check that MUST fire at runtime — the prior
-        // review rejected an inert take; a rejection test pins that it does. A login with no issuer while
-        // the link has one lands here too (ClassifyIssuer treats it as a mismatch), so a token omitting
-        // `iss` cannot slip past a stamped binding.
-        if (subjectLink.HasValue && subjectIssuer == IssuerBinding.Mismatch)
-        {
-            _logger.LogWarning(
-                "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
-            throw new AccountLinkForbiddenException("The account link was minted under a different issuer; refusing to resolve it after an apparent provider repoint.");
-        }
+        RefuseRepointedIssuer(candidates, mode, provider, username);
 
         // The account currently bearing the display name, resolved once (outside the config lock — it is
         // a user-manager read, not a config read). It is both the same-name adoption candidate for the
@@ -239,44 +178,16 @@ internal sealed class CanonicalLinkService
         // for the terminal branches to label (a fresh-account orphan, or a reject), never followed.
         var existingAccount = _userManager.GetUserByName(username);
         Guid? existingAccountUserId = existingAccount?.Id;
-        bool legacyNameStillHeldByTarget = legacyLink.HasValue && existingAccountUserId == legacyLink;
+        bool legacyNameStillHeldByTarget = candidates.LegacyLink.HasValue && existingAccountUserId == candidates.LegacyLink;
 
-        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(subjectLink, legacyLink, legacyNameStillHeldByTarget, allowExistingAccountLink);
+        var (linkedUserId, migrateLegacy) = AccountLinkResolver.ResolveCanonicalLink(candidates.SubjectLink, candidates.LegacyLink, legacyNameStillHeldByTarget, allowExistingAccountLink);
         if (migrateLegacy)
         {
-            // The legacy re-key is name-based account matching too (#218): migration fires only when the
-            // account currently bearing the name IS the legacy target (legacyNameStillHeldByTarget), so
-            // that target is exactly existingAccount. Apply the admin refusal here as well — an attacker
-            // presenting a new subject with a victim admin's preferred_username would otherwise re-key the
-            // admin's legacy link onto their own subject and take the account over. Admin-only gate
-            // (AdoptionGate.None): the verified-email requirement is deliberately not applied to the
-            // re-key, which continues a relationship established under the pre-#155 scheme rather than
-            // forming a new one. Link an admin account explicitly via the admin endpoint instead.
-            if (AdoptionEligibilityResolver.Resolve(existingAccount!.HasPermission(PermissionKind.IsAdministrator), AdoptionGate.None) != AdoptionVerdict.Allow)
-            {
-                _logger.LogWarning(
-                    "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
-                    username?.ReplaceLineEndings(string.Empty),
-                    mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
-                throw new AccountLinkForbiddenException();
-            }
-
-            // Re-key the legacy link AND re-resolve the identity in ONE config transaction (#363), then
-            // bind the login to the value that transaction returns. The candidate resolution above was a
-            // separate lock acquisition, so a concurrent login could migrate this same identity between
-            // that snapshot and the re-key; taking the authoritative mapping from inside the re-key
-            // transaction — rather than the pre-migration snapshot's linkedUserId — closes that window
-            // instead of reasoning about its (previously argued-benign) safety. A concurrent winner's live
-            // subject link is used as-is; the deleted-target edge resolves to null so the login falls
-            // through to the create/adopt gate rather than binding to a dead account.
-            linkedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username, issuer);
-            _logger.LogInformation(
-                "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+            // Migration fires only when the account currently bearing the name IS the legacy target
+            // (legacyNameStillHeldByTarget), so that target is exactly existingAccount (non-null here).
+            linkedUserId = MigrateLegacyLinkIfEligible(mode, provider, canonicalKey, username, issuer, existingAccount!);
         }
-        else if (subjectLink.HasValue && subjectIssuer == IssuerBinding.Absent)
+        else if (candidates.SubjectLink.HasValue && candidates.SubjectIssuer == IssuerBinding.Absent)
         {
             // Trust-on-first-use migration (#186): the resolved subject link carries no stored issuer — it
             // was minted before this store existed, or by a null-issuer path. The provider is unchanged
@@ -307,108 +218,245 @@ internal sealed class CanonicalLinkService
                 return decision.UserId;
 
             case AccountLinkAction.AdoptExistingAccount:
-            {
-                // Same-name adoption trusts the identity provider to make usernames unique and
-                // non-reassignable (#218): a new principal asserting an existing user's name is otherwise
-                // routed straight to that account. Before writing the link, clear the eligibility gate —
-                // an administrator target is never adopted by name (link it explicitly via the admin
-                // endpoint), and a provider that requires a verified email must have carried
-                // email_verified == true. Fail closed: a refusal writes no link and emits no adoption
-                // audit. existingAccount is non-null here (adoption is only chosen when a named account
-                // resolved), so the admin read cannot NRE.
-                var verdict = AdoptionEligibilityResolver.Resolve(
-                    existingAccount!.HasPermission(PermissionKind.IsAdministrator),
-                    adoptionGate);
-                if (verdict != AdoptionVerdict.Allow)
-                {
-                    _logger.LogWarning(
-                        "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
-                        username?.ReplaceLineEndings(string.Empty),
-                        mode.ToToken(),
-                        provider?.ReplaceLineEndings(string.Empty),
-                        verdict);
-                    throw new AccountLinkForbiddenException();
-                }
-
-                // Atomic check-then-link (#133): if a concurrent first-login already linked this
-                // identity, that winner is used and no second write or duplicate audit occurs. The link
-                // write also stamps the login's issuer (#186), so the adopted link is issuer-bound.
-                var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, decision.UserId, issuer);
-                if (wrote)
-                {
-                    SsoAudit.AccountAdopted(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, username);
-                }
-
-                return adoptedUserId;
-            }
+                // existingAccount is non-null here (adoption is only chosen when a named account resolved).
+                return AdoptExistingAccount(mode, provider, canonicalKey, username, issuer, existingAccount!, adoptionGate, decision.UserId);
 
             case AccountLinkAction.CreateNewAccount:
-            {
-                if (legacyLink.HasValue && _legacyLinkWarnGate.TryEnter(_clock()))
-                {
-                    // The dangerous, previously-silent case (#354/#361): a legacy username-keyed link
-                    // exists and its target still exists, but no live account bears the name anymore (the
-                    // account was renamed on the Jellyfin side), so the legacy link was NOT followed —
-                    // whether adoption is off, or on but the name no longer resolves to the recorded target
-                    // (#361, the stale-name superset the flag-on arm used to hand over). We are about to
-                    // provision a FRESH account under this subject, leaving the original — the one the
-                    // legacy key points at — orphaned from this identity. This warning is the single
-                    // observable signal of that outcome; recover by linking the original account to this
-                    // subject via the admin endpoints. See the upgrade runbook in providers.md. Throttled
-                    // through the shared once-per-interval gate (#362) so a login loop cannot flood it; the
-                    // account is still provisioned on every login regardless of whether the line is emitted.
-                    _logger.LogWarning(
-                        "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
-                        username?.ReplaceLineEndings(string.Empty),
-                        mode.ToToken(),
-                        provider?.ReplaceLineEndings(string.Empty));
-                }
-
-                _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username?.ReplaceLineEndings(string.Empty));
-                var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
-                user.AuthenticationProviderId = typeof(SSOController).FullName;
-                // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
-                user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
-
-                // Atomic check-then-link (#133): if a concurrent first-login for the same identity
-                // linked meanwhile, use its account — this freshly created user is left unlinked rather
-                // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
-                // link write stamps the login's issuer (#186), so the new link is issuer-bound.
-                var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer);
-                return effectiveUserId;
-            }
+                return await CreateNewAccountAsync(mode, provider, canonicalKey, username, issuer, candidates.LegacyLink).ConfigureAwait(false);
 
             case AccountLinkAction.RejectNameTaken:
-                if (legacyLink.HasValue)
-                {
-                    // Refused, but specifically because a legacy username-keyed link (#354) is pending
-                    // and a live account still bears the name — the migratable case, distinct from an
-                    // ordinary #95 name collision. Throttled through the shared once-per-interval gate
-                    // (#362) so a login loop for a not-yet-migrated user cannot flood it; the refusal below
-                    // still throws on every login regardless of whether this line is emitted.
-                    if (_legacyLinkWarnGate.TryEnter(_clock()))
-                    {
-                        _logger.LogWarning(
-                            "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
-                            username?.ReplaceLineEndings(string.Empty),
-                            mode.ToToken(),
-                            provider?.ReplaceLineEndings(string.Empty));
-                    }
-                }
-                else
-                {
-                    _logger.LogWarning(
-                        "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                        username?.ReplaceLineEndings(string.Empty),
-                        mode.ToToken(),
-                        provider?.ReplaceLineEndings(string.Empty));
-                }
-
-                throw new AccountLinkForbiddenException();
+                throw RejectNameTaken(candidates.LegacyLink, mode, provider, username);
 
             default:
                 throw new InvalidOperationException($"Unhandled account-link action: {decision.Action}");
         }
+    }
+
+    // Reads both candidate links (subject-keyed and legacy username-keyed) AND the subject link's issuer
+    // binding in ONE pass under the config lock, so the whole verdict is linearized against a concurrent
+    // migration or issuer stamp/repoint.
+    //
+    // The link is keyed on the stable identity. A legacy OpenID link (#155) was keyed on the mutable
+    // username instead; when no subject-keyed link exists yet but a legacy one resolves, the caller
+    // adopts and re-keys it, locking it to the subject so a later provider-side rename cannot detach it.
+    // Because the legacy key is a name the identity provider controls, following it is name-based account
+    // matching, so it honors AllowExistingAccountLink exactly like same-named adoption (#354): with the
+    // flag off, a login whose preferred_username points at another user's entry is refused by the
+    // adoption gate instead of being handed that account. Even with the flag on it is followed ONLY while
+    // the recorded target still bears the name (#361); a target renamed away from it is not handed over
+    // on the strength of a stale name key. Only OpenID differs key from name; SAML passes key == name.
+    // Both candidates are read in ONE pass under the config lock: with separate reads, a concurrent
+    // login's migration could commit between them, so this login would see the subject key before the
+    // re-key and the legacy key after it, resolve neither, and bounce a legitimate user off the adoption
+    // gate with a spurious 403. A link whose target user was deleted counts as absent (dangling links are
+    // dead, not identities).
+    private ResolutionCandidates ReadResolutionCandidates(ProviderMode mode, string provider, string canonicalKey, string username, string issuer)
+    {
+        return _configStore.Read(configuration =>
+        {
+            // The login callbacks resolve the provider before calling, so it is normally present and
+            // enabled. If it was deleted OR DISABLED in the race between that lookup and here, fail
+            // CLOSED: refuse rather than fall through to the adoption gate, whose create/adopt arms
+            // would otherwise mint a session with the provider's pre-delete/pre-disable settings (#373,
+            // #380 — a missing provider must never default the login to valid, and the same holds for a
+            // disabled one). Residual window, documented honestly: the mint itself always runs OUTSIDE
+            // the config lock, so a delete/disable after the LAST guarded transaction of any arm — this
+            // single read on the UseExistingLink path, the link write on adopt/create, the migration on
+            // the legacy path — still mints once. The guards move the final checkpoint later; #343's
+            // "disabling takes effect immediately" stays best-effort for an in-flight request unless the
+            // lock were held through minting.
+            if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
+            {
+                throw new AccountLinkForbiddenException("The SSO provider is no longer configured or is disabled; refusing to resolve or create an account.");
+            }
+
+            Guid? bySubject = links.TryGetValue(canonicalKey, out var s) && _userManager.GetUserById(s) != null
+                ? s : null;
+            Guid? byName = bySubject is null
+                && !string.Equals(canonicalKey, username, StringComparison.Ordinal)
+                && links.TryGetValue(username, out var n) && _userManager.GetUserById(n) != null
+                ? n : (Guid?)null;
+
+            // Classify the subject link's issuer binding in the SAME locked read (#186), so the verdict
+            // cannot tear against a concurrent stamp or repoint. NotBound unless a subject link resolved
+            // for an OpenID provider.
+            var issuerVerdict = bySubject is null
+                ? IssuerBinding.NotBound
+                : ClassifyIssuer(configuration, mode, provider, canonicalKey, issuer);
+            return new ResolutionCandidates(bySubject, byName, issuerVerdict);
+        });
+    }
+
+    // Non-inert issuer binding (#186): the subject-keyed link this identity resolves to was minted under a
+    // DIFFERENT issuer than the login now presents — an admin repointed the provider entry at another
+    // identity provider behind the same discovery URL, or (with the URL edited) the belt has not yet run.
+    // Refuse rather than map this login onto the old link's account; a colliding `sub` from a new IdP
+    // (realistic for short numeric subjects like "1") no longer inherits the old user. Fail closed,
+    // self-healing: the admin re-establishes the link, or an endpoint edit clears the stale links
+    // (ServerManagedFields belt). This is the check that MUST fire at runtime — the prior review rejected
+    // an inert take; a rejection test pins that it does. A login with no issuer while the link has one
+    // lands here too (ClassifyIssuer treats it as a mismatch), so a token omitting `iss` cannot slip past
+    // a stamped binding.
+    private void RefuseRepointedIssuer(ResolutionCandidates candidates, ProviderMode mode, string provider, string username)
+    {
+        if (candidates.SubjectLink.HasValue && candidates.SubjectIssuer == IssuerBinding.Mismatch)
+        {
+            _logger.LogWarning(
+                "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+            throw new AccountLinkForbiddenException("The account link was minted under a different issuer; refusing to resolve it after an apparent provider repoint.");
+        }
+    }
+
+    // The #155 legacy re-key, gated by the admin refusal and folded into ONE config transaction (#363).
+    // Returns the authoritative user id the identity now resolves to (the value the login binds to), or
+    // throws when an administrator target must not be adopted by name. The name contains "Migrate", so the
+    // #363 conformance rule pins its Guid? return type.
+    private Guid? MigrateLegacyLinkIfEligible(ProviderMode mode, string provider, string canonicalKey, string username, string issuer, User existingAccount)
+    {
+        // The legacy re-key is name-based account matching too (#218): migration fires only when the
+        // account currently bearing the name IS the legacy target (legacyNameStillHeldByTarget), so
+        // that target is exactly existingAccount. Apply the admin refusal here as well — an attacker
+        // presenting a new subject with a victim admin's preferred_username would otherwise re-key the
+        // admin's legacy link onto their own subject and take the account over. Admin-only gate
+        // (AdoptionGate.None): the verified-email requirement is deliberately not applied to the
+        // re-key, which continues a relationship established under the pre-#155 scheme rather than
+        // forming a new one. Link an admin account explicitly via the admin endpoint instead.
+        if (AdoptionEligibilityResolver.Resolve(existingAccount.HasPermission(PermissionKind.IsAdministrator), AdoptionGate.None) != AdoptionVerdict.Allow)
+        {
+            _logger.LogWarning(
+                "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+            throw new AccountLinkForbiddenException();
+        }
+
+        // Re-key the legacy link AND re-resolve the identity in ONE config transaction (#363), then
+        // bind the login to the value that transaction returns. The candidate resolution above was a
+        // separate lock acquisition, so a concurrent login could migrate this same identity between
+        // that snapshot and the re-key; taking the authoritative mapping from inside the re-key
+        // transaction — rather than the pre-migration snapshot's linkedUserId — closes that window
+        // instead of reasoning about its (previously argued-benign) safety. A concurrent winner's live
+        // subject link is used as-is; the deleted-target edge resolves to null so the login falls
+        // through to the create/adopt gate rather than binding to a dead account.
+        var migratedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username, issuer);
+        _logger.LogInformation(
+            "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
+            mode.ToToken(),
+            provider?.ReplaceLineEndings(string.Empty));
+        return migratedUserId;
+    }
+
+    // Adopts the pre-existing account that shares the display name, after clearing the eligibility gate.
+    // existingAccount is non-null (the caller passes it only when a named account resolved), so the admin
+    // read cannot NRE.
+    private Guid AdoptExistingAccount(ProviderMode mode, string provider, string canonicalKey, string username, string issuer, User existingAccount, AdoptionGate adoptionGate, Guid candidateUserId)
+    {
+        // Same-name adoption trusts the identity provider to make usernames unique and
+        // non-reassignable (#218): a new principal asserting an existing user's name is otherwise
+        // routed straight to that account. Before writing the link, clear the eligibility gate —
+        // an administrator target is never adopted by name (link it explicitly via the admin
+        // endpoint), and a provider that requires a verified email must have carried
+        // email_verified == true. Fail closed: a refusal writes no link and emits no adoption audit.
+        var verdict = AdoptionEligibilityResolver.Resolve(
+            existingAccount.HasPermission(PermissionKind.IsAdministrator),
+            adoptionGate);
+        if (verdict != AdoptionVerdict.Allow)
+        {
+            _logger.LogWarning(
+                "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty),
+                verdict);
+            throw new AccountLinkForbiddenException();
+        }
+
+        // Atomic check-then-link (#133): if a concurrent first-login already linked this
+        // identity, that winner is used and no second write or duplicate audit occurs. The link
+        // write also stamps the login's issuer (#186), so the adopted link is issuer-bound.
+        var (adoptedUserId, wrote) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, candidateUserId, issuer);
+        if (wrote)
+        {
+            SsoAudit.AccountAdopted(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, username);
+        }
+
+        return adoptedUserId;
+    }
+
+    // Provisions a fresh Jellyfin account for this identity and links it on the subject key, warning first
+    // when a now-orphaned legacy link is being left behind.
+    private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string issuer, Guid? legacyLink)
+    {
+        if (legacyLink.HasValue && _legacyLinkWarnGate.TryEnter(_clock()))
+        {
+            // The dangerous, previously-silent case (#354/#361): a legacy username-keyed link
+            // exists and its target still exists, but no live account bears the name anymore (the
+            // account was renamed on the Jellyfin side), so the legacy link was NOT followed —
+            // whether adoption is off, or on but the name no longer resolves to the recorded target
+            // (#361, the stale-name superset the flag-on arm used to hand over). We are about to
+            // provision a FRESH account under this subject, leaving the original — the one the
+            // legacy key points at — orphaned from this identity. This warning is the single
+            // observable signal of that outcome; recover by linking the original account to this
+            // subject via the admin endpoints. See the upgrade runbook in providers.md. Throttled
+            // through the shared once-per-interval gate (#362) so a login loop cannot flood it; the
+            // account is still provisioned on every login regardless of whether the line is emitted.
+            _logger.LogWarning(
+                "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
+        _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username?.ReplaceLineEndings(string.Empty));
+        var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
+        user.AuthenticationProviderId = typeof(SSOController).FullName;
+        // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
+        user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+
+        // Atomic check-then-link (#133): if a concurrent first-login for the same identity
+        // linked meanwhile, use its account — this freshly created user is left unlinked rather
+        // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
+        // link write stamps the login's issuer (#186), so the new link is issuer-bound.
+        var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer);
+        return effectiveUserId;
+    }
+
+    // Logs the name-taken refusal (distinguishing a pending migratable legacy link from an ordinary #95
+    // collision) and RETURNS the exception the caller throws, so the terminal switch arm reads as the
+    // refusal it is. The refusal throws on every login; only the WARNING is throttled through the shared
+    // once-per-interval gate (#362) so a login loop for a not-yet-migrated user cannot flood the log.
+    private AccountLinkForbiddenException RejectNameTaken(Guid? legacyLink, ProviderMode mode, string provider, string username)
+    {
+        if (legacyLink.HasValue)
+        {
+            // Refused, but specifically because a legacy username-keyed link (#354) is pending
+            // and a live account still bears the name — the migratable case, distinct from an
+            // ordinary #95 name collision. Throttled through the shared once-per-interval gate
+            // (#362) so a login loop for a not-yet-migrated user cannot flood it; the refusal
+            // still throws on every login regardless of whether this line is emitted.
+            if (_legacyLinkWarnGate.TryEnter(_clock()))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
+        }
+        else
+        {
+            _logger.LogWarning(
+                "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
+        return new AccountLinkForbiddenException();
     }
 
     /// <summary>
@@ -849,4 +897,9 @@ internal sealed class CanonicalLinkService
             issuers.Remove(canonicalKey);
         }
     }
+
+    // The result of the single under-lock candidate read: the subject-keyed link (if live), the legacy
+    // username-keyed link (if live), and the subject link's issuer binding against the login (#186) — all
+    // resolved in one locked pass so the orchestrator acts on a self-consistent snapshot.
+    private readonly record struct ResolutionCandidates(Guid? SubjectLink, Guid? LegacyLink, IssuerBinding SubjectIssuer);
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -371,7 +371,7 @@ internal sealed class CanonicalLinkService
                 username?.ReplaceLineEndings(string.Empty),
                 mode.ToToken(),
                 provider?.ReplaceLineEndings(string.Empty),
-                verdict);
+                DescribeAdoptionRefusal(verdict));
             throw new AccountLinkForbiddenException();
         }
 
@@ -386,6 +386,21 @@ internal sealed class CanonicalLinkService
 
         return adoptedUserId;
     }
+
+    // Maps an adoption refusal verdict to a fixed, non-PII reason phrase for the log line above. The
+    // AdoptionVerdict is a reason CODE (RefusePrivileged / RefuseUnverifiedEmail), never an email or any
+    // user data — but logging the enum value directly makes CodeQL's cs/exposure-of-private-information
+    // heuristic trip on the "Email" in the RefuseUnverifiedEmail member name (a false positive, latent on
+    // main and surfaced only once the log moved into this small helper where the flow is interprocedural).
+    // Returning a literal phrase per arm keeps the refusal reason in the audit line — and reads clearer than
+    // the raw enum name — while cutting the data flow the heuristic followed. The Allow arm is unreachable
+    // (the caller logs only on a refusal); it is a belt for a future verdict value.
+    private static string DescribeAdoptionRefusal(AdoptionVerdict verdict) => verdict switch
+    {
+        AdoptionVerdict.RefusePrivileged => "the target account is an administrator; link it explicitly via the admin endpoints",
+        AdoptionVerdict.RefuseUnverifiedEmail => "the provider requires a verified email for adoption and the login carried none",
+        _ => "the account is not eligible for name-based adoption",
+    };
 
     // Provisions a fresh Jellyfin account for this identity and links it on the subject key, warning first
     // when a now-orphaned legacy link is being left behind.

--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -46,6 +46,15 @@
               >${Help}</a
             >
           </div>
+          <div
+            id="sso-linking-error"
+            class="sso-linking-error"
+            role="alert"
+            hidden
+          >
+            Something went wrong loading or updating your links. Please reload
+            the page and try again.
+          </div>
           <p>
             Use the
             <span class="fab" aria-hidden="true">

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,5 +1,15 @@
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
+
+  // A single generic banner for a failed request on this page (existing-links load or unlink, #536).
+  // It never carries a status code or server message, so a rejection cannot leak an internal detail
+  // into the admin UI; it just tells the user the page is no longer trustworthy as shown.
+  showError: () => {
+    const banner = document.querySelector("#sso-linking-error");
+    if (banner) {
+      banner.hidden = false;
+    }
+  },
   loadProviders: (view) => {
     ["oid", "saml"].forEach((provider_mode) => {
       const container = view.querySelector(
@@ -44,8 +54,9 @@ const ssoConfigLinking = {
           url: ApiClient.getUrl(`sso/${provider_mode}/links/${currentUserId}`),
         },
         true,
-      ).then((resp) => {
-        resp.json().then((provider_map) => {
+      )
+        .then((resp) => resp.json())
+        .then((provider_map) => {
           Object.keys(provider_map).forEach((provider_name) => {
             let existing_links = container.querySelector(
               `.sso-provider-existing-links-container[data-provider="${CSS.escape(provider_name)}"]`,
@@ -77,8 +88,10 @@ const ssoConfigLinking = {
               provider_map[provider_name],
             );
           });
-        });
-      });
+        })
+        // ApiClient.fetch rejects on a non-2xx status (auth expiry, a server error, ...), so a failed
+        // existing-links load surfaces the banner instead of silently leaving the list empty (#536).
+        .catch(() => ssoConfigLinking.showError());
     }
   },
 
@@ -223,9 +236,14 @@ const ssoConfigLinking = {
         });
       });
 
-    Promise.all(delete_requests).then((values) => {
-      window.location.reload();
-    });
+    Promise.all(delete_requests)
+      .then(() => {
+        window.location.reload();
+      })
+      // ApiClient.fetch rejects on a non-2xx status, so a rejected DELETE must not fall through to
+      // the unconditional reload below it: that would show the exact same page a successful removal
+      // shows, with no indication that the link the user asked to remove is still present (#536).
+      .catch(() => ssoConfigLinking.showError());
   },
 };
 

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -1,9 +1,10 @@
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
 
-  // A single generic banner for a failed request on this page (existing-links load or unlink, #536).
-  // It never carries a status code or server message, so a rejection cannot leak an internal detail
-  // into the admin UI; it just tells the user the page is no longer trustworthy as shown.
+  // A single generic banner for a failed request on this page (GetNames load, existing-links load,
+  // or unlink, #536/#564). It never carries a status code or server message, so a rejection cannot
+  // leak an internal detail into the admin UI; it just tells the user the page is no longer
+  // trustworthy as shown.
   showError: () => {
     const banner = document.querySelector("#sso-linking-error");
     if (banner) {
@@ -17,19 +18,25 @@ const ssoConfigLinking = {
       );
       container.innerHTML = "";
 
-      fetch(
-        new Request(
-          ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
-        ),
-      ).then((resp) => {
-        resp.json().then((config_names) => {
+      ApiClient.fetch(
+        {
+          type: "GET",
+          url: ApiClient.getUrl(`sso/${provider_mode.toUpperCase()}/GetNames`),
+        },
+        true,
+      )
+        .then((resp) => resp.json())
+        .then((config_names) => {
           ssoConfigLinking.loadProviderList(
             container,
             config_names,
             provider_mode,
           );
-        });
-      });
+        })
+        // ApiClient.fetch rejects on a non-2xx status (auth expiry, a server error, ...), the same as
+        // the existing-links load below, so a failed GetNames load surfaces the banner instead of
+        // silently rendering an empty provider list (#564).
+        .catch(() => ssoConfigLinking.showError());
     });
   },
   loadProviderList: (container, providers, provider_mode) => {

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -35,6 +35,14 @@
   margin-top: 0.25em;
 }
 
+.sso-linking-error {
+  color: #ff8a80;
+  border: 1px solid #ff8a80;
+  border-radius: 0.25em;
+  padding: 0.75em 1em;
+  margin-bottom: 1em;
+}
+
 .sso-role-mapping-container,
 .sso-bordered-list {
   border-color: rgba(255, 255, 255, 0.135);


### PR DESCRIPTION
Forward-merge per docs/BRANCHING.md, brings the released-line fixes/hardening into the 4.2 feature-dev branch: #536/#564 linking.js XHR error surfacing (PR #565/#570), #505 ResolveOrCreateAsync decomposition (#568), and #412 challenge-NewPath atomic write + throttle (#571). No 4.2-only commits since the last forward-merge conflict with these (disjoint files); the SamlLoginService touch in #571 will need a rebase on the in-flight #491 4.2 PR, handled there.