### PR TITLE
Add paramName to ArgumentException throws (#104 Unit 2, MA0015)

### DIFF
--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -174,7 +174,7 @@ public class SSOController : ControllerBase
     {
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
         {
-            throw new ArgumentException("The Base URL override must be an absolute http(s) URL such as https://jellyfin.example.com, or left blank.");
+            throw new ArgumentException("The Base URL override must be an absolute http(s) URL such as https://jellyfin.example.com, or left blank.", nameof(baseUrlOverride));
         }
     }
 
@@ -187,7 +187,7 @@ public class SSOController : ControllerBase
     {
         if (SamlCertificate.IsInvalid(certificateStr))
         {
-            throw new ArgumentException("The SAML signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.");
+            throw new ArgumentException("The SAML signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.", nameof(certificateStr));
         }
     }
 
@@ -200,7 +200,7 @@ public class SSOController : ControllerBase
     {
         if (SamlCertificate.IsInvalid(certificateStr))
         {
-            throw new ArgumentException("The SAML secondary signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.");
+            throw new ArgumentException("The SAML secondary signing certificate must be a Base64-encoded (DER) X.509 certificate, or left blank.", nameof(certificateStr));
         }
     }
 
@@ -212,7 +212,7 @@ public class SSOController : ControllerBase
     {
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
-            throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key, or left blank.");
+            throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key, or left blank.", nameof(signingKeyPfx));
         }
     }
 
@@ -225,7 +225,7 @@ public class SSOController : ControllerBase
     {
         if (config is null)
         {
-            throw new ArgumentException("The provider configuration body must not be empty.");
+            throw new ArgumentException("The provider configuration body must not be empty.", nameof(config));
         }
     }
 
@@ -241,7 +241,7 @@ public class SSOController : ControllerBase
     {
         if (!providerExists && ProviderNameValidator.IsInvalid(provider))
         {
-            throw new ArgumentException("A new provider name must not contain control characters, a backslash, or any of % : / ? # [ ] @ ! $ & ' ( ) * + , ; = because the name becomes part of the callback URL registered with the identity provider.");
+            throw new ArgumentException("A new provider name must not contain control characters, a backslash, or any of % : / ? # [ ] @ ! $ & ' ( ) * + , ; = because the name becomes part of the callback URL registered with the identity provider.", nameof(provider));
         }
     }
 
@@ -951,7 +951,7 @@ public class SSOController : ControllerBase
     private static ProviderMode ParseMode(string mode) =>
         ProviderModeParser.TryParse(mode, out var parsed)
             ? parsed
-            : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'");
+            : throw new ArgumentException($"{mode} is not a valid choice between 'saml' and 'oid'", nameof(mode));
 
     // Fronts a rate-limited endpoint with the shared per-client gate (#128, #160, #382, #516): null when the
     // request may proceed, else the throttled outcome the single mapper renders (#474). The anonymous login

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -68,7 +68,8 @@ internal static class ProviderConfigValidator
             // that ReplaceLineEndings covers and char.IsControl does not.
             var echoName = string.Concat((provider ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
             throw new ArgumentException(
-                $"{protocol} provider '{echoName}' has a name with control characters, URI-reserved characters, or a backslash; the name becomes part of the callback URL registered with the identity provider, so a new name must not contain control characters, a backslash, or any of % : / ? # [ ] @ ! $ & ' ( ) * + , ; =.");
+                $"{protocol} provider '{echoName}' has a name with control characters, URI-reserved characters, or a backslash; the name becomes part of the callback URL registered with the identity provider, so a new name must not contain control characters, a backslash, or any of % : / ? # [ ] @ ! $ & ' ( ) * + , ; =.",
+                nameof(provider));
         }
     }
 
@@ -80,7 +81,8 @@ internal static class ProviderConfigValidator
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
         {
             throw new ArgumentException(
-                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.");
+                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.",
+                nameof(baseUrlOverride));
         }
     }
 
@@ -91,7 +93,8 @@ internal static class ProviderConfigValidator
         if (SamlCertificate.IsInvalid(certificate))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
+                nameof(certificate));
         }
     }
 
@@ -105,7 +108,8 @@ internal static class ProviderConfigValidator
         if (SamlCertificate.IsInvalid(certificate))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.");
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
+                nameof(certificate));
         }
     }
 
@@ -118,7 +122,8 @@ internal static class ProviderConfigValidator
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
             throw new ArgumentException(
-                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.");
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.",
+                nameof(signingKeyPfx));
         }
     }
 }


### PR DESCRIPTION
Part of #104 (MA0015). Adds the offending `paramName` (`nameof(...)`) to every bare `throw new ArgumentException` in two files. **No message text changed**, the verbatim-message-assertion tests (incl. the login-path `ParseMode` throw) stay green, which is the proof.

12 sites: `SSO-Auth/Api/SSOController.cs` (7, the Add-endpoint reject helpers + `ParseMode`), `SSO-Auth/Config/ProviderConfigValidator.cs` (5, the Validate* helpers). `IntervalGate.cs` needed no change (its guard already uses `ArgumentOutOfRangeException.ThrowIfNegativeOrZero`, a throw-helper, not an MA0015 site).

## Type of change
- [x] Refactor (analyzer, additive, only the paramName argument added; messages verbatim)

## Verification
- [x] No message text altered (verbatim message-assertion tests green).
- [x] build `--warnaserror` 0/0 + test 1274 passed on net9.0 + net10.0.

Refs #104