### PR TITLE
Test [Authorize]-policy enforcement end-to-end (#192)

### DIFF
--- a/SSO-Auth.Tests/EndpointCatalog.cs
+++ b/SSO-Auth.Tests/EndpointCatalog.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// One concrete, callable endpoint discovered from the running host's live routing table, together with the
+/// authorization verdict the middleware will apply to it.
+/// </summary>
+/// <param name="Method">The HTTP method to use.</param>
+/// <param name="Url">A concrete request path with the route parameters filled by placeholders.</param>
+/// <param name="Policy">The named authorization policy, or <c>null</c> for a bare <c>[Authorize]</c>.</param>
+/// <param name="Action">The controller action method name, for a readable completeness assertion.</param>
+public sealed record GatedEndpoint(string Method, string Url, string? Policy, string Action)
+{
+    public override string ToString() => $"{Method} {Url} [{Policy ?? "authenticated"}] ({Action})";
+}
+
+/// <summary>
+/// Enumerates the host's <see cref="EndpointDataSource"/> and classifies every attribute-routed endpoint by
+/// its authorization requirement. Reading the LIVE endpoint table (not a hardcoded list) means a newly added
+/// guarded endpoint is discovered automatically, so the completeness assertion cannot silently under-cover.
+/// </summary>
+public sealed class EndpointCatalog
+{
+    private readonly List<GatedEndpoint> _elevationGated = new();
+    private readonly List<GatedEndpoint> _authenticatedOnly = new();
+
+    public EndpointCatalog(IServiceProvider services)
+    {
+        var source = services.GetRequiredService<EndpointDataSource>();
+        foreach (var endpoint in source.Endpoints.OfType<RouteEndpoint>())
+        {
+            // An explicit [AllowAnonymous] beats any [Authorize]; such an endpoint is not gated.
+            if (endpoint.Metadata.GetMetadata<IAllowAnonymous>() is not null)
+            {
+                continue;
+            }
+
+            var authorizeAttributes = endpoint.Metadata.GetOrderedMetadata<AuthorizeAttribute>();
+            if (authorizeAttributes.Count == 0)
+            {
+                continue;
+            }
+
+            var policy = authorizeAttributes.Select(a => a.Policy).FirstOrDefault(p => !string.IsNullOrEmpty(p));
+            var methods = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()?.HttpMethods ?? new[] { HttpMethods.Get };
+            var url = BuildConcreteUrl(endpoint.RoutePattern.RawText ?? string.Empty);
+            var action = endpoint.Metadata.GetMetadata<ControllerActionDescriptor>()?.ActionName ?? endpoint.DisplayName ?? url;
+
+            foreach (var method in methods)
+            {
+                var gated = new GatedEndpoint(method, url, policy, action);
+                if (string.IsNullOrEmpty(policy))
+                {
+                    _authenticatedOnly.Add(gated);
+                }
+                else
+                {
+                    _elevationGated.Add(gated);
+                }
+            }
+        }
+    }
+
+    /// <summary>Gets the endpoints guarded by a named policy (the elevation-gated admin surface).</summary>
+    public IReadOnlyList<GatedEndpoint> ElevationGated => _elevationGated;
+
+    /// <summary>Gets the endpoints guarded by a bare <c>[Authorize]</c> (any authenticated caller).</summary>
+    public IReadOnlyList<GatedEndpoint> AuthenticatedOnly => _authenticatedOnly;
+
+    // Fills every route parameter with a placeholder segment. A GUID is used everywhere: it is a valid
+    // non-empty value for a string parameter and also parses for a Guid-typed one, so routing always reaches
+    // the endpoint (the authorization middleware runs before any model binding could reject the value).
+    private static string BuildConcreteUrl(string rawTemplate)
+    {
+        var segments = rawTemplate.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var filled = segments.Select(segment => segment.StartsWith('{') ? Guid.NewGuid().ToString() : segment);
+        return "/" + string.Join('/', filled);
+    }
+}

--- a/SSO-Auth.Tests/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAuthorizationTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Proves the elevation guard on the SSO admin surface is genuinely ENFORCED, not merely present. The
+/// production <see cref="Jellyfin.Plugin.SSO_Auth.Api.SSOController"/> is hosted in a real in-process Kestrel
+/// server (see <see cref="SsoAuthorizationServerFixture"/>); requests travel through the same ASP.NET Core
+/// routing + authentication + authorization middleware that runs inside Jellyfin. A non-elevated caller is
+/// rejected before the action body executes, on EVERY <c>[Authorize(RequiresElevation)]</c> endpoint,
+/// enumerated from the live routing table rather than a hand-maintained list.
+///
+/// This complements the reflection checks (which assert the attribute is on the method) by exercising the
+/// enforcement path end to end: a stray <c>[AllowAnonymous]</c>, a wrong/absent policy name, a controller-level
+/// override, or a new unguarded admin endpoint would all fail here where a reflection check on the old set
+/// would pass.
+/// </summary>
+[Collection("SSOController")]
+public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthorizationServerFixture>
+{
+    private static readonly int[] Rejections = { StatusCodes401, StatusCodes403 };
+
+    private const int StatusCodes401 = (int)HttpStatusCode.Unauthorized;
+    private const int StatusCodes403 = (int)HttpStatusCode.Forbidden;
+
+    // The admin surface expected to be elevation-gated. The dynamic theories below cover whatever the live
+    // table exposes; this fixed set is the completeness anchor — an endpoint silently losing its guard drops
+    // out of the discovered set and fails CoversExactlyTheKnownElevationSurface.
+    private static readonly string[] ExpectedElevationActions =
+    {
+        "OidAdd", "OidDel", "OidProviders", "OidTest", "OidStates",
+        "SamlAdd", "SamlDel", "SamlProviders", "SamlTest",
+        "ExportConfig", "ImportConfig", "Unregister",
+    };
+
+    // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) — the canonical
+    // link management surface.
+    private static readonly string[] ExpectedAuthenticatedActions =
+    {
+        "AddCanonicalLink", "DeleteCanonicalLink", "GetSamlLinksByUser", "GetOidLinksByUser",
+    };
+
+    private readonly SsoAuthorizationServerFixture _fixture;
+
+    public SSOControllerAuthorizationTests(SsoAuthorizationServerFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void CoversExactlyTheKnownElevationSurface()
+    {
+        // The live routing table's elevation-gated actions must be exactly the known admin surface. A NEW
+        // guarded endpoint (uncovered) or a guard REMOVED from a known one both break this, forcing a review.
+        var discovered = _fixture.Endpoints.ElevationGated.Select(e => e.Action).Distinct().OrderBy(n => n, StringComparer.Ordinal);
+        Assert.Equal(ExpectedElevationActions.OrderBy(n => n, StringComparer.Ordinal), discovered);
+    }
+
+    [Fact]
+    public void PlainAuthorizeSurfaceIsDistinctFromElevation()
+    {
+        var discovered = _fixture.Endpoints.AuthenticatedOnly.Select(e => e.Action).Distinct().OrderBy(n => n, StringComparer.Ordinal);
+        Assert.Equal(ExpectedAuthenticatedActions.OrderBy(n => n, StringComparer.Ordinal), discovered);
+    }
+
+    [Fact]
+    public async Task UnauthenticatedCaller_IsRejectedOnEveryElevationEndpoint()
+    {
+        await AssertAllAsync(
+            _fixture.Endpoints.ElevationGated,
+            role: null,
+            expected: status => status == StatusCodes401,
+            because: "an unauthenticated caller must get 401");
+    }
+
+    [Fact]
+    public async Task AuthenticatedNonAdmin_IsForbiddenOnEveryElevationEndpoint()
+    {
+        await AssertAllAsync(
+            _fixture.Endpoints.ElevationGated,
+            role: TestRoles.User,
+            expected: status => status == StatusCodes403,
+            because: "an authenticated non-administrator must get 403");
+    }
+
+    [Fact]
+    public async Task Administrator_PassesTheAuthorizationStageOnEveryElevationEndpoint()
+    {
+        // An administrator clears the guard, so the response is whatever the action body produces — never a
+        // 401/403. Proving "not rejected" is the point: the guard admits the elevated caller.
+        await AssertAllAsync(
+            _fixture.Endpoints.ElevationGated,
+            role: TestRoles.Admin,
+            expected: status => !Rejections.Contains(status),
+            because: "an administrator must pass the elevation guard (no 401/403)");
+    }
+
+    [Fact]
+    public async Task UnauthenticatedCaller_IsRejectedOnEveryAuthenticatedEndpoint()
+    {
+        await AssertAllAsync(
+            _fixture.Endpoints.AuthenticatedOnly,
+            role: null,
+            expected: status => status == StatusCodes401,
+            because: "a bare [Authorize] endpoint must reject an unauthenticated caller with 401");
+    }
+
+    [Fact]
+    public async Task AuthenticatedNonAdmin_PassesTheAuthorizationStageOnEveryAuthenticatedEndpoint()
+    {
+        // The distinction matters: a plain [Authorize] endpoint must NOT be treated as elevation-gated, so a
+        // non-admin authenticated caller passes the authorization stage (no 401/403).
+        await AssertAllAsync(
+            _fixture.Endpoints.AuthenticatedOnly,
+            role: TestRoles.User,
+            expected: status => !Rejections.Contains(status),
+            because: "a bare [Authorize] endpoint must admit any authenticated caller (no 401/403)");
+    }
+
+    private async Task AssertAllAsync(
+        IReadOnlyList<GatedEndpoint> endpoints,
+        string? role,
+        Func<int, bool> expected,
+        string because)
+    {
+        Assert.NotEmpty(endpoints);
+
+        var failures = new List<string>();
+        foreach (var endpoint in endpoints)
+        {
+            var status = (int)(await SendAsync(endpoint, role).ConfigureAwait(false)).StatusCode;
+            if (!expected(status))
+            {
+                failures.Add($"{endpoint} -> {status}");
+            }
+        }
+
+        Assert.True(failures.Count == 0, $"{because}, but these did not: {string.Join("; ", failures)}");
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(GatedEndpoint endpoint, string? role)
+    {
+        using var request = new HttpRequestMessage(new HttpMethod(endpoint.Method), endpoint.Url);
+        if (role is not null)
+        {
+            request.Headers.Add(TestRoles.Header, role);
+        }
+
+        // A minimal JSON body for methods that carry one, so a [FromBody] action does not 415 before running.
+        // Irrelevant to the assertions (they only care whether the guard produced a 401/403), but it keeps the
+        // authorized-path responses to genuine action outcomes.
+        if (HttpMethod.Post.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase)
+            || HttpMethod.Put.Method.Equals(endpoint.Method, StringComparison.OrdinalIgnoreCase))
+        {
+            request.Content = new StringContent("null", Encoding.UTF8, "application/json");
+        }
+
+        return await _fixture.Client.SendAsync(request).ConfigureAwait(false);
+    }
+}

--- a/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using MediaBrowser.Common.Api;
+using MediaBrowser.Common.Configuration;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Net;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Cryptography;
+using MediaBrowser.Model.Serialization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Header value that selects the impersonated caller for a request against the fixture host.
+/// </summary>
+public static class TestRoles
+{
+    /// <summary>The header the test authentication scheme reads to decide who the caller is.</summary>
+    public const string Header = "X-Test-Role";
+
+    /// <summary>An authenticated, non-administrator caller (passes a plain <c>[Authorize]</c>, fails elevation).</summary>
+    public const string User = "user";
+
+    /// <summary>An authenticated administrator (passes both the default policy and the elevation policy).</summary>
+    public const string Admin = "admin";
+}
+
+/// <summary>
+/// Hosts the real <see cref="SSOController"/> in an in-process Kestrel server so the
+/// <c>[Authorize(Policy = Policies.RequiresElevation)]</c> attributes on the production endpoints are
+/// enforced by the genuine ASP.NET Core routing + authentication + authorization middleware — the same
+/// pipeline that runs inside Jellyfin — rather than merely asserted present by reflection.
+///
+/// What is REAL here (not mocked away):
+///   * the production controller type, loaded via <c>AddApplicationPart</c> over the shipped assembly;
+///   * its <c>[Authorize]</c> / <c>[Authorize(RequiresElevation)]</c> attributes;
+///   * ASP.NET Core's attribute routing, authentication challenge, and the authorization middleware that
+///     reads those attributes and rejects a caller (401/403) BEFORE the action body (and its model binding)
+///     ever runs.
+///
+/// What the FIXTURE supplies (the host's responsibility inside Jellyfin, not the plugin's):
+///   * a test authentication scheme keyed off the <see cref="TestRoles.Header"/> header, and
+///   * the <see cref="Policies.RequiresElevation"/> policy registered to require an authenticated caller
+///     in the "Administrator" role — mirroring Jellyfin's own RequiresElevation handler
+///     (<c>context.User.IsInRole(UserRoles.Administrator)</c>). The plugin's contract is only that it marks
+///     these endpoints with the attribute and relies on the host to enforce it; this fixture stands in for
+///     that host so the enforcement path is exercised end to end.
+/// </summary>
+public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    public SsoAuthorizationServerFixture()
+    {
+        // Set the process-wide SSOPlugin.Instance the controller reads at construction
+        // (SSOPlugin.Instance.ConfigStore in the SSOController ctor). Mirrors SsoControllerHarness so an
+        // authorized request reaches the action body cleanly instead of NRE-ing into a 500. The rejection
+        // paths (401/403) never construct the controller, so they do not depend on this.
+        var appPaths = Substitute.For<IApplicationPaths>();
+        appPaths.PluginConfigurationsPath.Returns(Path.Combine(Path.GetTempPath(), "sso-authz-test-" + Guid.NewGuid()));
+        appPaths.PluginsPath.Returns(Path.Combine(Path.GetTempPath(), "sso-authz-test-plugins-" + Guid.NewGuid()));
+        var xml = Substitute.For<IXmlSerializer>();
+        xml.DeserializeFromFile(Arg.Any<Type>(), Arg.Any<string>()).Returns(new Jellyfin.Plugin.SSO_Auth.Config.PluginConfiguration());
+        _ = new SSOPlugin(appPaths, xml, Substitute.For<ILogger<SSOPlugin>>());
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+
+        // The nine constructor collaborators of SSOController, resolved from DI when the framework activates
+        // the controller. They are substitutes: this fixture proves the AUTHORIZATION gate, not the action
+        // bodies (those are covered by the in-process SsoControllerHarness tests).
+        builder.Services.AddSingleton(Substitute.For<ISessionManager>());
+        builder.Services.AddSingleton(Substitute.For<IUserManager>());
+        builder.Services.AddSingleton(Substitute.For<IAuthorizationContext>());
+        builder.Services.AddSingleton<ICryptoProvider>(new FakeCryptoProvider());
+        builder.Services.AddSingleton(Substitute.For<IProviderManager>());
+        builder.Services.AddSingleton(Substitute.For<IServerConfigurationManager>());
+        builder.Services.AddHttpClient();
+
+        builder.Services.AddAuthentication(TestAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(TestAuthHandler.SchemeName, null);
+
+        // The default policy (used by a bare [Authorize]) requires an authenticated caller; the elevation
+        // policy additionally requires the Administrator role, mirroring Jellyfin's RequiresElevation.
+        builder.Services.AddAuthorizationBuilder()
+            .AddPolicy(Policies.RequiresElevation, policy => policy.RequireAuthenticatedUser().RequireRole(AdministratorRole));
+
+        builder.Services.AddControllers().AddApplicationPart(typeof(SSOController).Assembly);
+
+        _app = builder.Build();
+        _app.UseRouting();
+        _app.UseAuthentication();
+        _app.UseAuthorization();
+        _app.MapControllers();
+        _app.StartAsync().GetAwaiter().GetResult();
+
+        var address = _app.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()!.Addresses.GetEnumerator();
+        address.MoveNext();
+        Client = new HttpClient { BaseAddress = new Uri(address.Current) };
+
+        Endpoints = new EndpointCatalog(_app.Services);
+    }
+
+    /// <summary>Gets an <see cref="HttpClient"/> bound to the running host's loopback base address.</summary>
+    public HttpClient Client { get; }
+
+    /// <summary>Gets the authorization metadata discovered from the live endpoint table.</summary>
+    public EndpointCatalog Endpoints { get; }
+
+    /// <summary>The role name Jellyfin grants administrators; the elevation policy requires it.</summary>
+    internal const string AdministratorRole = "Administrator";
+
+    public async ValueTask DisposeAsync()
+    {
+        Client.Dispose();
+        await _app.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// A trivial authentication scheme: the <see cref="TestRoles.Header"/> header selects the caller.
+    /// Absent header -> unauthenticated (any [Authorize] yields 401). "user" -> authenticated, no role.
+    /// "admin" -> authenticated with the Administrator role.
+    /// </summary>
+    private sealed class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string SchemeName = "Test";
+
+        public TestAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+            : base(options, logger, encoder)
+        {
+        }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            if (!Request.Headers.TryGetValue(TestRoles.Header, out var role) || role.Count == 0)
+            {
+                return Task.FromResult(AuthenticateResult.NoResult());
+            }
+
+            var claims = new List<Claim> { new(ClaimTypes.Name, "test-caller") };
+            if (string.Equals(role.ToString(), TestRoles.Admin, StringComparison.Ordinal))
+            {
+                claims.Add(new Claim(ClaimTypes.Role, AdministratorRole));
+            }
+
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+            return Task.FromResult(AuthenticateResult.Success(ticket));
+        }
+    }
+}


### PR DESCRIPTION
Part of #192 Wave B. Elevates authz coverage from attribute-present to genuinely ENFORCED via a real in-process Kestrel host loading the production SSOController (AddApplicationPart) through the real routing->auth->authorization middleware. 7 facts: unauthenticated->401 and non-admin->403 on all 12 elevation-gated endpoints; admin clears; the 4 bare-[Authorize] link endpoints reject unauthenticated but admit non-admin; and the discovered elevation surface must equal the known 12 (a dropped/new guard fails the build). Not hollow: same non-admin caller yields 403 on elevation endpoints yet passes the 4 plain-[Authorize] ones. Test-only; 1380 passed net9.0+net10.0.

Refs #192