### PR TITLE
Adopt System.Threading.Lock in three lock sites (#104 Unit 3)

### DIFF
--- a/SSO-Auth/Api/SecretStore.cs
+++ b/SSO-Auth/Api/SecretStore.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 internal sealed class SecretStore
 {
     private readonly string _keyFilePath;
-    private readonly object _lock = new object();
+    private readonly System.Threading.Lock _lock = new();
     private byte[] _cachedKey;
 
     /// <summary>

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -37,7 +37,7 @@ internal sealed class SsoRateLimiter
 
     // Serializes only the rare "new key" cap-check-and-insert so it is atomic; the hot "existing
     // key" path never touches it.
-    private readonly object _capLock = new object();
+    private readonly System.Threading.Lock _capLock = new();
 
     // Throttles the #195 observability signal to one drain per SignalInterval; the gate owns the atomic
     // cursor. The tally (_throttledHits) it drains stays a mutable field below — see RecordThrottledHit.

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -21,7 +21,7 @@ internal sealed class ProviderConfigStore
     // Static on purpose: it keeps the process-wide serialization of the old SSOPlugin lock, so two
     // plugin instances (tests construct several; production has one) can never interleave writes.
     // It becomes an instance field once the store is a DI singleton (#318 step 9).
-    private static readonly object Sync = new object();
+    private static readonly System.Threading.Lock Sync = new();
 
     private readonly Func<PluginConfiguration> _live;
     private readonly Action<BasePluginConfiguration> _persist;


### PR DESCRIPTION
Part of #104 (MA0158). Pure lock-primitive swap `object` → `System.Threading.Lock` (the .NET 9+ recommended drop-in with identical `lock(){}` mutual-exclusion semantics) in three files. Each field was verified to be used ONLY as a `lock(){}` monitor, no Monitor.TryEnter / Wait / Pulse / pass-as-object:
- `SSO-Auth/Api/SecretStore.cs` `_lock` (DEK load-or-create critical section).
- `SSO-Auth/Api/SsoRateLimiter.cs` `_capLock` (new-key cap-check-and-insert; the separate `lock(counter)` sites lock a `Counter`, not this field, and are untouched).
- `SSO-Auth/Config/ProviderConfigStore.cs` `Sync` (config read-modify-write).

No critical section changed; no conditional compilation needed (Lock exists on net9.0 + net10.0).

## Type of change
- [x] Refactor (analyzer, semantics-preserving; touches SecretStore, reviewed as a pure primitive swap, no change to DEK/critical-section logic)

## Security checklist
- [x] Lock-type swap only; locked state, critical sections, and ordering unchanged.
- [x] Concurrency/rate-limiter tests green.

## Verification
- [x] build `--warnaserror` 0/0 + test 1274 passed on net9.0 + net10.0.

Refs #104