### PR TITLE
Document the whole-object-replace contract on provider config (S6964, #196)

### DIFF
--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -64,6 +64,18 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
 /// deserialization is by element name, so moving these up — which places them before the
 /// provider-specific elements in newly written XML — does not stop existing configs from loading.
 /// </summary>
+// Model-binding contract for every value-type member here and on the derived SamlConfig/OidConfig
+// (the bool flags and the int? PortOverride): the OID/SAML `Add` endpoints (SSOController.OidAdd /
+// SamlAdd) and the config-page PUT bind the whole provider object [FromBody] under RequiresElevation
+// and REPLACE it wholesale (configuration.OidConfigs[provider] = config), re-injecting only the
+// server-managed fields via ServerManagedFields.Preserve. An omitted bool therefore deserializes to
+// its default and that default is persisted BY DESIGN — the admin is replacing the object, not
+// patching it. This is why the value-type properties stay non-nullable and un-annotated (SonarCloud
+// S6964, #196): marking them [JsonRequired] would reject the intended partial post and break the
+// write-only-secret / blank-means-keep save flows that deliberately omit fields, while bool? would
+// invent an "unset" third state the replace contract does not have. Under-posting here is admin-only
+// and crosses no privilege boundary (non-security), so the documented whole-object-replace contract
+// is the disposition rather than a per-property annotation.
 public abstract class ProviderConfigBase
 {
     private SerializableDictionary<string, Guid> _canonicalLinks;


### PR DESCRIPTION
Part of the #196 analyzer sweep. S2699 and S125 were already resolved on 4.2 (commit 3318f7e for the null-config-maps assertions; SamlRequestCache has no dead comment). The only remaining item is **S6964 x2** on `PluginConfiguration.cs`.

**Disposition: document, not annotate.** The `SamlConfig`/`OidConfig` value-type (bool) props bind `[FromBody]` on the `OidAdd`/`SamlAdd` endpoints, which are `[Authorize(RequiresElevation)]` and replace the whole provider object (re-injecting server-managed fields via `ServerManagedFields.Preserve`). So an omitted bool defaulting is BY DESIGN. Annotation is actively wrong here: `[JsonRequired]` would break the partial-post deserialization the config-preservation tests and blank-means-keep secret flows rely on; `[Required]` on a non-nullable bool is a no-op; `bool?` invents an unset third state the contract does not have. A 12-line prose comment on `ProviderConfigBase` documents the contract for every value-type member and gives S6964 a documented disposition.

## Type of change
- [x] Documentation / analyzer disposition (comment-only, no behavior change)

## Verification
- [x] Diff is comment-only (0 code lines changed).
- [x] `dotnet build -c Release --warnaserror` → 0/0 on net9.0 + net10.0.
- [x] `dotnet test -c Release` → 1272 passed on each TFM.

Refs #196