### PR TITLE
Make WebResponse string ops culture-invariant (#104 Unit 1)

### DIFF
--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -92,4 +92,29 @@ public class WebResponseTests
         Assert.DoesNotContain("style=\"", html);
         Assert.Contains("#iframe-main", html);
     }
+
+    [Theory]
+    [InlineData("https://jf.example.com", "const ssoBaseUrl = \"https://jf.example.com\";")]
+    [InlineData("http://jf.example.com", "const ssoBaseUrl = \"http://jf.example.com\";")]
+    public void Generator_SplitsProtocolFromDomain_PreservingScheme(string baseUrl, string expected)
+    {
+        // The `//` protocol separator is located ordinally (independent of the current culture) and
+        // the scheme is preserved verbatim while the domain is punycode-mapped and reassembled. The
+        // http/https cases put the separator at different offsets, exercising the split itself.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", baseUrl, "OID", "n0nce");
+
+        Assert.Contains(expected, html);
+    }
+
+    [Theory]
+    [InlineData(true, "if (true) {")]
+    [InlineData(false, "if (false) {")]
+    public void Generator_EmitsIsLinkingAsJsBooleanLiteral(bool isLinking, string expected)
+    {
+        // isLinking guards the link leg as a bare JS boolean literal; it must render exactly as
+        // `true`/`false` (culture-invariant), never `True`/`False` or a localized casing.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce", isLinking);
+
+        Assert.Contains(expected, html);
+    }
 }

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -239,7 +239,7 @@ const sleep = (milliseconds) => {
 
         // Strip out the protocol (http:// or https://) and convert the domain to Punycode
         var idnMapping = new IdnMapping();
-        var protocolSeparatorIndex = baseUrl.IndexOf("//");
+        var protocolSeparatorIndex = baseUrl.IndexOf("//", System.StringComparison.Ordinal);
         var protocol = baseUrl.Substring(0, protocolSeparatorIndex + 2);
         var domain = baseUrl.Substring(protocolSeparatorIndex + 2);
         var punycodeDomain = idnMapping.GetAscii(domain);
@@ -306,7 +306,7 @@ async function main() {
 
     var request = {deviceId, appName, appVersion, deviceName, data};
 
-    if (" + $"{isLinking}".ToLower() + @") {
+    if (" + (isLinking ? "true" : "false") + @") {
         // Surface a rejected link instead of swallowing it (#344): the link leg fail-closes with a
         // non-2xx when the provider is disabled (#343), the caller is not allowed, or the request is
         // throttled. Left silent, the page would fall through to the auth leg and show a misleading


### PR DESCRIPTION
Part of #104. Two culture-sensitive string ops in `SSO-Auth/WebResponse.cs` (the auth/link page generator) made explicit and invariant. Both are byte-for-byte output-identical:
- L242 `baseUrl.IndexOf("//")` → `IndexOf("//", System.StringComparison.Ordinal)` (CA1310/MA0074). Ordinal locates the same index for the ASCII "//" separator. Fully-qualified `System.StringComparison` matches the file style (no `using System;`).
- L309 `$"{isLinking}".ToLower()` → `(isLinking ? "true" : "false")` (CA1304/CA1311/MA0011). `bool.ToString()` is "True"/"False" → lowercased "true"/"false" in every culture (no dotted-I); the conditional emits the same JS literal.

Added 2 characterization `[Theory]` tests (protocol split for http/https; JS boolean literal for both isLinking values).

## Type of change
- [x] Fix (analyzer, behavior-preserving on the login/link page path)

## Verification
- [x] Output byte-for-byte identical; characterization tests added.
- [x] build `--warnaserror` 0/0 + test 1278 passed on net9.0 + net10.0.

Refs #104