### PR TITLE
Forward-merge main into 4.2, set 4.2 to its 4.2.0 feature target

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -65,13 +65,18 @@ jobs:
       run: dotnet build --no-restore --warnaserror
     - name: Derive the beta version
       id: version
-      # Beta version = the release line from build.yaml (A.B.C) with the workflow
-      # run number as the fourth octet, e.g. 4.1.1.<run_number>. This is always
-      # ABOVE the last stable in that line (…․0) so a beta tester is offered it, and
-      # BELOW the next line's stable (a bump of A/B/C outranks any ….<run_number>),
-      # so cutting the next stable supersedes the beta cleanly. The build number is
-      # monotonic within this workflow, which is all Jellyfin's version precedence
-      # needs; the beta stays out of the stable manifest because it is a prerelease.
+      # Beta version = build.yaml's `version`, which is the NEXT RELEASE TARGET (the
+      # version main is developing toward), with the workflow run number as the fourth
+      # octet: <target>.<run_number>, released as "<target>-beta". The maintainer sets
+      # the target per change class — a patch (4.1.1 stable -> 4.1.2), a feature
+      # (-> 4.2.0), or a breaking release (-> 5.0.0) — so the beta always tracks the
+      # actual next release: 4.1.2-beta, then 4.2.0-beta, then 5.0.0-beta. The same
+      # target is what a `<target>-stable` tag releases; after a stable ships the
+      # maintainer bumps build.yaml to the next target. Betas therefore always outrank
+      # the current stable; the two channels are separate manifests, so that is fine.
+      # The build number is monotonic within this workflow, which is all Jellyfin's
+      # version precedence needs; the beta stays out of the stable manifest because it
+      # is a prerelease.
       # The grep pins the three-part shape so a malformed build.yaml fails here rather
       # than producing a bogus tag. RUN_NUMBER is passed via env (not inlined into the
       # script) so no ${{ }} expansion is spliced into the shell.

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.1.1</AssemblyVersion>
-    <FileVersion>4.1.1</FileVersion>
+    <AssemblyVersion>4.1.2</AssemblyVersion>
+    <FileVersion>4.1.2</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.1.1"
+version: "4.1.2"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at


### PR DESCRIPTION
Forward-merge (BRANCHING.md): brings main's beta-tracks-next-target model + 4.1.2 short-term line (#602) onto 4.2. Then sets 4.2 to its own feature milestone **4.2.0** (build.yaml + csproj) per the version scheme, main = short-term 4.1.X, the `4.2` branch = the 4.2.0 feature, JF12 = 5.0.

Clean auto-merge. Verified: compat consistent (4.2.0), build 0/0, 1280 tests green on net9.0 + net10.0.