### PR TITLE
Evaluate SAML assertion roles once per login (#479)

### DIFF
--- a/SSO-Auth.Tests/SamlAssertionValidatorTests.cs
+++ b/SSO-Auth.Tests/SamlAssertionValidatorTests.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlAssertionValidator.TryProduceVerifiedIdentity"/> that pin the single-evaluation
+/// role threading (#479): the flow service evaluates the assertion's Role attribute ONCE for the login
+/// allow-list and threads that list in here, so the privilege derivation must consume the roles it is
+/// PASSED rather than re-reading the assertion — the property the dedup relies on.
+/// </summary>
+public class SamlAssertionValidatorTests
+{
+    private static SamlResponse SignedResponse(string role)
+    {
+        var fixture = SamlTestFactory.Create(nameId: "alice", role: role);
+        return new SamlResponse(fixture.CertificateBase64, fixture.EncodeResponse());
+    }
+
+    [Fact]
+    public void TryProduceVerifiedIdentity_DerivesPrivilegesFromThreadedRoles_NotFromAssertion()
+    {
+        // Replay is a process-wide static; reset so a prior test's consumed assertion id cannot interfere.
+        SamlAssertionValidator.ResetReplaysForTests();
+        var validator = new SamlAssertionValidator(Substitute.For<ILogger>());
+
+        // The assertion carries a NON-admin role, but the caller threads in a role list that DOES grant admin
+        // (the single evaluation the flow service already performed, #479). If this method reused the threaded
+        // list, the derived identity is an admin; if it re-read the assertion, it would not be. Asserting admin
+        // pins that the passed roles — not a second read of the assertion — drive the derivation.
+        var response = SignedResponse("plain-users");
+        var config = new SamlConfig { AdminRoles = new[] { "admins" } };
+
+        var produced = validator.TryProduceVerifiedIdentity(
+            config,
+            "adfs",
+            response,
+            new List<string> { "admins" },
+            out var identity,
+            out var rejection);
+
+        Assert.True(produced);
+        Assert.Null(rejection);
+        Assert.NotNull(identity);
+        Assert.True(identity.Admin);
+    }
+}

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -182,14 +182,19 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
+        // Evaluate the assertion's role attribute ONCE per response (#479): the same list feeds the allow-list
+        // gate here, the denied-path warning below, and the privilege derivation in TryProduceVerifiedIdentity
+        // on the mint path — the assertion is immutable here, so the role XPath runs once instead of at each use.
+        var assertionRoles = SamlAssertionValidator.GetAssertionRoles(samlResponse);
+
+        if (!SamlLoginPolicy.IsLoginAllowed(assertionRoles, config.Roles))
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
                 _logger.LogWarning(
                     "SAML user: {UserId} has insufficient roles: {@Roles}. Expected any one of: {@ExpectedRoles}",
                     samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
-                    SamlAssertionValidator.GetAssertionRoles(samlResponse).Select(r => r?.ReplaceLineEndings(string.Empty)),
+                    assertionRoles.Select(r => r?.ReplaceLineEndings(string.Empty)),
                     config.Roles);
             }
 
@@ -258,7 +263,7 @@ internal sealed class SamlLoginService
         bool committed = false;
         try
         {
-            if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
+            if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, assertionRoles, out var identity, out var rejection))
             {
                 // A genuine replay (or an assertion with no usable NameID) still fails closed here, minting
                 // nothing — so moving the capacity check ahead of the consume never lets a replayed assertion
@@ -621,10 +626,15 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
+        // Evaluate the assertion's role attribute ONCE (#479): the same list feeds the allow-list gate here
+        // and the privilege derivation in TryProduceVerifiedIdentity below, so the role XPath runs once for
+        // this legacy leg rather than once for the gate and again for the derivation.
+        var assertionRoles = SamlAssertionValidator.GetAssertionRoles(samlResponse);
+
         // Enforce the login allow-list here too, not only at the assertion-consumer page: a legacy caller
         // can POST an assertion straight to this session-minting endpoint and skip the page, so checking it
         // only there would be fail-open.
-        if (!SamlLoginPolicy.IsLoginAllowed(SamlAssertionValidator.GetAssertionRoles(samlResponse), config.Roles))
+        if (!SamlLoginPolicy.IsLoginAllowed(assertionRoles, config.Roles))
         {
             if (_logger.IsEnabled(LogLevel.Warning))
             {
@@ -639,7 +649,7 @@ internal sealed class SamlLoginService
         // Complete the assertion validation in the dedicated validator: the one-time replay consume and the
         // non-empty-NameID guard, then — and only then — the verified identity through FromValidatedSaml
         // (#496). A replay fails as an invalid response and a missing NameID as a denial.
-        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, out var identity, out var rejection))
+        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, assertionRoles, out var identity, out var rejection))
         {
             return LoginStatusMapper.ToActionResult(rejection);
         }

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -139,10 +139,12 @@ internal sealed class SamlAssertionValidator
     /// <param name="config">The provider configuration the privileges are derived against.</param>
     /// <param name="provider">The provider that verified the login.</param>
     /// <param name="samlResponse">The validated, allow-listed, correlated response.</param>
+    /// <param name="assertionRoles">The assertion's role values, already evaluated once by the flow service for
+    /// the login allow-list; reused here for the privilege derivation instead of re-reading the assertion (#479).</param>
     /// <param name="identity">The verified identity on success; otherwise null.</param>
     /// <param name="rejection">The fail-closed outcome on failure; otherwise null.</param>
     /// <returns>True with <paramref name="identity"/> set on success; false with <paramref name="rejection"/> set.</returns>
-    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, out VerifiedIdentity identity, out LoginOutcome rejection)
+    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, IReadOnlyList<string> assertionRoles, out VerifiedIdentity identity, out LoginOutcome rejection)
     {
         identity = null;
 
@@ -158,10 +160,12 @@ internal sealed class SamlAssertionValidator
         }
 
         // Derive the authorize-state privileges (admin, Live TV, Live TV management, folders) from the
-        // assertion's roles and the provider configuration. Login validity was already decided by
-        // SamlLoginPolicy at the flow service and the username is the assertion's NameID, so neither is
-        // derived here.
-        var derived = SamlAuthorizeStateBuilder.Build(GetAssertionRoles(samlResponse), config);
+        // assertion's roles and the provider configuration. The roles were already evaluated once by the flow
+        // service for the login allow-list and are threaded in here, so the role XPath runs a single time per
+        // response rather than once for the gate and again for this derivation (#479). Login validity was
+        // already decided by SamlLoginPolicy at the flow service and the username is the assertion's NameID, so
+        // neither is derived here.
+        var derived = SamlAuthorizeStateBuilder.Build(assertionRoles, config);
 
         // Fail closed (#95): an assertion without a usable NameID carries no identity to log in — reject it
         // as an invalid login instead of failing downstream on a null canonical name. Whitespace-only counts


### PR DESCRIPTION
Behaviour-preserving tech-debt fix (#479): the SAML login path evaluated `GetAssertionRoles` twice per successful login (the flow-service allow-list read + the validator's privilege derivation). Both legs now evaluate once and thread the list through.

Files: `SamlAssertionValidator.cs` (`TryProduceVerifiedIdentity` takes the roles list), `Flows/SamlLoginService.cs` (both legs thread it), new `SamlAssertionValidatorTests.cs` pinning the dedup.

Behaviour unchanged: assertion is immutable at these points, every consumer read-only, allow-list gate still runs before identity minting. Local gate green (1281 tests both net9.0 + net10.0). Closes #479.

Security review to run (touches the SAML authz path).