### PR TITLE
Bump github/codeql-action to v4.37.0 (consolidates #611/#612/#613)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,7 +87,7 @@ jobs:
           dotnet-version: 9.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Surface the findings in the code-scanning tab, alongside CodeQL and zizmor.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -73,7 +73,7 @@ jobs:
         # skip the "Fail on actionable findings" step below.
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
Consolidates the three split Dependabot PRs (#611 init, #612 analyze, #613 upload-sarif) into one. The codeql-action is a monorepo, all sub-actions share a single release SHA, so init/analyze MUST move together, which the split PRs could not do (bumping init without analyze mismatched the CodeQL version and failed CI). Bumps all four refs (codeql.yml init+analyze, scorecard.yml + zizmor.yml upload-sarif) from v4.36.0 (7211b7c8) to v4.37.0 (99df26d4).

Closes #611
Closes #612
Closes #613