### PR TITLE
Add a SAML SP signing-key rollover (part 1 of #491)

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -400,6 +400,98 @@ public class ConfigPreservationTests
         Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
     }
 
+    // --- SAML rollover signing key: write-only secret + preserve-on-blank (#491) ---
+
+    [Fact]
+    public void SamlRolloverSigningKey_SerializedValueIsHidden_ButStaysDeserializableAndInXml()
+    {
+        var config = new SamlConfig { SamlClientId = "sp", SamlRolloverSigningKeyPfx = "rollover-secret-blob" };
+
+        // JSON responses must not leak the rollover private-key blob; it is emitted as null (write-only),
+        // exactly like the primary signing key.
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("rollover-secret-blob", json, StringComparison.Ordinal);
+        Assert.Contains("\"SamlRolloverSigningKeyPfx\":null", json, StringComparison.Ordinal);
+
+        var camel = System.Text.Json.JsonSerializer.Serialize(
+            config,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase });
+        Assert.DoesNotContain("rollover-secret-blob", camel, StringComparison.Ordinal);
+
+        // XML (on-disk config) must still persist it, so the overlap window survives a restart.
+        var serializer = new XmlSerializer(typeof(SamlConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("SamlRolloverSigningKeyPfx", xml, StringComparison.Ordinal);
+        Assert.Contains("rollover-secret-blob", xml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlRolloverSigningKey_IsDeserializedFromJson_SoItCanBeSetAndRotated()
+    {
+        const string body = "{\"SamlClientId\":\"sp\",\"SamlRolloverSigningKeyPfx\":\"typed-rollover-pfx\"}";
+        var parsed = System.Text.Json.JsonSerializer.Deserialize<SamlConfig>(body);
+        Assert.Equal("typed-rollover-pfx", parsed!.SamlRolloverSigningKeyPfx);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Preserve_BlankIncomingRolloverKey_KeepsLiveKey(string? incomingKey)
+    {
+        // A config-page/API save arrives with the withheld rollover key blank and must keep the stored one,
+        // so an unrelated edit cannot silently end the overlap window mid-rotation.
+        var live = new PluginConfiguration();
+        live.SamlConfigs["adfs"] = new SamlConfig { SamlRolloverSigningKeyPfx = "live-rollover-pfx" };
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["adfs"] = new SamlConfig { SamlRolloverSigningKeyPfx = incomingKey };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal("live-rollover-pfx", incoming.SamlConfigs["adfs"].SamlRolloverSigningKeyPfx);
+    }
+
+    [Fact]
+    public void Preserve_NonBlankIncomingRolloverKey_IsKeptAsRotation()
+    {
+        var live = new PluginConfiguration();
+        live.SamlConfigs["adfs"] = new SamlConfig { SamlRolloverSigningKeyPfx = "old-rollover-pfx" };
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["adfs"] = new SamlConfig { SamlRolloverSigningKeyPfx = "new-rollover-pfx" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal("new-rollover-pfx", incoming.SamlConfigs["adfs"].SamlRolloverSigningKeyPfx);
+    }
+
+    [Fact]
+    public void Preserve_PrimaryAndRolloverKeys_ArePreservedIndependently()
+    {
+        // A save that rotates ONLY the primary (blank rollover) must keep the stored rollover, and vice
+        // versa — the two write-only keys never bleed into each other.
+        var live = new PluginConfiguration();
+        live.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = "live-primary", SamlRolloverSigningKeyPfx = "live-rollover" };
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["adfs"] = new SamlConfig { SamlSigningKeyPfx = "rotated-primary", SamlRolloverSigningKeyPfx = null };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal("rotated-primary", incoming.SamlConfigs["adfs"].SamlSigningKeyPfx);
+        Assert.Equal("live-rollover", incoming.SamlConfigs["adfs"].SamlRolloverSigningKeyPfx);
+    }
+
+    [Fact]
+    public void ValidateSamlRolloverSigningKey_GarbageKey_ThrowsNamingProvider()
+    {
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig { SamlRolloverSigningKeyPfx = "QUJD" }; // valid base64, not a PKCS#12
+
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+    }
+
     // --- Base-URL override validation on save (#139) ---
 
     [Fact]

--- a/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
@@ -80,6 +80,57 @@ public class ConfigSecretProtectionTests
     }
 
     [Fact]
+    public void ProtectAll_EncryptsTheRolloverSigningKey_AndRevealRecoversIt()
+    {
+        WithStore(store =>
+        {
+            // The rollover signing key (#491) carries a private key, so it must be encrypted at rest exactly
+            // like the primary — a plaintext rollover key would be a secrets-at-rest regression.
+            var config = new PluginConfiguration();
+            config.SamlConfigs["keycloak"] = new SamlConfig
+            {
+                SamlSigningKeyPfx = "primary-pfx-blob",
+                SamlRolloverSigningKeyPfx = "rollover-pfx-blob",
+            };
+
+            ConfigSecretProtection.ProtectAll(config, store);
+
+            Assert.True(SecretEnvelope.IsProtected(config.SamlConfigs["keycloak"].SamlSigningKeyPfx));
+            Assert.True(SecretEnvelope.IsProtected(config.SamlConfigs["keycloak"].SamlRolloverSigningKeyPfx));
+            Assert.Equal("primary-pfx-blob", store.Reveal(config.SamlConfigs["keycloak"].SamlSigningKeyPfx));
+            Assert.Equal("rollover-pfx-blob", store.Reveal(config.SamlConfigs["keycloak"].SamlRolloverSigningKeyPfx));
+        });
+    }
+
+    [Fact]
+    public void HasAnyEnvelope_ARolloverEnvelopeAlone_IsDetected_SoAMissingKeyFailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        try
+        {
+            // Encrypt a value so a real envelope exists, place it ONLY in the rollover field, then lose the
+            // key: ProtectAll must still see the config holds an envelope and refuse to mint a fresh key over
+            // it (orphan-prevention must cover the rollover field, not just the primary).
+            var envelope = new SecretStore(path).Protect("old-rollover");
+            File.Delete(path);
+
+            var config = new PluginConfiguration();
+            config.SamlConfigs["a"] = new SamlConfig { SamlRolloverSigningKeyPfx = envelope };
+            config.OidConfigs["b"] = new OidConfig { OidSecret = "new-plaintext" };
+
+            Assert.Throws<CryptographicException>(() => ConfigSecretProtection.ProtectAll(config, new SecretStore(path)));
+            Assert.False(File.Exists(path)); // no replacement key minted
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void ProtectAll_IsIdempotent()
     {
         WithStore(store =>

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -107,6 +107,32 @@ public class SSOControllerChallengeTests
     }
 
     [Fact]
+    public void SamlChallenge_RolloverKeySet_StillSignsWithThePrimaryKey_NotTheRollover()
+    {
+        // The rollover key (#491) is PUBLISH-ONLY (SP metadata overlap): the AuthnRequest signature must
+        // still verify against the PRIMARY public key and must NOT verify against the rollover key.
+        var (primaryPfx, primaryPublic) = SamlSigningKeyFactory.CreatePair();
+        var (rolloverPfx, rolloverPublic) = SamlSigningKeyFactory.CreatePair();
+        using (primaryPublic)
+        using (rolloverPublic)
+        {
+            var harness = new SsoControllerHarness(c =>
+            {
+                var config = EnabledProvider();
+                config.SignAuthnRequests = true;
+                config.SamlSigningKeyPfx = primaryPfx;
+                config.SamlRolloverSigningKeyPfx = rolloverPfx;
+                c.SamlConfigs["adfs"] = config;
+            });
+
+            var result = Assert.IsType<RedirectResult>(harness.Controller.SamlChallenge("adfs"));
+
+            Assert.True(RedirectSignatureVerifies(result.Url, primaryPublic), "The AuthnRequest must be signed with the primary key.");
+            Assert.False(RedirectSignatureVerifies(result.Url, rolloverPublic), "The rollover key is publish-only and must never sign the AuthnRequest.");
+        }
+    }
+
+    [Fact]
     public void SamlChallenge_SigningEnabledButKeyMissing_FailsClosedWith500_AndNoRedirect()
     {
         // An operator who turned signing on but has no key must NOT get a silent unsigned request: fail

--- a/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -153,6 +154,97 @@ public class SSOControllerSamlMetadataTests
         Assert.False(loaded.HasPrivateKey);
         // The stored PFX (which carries the private key) never appears in the response.
         Assert.DoesNotContain(pfxBase64, result.Content!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SamlMetadata_RolloverSet_AdvertisesBothPublicCertificates_AsTwoSigningKeyDescriptors()
+    {
+        // The overlap window (#491): with a rollover key configured the endpoint publishes BOTH public
+        // certificates, so the identity provider trusts either while the admin swaps the SP signing cert.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        using var rollover = SamlSigningKeyFactory.CreateCertificate();
+        var primaryPfx = Convert.ToBase64String(primary.Export(X509ContentType.Pfx));
+        var rolloverPfx = Convert.ToBase64String(rollover.Export(X509ContentType.Pfx));
+        var expectedPrimaryPublic = Convert.ToBase64String(primary.RawData);
+        var expectedRolloverPublic = Convert.ToBase64String(rollover.RawData);
+
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = primaryPfx,
+            SamlRolloverSigningKeyPfx = rolloverPfx,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(200, result.StatusCode);
+        var spDescriptor = XDocument.Parse(result.Content!).Root!.Element(Md + "SPSSODescriptor");
+        var advertised = spDescriptor!
+            .Elements(Md + "KeyDescriptor")
+            .Select(kd => kd.Element(Ds + "KeyInfo")!.Element(Ds + "X509Data")!.Element(Ds + "X509Certificate")!.Value)
+            .ToList();
+
+        Assert.Equal(new[] { expectedPrimaryPublic, expectedRolloverPublic }, advertised);
+        // Neither PFX (each carrying a private key) ever appears in the served metadata.
+        Assert.DoesNotContain(primaryPfx, result.Content!, StringComparison.Ordinal);
+        Assert.DoesNotContain(rolloverPfx, result.Content!, StringComparison.Ordinal);
+        foreach (var certificateBase64 in advertised)
+        {
+            using var loaded = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateBase64));
+            Assert.False(loaded.HasPrivateKey);
+        }
+    }
+
+    [Fact]
+    public void SamlMetadata_RolloverEqualToPrimary_CollapsesToASingleKeyDescriptor()
+    {
+        // Promoting the rollover into the primary field (both hold the same cert) is the end state of a
+        // rotation: the redundant second descriptor is dropped, returning to a single-key document without
+        // the admin having to blank the write-only, blank-keeps-stored rollover key.
+        using var certificate = SamlSigningKeyFactory.CreateCertificate();
+        var pfx = Convert.ToBase64String(certificate.Export(X509ContentType.Pfx));
+
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = pfx,
+            SamlRolloverSigningKeyPfx = pfx,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(200, result.StatusCode);
+        var spDescriptor = XDocument.Parse(result.Content!).Root!.Element(Md + "SPSSODescriptor");
+        Assert.Single(spDescriptor!.Elements(Md + "KeyDescriptor"));
+    }
+
+    [Fact]
+    public void SamlMetadata_RolloverSetButUnloadable_FailsClosed()
+    {
+        // A set-but-unloadable rollover key surfaces loudly (409), the same fail-closed posture as the
+        // primary — it never emits a broken KeyDescriptor and never silently drops a configured key.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        var primaryPfx = Convert.ToBase64String(primary.Export(X509ContentType.Pfx));
+
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = primaryPfx,
+            SamlRolloverSigningKeyPfx = "not-a-valid-pfx",
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(409, result.StatusCode);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -97,6 +98,87 @@ public class SamlSpMetadataBuilderTests
 
         using var loaded = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(advertised));
         Assert.False(loaded.HasPrivateKey);
+    }
+
+    [Fact]
+    public void Build_WithRollover_AdvertisesBothSigningCertificates_AsTwoKeyDescriptors()
+    {
+        // The overlap window (#491): the SP publishes BOTH its primary and its rollover PUBLIC certificate
+        // so the identity provider trusts either while the admin swaps the SP's own signing cert.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        using var rollover = SamlSigningKeyFactory.CreateCertificate();
+        var primaryBase64 = Convert.ToBase64String(primary.RawData);
+        var rolloverBase64 = Convert.ToBase64String(rollover.RawData);
+
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, primaryBase64, rolloverBase64));
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+
+        Assert.Equal("true", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+
+        var keyDescriptors = spDescriptor.Elements(Md + "KeyDescriptor").ToList();
+        Assert.Equal(2, keyDescriptors.Count);
+        Assert.All(keyDescriptors, kd => Assert.Equal("signing", (string?)kd.Attribute("use")));
+
+        var advertised = keyDescriptors
+            .Select(kd => kd.Element(Ds + "KeyInfo")!.Element(Ds + "X509Data")!.Element(Ds + "X509Certificate")!.Value)
+            .ToList();
+
+        // Both public certificates appear, primary first, in the order they were supplied.
+        Assert.Equal(new[] { primaryBase64, rolloverBase64 }, advertised);
+    }
+
+    [Fact]
+    public void Build_WithRollover_BothAdvertisedCertificatesCarryNoPrivateKey()
+    {
+        // Neither the primary nor the rollover descriptor may leak a private key: both load public-only.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        using var rollover = SamlSigningKeyFactory.CreateCertificate();
+        var primaryBase64 = Convert.ToBase64String(primary.RawData);
+        var rolloverBase64 = Convert.ToBase64String(rollover.RawData);
+
+        var document = XDocument.Parse(SamlSpMetadataBuilder.Build(EntityId, AcsUrl, primaryBase64, rolloverBase64));
+
+        var advertised = document.Root!
+            .Element(Md + "SPSSODescriptor")!
+            .Elements(Md + "KeyDescriptor")
+            .Select(kd => kd.Element(Ds + "KeyInfo")!.Element(Ds + "X509Data")!.Element(Ds + "X509Certificate")!.Value);
+
+        foreach (var certificateBase64 in advertised)
+        {
+            using var loaded = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateBase64));
+            Assert.False(loaded.HasPrivateKey);
+        }
+    }
+
+    [Fact]
+    public void Build_RolloverWithoutPrimary_EmitsNoKeyDescriptor()
+    {
+        // A rollover with no primary is nonsensical (signing is off), so no key is advertised at all — the
+        // rollover is only ever meaningful alongside a primary.
+        using var rollover = SamlSigningKeyFactory.CreateCertificate();
+        var rolloverBase64 = Convert.ToBase64String(rollover.RawData);
+
+        var document = XDocument.Parse(
+            SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null, rolloverSigningCertificateBase64: rolloverBase64));
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+
+        Assert.Equal("false", (string?)spDescriptor!.Attribute("AuthnRequestsSigned"));
+        Assert.Empty(spDescriptor.Elements(Md + "KeyDescriptor"));
+    }
+
+    [Fact]
+    public void Build_WithoutRollover_EmitsExactlyOneKeyDescriptor_PreservingSingleKeyBehavior()
+    {
+        // Rollover unset (the default) is byte-for-byte the pre-#491 single-KeyDescriptor output.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        var primaryBase64 = Convert.ToBase64String(primary.RawData);
+
+        var withDefault = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, primaryBase64);
+        var withExplicitNullRollover = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, primaryBase64, rolloverSigningCertificateBase64: null);
+
+        Assert.Equal(withDefault, withExplicitNullRollover);
+        var spDescriptor = XDocument.Parse(withDefault).Root!.Element(Md + "SPSSODescriptor");
+        Assert.Single(spDescriptor!.Elements(Md + "KeyDescriptor"));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -125,6 +125,14 @@ public class SamlSpMetadataBuilderTests
 
         // Both public certificates appear, primary first, in the order they were supplied.
         Assert.Equal(new[] { primaryBase64, rolloverBase64 }, advertised);
+
+        // XSD order: within SPSSODescriptor every KeyDescriptor must precede the AssertionConsumerService
+        // element. Pin it against document order so a future edit that emits a descriptor after the ACS
+        // (invalid metadata) fails here, not only against a real identity provider.
+        var childNames = spDescriptor.Elements().Select(e => e.Name).ToList();
+        var lastKeyDescriptorIndex = childNames.FindLastIndex(n => n == Md + "KeyDescriptor");
+        var acsIndex = childNames.FindIndex(n => n == Md + "AssertionConsumerService");
+        Assert.True(lastKeyDescriptorIndex < acsIndex, "Every KeyDescriptor must precede AssertionConsumerService (SAML metadata XSD order).");
     }
 
     [Fact]

--- a/SSO-Auth/Api/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/ConfigSecretProtection.cs
@@ -52,6 +52,10 @@ internal static class ConfigSecretProtection
                 }
 
                 saml.SamlSigningKeyPfx = store.Protect(saml.SamlSigningKeyPfx, configHasEnvelopes);
+
+                // The rollover signing key (#491) carries a private key too, so it is encrypted at rest
+                // exactly like the primary — a plaintext rollover key would be a secrets-at-rest regression.
+                saml.SamlRolloverSigningKeyPfx = store.Protect(saml.SamlRolloverSigningKeyPfx, configHasEnvelopes);
             }
         }
     }
@@ -77,7 +81,9 @@ internal static class ConfigSecretProtection
         {
             foreach (var saml in configuration.SamlConfigs.Values)
             {
-                if (saml != null && SecretEnvelope.IsWellFormedEnvelope(saml.SamlSigningKeyPfx))
+                if (saml != null
+                    && (SecretEnvelope.IsWellFormedEnvelope(saml.SamlSigningKeyPfx)
+                        || SecretEnvelope.IsWellFormedEnvelope(saml.SamlRolloverSigningKeyPfx)))
                 {
                     return true;
                 }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -423,42 +423,80 @@ internal sealed class SamlLoginService
         // (SsoUrlBuilder.SamlExpectedAcsUrls), so publishing one is unambiguous for the identity provider.
         var acsUrl = SsoUrlBuilder.SamlAcsUrl(baseUrl, newPath: true, provider);
 
-        if (!TryResolveSigningCertificate(config, out var signingCertificateBase64))
+        if (!TryResolveSigningCertificates(config, out var signingCertificateBase64, out var rolloverSigningCertificateBase64))
         {
-            // Request signing is enabled but the key could not be loaded — the same fail-closed posture the
-            // signed challenge takes, so metadata never advertises signing the challenge would then fail to
-            // perform.
+            // Request signing is enabled but a configured signing key could not be loaded — the same
+            // fail-closed posture the signed challenge takes, so metadata never advertises signing the
+            // challenge would then fail to perform, and never emits a broken KeyDescriptor for a set-but-
+            // unloadable rollover key (#491).
             return FlowResponses.PlainTextError(
                 StatusCodes.Status409Conflict,
-                "SAML metadata is unavailable: request signing is enabled but the signing key could not be loaded.");
+                "SAML metadata is unavailable: request signing is enabled but a configured signing key could not be loaded.");
         }
 
         return new ContentResult
         {
-            Content = SamlSpMetadataBuilder.Build(entityId, acsUrl, signingCertificateBase64),
+            Content = SamlSpMetadataBuilder.Build(entityId, acsUrl, signingCertificateBase64, rolloverSigningCertificateBase64),
             ContentType = "application/samlmetadata+xml",
             StatusCode = StatusCodes.Status200OK,
         };
     }
 
-    // Resolves the PUBLIC signing certificate to advertise in the metadata: null when request signing is
-    // off (no KeyDescriptor is emitted), the Base64 (DER) public certificate when it is on, and false (fail
-    // closed) when it is on but the key cannot be loaded/decrypted — mirroring BuildChallengeRedirectUrl.
-    // Only the certificate's public RawData is exported; the private key never leaves this method.
-    private static bool TryResolveSigningCertificate(SamlConfig config, out string signingCertificateBase64)
+    // Resolves the PUBLIC signing certificate(s) to advertise in the metadata. Both out values are null when
+    // request signing is off (no KeyDescriptor). When it is on, the PRIMARY is mandatory — a set-but-
+    // unloadable primary fails closed (false), mirroring BuildChallengeRedirectUrl so metadata never
+    // advertises signing the challenge could not perform. The ROLLOVER (#491) is optional: a blank stored
+    // value means no overlap window (single descriptor, byte-for-byte the pre-#491 output); a set-but-
+    // unloadable rollover key also fails closed (false), so a hand-corrupted rollover key surfaces loudly as
+    // a 409 rather than silently dropping a key the admin configured. When the rollover certificate is
+    // identical to the primary — the natural end state after promoting the rollover into the primary field —
+    // the redundant second descriptor is dropped, returning to a single descriptor without needing to blank
+    // the write-only, blank-keeps-stored rollover key. Only the public RawData of each certificate is
+    // exported; no private key ever leaves this method.
+    private static bool TryResolveSigningCertificates(SamlConfig config, out string signingCertificateBase64, out string rolloverSigningCertificateBase64)
     {
         signingCertificateBase64 = null;
+        rolloverSigningCertificateBase64 = null;
         if (!config.SignAuthnRequests)
         {
             return true;
         }
 
+        if (!TryRevealPublicCertificate(config.SamlSigningKeyPfx, out signingCertificateBase64))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(config.SamlRolloverSigningKeyPfx))
+        {
+            return true;
+        }
+
+        if (!TryRevealPublicCertificate(config.SamlRolloverSigningKeyPfx, out rolloverSigningCertificateBase64))
+        {
+            return false;
+        }
+
+        if (string.Equals(rolloverSigningCertificateBase64, signingCertificateBase64, StringComparison.Ordinal))
+        {
+            rolloverSigningCertificateBase64 = null;
+        }
+
+        return true;
+    }
+
+    // Reveals a stored signing key (encrypted at rest, #158) and exports its PUBLIC certificate as Base64
+    // (DER). Fail-closed: a missing/corrupt at-rest key throws CryptographicException, and a garbage or
+    // private-key-less PKCS#12 fails to load — both return false so the caller emits no descriptor for it.
+    // The private key never leaves this method; only certificate.RawData (the public DER) is exported.
+    private static bool TryRevealPublicCertificate(string storedPfx, out string publicCertificateBase64)
+    {
+        publicCertificateBase64 = null;
+
         string revealed;
         try
         {
-            // The signing key is stored encrypted at rest (#158); reveal it at the point of use. A missing
-            // or corrupt key file throws CryptographicException — fail closed here rather than surface a 500.
-            revealed = SSOPlugin.Instance.Secrets.Reveal(config.SamlSigningKeyPfx);
+            revealed = SSOPlugin.Instance.Secrets.Reveal(storedPfx);
         }
         catch (CryptographicException)
         {
@@ -472,7 +510,7 @@ internal sealed class SamlLoginService
 
         using (certificate)
         {
-            signingCertificateBase64 = Convert.ToBase64String(certificate.RawData);
+            publicCertificateBase64 = Convert.ToBase64String(certificate.RawData);
             return true;
         }
     }

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -463,6 +463,7 @@ public class SSOController : ControllerBase
         RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
         RejectInvalidSamlCertificate(newConfig.SamlCertificate);
         RejectInvalidSamlSigningKey(newConfig.SamlSigningKeyPfx);
+        RejectInvalidSamlSigningKey(newConfig.SamlRolloverSigningKeyPfx);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/SamlSpMetadataBuilder.cs
@@ -11,10 +11,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// <c>SPSSODescriptor</c> — that an administrator can hand to an identity provider so it registers this
 /// service provider by URL instead of by hand (#162). Pure and request-free: it emits exactly the entity
 /// id, the HTTP-POST assertion-consumer URL, and — only when request signing is enabled — the PUBLIC
-/// signing certificate it is given. It never touches a private key or any secret, and it never reads the
-/// request <c>Host</c>: the caller resolves the entity id and ACS URL from the configured canonical Base
-/// URL (#139), so a spoofed or proxy-forwarded host cannot poison the ACS the identity provider is told to
-/// POST assertions to.
+/// signing certificate(s) it is given. During a signing-key rollover (#491) it advertises BOTH the primary
+/// and the optional rollover PUBLIC certificate as two <c>KeyDescriptor use="signing"</c> entries, so the
+/// identity provider trusts either while the administrator swaps. It never touches a private key or any
+/// secret, and it never reads the request <c>Host</c>: the caller resolves the entity id and ACS URL from
+/// the configured canonical Base URL (#139), so a spoofed or proxy-forwarded host cannot poison the ACS the
+/// identity provider is told to POST assertions to.
 /// </summary>
 internal static class SamlSpMetadataBuilder
 {
@@ -39,8 +41,16 @@ internal static class SamlSpMetadataBuilder
     /// when request signing is enabled, or <see langword="null"/> to advertise no signing key. This is only
     /// ever the public certificate — the private key must never be passed here.
     /// </param>
+    /// <param name="rolloverSigningCertificateBase64">
+    /// The OPTIONAL Base64 (DER) PUBLIC rollover signing certificate (#491), advertised as a SECOND
+    /// <c>KeyDescriptor use="signing"</c> so the identity provider trusts either during an overlap window.
+    /// <see langword="null"/> (the default) means no rollover — a single KeyDescriptor, byte-for-byte the
+    /// pre-#491 output. Ignored when <paramref name="signingCertificateBase64"/> is <see langword="null"/>
+    /// (no primary means signing is off, so there is nothing to roll over). Again only ever the public
+    /// certificate — never a private key.
+    /// </param>
     /// <returns>The metadata document as an XML string.</returns>
-    internal static string Build(string entityId, string assertionConsumerServiceUrl, string? signingCertificateBase64)
+    internal static string Build(string entityId, string assertionConsumerServiceUrl, string? signingCertificateBase64, string? rolloverSigningCertificateBase64 = null)
     {
         // A StringWriter is UTF-16 internally, which would make XmlWriter stamp encoding="utf-16" into the
         // XML declaration even though the bytes are served as UTF-8; report UTF-8 so the declaration matches
@@ -68,16 +78,15 @@ internal static class SamlSpMetadataBuilder
 
             if (signingCertificateBase64 is not null)
             {
-                xml.WriteStartElement("md", "KeyDescriptor", MetadataNamespace);
-                xml.WriteAttributeString("use", "signing");
-                xml.WriteStartElement("ds", "KeyInfo", DsigNamespace);
-                xml.WriteStartElement("ds", "X509Data", DsigNamespace);
-                xml.WriteStartElement("ds", "X509Certificate", DsigNamespace);
-                xml.WriteString(signingCertificateBase64);
-                xml.WriteEndElement(); // ds:X509Certificate
-                xml.WriteEndElement(); // ds:X509Data
-                xml.WriteEndElement(); // ds:KeyInfo
-                xml.WriteEndElement(); // md:KeyDescriptor
+                WriteSigningKeyDescriptor(xml, signingCertificateBase64);
+
+                // The rollover certificate (#491) is a SECOND signing KeyDescriptor during the overlap
+                // window. It is only meaningful alongside a primary (signing must be on), so it is nested
+                // under the primary guard; a null rollover leaves the single-descriptor output unchanged.
+                if (rolloverSigningCertificateBase64 is not null)
+                {
+                    WriteSigningKeyDescriptor(xml, rolloverSigningCertificateBase64);
+                }
             }
 
             xml.WriteStartElement("md", "AssertionConsumerService", MetadataNamespace);
@@ -92,6 +101,22 @@ internal static class SamlSpMetadataBuilder
         }
 
         return writer.ToString();
+    }
+
+    // Writes one <md:KeyDescriptor use="signing"> wrapping the given PUBLIC certificate DER. The caller
+    // passes only the public certificate (certificate.RawData); no private-key material ever reaches here.
+    private static void WriteSigningKeyDescriptor(XmlWriter xml, string signingCertificateBase64)
+    {
+        xml.WriteStartElement("md", "KeyDescriptor", MetadataNamespace);
+        xml.WriteAttributeString("use", "signing");
+        xml.WriteStartElement("ds", "KeyInfo", DsigNamespace);
+        xml.WriteStartElement("ds", "X509Data", DsigNamespace);
+        xml.WriteStartElement("ds", "X509Certificate", DsigNamespace);
+        xml.WriteString(signingCertificateBase64);
+        xml.WriteEndElement(); // ds:X509Certificate
+        xml.WriteEndElement(); // ds:X509Data
+        xml.WriteEndElement(); // ds:KeyInfo
+        xml.WriteEndElement(); // md:KeyDescriptor
     }
 
     // A StringWriter that reports UTF-8 so XmlWriter emits encoding="utf-8" in the XML declaration (the

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -273,6 +273,23 @@ public class SamlConfig : ProviderConfigBase
     /// </summary>
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
     public string SamlSigningKeyPfx { get; set; }
+
+    /// <summary>
+    /// Gets or sets an OPTIONAL second service-provider signing key for a zero-downtime rollover of the
+    /// SP's own signing certificate (#491, capability 1), as a Base64-encoded, unencrypted PKCS#12 (PFX)
+    /// blob in the same shape as <see cref="SamlSigningKeyPfx"/>. It is PUBLISH-ONLY: outgoing
+    /// AuthnRequests are always signed with the PRIMARY <see cref="SamlSigningKeyPfx"/>, and this key is
+    /// never used to sign. Its purpose is the metadata overlap window — when it is set and
+    /// <see cref="SignAuthnRequests"/> is on, the SP metadata advertises BOTH public certificates as two
+    /// <c>KeyDescriptor use="signing"</c> entries, so the identity provider accepts the primary's
+    /// signature while the administrator stages the swap (publish both, then promote the rollover key
+    /// into the primary field, then clear this one). Blank means no overlap: byte-for-byte the pre-#491
+    /// single-key, single-KeyDescriptor behavior. It carries the same private key, so it is treated as a
+    /// secret exactly like the primary: write-only across the JSON boundary, encrypted at rest (#158),
+    /// and preserved on a save that leaves it blank.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
+    public string SamlRolloverSigningKeyPfx { get; set; }
 }
 
 /// <summary>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -46,6 +46,7 @@ internal static class ProviderConfigValidator
                 ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
                 ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
+                ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
             }
         }
     }

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -92,6 +92,11 @@ internal static class ServerManagedFields
 
         incoming.CanonicalLinks = live.CanonicalLinks;
         incoming.SamlSigningKeyPfx = ResolveUpdatedSigningKey(incoming, live);
+
+        // The rollover signing key (#491) is withheld from JSON exactly like the primary, so a config-page
+        // save arrives with it blank and must keep the stored value; a non-blank incoming value is an
+        // intentional rotation of the overlap key and wins. Same no-identity-guard reasoning as the primary.
+        incoming.SamlRolloverSigningKeyPfx = ResolveUpdatedRolloverSigningKey(incoming, live);
     }
 
     /// <summary>
@@ -107,6 +112,20 @@ internal static class ServerManagedFields
     /// <returns>The signing key to persist for the updated provider.</returns>
     internal static string ResolveUpdatedSigningKey(SamlConfig incoming, SamlConfig live)
         => string.IsNullOrWhiteSpace(incoming.SamlSigningKeyPfx) ? live.SamlSigningKeyPfx : incoming.SamlSigningKeyPfx;
+
+    /// <summary>
+    /// Decides which OPTIONAL rollover signing key an updated SAML provider should keep (#491), the exact
+    /// same blank-keeps-stored / non-blank-rotates rule as <see cref="ResolveUpdatedSigningKey"/>: the
+    /// rollover key is withheld from JSON, so a config-page save arrives blank and must keep the stored
+    /// value rather than silently ending the overlap window, while an explicit non-blank value stages a new
+    /// overlap certificate. Like the primary it is never transmitted (publish-only, used to export its
+    /// public certificate into metadata), so it carries no provider-identity guard.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted.</param>
+    /// <param name="live">The current live provider config.</param>
+    /// <returns>The rollover signing key to persist for the updated provider.</returns>
+    internal static string ResolveUpdatedRolloverSigningKey(SamlConfig incoming, SamlConfig live)
+        => string.IsNullOrWhiteSpace(incoming.SamlRolloverSigningKeyPfx) ? live.SamlRolloverSigningKeyPfx : incoming.SamlRolloverSigningKeyPfx;
 
     /// <summary>
     /// Decides which OpenID client secret an updated provider should keep (#189), the single rule

--- a/providers.md
+++ b/providers.md
@@ -226,10 +226,10 @@ expiry). A few provider settings must therefore match, or login is refused (fail
 
 ## Secrets encrypted at rest and downgrade
 
-The plugin's two at-rest secrets — the OpenID client secret (`OidSecret`) and the SAML
-request-signing key (`SamlSigningKeyPfx`) — are encrypted in the configuration XML. Each is stored as
-an **AES-256-GCM `ssoenc:v1:` envelope** rather than plaintext, so a leaked config file alone does not
-reveal them.
+The plugin's at-rest secrets — the OpenID client secret (`OidSecret`) and the SAML request-signing keys
+(`SamlSigningKeyPfx` and, during a rollover, `SamlRolloverSigningKeyPfx`) — are encrypted in the
+configuration XML. Each is stored as an **AES-256-GCM `ssoenc:v1:` envelope** rather than plaintext, so a
+leaked config file alone does not reveal them.
 
 - **Key file.** The data-encryption key lives in a dedicated file, `sso-secret.key`, in the plugin data
   folder — **separate from the config XML**, and outside the config directory. On Linux it is created
@@ -372,15 +372,43 @@ not reset them):
   that leaves it blank keeps the stored key. It is persisted only to the server's on-disk config, and
   there it is **encrypted at rest** (see
   [Secrets encrypted at rest and downgrade](#secrets-encrypted-at-rest-and-downgrade)).
+- **`SamlRolloverSigningKeyPfx`** _(optional)_ — a **second** service-provider signing key, in the same
+  Base64-encoded PKCS#12 shape as `SamlSigningKeyPfx`, used **only** for a zero-downtime rollover of the
+  SP's own signing certificate (see [SP signing-key rollover](#saml-sp-signing-key-rollover) below). It
+  is **publish-only**: `AuthnRequests` are always signed with the **primary** key, never this one. When
+  it is set, the [SP metadata](#saml-service-provider-metadata) advertises **both** public certificates
+  so the identity provider trusts either during the overlap. It is treated as a secret exactly like the
+  primary key — withheld from config responses, encrypted at rest, and preserved on a blank save. Leave
+  it blank when you are not mid-rotation: behaviour is then identical to a single signing key.
 
-**Fail-closed:** if `SignAuthnRequests` is on but the signing key is missing or unloadable, the login
-challenge is refused with an error — it never silently falls back to sending an unsigned request, so an
-operator who turned signing on cannot get a silent downgrade. A garbage key is also rejected when the
-provider is saved.
+**Fail-closed:** if `SignAuthnRequests` is on but the primary signing key is missing or unloadable, the
+login challenge is refused with an error — it never silently falls back to sending an unsigned request,
+so an operator who turned signing on cannot get a silent downgrade. A garbage primary **or rollover** key
+is rejected when the provider is saved.
 
-> Signing with more than one certificate (primary + rollover) for zero-downtime key rotation, and
-> accepting multiple inbound IdP verification certificates during a rotation window, are tracked
-> separately and not yet implemented.
+### SAML SP signing-key rollover
+
+To rotate the service provider's **own** signing certificate without a hard cutover that would break
+logins the moment the identity provider stops trusting the old certificate, publish both the old and new
+public certificates during an overlap window while continuing to sign with the old one, then switch:
+
+1. **Stage the new key.** Generate the new keypair and set `SamlRolloverSigningKeyPfx` to it (leave
+   `SamlSigningKeyPfx` — the primary — as the current key). The plugin keeps signing `AuthnRequests`
+   with the primary (old) key, but the SP metadata now advertises **two** `KeyDescriptor use="signing"`
+   entries — the old and the new public certificate.
+2. **Let the identity provider pick up both certificates.** Re-import the metadata (or wait for it to
+   refresh if the IdP fetches it by URL) so the IdP trusts signatures from **either** certificate. There
+   is no downtime: logins keep verifying against the old certificate throughout.
+3. **Promote the new key.** Move the new key into the primary field — set `SamlSigningKeyPfx` to the new
+   key. The plugin now signs with the new key, which the IdP already trusts from step 2.
+4. **Return to a single certificate.** With the primary now equal to the staged key, the metadata
+   automatically collapses back to a **single** `KeyDescriptor` (the duplicate is dropped), so no
+   separate "clear the rollover key" step is needed. Once the IdP has re-imported this final metadata,
+   only the new certificate is trusted and the rotation is complete.
+
+Because the rollover key is publish-only and withheld from config responses, it can only be set or
+changed by posting a non-blank value; a blank save keeps whatever is stored, so an unrelated edit cannot
+end the overlap window by accident.
 
 ## SAML service-provider metadata
 
@@ -402,6 +430,10 @@ for example `https://jellyfin.example.com/sso/SAML/metadata/keycloak`. The respo
   **only when [request signing](#saml-request-signing-optional) (`SignAuthnRequests`) is enabled** for
   that provider. Only the public certificate is published; the private key (`SamlSigningKeyPfx`) never
   leaves the server. When signing is off, no `KeyDescriptor` is emitted and `AuthnRequestsSigned="false"`.
+  During an [SP signing-key rollover](#saml-sp-signing-key-rollover) — when `SamlRolloverSigningKeyPfx`
+  is also set — **two** signing `KeyDescriptor` entries are published (the primary and the rollover
+  public certificate), so the identity provider trusts either while you swap; again only the public
+  certificates are ever published.
 
 The endpoint is **anonymous** — SP metadata is public information, and a real identity provider fetches
 it unauthenticated.
@@ -412,8 +444,9 @@ request `Host` header.** This is deliberate and security-critical: metadata is c
 provider to decide where it POSTs assertions, so deriving the ACS from a spoofable (proxy-forwarded)
 host would let an attacker point your identity provider at an attacker-controlled endpoint. Therefore the
 endpoint **fails closed** — it returns `409 Conflict` and publishes nothing — when the provider has no
-`BaseUrlOverride` set (or no client ID, or request signing is on but the signing key cannot be loaded).
-Set the provider's `BaseUrlOverride` first, then fetch its metadata.
+`BaseUrlOverride` set (or no client ID, or request signing is on but the primary — or a configured
+rollover — signing key cannot be loaded; a broken `KeyDescriptor` is never published). Set the
+provider's `BaseUrlOverride` first, then fetch its metadata.
 
 ## SAML login browser binding
 


### PR DESCRIPTION
# What & why

Part 1 of #491. It lets the SAML service provider rotate its **own** signing
certificate with zero downtime by publishing both the old and the new public
certificate in the SP metadata during an overlap window, while still signing
`AuthnRequests` with a single (primary) key. Refs #491, this delivers only
capability 1 (outbound SP signing-key rollover); capability 2 (inbound IdP
verification-cert rotation) stays open for a follow-up, so this does **not**
close the issue.

Today `SamlConfig.SamlSigningKeyPfx` holds one SP signing key: it signs the
outgoing `AuthnRequest` (#167/#493) and is exposed as a single signing
`KeyDescriptor` in the SP metadata (#567). We add an optional second key,
`SamlRolloverSigningKeyPfx`:

- **Signing is unchanged.** Outgoing `AuthnRequests` are always signed with the
  **primary** key only. The rollover key is **publish-only**, it never signs.
- **Metadata advertises both.** When the rollover key is set and its
  certificate loads, the metadata publishes **two** `KeyDescriptor use="signing"`
  entries (primary then rollover, public certificates only), so the identity
  provider trusts either while the admin swaps. When the rollover key is unset,
  the output is byte-for-byte the previous single-`KeyDescriptor` document.
- **Clean end state.** When the rollover certificate equals the primary (the
  natural state once the admin promotes the rollover into the primary field),
  the redundant second descriptor is dropped, returning to a single key, no
  separate "clear the key" step is needed (the rollover key is write-only, so a
  blank save cannot clear it; the dedup makes that unnecessary).
- **The rollover key is a secret** (a private PFX) and is handled exactly like
  the primary: write-only JSON redaction (`WriteOnlySecretConverter` → `null` on
  read), **encrypted at rest** via `ConfigSecretProtection.ProtectAll` (and
  covered by `HasAnyEnvelope` so the missing-key orphan-prevention still fires),
  **preserved on a blank save** (`ServerManagedFields.ResolveUpdatedRolloverSigningKey`),
  and a garbage value is rejected at every admin write door (`SAML/Add` and the
  config-page save validator).
- **Fail-closed.** A set-but-unloadable rollover key returns `409` and publishes
  nothing (never a broken `KeyDescriptor`), mirroring the primary key. Only
  public certificate DER (`certificate.RawData`) ever reaches the builder; no
  private key leaves the server. #567's anti-spoofing (entity id/ACS from the
  canonical `BaseUrlOverride` only, fail-closed `409`) and the metadata XSD
  element order are preserved.

`providers.md` documents the new field and the step-by-step overlap-window
rotation procedure.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (A set-but-unloadable rollover key →
      `409`, never a broken/omitted descriptor; signing off → no descriptor.)
- [x] No secrets logged; secrets are redacted on config export. (The rollover
      private key is write-only across JSON and never logged; only public DER is
      published.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Four-lens adversarial gate —
      availability / security-bypass / correctness / integration — all PASS; see
      Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new log
      lines take IdP-controlled input in this change.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. (Shared `WriteSigningKeyDescriptor` helper; shared
      `TryRevealPublicCertificate` reveal/export; `ResolveUpdatedRolloverSigningKey`
      mirrors the primary.)
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (The signing keys are XML/API-only, so they correctly stay out of the
      OIDC-form security-critical roster; no new structural rule is needed.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings.)
- [x] `dotnet test` is green. (1211/1211, Debug and Release.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      (`providers.md`.)

## Notes

**Adversarial review gate (4 lenses, refute-by-default), all PASS:**

- **Availability / mass-lockout:** PASS. The login path (challenge/callback/
  authenticate) never reads the rollover key, it is metadata-only. Rollover
  unset is byte-for-byte the prior behavior; the `409`-on-unloadable-rollover is
  off the login path and cannot brick logins; blank-keeps-stored cannot wipe a
  mid-rotation overlap on an unrelated save, and a non-blank value still rotates.
- **Security-bypass:** PASS. No private-key leak (only `certificate.RawData` is
  published; the stored PFX never appears in the response), no plaintext-at-rest
  (encrypted via `ProtectAll`; `HasAnyEnvelope` covers it), redacted on export,
  signing uses the primary only (verified cryptographically in a test), garbage
  keys rejected, `Reveal` fails closed on `CryptographicException`.
- **Correctness:** PASS. Valid SAML 2.0 with two signing `KeyDescriptor`s in XSD
  element order (KeyDescriptor before AssertionConsumerService, now pinned by a
  test), `AuthnRequestsSigned="true"`, ordinal dedup only on byte-identical DER,
  signing-off emits no descriptor, non-vacuous tests.
- **Integration:** PASS. #158 config-secret machinery covers the field on every
  door (protect, envelope-detect, preserve-on-blank, validate, reject); #567
  anti-spoofing preserved; JSON write-only + XML persisted round-trip; correctly
  out of the OIDC-only conformance roster; backward-compatible with configs that
  lack the element.

**Out of scope / follow-up:** capability 2 of #491 - inbound IdP
verification-cert rotation (accept a response verifying against either the
primary `SamlCertificate` or an optional secondary, reject expired certs) - 
remains open in #491 for a separate PR. #491 is closed manually only once both
parts land. Base branch is `4.2` (feature line), which is non-default.
