### PR TITLE
Attest SLSA build provenance for the release plugin zip (#147)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,28 @@ on:
         default: "net9.0"
         description: "The .NET target to set for JPRM"
         type: string
+      attest:
+        required: false
+        default: false
+        description: "Emit a signed SLSA build-provenance attestation for the built artifact. Release-only; leave false for CI/PR builds."
+        type: boolean
 
-# Read-only: this reusable workflow only builds the plugin and uploads the
-# resulting artifact, no job here needs write access.
-permissions:
-  contents: read
+# Deny-all at the workflow level; the build job opts into exactly the scopes it
+# needs. The plain build only reads; provenance attestation (opt-in via `attest`)
+# additionally needs an OIDC token and attestation write, which the caller must
+# grant — for a non-attesting caller those scopes are capped away, so the extra
+# grants are inert.
+permissions: {}
 
 jobs:
   build:
     name: Build package
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -41,6 +52,20 @@ jobs:
         id: jprm
         with:
           dotnet-target: "${{ inputs.dotnet-target }}"
+
+      # SLSA v1.1 Build L3 provenance for the plugin zip. Running the attestation
+      # inside this reusable workflow is what lifts the provenance from Build L2 to
+      # L3: the recorded builder is a trusted, reusable workflow rather than an
+      # inline job. Gated on `attest` so only the release pipeline signs (CI/PR
+      # builds neither ship an artifact nor hold the signing token). The bytes
+      # attested here are the exact bytes the release ships (upload/download of
+      # `build-artifact` preserves them), so a downloaded release zip verifies with:
+      #   gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
+      - name: Attest build provenance
+        if: ${{ inputs.attest }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "${{ steps.jprm.outputs.artifact }}"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,19 @@ permissions:
 jobs:
   build:
     name: Build package
+    # A called reusable workflow is capped by the calling job's permissions, so
+    # grant the signing scopes here (least privilege: only this job gets them) for
+    # build.yml's provenance attestation. id-token: write mints the OIDC token
+    # Sigstore signs with; attestations: write records the provenance.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.*"
       dotnet-target:  "net9.0"
+      attest: true
   upload:
     name: Upload release assets
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,25 @@ reporting.
 
 The latest released version is the only supported version.
 
+## Verifying a release download
+
+Every stable release asset ships with an `.md5` and a `.sha256` sidecar per
+plugin `.zip`; the `.md5` is the checksum the Jellyfin manifest uses to validate
+the download, and it is unchanged.
+
+In addition, each stable release zip carries a **signed SLSA build-provenance
+attestation** (SLSA v1.1, Build L3 — the package build runs in a reusable GitHub
+Actions workflow, which is what raises the provenance from L2 to L3). After
+downloading a release zip you can verify it was produced by this repository's
+release pipeline and has not been tampered with:
+
+```sh
+gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
+```
+
+The provenance attestation complements the checksum sidecars — it does not
+replace the manifest MD5.
+
 ## Repository security controls
 
 - **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.


### PR DESCRIPTION
Adds SLSA **Build L3** provenance to the shipped plugin zip (#147). The `actions/attest-build-provenance` step (SHA-pinned `@0f67c3f4… # v4.1.1`) sits inside the REUSABLE `build.yml` right after the JPRM build, attesting the plugin zip, attesting inside a reusable workflow is what lifts provenance from GitHub's default L2 to L3.

- Opt-in via a new `attest` boolean input (default `false`): only `publish.yml` (stable release) sets `attest: true`; `dotnet.yml` (CI/PR) leaves it off, so CI neither requests the signing token nor emits attestations. Beta workflows build inline (not via build.yml), correctly out of scope.
- Least privilege: `build.yml` workflow-level `permissions: {}`, the build job grants `contents: read` + `id-token: write` + `attestations: write`; `publish.yml`'s caller job grants the same (a reusable workflow is capped by the caller). `dotnet.yml` stays capped at `contents: read`.
- Verification documented in `SECURITY.md` (docs/ is gitignored): `gh attestation verify <zip> --repo iderex/jellyfin-plugin-sso`. The md5/sha256 sidecars are retained.

## Type of change
- [x] Security hardening (release pipeline)

## Security checklist
- [x] SHA-pinned action; workflow `permissions: {}` + job-scoped grants; no `${{ }}` in run.
- [x] Signing token requested ONLY on the release path (opt-in), not CI.
- [x] zizmor + security review to confirm.

## Verification
- [x] Both touched workflows valid YAML; SECURITY.md prettier-clean; commit touches only the 3 files.
- [ ] Release-only, the attestation first emits on a real stable release; CI zizmor confirms the workflow security now.

Acceptance criterion 1 (update the tracked SLSA issue body) is an issue edit I do myself, left out of the PR.