### PR TITLE
Show link success instead of "Login failed" after account linking (#614)

### DIFF
--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -135,6 +135,17 @@ public class WebResponseTests
         // exact predicate must be gone so a successful link can no longer proceed to a login post.
         Assert.DoesNotContain("linkStatus < 200 || linkStatus >= 300", html);
         Assert.Contains("if (linkStatus !== undefined) {", html);
+
+        // The terminality is enforced by a `return;` inside the definitive-status branch, BEFORE the
+        // fall-through to the .../Auth post. Assert the ordering directly, so deleting that `return;`
+        // (which would silently reintroduce the #614 fall-through) fails this test.
+        var gateIdx = html.IndexOf("if (linkStatus !== undefined) {", System.StringComparison.Ordinal);
+        var returnAfterGate = html.IndexOf("return;", gateIdx, System.StringComparison.Ordinal);
+        var authPostAfterGate = html.IndexOf("/Auth/", gateIdx, System.StringComparison.Ordinal);
+        Assert.True(returnAfterGate >= 0 && authPostAfterGate >= 0);
+        Assert.True(
+            returnAfterGate < authPostAfterGate,
+            "a definitive link status must return before the .../Auth post");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -117,4 +117,34 @@ public class WebResponseTests
 
         Assert.Contains(expected, html);
     }
+
+    [Fact]
+    public void Generator_SuccessfulLink_IsTerminal_ShowsSuccessAndDoesNotPostToAuthUnconditionally()
+    {
+        // #614: a successful link (a 2xx from .../Link) is a terminal SUCCESS on the page — it renders a
+        // clear success message and must NOT fall through to post the same one-time-consumed assertion /
+        // state on to .../Auth (which could never redeem it, so the page showed a misleading login failure).
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce", isLinking: true);
+
+        // The success branch renders the account-linked message keyed on the 2xx range.
+        Assert.Contains("linkStatus >= 200 && linkStatus < 300", html);
+        Assert.Contains("Account linked. You can now log in with SSO.", html);
+
+        // A definitive link outcome (any non-undefined status) stops the flow before the auth leg. The
+        // former `linkStatus < 200 || linkStatus >= 300` condition let a 2xx fall through to .../Auth; that
+        // exact predicate must be gone so a successful link can no longer proceed to a login post.
+        Assert.DoesNotContain("linkStatus < 200 || linkStatus >= 300", html);
+        Assert.Contains("if (linkStatus !== undefined) {", html);
+    }
+
+    [Fact]
+    public void Generator_LinkingPage_KeepsRejectedLinkMessages()
+    {
+        // The failure path is preserved (#344): a genuinely rejected link still surfaces its own message
+        // rather than the login-failure text — a throttled attempt (429) and any other non-2xx are distinct.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce", isLinking: true);
+
+        Assert.Contains("Too many attempts. Please wait a moment and try again.", html);
+        Assert.Contains("Could not link this account. The provider may be disabled, or linking is not permitted.", html);
+    }
 }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -202,13 +202,13 @@ internal sealed class SamlLoginService
         }
 
         // Linking keeps the assertion-embedded page (#251 is scoped to the login round-trip): the page JS
-        // posts its data to BOTH SAML/Link and SAML/Auth. The link redeem (SamlLoginService.Link) consumes the
-        // assertion's one-time-use id on its own leg; the follow-on SAML/Auth post carries that same assertion
-        // (not a login-outcome token), so it does not redeem a live token and is rejected fail-closed at the
-        // mint leg — a harmless no-op, since the link already completed on its own leg. This was already the
-        // effective behaviour before #528: post-link the assertion's replay id was consumed, so the old
-        // deprecation branch rejected the follow-on post too. Removing that branch (#528) changes only WHERE
-        // the follow-on post is rejected (token-miss vs. a re-validated replay), not that it is rejected.
+        // posts its data to SAML/Link. The link redeem (SamlLoginService.Link) consumes the assertion's
+        // one-time-use id on its own leg. Since #614 a definitive Link outcome is TERMINAL on the page — a
+        // successful link (204) renders success and the page does NOT go on to post to SAML/Auth. That
+        // follow-on post could never have succeeded anyway: it carried the same, now-consumed assertion (not
+        // a login-outcome token), so it fail-closed at the mint leg — but left in place it rendered a
+        // misleading 'Login failed' over a link that had actually completed. Dropping the follow-on post
+        // removes that false failure without touching the Link leg's validation or its one-time consume.
         if (isLinking)
         {
             return FlowResponses.AuthPage(response, nonce =>

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -307,18 +307,24 @@ async function main() {
     var request = {deviceId, appName, appVersion, deviceName, data};
 
     if (" + (isLinking ? "true" : "false") + @") {
-        // Surface a rejected link instead of swallowing it (#344): the link leg fail-closes with a
-        // non-2xx when the provider is disabled (#343), the caller is not allowed, or the request is
-        // throttled. Left silent, the page would fall through to the auth leg and show a misleading
-        // 'Login failed', so a rejected link stops here with its own message. A missing status
-        // (undefined: no stored credentials, or a network error) keeps the prior behavior of
-        // proceeding, since the outcome cannot be told apart from success.
+        // Linking is NOT a login round-trip, so a DEFINITIVE link outcome is terminal here — the page does
+        // NOT go on to post to .../Auth (#614). The Link leg one-time-consumes the assertion / state token,
+        // so the old unconditional follow-on Auth post could never redeem it: it fail-closed at the mint leg
+        // and rendered a misleading 'Login failed. Please try again.' even though the link itself had already
+        // succeeded on its own leg.
+        //   - A 2xx is a completed link: show success and stop (do not attempt a login).
+        //   - A non-2xx is a rejected link (#344): the provider is disabled (#343), the caller is not
+        //     allowed, or the request is throttled — surface it and stop, never fall through to a login.
+        //   - A missing status (undefined: no stored credentials, or a network error) keeps the prior
+        //     behavior of proceeding to the auth leg, since that outcome cannot be told apart from success.
         var linkStatus = await link(request);
-        if (linkStatus !== undefined && (linkStatus < 200 || linkStatus >= 300)) {
+        if (linkStatus !== undefined) {
             document.querySelector('p').textContent =
-                linkStatus === 429
-                    ? 'Too many attempts. Please wait a moment and try again.'
-                    : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
+                linkStatus >= 200 && linkStatus < 300
+                    ? 'Account linked. You can now log in with SSO.'
+                    : linkStatus === 429
+                        ? 'Too many attempts. Please wait a moment and try again.'
+                        : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
             return;
         }
     }


### PR DESCRIPTION
Fixes #614. The shared linking-page JS (`WebResponse.Generator`, used by BOTH SAML and OIDC linking) `await`ed `link()` then, on any non-error, UNCONDITIONALLY posted the same credential to `.../Auth`. Both Link legs one-time-consume the credential (SAML assertion via TryConsumeReplay, OIDC state via StateStore.TryRedeem), so the follow-on Auth post can never redeem it → fail-closes 400, and a SUCCESSFUL link (204) rendered "Login failed. Please try again."

**Fix:** on a successful link (2xx) the page is now terminal, shows "Account linked. You can now log in with SSO." and does NOT post to Auth. Non-2xx keeps the existing rejected-link messages (429 / disabled / not-permitted). The `undefined`-status fall-through (no stored credentials / network error) is unchanged. No touch to link validation or the one-time-consume; failure path preserved.

## Type of change
- [x] Bug fix (login/link web-ui path)

## Verification
- [x] 2 new WebResponseTests characterization tests (success terminal + no unconditional Auth post; rejected-link messages retained).
- [x] build --warnaserror 0/0 + test 1389 passed on net9.0 + net10.0.

Closes #614