### PR TITLE
Pin OidcClient to 6.x to restore loading on Jellyfin 10.11 (4.1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to this plugin are documented here. Versions follow the
 four-part `X.Y.Z.W` scheme described in the release policy (breaking / feature /
 bug-fix / security).
 
+## 4.1.1.0
+
+A bug-fix release that restores plugin loading on Jellyfin 10.11. No
+configuration changes.
+
+### Fixed
+
+- **The plugin no longer fails to load on Jellyfin 10.11 (#590).** 4.1.0.0
+  shipped with `Duende.IdentityModel.OidcClient` 7.x, whose assemblies are built
+  against the .NET 10 framework and reference
+  `Microsoft.Extensions.Logging.Abstractions` 10.0.0.0 in their manifest — an
+  assembly the host provides (Jellyfin 10.11 runs on .NET 9 and ships 9.0.0.0)
+  and the plugin therefore does not bundle. Because .NET rolls a host assembly
+  reference forward to a newer host but never down a major version, the packaged
+  plugin threw `FileNotFoundException` the moment the host constructed it, and
+  the server disabled it at startup — taking down every OpenID and SAML login.
+  `dotnet build` and `dotnet test` stayed green because they run against the full
+  publish output, which contains the 10.x assembly; the failure only surfaced on
+  a real host, the same blind spot the SAML/OIDC crypto DLLs hit in 4.1.0.0.
+
+  The OIDC client is pinned back to the 6.x line, which references
+  `Logging.Abstractions` 8.0.0.0 and rolls forward onto the host's 9.0.0.0
+  cleanly; the whole dependency graph stays on the .NET 9 ABI. No behaviour
+  changes — the OpenID and SAML flows are identical to 4.1.0.0.
+
+### Added
+
+- **A conformance test locks the ABI floor in.**
+  `ArchitectureConformanceTests.HostProvidedFrameworkAssemblies_StayOnTheHostNet9Abi`
+  fails the build if any host-provided `Microsoft.Extensions.*` assembly is
+  referenced above the .NET 9 host ABI, so a future dependency bump that
+  re-crosses the floor is caught before release instead of in the field.
+
 ## 4.1.0.0
 
 The first feature release of the revived plugin. It folds in a full

--- a/SSO-Auth.Fuzz/packages.lock.json
+++ b/SSO-Auth.Fuzz/packages.lock.json
@@ -30,19 +30,16 @@
       },
       "Duende.IdentityModel": {
         "type": "Transitive",
-        "resolved": "8.1.0",
-        "contentHash": "ncmC2ISg0efTqY74xI6gaLKlv4mErT5ruYK262dkSnAv07g9qYC2++q7AWWs1FyP2c0YZ6LvUtcoJmxZqYyVrA==",
-        "dependencies": {
-          "Microsoft.BCL.Memory": "10.0.4"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "h6xvWQi9bASgroNh+6Z/BpSUpKTy/sSuc2l4twi0igSY0X0z7Y8eYMGMHB7trwdT56EGlWeXLA6qAb8VOg8ATA=="
       },
       "Duende.IdentityModel.OidcClient": {
         "type": "Transitive",
-        "resolved": "7.1.0",
-        "contentHash": "5i/eSXgMtqM01ntFZ4pMRkJu8VaLATZL0Ck87XlVUy8SFHy0+n2WuK9LkqT6VLhT4z/We10hoguv6pTH1iUz6g==",
+        "resolved": "6.0.1",
+        "contentHash": "9+1O6HKnEpzUAu6/v0h35cwNRNUQa2EbZnbwczO2Nr34MkrDa2BmRKoHV2tOH6VuIv0zAAJohInEIapFZAuplQ==",
         "dependencies": {
-          "Duende.IdentityModel": "8.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
+          "Duende.IdentityModel": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0"
         }
       },
       "ICU4N": {
@@ -154,11 +151,6 @@
         "resolved": "10.0.9",
         "contentHash": "iSljz/oaqFzH7c4mNKwYt8GqK1mxoDMgP0wliKaEF9TejFxyZ3acLopin1v5PAQIa9GE0flOESkwOnik83X0YA=="
       },
-      "Microsoft.Bcl.Memory": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "ayoY21xuhuY6cYZkG92bdYsulmJlLS558b3Ez1rWFkBZ+QIUSeAlALzT1UK+ZZeEmhzFWjemG4bBcMRhdiHntA=="
-      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "9.0.11",
@@ -237,8 +229,8 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "SIe9zlVQJecnk/DTmevIcl6+aEDYhoVLc2eG2AKwVeNEC8CSyxHAbh4lf0xtHq9JUum0vVTEByGNTK+b6oihTQ=="
+        "resolved": "9.0.11",
+        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -252,11 +244,10 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "resolved": "9.0.11",
+        "contentHash": "UKWFTDwtZQIoypyt1YPVsxTnDK+0sKn26+UeSGeNlkRQddrkt9EC6kP4g94rgO/WOZkz94bKNlF1dVZN3QfPFQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "System.Diagnostics.DiagnosticSource": "10.0.4"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -342,11 +333,6 @@
         "resolved": "2.2.0",
         "contentHash": "biITWpwnMR7HUp43lAGU97DWq/4LfyXqqhuOK0Z4IuRP97KjQMOe/GKq3wE1KY21gNrc7OPO9HbAtQUvMKTImA=="
       },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "WBD8SloNQ9Fp+6Iz+H42w5/VdwYPz9q7iuT6V5ng2FrtR1bYsewmQ3i2PqRR4NnuSZobJ/XtiKkbQyrheDHHdQ=="
-      },
       "System.Formats.Asn1": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -406,7 +392,7 @@
       "sso-auth": {
         "type": "Project",
         "dependencies": {
-          "Duende.IdentityModel.OidcClient": "[7.1.0, )",
+          "Duende.IdentityModel.OidcClient": "[6.0.1, )",
           "Jellyfin.Controller": "[10.11.11, )",
           "Jellyfin.Model": "[10.11.11, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[8.19.1, )",

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -980,6 +980,44 @@ public class ArchitectureConformanceTests
             "Every persisting provider-form field (sso-text/sso-line-list/sso-toggle/sso-folder-list/sso-role-map) must have an id equal to an OidConfig property; these do not: " + string.Join(" | ", offenders));
     }
 
+    [Fact]
+    public void HostProvidedFrameworkAssemblies_StayOnTheHostNet9Abi()
+    {
+        // Locked in by #590 (the 4.1.0.0 field regression). Jellyfin 10.11 runs on .NET 9, so every
+        // assembly the ASP.NET Core shared framework provides — the whole Microsoft.Extensions.* family
+        // (logging, DI, configuration, …) — is host-provided and is deliberately NOT in build.yaml's
+        // artifacts. .NET rolls a host assembly reference FORWARD to a newer host but never DOWN a major
+        // version, so if a dependency drags one of these to the .NET 10 line (10.0.0.0) the plugin still
+        // compiles and `dotnet test` stays green (both run against the full publish output, which carries
+        // the 10.x DLL), yet the packaged plugin throws FileNotFoundException the moment the host DI
+        // constructs it against its own 9.0.0.0 assembly — disabling it. That is exactly how OidcClient
+        // 7.x (whose manifest references Logging.Abstractions 10.0.0.0) broke 4.1.0.0. Pin the compiled
+        // reference here: no Microsoft.Extensions.* assembly SSO-Auth.dll references may be newer than the
+        // .NET 9 host provides, so a future dependency bump that re-crosses the floor fails at build time
+        // rather than in the field. Raise hostAbiMajor in lockstep with build.yaml's `framework` only when
+        // the oldest supported Jellyfin server moves to a newer .NET.
+        const int hostAbiMajor = 9;
+        var references = typeof(SSOPlugin).Assembly.GetReferencedAssemblies();
+
+        var overshoot = references
+            .Where(a => a.Name is { } n && n.StartsWith("Microsoft.Extensions.", StringComparison.Ordinal))
+            .Where(a => a.Version is { } v && v.Major > hostAbiMajor)
+            .Select(a => $"{a.Name} {a.Version}")
+            .ToList();
+
+        Assert.True(
+            overshoot.Count == 0,
+            $"SSO-Auth references a host-provided Microsoft.Extensions.* assembly above the .NET {hostAbiMajor} host ABI; Jellyfin 10.11 provides only {hostAbiMajor}.x and .NET does not roll a host assembly down, so the packaged plugin would throw FileNotFoundException at construction and be disabled (#590): " + string.Join(", ", overshoot));
+
+        // Sentinel against a vacuous pass: the keystone that broke 4.1.0.0 is
+        // Microsoft.Extensions.Logging.Abstractions — SSOPlugin's ILogger<> constructor dependency, the
+        // very reference the host could not satisfy. It must remain referenced, or the scan above would
+        // pass for the wrong reason (an empty match set).
+        Assert.True(
+            references.Any(a => a.Name == "Microsoft.Extensions.Logging.Abstractions"),
+            "SSO-Auth no longer references Microsoft.Extensions.Logging.Abstractions; the #590 ABI-floor scan would pass vacuously — re-anchor it on the host-provided framework assembly the plugin actually uses.");
+    }
+
     // The markup of the #sso-new-oidc-provider settings form (from the opening tag's id attribute to its
     // closing </form>). Forms are not nested here, so the first </form> after the id marker closes it; the
     // preceding #sso-load-config form is left out because its </form> sits before the marker.

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -65,19 +65,16 @@
       },
       "Duende.IdentityModel": {
         "type": "Transitive",
-        "resolved": "8.1.0",
-        "contentHash": "ncmC2ISg0efTqY74xI6gaLKlv4mErT5ruYK262dkSnAv07g9qYC2++q7AWWs1FyP2c0YZ6LvUtcoJmxZqYyVrA==",
-        "dependencies": {
-          "Microsoft.BCL.Memory": "10.0.4"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "h6xvWQi9bASgroNh+6Z/BpSUpKTy/sSuc2l4twi0igSY0X0z7Y8eYMGMHB7trwdT56EGlWeXLA6qAb8VOg8ATA=="
       },
       "Duende.IdentityModel.OidcClient": {
         "type": "Transitive",
-        "resolved": "7.1.0",
-        "contentHash": "5i/eSXgMtqM01ntFZ4pMRkJu8VaLATZL0Ck87XlVUy8SFHy0+n2WuK9LkqT6VLhT4z/We10hoguv6pTH1iUz6g==",
+        "resolved": "6.0.1",
+        "contentHash": "9+1O6HKnEpzUAu6/v0h35cwNRNUQa2EbZnbwczO2Nr34MkrDa2BmRKoHV2tOH6VuIv0zAAJohInEIapFZAuplQ==",
         "dependencies": {
-          "Duende.IdentityModel": "8.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
+          "Duende.IdentityModel": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0"
         }
       },
       "FSharp.Core": {
@@ -207,11 +204,6 @@
         "resolved": "10.0.9",
         "contentHash": "iSljz/oaqFzH7c4mNKwYt8GqK1mxoDMgP0wliKaEF9TejFxyZ3acLopin1v5PAQIa9GE0flOESkwOnik83X0YA=="
       },
-      "Microsoft.Bcl.Memory": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "ayoY21xuhuY6cYZkG92bdYsulmJlLS558b3Ez1rWFkBZ+QIUSeAlALzT1UK+ZZeEmhzFWjemG4bBcMRhdiHntA=="
-      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "18.7.0",
@@ -295,8 +287,8 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "SIe9zlVQJecnk/DTmevIcl6+aEDYhoVLc2eG2AKwVeNEC8CSyxHAbh4lf0xtHq9JUum0vVTEByGNTK+b6oihTQ=="
+        "resolved": "9.0.11",
+        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -310,11 +302,10 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "resolved": "9.0.11",
+        "contentHash": "UKWFTDwtZQIoypyt1YPVsxTnDK+0sKn26+UeSGeNlkRQddrkt9EC6kP4g94rgO/WOZkz94bKNlF1dVZN3QfPFQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "System.Diagnostics.DiagnosticSource": "10.0.4"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -458,8 +449,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "WBD8SloNQ9Fp+6Iz+H42w5/VdwYPz9q7iuT6V5ng2FrtR1bYsewmQ3i2PqRR4NnuSZobJ/XtiKkbQyrheDHHdQ=="
+        "resolved": "5.0.0",
+        "contentHash": "tCQTzPsGZh/A9LhhA6zrqCRV4hOHsK90/G7q3Khxmn6tnB1PuNU0cRaKANP2AWcF9bn0zsuOoZOSrHuJk6oNBA=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -609,7 +600,7 @@
       "sso-auth": {
         "type": "Project",
         "dependencies": {
-          "Duende.IdentityModel.OidcClient": "[7.1.0, )",
+          "Duende.IdentityModel.OidcClient": "[6.0.1, )",
           "Jellyfin.Controller": "[10.11.11, )",
           "Jellyfin.Model": "[10.11.11, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[8.19.1, )",

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <FileVersion>4.1.0.0</FileVersion>
+    <AssemblyVersion>4.1.1.0</AssemblyVersion>
+    <FileVersion>4.1.1.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->
@@ -48,7 +48,17 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
+    <!-- OidcClient is pinned to the 6.x line, NOT 7.x, on purpose (#590). The 7.x assemblies are
+         built against the .NET 10 framework and reference Microsoft.Extensions.Logging.Abstractions
+         10.0.0.0 in their manifest. That assembly is host-provided (Jellyfin 10.11 runs on .NET 9 and
+         ships 9.0.0.0) so it is deliberately NOT in build.yaml's artifacts, and .NET does not roll a
+         host assembly DOWN a major version — so a 7.x build loads on the server only to throw
+         FileNotFoundException for Logging.Abstractions 10.0.0.0 the moment the plugin is constructed,
+         disabling it (the 4.1.0.0 field regression). 6.0.1's manifest references Logging.Abstractions
+         8.0.0.0, which rolls FORWARD onto the host's 9.0.0.0 cleanly. The
+         ArchitectureConformanceTests.HostProvidedFrameworkAssemblies_StayOnTheHostNet9Abi test locks
+         this in: no host-provided Microsoft.Extensions.* assembly may be referenced above the .NET 9 floor. -->
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageReference Include="Jellyfin.Controller" Version="$(JellyfinVersion)" />
     <!-- id_token validation (#134): OidcClient 7.x carries no JWT validation stack of its own. -->
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.19.1" />

--- a/SSO-Auth/packages.lock.json
+++ b/SSO-Auth/packages.lock.json
@@ -4,12 +4,12 @@
     "net9.0": {
       "Duende.IdentityModel.OidcClient": {
         "type": "Direct",
-        "requested": "[7.1.0, )",
-        "resolved": "7.1.0",
-        "contentHash": "5i/eSXgMtqM01ntFZ4pMRkJu8VaLATZL0Ck87XlVUy8SFHy0+n2WuK9LkqT6VLhT4z/We10hoguv6pTH1iUz6g==",
+        "requested": "[6.0.1, )",
+        "resolved": "6.0.1",
+        "contentHash": "9+1O6HKnEpzUAu6/v0h35cwNRNUQa2EbZnbwczO2Nr34MkrDa2BmRKoHV2tOH6VuIv0zAAJohInEIapFZAuplQ==",
         "dependencies": {
-          "Duende.IdentityModel": "8.1.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.4"
+          "Duende.IdentityModel": "7.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0"
         }
       },
       "Jellyfin.Controller": {
@@ -110,11 +110,8 @@
       },
       "Duende.IdentityModel": {
         "type": "Transitive",
-        "resolved": "8.1.0",
-        "contentHash": "ncmC2ISg0efTqY74xI6gaLKlv4mErT5ruYK262dkSnAv07g9qYC2++q7AWWs1FyP2c0YZ6LvUtcoJmxZqYyVrA==",
-        "dependencies": {
-          "Microsoft.BCL.Memory": "10.0.4"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "h6xvWQi9bASgroNh+6Z/BpSUpKTy/sSuc2l4twi0igSY0X0z7Y8eYMGMHB7trwdT56EGlWeXLA6qAb8VOg8ATA=="
       },
       "ICU4N": {
         "type": "Transitive",
@@ -198,11 +195,6 @@
         "resolved": "10.0.9",
         "contentHash": "iSljz/oaqFzH7c4mNKwYt8GqK1mxoDMgP0wliKaEF9TejFxyZ3acLopin1v5PAQIa9GE0flOESkwOnik83X0YA=="
       },
-      "Microsoft.Bcl.Memory": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "ayoY21xuhuY6cYZkG92bdYsulmJlLS558b3Ez1rWFkBZ+QIUSeAlALzT1UK+ZZeEmhzFWjemG4bBcMRhdiHntA=="
-      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "9.0.11",
@@ -281,8 +273,8 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "SIe9zlVQJecnk/DTmevIcl6+aEDYhoVLc2eG2AKwVeNEC8CSyxHAbh4lf0xtHq9JUum0vVTEByGNTK+b6oihTQ=="
+        "resolved": "9.0.11",
+        "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -296,11 +288,10 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "resolved": "9.0.11",
+        "contentHash": "UKWFTDwtZQIoypyt1YPVsxTnDK+0sKn26+UeSGeNlkRQddrkt9EC6kP4g94rgO/WOZkz94bKNlF1dVZN3QfPFQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
-          "System.Diagnostics.DiagnosticSource": "10.0.4"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.11"
         }
       },
       "Microsoft.Extensions.Options": {
@@ -372,11 +363,6 @@
         "type": "Transitive",
         "resolved": "1.2.0.556",
         "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "10.0.4",
-        "contentHash": "WBD8SloNQ9Fp+6Iz+H42w5/VdwYPz9q7iuT6V5ng2FrtR1bYsewmQ3i2PqRR4NnuSZobJ/XtiKkbQyrheDHHdQ=="
       },
       "System.Formats.Asn1": {
         "type": "Transitive",

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.1.0.0"
+version: "4.1.1.0"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at
@@ -19,10 +19,6 @@ artifacts:
   - "SSO-Auth.dll"
   - "Duende.IdentityModel.OidcClient.dll"
   - "Duende.IdentityModel.dll"
-  # Duende.IdentityModel's own runtime dependency the host does not provide (a latent
-  # omission from the #134 list, surfaced verifying #181 against SSO-Auth.deps.json —
-  # its only parent is Duende.IdentityModel, not the SAML crypto chain below).
-  - "Microsoft.Bcl.Memory.dll"
   # id_token validation (#134): the runtime closure of the JWT validator that the
   # Jellyfin host does not provide. Jellyfin 10.11 ships no Microsoft.IdentityModel.*
   # and no Microsoft.Bcl.Cryptography, so these must travel in the plugin zip or every
@@ -45,6 +41,7 @@ artifacts:
   - "System.Security.Cryptography.Pkcs.dll"
   - "System.Formats.Asn1.dll"
 changelog: |
+  4.1.1.0: Bug fix. Restore plugin loading on Jellyfin 10.11 (.NET 9). 4.1.0.0 pulled Duende.IdentityModel.OidcClient 7.x, whose assemblies reference the .NET 10 Microsoft.Extensions.Logging.Abstractions (10.0.0.0) that the host does not provide and the plugin does not ship, so it threw FileNotFoundException at construction and was disabled at startup. Pin OidcClient to the 6.x line (net9 ABI) and add a conformance test that no host-provided assembly is referenced above the .NET 9 floor. No configuration changes.
   4.1.0.0: Feature (BREAKING - on-disk secret format changed; forward-transparent, downgrade requires re-entering secrets). Security-parity hardening of the SAML and OpenID login path, secrets encrypted at rest, SAML AuthnRequest signing (RSA and ECDSA), admin-UI provider toggles, and the thin-controller architecture rework. See CHANGELOG.md.
   4.0.0.4: Fix security issue in SAML
   4.0.0.0: Jellyfin 10.11


### PR DESCRIPTION
# What & why

Restores plugin loading on a stock Jellyfin 10.11 server. 4.1.0.0 is disabled at startup, the plugin loads but throws `FileNotFoundException: Microsoft.Extensions.Logging.Abstractions, Version=10.0.0.0` while the host constructs `SSOPlugin`, and the server disables it, taking down every OpenID and SAML login.

Root cause: 4.1.0.0 bumped `Duende.IdentityModel.OidcClient` 6.0.1 → 7.1.0. The 7.x assemblies are built against the .NET 10 framework and their manifest references `Logging.Abstractions` 10.0.0.0 (verified with MetadataLoadContext over the shipped DLL), which pulls `SSO-Auth.dll`'s own compiled reference up to 10.0.0.0. That assembly is host-provided (Jellyfin 10.11 runs on .NET 9, ships 9.0.0.0) so it is correctly NOT bundled; .NET never rolls a host assembly down a major version, so the reference cannot be satisfied. `dotnet build`/`dotnet test` stay green because they run against the full publish output, the same blind spot #134/#181 documented.

Fix: pin OidcClient to 6.0.1. Its manifest references `Logging.Abstractions` 8.0.0.0, which rolls forward onto the host's 9.0.0.0; the restored graph settles on the .NET 9 ABI (verified: `SSO-Auth.dll` references 9.0.0.0). The OIDC code compiles unchanged, every 7.x member it uses (PAR toggle, `IIdentityTokenValidator`, `Policy.RequireIdentityTokenSignature`) exists in 6.0.1. `Microsoft.Bcl.Memory` leaves the publish closure and is dropped from `build.yaml` artifacts. A new `ArchitectureConformanceTests` fitness function fails the build if any host-provided `Microsoft.Extensions.*` assembly is referenced above the .NET 9 host ABI (verified it fails on 7.1.0).

Ships as 4.1.1.0 (bug fix). No behaviour or configuration changes.

Closes #590

## Type of change

- [x] Bug fix

## Security checklist

- [x] Fail-closed preserved: the id_token validator (#134) is unchanged and version-independent (Microsoft.IdentityModel.JsonWebTokens 8.19.1); OidcIdTokenValidatorTests stay green. No SAML/OIDC validation logic changed, only the OidcClient package major.
- [x] No secrets logged.
- [x] A security review was performed (7.x→6.x OIDC-flow parity + supply chain); notes below.
- [x] Log inputs from the IdP are sanitized inline (unchanged).

## Quality checklist

- [x] No duplicated logic; the ABI-floor rule is one small fitness function.
- [x] Minimal: a dependency pin + a guard test; no source logic changed.
- [x] Self-documenting; the csproj/build.yaml/test comments explain the why.
- [x] Architecture-conformance tests pass; the new ABI-floor property is locked in as a rule.

## Verification

- [x] `dotnet build -c Release` green (0 warnings under warnaserror).
- [x] `dotnet test` green: 1188 passed, 0 failed.
- [x] Negative check: reverting to OidcClient 7.1.0 makes the new ABI-floor test fail (guard proven non-vacuous).
- [x] `SSO-Auth.dll` assembly reference to Logging.Abstractions is 9.0.0.0 (was 10.0.0.0); publish closure no longer contains Microsoft.Bcl.Memory.
- [x] Prettier clean for CHANGELOG.md.

## Notes

The mature sibling jellyfin-plugin-sso-V2 (5.0.0.1) carries the same latent OidcClient 7.1.0 dependency and should get the same pin. Separately, a server pointing at the manifest URL `iderex/jellyfin-plugin-sso-V2/manifest-release/manifest.json` currently 404s, a distribution issue tracked apart from this fix.