### PR TITLE
Guard computed logging arguments behind IsEnabled (net10 CA1873 prep)

### DIFF
--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -158,7 +158,11 @@ internal sealed class OidcLoginService
             // and no metadata to build the authorization request from. Reject rather than fall back to a
             // second, divergent fetch or a silent tolerant default. This is not a new lockout: without
             // discovery, PrepareLoginAsync could not build the authorize redirect either.
-            _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization server's discovery document could not be read.", provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization server's discovery document could not be read.", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login: the authorization server's discovery document could not be read.");
         }
 
@@ -171,7 +175,11 @@ internal sealed class OidcLoginService
         {
             if (config.RequirePkce)
             {
-                _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning("OpenID login refused for provider {Provider}: RequirePkce is set but the authorization server does not advertise PKCE (S256).", provider?.ReplaceLineEndings(string.Empty));
+                }
+
                 return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.PkceNotSupported));
             }
 
@@ -216,7 +224,10 @@ internal sealed class OidcLoginService
         {
             if (shouldWarnCapacity)
             {
-                _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning("OpenID authorize state refused for provider {Provider}: a CSPRNG-token collision (effectively impossible) or the store is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                }
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
@@ -286,7 +297,11 @@ internal sealed class OidcLoginService
         if (!config.DoNotValidateResponseIssuer
             && OidcResponseIssuer.IsRejected(request.Query["iss"], oidcClient.Options.ProviderInformation?.IssuerName, result.IdentityToken, pending.ResponseIssuerRequired))
         {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the authorization-response issuer was absent-but-required or matched neither the discovery issuer nor the id_token issuer (RFC 9207 mix-up check).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SsoResponseInvalid));
         }
 
@@ -303,7 +318,11 @@ internal sealed class OidcLoginService
         // keying on the mutable username.
         if (derived.Valid && string.IsNullOrWhiteSpace(derived.Subject))
         {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login denied for provider {Provider}: the id_token carried no 'sub' claim to key the account link on.", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 
@@ -312,11 +331,14 @@ internal sealed class OidcLoginService
             // The role gate did not pass: leave the Pending unpromoted (never redeemable — the redeem
             // requires a Ready) so it simply expires. Checked before Promote so no Ready is ever created
             // for a denied login.
-            _logger.LogWarning(
-                "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
-                derived.Username?.ReplaceLineEndings(string.Empty),
-                result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
-                config.Roles);
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "OpenID login denied for {Username}: no role matched the allow-list, or the login resolved no username. Claims: {@Claims}. Roles expected (any one of): {@ExpectedClaims}",
+                    derived.Username?.ReplaceLineEndings(string.Empty),
+                    result.User.Claims.Select(o => new { Type = o.Type?.ReplaceLineEndings(string.Empty), Value = o.Value?.ReplaceLineEndings(string.Empty) }),
+                    config.Roles);
+            }
 
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
@@ -376,7 +398,11 @@ internal sealed class OidcLoginService
         // guards same-name account adoption; this gates every login for the provider. Needs the email scope.
         if (config.RequireVerifiedEmailForLogin && redeemed.Identity.EmailVerified != true)
         {
-            _logger.LogWarning("OpenID login denied for provider {Provider}: RequireVerifiedEmailForLogin is set but the login did not carry email_verified == true (absent, false, or unparseable).", provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login denied for provider {Provider}: RequireVerifiedEmailForLogin is set but the login did not carry email_verified == true (absent, false, or unparseable).", provider?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.EmailNotVerified));
         }
 
@@ -531,7 +557,11 @@ internal sealed class OidcLoginService
         catch (Exception ex) when (ex is CryptographicException or FormatException)
         {
             built = default;
-            _logger.LogError("OpenID login refused for provider {Provider}: the stored client secret could not be decrypted ({Reason}); the at-rest key file is missing or corrupt.", provider?.ReplaceLineEndings(string.Empty), ex.Message?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError("OpenID login refused for provider {Provider}: the stored client secret could not be decrypted ({Reason}); the at-rest key file is missing or corrupt.", provider?.ReplaceLineEndings(string.Empty), ex.Message?.ReplaceLineEndings(string.Empty));
+            }
+
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not process login; the OpenID client secret could not be decrypted.");
         }
     }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -162,9 +162,12 @@ internal sealed class SamlLoginService
 
         // relayState is attacker-controllable; strip line endings inline at the log call to prevent
         // log forging (structured logging alone does not sanitize a newline-bearing value).
-        _logger.LogInformation(
-            "SAML request has relayState of {RelayState}",
-            relayState?.ReplaceLineEndings(string.Empty));
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "SAML request has relayState of {RelayState}",
+                relayState?.ReplaceLineEndings(string.Empty));
+        }
 
         // Bind SAMLResponse via [FromForm] rather than reading Request.Form directly: a non-form
         // content-type binds null (the form value provider is skipped, so Request.Form is never
@@ -181,11 +184,15 @@ internal sealed class SamlLoginService
 
         if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
         {
-            _logger.LogWarning(
-                "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
-                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-                SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
-                config.Roles);
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
+                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
+                    SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
+                    config.Roles);
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 
@@ -234,7 +241,10 @@ internal sealed class SamlLoginService
             // cannot amplify into log volume (CWE-400).
             if (shouldWarnCapacity)
             {
-                _logger.LogWarning("SAML login outcome refused for provider {Provider}: the per-client sub-cap or the outcome store is at capacity (warning throttled); the assertion was not consumed, so the login can be retried.", provider?.ReplaceLineEndings(string.Empty));
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning("SAML login outcome refused for provider {Provider}: the per-client sub-cap or the outcome store is at capacity (warning throttled); the assertion was not consumed, so the login can be retried.", provider?.ReplaceLineEndings(string.Empty));
+                }
             }
 
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
@@ -361,7 +371,10 @@ internal sealed class SamlLoginService
                 // (CWE-400) — parity with the OpenID challenge refusal.
                 if (shouldWarnCapacity)
                 {
-                    _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                    if (_logger.IsEnabled(LogLevel.Warning))
+                    {
+                        _logger.LogWarning("SAML request refused for provider {Provider}: the per-client sub-cap or the outstanding-request cache is at capacity (warning throttled).", provider?.ReplaceLineEndings(string.Empty));
+                    }
                 }
 
                 return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; please retry.");
@@ -387,7 +400,11 @@ internal sealed class SamlLoginService
             // stored envelope is corrupt (FormatException, #158). ANY of these fails closed with a clean
             // 500 — never a silent unsigned request — rather than escaping as a raw host 500. The key
             // material is not part of the message, so nothing sensitive is logged.
-            _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError("SAML challenge for provider {Provider} could not sign the AuthnRequest: {Reason}", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+            }
+
             return FlowResponses.PlainTextError(StatusCodes.Status500InternalServerError, "Could not start login; the SAML request signing key is misconfigured.");
         }
 
@@ -467,9 +484,13 @@ internal sealed class SamlLoginService
         // only there would be fail-open.
         if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
         {
-            _logger.LogWarning(
-                "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
-                samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
+                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -301,11 +301,15 @@ internal sealed class CanonicalLinkService
     {
         if (candidates.SubjectLink.HasValue && candidates.SubjectIssuer == IssuerBinding.Mismatch)
         {
-            _logger.LogWarning(
-                "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "OpenID login for {Name} via {Mode}/{Provider} refused: the account link's stored issuer does not match the login's issuer (the provider entry may have been repointed at a different identity provider). Re-establish the link via the admin endpoints.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
+
             throw new AccountLinkForbiddenException("The account link was minted under a different issuer; refusing to resolve it after an apparent provider repoint.");
         }
     }
@@ -326,11 +330,15 @@ internal sealed class CanonicalLinkService
         // forming a new one. Link an admin account explicitly via the admin endpoint instead.
         if (AdoptionEligibilityResolver.Resolve(existingAccount.HasPermission(PermissionKind.IsAdministrator), AdoptionGate.None) != AdoptionVerdict.Allow)
         {
-            _logger.LogWarning(
-                "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link points at an administrator account, which is not adopted by name. Link it explicitly via the admin endpoints.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
+
             throw new AccountLinkForbiddenException();
         }
 
@@ -343,10 +351,14 @@ internal sealed class CanonicalLinkService
         // subject link is used as-is; the deleted-target edge resolves to null so the login falls
         // through to the create/adopt gate rather than binding to a dead account.
         var migratedUserId = MigrateAndResolveCanonicalLink(mode, provider, canonicalKey, username, issuer);
-        _logger.LogInformation(
-            "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
-            mode.ToToken(),
-            provider?.ReplaceLineEndings(string.Empty));
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "Migrated {Mode}/{Provider} canonical link from the legacy username key to the stable subject key.",
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+
         return migratedUserId;
     }
 
@@ -366,12 +378,16 @@ internal sealed class CanonicalLinkService
             adoptionGate);
         if (verdict != AdoptionVerdict.Allow)
         {
-            _logger.LogWarning(
-                "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty),
-                DescribeAdoptionRefusal(verdict));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused adoption of a pre-existing account: {Reason}.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty),
+                    DescribeAdoptionRefusal(verdict));
+            }
+
             throw new AccountLinkForbiddenException();
         }
 
@@ -419,14 +435,21 @@ internal sealed class CanonicalLinkService
             // subject via the admin endpoints. See the upgrade runbook in providers.md. Throttled
             // through the shared once-per-interval gate (#362) so a login loop cannot flood it; the
             // account is still provisioned on every login regardless of whether the line is emitted.
-            _logger.LogWarning(
-                "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider}: a legacy username-keyed link exists but no live account bears the name (it was renamed on the Jellyfin side), so a fresh account is being provisioned and the original account is now orphaned. Re-link it to this subject via the admin endpoints.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
         }
 
-        _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username?.ReplaceLineEndings(string.Empty));
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username?.ReplaceLineEndings(string.Empty));
+        }
+
         var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
         user.AuthenticationProviderId = typeof(SSOController).FullName;
         // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
@@ -455,20 +478,26 @@ internal sealed class CanonicalLinkService
             // still throws on every login regardless of whether this line is emitted.
             if (_legacyLinkWarnGate.TryEnter(_clock()))
             {
-                _logger.LogWarning(
-                    "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
-                    username?.ReplaceLineEndings(string.Empty),
-                    mode.ToToken(),
-                    provider?.ReplaceLineEndings(string.Empty));
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning(
+                        "SSO login for {Name} via {Mode}/{Provider} refused: a legacy username-keyed link is pending but AllowExistingAccountLink is off and a live account still bears the name. Enable AllowExistingAccountLink (a short controlled window) or link the account via the admin endpoints to migrate it.",
+                        username?.ReplaceLineEndings(string.Empty),
+                        mode.ToToken(),
+                        provider?.ReplaceLineEndings(string.Empty));
+                }
             }
         }
         else
         {
-            _logger.LogWarning(
-                "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
-                username?.ReplaceLineEndings(string.Empty),
-                mode.ToToken(),
-                provider?.ReplaceLineEndings(string.Empty));
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: a pre-existing unlinked Jellyfin account exists and AllowExistingAccountLink is disabled for this provider.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
         }
 
         return new AccountLinkForbiddenException();

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -9,6 +9,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// entry shares the "[SSO Audit]" prefix so operators can filter the trail, and only non-sensitive
 /// fields are logged (never secrets or certificates). Identity-provider- and admin-supplied values
 /// are stripped of line endings inline before logging so they cannot forge or split an entry.
+/// Each call is guarded by <see cref="ILogger.IsEnabled(LogLevel)"/> so the inline line-ending
+/// sanitizer is not evaluated when the level is disabled (net10 CA1873, #566); the sanitizer stays
+/// at the logging call so CodeQL's log-forging taint tracking still sees it inline.
 /// </summary>
 internal static class SsoAudit
 {
@@ -19,12 +22,19 @@ internal static class SsoAudit
     /// <param name="username">The Jellyfin username the session was issued for.</param>
     /// <param name="isAdmin">Whether the session was granted administrator rights.</param>
     internal static void LoginSucceeded(ILogger logger, string protocol, string provider, string username, bool isAdmin)
-        => logger.LogInformation(
+    {
+        if (!logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        logger.LogInformation(
             "[SSO Audit] Login succeeded: {Username} via {Protocol} provider '{Provider}' (admin={IsAdmin}).",
             username?.ReplaceLineEndings(string.Empty),
             protocol,
             provider?.ReplaceLineEndings(string.Empty),
             isAdmin);
+    }
 
     /// <summary>Records an SSO identity being linked to a pre-existing account (the opt-in adoption path).</summary>
     /// <param name="logger">The logger.</param>
@@ -32,39 +42,67 @@ internal static class SsoAudit
     /// <param name="provider">The provider name.</param>
     /// <param name="displayName">The adopted account's name.</param>
     internal static void AccountAdopted(ILogger logger, string protocol, string provider, string displayName)
-        => logger.LogWarning(
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
             "[SSO Audit] SSO identity linked to existing account '{DisplayName}' via {Protocol} provider '{Provider}' (AllowExistingAccountLink).",
             displayName?.ReplaceLineEndings(string.Empty),
             protocol,
             provider?.ReplaceLineEndings(string.Empty));
+    }
 
     /// <summary>Records a provider being added or updated.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
     internal static void ProviderConfigured(ILogger logger, string protocol, string provider)
-        => logger.LogInformation(
+    {
+        if (!logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        logger.LogInformation(
             "[SSO Audit] Provider configured: {Protocol} '{Provider}'.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty));
+    }
 
     /// <summary>Records a provider being removed.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
     internal static void ProviderRemoved(ILogger logger, string protocol, string provider)
-        => logger.LogInformation(
+    {
+        if (!logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        logger.LogInformation(
             "[SSO Audit] Provider removed: {Protocol} '{Provider}'.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty));
+    }
 
     /// <summary>Records that a provider's authorization server does not advertise PKCE S256 support (#141).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="provider">The provider name.</param>
     internal static void PkceNotAdvertised(ILogger logger, string provider)
-        => logger.LogWarning(
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
             "[SSO Audit] OpenID provider '{Provider}' does not advertise PKCE (S256) in its discovery document (code_challenge_methods_supported). PKCE is still sent, but a server that ignores it leaves cross-session authorization-code injection undetectable (RFC 9700 §2.1.1). Set RequirePkce to fail closed once the provider supports it.",
             provider?.ReplaceLineEndings(string.Empty));
+    }
 
     /// <summary>Records a provider being saved with one or more security checks disabled (#140).</summary>
     /// <param name="logger">The logger.</param>
@@ -72,9 +110,16 @@ internal static class SsoAudit
     /// <param name="provider">The provider name.</param>
     /// <param name="options">The enabled insecure option names (configuration keys, not user input).</param>
     internal static void InsecureOptionsEnabled(ILogger logger, string protocol, string provider, IReadOnlyList<string> options)
-        => logger.LogWarning(
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
             "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. These weaken RFC 9700 transport/issuer/endpoint validation; keep them only if the provider genuinely requires it. DisableHttps in particular exposes the id_token signing keys (JWKS) to a man-in-the-middle.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty),
             string.Join(", ", options));
+    }
 }


### PR DESCRIPTION
# What & why

Prep step 1 for the 5.0 / Jellyfin-12 / net10 line (#135). The net10 SDK
raises **CA1873** (avoid evaluating logging arguments when the log level is
disabled) at every `logger.Log*(...)` call site that passes a *computed*
argument. With `--warnaserror` this would block the net10 build, so we
structure the sites now, on the still-green net9 line, to remove the 5.0
blocker in advance. This is pure logging hygiene: **no message, level,
structured property, or logged value changes.**

We wrap each call site whose arguments contain a method invocation (the inline
`ReplaceLineEndings` line-ending sanitizer, `mode.ToToken()`, the claim/role
projections, `DescribeAdoptionRefusal`, `string.Join`) in
`if (_logger.IsEnabled(level)) { ... }`, so the computation runs only when the
level is enabled. The `SsoAudit` expression-bodied helpers become block bodies
with an early `return` when the level is disabled.

We keep the inline sanitizer **at each logging call** rather than converting to
`LoggerMessage` source-gen. Source-gen would move the sanitized value across
the generated-method boundary, where CodeQL's `cs/log-forging` taint tracking
would no longer see the sanitizer inline (CLAUDE.md invariant), and it would
add partial-class boilerplate. `IsEnabled` guarding is less code and keeps every
sanitizer where CodeQL expects it. The `IsEnabled(level)` matches the wrapped
call's level exactly, so what is emitted is byte-for-byte unchanged.

Sites changed: **SsoAudit (6), SamlLoginService (6), OidcLoginService (8),
CanonicalLinkService (8).** SessionMinter and SSOController pass only literals,
locals, and simple property reads, so they carry no CA1873 site and are
untouched.

**CA1873 is a net10-SDK rule and does not fire on net9**, so it cannot be seen
to go green here, the net9 build is already green. This PR structures the sites
correctly so CA1873 will not fire at the #135 retarget, which is where CA1873 is
actually verified. We do **not** touch the `System.Security.Cryptography.Xml`
reference (NU1510 is net10-only; net9 still needs it), that lands with #135.

Closes #566
Refs #135

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. (No control flow changed — every
      reject/throw/return stays outside the `IsEnabled` guard; only the `Log*`
      call is inside it.)
- [x] No secrets logged; secrets are redacted on config export. (No logged value
      changed; the same arguments are logged, only guarded.)
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. (Correctness + security-bypass
      lenses — verdicts under Notes.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (Every
      `ReplaceLineEndings` sanitizer stays inline at its original `Log*` call,
      now merely inside an `IsEnabled` guard in the same method.)

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires. (The `IsEnabled`
      guard is the documented CA1873 fix and is less code than source-gen here.)
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      (No new structural property; the conformance suite stays green.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. (Debug and Release,
      0 warnings.)
- [x] `dotnet test` is green. (1187 passed, 0 failed.)
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (None - 
      C# only.)

## Notes

**Adversarial-review gate (login-path change).** Two lenses reviewed the diff:

- **Correctness, PASS.** Every `IsEnabled(level)` matches its wrapped call's
  level; no message/property/value drift; no swallowed return/throw; no relocated
  side effect; the `SsoAudit` expression→block conversion is exactly equivalent
  (those methods did nothing but log).
- **Security-bypass, PASS.** Every `ReplaceLineEndings` sanitizer stays inline
  at its log call (no helper-boundary move → no `cs/log-forging` regression); no
  new sensitive value introduced (`DescribeAdoptionRefusal` enum-name laundering
  untouched); every reject/throw/return stays outside the `IsEnabled` guard.

**Deliberately behavior-preserving detail:** in the two throttled-warning sites
(`CanonicalLinkService.CreateNewAccountAsync`, `RejectNameTaken`), the
side-effecting throttle gate `_legacyLinkWarnGate.TryEnter(_clock())` stays in
the outer `if` condition, evaluated regardless of level, exactly as before
(previously the gate advanced and the `Log*` call was then dropped by the
disabled level). Pulling it inside the `IsEnabled` check would *change* behavior
(the gate would stop advancing when the level is disabled), so it is left as-is.

**Out of scope (follow-up).** Other files carry the same computed-argument log
pattern (AvatarService, OidcDiscoveryReader, SamlAssertionValidator,
SsoRateLimitGate). #566 scopes to the six named files; we will track the
remaining CA1873 sites in a separate issue so the net10 blocker is fully closed
before the #135 retarget.

**Forward-merge reminder:** this is a `fix`/`chore` off `main`; forward-merge
into `4.2` after it lands so the feature branch does not regress the guard.
