### PR TITLE
Weekly SharpFuzz job over the SAML parse surface (#174)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -145,7 +145,7 @@ jobs:
         # The reproducers are the finding. Always upload; ignore if none were
         # written (the expected clean-run case).
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sharpfuzz-crashers-${{ matrix.target }}
           path: findings/${{ matrix.target }}/
@@ -156,7 +156,7 @@ jobs:
         # The corpus libFuzzer grew this run — reseeds the next run and documents
         # the coverage reached.
         if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sharpfuzz-corpus-${{ matrix.target }}
           path: SSO-Auth.Fuzz/corpus/${{ matrix.target }}/

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,183 @@
+# Weekly coverage-guided fuzzing of the login-path parse/validate surface (#174).
+#
+# Runs the out-of-band SharpFuzz harness (SSO-Auth.Fuzz, #402) under libFuzzer on
+# Linux — the only platform where the `sharpfuzz` instrumentation CLI and the
+# libFuzzer runtime work. The headline target is the SAML response parse/validate
+# path (`SamlResponseLoader.TryParse` -> `SamlResponse` ctor + `IsValid` + every
+# claim getter, seeded from the SamlTestFactory-shaped corpus), which is what
+# #174 asks for; the same harness also exposes the OIDC `discovery` and `idtoken`
+# parse readers, fuzzed in the same sweep at no extra maintenance.
+#
+# NON-GATING BY CONSTRUCTION: this workflow runs ONLY on a weekly schedule and on
+# manual dispatch — never on push or pull_request — so it is not a PR check and
+# gates no merge. A crasher is treated as its own security finding (triage +
+# minimise + a separate parser fix, GHSA path if exploitable; see the harness
+# README), never a silent in-harness patch. The job therefore ARCHIVES every
+# crasher and the evolved corpus as artifacts and, when a crasher is found, marks
+# the run red purely as a notification signal to the maintainer.
+#
+# Hardened per the repo workflow policy (see zizmor.yml): every action is
+# SHA-pinned with a version comment, checkout runs with persist-credentials:false,
+# permissions are deny-all at the top level with the job granted only
+# contents:read, and no untrusted context is interpolated into a run script (the
+# matrix target and the dispatch duration are passed through `env`).
+name: Fuzz (SharpFuzz)
+
+on:
+  schedule:
+    # Weekly, Mondays 05:42 UTC. Off the top of the hour (GitHub throttles exact
+    # :00 crons) and distinct from the CodeQL weekly scan (17 3 * * 1).
+    - cron: "42 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      max_total_time:
+        description: "libFuzzer -max_total_time per target, in seconds."
+        required: false
+        default: "600"
+
+# Explicit deny-all at workflow level; the job below grants only what it needs.
+permissions: {}
+
+# A newer run on the same ref supersedes an in-flight one; this is analysis, not
+# a publish, so cancelling a superseded run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Fuzz ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    # Generous ceiling: three targets, each bounded below by -max_total_time
+    # (600s default), plus the SDK/instrumentation build and the clang compile.
+    timeout-minutes: 60
+    permissions:
+      contents: read # check out the repo, harness, and seed corpus to fuzz
+    strategy:
+      # One target's crasher (a real finding) must not cancel the others' runs.
+      fail-fast: false
+      matrix:
+        # saml is the #174 target and is listed first; discovery/idtoken are the
+        # sibling parse readers the same harness (#402) exposes.
+        target: [saml, discovery, idtoken]
+    env:
+      # The managed harness executable libFuzzer drives, and the plugin assembly
+      # SharpFuzz instruments in place (loaded by the harness from the same dir).
+      FUZZ_DLL: SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll
+      PLUGIN_DLL: SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll
+      # libfuzzer-dotnet is the native shim (built with clang -fsanitize=fuzzer)
+      # that hosts the CLR and bridges Fuzzer.LibFuzzer.Run to libFuzzer. Pinned
+      # to an immutable commit so the compiled-from-source shim is reproducible.
+      LIBFUZZER_DOTNET_REF: c33d28305eba24261ce1945a39576e659f437b90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          # No step pushes via git, so do not persist the GITHUB_TOKEN in
+          # .git/config (zizmor "artipacked" hardening).
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          # The harness targets net9.0; the referenced multi-target plugin also
+          # has a net10.0 leg, so install both SDKs (as the .NET build job does)
+          # to keep the locked-mode restore of the reference graph deterministic.
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: Restore harness (locked)
+        # --locked-mode fails if the committed packages.lock.json would change, so
+        # a drifted/tampered dependency graph cannot build here either.
+        run: dotnet restore SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --locked-mode
+
+      - name: Build harness (Release)
+        run: dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror
+
+      - name: Install clang (libFuzzer)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang
+
+      - name: Build libfuzzer-dotnet
+        # Fetch the pinned native shim source and compile it with libFuzzer linked
+        # in. -fsanitize=fuzzer pulls libFuzzer from the clang runtime, so no
+        # separate libFuzzer package is needed.
+        env:
+          REF: ${{ env.LIBFUZZER_DOTNET_REF }}
+        run: |
+          curl -fsSL -o libfuzzer-dotnet.cc \
+            "https://raw.githubusercontent.com/Metalnem/libfuzzer-dotnet/${REF}/libfuzzer-dotnet.cc"
+          clang -O2 -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet
+
+      - name: Install SharpFuzz CLI
+        # Pinned to the SharpFuzz runtime version the harness references (2.3.0).
+        run: |
+          dotnet tool install --global SharpFuzz.CommandLine --version 2.3.0
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Instrument the plugin assembly
+        # SharpFuzz rewrites SSO-Auth.dll in place to emit libFuzzer coverage
+        # feedback; the harness loads that instrumented copy from the same dir.
+        run: sharpfuzz "$PLUGIN_DLL"
+
+      - name: Fuzz
+        # continue-on-error keeps a crasher (non-zero libFuzzer exit) from failing
+        # the job here; the archive + report steps below run regardless and the
+        # report step is what turns a real finding red.
+        continue-on-error: true
+        env:
+          TARGET: ${{ matrix.target }}
+          MAX_TOTAL_TIME: ${{ github.event.inputs.max_total_time }}
+          SSO_FUZZ_TARGET: ${{ matrix.target }}
+        run: |
+          duration="${MAX_TOTAL_TIME:-600}"
+          mkdir -p "findings/${TARGET}"
+          ./libfuzzer-dotnet \
+            -timeout=25 \
+            -max_total_time="${duration}" \
+            -print_final_stats=1 \
+            -artifact_prefix="findings/${TARGET}/" \
+            --target_path=dotnet \
+            --target_arg="${PWD}/${FUZZ_DLL}" \
+            "SSO-Auth.Fuzz/corpus/${TARGET}"
+
+      - name: Archive crashers
+        # The reproducers are the finding. Always upload; ignore if none were
+        # written (the expected clean-run case).
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: sharpfuzz-crashers-${{ matrix.target }}
+          path: findings/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: Archive evolved corpus
+        # The corpus libFuzzer grew this run — reseeds the next run and documents
+        # the coverage reached.
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        with:
+          name: sharpfuzz-corpus-${{ matrix.target }}
+          path: SSO-Auth.Fuzz/corpus/${{ matrix.target }}/
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Report findings
+        # Non-gating notification: if libFuzzer wrote any reproducer, surface it
+        # loudly and fail THIS leg so the scheduled run goes red and notifies the
+        # maintainer. This is a signal to open a security finding, not a merge
+        # gate — the workflow never runs on a pull request.
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          if [ -n "$(find "findings/${TARGET}" -type f -print -quit 2>/dev/null)" ]; then
+            echo "::error::SharpFuzz found a crasher on the '${TARGET}' parse surface. Download the sharpfuzz-crashers-${TARGET} artifact, minimise the reproducer, and file it as its own security finding (GHSA path if exploitable). Do NOT patch the harness."
+            {
+              echo "## SharpFuzz finding: ${TARGET}"
+              echo "libFuzzer wrote a reproducer to \`findings/${TARGET}/\` (archived as \`sharpfuzz-crashers-${TARGET}\`)."
+              echo "Triage as a security finding per the harness README; this run is a notification, not a merge gate."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "No crasher on the '${TARGET}' parse surface this run."


### PR DESCRIPTION
Adds a scheduled (weekly) SharpFuzz coverage-guided fuzzing workflow (#174) over the SAML parse/validate entry point `SamlResponseLoader.TryParse` (+ the discovery/idtoken parse readers as a matrix). New file: `.github/workflows/fuzz.yml` only, the `SSO-Auth.Fuzz/` harness already targeted this path (verified in smoke mode). Schedule/dispatch only (no PR trigger) → non-gating; a crasher is archived + flags the run as a notification to me, never patched in-suite. SHA-pinned (incl. the libfuzzer-dotnet shim commit + SharpFuzz.CommandLine 2.3.0), `permissions: {}` top-level, no `${{ }}` in run. Closes #174.