### PR TITLE
Release 4.2.1: authz null-context hardening + CI fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this plugin are documented here. Versions follow the
 four-part `X.Y.Z.W` scheme described in the release policy (breaking / feature /
 bug-fix / security).
 
+## 4.2.1.0
+
+A bug-fix release.
+
+### Fixed
+
+- **Admin-or-self authorization now denies explicitly on a null auth context
+  (#626).** `RequestHelpers.AssertCanUpdateUser` previously failed closed by
+  throwing a `NullReferenceException` (which could surface as a 500) on a null
+  or ambiguous authorization context. It now returns an explicit `false` — a
+  clean, total deny. Normal authenticated requests are unaffected; the fix
+  removes a fragile reliance on an exception for a security-critical denial and
+  eliminates the internal-error surface. A masked test that had tolerated the
+  old exception was corrected to assert the explicit deny.
+
 ## 4.2.0.0
 
 A breaking release.

--- a/SSO-Auth.Tests/RequestHelpersTests.cs
+++ b/SSO-Auth.Tests/RequestHelpersTests.cs
@@ -18,8 +18,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// authorization contract has three independent terms and each row below pins one of them: self is allowed
 /// without admin, an administrator may act on another user, a plain caller may not, the preference-access
 /// term gates every path (even self, even admin), and a request with no authenticated user faults closed
-/// rather than returning an allow. The deny rows assert <c>false</c> (or a throw), so loosening the helper
-/// to default-allow makes them fail. These tests drive the helper directly through a substituted
+/// via an explicit deny rather than returning an allow. The deny rows assert <c>false</c>, so loosening the
+/// helper to default-allow makes them fail. These tests drive the helper directly through a substituted
 /// <see cref="IAuthorizationContext"/>; they touch no process-wide state and so need no test collection.
 /// </summary>
 public class RequestHelpersTests
@@ -77,13 +77,12 @@ public class RequestHelpersTests
     [Fact]
     public async Task UnauthenticatedContext_FailsClosed()
     {
-        // No authenticated user resolved: the helper dereferences the (null) user and faults with a
-        // NullReferenceException rather than returning an allow — the ambiguous case never yields true. A
-        // future explicit null-guard should return false; if that lands, update this to Assert.False.
+        // No authenticated user resolved: the explicit null-guard returns a clean deny rather than
+        // dereferencing the (null) user and faulting with a NullReferenceException — the ambiguous case
+        // never yields true and never surfaces as a 500.
         var authContext = ContextFor(user: null);
 
-        await Assert.ThrowsAsync<NullReferenceException>(
-            async () => await RequestHelpers.AssertCanUpdateUser(authContext, Request(), Other));
+        Assert.False(await RequestHelpers.AssertCanUpdateUser(authContext, Request(), Other));
     }
 
     private static IAuthorizationContext ContextFor(User? user)

--- a/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/SsoAuthorizationServerFixture.cs
@@ -5,6 +5,9 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using MediaBrowser.Common.Api;
@@ -21,6 +24,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -90,7 +94,7 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
         // bodies (those are covered by the in-process SsoControllerHarness tests).
         builder.Services.AddSingleton(Substitute.For<ISessionManager>());
         builder.Services.AddSingleton(Substitute.For<IUserManager>());
-        builder.Services.AddSingleton(Substitute.For<IAuthorizationContext>());
+        builder.Services.AddSingleton(BuildAuthorizationContext());
         builder.Services.AddSingleton<ICryptoProvider>(new FakeCryptoProvider());
         builder.Services.AddSingleton(Substitute.For<IProviderManager>());
         builder.Services.AddSingleton(Substitute.For<IServerConfigurationManager>());
@@ -129,6 +133,26 @@ public sealed class SsoAuthorizationServerFixture : IAsyncDisposable
 
     /// <summary>The role name Jellyfin grants administrators; the elevation policy requires it.</summary>
     internal const string AdministratorRole = "Administrator";
+
+    /// <summary>
+    /// Resolves the caller to a real host user so the bare-<c>[Authorize]</c> canonical-link endpoints, which
+    /// run an in-body owner check (<see cref="Jellyfin.Plugin.SSO_Auth.Helpers.RequestHelpers.AssertCanUpdateUser"/>),
+    /// pass that check and reach their action bodies. That check is orthogonal to the MIDDLEWARE authorization
+    /// stage these tests target: it is covered directly by <c>RequestHelpersTests</c>. Leaving the caller
+    /// unresolved would make the helper deny (a clean 403) and make an in-body denial indistinguishable from a
+    /// mistaken elevation-gate; seeding an administrator with preference access isolates these tests to the
+    /// middleware so any remaining 401/403 is genuinely the attribute pipeline's doing.
+    /// </summary>
+    private static IAuthorizationContext BuildAuthorizationContext()
+    {
+        var hostUser = new User("test-caller", "SSO-Auth", "Default") { EnableUserPreferenceAccess = true };
+        hostUser.SetPermission(PermissionKind.IsAdministrator, true);
+
+        var authContext = Substitute.For<IAuthorizationContext>();
+        authContext.GetAuthorizationInfo(Arg.Any<HttpRequest>())
+            .Returns(Task.FromResult(new AuthorizationInfo { User = hostUser }));
+        return authContext;
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/SSO-Auth/Api/RequestHelpers.cs
+++ b/SSO-Auth/Api/RequestHelpers.cs
@@ -30,9 +30,22 @@ public static class RequestHelpers
     /// <returns>A <see cref="bool"/> whether the user can update the entry.</returns>
     internal static async Task<bool> AssertCanUpdateUser(IAuthorizationContext authContext, HttpRequest requestContext, Guid userId)
     {
+        if (authContext is null)
+        {
+            return false;
+        }
+
         var auth = await authContext.GetAuthorizationInfo(requestContext).ConfigureAwait(false);
 
-        var authenticatedUser = auth.User;
+        var authenticatedUser = auth?.User;
+
+        // Fail closed on an unresolved caller: a null authorization result or unauthenticated request
+        // is an explicit deny, not a NullReferenceException that would surface as a 500. Every real
+        // caller sits behind [Authorize], so this only guards the ambiguous/misconfigured case.
+        if (authenticatedUser is null)
+        {
+            return false;
+        }
 
         // Updating the record of another user requires an administrator; every caller edits user
         // preferences, so the upstream restrictUserPreferences flag is folded in as always-on here.

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -7,8 +7,8 @@
          publish pipeline builds each target into its own package with its own targetAbi. -->
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.2.0</AssemblyVersion>
-    <FileVersion>4.2.0</FileVersion>
+    <AssemblyVersion>4.2.1</AssemblyVersion>
+    <FileVersion>4.2.1</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.2.0"
+version: "4.2.1"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at
@@ -41,6 +41,7 @@ artifacts:
   - "System.Security.Cryptography.Pkcs.dll"
   - "System.Formats.Asn1.dll"
 changelog: |
+  4.2.1.0: Bug fix. The admin-or-self authorization check (AssertCanUpdateUser) now returns an explicit deny on a null or ambiguous authorization context instead of failing closed via an unhandled NullReferenceException that could surface as a 500 (#626). No change to normal authenticated requests.
   4.2.0.0: Feature release (BREAKING). SAML/Auth now accepts ONLY the one-time login-outcome token introduced in #251; the deprecation window that also accepted a raw pre-#251 assertion POSTed straight to SAML/Auth is removed (#528). A scripted client that posts a raw assertion, bypassing the rendered token page, is now rejected fail-closed. The normal browser login and linking flows are unaffected.
   4.1.1.0: Bug fix. Restore plugin loading on Jellyfin 10.11 (.NET 9). 4.1.0.0 pulled Duende.IdentityModel.OidcClient 7.x, whose assemblies reference the .NET 10 Microsoft.Extensions.Logging.Abstractions (10.0.0.0) that the host does not provide and the plugin does not ship, so it threw FileNotFoundException at construction and was disabled at startup. Pin OidcClient to the 6.x line (net9 ABI) and add a conformance test that no host-provided assembly is referenced above the .NET 9 floor. No configuration changes.
   4.1.0.0: Feature (BREAKING - on-disk secret format changed; forward-transparent, downgrade requires re-entering secrets). Security-parity hardening of the SAML and OpenID login path, secrets encrypted at rest, SAML AuthnRequest signing (RSA and ECDSA), admin-UI provider toggles, and the thin-controller architecture rework. See CHANGELOG.md.


### PR DESCRIPTION
Patch release **4.2.1** off main.

**Ships:**
- **#626**, `AssertCanUpdateUser` returns an explicit deny on a null/ambiguous auth context instead of failing closed by an unhandled `NullReferenceException` (500 surface). Cherry-picked from 4.2; adversarial bypass review already PASS. Includes the fixture correction for a masked test.
- The **.NET CI reusable-workflow permission fix** (already on main via #642) that resolved the `startup_failure`, the red CI that prompted this patch.

`build.yaml` → 4.2.1 (+ changelog entry), `CHANGELOG.md` → `## 4.2.1.0`.

After this merges green, I push `4.2.1-stable` to trigger publish.yml (public release + manifest-release update).

## Verification
- [ ] CI green (incl. the now-fixed .NET workflow).
