### PR TITLE
Fix .NET CI startup_failure on main (reusable build.yml permissions)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -104,6 +104,15 @@ jobs:
   # targeted ABI and produces the manifest) on every PR, not only at release time.
   package:
     name: Package (JPRM)
+    # build.yml is a reusable workflow whose build job declares id-token/attestations: write for its
+    # release-only SLSA attest step (#147). A caller must grant every permission the callee declares, or
+    # the reusable-workflow call fails to start ("workflow file issue"). This CI caller leaves `attest`
+    # at its default (false), so the attest step never runs and no token or attestation is minted — the
+    # grant only satisfies the reusable-workflow permission check.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.x"


### PR DESCRIPTION
**Urgent:** the .NET workflow has been a 0-1s `startup_failure` on main since the 4.2.0 release merge (and on every 4.2-based ref since #609), a red, publicly-visible CI.

**Root cause:** `dotnet.yml`'s `package` job calls the reusable `build.yml`, whose build job declares `id-token: write` + `attestations: write` for the release-only SLSA attest step (#147). A reusable-workflow caller must grant every permission the callee declares, or the call fails to start. `dotnet.yml` only had `contents: read`.

**Fix:** grant `id-token`/`attestations: write` on the `package` job. This CI caller leaves `attest` at its default (false), so the attest step never runs and nothing is minted, the grant only satisfies the reusable-workflow permission check.

## Verification
- [ ] The .NET run on THIS PR STARTS (no startup_failure) and build/test/package pass.

To be propagated to 4.2 and 4.3 (same dotnet.yml).