### PR TITLE
Drop the deprecated assertion-embedded SAML/Auth path (#528)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this plugin are documented here. Versions follow the
 four-part `X.Y.Z.W` scheme described in the release policy (breaking / feature /
 bug-fix / security).
 
+## 4.2.0.0
+
+A breaking release.
+
+### Removed
+
+- **`SAML/Auth` no longer accepts a raw SAML assertion (BREAKING, #528).** #251
+  replaced the assertion browser round-trip with a one-time, server-side login
+  outcome token: the assertion-consumer callback (`SAML/post`) validates the
+  signed assertion once and hands the intermediate page only an opaque token,
+  and `SAML/Auth` redeems that token to mint the session without re-parsing the
+  assertion. For one release `SAML/Auth` also still accepted and fully
+  re-validated the pre-#251 shape — a full base64 assertion POSTed straight to
+  it — so a login already in flight during an upgrade would not break. That
+  deprecation window has now closed: `SAML/Auth` accepts **only** the opaque
+  outcome token. A scripted client that POSTs a raw assertion straight to
+  `SAML/Auth`, bypassing the rendered page, is now rejected fail-closed (a clean
+  400 in the uniform SAML body, nothing minted). The normal browser login and
+  linking flows are unaffected — the plugin has rendered only tokens for login
+  since #251. Callers that scripted the legacy direct-assertion POST must switch
+  to the callback-plus-token round-trip.
+
 ## 4.1.1.0
 
 A bug-fix release that restores plugin loading on Jellyfin 10.11. No

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -11,16 +12,55 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// In-process tests of the SAML auth callback (<c>SamlAuth</c>) via <see cref="SsoControllerHarness"/>,
-/// using <see cref="SamlTestFactory"/> to produce a real, cryptographically-signed response so the
-/// actual signature-validation path runs. They cover the guard branches (disabled provider, invalid
-/// signature, role not allowed) and the happy path, where a valid signed assertion provisions the
-/// account and mints a session.
+/// In-process tests of the SAML session-minting leg (<c>SamlAuth</c>) via <see cref="SsoControllerHarness"/>.
+/// Since #251 that leg redeems the one-time login-outcome token the ACS callback minted, and since #528 it
+/// accepts ONLY that token — the assertion is validated once at the callback (covered by
+/// <see cref="SSOControllerSamlPostTests"/> and the validator suites) and never re-parsed here. These tests
+/// therefore drive the mint leg through the real token flow (callback renders a token, the token posts to
+/// SamlAuth) and pin the fail-closed browser-binding / correlation branches of <c>CorrelateAndBind</c> that
+/// are NOT exercised by the happy-path token tests in <see cref="SSOControllerSamlTokenTests"/>: a solicited
+/// login whose token is redeemed with the wrong binding cookie, a lost solicited correlation, and an
+/// unsolicited response under the solicited-only mode. The top-level disabled-provider guard (which precedes
+/// any redeem) is checked directly.
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerSamlAuthTests
 {
     private static readonly Guid UserId = Guid.Parse("88888888-8888-8888-8888-888888888888");
+    private const string AuthnRequestId = "_authnreq-415";
+    private const string Binding = "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF001122334455667788";
+
+    // Extracts the one-time token the callback's auth page carries: WebResponse renders it as
+    // `var data = "<hex>";`. Mirrors SSOControllerSamlTokenTests.ExtractToken.
+    private static string ExtractToken(ActionResult callbackResult)
+    {
+        var page = Assert.IsType<ContentResult>(callbackResult);
+        var match = Regex.Match(page.Content!, "var data = \"([0-9A-F]{64})\"");
+        Assert.True(match.Success, "the login auth page must carry a 64-hex one-time token, not the assertion");
+        return match.Groups[1].Value;
+    }
+
+    // Builds a harness whose "adfs" provider provisions "alice"; ValidateInResponseTo toggles the
+    // solicited-only mode the unsolicited-rejection test needs.
+    private static SsoControllerHarness ProvisioningHarness(SamlFixture fixture, bool validateInResponseTo = false)
+    {
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            EnableAuthorization = false,
+            AllowExistingAccountLink = false,
+            ValidateInResponseTo = validateInResponseTo,
+        });
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(UserId).Returns(user);
+        return harness;
+    }
+
+    private static void SetSamlBindingCookie(SsoControllerHarness harness, string value) =>
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.SamlCookieName}={value}";
 
     [Fact]
     public async Task SamlAuth_DisabledProvider_RejectsAsUnknownProvider()
@@ -29,233 +69,28 @@ public class SSOControllerSamlAuthTests
 
         var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = "irrelevant" });
 
-        // A disabled provider is a client-caused 400 byte-identical to the unknown-provider case, not a
-        // 500, so neither can be probed apart (#318).
+        // The disabled-provider guard precedes the token redeem, so a disabled provider is a client-caused 400
+        // byte-identical to the unknown-provider case, not a 500, so neither can be probed apart (#318).
         var content = Assert.IsType<ContentResult>(result);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("No matching provider found", content.Content);
     }
 
     [Fact]
-    public async Task SamlAuth_ReplayedAssertion_RejectsAsInvalidWithoutDisclosingTheReplay()
+    public async Task SamlAuth_SolicitedTokenRedeemedWithWrongBindingCookie_RejectsWithoutProvisioning()
     {
-        var fixture = SamlTestFactory.Create(nameId: "alice");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            EnableAuthorization = false,
-            AllowExistingAccountLink = false,
-        });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
-        harness.UserManager.CreateUserAsync("alice").Returns(user);
-        harness.UserManager.GetUserById(UserId).Returns(user);
-        var payload = fixture.EncodeResponse();
-
-        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = payload }));
-
-        // The replay is refused by the one-time-use cache, now as a client-caused 400 in the uniform
-        // SAML body (never a 500) that does not disclose the replay cache to the attacker who replayed.
-        var replay = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = payload }));
-        Assert.Equal(400, replay.StatusCode);
-        Assert.Equal("SAML response validation failed", replay.Content);
-    }
-
-    [Fact]
-    public async Task SamlAuth_UnsolicitedResponse_RejectsInTheUniformBody()
-    {
-        // With ValidateInResponseTo on and no AuthnRequest issued, the response carries no correlated
-        // InResponseTo and is refused — a client-caused 400 in the uniform SAML body, not a 500, and it
-        // no longer discloses the InResponseTo correlation to the submitter.
-        var fixture = SamlTestFactory.Create(nameId: "alice");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            ValidateInResponseTo = true,
-        });
-
-        var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
-        Assert.Equal(400, result.StatusCode);
-        Assert.Equal("SAML response validation failed", result.Content);
-    }
-
-    [Fact]
-    public async Task SamlAuth_SignedByAnotherCertificate_Returns400()
-    {
-        var fixture = SamlTestFactory.Create();
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            // The provider trusts a DIFFERENT certificate, so the real signature check must reject it.
-            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
-        });
-
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
-
-        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
-    }
-
-    [Fact]
-    public async Task SamlAuth_SignedBySecondaryCertificate_DuringRotation_ReturnsOk()
-    {
-        // Inbound verification-cert rotation (#491): the identity provider has rolled its signing key, so
-        // the primary now holds an unrelated (old) certificate and the response is signed by the key whose
-        // certificate the administrator staged in the secondary field. The full callback must authenticate
-        // it via the secondary, end-to-end through the real controller and config.
-        var fixture = SamlTestFactory.Create(nameId: "alice");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
-            SamlSecondaryCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            EnableAuthorization = false,
-            AllowExistingAccountLink = false,
-        });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
-        harness.UserManager.CreateUserAsync("alice").Returns(user);
-        harness.UserManager.GetUserById(UserId).Returns(user);
-
-        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
-    }
-
-    [Fact]
-    public async Task SamlAuth_NeitherCertificateVerifies_Returns400()
-    {
-        // Fail closed: with a secondary configured, a response signed by neither the primary nor the
-        // secondary is still rejected — "a certificate is configured" is never acceptance.
-        var fixture = SamlTestFactory.Create();
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = SamlFixture.ForeignCertificateBase64(),
-            SamlSecondaryCertificate = SamlFixture.ForeignCertificateBase64(),
-            DoNotValidateAudience = true,
-        });
-
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
-
-        Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
-    }
-
-    [Fact]
-    public async Task SamlAuth_RoleNotAllowed_Returns401()
-    {
-        var fixture = SamlTestFactory.Create(role: "jellyfin-users");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true, // audience validation is covered separately; exercise the role gate here
-            // A non-empty allow-list the assertion's role is not in, so login is refused after the
-            // signature validates.
-            Roles = new[] { "only-admins" },
-        });
-
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
-
-        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
-    }
-
-    [Fact]
-    public async Task SamlAuth_ValidSignedResponse_ProvisionsAccount_ReturnsOk()
-    {
-        var fixture = SamlTestFactory.Create(nameId: "alice");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true, // audience validation is covered separately; exercise the callback here
-            EnableAuthorization = false, // skip permission application; not under test here
-            AllowExistingAccountLink = false,
-        });
-
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
-        harness.UserManager.CreateUserAsync("alice").Returns(user);
-        harness.UserManager.GetUserById(UserId).Returns(user);
-
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse
-        {
-            Data = fixture.EncodeResponse(),
-            DeviceID = "device-1",
-            DeviceName = "Test Device",
-            AppName = "Jellyfin Web",
-            AppVersion = "1.0",
-        });
-
-        Assert.IsType<OkObjectResult>(result);
-        await harness.UserManager.Received(1).CreateUserAsync("alice");
-    }
-
-    private const string AuthnRequestId = "_authnreq-415";
-    private const string Binding = "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF001122334455667788";
-
-    // Builds a harness whose "adfs" provider will provision "alice", and seeds an outstanding SAML
-    // AuthnRequest for it carrying the given binding id — the state SamlChallenge would have set (#415).
-    private static SsoControllerHarness SolicitedHarness(SamlFixture fixture, string bindingId)
-    {
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            EnableAuthorization = false,
-            AllowExistingAccountLink = false,
-        });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
-        harness.UserManager.CreateUserAsync("alice").Returns(user);
-        harness.UserManager.GetUserById(UserId).Returns(user);
-        SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, bindingId, DateTime.UtcNow.AddMinutes(15));
-        return harness;
-    }
-
-    private static void SetSamlBindingCookie(SsoControllerHarness harness, string value) =>
-        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.SamlCookieName}={value}";
-
-    [Fact]
-    public async Task SamlAuth_SolicitedResponse_MatchingBindingCookie_ProvisionsAccount()
-    {
-        // #415: a solicited response whose InResponseTo matches an outstanding request completes only
-        // when the request carries the binding cookie the challenge set — the initiating browser.
+        // #415 on the token path: a solicited login's token is redeemed by a browser presenting a DIFFERENT
+        // browser's binding id. The mint leg consumes the outstanding request, finds the binding mismatch, and
+        // fails closed — nothing is provisioned.
         var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
-        var harness = SolicitedHarness(fixture, Binding);
-        SetSamlBindingCookie(harness, Binding);
+        var harness = ProvisioningHarness(fixture);
+        SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
 
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
-
-        Assert.IsType<OkObjectResult>(result);
-        await harness.UserManager.Received(1).CreateUserAsync("alice");
-    }
-
-    [Fact]
-    public async Task SamlAuth_SolicitedResponse_MissingBindingCookie_RejectsWithoutProvisioning()
-    {
-        // The forced-login shape: the response is lured into a browser that never started the flow, so
-        // it carries no binding cookie. Fail closed with the uniform SAML body; nothing is provisioned.
-        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
-        var harness = SolicitedHarness(fixture, Binding);
-        // No binding cookie set.
-
-        var result = Assert.IsType<ContentResult>(
-            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
-
-        Assert.Equal(400, result.StatusCode);
-        Assert.Equal("SAML response validation failed", result.Content);
-        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
-    }
-
-    [Fact]
-    public async Task SamlAuth_SolicitedResponse_WrongBindingCookie_RejectsWithoutProvisioning()
-    {
-        var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: AuthnRequestId);
-        var harness = SolicitedHarness(fixture, Binding);
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
         SetSamlBindingCookie(harness, "a-different-browsers-binding-id");
 
         var result = Assert.IsType<ContentResult>(
-            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
 
         Assert.Equal(400, result.StatusCode);
         Assert.Equal("SAML response validation failed", result.Content);
@@ -263,28 +98,21 @@ public class SSOControllerSamlAuthTests
     }
 
     [Fact]
-    public async Task SamlAuth_InResponseToPresentButNoOutstandingRequest_RejectsEvenWithValidateOff()
+    public async Task SamlAuth_TokenCarriesInResponseToButNoOutstandingRequest_RejectsEvenWithValidateOff()
     {
-        // The bypass this fix closes: a response that DOES carry an InResponseTo (so it claims to be
-        // solicited) but whose outstanding entry is gone — expired, evicted, lost to a restart or a
-        // non-sticky multi-node hop — must NOT be treated as unsolicited and waved through. Without an
-        // entry there is no binding to check, so a lost correlation fails closed even when
-        // ValidateInResponseTo is off (the default). Otherwise an attacker could defeat the binding by
-        // submitting a signature-valid response after its 15-minute window elapsed.
+        // The lost-correlation bypass the binding closes: the redeemed outcome carries an InResponseTo (so it
+        // claims to be solicited) but the outstanding entry is gone — expired, evicted, lost to a restart or a
+        // non-sticky multi-node hop. With no entry there is no binding to check, so it MUST fail closed even
+        // when ValidateInResponseTo is off (the default); otherwise a response replayed past its 15-minute
+        // window would defeat the binding.
         var fixture = SamlTestFactory.Create(nameId: "alice", inResponseTo: "_authnreq-expired");
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            EnableAuthorization = false,
-            AllowExistingAccountLink = false,
-            // ValidateInResponseTo deliberately left off (the default) — the reject must not depend on it.
-        });
+        var harness = ProvisioningHarness(fixture); // ValidateInResponseTo off (default)
         // No SeedSamlRequestForTests: the outstanding entry does not exist.
 
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+
         var result = Assert.IsType<ContentResult>(
-            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
 
         Assert.Equal(400, result.StatusCode);
         Assert.Equal("SAML response validation failed", result.Content);
@@ -292,27 +120,22 @@ public class SSOControllerSamlAuthTests
     }
 
     [Fact]
-    public async Task SamlAuth_UnsolicitedResponse_NoBindingRequired_StillProvisions()
+    public async Task SamlAuth_UnsolicitedTokenUnderSolicitedOnlyMode_RejectsWithoutProvisioning()
     {
-        // IdP-initiated / unsolicited: no matching outstanding request, so browser binding imposes no
-        // requirement and (with ValidateInResponseTo off, the default) the login proceeds — the change
-        // does not break IdP-initiated deployments. No cookie is present, proving binding did not fire.
+        // With ValidateInResponseTo on and no AuthnRequest issued, the callback still renders a token (it does
+        // not gate on InResponseTo), but the redeemed outcome carries no InResponseTo, so the mint leg refuses
+        // it under the opt-in solicited-only mode — a client-caused 400 in the uniform SAML body, nothing
+        // provisioned.
         var fixture = SamlTestFactory.Create(nameId: "alice"); // no InResponseTo
-        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
-        {
-            Enabled = true,
-            SamlCertificate = fixture.CertificateBase64,
-            DoNotValidateAudience = true,
-            EnableAuthorization = false,
-            AllowExistingAccountLink = false,
-        });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
-        harness.UserManager.CreateUserAsync("alice").Returns(user);
-        harness.UserManager.GetUserById(UserId).Returns(user);
+        var harness = ProvisioningHarness(fixture, validateInResponseTo: true);
 
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
 
-        Assert.IsType<OkObjectResult>(result);
-        await harness.UserManager.Received(1).CreateUserAsync("alice");
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
 }

--- a/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
@@ -17,8 +17,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// (never the assertion); posting that token to SAML/Auth redeems the already-verified outcome and mints
 /// the session without re-parsing or re-validating the assertion. They pin the token is single-use, an
 /// unknown/expired token is refused, the one-time replay guard fires exactly once (at the callback), the
-/// browser binding still gates a solicited login on the token path, and the pre-#251 deprecation shape
-/// (the full assertion posted to SAML/Auth) still fully validates and logs in during the window.
+/// browser binding still gates a solicited login on the token path, and — since #528 dropped the
+/// deprecation window — a pre-#251 full assertion posted straight to SAML/Auth is now rejected fail-closed
+/// (SAML/Auth accepts ONLY the opaque token).
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerSamlTokenTests
@@ -90,9 +91,8 @@ public class SSOControllerSamlTokenTests
         var fixture = SamlTestFactory.Create(nameId: "alice");
         var harness = ProvisioningHarness(fixture, out _);
 
-        // A token that was never issued misses the store and falls through to the deprecation validation,
-        // which fails closed: its decoded bytes are not a SAML response, so the XML parse rejects it — a
-        // clean fail-closed 400, nothing minted.
+        // A token that was never issued misses the store and is rejected fail-closed right there (#528 removed
+        // the deprecation fallback): a clean 400 in the uniform SAML body, nothing minted.
         var result = Assert.IsType<ContentResult>(
             await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = SamlOutcomeStore.NewToken() }));
         Assert.Equal(400, result.StatusCode);
@@ -137,19 +137,22 @@ public class SSOControllerSamlTokenTests
     }
 
     [Fact]
-    public async Task DeprecationWindow_FullAssertionPostedToAuth_StillValidatesAndLogsIn()
+    public async Task PreDeprecationAssertionPostedToAuth_IsRejectedFailClosed()
     {
-        // The pre-#251 intermediate page embeds the full assertion and posts it straight to SAML/Auth. For
-        // the deprecation window that legacy shape must still FULLY validate and mint, so an admin upgrading
-        // mid-login does not break a user's in-flight login. (No prior callback ran, so nothing consumed the
-        // assertion's one-time id — the deprecation branch validates and consumes it here.)
+        // #528 (BREAKING): the pre-#251 shape — a full base64 assertion POSTed straight to SAML/Auth,
+        // bypassing the rendered token page — is no longer accepted. It is not a live login-outcome token, so
+        // it misses the redeem and is rejected fail-closed (a clean 400 in the uniform SAML body), NEVER
+        // re-parsed and re-validated as an assertion and never minting a session. This is the wire-contract
+        // break #251 flagged: a scripted client that skips the page and posts a raw assertion is refused.
         var fixture = SamlTestFactory.Create(nameId: "alice");
         var harness = ProvisioningHarness(fixture, out _);
 
-        var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() });
+        var result = Assert.IsType<ContentResult>(
+            await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = fixture.EncodeResponse() }));
 
-        Assert.IsType<OkObjectResult>(result);
-        await harness.UserManager.Received(1).CreateUserAsync("alice");
+        Assert.Equal(400, result.StatusCode);
+        Assert.Equal("SAML response validation failed", result.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -66,11 +66,11 @@ public class SamlLoginServiceTests
     [Fact]
     public async Task AuthenticateAsync_DisabledProvider_RejectsAsUnknownProvider()
     {
-        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
+        var (service, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
 
         // Guard precedes the state consume, so a disabled provider is rejected without touching any
         // collaborator — the same uniform body an unknown provider gets.
-        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "irrelevant" }, bindingCookie: null, context.Request, () => "127.0.0.1");
+        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "irrelevant" }, bindingCookie: null, () => "127.0.0.1");
 
         AssertUnknownProvider(result);
     }
@@ -78,11 +78,12 @@ public class SamlLoginServiceTests
     [Fact]
     public async Task AuthenticateAsync_MalformedResponse_RejectsAsInvalid()
     {
-        var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, DoNotValidateAudience = true });
+        var (service, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, DoNotValidateAudience = true });
 
-        // A non-base64 / malformed response fails TryParse and is rejected the same way an invalid one is —
-        // a clean 4xx in the uniform SAML body, never an unhandled 500 (#199).
-        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "not-a-saml-response" }, bindingCookie: null, context.Request, () => "127.0.0.1");
+        // A non-base64 / malformed response is not a live outcome token, so it misses the one-time redeem and
+        // is rejected the same way an invalid one is — a clean 4xx in the uniform SAML body, never an
+        // unhandled 500 (#199).
+        var result = await service.AuthenticateAsync("adfs", new AuthResponse { Data = "not-a-saml-response" }, bindingCookie: null, () => "127.0.0.1");
 
         var content = Assert.IsType<ContentResult>(result);
         Assert.Equal(400, content.StatusCode);

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -202,10 +202,13 @@ internal sealed class SamlLoginService
         }
 
         // Linking keeps the assertion-embedded page (#251 is scoped to the login round-trip): the page JS
-        // posts its data to BOTH SAML/Link and SAML/Auth, and the one-time outcome token is single-use, so a
-        // token would satisfy only the first of the two posts. The link redeem (SamlLoginService.Link)
-        // consumes the assertion's one-time-use id on its own leg, and the follow-on SAML/Auth post then
-        // falls to the fully-validating deprecation branch below — byte-for-byte the pre-#251 linking flow.
+        // posts its data to BOTH SAML/Link and SAML/Auth. The link redeem (SamlLoginService.Link) consumes the
+        // assertion's one-time-use id on its own leg; the follow-on SAML/Auth post carries that same assertion
+        // (not a login-outcome token), so it does not redeem a live token and is rejected fail-closed at the
+        // mint leg — a harmless no-op, since the link already completed on its own leg. This was already the
+        // effective behaviour before #528: post-link the assertion's replay id was consumed, so the old
+        // deprecation branch rejected the follow-on post too. Removing that branch (#528) changes only WHERE
+        // the follow-on post is rejected (token-miss vs. a re-validated replay), not that it is rejected.
         if (isLinking)
         {
             return FlowResponses.AuthPage(response, nonce =>
@@ -555,19 +558,19 @@ internal sealed class SamlLoginService
     }
 
     /// <summary>
-    /// The SAML session-minting authenticate leg: validates the signed response, correlates it to an
-    /// AuthnRequest this server issued (browser binding, #156/#415), enforces the login allow-list and
-    /// one-time replay consume, then hands the fully-verified identity to the shared completion tail. The
-    /// controller applies the shared rate-limit gate before delegating and supplies the binding cookie and
-    /// remote-endpoint resolver.
+    /// The SAML session-minting authenticate leg: redeems the one-time login-outcome token the ACS callback
+    /// minted (#251), correlates the carried InResponseTo to an AuthnRequest this server issued (browser
+    /// binding, #156/#415), then hands the already-verified identity to the shared completion tail. Since #528
+    /// this leg accepts ONLY the token — the assertion was validated once at the callback and is never
+    /// re-parsed here — so a request that does not redeem a live token fails closed. The controller applies the
+    /// shared rate-limit gate before delegating and supplies the binding cookie and remote-endpoint resolver.
     /// </summary>
     /// <param name="provider">The provider to authenticate against.</param>
     /// <param name="response">The client's auth request context (app/device) plus the SAML response in <c>Data</c>.</param>
     /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#415).</param>
-    /// <param name="request">The current request; read for the assertion-consumer base URL (recipient binding).</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177).</param>
     /// <returns>The minted session, or a fail-closed rejection.</returns>
-    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, HttpRequest request, Func<string> remoteEndPointResolver)
+    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
     {
         // Unknown and disabled providers share one rejection so neither can be probed apart — this
         // unifies the previously JSON unknown-provider body and the disabled provider's 500.
@@ -577,81 +580,35 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        // The one-time outcome-token path (#251): the plugin now renders a token (not the assertion) for
-        // login flows. Redeem it once — an atomic claim, so a replayed token misses and a token minted for
-        // another provider is refused (details on SamlOutcomeStore.TryRedeem). The assertion was already
-        // fully validated at the ACS callback (signature, time, audience, recipient, role gate, the one-time
-        // replay consume and the verified-identity construction), so NOTHING is re-parsed or re-validated
-        // here: only the browser binding remains, checked at this same-origin leg where the SameSite=Lax
-        // cookie is sent (the cross-site ACS POST could not carry it). A miss falls through to the
-        // deprecation branch below, so an unknown/expired/replayed token is rejected there rather than minting.
-        if (_outcomes.TryRedeem(response?.Data, provider, DateTime.UtcNow) is { } outcome)
-        {
-            if (!CorrelateAndBind(provider, outcome.InResponseTo, bindingCookie, config.ValidateInResponseTo))
-            {
-                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-            }
-
-            // From here the SAML and OpenID paths are one: the verified identity flows into the shared
-            // completion tail. SAML keys the link on the NameID and carries no email_verified claim, so
-            // AdoptionGate.None; the resolver's admin-adoption refusal (#218) still applies.
-            return await _loginCompletion.CompleteAsync(
-                outcome.Identity,
-                response,
-                config,
-                AdoptionGate.None,
-                remoteEndPointResolver).ConfigureAwait(false);
-        }
-
-        // DEPRECATION WINDOW (#251, drop scheduled by #528): a page rendered by a PRE-#251
-        // plugin still embeds the full base64 assertion and posts it here. For one release SAML/Auth also
-        // accepts that legacy shape and FULLY validates it — signature/time/audience/recipient, the
-        // InResponseTo correlation + browser binding, the login allow-list, and the one-time replay consume —
-        // exactly as before #251, so an admin upgrading mid-login does not break a user's in-flight login.
-        // The plugin itself renders only tokens going forward; this branch is removed once the window closes.
-        var requestBase = GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride);
-        if (!_validator.TryValidate(config, provider, requestBase, response?.Data, out var samlResponse))
-        {
-            // A malformed body, an unknown/expired/replayed token that reached this fallback, or a failed
-            // signature/time/audience/recipient check is rejected the same way — a clean 4xx, never a 500 (#199).
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
-        }
-
-        if (!CorrelateAndBind(provider, samlResponse.GetInResponseTo(), bindingCookie, config.ValidateInResponseTo))
+        // The one-time outcome-token path (#251) is now the ONLY shape SAML/Auth accepts (#528): the plugin
+        // renders a token (never the assertion) for login flows. Redeem it once — an atomic claim, so a
+        // replayed token misses and a token minted for another provider is refused (details on
+        // SamlOutcomeStore.TryRedeem). A miss fails CLOSED right here: an unknown, expired, or replayed token,
+        // OR the pre-#251 assertion-embedded shape a legacy page still posts (the deprecation branch #251 kept
+        // for one release, dropped by #528). That legacy body is NOT re-parsed or re-validated as an assertion
+        // — it simply is not a live token, so it is rejected the same uniform way as any other non-token, never
+        // falling through open. The removal is the wire-contract break #251 flagged: a scripted client that
+        // POSTs a raw assertion straight to SAML/Auth (bypassing the rendered page) is now rejected.
+        if (_outcomes.TryRedeem(response?.Data, provider, DateTime.UtcNow) is not { } outcome)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Evaluate the assertion's role attribute ONCE (#479): the same list feeds the allow-list gate here
-        // and the privilege derivation in TryProduceVerifiedIdentity below, so the role XPath runs once for
-        // this legacy leg rather than once for the gate and again for the derivation.
-        var assertionRoles = SamlAssertionValidator.GetAssertionRoles(samlResponse);
-
-        // Enforce the login allow-list here too, not only at the assertion-consumer page: a legacy caller
-        // can POST an assertion straight to this session-minting endpoint and skip the page, so checking it
-        // only there would be fail-open.
-        if (!SamlLoginPolicy.IsLoginAllowed(assertionRoles, config.Roles))
+        if (!CorrelateAndBind(provider, outcome.InResponseTo, bindingCookie, config.ValidateInResponseTo))
         {
-            if (_logger.IsEnabled(LogLevel.Warning))
-            {
-                _logger.LogWarning(
-                    "SAML user: {UserId} has insufficient roles at the session-minting endpoint; login denied.",
-                    samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty));
-            }
-
-            return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Complete the assertion validation in the dedicated validator: the one-time replay consume and the
-        // non-empty-NameID guard, then — and only then — the verified identity through FromValidatedSaml
-        // (#496). A replay fails as an invalid response and a missing NameID as a denial.
-        if (!_validator.TryProduceVerifiedIdentity(config, provider, samlResponse, assertionRoles, out var identity, out var rejection))
-        {
-            return LoginStatusMapper.ToActionResult(rejection);
-        }
-
+        // The assertion was already fully validated at the ACS callback (signature, time, audience, recipient,
+        // role gate, the one-time replay consume and the verified-identity construction), so NOTHING is
+        // re-parsed or re-validated here: only the browser binding remained, checked at this same-origin leg
+        // where the SameSite=Lax cookie is sent (the cross-site ACS POST could not carry it).
+        //
+        // From here the SAML and OpenID paths are one: the verified identity flows into the shared completion
+        // tail. SAML keys the link on the NameID and carries no email_verified claim, so AdoptionGate.None; the
+        // resolver's admin-adoption refusal (#218) still applies.
         return await _loginCompletion.CompleteAsync(
-            identity,
+            outcome.Identity,
             response,
             config,
             AdoptionGate.None,
@@ -668,8 +625,8 @@ internal sealed class SamlLoginService
     // is exactly the forced-login bypass the binding exists to close (login validity must never default to
     // true). The consume is the atomic claim of the outstanding request; the cookie match is checked at this
     // same-origin auth endpoint, not at the cross-site ACS POST which would not carry a SameSite=Lax cookie.
-    // Shared by the token-redeem mint path (on the stored outcome's InResponseTo) and the deprecation branch
-    // (on the freshly parsed response), so both enforce the identical correlation.
+    // Called by the token-redeem mint path on the stored outcome's InResponseTo (the sole caller since the
+    // pre-#251 deprecation branch was removed in #528).
     private bool CorrelateAndBind(string provider, string inResponseTo, string bindingCookie, bool validateInResponseTo)
     {
         if (!string.IsNullOrEmpty(inResponseTo))

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -687,16 +687,16 @@ public class SSOController : ControllerBase
             return throttled;
         }
 
-        // The SAML session-minting authenticate leg lives in the flow service (#160, #318): it validates
-        // the signed response, correlates it to an AuthnRequest this server issued (browser binding),
-        // enforces the login allow-list and one-time replay consume, and hands the verified identity to the
-        // shared completion tail. The controller passes the presented binding cookie and the
-        // HttpContext-derived remote endpoint in, keeping the flow tier HttpContext-free (#177).
+        // The SAML session-minting authenticate leg lives in the flow service (#160, #318): it redeems the
+        // one-time login-outcome token the ACS callback minted (#251; since #528 the token is the only
+        // accepted shape), correlates the carried InResponseTo to an AuthnRequest this server issued (browser
+        // binding), and hands the already-verified identity to the shared completion tail. The controller
+        // passes the presented binding cookie and the HttpContext-derived remote endpoint in, keeping the flow
+        // tier HttpContext-free (#177).
         return await _saml.AuthenticateAsync(
             provider,
             response,
             Request.Cookies[AuthorizeStateBinding.SamlCookieName],
-            Request,
             () => HttpContext.GetNormalizedRemoteIP().ToString()).ConfigureAwait(false);
     }
 

--- a/build.yaml
+++ b/build.yaml
@@ -41,6 +41,7 @@ artifacts:
   - "System.Security.Cryptography.Pkcs.dll"
   - "System.Formats.Asn1.dll"
 changelog: |
+  4.2.0.0: Feature release (BREAKING). SAML/Auth now accepts ONLY the one-time login-outcome token introduced in #251; the deprecation window that also accepted a raw pre-#251 assertion POSTed straight to SAML/Auth is removed (#528). A scripted client that posts a raw assertion, bypassing the rendered token page, is now rejected fail-closed. The normal browser login and linking flows are unaffected.
   4.1.1.0: Bug fix. Restore plugin loading on Jellyfin 10.11 (.NET 9). 4.1.0.0 pulled Duende.IdentityModel.OidcClient 7.x, whose assemblies reference the .NET 10 Microsoft.Extensions.Logging.Abstractions (10.0.0.0) that the host does not provide and the plugin does not ship, so it threw FileNotFoundException at construction and was disabled at startup. Pin OidcClient to the 6.x line (net9 ABI) and add a conformance test that no host-provided assembly is referenced above the .NET 9 floor. No configuration changes.
   4.1.0.0: Feature (BREAKING - on-disk secret format changed; forward-transparent, downgrade requires re-entering secrets). Security-parity hardening of the SAML and OpenID login path, secrets encrypted at rest, SAML AuthnRequest signing (RSA and ECDSA), admin-UI provider toggles, and the thin-controller architecture rework. See CHANGELOG.md.
   4.0.0.4: Fix security issue in SAML


### PR DESCRIPTION
Removes the pre-#251 SAML leg where a full base64 SAML assertion POSTed straight to `SAML/Auth` was re-validated and could mint a session. Since #251 the plugin renders only one-time outcome TOKENS for login, so the direct-assertion path has been dead weight and an extra attack surface. **Breaking:** any client that scripted the legacy direct-assertion POST (bypassing the rendered page) now gets a clean 400; normal browser login and account linking are unaffected.

## What changed
- `SamlLoginService.AuthenticateAsync`: the `TryValidate`+`CorrelateAndBind`+allow-list+`TryProduceVerifiedIdentity` branch on a raw assertion is gone. The one-time token redeem (#251) is untouched and was **restructured to a guard clause**, any miss (unknown/expired/replayed token, or a raw assertion that isn't a live token) returns `LoginOutcome.Rejected(SamlResponseInvalid)` → 400, nothing minted. **Cannot fall through open.**
- `SSOController`: dropped the now-dead `HttpRequest` arg (its only consumer was the removed branch), mirroring the OIDC twin. Comment refreshed.
- No helper became dead: `_validator.*`, `GetRequestBase`, `GetAssertionRoles`, `IsLoginAllowed`, `CorrelateAndBind` all stay live on the `Callback`/`Link`/token-redeem paths.
- **Linking flow re-checked:** `SAML/Link` (consumes the one-time id) then the follow-on `SAML/Auth` post, that post already no-op-rejected after the replay id was consumed, and still rejects (now as a token miss). No functional change; comment documents it.

## Type of change
- [x] Breaking change (login wire contract)

## Security checklist
- [x] Fail-closed preserved and made explicit (guard clause; negative test).
- [x] No fail-closed coverage lost: the mint-leg `CorrelateAndBind` branches (wrong binding cookie, lost solicited correlation, unsolicited under solicited-only) were migrated to the token flow; signature/role/replay/cert-rotation stay covered at the ACS callback + validator suites.
- [x] Attack surface reduced (one whole assertion-ingest entry point removed).

## Verification
- [x] `dotnet build -c Release --warnaserror` → 0/0 on net9.0 + net10.0.
- [x] `dotnet test -c Release` → 1272 passed, 0 failed, 0 skipped on each TFM.
- [x] New negative test `PreDeprecationAssertionPostedToAuth_IsRejectedFailClosed` (assertion → 400, `DidNotReceive().CreateUserAsync`).

Adversarial SAML review (login-path break) is the gate and runs on this PR.

Closes #528