### PR TITLE
Collapse SamlChallenge relayState init to a ternary (#456)

### DIFF
--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -331,11 +331,7 @@ internal sealed class SamlLoginService
         bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
-        string relayState = null;
-        if (isLinking)
-        {
-            relayState = "linking";
-        }
+        string relayState = isLinking ? "linking" : null;
 
         var samlRequest = new SamlAuthnRequest(
             config.SamlClientId.Trim(),


### PR DESCRIPTION
#456 reduction 3 (behaviour-preserving): `string relayState = null; if (isLinking) { relayState = "linking"; }` → `string relayState = isLinking ? "linking" : null;` in `SamlLoginService.SamlChallenge`. Method-local, assigned once, read once at the challenge redirect. No security surface.

**#456's other two reductions are superseded** by the controller thinning / SAML extraction that landed since the issue was filed:
- R1 (unify the two error builders): `SSOController.ReturnError` no longer exists, dynamic-message errors already route through `FlowResponses` / `LoginStatusMapper.Emit`.
- R2 (collapse the three-site SAML parse+validate guard): the SAML flow moved to `SamlLoginService`/`SamlAssertionValidator` (#160/#496); the parse+validate is now a single definition in `SamlAssertionValidator`, not three copies in the controller.

So this PR closes #456. Verified: build 0/0, 1281 tests green on net9.0 + net10.0.