### PR TITLE
Explicit deny in AssertCanUpdateUser on a null auth context (#626)

### DIFF
--- a/SSO-Auth.Tests/RequestHelpersTests.cs
+++ b/SSO-Auth.Tests/RequestHelpersTests.cs
@@ -18,8 +18,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// authorization contract has three independent terms and each row below pins one of them: self is allowed
 /// without admin, an administrator may act on another user, a plain caller may not, the preference-access
 /// term gates every path (even self, even admin), and a request with no authenticated user faults closed
-/// rather than returning an allow. The deny rows assert <c>false</c> (or a throw), so loosening the helper
-/// to default-allow makes them fail. These tests drive the helper directly through a substituted
+/// via an explicit deny rather than returning an allow. The deny rows assert <c>false</c>, so loosening the
+/// helper to default-allow makes them fail. These tests drive the helper directly through a substituted
 /// <see cref="IAuthorizationContext"/>; they touch no process-wide state and so need no test collection.
 /// </summary>
 public class RequestHelpersTests
@@ -77,13 +77,12 @@ public class RequestHelpersTests
     [Fact]
     public async Task UnauthenticatedContext_FailsClosed()
     {
-        // No authenticated user resolved: the helper dereferences the (null) user and faults with a
-        // NullReferenceException rather than returning an allow — the ambiguous case never yields true. A
-        // future explicit null-guard should return false; if that lands, update this to Assert.False.
+        // No authenticated user resolved: the explicit null-guard returns a clean deny rather than
+        // dereferencing the (null) user and faulting with a NullReferenceException — the ambiguous case
+        // never yields true and never surfaces as a 500.
         var authContext = ContextFor(user: null);
 
-        await Assert.ThrowsAsync<NullReferenceException>(
-            async () => await RequestHelpers.AssertCanUpdateUser(authContext, Request(), Other));
+        Assert.False(await RequestHelpers.AssertCanUpdateUser(authContext, Request(), Other));
     }
 
     private static IAuthorizationContext ContextFor(User? user)

--- a/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
@@ -5,6 +5,9 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using MediaBrowser.Common.Api;
@@ -21,6 +24,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -90,7 +94,7 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
         // bodies (those are covered by the in-process SsoControllerHarness tests).
         builder.Services.AddSingleton(Substitute.For<ISessionManager>());
         builder.Services.AddSingleton(Substitute.For<IUserManager>());
-        builder.Services.AddSingleton(Substitute.For<IAuthorizationContext>());
+        builder.Services.AddSingleton(BuildAuthorizationContext());
         builder.Services.AddSingleton<ICryptoProvider>(new FakeCryptoProvider());
         builder.Services.AddSingleton(Substitute.For<IProviderManager>());
         builder.Services.AddSingleton(Substitute.For<IServerConfigurationManager>());
@@ -129,6 +133,26 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
 
     /// <summary>The role name Jellyfin grants administrators; the elevation policy requires it.</summary>
     internal const string AdministratorRole = "Administrator";
+
+    /// <summary>
+    /// Resolves the caller to a real host user so the bare-<c>[Authorize]</c> canonical-link endpoints, which
+    /// run an in-body owner check (<see cref="Jellyfin.Plugin.SSO_Auth.Helpers.RequestHelpers.AssertCanUpdateUser"/>),
+    /// pass that check and reach their action bodies. That check is orthogonal to the MIDDLEWARE authorization
+    /// stage these tests target: it is covered directly by <c>RequestHelpersTests</c>. Leaving the caller
+    /// unresolved would make the helper deny (a clean 403) and make an in-body denial indistinguishable from a
+    /// mistaken elevation-gate; seeding an administrator with preference access isolates these tests to the
+    /// middleware so any remaining 401/403 is genuinely the attribute pipeline's doing.
+    /// </summary>
+    private static IAuthorizationContext BuildAuthorizationContext()
+    {
+        var hostUser = new User("test-caller", "SSO-Auth", "Default") { EnableUserPreferenceAccess = true };
+        hostUser.SetPermission(PermissionKind.IsAdministrator, true);
+
+        var authContext = Substitute.For<IAuthorizationContext>();
+        authContext.GetAuthorizationInfo(Arg.Any<HttpRequest>())
+            .Returns(Task.FromResult(new AuthorizationInfo { User = hostUser }));
+        return authContext;
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/SSO-Auth/Api/RequestHelpers.cs
+++ b/SSO-Auth/Api/RequestHelpers.cs
@@ -30,9 +30,22 @@ public static class RequestHelpers
     /// <returns>A <see cref="bool"/> whether the user can update the entry.</returns>
     internal static async Task<bool> AssertCanUpdateUser(IAuthorizationContext authContext, HttpRequest requestContext, Guid userId)
     {
+        if (authContext is null)
+        {
+            return false;
+        }
+
         var auth = await authContext.GetAuthorizationInfo(requestContext).ConfigureAwait(false);
 
-        var authenticatedUser = auth.User;
+        var authenticatedUser = auth?.User;
+
+        // Fail closed on an unresolved caller: a null authorization result or unauthenticated request
+        // is an explicit deny, not a NullReferenceException that would surface as a 500. Every real
+        // caller sits behind [Authorize], so this only guards the ambiguous/misconfigured case.
+        if (authenticatedUser is null)
+        {
+            return false;
+        }
 
         // Updating the record of another user requires an administrator; every caller edits user
         // preferences, so the upstream restrictUserPreferences flag is folded in as always-on here.


### PR DESCRIPTION
Closes #626. `AssertCanUpdateUser` failed closed by throwing `NullReferenceException` on a null `IAuthorizationContext`/user (which could surface as a 500) rather than an explicit deny. Adds a top guard: `if (authContext is null) return false;` and `if (auth?.User is null) return false;`. All non-null paths byte-for-byte unchanged (self→allow, admin→allow, non-admin-on-other→deny, EnableUserPreferenceAccess gate). Strictly more fail-closed.

**Surfaced a masked test dependency (authz):** `SSOControllerAuthorizationTests.AuthenticatedNonAdmin_PassesTheAuthorizationStageOnEveryAuthenticatedEndpoint` (from #192 Unit 8) was tolerating the null-user NRE→500 on the 3 in-body link endpoints (500 ∉ {401,403}). The clean 403 made it fail, it relied on the very bug #626 describes. Fixed at the correct layer: `SsoAuthorizationServerFixture` now seeds a real host user (admin + preference access) into `IAuthorizationContext`, so those endpoints reach their bodies and the test again measures the middleware attribute pipeline, not a masked NRE. The owner check stays fully covered by `RequestHelpersTests`.

## Type of change
- [x] Security hardening (authz surface)

## Verification
- [x] build --warnaserror 0/0 + test 1387 passed on net9.0 + net10.0.
- [ ] adversarial bypass + correctness review (authz).

Closes #626