### PR TITLE
Fix beta publish under immutable releases (draft + unique tag)

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -26,7 +26,7 @@ on:
 permissions: {}
 
 # Serialize beta publishes: a burst of merges to main must not run two of these
-# concurrently, or their manifest-branch pushes / rolling-release updates race
+# concurrently, or their manifest-branch pushes / draft-publish steps race
 # (a transient non-fast-forward, or an out-of-order manifest regeneration).
 # cancel-in-progress is false on purpose — a publish must never be killed
 # mid-run (it holds contents:write and moves a release + a manifest branch),
@@ -117,27 +117,46 @@ jobs:
         done
         ls -l
         popd
-    - name: Publish output artifacts
+    - name: Upload beta assets to a draft release
       id: publish-assets
       uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
       with:
-          # Prerelease so publish.yml's stable manifest (ignorePrereleases: true)
-          # never picks it up; only the beta manifest below (ignorePrereleases:
-          # false) surfaces it. The rolling `nightly` tag is reused as the single
-          # moving prerelease pointer, so each build updates the one release in
-          # place rather than accreting a release per push.
+          # This repo has IMMUTABLE RELEASES on (deliberately — publish.yml relies on
+          # it). A published release is sealed, so assets cannot be attached after it
+          # is published: creating a published prerelease and then uploading its zip
+          # fails ("Cannot upload asset ... to an immutable release"). So attach the
+          # assets while the release is still a DRAFT (drafts are mutable), then
+          # publish the draft in the next step (which seals it WITH its assets).
+          #
+          # The tag is UNIQUE per build (beta-<version>), not a rolling pointer: an
+          # immutable published release cannot be updated in place, so a moving tag
+          # would fail on its second run. `beta-*` never matches publish.yml's
+          # v[0-9]+.[0-9]+.[0-9]+.[0-9]+ stable glob, so a beta never triggers the
+          # stable channel; and prerelease: true keeps it out of the stable manifest
+          # (ignorePrereleases: true) — only the beta manifest below surfaces it.
+          draft: true
           prerelease: true
           fail_on_unmatched_files: true
-          tag_name: nightly
+          tag_name: beta-${{ steps.version.outputs.beta }}
           files: |
             _dist/*
             build.yaml
           body: |
-            Rolling Jellyfin 10.11 beta build (${{ steps.version.outputs.beta }}).
+            Jellyfin 10.11 beta build (${{ steps.version.outputs.beta }}).
             Install via the beta repository URL:
             https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish the draft release
+      # Seal the draft — assets already attached — into an immutable published
+      # prerelease (fires release.published). A draft has no git tag yet, so it is
+      # published by its release id from the step above, not by tag name. -F sends
+      # draft as a typed boolean.
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_ID: ${{ steps.publish-assets.outputs.id }}
+        REPO: ${{ github.repository }}
+      run: gh api "repos/${REPO}/releases/${RELEASE_ID}" -X PATCH -F draft=false
     - name: Publish Beta Plugin Manifest
       # ignorePrereleases: false so the beta build is included. Writes the SEPARATE
       # `manifest-beta` branch; the stable `manifest-release` is only ever written

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish Release
 # release from that tag in CI (action-gh-release creates the release when none
 # exists) — the release is never minted out of band, because a deleted immutable
 # release permanently burns its tag. The glob matches only our numeric four-part
-# tags, never the branch-triggered rolling beta prerelease (the `nightly` tag).
+# tags, never the branch-triggered beta prereleases (the `beta-*` tags).
 on:
   push:
     tags:


### PR DESCRIPTION
# What & why

The first `publish-beta` run on main (after #593) FAILED: this repo has **immutable releases** enabled, so `action-gh-release` could not upload the plugin zip to the prerelease it had just published, `Cannot upload asset sso-authentication_4.1.1.1.zip.meta.json to an immutable release`. The version derivation, build, and JPRM packaging all worked (it built `4.1.1.1`); only the release-asset upload failed. Empirically, the stable path (`publish.yml`, `prerelease: false`) attaches assets fine because it creates the release with its assets in one shot; the prerelease path hit the seal-on-publish timing the action's own error message describes.

## Fix

- **Draft, then publish.** Attach the assets while the release is a **draft** (drafts stay mutable on an immutable-releases repo), then publish the draft **by its release id** (a draft has no git tag yet, so `gh release edit <tag>` can't find it) via `gh api ... -X PATCH -F draft=false`. Publishing seals it immutable with its assets already attached and fires `release.published`.
- **Unique per-build tag `beta-<version>`** instead of the rolling `nightly` pointer: an immutable published release cannot be updated in place, so a moving tag fails on its second run. Each build is its own immutable `beta-4.1.1.N` prerelease.

## Channel isolation preserved (unchanged from the #593 review)

- `beta-*` never matches `publish.yml`'s stable glob `v[0-9]+.[0-9]+.[0-9]+.[0-9]+`, so a beta never triggers the stable workflow.
- `prerelease: true` keeps every beta out of the stable manifest (`ignorePrereleases: true`); only the beta manifest (`ignorePrereleases: false`) surfaces it.
- The new `gh api` step passes repo/id/token via **env**, no `${{ }}` spliced into the shell. All `uses:` stay SHA-pinned; permissions unchanged (`contents: write`, job-scoped).

The #593 adversarial review's isolation/injection/permission findings still hold; this changes only the immutable-release publish mechanics, so it is covered by that review plus the CI zizmor gate rather than a fresh full review.

## Type of change

- [x] Bug fix (release pipeline)

## Verification

- [x] YAML validates (js-yaml).
- [ ] Release-only workflow, cannot run on a PR. On merge, the corrected job runs on main: it will publish `beta-4.1.1.<run_number>` and populate `manifest-beta`. I will verify that run.

## Notes

- The failed first run left an **empty, published `nightly` prerelease (0 assets)**. It is harmless to the manifest generator (no plugin zip → skipped) but should be **deleted by me** (deleting/creating releases is hook-gated for the agent). The workflow no longer uses the `nightly` tag.
- Beta releases now accrete one immutable `beta-*` release per merge to main, the immutable-native pattern; prune old ones if desired.
