### PR TITLE
Fix .NET CI startup_failure on 4.3 (reusable build.yml permissions)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -104,6 +104,15 @@ jobs:
   # targeted ABI and produces the manifest) on every PR, not only at release time.
   package:
     name: Package (JPRM)
+    # build.yml is a reusable workflow whose build job declares id-token/attestations: write for its
+    # release-only SLSA attest step (#147). A caller must grant every permission the callee declares, or
+    # the reusable-workflow call fails to start ("workflow file issue"). This CI caller leaves `attest`
+    # at its default (false), so the attest step never runs and no token or attestation is minted — the
+    # grant only satisfies the reusable-workflow permission check.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.x"


### PR DESCRIPTION
Same fix as the main-branch #642: `dotnet.yml`'s `package` job calls the reusable `build.yml`, which declares `id-token`/`attestations: write` for its release-only SLSA attest step (#147). A reusable-workflow caller must grant what the callee declares or the call fails to start, that took the whole .NET run to a startup_failure on `4.3`. Grant the scopes on the `package` job; `attest` stays false in CI so nothing is minted.

Propagation of the main fix to `4.3`.