### PR TITLE
Anchor JF12 beta releases to the built 4.2 commit (#627)

### DIFF
--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -119,6 +119,14 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
           tag_name: ${{ steps.version.outputs.base }}-JF12-beta.${{ github.run_number }}
+          # Anchor the tag to the 4.2 commit this build ran on. Without this, the create-release API
+          # defaults target_commitish to the repository DEFAULT branch (main) — which is not where JF12
+          # publishing happens — so every JF12 beta tag was created on main's stale HEAD (stuck at #606)
+          # instead of the 4.2 commit that triggered the run. That made generate_release_notes compute
+          # its "What's Changed" from main's history (always the last main-merge, #606) rather than the
+          # 4.2 changes actually shipped. Pinning it to github.sha (the pushed 4.2 commit) tags the
+          # correct commit and lets the auto-notes diff the real 4.2 range against the previous JF12 beta.
+          target_commitish: ${{ github.sha }}
           files: |
             _dist/*
             build.yaml


### PR DESCRIPTION
Fixes #627, every `5.0.0-JF12-beta.N` showed the same useless "What's Changed" (only #606, `4.1.2-beta.4...` compare).

**Root cause:** the release step never set `target_commitish`, so the create-release API defaulted it to the repository **default branch (main)**. JF12 publishing runs on **4.2**, but main's HEAD is stuck at the #606 merge, so every JF12 beta tag was created on that stale main commit, not the 4.2 commit that triggered the build. `generate_release_notes` then diffed main's history (the last main-merge, #606, against a cross-lineage 4.1.x base). Artifacts were still built correctly from the 4.2 checkout; only the tag anchor + notes were wrong.

**Fix (one line):** `target_commitish: ${{ github.sha }}`, anchors the tag to the pushed 4.2 commit; the auto-notes then diff the real 4.2 range against the previous JF12 beta.

**Empirically verified:** `releases/generate-notes` with `target_commitish` = the real 4.2 HEAD returns the full correct 4.2 PR list (#562…#625); anchored to main it returns only #606. `publish-beta.yml` (JF11) runs on `main` where default==built branch, so it is unaffected.

## Type of change
- [x] Bug fix (release pipeline)

## Security review
- `${{ github.sha }}` is a trusted immutable commit SHA, placed in a `with:` input (not spliced into a `run:` block) → no template-injection surface. zizmor gates the workflow.
- No change to build inputs, artifacts, permissions, or the draft→publish immutable-release flow, only where the tag is anchored.

## Verification
- [x] Empirical generate-notes comparison (4.2 HEAD vs main anchor).
- [x] Diff is a single `with:` key + comment; indentation matches siblings.
- [ ] zizmor / actionlint on this PR.

Closes #627