### PR TITLE
Forward-merge main into 4.2 (3-part versions + release naming)

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -72,7 +72,7 @@ jobs:
       # so cutting the next stable supersedes the beta cleanly. The build number is
       # monotonic within this workflow, which is all Jellyfin's version precedence
       # needs; the beta stays out of the stable manifest because it is a prerelease.
-      # The grep pins the four-part shape so a malformed build.yaml fails here rather
+      # The grep pins the three-part shape so a malformed build.yaml fails here rather
       # than producing a bogus tag. RUN_NUMBER is passed via env (not inlined into the
       # script) so no ${{ }} expansion is spliced into the shell.
       #
@@ -85,11 +85,12 @@ jobs:
       env:
         RUN_NUMBER: ${{ github.run_number }}
       run: |
-        base=$(grep -E '^version:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"' build.yaml \
-          | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+".*/\1/')
+        base=$(grep -E '^version:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' build.yaml \
+          | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
         if [ -z "$base" ]; then
-          echo "::error::Could not read a four-part version from build.yaml"; exit 1
+          echo "::error::Could not read a three-part version from build.yaml"; exit 1
         fi
+        echo "base=${base}" >> "$GITHUB_OUTPUT"
         echo "beta=${base}.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
     - name: "Set the beta version in build.yaml"
       uses: fjogeleit/yaml-update-action@dffe9a5223d84653c13374032382f6bb5de8e5ef # v0.17.0
@@ -128,21 +129,27 @@ jobs:
           # assets while the release is still a DRAFT (drafts are mutable), then
           # publish the draft in the next step (which seals it WITH its assets).
           #
-          # The tag is UNIQUE per build (beta-<version>), not a rolling pointer: an
-          # immutable published release cannot be updated in place, so a moving tag
-          # would fail on its second run. `beta-*` never matches publish.yml's
-          # v[0-9]+.[0-9]+.[0-9]+.[0-9]+ stable glob, so a beta never triggers the
-          # stable channel; and prerelease: true keeps it out of the stable manifest
-          # (ignorePrereleases: true) — only the beta manifest below surfaces it.
+          # Release NAME is the clean three-part X.Y.Z-beta; the git TAG carries the
+          # build number (X.Y.Z-beta.<run>) to stay UNIQUE per run — an immutable
+          # published release cannot be updated in place, so a rolling tag would fail
+          # on its second run. The tag never matches publish.yml's
+          # [0-9]+.[0-9]+.[0-9]+-stable glob, so a beta never triggers the stable
+          # channel; and prerelease: true keeps it out of the stable manifest
+          # (ignorePrereleases: true) — only the beta manifest below surfaces it. The
+          # INSTALLED plugin version is X.Y.Z.<run> (the hidden fourth octet keeps
+          # Jellyfin's update ordering monotonic across betas).
           draft: true
           prerelease: true
+          name: ${{ steps.version.outputs.base }}-beta
+          # Always auto-generate the release notes from the commits since the previous tag.
+          generate_release_notes: true
           fail_on_unmatched_files: true
-          tag_name: beta-${{ steps.version.outputs.beta }}
+          tag_name: ${{ steps.version.outputs.base }}-beta.${{ github.run_number }}
           files: |
             _dist/*
             build.yaml
           body: |
-            Jellyfin 10.11 beta build (${{ steps.version.outputs.beta }}).
+            Jellyfin 10.11 beta ${{ steps.version.outputs.base }}-beta (plugin version ${{ steps.version.outputs.beta }}).
             Install via the beta repository URL:
             https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,18 @@
 name: Publish Release
 
-# A four-part version tag push (e.g. v4.1.0.0) is the ONLY publish trigger, per
-# docs/RELEASE-POLICY.md. The upload job below CREATES and publishes the GitHub
-# release from that tag in CI (action-gh-release creates the release when none
-# exists) — the release is never minted out of band, because a deleted immutable
-# release permanently burns its tag. The glob matches only our numeric four-part
-# tags, never the branch-triggered beta prereleases (the `beta-*` tags).
+# A three-part stable tag push (e.g. 4.1.1-stable) is the ONLY publish trigger,
+# per docs/RELEASE-POLICY.md. The channel/generation is the tag SUFFIX — this is
+# the JF10.11 line, so `X.Y.Z-stable`; the JF12 line publishes from `X.Y.Z-JF12-stable`
+# on its own branch. The numeric X.Y.Z is the plugin version Jellyfin installs (it
+# must be numeric — the suffix lives only in the tag + release name); it must match
+# build.yaml's `version` (checked in the upload job). The glob matches only the
+# `-stable` tags, never the beta prereleases (`X.Y.Z-beta.*`). The upload job CREATES
+# and publishes the release from the tag in CI — never minted out of band, because a
+# deleted immutable release permanently burns its tag.
 on:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-stable"
   workflow_dispatch:
 
 # Default to read-only; the jobs that create the release and update the
@@ -55,6 +58,9 @@ jobs:
       with:
           name: ${{ github.ref_name }}
           prerelease: false
+          # Always auto-generate the release notes from the merged PRs/commits since
+          # the previous tag, on every release.
+          generate_release_notes: true
           fail_on_unmatched_files: true
           tag_name: ${{ github.ref_name }}
           files: ./*

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.1.1.0</AssemblyVersion>
-    <FileVersion>4.1.1.0</FileVersion>
+    <AssemblyVersion>4.1.1</AssemblyVersion>
+    <FileVersion>4.1.1</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.1.1.0"
+version: "4.1.1"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at


### PR DESCRIPTION
Per BRANCHING.md, forward-merge the released line into the next-feature branch. Brings main's three-part version + `X.Y.Z-<channel>` release naming + `generate_release_notes` (#597) onto 4.2's multi-target build.

Clean auto-merge (no conflicts): 4.2's multi-target csproj now carries `AssemblyVersion 4.1.1`, and build.yaml is `4.1.1`.

Verification: compat consistent; build 0/0; **1280 tests green on both net9.0 and net10.0**.