### PR TITLE
Add admin config export/import (#161)

### DIFF
--- a/SSO-Auth.Tests/ConfigExportImportTests.cs
+++ b/SSO-Auth.Tests/ConfigExportImportTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the config export/import helpers (#161): <see cref="ConfigExport"/> produces a document whose
+/// serialization redacts every secret and server-managed link (reusing the config's own JSON-boundary
+/// withholding, not a second redaction), and <see cref="ConfigImport"/> validates fail-closed and merges
+/// without wiping the target's secrets, links, or NewPath. The controller wiring is covered separately
+/// (SSOControllerConfigTransferTests); these pin the pure logic with no plugin instance involved.
+/// </summary>
+public class ConfigExportImportTests
+{
+    private static readonly Guid TargetUser = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid SourceUser = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    // A round-trip through System.Text.Json, exactly as the export endpoint (serialize) and the import
+    // endpoint (deserialize) do, so a test starts from the real on-the-wire (redacted) document.
+    private static ConfigExportDocument WireRoundTrip(ConfigExportDocument document) =>
+        JsonSerializer.Deserialize<ConfigExportDocument>(JsonSerializer.Serialize(document))!;
+
+    [Fact]
+    public void Export_SerializedDocument_ContainsNoSecretEnvelopeOrLink()
+    {
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com/.well-known/openid-configuration",
+            OidClientId = "client-1",
+            OidSecret = "TOP-SECRET-OIDC-VALUE",
+            EnableAuthorization = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = TargetUser },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = "https://idp.example.com" },
+        };
+        live.SamlConfigs["saml"] = new SamlConfig
+        {
+            SamlEndpoint = "https://saml.example.com/sso",
+            SamlSigningKeyPfx = "TOP-SECRET-SAML-SIGNING-KEY",
+            SamlRolloverSigningKeyPfx = "TOP-SECRET-SAML-ROLLOVER-KEY",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = TargetUser },
+        };
+
+        var json = JsonSerializer.Serialize(ConfigExport.Build(live));
+
+        // The secrets and link maps are withheld by the config's own converters/[JsonIgnore] (#189/#157/#186),
+        // so no secret value, no ssoenc: envelope prefix, and no canonical-link map name can appear.
+        Assert.DoesNotContain("TOP-SECRET-OIDC-VALUE", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("TOP-SECRET-SAML-SIGNING-KEY", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("TOP-SECRET-SAML-ROLLOVER-KEY", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("CanonicalLinks", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("CanonicalLinkIssuers", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("nameid-1", json, StringComparison.Ordinal);
+
+        // But the non-secret configuration IS present, so the document is a usable export.
+        Assert.Contains("idp", json, StringComparison.Ordinal);
+        Assert.Contains("client-1", json, StringComparison.Ordinal);
+        Assert.Contains("https://saml.example.com/sso", json, StringComparison.Ordinal);
+        Assert.Contains("\"FormatVersion\":1", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Import_RoundTrip_PreservesTargetSecretLinksAndNewPath_AndMergesNonSecretConfig()
+    {
+        // Source instance: a provider with a secret and its own links, plus a security toggle to merge.
+        var source = new PluginConfiguration();
+        source.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com",
+            OidClientId = "client-1",
+            OidSecret = "SOURCE-SECRET",
+            EnableAuthorization = true,
+            NewPath = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-src"] = SourceUser },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-src"] = "https://idp.example.com" },
+        };
+
+        var wire = WireRoundTrip(ConfigExport.Build(source));
+
+        // Target instance already has the provider with its OWN stored secret, links and NewPath.
+        var target = new PluginConfiguration();
+        target.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com",
+            OidClientId = "client-1",
+            OidSecret = "TARGET-SECRET",
+            NewPath = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-tgt"] = TargetUser },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-tgt"] = "https://idp.example.com" },
+        };
+
+        ConfigImport.Apply(target, wire);
+
+        var merged = target.OidConfigs["idp"];
+        // Blank (redacted) secret in the import keeps the target's stored secret (#189).
+        Assert.Equal("TARGET-SECRET", merged.OidSecret);
+        // Server-managed links/issuers are the target's, never wiped by the import (#157/#186).
+        Assert.Equal(TargetUser, merged.CanonicalLinks["sub-tgt"]);
+        Assert.Equal("https://idp.example.com", merged.CanonicalLinkIssuers["sub-tgt"]);
+        Assert.False(merged.CanonicalLinks.ContainsKey("sub-src"));
+        // NewPath (server-managed runtime state) is kept from the target, not overwritten by the document.
+        Assert.True(merged.NewPath);
+        // The non-secret config IS merged from the import.
+        Assert.True(merged.EnableAuthorization);
+    }
+
+    [Fact]
+    public void Import_SamlProvider_KeepsTargetSigningKeys_WhenImportRedacted()
+    {
+        var source = new PluginConfiguration();
+        source.SamlConfigs["saml"] = new SamlConfig
+        {
+            SamlEndpoint = "https://saml.example.com/sso",
+            SignAuthnRequests = true,
+            SamlSigningKeyPfx = "SOURCE-KEY",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-src"] = SourceUser },
+        };
+        var wire = WireRoundTrip(ConfigExport.Build(source));
+
+        var target = new PluginConfiguration();
+        target.SamlConfigs["saml"] = new SamlConfig
+        {
+            SamlEndpoint = "https://old.example.com/sso",
+            SamlSigningKeyPfx = "TARGET-KEY",
+            SamlRolloverSigningKeyPfx = "TARGET-ROLLOVER",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-tgt"] = TargetUser },
+        };
+
+        ConfigImport.Apply(target, wire);
+
+        var merged = target.SamlConfigs["saml"];
+        Assert.Equal("TARGET-KEY", merged.SamlSigningKeyPfx);
+        Assert.Equal("TARGET-ROLLOVER", merged.SamlRolloverSigningKeyPfx);
+        Assert.Equal(TargetUser, merged.CanonicalLinks["nameid-tgt"]);
+        // The non-secret endpoint IS merged.
+        Assert.Equal("https://saml.example.com/sso", merged.SamlEndpoint);
+        Assert.True(merged.SignAuthnRequests);
+    }
+
+    [Fact]
+    public void Import_NewProvider_ArrivesWithBlankSecret_FailsClosed()
+    {
+        var source = new PluginConfiguration();
+        source.OidConfigs["fresh"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com",
+            OidClientId = "client-fresh",
+            OidSecret = "SOURCE-SECRET",
+        };
+        var wire = WireRoundTrip(ConfigExport.Build(source));
+
+        var target = new PluginConfiguration();
+
+        ConfigImport.Apply(target, wire);
+
+        // The provider is added, but its secret is blank (redacted out of the export) — the login fails
+        // closed until an admin re-enters it; no attacker-chosen secret was imported.
+        Assert.True(target.OidConfigs.ContainsKey("fresh"));
+        Assert.True(string.IsNullOrEmpty(target.OidConfigs["fresh"].OidSecret));
+        Assert.Empty(target.OidConfigs["fresh"].CanonicalLinks);
+    }
+
+    [Fact]
+    public void Import_LeavesTargetOnlyProvidersUntouched_ItIsAMergeNotAReplace()
+    {
+        var source = new PluginConfiguration();
+        source.OidConfigs["from-import"] = new OidConfig { OidEndpoint = "https://idp.example.com", OidClientId = "c" };
+        var wire = WireRoundTrip(ConfigExport.Build(source));
+
+        var target = new PluginConfiguration();
+        target.OidConfigs["target-only"] = new OidConfig { OidClientId = "keep-me" };
+
+        ConfigImport.Apply(target, wire);
+
+        Assert.True(target.OidConfigs.ContainsKey("target-only"));
+        Assert.Equal("keep-me", target.OidConfigs["target-only"].OidClientId);
+        Assert.True(target.OidConfigs.ContainsKey("from-import"));
+    }
+
+    [Fact]
+    public void Import_DoesNotImportGlobalRateLimitSettings_KeepsTheTargetsOwn()
+    {
+        // Rate-limit tuning is instance-local operational config (reverse-proxy dependent); importing it
+        // would let a document with rate limiting off SILENTLY disable a DoS control on a target that had it
+        // on. The import keeps the target's limiter configuration.
+        var source = new PluginConfiguration { EnableRateLimit = false, RateLimitMaxAttempts = 999, RateLimitWindowSeconds = 1 };
+        var wire = WireRoundTrip(ConfigExport.Build(source));
+        var target = new PluginConfiguration { EnableRateLimit = true, RateLimitMaxAttempts = 7, RateLimitWindowSeconds = 90 };
+
+        ConfigImport.Apply(target, wire);
+
+        Assert.True(target.EnableRateLimit);
+        Assert.Equal(7, target.RateLimitMaxAttempts);
+        Assert.Equal(90, target.RateLimitWindowSeconds);
+    }
+
+    [Fact]
+    public void Export_RedactionSurvivesTheMvcCamelCaseSerializer()
+    {
+        // The endpoint returns Ok(document); ASP.NET Core MVC serializes with camelCase + case-insensitive
+        // read. Prove the write-only secret redaction (which is attribute-, not name-, based) still holds and
+        // a round-trip through those options works — the on-the-wire path the controller actually uses.
+        var options = new System.Text.Json.JsonSerializerOptions
+        {
+            PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+        };
+
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://idp.example.com", OidClientId = "client-1", OidSecret = "MVC-WIRE-SECRET" };
+
+        var json = JsonSerializer.Serialize(ConfigExport.Build(live), options);
+        Assert.DoesNotContain("MVC-WIRE-SECRET", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+
+        // The camelCase document deserializes back (case-insensitive) with the provider intact and the secret
+        // still redacted to null.
+        var wire = JsonSerializer.Deserialize<ConfigExportDocument>(json, options)!;
+        Assert.Equal("client-1", wire.Configuration.OidConfigs["idp"].OidClientId);
+        Assert.True(string.IsNullOrEmpty(wire.Configuration.OidConfigs["idp"].OidSecret));
+    }
+
+    [Fact]
+    public void Import_UnsupportedVersion_Throws_AndLeavesTargetUntouched()
+    {
+        var target = new PluginConfiguration();
+        target.OidConfigs["existing"] = new OidConfig { OidClientId = "unchanged" };
+        var document = new ConfigExportDocument { FormatVersion = 999, Configuration = new PluginConfiguration() };
+
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(target, document));
+
+        Assert.Single(target.OidConfigs);
+        Assert.Equal("unchanged", target.OidConfigs["existing"].OidClientId);
+    }
+
+    [Fact]
+    public void Import_NullPayload_Throws()
+    {
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = null };
+
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(new PluginConfiguration(), document));
+    }
+
+    [Fact]
+    public void Import_InvalidProvider_Throws_AndPersistsNothing_FailClosed()
+    {
+        // A hostile document with a malformed Base URL override must be rejected by ProviderConfigValidator
+        // before any provider is merged, so the target is left exactly as it was (atomic, fail-closed).
+        var target = new PluginConfiguration();
+        target.OidConfigs["existing"] = new OidConfig { OidClientId = "unchanged" };
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["bad"] = new OidConfig { BaseUrlOverride = "not-a-url" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(target, document));
+
+        Assert.False(target.OidConfigs.ContainsKey("bad"));
+        Assert.Single(target.OidConfigs);
+        Assert.Equal("unchanged", target.OidConfigs["existing"].OidClientId);
+    }
+
+    [Fact]
+    public void Import_NewProviderWithReservedName_Throws_FailClosed()
+    {
+        // A new provider name with URI-reserved characters becomes part of the callback URL, so the import
+        // rejects it exactly as the config-page save does (#336/#360).
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["my/realm"] = new OidConfig();
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.Throws<ArgumentException>(() => ConfigImport.Apply(new PluginConfiguration(), document));
+    }
+
+    [Fact]
+    public void Import_NullConfigurationOrDocument_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => ConfigImport.Apply(null!, new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = new PluginConfiguration() }));
+        Assert.Throws<ArgumentNullException>(() => ConfigImport.Apply(new PluginConfiguration(), null!));
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerConfigTransferTests.cs
+++ b/SSO-Auth.Tests/SSOControllerConfigTransferTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the config export/import endpoints (#161) via <see cref="SsoControllerHarness"/>,
+/// so the export redaction and the import merge run through the REAL configuration store and secret-at-rest
+/// encryption, not just the pure helpers (ConfigExportImportTests covers those). Proves: the exported
+/// document leaks no secret; a round-trip import keeps the target's stored secret and links while merging
+/// the non-secret config; and a malformed/invalid import is rejected fail-closed and persists nothing.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerConfigTransferTests
+{
+    private static readonly Guid TargetUser = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+    private static ConfigExportDocument WireRoundTrip(ConfigExportDocument document) =>
+        JsonSerializer.Deserialize<ConfigExportDocument>(JsonSerializer.Serialize(document))!;
+
+    private static ConfigExportDocument ExportedDocument(SsoControllerHarness harness) =>
+        Assert.IsType<ConfigExportDocument>(Assert.IsType<OkObjectResult>(harness.Controller.ExportConfig()).Value);
+
+    [Fact]
+    public void ExportConfig_SerializedResponse_LeaksNoSecret()
+    {
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["idp"] = new OidConfig { OidClientId = "client-1", OidSecret = "PLAINTEXT-OIDC-SECRET" };
+            c.SamlConfigs["saml"] = new SamlConfig { SamlEndpoint = "https://saml.example.com", SamlSigningKeyPfx = "PLAINTEXT-SAML-KEY" };
+        });
+
+        var json = JsonSerializer.Serialize(ExportedDocument(harness));
+
+        Assert.DoesNotContain("PLAINTEXT-OIDC-SECRET", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("PLAINTEXT-SAML-KEY", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.Contains("idp", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ImportConfig_RoundTrip_KeepsStoredSecretAndLinks_AndMergesNonSecretConfig()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com",
+            OidClientId = "client-1",
+            OidSecret = "STORED-SECRET",
+            EnableAuthorization = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = TargetUser },
+        });
+
+        // Take the redacted document the export would hand out, flip a non-secret setting, and re-import it.
+        var wire = WireRoundTrip(ExportedDocument(harness));
+        wire.Configuration.OidConfigs["idp"].EnableAuthorization = true;
+
+        var result = harness.Controller.ImportConfig(wire);
+
+        Assert.IsType<NoContentResult>(result);
+        var merged = harness.Configuration.OidConfigs["idp"];
+        // The stored secret survives the round-trip (blank-means-keep, #189) — revealed because the persist
+        // path encrypts it at rest (#158).
+        Assert.Equal("STORED-SECRET", SSOPlugin.Instance.Secrets.Reveal(merged.OidSecret));
+        // The server-managed link is preserved (#157), and the non-secret toggle is merged from the import.
+        Assert.Equal(TargetUser, merged.CanonicalLinks["sub-1"]);
+        Assert.True(merged.EnableAuthorization);
+    }
+
+    [Fact]
+    public void ImportConfig_NullDocument_ReturnsBadRequest_PersistsNothing()
+    {
+        var harness = new SsoControllerHarness();
+
+        Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(null!));
+
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void ImportConfig_UnsupportedVersion_ReturnsBadRequest_PersistsNothing()
+    {
+        var harness = new SsoControllerHarness();
+        var document = new ConfigExportDocument { FormatVersion = 999, Configuration = new PluginConfiguration() };
+
+        Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(document));
+
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void ImportConfig_InvalidProvider_ReturnsBadRequest_PersistsNothing_AndLeavesConfigUntouched()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["existing"] = new OidConfig { OidClientId = "unchanged" });
+
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["bad"] = new OidConfig { BaseUrlOverride = "not-a-url" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.IsType<BadRequestObjectResult>(harness.Controller.ImportConfig(document));
+
+        // Fail-closed: the invalid document is rejected before anything is persisted or merged in memory.
+        harness.Xml.DidNotReceive().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+        Assert.False(harness.Configuration.OidConfigs.ContainsKey("bad"));
+        Assert.Equal("unchanged", harness.Configuration.OidConfigs["existing"].OidClientId);
+    }
+
+    [Fact]
+    public void ImportConfig_ValidDocument_Persists()
+    {
+        var harness = new SsoControllerHarness();
+        var imported = new PluginConfiguration();
+        imported.OidConfigs["new-idp"] = new OidConfig { OidEndpoint = "https://idp.example.com", OidClientId = "c" };
+        var document = new ConfigExportDocument { FormatVersion = ConfigExport.FormatVersion, Configuration = imported };
+
+        Assert.IsType<NoContentResult>(harness.Controller.ImportConfig(document));
+
+        harness.Xml.Received().SerializeToFile(Arg.Any<object>(), Arg.Any<string>());
+        Assert.True(harness.Configuration.OidConfigs.ContainsKey("new-idp"));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -43,6 +43,11 @@ public class SSOController : ControllerBase
     private const string OpenIdProtocol = "OpenID";
     private const string SamlProtocol = "SAML";
 
+    // Hard cap on the config-import request body (#161): a whole plugin configuration is small (kilobytes),
+    // so 1 MiB is generous headroom while an oversized document is rejected fail-closed (413) before it is
+    // parsed, rather than being deserialized into memory.
+    private const long ConfigImportMaxBytes = 1024 * 1024;
+
     private readonly IUserManager _userManager;
     // The shared login-completion tail (#160, #318): resolve/adopt the link, build the session parameters,
     // mint under the revocation gate, audit, map to a LoginOutcome. The controller passes the
@@ -570,6 +575,86 @@ public class SSOController : ControllerBase
         }
 
         return Ok(ProviderConnectionTester.TestSaml(config));
+    }
+
+    /// <summary>
+    /// Exports the whole plugin configuration as a redacted, importable document (#161). Requires
+    /// administrator privileges, like the other config endpoints — the document lists every provider's
+    /// settings. The redaction is the config's OWN JSON-boundary withholding, reused: the provider secrets
+    /// (OidSecret, the SAML signing keys) are serialized as null by their WriteOnlySecretConverter (#189) and
+    /// the server-managed canonical-link maps are dropped by [JsonIgnore] (#157/#186), so the document carries
+    /// no plaintext secret, no <c>ssoenc:</c> envelope, and no link map. The at-rest data-encryption key
+    /// (sso-secret.key) lives in a separate file and is never part of the configuration object at all.
+    /// </summary>
+    /// <returns>The redacted export document.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Config/Export")]
+    public ActionResult ExportConfig()
+    {
+        // Snapshot under the config lock; the JSON formatter redacts the secrets and links as it serializes
+        // the returned document (the same withholding OID/Get relies on), after the lock is released.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(ConfigExport.Build));
+    }
+
+    /// <summary>
+    /// Imports a configuration export document into this instance (#161). Requires administrator privileges.
+    /// The import is a fail-closed MERGE: the document is validated through the same ProviderConfigValidator
+    /// the config-page save uses, and only if the whole document is valid is it merged — atomically, through
+    /// MutateConfiguration — reusing ServerManagedFields.Preserve so a redacted (blank) secret keeps this
+    /// instance's stored secret and the server-managed links/issuers are never wiped. A provider new to this
+    /// instance arrives with a blank secret and fails its login closed until an administrator re-enters it.
+    /// The request body is size-capped so an oversized document is rejected before it is parsed.
+    /// </summary>
+    /// <param name="document">The export document to import.</param>
+    /// <returns>No content on success, or 400 when the document is missing, unsupported, or invalid.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("Config/Import")]
+    [RequestSizeLimit(ConfigImportMaxBytes)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public ActionResult ImportConfig([FromBody] ConfigExportDocument document)
+    {
+        if (document is null)
+        {
+            return BadRequest("The configuration import document is missing or is not valid JSON.");
+        }
+
+        try
+        {
+            // Validate-then-merge lives in the Config helper; the mutation persists only if it returns without
+            // throwing (an invalid document throws inside the lambda, so MutateConfiguration persists nothing).
+            SSOPlugin.Instance.MutateConfiguration(configuration => ConfigImport.Apply(configuration, document));
+        }
+        catch (ArgumentException ex)
+        {
+            // The validator and the import throw ArgumentException for a hostile/malformed document (a bad
+            // Base URL override, an unloadable certificate/key, a reserved-character provider name, an
+            // unsupported version). Strip line endings from the echoed message so it cannot split a log line.
+            return BadRequest(ex.Message?.ReplaceLineEndings(string.Empty));
+        }
+
+        // Audit the import and any provider that arrived with a security check disabled (#140), so importing
+        // an escape hatch (DisableHttps, DoNotValidateIssuerName, …) leaves the same trace a form save would.
+        var oidCount = document.Configuration?.OidConfigs?.Count ?? 0;
+        var samlCount = document.Configuration?.SamlConfigs?.Count ?? 0;
+        SsoAudit.ConfigImported(_logger, oidCount, samlCount);
+        if (document.Configuration?.OidConfigs is { } oidConfigs)
+        {
+            foreach (var kvp in oidConfigs)
+            {
+                if (kvp.Value is null)
+                {
+                    continue;
+                }
+
+                var insecure = OidcInsecureToggles.Enabled(kvp.Value);
+                if (insecure.Count > 0)
+                {
+                    SsoAudit.InsecureOptionsEnabled(_logger, OpenIdProtocol, kvp.Key, insecure);
+                }
+            }
+        }
+
+        return NoContent();
     }
 
     /// <summary>

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -66,6 +66,16 @@ internal static class SsoAudit
             "[SSO Audit] OpenID provider '{Provider}' does not advertise PKCE (S256) in its discovery document (code_challenge_methods_supported). PKCE is still sent, but a server that ignores it leaves cross-session authorization-code injection undetectable (RFC 9700 §2.1.1). Set RequirePkce to fail closed once the provider supports it.",
             provider?.ReplaceLineEndings(string.Empty));
 
+    /// <summary>Records an administrator importing a configuration document (#161).</summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="oidProviders">How many OpenID providers the import merged.</param>
+    /// <param name="samlProviders">How many SAML providers the import merged.</param>
+    internal static void ConfigImported(ILogger logger, int oidProviders, int samlProviders)
+        => logger.LogWarning(
+            "[SSO Audit] Configuration imported by an administrator: {OidProviders} OpenID and {SamlProviders} SAML provider(s) merged. Server-managed secrets and links were preserved; redacted secrets must be re-entered on this instance.",
+            oidProviders,
+            samlProviders);
+
     /// <summary>Records a provider being saved with one or more security checks disabled (#140).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Config/ConfigExport.cs
+++ b/SSO-Auth/Config/ConfigExport.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Builds the redacted, importable configuration export document (#161). It does NOT re-implement any
+/// redaction: the plugin configuration already withholds its secrets and server-managed link maps at the
+/// JSON boundary (the <see cref="WriteOnlySecretConverter"/> on the three secret fields, #189, and
+/// <c>[JsonIgnore]</c> on the canonical-link maps, #157/#186), so serializing the snapshot this builds is
+/// redacted by construction — the export reflects the same withholding an <c>OID/Get</c> response already
+/// does, reused rather than duplicated. This type only detaches the live configuration so the JSON
+/// formatter (which runs after the config lock is released) serializes a stable snapshot rather than a
+/// live, concurrently-mutated object.
+/// </summary>
+internal static class ConfigExport
+{
+    /// <summary>
+    /// The current export/import document format version. Bumped only on a breaking change to the document
+    /// shape; the import rejects any other version fail-closed (<see cref="ConfigImport.Apply"/>).
+    /// </summary>
+    internal const int FormatVersion = 1;
+
+    /// <summary>
+    /// Builds the export document from the live configuration. Call it under the config lock (through
+    /// <c>ReadConfiguration</c>) so the snapshot is taken atomically; the returned document holds a detached
+    /// copy of the provider maps, so the JSON formatter serializing it later cannot tear against a concurrent
+    /// provider add/remove.
+    /// </summary>
+    /// <param name="live">The live plugin configuration to snapshot.</param>
+    /// <returns>The redacted export document.</returns>
+    internal static ConfigExportDocument Build(PluginConfiguration live)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        return new ConfigExportDocument
+        {
+            FormatVersion = FormatVersion,
+            Configuration = Snapshot(live),
+        };
+    }
+
+    // A fresh configuration carrying the live scalars and shallow copies of the provider maps. The provider
+    // objects are shared (not cloned): their secrets and link maps are withheld by the JSON converters, and
+    // the only in-place write on the login hot path is the NewPath scalar flip — which cannot tear a JSON
+    // serialization — so a shallow copy is the same safe snapshot SSOController.SnapshotConfigs relies on
+    // (#157/F-10).
+    private static PluginConfiguration Snapshot(PluginConfiguration live) => new()
+    {
+        EnableRateLimit = live.EnableRateLimit,
+        RateLimitMaxAttempts = live.RateLimitMaxAttempts,
+        RateLimitWindowSeconds = live.RateLimitWindowSeconds,
+        OidConfigs = ShallowCopy(live.OidConfigs),
+        SamlConfigs = ShallowCopy(live.SamlConfigs),
+    };
+
+    private static SerializableDictionary<string, T> ShallowCopy<T>(SerializableDictionary<string, T> source)
+    {
+        var copy = new SerializableDictionary<string, T>();
+        if (source is not null)
+        {
+            foreach (var kvp in source)
+            {
+                copy[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return copy;
+    }
+}

--- a/SSO-Auth/Config/ConfigExportDocument.cs
+++ b/SSO-Auth/Config/ConfigExportDocument.cs
@@ -1,0 +1,28 @@
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The portable document produced by the admin config export and consumed by the import (#161): a version
+/// marker plus the redacted plugin configuration. It is a JSON-only transport shape — never persisted to
+/// the config XML — so it carries no XML-serialization attributes. Serializing it applies the config's
+/// existing JSON-boundary redaction unchanged: the provider secrets (<see cref="OidConfig.OidSecret"/>,
+/// <see cref="SamlConfig.SamlSigningKeyPfx"/>, <see cref="SamlConfig.SamlRolloverSigningKeyPfx"/>) are
+/// withheld by their <see cref="WriteOnlySecretConverter"/> and the server-managed link maps by
+/// <c>[JsonIgnore]</c>, so an exported document can contain neither a plaintext secret, an <c>ssoenc:</c>
+/// envelope, nor a canonical-link map. The <see cref="FormatVersion"/> lets the import reject a document it
+/// does not understand fail-closed rather than partially applying it.
+/// </summary>
+public class ConfigExportDocument
+{
+    /// <summary>
+    /// Gets or sets the document format version. The import refuses a version it does not recognise (#161),
+    /// so a future breaking change to the shape cannot be half-applied to an older instance.
+    /// </summary>
+    public int FormatVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the redacted plugin configuration. On export it is a detached snapshot of the live
+    /// configuration whose secrets and server-managed link maps are withheld at the JSON boundary; on import
+    /// it is the incoming configuration to merge into the target.
+    /// </summary>
+    public PluginConfiguration Configuration { get; set; }
+}

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -1,0 +1,113 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Applies a redacted export document (<see cref="ConfigExportDocument"/>) onto the live configuration as a
+/// MERGE (#161), reusing the config tier's own validation and server-managed-field preservation rather than
+/// hand-rolling a merge that bypasses them. Two invariants make an import safe:
+/// <list type="bullet">
+/// <item>Fail-closed: the whole incoming set is validated through <see cref="ProviderConfigValidator"/>
+/// BEFORE anything is mutated, so a malformed or hostile document is rejected without partially applying it.
+/// Call this inside <c>MutateConfiguration</c>, which persists only when the mutation returns without
+/// throwing, so a rejected import leaves the stored configuration untouched (atomic).</item>
+/// <item>No accidental wipe: each imported provider is merged through <see cref="ServerManagedFields.Preserve(OidConfig, OidConfig)"/>
+/// (and its SAML overload), so a redacted (blank) secret keeps the target's stored secret (#189) and the
+/// server-managed links/issuers are re-injected from the target (#157/#186) as long as the provider's
+/// identity is unchanged. The ONE deliberate exception is Preserve's OpenID repoint belt (#186): if the
+/// imported document changes an existing OpenID provider's discovery endpoint or client id, that is treated
+/// as a repoint to a potentially different identity provider, so its links/issuers are cleared and its
+/// stored secret is not carried over — exactly as a config-page edit behaves, so a foreign IdP cannot
+/// inherit the old one's account mappings. SAML links are preserved regardless.</item>
+/// </list>
+/// A merge (upsert), not a replace: a provider that exists only on the target is left untouched, and a
+/// provider new to the target is added with its own empty link maps and a blank secret (fail closed until an
+/// admin re-enters it — a redacted export cannot ship the secret).
+/// </summary>
+internal static class ConfigImport
+{
+    /// <summary>
+    /// Validates and merges the export document into <paramref name="live"/>. Throws before any mutation on a
+    /// document with an unsupported version, an absent payload, or an invalid provider, so the caller's
+    /// <c>MutateConfiguration</c> persists nothing.
+    /// </summary>
+    /// <param name="live">The live configuration to merge into (mutated in place).</param>
+    /// <param name="document">The import document.</param>
+    /// <exception cref="ArgumentException">The document is unsupported, empty, or carries an invalid provider.</exception>
+    internal static void Apply(PluginConfiguration live, ConfigExportDocument document)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        ArgumentNullException.ThrowIfNull(document);
+
+        if (document.FormatVersion != ConfigExport.FormatVersion)
+        {
+            throw new ArgumentException(
+                $"Unsupported configuration export format version {document.FormatVersion}; this plugin imports version {ConfigExport.FormatVersion}.");
+        }
+
+        var imported = document.Configuration
+            ?? throw new ArgumentException("The configuration import document has no configuration payload.");
+
+        // 1. Validate the incoming providers fail-closed BEFORE touching the live configuration, exactly as
+        //    the config-page save does (ProviderConfigStore.Save): a malformed Base URL override (#139), an
+        //    unloadable SAML certificate/signing key (#206/#167), or a provider name new to this instance
+        //    carrying URI-reserved/control characters (#336/#360) rejects the whole import. The live config is
+        //    passed so a reserved-character name this instance already holds stays importable.
+        ProviderConfigValidator.Validate(imported, live);
+
+        // 2. Only now — with the document proven valid — merge each provider. ServerManagedFields.Preserve is
+        //    the SAME re-injection the config-page save and OID/SAML Add use, so blank-means-keep for secrets
+        //    and the server-managed link/issuer maps behave identically on every write path (#318). The
+        //    global rate-limit settings (EnableRateLimit/RateLimitMaxAttempts/RateLimitWindowSeconds) are
+        //    deliberately NOT imported: they are instance-local operational tuning (reverse-proxy dependent —
+        //    see the config-page caution), and a scalar has no blank-means-keep signal, so importing them
+        //    would let a foreign or partial document SILENTLY disable this instance's rate limiter (a DoS
+        //    control) down to the deserialized defaults. The target keeps its own limiter configuration; an
+        //    admin tunes it on the config page, not by import.
+        MergeProviders(live.OidConfigs, imported.OidConfigs, ServerManagedFields.Preserve);
+        MergeProviders(live.SamlConfigs, imported.SamlConfigs, ServerManagedFields.Preserve);
+    }
+
+    // Upserts each imported provider into the target map. An existing target provider has its server-managed
+    // fields re-injected (Preserve carries the stored secret when the import's is blank, and the links/issuers
+    // always) before the imported object replaces it, so nothing server-owned is wiped; a provider new to the
+    // target is added as-is (its own empty link maps, a blank secret that fails the login closed until an
+    // admin supplies one). A provider present only on the target is not in this loop, so it is left untouched
+    // (merge, not replace). A null-valued incoming entry carries nothing to import and is skipped rather than
+    // dereferenced (#538).
+    private static void MergeProviders<T>(
+        SerializableDictionary<string, T> live,
+        SerializableDictionary<string, T> imported,
+        Action<T, T> preserve)
+        where T : ProviderConfigBase
+    {
+        if (imported is null)
+        {
+            return;
+        }
+
+        foreach (var kvp in imported)
+        {
+            if (kvp.Value is null)
+            {
+                continue;
+            }
+
+            if (live.TryGetValue(kvp.Key, out var existing) && existing is not null)
+            {
+                preserve(kvp.Value, existing);
+
+                // NewPath is server-managed runtime state (which redirect-path spelling the last challenge
+                // used), not an admin setting, and it is meaningless across instances — so on a merge into an
+                // EXISTING provider we keep the target's own value rather than let the imported document
+                // overwrite it. ServerManagedFields.Preserve deliberately leaves NewPath to round-trip on the
+                // config-page save (same-instance), so this cross-instance carry-over is done here, on top of
+                // Preserve, not by changing that shared rule. A provider NEW to the target keeps whatever the
+                // import carried (defaults false); its next challenge sets it correctly.
+                kvp.Value.NewPath = existing.NewPath;
+            }
+
+            live[kvp.Key] = kvp.Value;
+        }
+    }
+}

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -441,6 +441,92 @@ const ssoConfigurationPage = {
     });
     container.appendChild(list);
   },
+  // Config export (#161). Fetches the redacted export document from the elevation-gated endpoint (the
+  // server withholds every secret and account-link map) and saves it as a JSON file via a Blob download —
+  // never navigation, so the admin's auth header is sent and no secret is placed in a URL. The filename is
+  // fixed text; nothing from the document reaches the DOM as markup.
+  exportConfig: (page) => {
+    const container = page.querySelector("#ConfigTransferResult");
+    ssoConfigurationPage.renderTransferMessage(container, "Exporting…");
+
+    return ApiClient.getJSON(ApiClient.getUrl("sso/Config/Export")).then(
+      (document_json) => {
+        const blob = new Blob([JSON.stringify(document_json, null, 2)], {
+          type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const anchor = window.document.createElement("a");
+        anchor.href = url;
+        anchor.download = "sso-config-export.json";
+        window.document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        URL.revokeObjectURL(url);
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          "Exported. Provider secrets and account links are redacted from the file.",
+        );
+      },
+      () =>
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          "Could not export the configuration. Make sure you are signed in as an administrator, then try again.",
+        ),
+    );
+  },
+  // Config import (#161). Reads the chosen file as text, parses it locally (a parse error is reported, never
+  // applied), and POSTs it to the elevation-gated import endpoint. The server validates and merges it
+  // fail-closed, keeping each unchanged provider's stored secret and links (an OpenID provider whose
+  // endpoint/client id the import changes has its links/secret cleared — the #186 repoint safety measure).
+  // On success the provider list is reloaded so the merged providers appear; the admin re-enters secrets.
+  importConfig: (page, file) => {
+    const container = page.querySelector("#ConfigTransferResult");
+    if (!file) {
+      return Promise.resolve();
+    }
+
+    ssoConfigurationPage.renderTransferMessage(container, "Importing…");
+    return file
+      .text()
+      .then((text) => {
+        let document_json;
+        try {
+          document_json = JSON.parse(text);
+        } catch (e) {
+          throw new Error("not-json");
+        }
+
+        return ApiClient.fetch({
+          type: "POST",
+          url: ApiClient.getUrl("sso/Config/Import"),
+          data: JSON.stringify(document_json),
+          contentType: "application/json",
+        });
+      })
+      .then(() => {
+        ssoConfigurationPage.loadConfiguration(page);
+        ssoConfigurationPage.renderTransferMessage(
+          container,
+          "Imported. Re-enter each provider's secret and save it — secrets are never included in an export.",
+        );
+      })
+      .catch((e) => {
+        // A local parse failure and a server rejection (an invalid or unsupported document, an expired
+        // session) are both fail-closed here: the message is generic and never reflects a server value.
+        const message =
+          e && e.message === "not-json"
+            ? "That file is not valid JSON. Choose a configuration file exported from this plugin."
+            : "Could not import the configuration. The file was rejected by the server, or you are not signed in as an administrator.";
+        ssoConfigurationPage.renderTransferMessage(container, message);
+      });
+  },
+  renderTransferMessage: (container, message) => {
+    container.replaceChildren();
+    const line = window.document.createElement("p");
+    line.classList.add("fieldDescription");
+    line.textContent = message;
+    container.appendChild(line);
+  },
   addTextAreaStyle: (view) => {
     const style = document.createElement("link");
     style.rel = "stylesheet";
@@ -499,6 +585,26 @@ export default function initSsoConfigurationPage(view) {
       ssoConfigurationPage.serializeRoleMappings(container);
     current_mappings.push({ Role: "", Folders: [] });
     ssoConfigurationPage.populateRoleMappings(current_mappings, container);
+  });
+
+  view.querySelector("#ExportConfig").addEventListener("click", (e) => {
+    ssoConfigurationPage.exportConfig(view);
+    e.preventDefault();
+    return false;
+  });
+
+  // The visible Import button drives the hidden file input; selecting a file runs the import.
+  view.querySelector("#ImportConfig").addEventListener("click", (e) => {
+    view.querySelector("#ImportConfigFile").click();
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#ImportConfigFile").addEventListener("change", (e) => {
+    const file = e.target.files && e.target.files[0];
+    // Clear the input so choosing the same file again re-triggers change.
+    e.target.value = "";
+    ssoConfigurationPage.importConfig(view, file);
   });
 
   view.querySelector("#sso-self-service-link").href =

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -66,6 +66,65 @@
             to accomplish this.
           </p>
 
+          <!--
+            Config export / import (#161). Export downloads a REDACTED, importable document — the provider
+            secrets and the server-managed canonical-link maps are withheld by the server, so the file carries
+            no secret, encrypted envelope, or key. Import merges the document into THIS instance, keeping the
+            stored secret and account links of each unchanged provider (an OpenID provider whose endpoint or
+            client id the import changes has its links/secret cleared — the #186 repoint safety measure);
+            because secrets are redacted, they are re-entered on the target after an import. Both endpoints
+            require administrator privileges. The download is built from a Blob and the status is rendered with
+            textContent (never innerHTML), so no document value reaches the DOM as markup (#221).
+          -->
+          <form id="sso-config-transfer" class="esqConfigurationForm">
+            <div
+              class="verticalSection"
+              is="emby-collapse"
+              title="Export / Import Configuration"
+            >
+              <div class="collapseContent">
+                <div class="fieldDescription">
+                  Export downloads a redacted copy of this plugin's
+                  configuration (provider secrets and account links are never
+                  included). Import merges an exported file into this instance,
+                  keeping the stored secret and account links of each unchanged
+                  provider — but if the import gives an OpenID provider a
+                  different discovery endpoint or client id, that provider's
+                  links and secret are cleared (a repoint safety measure), so
+                  review a file before importing it over a live provider.
+                  Re-enter each provider's secret here after importing. Requires
+                  administrator privileges.
+                </div>
+
+                <button
+                  id="ExportConfig"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span>Export Configuration</span>
+                </button>
+
+                <input
+                  id="ImportConfigFile"
+                  type="file"
+                  accept="application/json,.json"
+                  style="display: none"
+                />
+                <button
+                  id="ImportConfig"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-alt block emby-button"
+                >
+                  <span>Import Configuration</span>
+                </button>
+
+                <div id="ConfigTransferResult"></div>
+              </div>
+            </div>
+          </form>
+
           <form id="sso-load-config" class="esqConfigurationForm">
             <div
               class="verticalSection"

--- a/providers.md
+++ b/providers.md
@@ -480,6 +480,67 @@ A failing probe returns `Ok: false` with an actionable, **generic** message (wha
 HTTPS, the `.well-known` path, a parsable certificate) that never echoes a stored secret. Because the test
 reads the **stored** provider config, **save the provider first**, then test.
 
+## Configuration export / import (admin)
+
+The whole plugin configuration can be exported to a file on one instance and imported into another (for
+example when replicating a setup or migrating a server). Both actions live in the plugin's admin config
+page — an **Export Configuration** button and an **Import Configuration** button — and are also reachable
+directly:
+
+```
+GET  <base URL>/sso/Config/Export
+POST <base URL>/sso/Config/Import
+```
+
+Both endpoints **require administrator privileges**, like every other config endpoint. The request body of
+an import is size-capped, so an oversized document is rejected before it is parsed.
+
+### The export is redacted — secrets never leave the server
+
+The export document is the **same redaction the config already applies on the JSON boundary**, reused, not
+a second copy: the provider secrets — the OpenID **client secret** (`OidSecret`) and the SAML **signing
+keys** (`SamlSigningKeyPfx`, `SamlRolloverSigningKeyPfx`) — are withheld exactly as they are on a normal
+config load, and the **server-managed account-link maps** (`CanonicalLinks`, `CanonicalLinkIssuers`) are
+omitted entirely. So an exported file contains **no plaintext secret, no encrypted `ssoenc:` envelope, and
+no account-link data**. The at-rest data-encryption key (`sso-secret.key`) lives in a separate file and is
+never part of the configuration at all. Everything else — every provider's endpoints, client id, RBAC
+roles, folder mappings, and the security toggles — **is** included, so the document is a complete,
+shareable description of the setup minus its secrets. The global rate-limit settings are included in the
+export for reference, but are **not applied on import** (see below).
+
+### The import merges and preserves an unchanged provider's secrets and links
+
+An import is a **fail-closed merge**, not a blind overwrite:
+
+- It is **validated first** through the same rules the config-page save uses (a malformed Base URL
+  override, an unloadable SAML certificate or signing key, or a new provider name containing
+  URI-reserved/control characters is **rejected**), and only a wholly-valid document is applied —
+  **atomically**, so a rejected import changes nothing.
+- For a provider that **already exists** on the target instance and whose identity is **unchanged**, the
+  target's own **secret is kept** (the export carried none, so the blank value means "keep the stored
+  secret"), and its server-managed **account links, issuer bindings, and redirect-path state are
+  preserved**.
+- **Changing an OpenID provider's identity on import drops that provider's links and secret** — by design.
+  If the imported document gives an existing OpenID provider a **different discovery endpoint or client
+  id**, the plugin treats it as a repoint to a potentially different identity provider and, exactly as a
+  config-page edit does (#186), **clears that provider's account links and issuer bindings and does not
+  carry over its stored secret**. Its users must re-link and an admin must re-enter the secret. This is a
+  deliberate safety measure (a different IdP must not inherit the old one's account mappings), but because
+  the endpoint change can ride in from a file, **review an export before importing it over a live provider**.
+  SAML provider links are preserved regardless of endpoint changes.
+- Providers on the target that are **not** in the imported document are **left untouched** (it is a merge,
+  not a replace).
+- A provider that is **new** to the target is added with a **blank secret**, so its login fails closed
+  until an administrator supplies the secret.
+- The **global rate-limit settings are not imported** — they are instance-local operational tuning
+  (reverse-proxy dependent), so the target keeps its own limiter configuration. This is deliberate: a
+  document from an instance that never enabled rate limiting must not silently turn a DoS control off on a
+  target that had it on. Tune the limiter on the config page, not by import.
+
+**Round-trip in practice:** export from instance A, import into instance B, then on B open each provider,
+**re-enter its client secret / signing key, and save**. The export deliberately never carried the secrets,
+so re-entering them on the target is the final step — everything else is already in place.
+
 ## SAML login browser binding
 
 Every SP-initiated SAML login (one started from Jellyfin, i.e. `SAML/start/...`) is bound to the


### PR DESCRIPTION
# What & why

Closes #161.

Adds an admin-only **config export / import** surface so a plugin configuration can be exported from one instance and imported into another (replicating a setup, migrating a server). Two thin controller endpoints delegate to pure, testable Config helpers (per #318):

- `GET /sso/Config/Export` → `ConfigExport.Build` returns a **redacted** `ConfigExportDocument`.
- `POST /sso/Config/Import` → `ConfigImport.Apply` validates and **merges** the document into this instance.

Both are `[Authorize(Policy = Policies.RequiresElevation)]`, matching the other config endpoints. The admin config page gets **Export Configuration** / **Import Configuration** buttons.

**The redaction is reused, not duplicated.** The export serializes the `PluginConfiguration`, so the config's own JSON-boundary withholding applies unchanged: the three secret fields (`OidSecret`, `SamlSigningKeyPfx`, `SamlRolloverSigningKeyPfx`) are written as `null` by their `WriteOnlySecretConverter` (#189), and the server-managed link maps (`CanonicalLinks`, `CanonicalLinkIssuers`) are dropped by `[JsonIgnore]` (#157/#186). An exported document therefore carries no plaintext secret, no `ssoenc:` envelope, and no account-link data. The at-rest DEK (`sso-secret.key`) is a separate file, never part of the config object.

**The import preserves, it never wipes.** It is a fail-closed merge:

- Validated first through the same `ProviderConfigValidator` the config-page save uses (bad Base URL override #139, unloadable SAML cert/key #206/#167, reserved-character new provider name #336/#360 → rejected), and applied **atomically** via `MutateConfiguration`, a rejected document changes nothing.
- Each provider is merged through `ServerManagedFields.Preserve`, so a redacted (blank) secret keeps the target's stored secret (#189) and the server-managed links/issuers are re-injected from the target (#157/#186). `NewPath` (server-managed runtime state) is kept from the target for existing providers.
- Merge, not replace: a provider present only on the target is left untouched; a provider new to the target arrives with a blank secret and fails its login closed until an admin re-enters it.
- Imported non-blank secrets are encrypted at rest because persistence flows through `PersistBase → ConfigSecretProtection.ProtectAll`.

Round-trip documented in `providers.md`: export from A, import into B, then re-enter each provider's secret on B.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: an invalid/unsupported/oversized import is rejected and persists nothing; a new provider imports with a blank secret and fails its login closed.
- [x] No secrets logged; secrets are redacted on config export (reuses `WriteOnlySecretConverter`; a test asserts no secret/`ssoenc:`/link value appears in the serialized export).
- [x] A security review was performed, the four-lens adversarial gate (availability, security-bypass, correctness, integration); results under Notes.
- [x] Log inputs are sanitized inline at the log call (the import rejection message is `ReplaceLineEndings`-stripped; the audit reuses `SsoAudit`).

## Quality checklist

- [x] No duplicated logic; export/import live in small single-purpose helpers (`ConfigExport`, `ConfigImport`) that reuse `WriteOnlySecretConverter`, `ServerManagedFields.Preserve`, `ProviderConfigValidator`, `MutateConfiguration`.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; comments explain why (the redaction reuse, the preserve-not-wipe merge, the NewPath carry-over).
- [x] Architecture-conformance tests pass; the controller touches no link map directly (link handling stays in the Config-tier helper).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (Debug and Release).
- [x] `dotnet test` green (1259 tests; 15 new).
- [x] Prettier clean for the touched `.js` / `.html` / `.md`.

## Notes

Adversarial-review gate (refute-by-default, four lenses):

- Security-bypass: PASS. Both endpoints carry [Authorize(Policy = Policies.RequiresElevation)] (same gate as OID/Get, OID/Add, OID/Test); no anonymous path. Every serialized string property was enumerated: only the three secret fields carry WriteOnlySecretConverter and both link maps carry [JsonIgnore], so no secret, ssoenc: envelope, or link leaves the server. Import cannot inject links ([JsonIgnore] is bidirectional), cannot downgrade a secret to null (blank-means-keep), and grants an admin nothing beyond existing OID/Add power; a repoint drops links and does not carry the stored secret, so no foreign IdP inherits account mappings.
- Correctness: PASS after fixes. blank-means-keep, NewPath carry-over, version/null guards, and validate-before-mutate atomicity all verified. Two findings fixed: (1) the global rate-limit scalars were overwrite-wins and a partial/foreign document could silently disable the limiter, the import now does not apply them (instance-local operational tuning; the target keeps its own); (2) added a test proving the redaction survives the MVC camelCase serializer round-trip.
- Availability / mass-lockout: PASS after fixes. Import runs under the same config lock the login path uses; it is atomic (no half-mutated live config); it deletes no target-only provider. The one wipe path, the OID repoint belt clearing links/secret when the imported endpoint or client id differs (correct #186 behavior), was over-stated by the docs/UI as "never wiped"; corrected in providers.md, the config page, config.js, and the ConfigImport class doc.
- Integration: PASS. The feature reuses ServerManagedFields.Preserve, ProviderConfigValidator, MutateConfiguration -> PersistBase -> ConfigSecretProtection.ProtectAll (an imported plaintext secret is encrypted at rest), and the WriteOnlySecretConverter/[JsonIgnore] redaction, rather than hand-rolling any of them. Routing, the authed client calls, the Blob download / textContent UI (no XSS), and the architecture-conformance gates are all clean.

No-secret-leak evidence: ConfigExportImportTests.Export_SerializedDocument_ContainsNoSecretEnvelopeOrLink and Export_RedactionSurvivesTheMvcCamelCaseSerializer, plus SSOControllerConfigTransferTests.ExportConfig_SerializedResponse_LeaksNoSecret, assert no secret value, no ssoenc: envelope, and no CanonicalLinks/CanonicalLinkIssuers name appears in the serialized export.

Out of scope / follow-up: re-entering each provider's secret on the target after import is the documented final step (a redacted export cannot ship secrets). A fitness pin that the export snapshot covers every future top-level global setting is a reasonable follow-up (the integration lens noted the list is hand-maintained; today it is complete).
