### PR TITLE
Jellyfin 12.0 (5.0) beta publish leg + two-channel manifest model (#135)

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -12,10 +12,10 @@ name: Publish Beta
 #     with ignorePrereleases: true; this beta job writes `manifest-beta` with
 #     ignorePrereleases: false, so the beta manifest surfaces the newest of the
 #     prerelease beta builds AND any stable release.
-#   - Generation (JF10.11 vs the future JF10.12) is a different BUILD. This job is
-#     the .NET 9 / Jellyfin 10.11 leg (OidcClient must stay 6.x, #590). The
-#     JF10.12 (.NET 10 / OidcClient 7.x) leg is added when a 10.12 SDK exists;
-#     it will feed `manifest-jf12-beta`.
+#   - Generation (Jellyfin 10.11 vs 12.0) is a different BUILD, not a different manifest. This job is
+#     the .NET 9 / Jellyfin 10.11 leg (OidcClient must stay 6.x, #590). The Jellyfin 12.0 (.NET 10 /
+#     OidcClient 7.x, the 5.0 line) leg is publish-jf12-beta.yml, which builds from the `4.2` branch and
+#     regenerates this SAME manifest-beta — the server filters the two generations by targetAbi (#135).
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -32,7 +32,7 @@ permissions: {}
 # mid-run (it holds contents:write and moves a release + a manifest branch),
 # matching the never-cancel posture noted in zizmor.yml.
 concurrency:
-  group: publish-beta
+  group: publish-manifest-beta
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -1,0 +1,149 @@
+name: Publish JF12 Beta
+
+# The Jellyfin 12.0 (.NET 10) BETA channel — the 5.0 line (#135). Jellyfin 12.0 moves the server to
+# .NET 10 and a 10.11-ABI plugin will not load there, so upgraders need a 12-targeted build. The
+# multi-target codebase (net9.0;net10.0) lives on the `4.2` branch, so JF12 betas publish from 4.2:
+# every push to 4.2 builds the net10 target and publishes an installable prerelease into the SHARED
+# `manifest-beta` branch. Jellyfin filters plugin versions client-side by targetAbi, so one beta
+# manifest carries BOTH generations (4.x at targetAbi 10.11, 5.0 at 12.0) and each server installs only
+# its compatible build — no separate JF12 manifest is needed. (The JF10.11 beta is published from `main`
+# by publish-beta.yml; both regenerate the same manifest-beta from all prerelease releases.) When 4.2.0
+# releases (4.2 -> main), this leg moves to main with the multi-target codebase.
+#
+# The JF12 build METADATA (version 5.0, targetAbi 12.0.0.0, framework net10.0, and the net10 shipping
+# closure) lives in build-jf12.yaml, which this job copies over build.yaml before JPRM builds — the
+# committed build.yaml stays the JF10.11 metadata.
+on:
+  push:
+    branches: [ 4.2 ]
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job below opts into write access explicitly.
+permissions: {}
+
+# Serialize JF12 beta publishes so a burst of merges to 4.2 cannot race the manifest-branch push /
+# draft-publish. cancel-in-progress is false — a publish must never be killed mid-run.
+concurrency:
+  group: publish-jf12-beta
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & publish JF12 beta
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Creates the GitHub release and updates the manifest branch, so it opts into write access.
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      with:
+        # Both SDKs: the multi-target restore/build needs net9.0, the JF12 package is net10.0.
+        # No NuGet cache: this job publishes with contents:write, so a poisoned cache could reach
+        # the artifact; the --locked-mode restore re-downloads against the committed lockfile.
+        dotnet-version: |
+          9.0.x
+          10.0.x
+    - name: Restore dependencies
+      run: dotnet restore --locked-mode
+    - name: Build Dotnet
+      run: dotnet build --no-restore --warnaserror
+    - name: Derive the JF12 beta version
+      id: version
+      # Beta version = build-jf12.yaml's `version` (the 5.0 line's next target) with the run number as
+      # the fourth octet: 5.0.0.<run>, released as "5.0.0-JF12-beta". Same monotonic-build-number model
+      # as publish-beta.yml; RUN_NUMBER via env (no ${{ }} spliced into the shell). Never rename this
+      # workflow without bumping build-jf12.yaml's version (github.run_number resets on rename).
+      env:
+        RUN_NUMBER: ${{ github.run_number }}
+      run: |
+        base=$(grep -E '^version:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' build-jf12.yaml \
+          | head -1 | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+        if [ -z "$base" ]; then
+          echo "::error::Could not read a three-part version from build-jf12.yaml"; exit 1
+        fi
+        echo "base=${base}" >> "$GITHUB_OUTPUT"
+        echo "beta=${base}.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+    - name: Use the JF12 build metadata
+      # JPRM reads build.yaml; swap in the JF12 metadata (version 5.0, targetAbi 12.0.0.0, framework
+      # net10.0, net10 artifacts) for this build only. The committed build.yaml is untouched on disk in
+      # the repo — this only rewrites the runner's checkout.
+      run: cp build-jf12.yaml build.yaml
+    - name: Set the JF12 beta version in build.yaml
+      uses: fjogeleit/yaml-update-action@dffe9a5223d84653c13374032382f6bb5de8e5ef # v0.17.0
+      with:
+        valueFile: 'build.yaml'
+        propertyPath: 'version'
+        value: ${{ steps.version.outputs.beta }}
+        commitChange: false
+        updateFile: true
+    - name: "JPRM: Build"
+      id: jrpm
+      uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
+      with:
+        version: ${{ steps.version.outputs.beta }}
+        verbosity: debug
+        path: .
+        dotnet-target: "net10.0"
+        output: _dist
+    - name: Prepare GitHub Release assets
+      run: |-
+        pushd _dist
+        for file in ./*.zip; do
+          md5sum ${file#./} >> ${file%.*}.md5
+          sha256sum ${file#./} >> ${file%.*}.sha256
+        done
+        ls -l
+        popd
+    - name: Upload JF12 beta assets to a draft release
+      id: publish-assets
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      with:
+          # Immutable-releases repo: attach assets while the release is a DRAFT, then publish the draft
+          # (same flow as publish-beta.yml). Release NAME is the clean 5.0.0-JF12-beta; the git TAG
+          # carries the build number (5.0.0-JF12-beta.<run>) to stay unique per run. The tag never
+          # matches publish.yml's [0-9]+.[0-9]+.[0-9]+-stable glob, so a JF12 beta never triggers the
+          # stable channel; prerelease: true keeps it out of any stable manifest. Installed plugin
+          # version is 5.0.0.<run> (hidden fourth octet keeps Jellyfin's update ordering monotonic).
+          draft: true
+          prerelease: true
+          name: ${{ steps.version.outputs.base }}-JF12-beta
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          tag_name: ${{ steps.version.outputs.base }}-JF12-beta.${{ github.run_number }}
+          files: |
+            _dist/*
+            build.yaml
+          body: |
+            Jellyfin 12.0 (.NET 10) beta ${{ steps.version.outputs.base }}-JF12-beta (plugin version ${{ steps.version.outputs.beta }}).
+            Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
+            https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish the draft release
+      # Seal the draft (assets attached) into an immutable published prerelease. A draft has no git tag
+      # yet, so publish by release id, not tag name. -F sends draft as a typed boolean.
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_ID: ${{ steps.publish-assets.outputs.id }}
+        REPO: ${{ github.repository }}
+      run: gh api "repos/${REPO}/releases/${RELEASE_ID}" -X PATCH -F draft=false
+    - name: Publish Beta Plugin Manifest
+      # ignorePrereleases: false so the beta is included. Regenerates the SHARED manifest-beta from ALL
+      # prerelease releases — both this JF12 build (5.0.0.<run>, targetAbi 12.0.0.0) and the JF10.11
+      # betas published from main (4.x.<run>, targetAbi 10.11.0.0). Each release ships its own build.yaml,
+      # so every version lands in the manifest with its correct targetAbi, and a Jellyfin server installs
+      # only the build matching its generation. publish-beta.yml (on main) regenerates the same branch, so
+      # whichever generation publishes last leaves manifest-beta complete for both.
+      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      with:
+        ignorePrereleases: false
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        pagesBranch: manifest-beta
+        pagesFile: manifest.json

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -21,10 +21,13 @@ on:
 # Explicit deny-all at workflow level; the job below opts into write access explicitly.
 permissions: {}
 
-# Serialize JF12 beta publishes so a burst of merges to 4.2 cannot race the manifest-branch push /
-# draft-publish. cancel-in-progress is false — a publish must never be killed mid-run.
+# Serialize ALL beta publishes that regenerate manifest-beta — this JF12 leg AND the JF10.11
+# publish-beta.yml on main — under ONE shared concurrency group, so their manifest-branch
+# regenerations never run concurrently and race (a reader-vs-pusher TOCTOU that could transiently drop
+# the other generation's just-published build from manifest-beta, #135 review). cancel-in-progress is
+# false — a publish holding contents:write must never be killed mid-run.
 concurrency:
-  group: publish-jf12-beta
+  group: publish-manifest-beta
   cancel-in-progress: false
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -57,16 +57,14 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 
 **Install from the Jellyfin plugin catalog (recommended for testing):**
 
-1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add the repository URL for your Jellyfin server generation and the channel you want. Add **one** of these:
+1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add the repository URL for the channel you want. **One URL serves both Jellyfin generations** — your server installs the matching build automatically. Add **one** of these:
 
-   | Server             | Channel    | Repository URL                                                                                     |
-   | ------------------ | ---------- | -------------------------------------------------------------------------------------------------- |
-   | Jellyfin **10.11** | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json`      |
-   | Jellyfin **10.11** | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`         |
-   | Jellyfin **10.12** | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-jf12-release/manifest.json` |
-   | Jellyfin **10.12** | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-jf12-beta/manifest.json`    |
-   - **stable** ships tagged releases only. **beta** tracks `main` — every merge publishes an installable build, so betas move fast and may break; use them for testing, not production.
-   - The **10.12** URLs already exist so you can add them now, but they stay **empty until the 10.12 build leg is enabled** — that generation runs on .NET 10 and there is no Jellyfin 10.12 SDK to build against yet. When it lands, the **10.12 beta** fills first; the **10.12 stable** URL only carries a build once there is an actual 10.12 stable release. On **10.11**, use the 10.11 URLs.
+   | Channel    | Repository URL                                                                                |
+   | ---------- | --------------------------------------------------------------------------------------------- |
+   | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json` |
+   | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`    |
+   - **stable** ships tagged releases only. **beta** publishes on every merge, so betas move fast and may break — use them for testing, not production.
+   - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** (the stable 12.0 build lands at a 12.0 stable release).
 
 2. Go to **Dashboard → Plugins → Catalog**, find **SSO Authentication**, and install it.
 3. **Restart Jellyfin** to load the plugin.

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -1,0 +1,38 @@
+name: "SSO Authentication"
+# Same plugin GUID as the JF10.11 build (build.yaml) — one plugin, so a JF12 server updates it in
+# place. The targetAbi below gates it to the 12.0 line, so a 10.11 server never offers this build and
+# vice versa (the two generations live in separate manifest branches, manifest-jf12-* vs manifest-*).
+guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
+imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
+# The JF12 (5.0) line's target version. The beta workflow overrides this to 5.0.0.<run> at build time;
+# a 5.0.0-JF12-stable tag releases 5.0.0. Bump per change class exactly like build.yaml's version.
+version: "5.0.0"
+# Jellyfin 12.0 moves the server to .NET 10; a 10.11-ABI plugin will not load there. This is the 12.0
+# line's ABI floor.
+targetAbi: "12.0.0.0"
+framework: "net10.0"
+owner: "iderex"
+overview: "Authenticate users against an SSO provider."
+description: |
+  This plugin allows users to sign in through an SSO provider (such as Google, Facebook, or your own provider). This enables one-click signin.
+  SSO sign-in works in the Jellyfin Web UI and in clients that support Quick Connect.
+  Review documentation at https://github.com/iderex/jellyfin-plugin-sso
+category: "Authentication"
+# The net10 shipping closure, empirically from `dotnet publish -f net10.0` (#135). It differs from the
+# net9 list in build.yaml: on .NET 10 the SAML crypto assemblies (System.Security.Cryptography.Xml /
+# .Pkcs, System.Formats.Asn1) and Microsoft.Bcl.Memory are framework-provided, so `dotnet publish`
+# does NOT copy them and they must NOT ship (shipping a host-provided assembly at a mismatched version
+# is the #590 class of failure). The id_token/JWT validator closure and Microsoft.Bcl.Cryptography are
+# still not in the .NET 10 ASP.NET shared framework, so they travel in the zip. Keep in sync with
+# `dotnet publish -f net10.0 -c Release` on every dependency change.
+artifacts:
+  - "SSO-Auth.dll"
+  - "Duende.IdentityModel.OidcClient.dll"
+  - "Duende.IdentityModel.dll"
+  - "Microsoft.IdentityModel.JsonWebTokens.dll"
+  - "Microsoft.IdentityModel.Tokens.dll"
+  - "Microsoft.IdentityModel.Logging.dll"
+  - "Microsoft.IdentityModel.Abstractions.dll"
+  - "Microsoft.Bcl.Cryptography.dll"
+changelog: |
+  5.0.0: Jellyfin 12.0 (.NET 10) line. First build targeting the Jellyfin 12.0 server generation — net10.0, OidcClient 7.x, targetAbi 12.0.0.0. Same feature set and login hardening as the 4.x (Jellyfin 10.11) line, retargeted for the .NET 10 host so SSO login keeps working after a 12.0 upgrade.


### PR DESCRIPTION
Publishes the **Jellyfin 12.0 / .NET 10 beta** (the 5.0 line). The multi-target codebase is on 4.2, so `publish-jf12-beta.yml` builds the net10 target on every push to 4.2 and publishes an installable `5.0.0-JF12-beta` prerelease. This prevents the SSO-login outage for users upgrading to Jellyfin 12.0 (the #590 class, on the new platform).

## Key pieces
- **`build-jf12.yaml`**: JF12 metadata (version 5.0, targetAbi 12.0.0.0, framework net10.0). The **net10 shipping closure is empirically 8 DLLs**, on .NET 10 the SAML crypto assemblies (Crypto.Xml/Pkcs, Formats.Asn1) and Bcl.Memory are framework-provided and must NOT ship (shipping a host-provided assembly at a mismatched version is the #590 failure). The workflow copies it over build.yaml for the JF12 build only.
- **Two-channel manifest model** (decision): Jellyfin filters versions client-side by targetAbi and the manifest action can't filter by generation, so per-generation manifests are redundant. Both generations publish to the SHARED `manifest-beta` (later `manifest-release`); each release carries its own targetAbi, so a 10.11 server installs 4.x and a 12.0 server installs 5.0 from the same URL. Deleted the redundant `manifest-jf12-*` placeholders; README collapsed to two URLs (fixing the stale “10.12” labels).

## Type of change
- [x] Feature (release pipeline)

## Security checklist
- [x] SHA-pinned actions, `permissions: {}` + job `contents: write`, no `${{ }}` in run (RUN_NUMBER/repo/id via env), `--locked-mode` restore, non-cancelling concurrency, mirrors publish-beta.yml.
- [x] Channel isolation: `5.0.0-JF12-beta.<n>` tags never match publish.yml's `[0-9]+.[0-9]+.[0-9]+-stable` glob; prerelease keeps them out of the stable manifest.
- [x] Security review to run (release pipeline).

## Verification
- [x] `dotnet publish -f net10.0` closure verified → the 8-DLL artifacts list.
- [x] Both new YAMLs valid; README prettier-clean.
- [ ] The workflow itself runs only on merge to 4.2 (release-only), I'll verify the first JF12 beta run then; the packaged-plugin load on a real Jellyfin 12.0-rc server is the beta channel's job to confirm.