### PR TITLE
publish-beta: shared publish-manifest-beta concurrency group

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -32,7 +32,7 @@ permissions: {}
 # mid-run (it holds contents:write and moves a release + a manifest branch),
 # matching the never-cancel posture noted in zizmor.yml.
 concurrency:
-  group: publish-beta
+  group: publish-manifest-beta
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Completes the #605 review fix: main's JF10.11 `publish-beta.yml` shares the `publish-manifest-beta` concurrency group with 4.2's `publish-jf12-beta.yml`, so the two workflows that both fully regenerate `manifest-beta` serialize repo-wide instead of racing (a rare, self-healing reader-vs-pusher TOCTOU). 4.2's copy already uses this group.

After merge: forward-merge main → 4.2 (no-op on the group, already aligned there).