### PR TITLE
Add daily beta scheduler; stop per-push betas (#632)

### DIFF
--- a/.github/workflows/nightly-betas.yml
+++ b/.github/workflows/nightly-betas.yml
@@ -1,0 +1,40 @@
+name: Nightly betas
+
+# Publish betas on a daily cadence instead of on every push (#632). GitHub `schedule` events only run
+# a workflow from the DEFAULT branch, so this single scheduler lives on main and dispatches both beta
+# legs: publish-beta.yml (JF10.11, on main) and publish-jf12-beta.yml (JF12, on the 4.2 branch,
+# dispatched with --ref 4.2). Each dispatched workflow has its own gate job that skips the build unless
+# its branch has advanced since that lineage's last beta, so an unchanged day mints nothing.
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC, once daily
+  workflow_dispatch:
+
+# Deny-all at the workflow level; the job opts into the single grant it needs.
+permissions: {}
+
+# Never run two dispatchers at once; never cancel one mid-flight.
+concurrency:
+  group: nightly-betas
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch the daily beta builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only permission needed: workflow_dispatch the two publish workflows. REPO is passed via env so no
+    # ${{ }} expansion is spliced into the shell.
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger the JF10.11 beta (main)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: gh workflow run publish-beta.yml --repo "$REPO" --ref main
+      - name: Trigger the JF12 beta (4.2)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref 4.2

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -16,9 +16,11 @@ name: Publish Beta
 #     the .NET 9 / Jellyfin 10.11 leg (OidcClient must stay 6.x, #590). The
 #     JF10.12 (.NET 10 / OidcClient 7.x) leg is added when a 10.12 SDK exists;
 #     it will feed `manifest-jf12-beta`.
+# No push trigger: a beta is no longer minted on every push to main (that spammed one release per
+# merge). nightly-betas.yml (the scheduler, also on the default branch) dispatches this once a day;
+# the gate job below then skips the build unless main has advanced since the last JF10.11 beta. Still
+# manually runnable via workflow_dispatch.
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 # Explicit deny-all at workflow level; the job below opts into write access
@@ -36,8 +38,47 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Publish only when main has advanced since the last JF10.11 beta, so a scheduled daily run on an
+  # unchanged branch does not mint a duplicate release. The tag regex matches only the JF10.11 line
+  # (X.Y.Z-beta.<n>) and excludes the JF12 line (X.Y.Z-JF12-beta.<n>), independent of the base version.
+  # Fail-open: on any API error or missing prior tag it builds — skipping a real change is worse than
+  # an occasional duplicate beta.
+  gate:
+    name: Gate on new main commits
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+    - name: Compare main HEAD to the last JF10.11 beta
+      id: check
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        CUR: ${{ github.sha }}
+      run: |
+        set -uo pipefail
+        last_tag=$(gh api --paginate "repos/${REPO}/git/refs/tags" \
+          --jq '.[].ref | sub("refs/tags/"; "") | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.[0-9]+$"))' 2>/dev/null \
+          | sort -t. -k4 -n | tail -1 || echo "")
+        last_sha=""
+        if [ -n "$last_tag" ]; then
+          last_sha=$(gh api "repos/${REPO}/git/refs/tags/${last_tag}" --jq '.object.sha' 2>/dev/null || echo "")
+        fi
+        echo "current main HEAD: ${CUR}"
+        echo "last JF10.11 beta: ${last_tag:-<none>} -> ${last_sha:-<none>}"
+        if [ -n "$last_sha" ] && [ "$last_sha" = "$CUR" ]; then
+          echo "No new commits since the last JF10.11 beta; skipping the build."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
   build:
     name: Build & publish beta
+    needs: gate
+    if: needs.gate.outputs.changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # This job creates the GitHub release and updates the manifest branch, so it


### PR DESCRIPTION
Part of #632 (the main leg). Moves beta publishing from per-push to a daily cadence.

- **New `nightly-betas.yml`** (`schedule`: daily 04:00 UTC + `workflow_dispatch`). Because `schedule` only runs from the default branch, this single scheduler on main dispatches BOTH legs: `publish-beta.yml` (main) and `publish-jf12-beta.yml` (`--ref 4.2`). Job grant: `actions: write` only.
- **`publish-beta.yml`**: drop the `push` trigger → `workflow_dispatch` only; add a **gate job** that skips the build unless main advanced since the last JF10.11 beta. The tag regex `^X.Y.Z-beta.N$` selects only the JF10.11 line and excludes JF12, base-version-agnostic. Fail-open.

The JF12 leg's matching change is the companion PR to `4.2`. Both stay manually runnable via `workflow_dispatch`.

## Type of change
- [x] Enhancement (release pipeline)

## Security
- `nightly-betas.yml`: workflow `permissions: {}`, job `actions: write` only; no `uses:` (gh CLI only); `${{ }}` only in `env:`.
- `publish-beta.yml` gate: `contents: read`; the build job's existing `contents: write` unchanged.
- Diff is minimal, only the `on:` block and the new gate job; no reformatting (prettier does not gate .yml here).

## Verification
- [x] Minimal diff confirmed (only the push block removed).
- [ ] zizmor / actionlint on this PR.

Refs #632