### PR TITLE
Accept a SAML response signed by an optional secondary IdP certificate (completes #491)

### DIFF
--- a/SSO-Auth.Tests/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/ConfigPreservationTests.cs
@@ -834,4 +834,36 @@ public class ConfigPreservationTests
     {
         ProviderConfigValidator.Validate(new PluginConfiguration { SamlConfigs = null }, new PluginConfiguration());
     }
+
+    [Fact]
+    public void ValidateSamlSecondaryCertificate_ValidOrBlank_DoesNotThrow()
+    {
+        // The inbound secondary verification certificate (#491) is validated on the whole-config save path
+        // exactly like the primary; a valid or blank value is accepted.
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["ok"] = new SamlConfig
+        {
+            SamlCertificate = SamlTestFactory.Create().CertificateBase64,
+            SamlSecondaryCertificate = SamlTestFactory.Create().CertificateBase64,
+        };
+        incoming.SamlConfigs["blank"] = new SamlConfig { SamlCertificate = null, SamlSecondaryCertificate = null };
+
+        ProviderConfigValidator.Validate(incoming, new PluginConfiguration());
+    }
+
+    [Fact]
+    public void ValidateSamlSecondaryCertificate_Garbage_Throws()
+    {
+        // A set-but-unloadable secondary certificate is rejected fail-closed before persistence, so it can
+        // never make every callback throw a CryptographicException 500.
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["idp"] = new SamlConfig
+        {
+            SamlCertificate = SamlTestFactory.Create().CertificateBase64,
+            SamlSecondaryCertificate = "QUJD", // valid base64, not a cert
+        };
+
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
+        Assert.Contains("secondary", ex.Message, StringComparison.Ordinal);
+    }
 }

--- a/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
@@ -60,6 +60,7 @@ public class ConfigSecretProtectionTests
             {
                 SamlSigningKeyPfx = "pfx-x",
                 SamlCertificate = "PUBLIC-IDP-CERT-X",
+                SamlSecondaryCertificate = "PUBLIC-IDP-CERT-SECONDARY-X",
             };
             config.SamlConfigs["y"] = new SamlConfig { SamlSigningKeyPfx = "pfx-y" };
 
@@ -75,6 +76,11 @@ public class ConfigSecretProtectionTests
             // it directly (never through Reveal), so encrypting it here would silently break every SAML
             // login. It - and non-secret ids - must be left verbatim.
             Assert.Equal("PUBLIC-IDP-CERT-X", config.SamlConfigs["x"].SamlCertificate);
+
+            // The inbound secondary verification certificate (#491) is likewise the identity provider's
+            // PUBLIC key, read directly by signature verification (never through Reveal); encrypting it would
+            // silently break rotation logins, so it too must be left verbatim.
+            Assert.Equal("PUBLIC-IDP-CERT-SECONDARY-X", config.SamlConfigs["x"].SamlSecondaryCertificate);
             Assert.Equal("client-a", config.OidConfigs["a"].OidClientId);
         });
     }

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -99,6 +99,49 @@ public class SSOControllerSamlAuthTests
     }
 
     [Fact]
+    public async Task SamlAuth_SignedBySecondaryCertificate_DuringRotation_ReturnsOk()
+    {
+        // Inbound verification-cert rotation (#491): the identity provider has rolled its signing key, so
+        // the primary now holds an unrelated (old) certificate and the response is signed by the key whose
+        // certificate the administrator staged in the secondary field. The full callback must authenticate
+        // it via the secondary, end-to-end through the real controller and config.
+        var fixture = SamlTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
+            SamlSecondaryCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+        });
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+    }
+
+    [Fact]
+    public async Task SamlAuth_NeitherCertificateVerifies_Returns400()
+    {
+        // Fail closed: with a secondary configured, a response signed by neither the primary nor the
+        // secondary is still rejected — "a certificate is configured" is never acceptance.
+        var fixture = SamlTestFactory.Create();
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
+            SamlSecondaryCertificate = SamlFixture.ForeignCertificateBase64(),
+            DoNotValidateAudience = true,
+        });
+
+        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+
+        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
+    }
+
+    [Fact]
     public async Task SamlAuth_RoleNotAllowed_Returns401()
     {
         var fixture = SamlTestFactory.Create(role: "jellyfin-users");

--- a/SSO-Auth.Tests/SamlCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlCertificateTests.cs
@@ -51,4 +51,25 @@ public class SamlCertificateTests
     {
         Assert.Throws<System.ArgumentException>(() => SSOController.RejectInvalidSamlCertificate("QUJD"));
     }
+
+    [Fact]
+    public void RejectInvalidSamlSecondaryCertificate_ValidOrBlank_DoesNotThrow()
+    {
+        // The inbound secondary verification certificate (#491) is validated exactly like the primary — a
+        // valid or blank value passes the Add-endpoint guard.
+        var exception = Record.Exception(() =>
+        {
+            SSOController.RejectInvalidSamlSecondaryCertificate(SamlTestFactory.Create().CertificateBase64);
+            SSOController.RejectInvalidSamlSecondaryCertificate(null);
+            SSOController.RejectInvalidSamlSecondaryCertificate(string.Empty);
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void RejectInvalidSamlSecondaryCertificate_Garbage_Throws()
+    {
+        Assert.Throws<System.ArgumentException>(() => SSOController.RejectInvalidSamlSecondaryCertificate("QUJD"));
+    }
 }

--- a/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
@@ -19,10 +19,11 @@ public class SamlSecondaryCertificateTests
         => new SamlResponse(primaryCertificateBase64, secondaryCertificateBase64, fixture.EncodeResponse());
 
     [Fact]
-    public void SecondaryUnset_PrimaryVerifies_ByteForBytePrimaryOnly()
+    public void SecondaryUnset_PrimaryOnly_MatchVerifies_MismatchRejected()
     {
-        // With no secondary configured, behavior is exactly today's: the primary must match, and a
-        // non-matching primary is rejected.
+        // With no secondary configured the trial narrows to the primary: a within-validity primary that
+        // matches verifies, and a non-matching primary is rejected. (The primary is additionally subject to
+        // the validity-window gate — see ExpiredPrimary_NoSecondary_Rejects.)
         var fixture = SamlTestFactory.Create();
 
         Assert.True(Load(fixture, fixture.CertificateBase64, null).IsValid());
@@ -142,6 +143,32 @@ public class SamlSecondaryCertificateTests
         subject.AppendChild(nameId);
         evil.AppendChild(subject);
         doc.DocumentElement!.PrependChild(evil);
+
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void DoublySignedWithOneCorruptedSignature_RejectedEvenWithSecondaryConfigured()
+    {
+        // "Validate all, not first-wins" must hold with a secondary configured: a doubly-signed response
+        // whose Response-level signature is corrupted is rejected even though the honest Assertion-level
+        // signature verifies against the secondary. A decoy cannot slip because the corrupted signature
+        // fails against EVERY candidate certificate, and the loop still requires every position-bound
+        // signature to validate.
+        const string DsNs = "http://www.w3.org/2000/09/xmldsig#";
+        var fixture = SamlTestFactory.CreateDoublySigned();
+        var doc = fixture.Document;
+        foreach (XmlElement signature in doc.GetElementsByTagName("Signature", DsNs))
+        {
+            if (signature.ParentNode == doc.DocumentElement)
+            {
+                var signatureValue = (XmlElement)signature.GetElementsByTagName("SignatureValue", DsNs)[0]!;
+                var bytes = Convert.FromBase64String(signatureValue.InnerText.Trim());
+                bytes[0] ^= 0xFF;
+                signatureValue.InnerText = Convert.ToBase64String(bytes);
+                break;
+            }
+        }
 
         Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
     }

--- a/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Xml;
+using Jellyfin.Plugin.SSO_Auth;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Trust-boundary tests for the inbound identity-provider verification-certificate rotation (#491): a
+/// response is accepted when its signature verifies against EITHER the primary <c>SamlCertificate</c> or
+/// an optional secondary certificate, under the SAME fail-closed checks (algorithm allowlist, signature
+/// scope, XXE/DOCTYPE reject), and an EXPIRED (or not-yet-valid) certificate never verifies. These pin
+/// the "either-cert" acceptance so it can never silently widen into "a cert is configured" and so the
+/// existing single-signature/XSW/allowlist invariants stay in force for both certificates.
+/// </summary>
+public class SamlSecondaryCertificateTests
+{
+    private static SamlResponse Load(SamlFixture fixture, string primaryCertificateBase64, string? secondaryCertificateBase64)
+        => new SamlResponse(primaryCertificateBase64, secondaryCertificateBase64, fixture.EncodeResponse());
+
+    [Fact]
+    public void SecondaryUnset_PrimaryVerifies_ByteForBytePrimaryOnly()
+    {
+        // With no secondary configured, behavior is exactly today's: the primary must match, and a
+        // non-matching primary is rejected.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.True(Load(fixture, fixture.CertificateBase64, null).IsValid());
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), null).IsValid());
+    }
+
+    [Fact]
+    public void VerifiesAgainstSecondary_WhenPrimaryRotatedOut()
+    {
+        // The overlap window: the identity provider now signs with the key whose public certificate the
+        // administrator has staged in the secondary field, while the primary still holds the old (here,
+        // unrelated) certificate. The response must authenticate via the secondary.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.True(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void VerifiesAgainstSecondary_AssertionScopeSignature()
+    {
+        // The either-cert trial applies whichever element is signed — an assertion-scope signature must
+        // also authenticate via the secondary certificate.
+        var fixture = SamlTestFactory.Create(scope: SamlTestFactory.SignatureScope.Assertion);
+
+        Assert.True(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void RejectsWhenNeitherCertificateVerifies()
+    {
+        // Fail closed: two configured certificates that both fail to verify the signature must reject the
+        // response — "a certificate is configured" is never acceptance.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), SamlFixture.ForeignCertificateBase64()).IsValid());
+    }
+
+    [Fact]
+    public void ExpiredPrimary_ValidSecondary_AcceptsViaSecondary()
+    {
+        // The common cutover: the primary certificate has expired (the identity provider rolled its key
+        // away) while the new certificate — within its validity window — is staged in the secondary. The
+        // login must still succeed, against the secondary.
+        var expiredPrimary = SamlTestFactory.Create(
+            certNotBefore: DateTimeOffset.UtcNow.AddDays(-30),
+            certNotAfter: DateTimeOffset.UtcNow.AddDays(-1));
+        var validResponse = SamlTestFactory.Create();
+
+        Assert.True(Load(validResponse, expiredPrimary.CertificateBase64, validResponse.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void BothCertificatesExpired_Rejects()
+    {
+        // Both configured certificates are outside their validity window: even the one that cryptographically
+        // matches the signature is expired and must be skipped, so the response is rejected fail-closed.
+        var expiredResponse = SamlTestFactory.Create(
+            certNotBefore: DateTimeOffset.UtcNow.AddDays(-30),
+            certNotAfter: DateTimeOffset.UtcNow.AddDays(-1));
+        var otherExpired = SamlTestFactory.Create(
+            certNotBefore: DateTimeOffset.UtcNow.AddDays(-30),
+            certNotAfter: DateTimeOffset.UtcNow.AddDays(-1));
+
+        Assert.False(Load(expiredResponse, expiredResponse.CertificateBase64, otherExpired.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void ExpiredPrimary_NoSecondary_Rejects()
+    {
+        // The certificate-expiry gate applies to the primary too: an expired primary that still matches the
+        // signature must NOT authenticate. This is the property that makes the overlap window terminate — an
+        // old key is rejected once it expires rather than working forever.
+        var expiredResponse = SamlTestFactory.Create(
+            certNotBefore: DateTimeOffset.UtcNow.AddDays(-30),
+            certNotAfter: DateTimeOffset.UtcNow.AddDays(-1));
+
+        Assert.False(Load(expiredResponse, expiredResponse.CertificateBase64, null).IsValid());
+    }
+
+    [Fact]
+    public void NotYetValidSecondary_Skipped_Rejects()
+    {
+        // A certificate whose NotBefore is in the future is not yet trusted: it must be skipped exactly like
+        // an expired one, so a response verifying only against a not-yet-valid secondary is rejected.
+        var notYetValid = SamlTestFactory.Create(
+            certNotBefore: DateTimeOffset.UtcNow.AddDays(1),
+            certNotAfter: DateTimeOffset.UtcNow.AddYears(1));
+
+        Assert.False(Load(notYetValid, SamlFixture.ForeignCertificateBase64(), notYetValid.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void Sha1Signature_RejectedEvenWhenSecondaryMatches()
+    {
+        // The algorithm allowlist runs per signature, cert-independently, ABOVE the certificate trial: a
+        // SHA-1 signature that verifies cryptographically against the secondary must still be rejected. The
+        // multi-cert trial does not open an algorithm-downgrade path.
+        var fixture = SamlTestFactory.Create(signWithSha1: true);
+
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void WrappingSecondAssertion_RejectedEvenWithSecondaryConfigured()
+    {
+        // XSW is blocked by the single-assertion / bound-signature invariants, which run before and
+        // independently of the certificate trial: injecting an unsigned first assertion must still reject,
+        // whether the signature would verify against the primary or the secondary.
+        var fixture = SamlTestFactory.Create(nameId: "alice", scope: SamlTestFactory.SignatureScope.Assertion);
+        var doc = fixture.Document;
+        var evil = doc.CreateElement("saml", "Assertion", "urn:oasis:names:tc:SAML:2.0:assertion");
+        evil.SetAttribute("ID", "_evil");
+        evil.SetAttribute("Version", "2.0");
+        var subject = doc.CreateElement("saml", "Subject", "urn:oasis:names:tc:SAML:2.0:assertion");
+        var nameId = doc.CreateElement("saml", "NameID", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nameId.InnerText = "attacker";
+        subject.AppendChild(nameId);
+        evil.AppendChild(subject);
+        doc.DocumentElement!.PrependChild(evil);
+
+        Assert.False(Load(fixture, SamlFixture.ForeignCertificateBase64(), fixture.CertificateBase64).IsValid());
+    }
+
+    [Fact]
+    public void DoctypeBody_RejectedAtParse_EvenWithSecondaryConfigured()
+    {
+        // The XXE/DOCTYPE guard is at parse time, before any certificate is consulted, so a configured
+        // secondary cannot reintroduce a DTD-processing path.
+        var body =
+            "<!DOCTYPE samlp:Response [ <!ENTITY x \"y\"> ]>" +
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"><saml:Assertion /></samlp:Response>";
+
+        Assert.Throws<XmlException>(() =>
+            new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(body)));
+    }
+
+    [Fact]
+    public void GarbageSecondaryCertificate_FailsClosedThroughLoader()
+    {
+        // A configured-but-unloadable secondary is rejected fail-closed at the loader (like a garbage
+        // primary, #206) rather than surfacing as an unhandled 500. The admin write paths reject it up
+        // front; a hand-edited config is caught here.
+        var fixture = SamlTestFactory.Create();
+
+        Assert.False(Jellyfin.Plugin.SSO_Auth.Api.SamlResponseLoader.TryParse(
+            fixture.CertificateBase64, "QUJD", fixture.EncodeResponse(), out var response));
+        Assert.Null(response);
+    }
+}

--- a/SSO-Auth.Tests/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/SamlTestFactory.cs
@@ -64,15 +64,24 @@ internal static class SamlTestFactory
         string? inResponseTo = null,
         string? destination = null,
         string? subjectConfirmationMethod = "urn:oasis:names:tc:SAML:2.0:cm:bearer",
-        string[][]? audienceRestrictions = null)
+        string[][]? audienceRestrictions = null,
+        DateTimeOffset? certNotBefore = null,
+        DateTimeOffset? certNotAfter = null)
     {
         var audienceList = audiences ?? (audience == null ? null : new[] { audience });
         const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
         var effectiveNotOnOrAfter = notOnOrAfter ?? DateTime.UtcNow.AddMinutes(5);
 
+        // The signing certificate's own validity window (default: valid — yesterday to ten years out).
+        // Overridable so the inbound verification-cert rotation tests (#491) can sign with an EXPIRED (or
+        // not-yet-valid) certificate; signing uses the private key and is unaffected by these dates, so the
+        // fixture stays a real, correctly-signed response whose acceptance turns solely on the validator's
+        // certificate-expiry gate.
         using var rsa = RSA.Create(2048);
         var request = new CertificateRequest("CN=Test SAML IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+        var certificate = request.CreateSelfSigned(
+            certNotBefore ?? DateTimeOffset.UtcNow.AddDays(-1),
+            certNotAfter ?? DateTimeOffset.UtcNow.AddYears(10));
 
         var responseId = "_" + Guid.NewGuid().ToString("N");
         var assertionId = "_" + Guid.NewGuid().ToString("N");

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -191,6 +191,19 @@ public class SSOController : ControllerBase
         }
     }
 
+    // Rejects a non-loadable inbound secondary verification certificate at the SAML/Add endpoint (#491),
+    // the same fail-closed door as the primary certificate guard above and for the same reason: a garbage
+    // secondary would persist and then throw a CryptographicException on every callback (an unhandled
+    // 500). It is the identity provider's PUBLIC certificate, so it is validated exactly like the primary.
+    // Blank is valid (no overlap window configured).
+    internal static void RejectInvalidSamlSecondaryCertificate(string certificateStr)
+    {
+        if (SamlCertificate.IsInvalid(certificateStr))
+        {
+            throw new ArgumentException("The SAML secondary signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.");
+        }
+    }
+
     // Rejects a non-loadable service-provider signing key at the SAML/Add endpoint (#167), the same
     // fail-closed door as the inbound certificate guard above: a garbage or private-key-less PKCS#12 set
     // here would persist and then fail every signed challenge. Blank is valid (signing simply stays off,
@@ -504,6 +517,7 @@ public class SSOController : ControllerBase
         RejectNullProviderBody(newConfig);
         RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
         RejectInvalidSamlCertificate(newConfig.SamlCertificate);
+        RejectInvalidSamlSecondaryCertificate(newConfig.SamlSecondaryCertificate);
         RejectInvalidSamlSigningKey(newConfig.SamlSigningKeyPfx);
         RejectInvalidSamlSigningKey(newConfig.SamlRolloverSigningKeyPfx);
         SSOPlugin.Instance.MutateConfiguration(configuration =>

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -80,8 +80,11 @@ internal sealed class SamlAssertionValidator
     internal bool TryValidate(SamlConfig config, string provider, string requestBaseUrl, string rawResponse, out SamlResponse samlResponse)
     {
         // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryParse and is
-        // rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199).
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, rawResponse, out samlResponse)
+        // rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199). The
+        // optional secondary certificate is passed alongside the primary so a response signed by either is
+        // accepted across an identity-provider signing-key overlap window (#491); when it is blank this is
+        // byte-for-byte the primary-only behavior.
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate, config.SamlSecondaryCertificate, rawResponse, out samlResponse)
             || !IsResponseValid(config, provider, requestBaseUrl, samlResponse))
         {
             return false;

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -82,8 +82,9 @@ internal sealed class SamlAssertionValidator
         // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryParse and is
         // rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199). The
         // optional secondary certificate is passed alongside the primary so a response signed by either is
-        // accepted across an identity-provider signing-key overlap window (#491); when it is blank this is
-        // byte-for-byte the primary-only behavior.
+        // accepted across an identity-provider signing-key overlap window (#491); when it is blank the
+        // trial narrows to the primary alone (both the primary and any secondary are additionally required
+        // to be within their validity window — see IsWithinValidityPeriod).
         if (!SamlResponseLoader.TryParse(config.SamlCertificate, config.SamlSecondaryCertificate, rawResponse, out samlResponse)
             || !IsResponseValid(config, provider, requestBaseUrl, samlResponse))
         {

--- a/SSO-Auth/Api/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/SamlResponseLoader.cs
@@ -22,14 +22,29 @@ internal static class SamlResponseLoader
     internal const int MaxEncodedResponseLength = 256 * 1024;
 
     /// <summary>
-    /// Tries to parse a SAML response, returning <see langword="false"/> (rather than throwing) on the
-    /// malformed-input exceptions the <see cref="SamlResponse"/> constructor raises.
+    /// Tries to parse a SAML response against a single signing certificate, returning
+    /// <see langword="false"/> (rather than throwing) on the malformed-input exceptions the
+    /// <see cref="SamlResponse"/> constructor raises.
     /// </summary>
     /// <param name="certificateStr">The identity provider's signing certificate as a Base64 string.</param>
     /// <param name="responseString">The untrusted SAML response (Base64).</param>
     /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
     internal static bool TryParse(string certificateStr, string responseString, out SamlResponse response)
+        => TryParse(certificateStr, null, responseString, out response);
+
+    /// <summary>
+    /// Tries to parse a SAML response against the primary signing certificate OR an optional secondary
+    /// certificate — the identity-provider verification-key overlap window (#491) — returning
+    /// <see langword="false"/> (rather than throwing) on the malformed-input exceptions the
+    /// <see cref="SamlResponse"/> constructor raises.
+    /// </summary>
+    /// <param name="certificateStr">The identity provider's primary signing certificate as a Base64 string.</param>
+    /// <param name="secondaryCertificateStr">The optional secondary certificate (Base64), or blank for none.</param>
+    /// <param name="responseString">The untrusted SAML response (Base64).</param>
+    /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
+    internal static bool TryParse(string certificateStr, string secondaryCertificateStr, string responseString, out SamlResponse response)
     {
         // A null or empty body is the most common malformed callback (an absent SAMLResponse form field
         // yields a null string on the unauthenticated ACS endpoint); reject it here rather than let
@@ -50,7 +65,7 @@ internal static class SamlResponseLoader
 
         try
         {
-            response = new SamlResponse(certificateStr, responseString);
+            response = new SamlResponse(certificateStr, secondaryCertificateStr, responseString);
             return true;
         }
         catch (Exception ex) when (ex is FormatException or XmlException or CryptographicException or ArgumentException)

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -228,8 +228,12 @@ public class SamlConfig : ProviderConfigBase
     /// Gets or sets an OPTIONAL second identity-provider signing certificate accepted alongside
     /// <see cref="SamlCertificate"/> during an INBOUND (IdP-side) signing-key rotation (#491). A response
     /// is accepted when its signature verifies against EITHER this certificate or the primary, under the
-    /// SAME algorithm allowlist (no SHA-1), signature-scope, and fail-closed checks; when blank, inbound
-    /// validation is byte-for-byte the primary-only behavior. Unlike <see cref="SamlSigningKeyPfx"/> and
+    /// SAME algorithm allowlist (no SHA-1), signature-scope, and fail-closed checks; when blank, the trial
+    /// narrows to the primary alone. Note the validity-window check added with this field applies to the
+    /// primary too, so an already-EXPIRED primary certificate — which the pre-#491 path still accepted, as
+    /// XML-DSig verification ignores certificate dates — is now rejected on upgrade unless a current
+    /// certificate is configured (here or promoted into <see cref="SamlCertificate"/>). Unlike
+    /// <see cref="SamlSigningKeyPfx"/> and
     /// <see cref="SamlRolloverSigningKeyPfx"/> — the SP's own PRIVATE signing keys — this is the identity
     /// provider's PUBLIC signing certificate, exactly like <see cref="SamlCertificate"/>: it is NOT a
     /// secret, so it carries no write-only/encrypted-at-rest handling and is stored and returned in the

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -225,6 +225,21 @@ public class SamlConfig : ProviderConfigBase
     public string SamlCertificate { get; set; }
 
     /// <summary>
+    /// Gets or sets an OPTIONAL second identity-provider signing certificate accepted alongside
+    /// <see cref="SamlCertificate"/> during an INBOUND (IdP-side) signing-key rotation (#491). A response
+    /// is accepted when its signature verifies against EITHER this certificate or the primary, under the
+    /// SAME algorithm allowlist (no SHA-1), signature-scope, and fail-closed checks; when blank, inbound
+    /// validation is byte-for-byte the primary-only behavior. Unlike <see cref="SamlSigningKeyPfx"/> and
+    /// <see cref="SamlRolloverSigningKeyPfx"/> — the SP's own PRIVATE signing keys — this is the identity
+    /// provider's PUBLIC signing certificate, exactly like <see cref="SamlCertificate"/>: it is NOT a
+    /// secret, so it carries no write-only/encrypted-at-rest handling and is stored and returned in the
+    /// clear. An expired certificate is rejected, so an administrator adds the identity provider's new
+    /// certificate here before the cutover and promotes it into <see cref="SamlCertificate"/> (clearing
+    /// this field) once the provider has fully rotated — with no login downtime across the overlap window.
+    /// </summary>
+    public string SamlSecondaryCertificate { get; set; }
+
+    /// <summary>
     /// Gets or sets the audience (SP entity id) that a SAML response must be addressed to. When
     /// unset, the SamlClientId is used. Ignored when <see cref="DoNotValidateAudience"/> is set.
     /// </summary>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -45,6 +45,7 @@ internal static class ProviderConfigValidator
                 ValidateProviderName("SAML", kvp.Key, isNew: live?.SamlConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
                 ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
+                ValidateSamlSecondaryCertificate(kvp.Key, kvp.Value?.SamlSecondaryCertificate);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
             }
@@ -91,6 +92,20 @@ internal static class ProviderConfigValidator
         {
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
+        }
+    }
+
+    // The optional inbound secondary verification certificate (#491) is the identity provider's PUBLIC
+    // certificate — the exact same kind of value as the primary, and rejected the exact same way: a
+    // set-but-unloadable value would be persisted and then throw a CryptographicException on every callback
+    // (an unhandled 500, #206). Blank is valid (no overlap window configured). Same inline line-ending
+    // strip as above.
+    internal static void ValidateSamlSecondaryCertificate(string provider, string certificate)
+    {
+        if (SamlCertificate.IsInvalid(certificate))
+        {
+            throw new ArgumentException(
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
         }
     }
 

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -40,23 +40,39 @@ internal sealed class SamlResponse
     private const string BearerSubjectConfirmationDataXPath =
         "/samlp:Response/saml:Assertion[1]/saml:Subject/saml:SubjectConfirmation[@Method='urn:oasis:names:tc:SAML:2.0:cm:bearer']/saml:SubjectConfirmationData";
 
-    private readonly X509Certificate2 _certificate;
+    private readonly List<X509Certificate2> _certificates;
     private readonly XmlDocument _xmlDoc;
     private readonly XmlNamespaceManager _xmlNameSpaceManager; // we need this one to run our XPath queries on the SAML XML
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SamlResponse"/> class.
+    /// Initializes a new instance of the <see cref="SamlResponse"/> class, verifying against a single
+    /// identity-provider signing certificate.
     /// </summary>
     /// <param name="certificateStr">The certificate formatted as a Base64 string.</param>
     /// <param name="responseString">The SAML response formatted as a string.</param>
     public SamlResponse(string certificateStr, string responseString)
+        : this(certificateStr, null, responseString)
     {
-        // Decode and load the certificate, then parse the response — in that exact order, so the exception
-        // sequence SamlResponseLoader.TryParse catches is unchanged: FormatException (bad certificate
-        // base64), CryptographicException (bad certificate), then FormatException/XmlException (bad body).
-        // The XML is loaded here, at construction, and the fields are readonly: a validated response
-        // object can never have different XML swapped into it afterwards (#396).
-        _certificate = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateStr));
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlResponse"/> class, verifying against the primary
+    /// signing certificate OR an optional secondary certificate — the identity-provider verification-key
+    /// overlap window (#491). The response is accepted when its signature verifies against EITHER
+    /// certificate under the same fail-closed checks; a blank secondary is byte-for-byte the primary-only
+    /// behavior.
+    /// </summary>
+    /// <param name="certificateStr">The primary certificate formatted as a Base64 string.</param>
+    /// <param name="secondaryCertificateStr">The optional secondary certificate (Base64), or blank for none.</param>
+    /// <param name="responseString">The SAML response formatted as a string.</param>
+    public SamlResponse(string certificateStr, string secondaryCertificateStr, string responseString)
+    {
+        // Decode and load the certificate(s), then parse the response — in that exact order, so the
+        // exception sequence SamlResponseLoader.TryParse catches is unchanged: FormatException (bad
+        // certificate base64), CryptographicException (bad certificate), then FormatException/XmlException
+        // (bad body). The XML is loaded here, at construction, and the fields are readonly: a validated
+        // response object can never have different XML swapped into it afterwards (#396).
+        _certificates = LoadCandidateCertificates(certificateStr, secondaryCertificateStr);
         _xmlDoc = ParseResponseXml(responseString);
         _xmlNameSpaceManager = GetNamespaceManager(); // lets construct a "manager" for XPath queries
     }
@@ -65,6 +81,27 @@ internal sealed class SamlResponse
     /// Gets the SAML response's XML data.
     /// </summary>
     public string Xml => _xmlDoc.OuterXml;
+
+    // Loads the candidate identity-provider signing certificates: the primary always, and the optional
+    // secondary only when configured (#491). The primary is loaded FIRST so the constructor's exception
+    // ordering — and therefore the fail-closed mapping in SamlResponseLoader.TryParse — is unchanged. Both
+    // are the identity provider's PUBLIC signing certificate; a configured-but-unloadable secondary throws
+    // the same load exceptions as the primary and is rejected the same fail-closed way (the admin write
+    // paths reject it up front via SamlCertificate.IsInvalid).
+    private static List<X509Certificate2> LoadCandidateCertificates(string certificateStr, string secondaryCertificateStr)
+    {
+        var certificates = new List<X509Certificate2>
+        {
+            X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateStr)),
+        };
+
+        if (!string.IsNullOrWhiteSpace(secondaryCertificateStr))
+        {
+            certificates.Add(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(secondaryCertificateStr)));
+        }
+
+        return certificates;
+    }
 
     // Parses the untrusted, Base64-encoded SAML response into a hardened XmlDocument. The body base64
     // decode runs after the certificate load (preserving the constructor's exception ordering), and the
@@ -132,7 +169,7 @@ internal sealed class SamlResponse
         {
             // EVERY position-bound signature must independently validate — its reference must cover the
             // Response root or the single Assertion, its algorithms must be allowed, and it must verify
-            // against the pinned certificate (#238). The Web Browser SSO profile permits signing the
+            // against a pinned certificate (#238). The Web Browser SSO profile permits signing the
             // Response, the Assertion, or BOTH; validating all of them (rather than only the first in
             // document order) removes the "which signature is authoritative" ambiguity without rejecting
             // a conformant IdP that signs both — a second, non-verifying signature rejects the whole
@@ -144,7 +181,7 @@ internal sealed class SamlResponse
 
                 if (!ValidateSignatureReference(signedXml, signatureElement)
                     || !IsSignatureAlgorithmAllowed(signedXml)
-                    || !signedXml.CheckSignature(_certificate, true))
+                    || !VerifiesAgainstCandidateCertificate(signedXml))
                 {
                     return false;
                 }
@@ -193,6 +230,39 @@ internal sealed class SamlResponse
         }
 
         return SamlSignatureAlgorithms.IsAllowed(signedXml.SignedInfo.SignatureMethod, digestMethods);
+    }
+
+    // The signature must verify against at least one candidate certificate that is CURRENTLY within its
+    // validity window (#491). Only the cryptographic key trial spans the primary and the optional
+    // secondary certificate; the position-bound signature selection, the single-reference /
+    // reference-covers-{root|assertion} / enveloped-within binding, and the algorithm allowlist all run
+    // once per signature ABOVE this, cert-independently — so trying a second certificate cannot relax any
+    // of them or open a wrapping/downgrade path, it only decides which key's signature is accepted. An
+    // expired (or not-yet-valid) candidate is skipped rather than trusted, so a signing key the identity
+    // provider has rolled away from can no longer authenticate even while it is still configured for the
+    // overlap window.
+    private bool VerifiesAgainstCandidateCertificate(SignedXml signedXml)
+    {
+        var utcNow = DateTime.UtcNow;
+        foreach (var certificate in _certificates)
+        {
+            if (IsWithinValidityPeriod(certificate, utcNow) && signedXml.CheckSignature(certificate, true))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Whether the certificate is within its own [NotBefore, NotAfter] validity window at verification
+    // time. SignedXml.CheckSignature(cert, verifySignatureOnly: true) validates only the cryptography and
+    // does NOT itself check the certificate dates, so this is the single place the window is enforced — an
+    // expired or not-yet-valid certificate is fail-closed rejected (#491). NotBefore/NotAfter are exposed
+    // as local time, so both sides are compared in UTC.
+    private static bool IsWithinValidityPeriod(X509Certificate2 certificate, DateTime utcNow)
+    {
+        return utcNow >= certificate.NotBefore.ToUniversalTime() && utcNow <= certificate.NotAfter.ToUniversalTime();
     }
 
     /// <summary>

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -259,10 +259,14 @@ internal sealed class SamlResponse
     // time. SignedXml.CheckSignature(cert, verifySignatureOnly: true) validates only the cryptography and
     // does NOT itself check the certificate dates, so this is the single place the window is enforced — an
     // expired or not-yet-valid certificate is fail-closed rejected (#491). NotBefore/NotAfter are exposed
-    // as local time, so both sides are compared in UTC.
+    // as local time, so both sides are compared in UTC. The same clock-skew tolerance every other time
+    // bound on this path uses (SamlAssertionTime.ClockSkew) is applied to both edges, so a small IdP/SP
+    // clock difference at a cutover — the moment a freshly staged certificate's NotBefore is a few minutes
+    // ahead of this server — does not spuriously reject an otherwise-valid signature.
     private static bool IsWithinValidityPeriod(X509Certificate2 certificate, DateTime utcNow)
     {
-        return utcNow >= certificate.NotBefore.ToUniversalTime() && utcNow <= certificate.NotAfter.ToUniversalTime();
+        return utcNow >= certificate.NotBefore.ToUniversalTime() - SamlAssertionTime.ClockSkew
+            && utcNow <= certificate.NotAfter.ToUniversalTime() + SamlAssertionTime.ClockSkew;
     }
 
     /// <summary>

--- a/providers.md
+++ b/providers.md
@@ -431,9 +431,17 @@ second certificate:
   clear.
 
 **Expired certificates are rejected.** A certificate is used to verify only while it is within its own
-`[NotBefore, NotAfter]` validity window; an expired (or not-yet-valid) certificate never verifies a
-response, whether it is the primary or the secondary. This is what makes the overlap window **terminate**:
-once the identity provider's old certificate expires, it stops authenticating logins on its own.
+`[NotBefore, NotAfter]` validity window (with the same five-minute clock-skew tolerance the other SAML
+time-bounds use); an expired (or not-yet-valid) certificate never verifies a response, whether it is the
+primary or the secondary. This is what makes the overlap window **terminate**: once the identity
+provider's old certificate expires, it stops authenticating logins on its own.
+
+> **Upgrade note.** Earlier versions did **not** check the certificate's validity dates at all (XML-DSig
+> verification ignores them), so a deployment whose identity-provider signing certificate has **already
+> expired** — but whose key still signs — kept working. From this version such a certificate is rejected.
+> If logins for a SAML provider start failing right after upgrading, the primary `SamlCertificate` is
+> likely expired: obtain the identity provider's **current** certificate and set it (in `SamlCertificate`,
+> or in `SamlSecondaryCertificate` during a rotation).
 
 Both are set through the SAML provider configuration (the `SAML/Add` API, like the other SAML options —
 there is no admin-UI toggle yet); include them whenever you re-post a provider's config so a save does

--- a/providers.md
+++ b/providers.md
@@ -410,6 +410,48 @@ Because the rollover key is publish-only and withheld from config responses, it 
 changed by posting a non-blank value; a blank save keeps whatever is stored, so an unrelated edit cannot
 end the overlap window by accident.
 
+## SAML identity-provider certificate rotation (inbound)
+
+The counterpart to the SP-side rollover above: when the **identity provider** rotates its **own**
+signing key, a hard cutover would break every login the moment it starts signing with the new key while
+the plugin still trusts only the old `SamlCertificate`. To roll over with no downtime, the plugin accepts
+a response whose signature verifies against **either** the primary `SamlCertificate` **or** an optional
+second certificate:
+
+- **`SamlCertificate`** — the identity provider's **public** signing certificate, as a Base64-encoded
+  (DER) X.509 certificate. This is the primary and only required certificate.
+- **`SamlSecondaryCertificate`** _(optional)_ — a **second** identity-provider public signing
+  certificate, in the same Base64-encoded (DER) X.509 shape. A response is accepted when its signature
+  verifies against **either** certificate, under the **same** checks as the primary (the no-SHA-1
+  algorithm allowlist, single-signature/anti-wrapping binding, XXE/DOCTYPE rejection, time-bound,
+  audience and recipient). Leave it blank when you are not mid-rotation: validation is then **byte-for-byte
+  the primary-only behaviour**. Unlike the SP's own signing keys (`SamlSigningKeyPfx` /
+  `SamlRolloverSigningKeyPfx`, which carry a **private** key and are encrypted at rest), these are the
+  identity provider's **public** certificates — **not secrets** — so they are stored and returned in the
+  clear.
+
+**Expired certificates are rejected.** A certificate is used to verify only while it is within its own
+`[NotBefore, NotAfter]` validity window; an expired (or not-yet-valid) certificate never verifies a
+response, whether it is the primary or the secondary. This is what makes the overlap window **terminate**:
+once the identity provider's old certificate expires, it stops authenticating logins on its own.
+
+Both are set through the SAML provider configuration (the `SAML/Add` API, like the other SAML options —
+there is no admin-UI toggle yet); include them whenever you re-post a provider's config so a save does
+not reset them. A garbage secondary certificate is rejected when the provider is saved, exactly like the
+primary.
+
+To roll the identity provider's signing key over:
+
+1. **Stage the new certificate.** Before the identity provider cuts over, obtain its **new** public
+   signing certificate and set `SamlSecondaryCertificate` to it (leave `SamlCertificate` — the primary —
+   as the current certificate). Logins now verify against **either**, so responses signed with the old
+   **or** the new key are accepted throughout the overlap.
+2. **Let the identity provider cut over.** When the provider starts signing with its new key, logins keep
+   working — they now verify against the secondary. There is no downtime.
+3. **Promote the new certificate.** Move the new certificate into the primary field — set
+   `SamlCertificate` to the new certificate — and **clear `SamlSecondaryCertificate`**. Validation is
+   back to a single certificate (the new one), and the rotation is complete.
+
 ## SAML service-provider metadata
 
 The plugin can publish standard SAML 2.0 **service-provider metadata** for a provider, so you can


### PR DESCRIPTION
# What & why

Completes #491 (part 2, the inbound half). Part 1, outbound SP signing-key
rollover, shipped in #573; this delivers the higher-value half: **inbound
verification-certificate rotation**, so an identity provider can roll its own
signing key over an overlap window instead of breaking every login at the
cutover.

A SAML response is now accepted when its signature verifies against **either**
the primary `SamlCertificate` **or** an optional new `SamlSecondaryCertificate`
(the IdP's PUBLIC signing certificate, mirroring the V2 field), and **expired
certificates are rejected**. When the secondary is blank, inbound validation is
byte-for-byte the primary-only behaviour.

How it works:

- `SamlResponse` loads the primary plus, when configured, the secondary
  certificate. A signature is accepted only when it verifies against at least
  one candidate that is **currently within its own `[NotBefore, NotAfter]`
  window**. The trial spans **only** the cryptographic key check, the
  single-assertion count, position-bound signature XPath, single-reference,
  reference-covers-{root|assertion}, enveloped-within binding, and the no-SHA-1
  algorithm/canonicalisation allowlist all still run once per signature,
  cert-independently, and the loop still requires **every** position-bound
  signature to validate. Trying a second certificate therefore only changes
  *which key* verifies the crypto, never *what* is signed or *which algorithm*
  is allowed.
- **Expiry gate.** `CheckSignature(cert, verifySignatureOnly: true)` does not
  itself check the certificate dates, so an explicit window check is the single
  place expiry is enforced, an expired (or not-yet-valid) candidate is skipped
  rather than trusted, for the primary as well as the secondary. This is what
  makes the overlap window terminate: an old key stops authenticating once it
  expires.
- **Public, not a secret.** `SamlSecondaryCertificate` is the IdP's public
  certificate, exactly like `SamlCertificate`, no `WriteOnlySecretConverter`,
  and left verbatim by `ConfigSecretProtection.ProtectAll` (contrast
  `SamlSigningKeyPfx` / `SamlRolloverSigningKeyPfx`, which hold a private key and
  are encrypted at rest). A set-but-unloadable value is rejected fail-closed at
  both admin write paths (`SAML/Add` and the whole-config save) and,
  defensively, at the login loader.
- `providers.md` documents the field and the inbound rotation procedure.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. A response verifying against neither
      certificate is rejected; an expired certificate never verifies.
- [x] No secrets logged; secrets are redacted on config export. The new field is
      a public certificate, not a secret.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. Four-lens adversarial gate
      plus the SAML domain reviewer — verdicts in Notes.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      sites; the existing algorithm-diagnostic log is unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit (`VerifiesAgainstCandidateCertificate` / `IsWithinValidityPeriod`,
      the certificate guards reuse `SamlCertificate.IsInvalid`).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. This change establishes no new
      structural property (the validation home is unchanged).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (1237 tests).
- [x] Prettier is clean for the `providers.md` change.

## Notes

Scope: inbound verification-cert rotation only; the outbound SP signing-key
rollover was #573. No admin-UI change, SAML providers are configured via the
`SAML/Add` API and config XML (the config page handles OpenID only), so the
field is reachable there, consistent with every other SAML option.

Adversarial-review gate (refute-by-default; SAML signature acceptance is the
primary verification for this change, CI cannot exercise a real IdP rotation,
so this review is the primary verification). Verdicts:

- Security-bypass / fail-open: PASS. Confirmed a response is accepted ONLY if it
  validly verifies against a real, in-validity primary or secondary certificate
 , never "a cert is configured". The multi-cert trial is a pure key-OR layered
  strictly beneath the unchanged per-signature checks; it opened no XSW /
  signature-wrapping and no algorithm-downgrade path.
- SAML domain review: PASS. Invariant-by-invariant: single-assertion count,
  position-bound signature XPath, single-reference/covers-{root|assertion}/
  enveloped-within, no-SHA-1 signature+digest+C14N allowlist all still run once
  per signature, cert-independently, and the loop still rejects the whole
  response if ANY position-bound signature fails against every valid candidate.
  XXE/DOCTYPE, time-bound, audience, recipient, replay/one-time-use, InResponseTo
  all untouched.
- Correctness: PASS. Empirically verified the local→UTC `NotBefore`/`NotAfter`
  conversion; expired/not-yet-valid certs cannot verify (the window gate short-
  circuits before `CheckSignature`, which with `verifySignatureOnly: true` does
  not check dates); tests prove a cryptographically-matching-but-expired cert is
  still rejected; exception ordering preserved for existing callers.
- Integration: PASS. `SamlSecondaryCertificate` is a PUBLIC value, no
  `WriteOnlySecretConverter`, left verbatim by `ConfigSecretProtection` (not
  encrypted), survives the OpenID-only config-page save, deserializes cleanly
  from legacy configs, rejected fail-closed on both admin write paths, no ABI
  break.
- Availability / mass-lockout: NEEDS_IMPROVEMENT on the first pass, then
  addressed and re-reviewed. The lens flagged that the newly-enforced
  certificate-expiry check now also rejects an ALREADY-EXPIRED primary (the
  pre-#491 path ignored certificate dates), a real upgrade behavior change. This
  is the issue's explicit "reject expired certs" requirement, so the behavior is
  kept (adding a fail-open "accept expired" toggle would contradict the mandate
  and the fail-closed posture); the upgrade risk is mitigated by applying the
  shared 5-minute `SamlAssertionTime.ClockSkew` to both edges of the window and a
  prominent providers.md upgrade note. The lens also asked to correct the
  misleading "byte-for-byte primary-only" wording (done) and the SAML reviewer
  asked for a doubly-signed-decoy-with-secondary test (added).

Standing decision for myself: rejecting an expired primary certificate
is required by #491 and is the correct fail-closed posture, but it is a
deployment-visible change for anyone running an expired-but-pinned IdP
certificate. We have documented it as an upgrade note and added clock-skew
tolerance rather than a fail-open override. This warrants a release-note callout
when 4.2 ships, and belongs on the manual E2E checklist (a real-IdP rotation is
not exercisable in CI).

