### PR TITLE
Document the review-gate coverage after external-reviewer removal (#101)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ CI restores in a separate step, so its build/test use `--no-restore`/`--no-build
 
 **Branching and pull requests.** `main` is the released line and is PR-only. Branch every change — even a one-liner — off `main` for fixes and security work, or off the feature branch for features, using a short kebab-case name with a `fix/`, `harden/`, `feature/`, `chore/`, or `refactor/` prefix. Reference the issue your change addresses (`Closes #N`) and fill in the [pull request template](.github/pull_request_template.md).
 
-This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why.
+This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why. The merge gate is internal-only (CI, the adversarial review, and the maintainer); [REVIEW-GATE.md](REVIEW-GATE.md) maps how those controls cover each class of issue an automated PR reviewer would catch.
 
 ### Improving The Documentation
 

--- a/REVIEW-GATE.md
+++ b/REVIEW-GATE.md
@@ -1,0 +1,195 @@
+# The review gate
+
+This repository once ran an external automated PR reviewer (GitHub Copilot's
+review, and briefly CodeRabbit) that left a comment on every diff. Both were
+uninstalled on 2026-07-16: the merge gate is deliberately **internal-only** — no
+external review, quality, or analysis service is trusted with this repository's
+code. Removing that reviewer left a **review-coverage gap** — the loss of an
+independent, whole-diff second perspective on every pull request.
+
+This document records, class by class, what a generic automated PR reviewer
+would have flagged and which concrete in-repo control now covers it, then names
+the one genuine residual and its disposition. It describes only controls that
+exist today; it invents nothing. When a control changes, update this file.
+
+A generic automated reviewer's findings fall into five classes: **correctness**,
+**security**, **style / maintainability**, **dependency**, and **secret**. Each
+is treated below.
+
+## What runs, and when
+
+- **Every pull request** (branch build): `dotnet build --warnaserror` + `dotnet
+test`, Prettier, CodeQL (security-extended), Opengrep repo-invariant rules,
+  zizmor workflow audit, the Trojan-Source/Unicode guard, dependency-review, and
+  the transitive vulnerable-dependency scan. `build`, `prettier`, and
+  `dependency-review` are required status checks on the protected branch (see
+  the comment in each workflow); CodeQL is intentionally a non-required check.
+- **On a weekly schedule** (not per-PR, non-gating by construction): Stryker.NET
+  mutation testing (scoped to the SAML/OIDC core), SharpFuzz fuzzing (SAML/OIDC
+  parse surface), OpenSSF Scorecard, and the CodeQL baseline re-scan.
+- **Process, per pull request**: at least two independent refute-by-default
+  review passes on every code PR, escalating to the full four-lens adversarial
+  review (plus the audit-integrity and authz domain lenses) on any change to the
+  login path, SAML/OIDC crypto, config persistence, or the release pipeline.
+
+## Coverage mapping
+
+### Correctness
+
+A generic reviewer flags logic slips, null dereferences, races, wrong control
+flow, and missed edge cases.
+
+- **Compiler as reviewer** — `TreatWarningsAsErrors` (Directory.Build.props) and
+  `dotnet build --warnaserror` in CI turn nullable-reference, unreachable-code,
+  and unused-symbol warnings into build failures.
+- **Roslyn analyzers** — AnalysisMode Recommended plus Roslynator and Meziantou,
+  with `CodeAnalysisTreatWarningsAsErrors`, fail the build on the analyzers'
+  reliability/correctness rules; the `.editorconfig` pins per-rule severities.
+- **Test suite** (`SSO-Auth.Tests`, required) — unit and endpoint tests with a
+  negative test for every fail-closed branch.
+- **Property-based tests** (`PropertyTests`, FsCheck) — invariants over the pure
+  login-decision helpers that must hold for all inputs, not just picked cases.
+- **Architecture-conformance fitness functions** (`ArchitectureConformanceTests`)
+  — structural invariants that close specific correctness/race classes:
+  torn-read-free immutable authorize/outcome variants (#341, #251), the
+  TOCTOU revocation re-check immediately before the mint (#232), and the
+  once-per-interval throttle discipline on the login-path caches.
+- **CodeQL** (security-extended) also catches correctness-adjacent faults
+  (null-deref, resource leaks, dead code).
+- **Mutation testing** (Stryker, weekly) surfaces correctness cases the tests
+  would miss, as a concrete test-writing prompt.
+- **Adversarial review** — the `correctness-lens` reads the full touched files
+  on login-path changes.
+
+### Security
+
+A generic reviewer flags injection, weak crypto, authz bypass, SSRF, and unsafe
+patterns.
+
+- **CodeQL security-extended** — ~135 taint/dataflow queries across `csharp`,
+  `javascript-typescript`, and `actions`, on every PR (and the release branches).
+- **Security analyzers at error** — `AnalysisModeSecurity=All` plus
+  `dotnet_analyzer_diagnostic.category-Security.severity = error`, so every
+  Security-category rule fails the build (e.g. CA5369, already caught and fixed).
+- **Opengrep repo-invariant rules** (`tools/opengrep/rules.yml`) — greppable,
+  language-parser-independent invariants: CSPRNG-only randomness, no
+  `Problem()`/`ProblemDetails` leak from the controllers, all config access
+  through the `ProviderConfigStore` facade, no raw outbound `HttpClient`, and no
+  `gh release` mutation in the pipeline. One rule per invariant, added per
+  regression.
+- **Fitness functions as un-forgeable-authz analogues** — `VerifiedIdentity`'s
+  private constructor with named validation factories (#473), the immutable
+  in-flight authorize/outcome sums, and the "controller holds no mutable static
+  state / touches no raw socket-DNS / no provider link map" boundary scans make
+  whole classes of login-path misuse a failing test rather than a review catch.
+- **zizmor** — static analysis of the workflow YAML itself (the release-critical
+  attack surface): template-injection, excessive-permissions, unpinned actions,
+  dangerous triggers.
+- **Trojan-Source / Unicode guard** — rejects bidirectional and invisible
+  control characters (CVE-2021-42574) that make source render differently from
+  how it executes.
+- **Fuzzing** (SharpFuzz, weekly) — coverage-guided fuzzing of the SAML response
+  and OIDC discovery/id-token parse surface.
+- **Adversarial multi-lens review** — the mandatory more-eyes gate on the
+  sensitive surface: bypass, availability, correctness, and integration lenses
+  plus the audit-integrity and authz domain lenses, each reading the full
+  touched files and their callers and citing the relevant ASVS chapters.
+
+### Style / maintainability
+
+A generic reviewer flags naming, duplication, dead code, and complexity.
+
+- **StyleCop + Roslynator + Meziantou** — style and maintainability rules,
+  migrated 1:1 from the legacy ruleset into `.editorconfig`, gated by
+  `--warnaserror`.
+- **Prettier** (required) — formats and checks `.js` / `.html` / `.md` / `.css`.
+- **Fitness functions as design conformance** — helper types must be internal
+  and sealed, everything lives under one root namespace, flow logic lives in the
+  extracted services, not the controller. These pin the design-consistency an
+  automated reviewer would otherwise nag about.
+- **PR quality checklist** — the template requires "no duplicated logic",
+  "no more code than the problem requires", and self-documenting code, answered
+  honestly per PR.
+
+### Dependency
+
+A generic reviewer flags vulnerable or outdated dependencies.
+
+- **dependency-review-action** (required, `fail-on-severity: low`) — blocks a PR
+  that introduces or upgrades to a known-vulnerable dependency.
+- **Transitive vulnerable scan** — `dotnet list package --vulnerable
+--include-transitive` fails the build on any known-vulnerable dependency.
+- **Dependabot** — watches both ecosystems (NuGet and github-actions).
+- **Locked-mode restore** — committed `packages.lock.json` files with
+  `RestoreLockedMode` in CI fail the restore on any drift or tampering.
+- **SHA-pinned actions + Scorecard** — every workflow `uses:` is pinned to a
+  full commit SHA; the weekly Scorecard scan audits Pinned-Dependencies,
+  Token-Permissions, and Dangerous-Workflow posture.
+
+This class is covered more strongly than a generic reviewer could manage.
+
+### Secret
+
+A generic reviewer flags credentials committed to the diff.
+
+- **Secret scanning with push protection** — a leaked identity-provider client
+  secret or CI token is blocked before the push lands, not merely commented on
+  after the fact. This is a hard gate, stronger than a reviewer's best-effort
+  spotting.
+- **Config secret redaction** — secrets are wrapped and redacted on config
+  export (`SecretEnvelope`, exercised by `ConfigSecretProtectionTests`).
+
+## Residual gap and disposition
+
+**The one class no current control fully reconstitutes:** an _independent_,
+per-line, whole-diff second reader on **every** pull request — including the
+low-risk, non-login, non-security diffs (routine refactors, tooling, docs) — that
+flags local logic slips, off-by-ones, and readability issues the static tools
+and the scoped test/fitness/fuzz suites do not specifically target.
+
+Why the existing controls narrow but do not close it:
+
+- The compiler, analyzers, CodeQL, Opengrep, and the test/fitness suites catch
+  the **mechanically detectable** subset on every PR, on every surface. They do
+  not reason about intent on an arbitrary diff.
+- The **adversarial multi-lens review** is deeper than any generic reviewer, but
+  it is mandatory only on the login / crypto / config / pipeline surface, and it
+  is run by the same solo maintainer (with AI assistance), so on a routine
+  low-risk PR it is not a genuinely _independent second party_.
+- Mutation testing and fuzzing are **weekly and non-gating**, scoped to the
+  SAML/OIDC core — so a test-quality regression or a parser crash on a non-core
+  surface is caught on the next weekly run, not at PR time.
+
+**Disposition: accepted residual risk, mitigated not eliminated.** This is a
+single-maintainer project by governance — no second human reviewer exists by
+design, and re-adding an external automated reviewer is explicitly out of scope
+(the merge gate is internal-only). The risk is bounded because:
+
+1. The **highest-risk surface** (the login path and the release pipeline) does
+   receive the mandatory adversarial review, so the residual is confined to
+   lower-risk diffs.
+2. The **mechanically detectable** subset is caught on every PR regardless of
+   surface by the compiler, analyzers, CodeQL, Opengrep, and the fitness/test
+   suites.
+3. Every code PR still gets **at least two independent refute-by-default review
+   passes**, which — while not an external party — is a deliberate more-eyes
+   process rather than a single unreviewed read.
+4. `CONTRIBUTING.md` places the second-reader duty on the author explicitly:
+   "understand and own every line you propose", backed by the PR quality
+   checklist.
+
+A staged, self-hosted fallback reviewer was scoped for this program but is
+deliberately **not adopted**, to keep the gate free of an external service
+dependency; if the residual is ever judged too wide, that is the lever to pull.
+The direction — an author-independent review perspective on every diff — is the
+standing goal; this document records how far the internal gate currently closes
+it.
+
+## Pointers
+
+- `SECURITY.md` — the repository security controls, condensed, and the private
+  vulnerability-reporting path.
+- `CONTRIBUTING.md` — the build/test commands and the branch → PR flow.
+- `.github/workflows/` — the CI workflows named above.
+- `tools/opengrep/rules.yml` — the greppable security invariants.
+- `SSO-Auth.Tests/ArchitectureConformanceTests.cs` — the fitness functions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,3 +51,5 @@ replace the manifest MD5.
 - **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.
 - **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
+
+For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [REVIEW-GATE.md](REVIEW-GATE.md).


### PR DESCRIPTION
Closes #101 (P5b). After the external automated PR reviewer (Copilot, then CodeRabbit) was removed for the internal-only gate policy, this records how the current controls close the coverage gap. Verified empirically, the issue's original plan (.coderabbit.yaml, SonarCloud) is obsolete and absent from the tree; the doc describes only controls that exist today.

`REVIEW-GATE.md` (new, root) maps each issue class → in-repo control: correctness (warnaserror + analyzers + xUnit + FsCheck + conformance tests + CodeQL + Stryker + correctness-lens), security (CodeQL security-extended + opengrep + fitness functions + zizmor + unicode-guard + SharpFuzz + adversarial multi-lens), style, dependency (dependency-review + vulnerable scan + Dependabot + SHA-pins + Scorecard), secret (scanning + push protection). Cross-referenced from SECURITY.md + CONTRIBUTING.md.

**Residual (honest):** an independent per-line second reader on EVERY PR (incl. low-risk diffs). Disposition: accepted, bounded, highest-risk surface gets the mandatory adversarial review, the mechanical subset is caught on every PR, external reviewer re-add is out of scope by governance; a staged self-hosted fallback remains the documented lever.

## Type of change
- [x] Documentation

Closes #101