### PR TITLE
Consolidate the milestone branches (P4/P5/P5b/P6 work) onto main

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -104,6 +104,15 @@ jobs:
   # targeted ABI and produces the manifest) on every PR, not only at release time.
   package:
     name: Package (JPRM)
+    # build.yml is a reusable workflow whose build job declares id-token/attestations: write for its
+    # release-only SLSA attest step (#147). A caller must grant every permission the callee declares, or
+    # the reusable-workflow call fails to start ("workflow file issue"). This CI caller leaves `attest`
+    # at its default (false), so the attest step never runs and no token or attestation is minted — the
+    # grant only satisfies the reusable-workflow permission check.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build.yml
     with:
       dotnet-version: "9.0.x"

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -1,0 +1,128 @@
+name: Publish JF12 Stable
+
+# The Jellyfin 12.0 (.NET 10) STABLE channel — the 5.0 line's GA publish leg (#607). Counterpart to
+# publish.yml (JF10.11 stable, X.Y.Z-stable) and publish-jf12-beta.yml (JF12 beta). Triggered ONLY by a
+# maintainer pushing an X.Y.Z-JF12-stable tag (e.g. 5.0.0-JF12-stable): publish.yml's
+# [0-9]+.[0-9]+.[0-9]+-stable glob deliberately does NOT match -JF12-stable, so the two stable legs never
+# cross-fire. Like the JF11 stable tag, this tag is MAINTAINER-GATED (guard-git.ps1) and pushed by hand.
+#
+# DORMANT until Jellyfin 12.0 reaches GA: no X.Y.Z-JF12-stable tag is pushed until a real 12.0 stable
+# server exists, so this workflow does not run before then — but the pipeline is ready so the 5.0 line can
+# cut a stable release the day 12.0 ships. Until GA, JF12 users are served by the beta channel (#605).
+#
+# The JF12 build METADATA (version 5.0.0, targetAbi 12.0.0.0, framework net10.0, the net10 shipping
+# closure) lives in build-jf12.yaml, copied over build.yaml before JPRM builds — the same swap as
+# publish-jf12-beta.yml; the committed build.yaml stays the JF10.11 metadata. The full release
+# (prerelease: false, one shot like publish.yml) regenerates the SHARED manifest-release
+# (ignorePrereleases: true) — the same stable pages branch publish.yml writes. Each release ships its own
+# build.yaml, so Jellyfin filters client-side by targetAbi: a 12.0 server installs the 5.0 build, a 10.11
+# server the 4.x build, from one stable manifest — no separate JF12 stable manifest is needed.
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+-JF12-stable"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job below opts into write access explicitly.
+permissions: {}
+
+# Serialize manifest-release regenerations so two stable publishes never race the pages branch (the same
+# reader-vs-pusher TOCTOU #135 fixed for manifest-beta). cancel-in-progress is false: a publish holding
+# contents:write must never be killed mid-run. NOTE: publish.yml (JF10.11 stable) predates this pattern
+# and does not yet share this group, so today this only serializes JF12-stable runs against each other;
+# a follow-up should add the same group name to publish.yml so the two stable legs are serialized against
+# each other as well.
+concurrency:
+  group: publish-manifest-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & publish JF12 stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Creates the GitHub release and updates the manifest branch, so it opts into write access.
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      with:
+        persist-credentials: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      with:
+        # Both SDKs: the multi-target restore/build needs net9.0, the JF12 package is net10.0.
+        # No NuGet cache: this job publishes with contents:write, so a poisoned cache could reach the
+        # artifact; the --locked-mode restore re-downloads against the committed lockfile.
+        dotnet-version: |
+          9.0.x
+          10.0.x
+    - name: Restore dependencies
+      run: dotnet restore --locked-mode
+    - name: Build Dotnet
+      run: dotnet build --no-restore --warnaserror
+    - name: Use the JF12 build metadata
+      # JPRM reads build.yaml; swap in the JF12 metadata (version 5.0.0, targetAbi 12.0.0.0, framework
+      # net10.0, net10 artifacts) for this build only. The committed build.yaml is untouched in the repo —
+      # this only rewrites the runner's checkout.
+      run: cp build-jf12.yaml build.yaml
+    - name: "JPRM: Build"
+      # No explicit version input: JPRM reads the version from build.yaml (now the JF12 metadata, 5.0.0),
+      # exactly as build.yml does for the JF10.11 stable path. The stable plugin version IS build-jf12.yaml's
+      # committed version and must equal the pushed tag's numeric prefix (5.0.0 <-> 5.0.0-JF12-stable);
+      # bump build-jf12.yaml per change class before tagging.
+      uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
+      with:
+        verbosity: debug
+        path: .
+        dotnet-target: "net10.0"
+        output: _dist
+    - name: Prepare GitHub Release assets
+      run: |-
+        pushd _dist
+        for file in ./*.zip; do
+          md5sum ${file#./} >> ${file%.*}.md5
+          sha256sum ${file#./} >> ${file%.*}.sha256
+        done
+        ls -l
+        popd
+    - name: Publish output artifacts
+      id: publish-assets
+      # Full stable release in ONE shot (prerelease: false), matching publish.yml — no draft flow. The
+      # git TAG is the pushed X.Y.Z-JF12-stable; the release NAME is that same tag. build.yaml (the JF12
+      # metadata) ships as an asset so the SHARED manifest-release picks up THIS release's targetAbi
+      # (12.0.0.0); without it the manifest would fall back to the repo's JF10.11 build.yaml and mislabel
+      # the 5.0 build. fail_on_unmatched_files stays true so a missing build asset fails the run rather
+      # than publishing an empty release.
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      with:
+          name: ${{ github.ref_name }}
+          prerelease: false
+          # Always auto-generate the release notes from the merged PRs/commits since the previous tag.
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          tag_name: ${{ github.ref_name }}
+          # Anchor the tag AND the auto-generated notes to the built commit (#627). Without this the
+          # create-release API defaults target_commitish to the repository DEFAULT branch, which tags the
+          # wrong commit and makes generate_release_notes diff the wrong range. github.sha is the commit
+          # the pushed X.Y.Z-JF12-stable tag points at.
+          target_commitish: ${{ github.sha }}
+          files: |
+            _dist/*
+            build.yaml
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish Plugin Manifest
+      # ignorePrereleases: true — the STABLE channel. Regenerates the SHARED manifest-release from all
+      # full (non-prerelease) releases: both this JF12 build (5.0.0, targetAbi 12.0.0.0) and the JF10.11
+      # stable releases from publish.yml (4.x, targetAbi 10.11.0.0). Each release ships its own build.yaml,
+      # so every version lands in the manifest with its correct targetAbi and a Jellyfin server installs
+      # only the build matching its generation.
+      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      with:
+        ignorePrereleases: true
+        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        repository: ${{ github.repository }}
+        pagesBranch: manifest-release
+        pagesFile: manifest.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ CI restores in a separate step, so its build/test use `--no-restore`/`--no-build
 
 **Branching and pull requests.** `main` is the released line and is PR-only. Branch every change — even a one-liner — off `main` for fixes and security work, or off the feature branch for features, using a short kebab-case name with a `fix/`, `harden/`, `feature/`, `chore/`, or `refactor/` prefix. Reference the issue your change addresses (`Closes #N`) and fill in the [pull request template](.github/pull_request_template.md).
 
-This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why.
+This is a security-sensitive login path: before opening a pull request, understand and own every line you propose, and be ready to explain what it does and why. The merge gate is internal-only (CI, the adversarial review, and the maintainer); [REVIEW-GATE.md](REVIEW-GATE.md) maps how those controls cover each class of issue an automated PR reviewer would catch.
 
 ### Improving The Documentation
 

--- a/DORA-METRICS.md
+++ b/DORA-METRICS.md
@@ -1,0 +1,127 @@
+# DORA delivery metrics
+
+How this repository measures delivery performance, and the honest limits of
+those measurements. The four DORA keys — deployment frequency, lead time for
+changes, change-failure rate (CFR), mean time to restore (MTTR) — are derived
+from data this project already produces: `X.Y.Z-stable` release tags, git commit
+history, and the `bug`-labelled issue timeline. No external analytics service is
+involved (the merge gate is internal-only).
+
+`scripts/dora-metrics.sh` computes every number below. It is **read-only** (local
+git objects plus optional read-only `gh` queries) and **deterministic** (same
+repo state → same report). It writes nothing to git or GitHub.
+
+```sh
+scripts/dora-metrics.sh
+```
+
+`gh` is optional: with it authenticated, the report adds the closed-`bug`-issue
+corpus as a corroborating change-failure signal; without it, the four keys are
+still computed from git alone.
+
+## Why the definitions are adapted
+
+The canonical DORA definitions assume a continuously deployed service with an
+incident tracker and production telemetry. This is a **self-hosted, single-binary
+Jellyfin plugin** with **solo governance**: "production" is a released `.dll` a
+server admin installs, there is no central runtime we observe, and there is no
+separate incident system. Each key is therefore operationalised against the
+delivery artifacts that actually exist here. Where that makes a metric an
+approximation, it is stated — measured, never assumed.
+
+## The delivery model this measures
+
+- **A deployment = one `X.Y.Z-stable` release tag.** Pre-production tags
+  (`*-beta`, `*-JF12-beta`, `nightly`, `v*`) are excluded — they are not shipped
+  to the stable channel.
+- **A change = a non-merge commit** that first ships in a given stable release,
+  i.e. a commit in the range `(previous-stable .. this-stable]`.
+- **A failure = a release that needed a same-line patch remediation.** Because
+  there is no runtime incident feed, the observable proxy for "this deployment
+  caused a problem" is: the next stable release on the same `X.Y` line is a
+  patch (`Z`) bump — a hotfix. This is the standard DORA CFR proxy and it is
+  auto-derivable from tag topology, so CFR stays measured, not assumed.
+
+## The four keys
+
+### 1. Deployment frequency
+
+Count of `*-stable` tags, with the calendar span between the first and last, and
+a per-week / per-month rate.
+
+- **Limitation:** the rate needs a span of at least a day to be meaningful; while
+  all stable releases sit within one day the script reports the count and marks
+  the rate `n/a` rather than printing a misleading extrapolated figure.
+
+### 2. Lead time for changes
+
+For every stable release that has a predecessor stable release, each non-merge
+commit in `(predecessor .. release]` contributes `release_date −
+commit_author_date`. Reported as median, p90, min, and max across all such
+commits.
+
+- **Limitation — earliest tag skipped:** the oldest stable tag has no predecessor
+  stable tag, so its interval would reach back to the repository root and swamp
+  the distribution. That interval is excluded; lead time is computed only over
+  intervals bounded by two stable tags.
+- **Limitation — author date:** commit author date can precede the real "work
+  started" moment (rebases, cherry-picks). It is the most faithful signal
+  available from git without heavier PR archaeology.
+
+### 3. Change-failure rate (CFR)
+
+`failures / judgeable releases`, where a release is a **failure** if its immediate
+same-line successor is a patch bump (a hotfix), and **judgeable** means every
+release except the newest (nothing follows the newest yet, so it cannot be
+judged — it is excluded from the denominator, not scored as a pass).
+
+Corroborating signals printed alongside, which do **not** change the primary
+count: the number of explicit `Revert` commits across the stable window, and
+(with `gh`) the count of closed `bug`-labelled issues.
+
+- **Limitation — small denominator:** with only a handful of releases, one hotfix
+  swings CFR by tens of percent. Read the trend across many releases, not a
+  single value.
+- **Limitation — topology, not causation:** a patch bump is assumed to be a
+  remediation. A deliberately-planned patch would be miscounted as a failure. The
+  script prints the time gap so a reader can tell a rushed hotfix (minutes) from
+  a long-planned patch (weeks); the `HOTFIX_WINDOW_DAYS` annotation flags the
+  fast ones.
+
+### 4. Mean time to restore (MTTR)
+
+For each failure→hotfix pair, `hotfix_date − failed_release_date`; reported as
+mean and median across pairs.
+
+- **Limitation — upper bound:** this measures release-to-release recovery. The
+  defect is usually discovered some time _after_ the release, so this overstates
+  user-facing time-to-restore. It is a consistent, conservative proxy.
+
+## Supplementary AI-risk / delivery-stability indicators
+
+Most changes here are agent-authored under solo governance. DORA's 2025/26
+guidance flags **instability of agent-authored change** as the leading delivery
+risk, so the report tracks three leading indicators beyond the four keys. The
+first two are git-derived; the third is tracked by hand.
+
+| Indicator                  | Definition                                                                         | Source                    | Cadence                    |
+| -------------------------- | ---------------------------------------------------------------------------------- | ------------------------- | -------------------------- |
+| **Revert rate**            | `Revert` commits ÷ non-merge commits across the stable window                      | git (auto)                | Per release                |
+| **Rework signal**          | count of `fixup`/`amend`/`re-fix`/`follow-up` commit subjects in the stable window | git (auto, heuristic)     | Per release                |
+| **Review-finding density** | real `/security-review` findings (FIX or reasoned DECLINE) per merged PR           | `/security-review` output | Per PR; reviewed per phase |
+
+- **Rework signal is a heuristic:** it matches commit-subject prefixes, so it
+  under-counts silent reworks and is only a directional smell, not an exact
+  rework rate.
+- **Review-finding density is not auto-derivable:** it needs the adversarial-review
+  lens output, which lives in the review record, not in git. It is recorded
+  manually per PR and reviewed once per delivery phase. Rising density on
+  agent-authored diffs is the signal to tighten the gate.
+
+## Stated cadence
+
+Run `scripts/dora-metrics.sh` **at each stable release** and record the four keys
+plus the two git-derived indicators. Review-finding density is logged **per PR**
+and read **per delivery phase**. The stability gates (green CI, the adversarial
+`/security-review`, maintainer sign-off) remain the firm merge bar; these metrics
+observe delivery, they do not relax the gate.

--- a/REVIEW-GATE.md
+++ b/REVIEW-GATE.md
@@ -1,0 +1,195 @@
+# The review gate
+
+This repository once ran an external automated PR reviewer (GitHub Copilot's
+review, and briefly CodeRabbit) that left a comment on every diff. Both were
+uninstalled on 2026-07-16: the merge gate is deliberately **internal-only** — no
+external review, quality, or analysis service is trusted with this repository's
+code. Removing that reviewer left a **review-coverage gap** — the loss of an
+independent, whole-diff second perspective on every pull request.
+
+This document records, class by class, what a generic automated PR reviewer
+would have flagged and which concrete in-repo control now covers it, then names
+the one genuine residual and its disposition. It describes only controls that
+exist today; it invents nothing. When a control changes, update this file.
+
+A generic automated reviewer's findings fall into five classes: **correctness**,
+**security**, **style / maintainability**, **dependency**, and **secret**. Each
+is treated below.
+
+## What runs, and when
+
+- **Every pull request** (branch build): `dotnet build --warnaserror` + `dotnet
+test`, Prettier, CodeQL (security-extended), Opengrep repo-invariant rules,
+  zizmor workflow audit, the Trojan-Source/Unicode guard, dependency-review, and
+  the transitive vulnerable-dependency scan. `build`, `prettier`, and
+  `dependency-review` are required status checks on the protected branch (see
+  the comment in each workflow); CodeQL is intentionally a non-required check.
+- **On a weekly schedule** (not per-PR, non-gating by construction): Stryker.NET
+  mutation testing (scoped to the SAML/OIDC core), SharpFuzz fuzzing (SAML/OIDC
+  parse surface), OpenSSF Scorecard, and the CodeQL baseline re-scan.
+- **Process, per pull request**: at least two independent refute-by-default
+  review passes on every code PR, escalating to the full four-lens adversarial
+  review (plus the audit-integrity and authz domain lenses) on any change to the
+  login path, SAML/OIDC crypto, config persistence, or the release pipeline.
+
+## Coverage mapping
+
+### Correctness
+
+A generic reviewer flags logic slips, null dereferences, races, wrong control
+flow, and missed edge cases.
+
+- **Compiler as reviewer** — `TreatWarningsAsErrors` (Directory.Build.props) and
+  `dotnet build --warnaserror` in CI turn nullable-reference, unreachable-code,
+  and unused-symbol warnings into build failures.
+- **Roslyn analyzers** — AnalysisMode Recommended plus Roslynator and Meziantou,
+  with `CodeAnalysisTreatWarningsAsErrors`, fail the build on the analyzers'
+  reliability/correctness rules; the `.editorconfig` pins per-rule severities.
+- **Test suite** (`SSO-Auth.Tests`, required) — unit and endpoint tests with a
+  negative test for every fail-closed branch.
+- **Property-based tests** (`PropertyTests`, FsCheck) — invariants over the pure
+  login-decision helpers that must hold for all inputs, not just picked cases.
+- **Architecture-conformance fitness functions** (`ArchitectureConformanceTests`)
+  — structural invariants that close specific correctness/race classes:
+  torn-read-free immutable authorize/outcome variants (#341, #251), the
+  TOCTOU revocation re-check immediately before the mint (#232), and the
+  once-per-interval throttle discipline on the login-path caches.
+- **CodeQL** (security-extended) also catches correctness-adjacent faults
+  (null-deref, resource leaks, dead code).
+- **Mutation testing** (Stryker, weekly) surfaces correctness cases the tests
+  would miss, as a concrete test-writing prompt.
+- **Adversarial review** — the `correctness-lens` reads the full touched files
+  on login-path changes.
+
+### Security
+
+A generic reviewer flags injection, weak crypto, authz bypass, SSRF, and unsafe
+patterns.
+
+- **CodeQL security-extended** — ~135 taint/dataflow queries across `csharp`,
+  `javascript-typescript`, and `actions`, on every PR (and the release branches).
+- **Security analyzers at error** — `AnalysisModeSecurity=All` plus
+  `dotnet_analyzer_diagnostic.category-Security.severity = error`, so every
+  Security-category rule fails the build (e.g. CA5369, already caught and fixed).
+- **Opengrep repo-invariant rules** (`tools/opengrep/rules.yml`) — greppable,
+  language-parser-independent invariants: CSPRNG-only randomness, no
+  `Problem()`/`ProblemDetails` leak from the controllers, all config access
+  through the `ProviderConfigStore` facade, no raw outbound `HttpClient`, and no
+  `gh release` mutation in the pipeline. One rule per invariant, added per
+  regression.
+- **Fitness functions as un-forgeable-authz analogues** — `VerifiedIdentity`'s
+  private constructor with named validation factories (#473), the immutable
+  in-flight authorize/outcome sums, and the "controller holds no mutable static
+  state / touches no raw socket-DNS / no provider link map" boundary scans make
+  whole classes of login-path misuse a failing test rather than a review catch.
+- **zizmor** — static analysis of the workflow YAML itself (the release-critical
+  attack surface): template-injection, excessive-permissions, unpinned actions,
+  dangerous triggers.
+- **Trojan-Source / Unicode guard** — rejects bidirectional and invisible
+  control characters (CVE-2021-42574) that make source render differently from
+  how it executes.
+- **Fuzzing** (SharpFuzz, weekly) — coverage-guided fuzzing of the SAML response
+  and OIDC discovery/id-token parse surface.
+- **Adversarial multi-lens review** — the mandatory more-eyes gate on the
+  sensitive surface: bypass, availability, correctness, and integration lenses
+  plus the audit-integrity and authz domain lenses, each reading the full
+  touched files and their callers and citing the relevant ASVS chapters.
+
+### Style / maintainability
+
+A generic reviewer flags naming, duplication, dead code, and complexity.
+
+- **StyleCop + Roslynator + Meziantou** — style and maintainability rules,
+  migrated 1:1 from the legacy ruleset into `.editorconfig`, gated by
+  `--warnaserror`.
+- **Prettier** (required) — formats and checks `.js` / `.html` / `.md` / `.css`.
+- **Fitness functions as design conformance** — helper types must be internal
+  and sealed, everything lives under one root namespace, flow logic lives in the
+  extracted services, not the controller. These pin the design-consistency an
+  automated reviewer would otherwise nag about.
+- **PR quality checklist** — the template requires "no duplicated logic",
+  "no more code than the problem requires", and self-documenting code, answered
+  honestly per PR.
+
+### Dependency
+
+A generic reviewer flags vulnerable or outdated dependencies.
+
+- **dependency-review-action** (required, `fail-on-severity: low`) — blocks a PR
+  that introduces or upgrades to a known-vulnerable dependency.
+- **Transitive vulnerable scan** — `dotnet list package --vulnerable
+--include-transitive` fails the build on any known-vulnerable dependency.
+- **Dependabot** — watches both ecosystems (NuGet and github-actions).
+- **Locked-mode restore** — committed `packages.lock.json` files with
+  `RestoreLockedMode` in CI fail the restore on any drift or tampering.
+- **SHA-pinned actions + Scorecard** — every workflow `uses:` is pinned to a
+  full commit SHA; the weekly Scorecard scan audits Pinned-Dependencies,
+  Token-Permissions, and Dangerous-Workflow posture.
+
+This class is covered more strongly than a generic reviewer could manage.
+
+### Secret
+
+A generic reviewer flags credentials committed to the diff.
+
+- **Secret scanning with push protection** — a leaked identity-provider client
+  secret or CI token is blocked before the push lands, not merely commented on
+  after the fact. This is a hard gate, stronger than a reviewer's best-effort
+  spotting.
+- **Config secret redaction** — secrets are wrapped and redacted on config
+  export (`SecretEnvelope`, exercised by `ConfigSecretProtectionTests`).
+
+## Residual gap and disposition
+
+**The one class no current control fully reconstitutes:** an _independent_,
+per-line, whole-diff second reader on **every** pull request — including the
+low-risk, non-login, non-security diffs (routine refactors, tooling, docs) — that
+flags local logic slips, off-by-ones, and readability issues the static tools
+and the scoped test/fitness/fuzz suites do not specifically target.
+
+Why the existing controls narrow but do not close it:
+
+- The compiler, analyzers, CodeQL, Opengrep, and the test/fitness suites catch
+  the **mechanically detectable** subset on every PR, on every surface. They do
+  not reason about intent on an arbitrary diff.
+- The **adversarial multi-lens review** is deeper than any generic reviewer, but
+  it is mandatory only on the login / crypto / config / pipeline surface, and it
+  is run by the same solo maintainer (with AI assistance), so on a routine
+  low-risk PR it is not a genuinely _independent second party_.
+- Mutation testing and fuzzing are **weekly and non-gating**, scoped to the
+  SAML/OIDC core — so a test-quality regression or a parser crash on a non-core
+  surface is caught on the next weekly run, not at PR time.
+
+**Disposition: accepted residual risk, mitigated not eliminated.** This is a
+single-maintainer project by governance — no second human reviewer exists by
+design, and re-adding an external automated reviewer is explicitly out of scope
+(the merge gate is internal-only). The risk is bounded because:
+
+1. The **highest-risk surface** (the login path and the release pipeline) does
+   receive the mandatory adversarial review, so the residual is confined to
+   lower-risk diffs.
+2. The **mechanically detectable** subset is caught on every PR regardless of
+   surface by the compiler, analyzers, CodeQL, Opengrep, and the fitness/test
+   suites.
+3. Every code PR still gets **at least two independent refute-by-default review
+   passes**, which — while not an external party — is a deliberate more-eyes
+   process rather than a single unreviewed read.
+4. `CONTRIBUTING.md` places the second-reader duty on the author explicitly:
+   "understand and own every line you propose", backed by the PR quality
+   checklist.
+
+A staged, self-hosted fallback reviewer was scoped for this program but is
+deliberately **not adopted**, to keep the gate free of an external service
+dependency; if the residual is ever judged too wide, that is the lever to pull.
+The direction — an author-independent review perspective on every diff — is the
+standing goal; this document records how far the internal gate currently closes
+it.
+
+## Pointers
+
+- `SECURITY.md` — the repository security controls, condensed, and the private
+  vulnerability-reporting path.
+- `CONTRIBUTING.md` — the build/test commands and the branch → PR flow.
+- `.github/workflows/` — the CI workflows named above.
+- `tools/opengrep/rules.yml` — the greppable security invariants.
+- `SSO-Auth.Tests/ArchitectureConformanceTests.cs` — the fitness functions.

--- a/ROLLBACK.md
+++ b/ROLLBACK.md
@@ -1,0 +1,235 @@
+# Release rollback (plugin downgrade) runbook
+
+For an authentication plugin a bad stable release is a **mass-lockout event**:
+every OpenID and SAML login can go down at once (this is exactly what 4.1.0.0 →
+4.1.1.0 fixed — 4.1.0.0 failed to load on Jellyfin 10.11 and the server disabled
+it at startup, taking down every login). Rollback is therefore the last-line
+**availability** control, and DORA's 2025/26 research names small batches plus a
+practised rollback path as the moderating capabilities for release instability.
+
+This document is the operator's rollback procedure, the per-version
+downgrade-safety notes drawn from the actual [CHANGELOG](CHANGELOG.md)
+format-change history, a pre-downgrade check, an operator drill, and the
+maintainer procedure to pull a bad release from the published manifest.
+
+Rollback is only ever needed for a **stable** channel release. Beta channels
+(`X.Y.Z-beta.*`, `manifest-beta`) are opt-in and are not covered here.
+
+---
+
+## 1. How Jellyfin installs and downgrades this plugin
+
+Jellyfin installs plugins from a **manifest** (`manifest.json`) served on the
+`manifest-release` branch and published by the release pipeline
+([`.github/workflows/publish.yml`](.github/workflows/publish.yml), via the
+`Kevinjil/jellyfin-plugin-repo-action`). Each manifest entry lists every
+published version with its `version`, `sourceUrl` (the release zip),
+`checksum`, and `targetAbi`.
+
+Key facts that make rollback possible:
+
+- **The manifest retains previous versions.** The publish action _appends_ the
+  new version to the existing manifest; it does not replace the list. As of this
+  writing the published `manifest-release/manifest.json` retains
+  `4.2.1`, `4.2.0`, `4.1.1`, and `4.1.0.0` (the manifest was introduced at
+  4.1.0.0; releases older than that live only as GitHub release assets, not in
+  the manifest). An operator can therefore select an **older version** from the
+  Jellyfin catalog and downgrade without leaving the dashboard.
+- **Higher version wins for "update", but install is explicit.** Jellyfin's
+  catalog offers the highest compatible version as the update. A downgrade is a
+  deliberate act: uninstall the current version and install the specific older
+  version, or install the older version's zip by hand.
+- **`targetAbi` gates visibility.** A version only appears installable on a
+  server whose ABI is >= the entry's `targetAbi` (currently `10.11.0.0`). A
+  downgrade target must itself satisfy the running server's ABI.
+
+There are two operator rollback mechanisms, in order of preference:
+
+1. **Catalog downgrade** — in the Jellyfin dashboard, uninstall the current SSO
+   plugin, then install the prior version from the plugin catalog (the manifest
+   still lists it). Restart Jellyfin.
+2. **Manual zip install** — download the prior version's
+   `sso-authentication_X.Y.Z.0.zip` from its GitHub release (the `sourceUrl` in
+   the manifest, or the Releases page), verify its `.sha256`, and drop it into
+   the plugin data folder as Jellyfin expects. Use this if the manifest itself
+   is the problem, or if the target version predates the manifest.
+
+---
+
+## 2. What actually breaks on downgrade
+
+Two on-disk surfaces determine whether an older build can run on data a newer
+build has already written:
+
+### 2a. `PluginConfiguration` (the config XML)
+
+The config is XML-serialized from
+[`SSO-Auth/Config/PluginConfiguration.cs`](SSO-Auth/Config/PluginConfiguration.cs)
+via Jellyfin's `BasePluginConfiguration`. **There is no schema-version field.**
+Compatibility rests on XmlSerializer's tolerance:
+
+- **Adding a field is downgrade-safe.** An older build simply ignores config
+  elements it does not know (e.g. the `EnableRateLimit` /
+  `RateLimitMaxAttempts` / `RateLimitWindowSeconds` fields added in 4.1.0.0 are
+  silently dropped by a pre-4.1.0.0 build; missing fields fall back to their
+  constructor defaults).
+- **The break is not the XML shape — it is the secret _values_ inside it.** See
+  2b. A config written by a newer build parses structurally under an older build;
+  the failure is that the older build cannot _decrypt_ the secret strings.
+
+So for this plugin, "config N-1 load compatibility" holds at the serialization
+layer across every adjacent version to date. The one real cross-version hazard
+is the secret-at-rest format boundary.
+
+### 2b. The secret-at-rest format (the downgrade boundary)
+
+The provider secrets — the OpenID client secret (`OidSecret`) and the SAML
+signing keys (`SamlSigningKeyPfx`, `SamlRolloverSigningKeyPfx`) — are, since
+**4.1.0.0 (#158)**, stored as an **AES-256-GCM `ssoenc:v1:` envelope** rather
+than plaintext (see
+[`SSO-Auth/Api/SecretEnvelope.cs`](SSO-Auth/Api/SecretEnvelope.cs) and
+[Secrets encrypted at rest and downgrade](providers.md#secrets-encrypted-at-rest-and-downgrade)).
+
+- **Upgrade is transparent / forward-compatible.** A plaintext config is read
+  as-is and each secret is re-wrapped as an envelope on the next save. No action
+  on the way up.
+- **Downgrade across this boundary is breaking.** A build _without_ #158 cannot
+  read `ssoenc:` values. After downgrading below 4.1.0.0, the affected
+  OpenID/SAML providers behave as if their secret were **unset** — logins fail
+  closed. The `ssoenc:v1:` envelope is a versioned, self-describing format, so
+  the format can evolve; any future bump of that version prefix is a new
+  downgrade boundary of the same kind.
+- **The data-encryption key is a separate file.** `sso-secret.key` lives in the
+  plugin data folder, separate from the config XML (owner-only `0600` on Linux).
+  Older versions ignore it; it can be left in place. Never delete it while any
+  `ssoenc:` value exists — without it, every encrypted secret is permanently
+  unrecoverable.
+
+**The crossing rule:** downgrading **from >= 4.1.0.0 to < 4.1.0.0** crosses the
+secret-format boundary and requires re-entering secrets (or restoring a
+pre-upgrade plaintext config backup). Downgrading **within the 4.1.x / 4.2.x
+range** (e.g. 4.2.1 → 4.2.0 → 4.1.1 → 4.1.0.0) does **not** cross it — every
+build in that range reads `ssoenc:v1:` — so no secret re-entry is needed.
+
+---
+
+## 3. Per-version downgrade-safety notes
+
+Read this as: "if I am downgrading _away from_ version X, what do I have to
+account for?" Flags come from the CHANGELOG / `build.yaml` format-change history.
+
+| Downgrading away from          | Crosses a format/compat boundary?                                                                                                                                  | What to do before rolling back                                                                                                                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **4.2.1.0** → 4.2.0.0          | No. Bug-fix only (null-context authz deny, #626).                                                                                                                  | Nothing beyond a config backup. Secrets stay `ssoenc:v1:`.                                                                                                                                                                                   |
+| **4.2.0.0** → 4.1.x            | Behavioural, not on-disk. 4.2.0.0 removed the legacy raw-SAML-assertion `SAML/Auth` path (#528); older builds still accept it.                                     | Nothing on-disk. Any client scripted against the one-time token flow keeps working on the older build too. Config/secrets unchanged.                                                                                                         |
+| **4.1.1.0** → 4.1.0.0          | No on-disk change, but **do not**: 4.1.0.0 is the broken build that fails to load on Jellyfin 10.11 (#590).                                                        | Avoid 4.1.0.0 as a rollback target on JF 10.11 — it will disable itself at startup. Roll back to 4.1.1.0 or hold.                                                                                                                            |
+| **4.1.0.0** → 4.0.x or earlier | **Yes — breaking on-disk secret format (#158).** Older builds cannot read `ssoenc:` secrets; **also** the OpenID legacy-username link migration (#358) is one-way. | Re-enter every provider secret in plaintext (or restore a pre-4.1.0.0 config backup) **before** installing the older build. Expect linked OpenID accounts keyed on legacy usernames to need admin re-linking. Leave/remove `sso-secret.key`. |
+| **4.0.x / 3.5.x and earlier**  | Pre-manifest, pre-encryption. Historic BREAKING markers: 4.0.0.0 (JF 10.11), 3.2.0.0 (hashmap switch).                                                             | Legacy territory; secrets were plaintext. Restore the matching-era config backup; these versions are not in `manifest.json` and must be installed from their GitHub release zip.                                                             |
+
+**One-line rule of thumb:** any downgrade that ends **below 4.1.0.0** requires
+secret re-entry or a plaintext config restore. Any downgrade **at or above
+4.1.0.0** is config-safe — just avoid landing exactly on 4.1.0.0 on JF 10.11.
+
+---
+
+## 4. Pre-downgrade check (do this before you roll back)
+
+- [ ] **Back up the config.** Copy the plugin's configuration XML
+      (`.../plugins/configurations/Jellyfin.Plugin.SSO_Auth.xml` or equivalent)
+      to a safe location. This is your restore point regardless of what breaks.
+- [ ] **Back up `sso-secret.key`** from the plugin data folder alongside the
+      config. (Needed if you re-upgrade later; harmless to an older build.)
+- [ ] **Identify the target version and whether it crosses the 4.1.0.0 secret
+      boundary** (section 3). If it lands below 4.1.0.0, plan the secret
+      re-entry step now — have each provider's client secret / signing key `.pfx`
+      to hand.
+- [ ] **Confirm the target version is manifest-listed and ABI-compatible.**
+      Check it appears in `manifest-release/manifest.json` with a `targetAbi`
+      your server satisfies (`10.11.0.0`). If not, plan a manual zip install
+      from the GitHub release and verify the `.sha256`.
+- [ ] **Do NOT choose 4.1.0.0 as a rollback target on Jellyfin 10.11** (#590 —
+      it disables itself at startup).
+- [ ] **Note whether a config export exists.** A `ConfigExport` document is
+      **redacted** — it carries no secret and no `ssoenc:` envelope
+      ([providers.md](providers.md#the-export-is-redacted--secrets-never-leave-the-server)),
+      so it is **not** a secret backup. It restores structure only; secrets
+      still need re-entry. The raw config XML plus `sso-secret.key` is the real
+      backup pair.
+
+---
+
+## 5. Operator drill (rollback in practice)
+
+A short, followable sequence. Practise it on a staging instance so it is muscle
+memory before a real incident.
+
+1. **Snapshot.** Stop Jellyfin (or at least stop new logins). Copy the config
+   XML and `sso-secret.key` out (section 4).
+2. **Decide the target.** Pick the last-known-good version. Determine from
+   section 3 whether it crosses the 4.1.0.0 secret boundary.
+3. **If crossing below 4.1.0.0:** while still on the newer build, either export
+   nothing useful for secrets — instead **restore the pre-upgrade plaintext
+   config backup** after the downgrade, or be ready to re-enter each secret on
+   the older build's settings page.
+4. **Uninstall** the current SSO plugin in the dashboard.
+5. **Install the target version** — catalog (older version still listed) or the
+   verified GitHub zip.
+6. **Restore config if needed** (plaintext backup for a below-4.1.0.0 target).
+7. **Restart Jellyfin.**
+8. **Verify the plugin loaded** (dashboard shows it active, no startup-disabled
+   state — the 4.1.0.0 failure mode manifested as the server disabling the
+   plugin at startup).
+9. **Smoke-test one OpenID and one SAML login** end to end (challenge →
+   callback → session minted). A "secret unset" symptom here means you crossed
+   the secret boundary and still owe a re-entry.
+10. **Re-enable logins / restore traffic.** Record what happened and why, and
+    open/annotate the issue for the bad release.
+
+---
+
+## 6. Maintainer: pull a bad release from the manifest
+
+If a published stable is bad, the fastest containment is to stop _new_
+installs/updates from picking it up, then ship a fix-forward.
+
+- **Preferred — fix forward.** Publish a higher patch version (as 4.1.1.0
+  superseded the broken 4.1.0.0). Because higher-version-wins drives the
+  catalog's "update", a good higher version pulls the fleet forward without any
+  manifest surgery. This is the primary path.
+- **Contain by de-listing the bad version.** To stop the bad version being
+  _offered_ for fresh installs, remove **that version's entry** from the
+  `versions` array in `manifest-release/manifest.json` (a commit on the
+  `manifest-release` branch). The manifest is the install source of truth;
+  de-listing removes it from every server's catalog. Leave the other entries
+  intact so downgrade targets remain available. The GitHub **release itself
+  stays** — do not delete it: a deleted immutable release permanently burns its
+  tag (`publish.yml` header), and the zip is still the `sourceUrl` for anyone
+  doing a manual install.
+- **Never delete the release or reuse the tag.** Tags are immutable and
+  single-use; a fix ships as a new version + new `-stable` tag, never a re-cut
+  of the old one.
+- **Announce.** Note the bad version and the fixed version in `CHANGELOG.md` and
+  the release notes so operators who already installed it know to move.
+
+---
+
+## 7. E2E downgrade smoke check (wire into `/release-prep`)
+
+Before publishing a stable, confirm the rollback path still works. This mirrors
+the manual-check discipline in
+[RELEASE-QA-CHECKLIST.md](RELEASE-QA-CHECKLIST.md) (packaging/install/upgrade is
+already a manual item there — this is its downgrade twin):
+
+- [ ] **Manifest retains prior versions.** After the dry-run/publish, confirm
+      the new `manifest.json` still lists the previous stable version(s), not
+      only the new one.
+- [ ] **Downgrade smoke.** On a staging server running the release candidate
+      with a saved config (secrets encrypted as `ssoenc:v1:`), uninstall it and
+      install the previous stable from the catalog. Confirm: the older build
+      **loads** (not startup-disabled), the config parses, and a login still
+      succeeds **without** re-entering secrets — proving no unintended secret- or
+      config-format boundary was crossed within the supported range.
+- [ ] **Boundary note reviewed.** If this release changes the secret envelope
+      version, the `PluginConfiguration` shape in a non-additive way, or any
+      other on-disk format, section 3 of this document and `CHANGELOG.md` are
+      updated with the new downgrade flag before publishing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,3 +51,5 @@ replace the manifest MD5.
 - **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.
 - **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
+
+For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [REVIEW-GATE.md](REVIEW-GATE.md).

--- a/SLO-DESIGN.md
+++ b/SLO-DESIGN.md
@@ -1,0 +1,207 @@
+# Single-Logout (SLO) design constraints
+
+**Status: NOT IMPLEMENTED.** This document records the constraints and the
+intended design so a future single-logout implementation starts from a
+threat-modelled position. No logout endpoint, logout-token receiver, or
+`LogoutRequest` issuer exists in the plugin today. This is a design record only
+(issue #154); building SLO is a separate, threat-modelled work item.
+
+## What the plugin retains today (the grounding facts)
+
+SLO of any flavour needs artifacts from the login that the plugin currently
+does **not** keep. The login pipeline verifies a protocol response, projects it
+to a small protocol-agnostic identity, and discards the raw protocol material:
+
+- **OIDC — the raw `id_token` is discarded after the callback.** In
+  `SSO-Auth/Api/Flows/OidcLoginService.cs` (`CallbackAsync`), `result.IdentityToken`
+  (the raw id_token from `ProcessResponseAsync`) is read for exactly two purposes:
+  the RFC 9207 response-`iss` mix-up check
+  (`OidcResponseIssuer.IsRejected(..., result.IdentityToken, ...)`) and to derive
+  the account-link issuer (`OidcResponseIssuer.IdTokenIssuer(result.IdentityToken)`,
+  which only extracts the `iss` claim — `SSO-Auth/Api/OidcResponseIssuer.cs`). The
+  token itself is never stored. It does not survive into `AuthorizeSession`/
+  `VerifiedIdentity`.
+- **`VerifiedIdentity` (the keystone carried into session minting) has no token
+  field.** `SSO-Auth/Api/VerifiedIdentity.cs` carries only `Subject`, `Issuer`
+  (the id_token `iss` string, not the token), `Username`, `EmailVerified`, and the
+  privilege flags — no `id_token`, no `sid`, no SAML `SessionIndex`.
+- **SAML — no `SessionIndex` is captured.** The assertion parser
+  (`SSO-Auth/Saml.cs`) exposes `GetNameID()`, `GetInResponseTo()`, and `Xml`, but
+  there is **no** `GetSessionIndex()` accessor. `SamlLoginService.AuthenticateAsync`
+  keeps only `InResponseTo` (for browser-binding correlation) in the in-flight
+  `SamlLoginOutcome`; the `NameID` survives as `VerifiedIdentity.Subject`. A SAML
+  `LogoutRequest` requires **both** the `NameID` and the `SessionIndex` of the
+  session being terminated — the latter is not retained.
+- **The OIDC `end_session_endpoint` is read but never persisted.**
+  `SSO-Auth/Api/OidcDiscoveryReader.cs` maps `discovery.EndSessionEndpoint` into the
+  in-memory `ProviderInformation`, but that object lives only for the duration of a
+  single login round-trip. Nothing writes the end-session endpoint anywhere durable.
+- **The account-link store persists no per-session data.** Canonical links
+  (`SSO-Auth/Api/Linking/CanonicalLinkService.cs`) key on
+  `provider + subject (+ issuer for OIDC)` → Jellyfin user id. There is no
+  mapping from an SSO subject/session to a concrete Jellyfin session or device,
+  and no place a logout handler could look up "which Jellyfin sessions belong to
+  this SSO login."
+- **In-flight stores are transient and capped.** `OidcStateStore` and
+  `SamlOutcomeStore`/`SamlRequestCache` are process-wide, in-memory, time-bounded
+  (~15 min), and CSPRNG-keyed. They are login-correlation caches, not a session
+  ledger; they are gone on restart and are the wrong home for anything a logout
+  needs minutes-to-hours later.
+
+**Consequence:** SLO is cheap to _plan for_ now and expensive to retrofit. The
+one prerequisite worth deciding now is **what to persist per Jellyfin session at
+login time** (see the OIDC and SAML sections). Persisting it later means it is
+simply absent for every session created before the change.
+
+### Library note (affects what OIDC SLO can call)
+
+The plugin multi-targets, and the OidcClient version differs per TFM
+(`SSO-Auth/SSO-Auth.csproj`): **OidcClient 6.0.1 on `net9.0`** (Jellyfin 10.11)
+and **OidcClient 7.1.0 on `net10.0`** (Jellyfin 12.0). Any reliance on
+7.1.0's `LogoutRequest`/`EndSessionEndpoint` modelling must be conditioned on
+the target — the `net9.0` build cannot assume the 7.x logout surface. RP-initiated
+logout is a plain front-channel redirect and can be built without the library
+either way.
+
+## OIDC single-logout
+
+### Prefer back-channel logout
+
+- **Back-channel logout (OP → RP `logout_token`) is the target.** The OP POSTs a
+  signed `logout_token` (a JWT) to a plugin-hosted back-channel logout URI; the
+  plugin validates it and terminates the corresponding Jellyfin session(s)
+  server-to-server. No browser, no third-party cookies.
+- **Front-channel logout is effectively dead and is ruled out.** The
+  OpenID Front-Channel Logout model relies on the OP loading per-RP `<iframe>`s in
+  the user's browser; under third-party-cookie blocking (now default in major
+  browsers) those iframes do not carry the RP session cookie, so the notification
+  silently fails. The spec itself warns of this. Do not build front-channel iframe
+  logout.
+- **Reachability caveat for LAN-only installs.** Back-channel logout requires the
+  **OP to reach the plugin's logout URI**. Jellyfin is frequently deployed
+  LAN-only / behind NAT with no inbound path from a public OP. Back-channel is
+  therefore _best-effort_: when the OP cannot reach the RP, no `logout_token`
+  arrives and the Jellyfin session is not terminated by SLO. The design must treat
+  a missing logout notification as "SLO did not happen," never as "logout
+  succeeded" — and must not present LAN-only operators a guarantee it cannot keep.
+
+### RP-initiated logout and the `id_token_hint` retention constraint
+
+- **RP-initiated logout** (user clicks "log out", the RP redirects the browser to
+  the OP's `end_session_endpoint`) is the realistic complement to best-effort
+  back-channel, and works through the browser without third-party cookies.
+- **It wants an `id_token_hint`.** `end_session_endpoint` takes `id_token_hint` so
+  the OP can identify the session to end and skip a logout-confirmation prompt.
+  Without it many OPs either refuse or force an interactive confirmation.
+- **The plugin does not retain the id_token today** (see grounding facts). To send
+  `id_token_hint`, the plugin must **persist the raw id_token** (or, as a minimum,
+  `iss` / `sid` / `sub`, which cover session correlation and back-channel
+  `logout_token` matching but do **not** satisfy `id_token_hint`, which wants the
+  full JWT) against the Jellyfin session at login time.
+
+**Security cost of storing the id_token (must be honoured, fail-closed):**
+
+- A stored id_token is **sensitive**: it is a signed assertion of identity and
+  claims. Treat it like the client secret and signing keys already are —
+  encrypted at rest via the existing `Secrets` envelope (`#158`, the same path
+  `OidSecret`/`SamlSigningKeyPfx` use), never logged, redacted on export.
+- **Scope-minimise.** Prefer persisting only `iss` + `sid` + `sub` when the OP
+  supports back-channel logout (that is all a `logout_token` needs to match), and
+  store the full id_token _only_ when RP-initiated `id_token_hint` is actually a
+  configured requirement for that provider.
+- **Expiry.** Bind the stored token/identifiers to the Jellyfin session lifetime
+  and purge on session end; do not keep an id_token past the session it belongs to.
+  An expired id_token is still a valid `id_token_hint` for `end_session` per spec,
+  so retention is a storage-lifetime decision, not an `exp` decision — but never
+  keep it beyond the session.
+- Persist it **per Jellyfin session**, so logout can map an SSO logout signal to
+  the specific session(s) to kill (see "Jellyfin session invalidation" below).
+
+## SAML single-logout
+
+- **Back-channel (SOAP) vs front-channel (HTTP-Redirect/POST).** SAML SLO exchanges
+  a `LogoutRequest`/`LogoutResponse`. Back-channel uses SOAP directly between SP and
+  IdP (no browser, same reachability caveat as OIDC back-channel — an inbound path
+  from the IdP to the plugin is required, often absent on LAN-only installs).
+  Front-channel uses browser redirects/POST and is subject to the same
+  third-party-context erosion, though SAML front-channel is a top-level navigation
+  rather than a hidden iframe, so it degrades less severely than OIDC
+  front-channel — it is a usable fallback, not dead.
+- **`NameID` + `SessionIndex` retention.** Building a `LogoutRequest` requires the
+  `NameID` **and** the `SessionIndex` of the authenticated session. The `NameID` is
+  retained today (as `VerifiedIdentity.Subject`); the **`SessionIndex` is not
+  captured at all** — `SSO-Auth/Saml.cs` has no accessor for it and nothing stores
+  it. Capturing and persisting the `SessionIndex` (alongside `NameID`) per Jellyfin
+  session at login is the SAML prerequisite, symmetric to the OIDC id_token/sid
+  retention.
+- The IdP's `SingleLogoutService` endpoint is **not** in the config today
+  (`SamlEndpoint` is the SSO endpoint only — `SSO-Auth/Config/PluginConfiguration.cs`);
+  SLO needs a separately configured logout endpoint (and, for signed logout, reuse
+  of the existing request-signing key material).
+
+## Constraints and threats (STRIDE-style, brief)
+
+Logout messages are **security-relevant inbound requests** and must be validated
+with the same rigour as login — an unauthenticated "log this user out" endpoint
+is itself an attack surface.
+
+- **Spoofing / Tampering (forged logout messages).** An OIDC `logout_token` and a
+  SAML `LogoutRequest` must be validated _exactly like a login assertion_:
+  signature verified against the provider's keys, `iss`/issuer bound to the
+  configured provider, audience/recipient checked, and timing/`iat` bounded. Reuse
+  the existing validators' posture (`OidcIdTokenValidator`, `SamlAssertionValidator`)
+  — do not hand-roll a laxer path for logout. A `logout_token` additionally must
+  carry the `events` claim and MUST NOT carry `nonce` (per the back-channel spec);
+  reject non-conformant tokens fail-closed.
+- **Replay.** Logout messages must be one-time, mirroring the login replay caches
+  (`jti` for `logout_token`; the SAML replay cache for `LogoutRequest`). A replayed
+  logout that merely re-kills an already-dead session is low-harm, but the
+  validation path must not become a weaker oracle than login.
+- **Elevation / DoS — "logout as an unauthenticated session-kill vector."** The
+  single most important threat: a logout endpoint must never let an unauthenticated
+  or cross-user caller terminate an arbitrary user's session. A logout only
+  terminates a session when the presenter **proves control** of the SSO session
+  being ended (a validly-signed `logout_token`/`LogoutRequest` from the bound
+  provider that correlates to a stored session identifier). RP-initiated logout
+  triggered from the browser must be CSRF-protected and may only end the caller's
+  own session. Fail closed: unresolvable correlation → terminate nothing, not
+  everything.
+- **Repudiation / audit.** Every SLO-driven session termination should be audited
+  the way logins are (`SsoAudit`), so an operator can see that a session ended via
+  SLO and why.
+- **Availability / mass-logout.** A malformed or storm of logout signals must not
+  become a mass-lockout: throttle like the login rate-limit gate, and never let one
+  logout signal fan out to kill unrelated sessions. Losing the correlation store on
+  restart must degrade to "SLO no-op" (sessions simply live out their normal
+  Jellyfin lifetime), never to "kill all sessions."
+
+### Jellyfin session invalidation mapping
+
+- Jellyfin sessions are minted through `ISessionManager` in
+  `SSO-Auth/Api/SessionMinter.cs` (`AuthenticateDirect`); the plugin holds **no**
+  mapping from an SSO subject/session to the resulting Jellyfin session/device.
+- To act on a logout signal, the design needs a durable
+  **`(provider, iss/sub, sid | SessionIndex)` → Jellyfin session/device** map,
+  written at mint time. Terminating the session then means invalidating that
+  Jellyfin session/token through the server's session API — the exact mechanism
+  (and whether the plugin may revoke a session it did not itself own) is an
+  open design question to resolve against the Jellyfin session API at
+  implementation time, empirically, not by assumption.
+
+## Fail-closed and scope notes
+
+- **Fail-closed throughout.** Missing/invalid signature, unresolvable session
+  correlation, unreachable OP/IdP, or an unconfigured logout endpoint → terminate
+  **no** session and surface the condition; never default to "logged out" and never
+  fan out to unrelated sessions.
+- **Scope of retained material is minimised and encrypted at rest.** Store the
+  least that satisfies the enabled logout mode (prefer `iss`/`sid`/`sub` and SAML
+  `SessionIndex`; full id_token only when `id_token_hint` is required), always via
+  the existing at-rest `Secrets` envelope, never logged, purged on session end.
+- **Best-effort, honestly presented.** Back-channel and SOAP SLO depend on OP/IdP →
+  plugin reachability that LAN-only installs usually lack; the feature must not
+  claim a logout guarantee it cannot deliver in those topologies.
+- **Not implemented yet.** This document records constraints only. The retention
+  decision (persist `iss`/`sid`/`sub` and SAML `SessionIndex` per Jellyfin session
+  at login) is the one cheap-now / expensive-later prerequisite to settle before or
+  alongside the first SLO code.

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -1040,6 +1041,178 @@ public class ArchitectureConformanceTests
         Assert.True(
             references.Any(a => a.Name == "Microsoft.Extensions.Logging.Abstractions"),
             "SSO-Auth no longer references Microsoft.Extensions.Logging.Abstractions; the #590 ABI-floor scan would pass vacuously — re-anchor it on the host-provided framework assembly the plugin actually uses.");
+    }
+
+    [Fact]
+    public void BuildYamlArtifacts_EqualTheTfmPublishClosure()
+    {
+        // Locked in by #608, the drop-list-completeness partner of HostProvidedFrameworkAssemblies_StayOnTheHostAbi
+        // above (which guards the OVER-reference direction — a host assembly pulled above the host ABI). JPRM
+        // packages the shipped plugin zip from exactly the files named in the build yaml's `artifacts:` list, so
+        // that hand-maintained list MUST equal the plugin's NON-HOST `dotnet publish` closure for the target
+        // framework. Two failure modes it closes, previously guarded only by a comment (the #605 review finding):
+        // a shipped runtime dependency MISSING from the list is dropped from the zip and throws
+        // FileNotFoundException the moment the host loads the plugin (the #590 class of field regression); a
+        // listed-but-unpublished file makes the JPRM package step fail on a missing artifact and is dead weight.
+        //
+        // The publish closure is read from SSO-Auth's own SSO-Auth.deps.json — the runtime-assembly manifest the
+        // ORDINARY build emits, so the test needs no separate `dotnet publish` invocation. Its per-target
+        // `runtime` set is exactly the set `dotnet publish -f <tfm>` copies: the whole package/reference closure
+        // MINUS the .NET + ASP.NET Core shared framework the host supplies through the FrameworkReference (proven
+        // byte-for-byte equal to the publish output when #608 was written). Subtracting the remaining
+        // HOST-PROVIDED families Jellyfin itself ships — Jellyfin/Emby/MediaBrowser and the EF Core, Polly and
+        // Unicode/text stacks they drag in, plus Microsoft.Extensions.* and Newtonsoft.Json — leaves precisely the
+        // set that must travel in the plugin zip. Per target, mirroring the ABI-floor test's #if: net9.0 ->
+        // build.yaml (Jellyfin 10.11, 11 DLLs), net10.0 -> build-jf12.yaml (Jellyfin 12.0, 8 DLLs — where the SAML
+        // crypto assemblies are framework-provided on .NET 10 and correctly absent from both closure and list).
+#if NET10_0_OR_GREATER
+        const string targetFramework = "net10.0";
+        const string buildYaml = "build-jf12.yaml";
+#else
+        const string targetFramework = "net9.0";
+        const string buildYaml = "build.yaml";
+#endif
+#if DEBUG
+        const string configuration = "Debug";
+#else
+        const string configuration = "Release";
+#endif
+
+        // SSO-Auth is a ProjectReference of this test project, so building the test for this configuration/target
+        // builds the plugin into SSO-Auth/bin/<config>/<tfm>/ with its deps.json alongside. RepoRoot() is the
+        // same compile-time-anchored source root the source-scan rules use; the plugin build output lives under
+        // it in CI (which builds and tests the one checkout).
+        var depsPath = Path.Combine(RepoRoot(), "SSO-Auth", "bin", configuration, targetFramework, "SSO-Auth.deps.json");
+        Assert.True(
+            File.Exists(depsPath),
+            $"SSO-Auth.deps.json for {configuration}/{targetFramework} was not found at {depsPath}; the plugin build output carrying the publish closure is missing, so the ship-list cannot be computed — build SSO-Auth for this target before the test runs (#608).");
+
+        var publishClosure = PublishClosureAssemblies(depsPath);
+
+        // Liveness against a vacuous closure: the plugin's own assembly must be in it, proving the deps.json parse
+        // found the real runtime set rather than an empty one that would make the set-equality below trivially true.
+        Assert.True(
+            publishClosure.Contains("SSO-Auth.dll"),
+            "The computed publish closure does not contain the plugin's own SSO-Auth.dll; the deps.json parse found nothing real, so the comparison would pass vacuously (#608).");
+
+        // Liveness against a vacuous FILTER: a keystone host-provided assembly Jellyfin ships (MediaBrowser.Common)
+        // must be present in the raw closure AND be removed by the host filter. If the closure ever stopped
+        // carrying it, or the filter stopped matching it, the host subtraction would be doing nothing and the
+        // equality could pass for the wrong reason — re-anchor the filter on what publish actually drags in.
+        Assert.True(
+            publishClosure.Contains("MediaBrowser.Common.dll") && IsHostProvidedAssembly("MediaBrowser.Common.dll"),
+            "The publish closure no longer carries the host-provided keystone MediaBrowser.Common.dll, or the host-provided filter stopped matching it; re-anchor HostProvidedAssemblyPrefixes on the plugin's real publish output (#608).");
+
+        var shipped = publishClosure.Where(dll => !IsHostProvidedAssembly(dll)).ToHashSet(StringComparer.Ordinal);
+
+        var declared = ParseBuildYamlArtifacts(Path.Combine(RepoRoot(), buildYaml));
+        Assert.True(
+            declared.Count > 0,
+            $"No artifacts were parsed from {buildYaml}; the `artifacts:` list is empty or the parse missed it, so the comparison would pass vacuously (#608).");
+
+        var missingFromYaml = shipped.Except(declared).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var extraInYaml = declared.Except(shipped).OrderBy(x => x, StringComparer.Ordinal).ToList();
+
+        Assert.True(
+            missingFromYaml.Count == 0 && extraInYaml.Count == 0,
+            $"{buildYaml}'s `artifacts:` list must equal the non-host {targetFramework} publish closure (#608). "
+            + $"Shipped but NOT listed (FileNotFoundException on plugin load): [{string.Join(", ", missingFromYaml)}]. "
+            + $"Listed but NOT in the publish output (JPRM fails / dead artifact): [{string.Join(", ", extraInYaml)}]. "
+            + "Reconcile the build yaml with `dotnet publish -f " + targetFramework + "`, or extend HostProvidedAssemblyPrefixes if a genuinely new host-provided family appeared.");
+    }
+
+    // The assembly-name families the Jellyfin host provides at runtime and therefore must NOT ship in the plugin
+    // zip, even though `dotnet publish` copies them into the plugin's own publish output (they are not part of the
+    // .NET/ASP.NET Core shared framework, so publish does not strip them the way it strips the framework). Matched
+    // on the assembly SIMPLE name so one entry covers a whole family: "Polly" -> Polly + Polly.Core, "ICU4N" ->
+    // ICU4N + ICU4N.Transliterator, "Microsoft.EntityFrameworkCore" -> its .Abstractions/.Relational, etc. This is
+    // the counterpart denylist to the build yaml's allow-list of shipped deps: a genuinely new host-provided family
+    // must be added here (with justification) and a new shipped dependency must be added to the build yaml —
+    // either way BuildYamlArtifacts_EqualTheTfmPublishClosure fails until the two agree (fail-closed). "Microsoft."
+    // is deliberately NOT a blanket prefix: Microsoft.IdentityModel.* and Microsoft.Bcl.Cryptography DO ship, so
+    // only the specific host-provided Microsoft families (Extensions, EntityFrameworkCore) are listed.
+    private static readonly string[] HostProvidedAssemblyPrefixes =
+    {
+        "Jellyfin", "Emby", "MediaBrowser", "Microsoft.Extensions", "Microsoft.EntityFrameworkCore",
+        "Newtonsoft", "Polly", "BitFaster", "Diacritics", "ICU4N", "J2N", "NEbml",
+    };
+
+    private static bool IsHostProvidedAssembly(string dllFileName)
+    {
+        var simpleName = dllFileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? dllFileName[..^4]
+            : dllFileName;
+        return HostProvidedAssemblyPrefixes.Any(p =>
+            simpleName.Equals(p, StringComparison.Ordinal)
+            || simpleName.StartsWith(p + ".", StringComparison.Ordinal));
+    }
+
+    // The runtime-assembly filenames from SSO-Auth.deps.json's single build target — the exact set
+    // `dotnet publish` copies for that framework (#608). A framework-dependent build has one target (the runtime
+    // target); read every library's `runtime` map and take each entry's leaf filename, because deps.json keys
+    // runtime items by their in-package path (e.g. "lib/net8.0/Duende.IdentityModel.dll"), not the bare name.
+    private static HashSet<string> PublishClosureAssemblies(string depsJsonPath)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(depsJsonPath));
+        var targets = doc.RootElement.GetProperty("targets");
+
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var target in targets.EnumerateObject())
+        {
+            foreach (var library in target.Value.EnumerateObject())
+            {
+                if (!library.Value.TryGetProperty("runtime", out var runtime))
+                {
+                    continue;
+                }
+
+                foreach (var asset in runtime.EnumerateObject())
+                {
+                    var leaf = asset.Name.Split('/', '\\').Last();
+                    if (leaf.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        result.Add(leaf);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    // The `.dll` names under the build yaml's `artifacts:` list. Minimal hand-parse (the test project takes no YAML
+    // dependency): once at the `artifacts:` key, collect the `- "X.dll"` list items, skip the interleaved comments,
+    // and stop at the next top-level key. build.yaml / build-jf12.yaml keep exactly one quoted dll per list item.
+    private static HashSet<string> ParseBuildYamlArtifacts(string yamlPath)
+    {
+        var artifacts = new HashSet<string>(StringComparer.Ordinal);
+        var inArtifacts = false;
+        foreach (var line in File.ReadAllLines(yamlPath))
+        {
+            if (!inArtifacts)
+            {
+                if (Regex.IsMatch(line, @"^artifacts:\s*$"))
+                {
+                    inArtifacts = true;
+                }
+
+                continue;
+            }
+
+            // A new top-level key (unindented and not a list item) ends the artifacts block.
+            if (line.Length > 0 && !char.IsWhiteSpace(line[0]) && !line.TrimStart().StartsWith('-'))
+            {
+                break;
+            }
+
+            var item = Regex.Match(line, "^\\s*-\\s*\"([^\"]+)\"\\s*$");
+            if (item.Success)
+            {
+                artifacts.Add(item.Groups[1].Value);
+            }
+        }
+
+        return artifacts;
     }
 
     // The markup of the #sso-new-oidc-provider settings form (from the opening tag's id attribute to its

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -135,6 +135,17 @@ public class WebResponseTests
         // exact predicate must be gone so a successful link can no longer proceed to a login post.
         Assert.DoesNotContain("linkStatus < 200 || linkStatus >= 300", html);
         Assert.Contains("if (linkStatus !== undefined) {", html);
+
+        // The terminality is enforced by a `return;` inside the definitive-status branch, BEFORE the
+        // fall-through to the .../Auth post. Assert the ordering directly, so deleting that `return;`
+        // (which would silently reintroduce the #614 fall-through) fails this test.
+        var gateIdx = html.IndexOf("if (linkStatus !== undefined) {", System.StringComparison.Ordinal);
+        var returnAfterGate = html.IndexOf("return;", gateIdx, System.StringComparison.Ordinal);
+        var authPostAfterGate = html.IndexOf("/Auth/", gateIdx, System.StringComparison.Ordinal);
+        Assert.True(returnAfterGate >= 0 && authPostAfterGate >= 0);
+        Assert.True(
+            returnAfterGate < authPostAfterGate,
+            "a definitive link status must return before the .../Auth post");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -117,4 +117,34 @@ public class WebResponseTests
 
         Assert.Contains(expected, html);
     }
+
+    [Fact]
+    public void Generator_SuccessfulLink_IsTerminal_ShowsSuccessAndDoesNotPostToAuthUnconditionally()
+    {
+        // #614: a successful link (a 2xx from .../Link) is a terminal SUCCESS on the page — it renders a
+        // clear success message and must NOT fall through to post the same one-time-consumed assertion /
+        // state on to .../Auth (which could never redeem it, so the page showed a misleading login failure).
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce", isLinking: true);
+
+        // The success branch renders the account-linked message keyed on the 2xx range.
+        Assert.Contains("linkStatus >= 200 && linkStatus < 300", html);
+        Assert.Contains("Account linked. You can now log in with SSO.", html);
+
+        // A definitive link outcome (any non-undefined status) stops the flow before the auth leg. The
+        // former `linkStatus < 200 || linkStatus >= 300` condition let a 2xx fall through to .../Auth; that
+        // exact predicate must be gone so a successful link can no longer proceed to a login post.
+        Assert.DoesNotContain("linkStatus < 200 || linkStatus >= 300", html);
+        Assert.Contains("if (linkStatus !== undefined) {", html);
+    }
+
+    [Fact]
+    public void Generator_LinkingPage_KeepsRejectedLinkMessages()
+    {
+        // The failure path is preserved (#344): a genuinely rejected link still surfaces its own message
+        // rather than the login-failure text — a throttled attempt (429) and any other non-2xx are distinct.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "SAML", "n0nce", isLinking: true);
+
+        Assert.Contains("Too many attempts. Please wait a moment and try again.", html);
+        Assert.Contains("Could not link this account. The provider may be disabled, or linking is not permitted.", html);
+    }
 }

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -202,13 +202,13 @@ internal sealed class SamlLoginService
         }
 
         // Linking keeps the assertion-embedded page (#251 is scoped to the login round-trip): the page JS
-        // posts its data to BOTH SAML/Link and SAML/Auth. The link redeem (SamlLoginService.Link) consumes the
-        // assertion's one-time-use id on its own leg; the follow-on SAML/Auth post carries that same assertion
-        // (not a login-outcome token), so it does not redeem a live token and is rejected fail-closed at the
-        // mint leg — a harmless no-op, since the link already completed on its own leg. This was already the
-        // effective behaviour before #528: post-link the assertion's replay id was consumed, so the old
-        // deprecation branch rejected the follow-on post too. Removing that branch (#528) changes only WHERE
-        // the follow-on post is rejected (token-miss vs. a re-validated replay), not that it is rejected.
+        // posts its data to SAML/Link. The link redeem (SamlLoginService.Link) consumes the assertion's
+        // one-time-use id on its own leg. Since #614 a definitive Link outcome is TERMINAL on the page — a
+        // successful link (204) renders success and the page does NOT go on to post to SAML/Auth. That
+        // follow-on post could never have succeeded anyway: it carried the same, now-consumed assertion (not
+        // a login-outcome token), so it fail-closed at the mint leg — but left in place it rendered a
+        // misleading 'Login failed' over a link that had actually completed. Dropping the follow-on post
+        // removes that false failure without touching the Link leg's validation or its one-time consume.
         if (isLinking)
         {
             return FlowResponses.AuthPage(response, nonce =>

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -307,18 +307,24 @@ async function main() {
     var request = {deviceId, appName, appVersion, deviceName, data};
 
     if (" + (isLinking ? "true" : "false") + @") {
-        // Surface a rejected link instead of swallowing it (#344): the link leg fail-closes with a
-        // non-2xx when the provider is disabled (#343), the caller is not allowed, or the request is
-        // throttled. Left silent, the page would fall through to the auth leg and show a misleading
-        // 'Login failed', so a rejected link stops here with its own message. A missing status
-        // (undefined: no stored credentials, or a network error) keeps the prior behavior of
-        // proceeding, since the outcome cannot be told apart from success.
+        // Linking is NOT a login round-trip, so a DEFINITIVE link outcome is terminal here — the page does
+        // NOT go on to post to .../Auth (#614). The Link leg one-time-consumes the assertion / state token,
+        // so the old unconditional follow-on Auth post could never redeem it: it fail-closed at the mint leg
+        // and rendered a misleading 'Login failed. Please try again.' even though the link itself had already
+        // succeeded on its own leg.
+        //   - A 2xx is a completed link: show success and stop (do not attempt a login).
+        //   - A non-2xx is a rejected link (#344): the provider is disabled (#343), the caller is not
+        //     allowed, or the request is throttled — surface it and stop, never fall through to a login.
+        //   - A missing status (undefined: no stored credentials, or a network error) keeps the prior
+        //     behavior of proceeding to the auth leg, since that outcome cannot be told apart from success.
         var linkStatus = await link(request);
-        if (linkStatus !== undefined && (linkStatus < 200 || linkStatus >= 300)) {
+        if (linkStatus !== undefined) {
             document.querySelector('p').textContent =
-                linkStatus === 429
-                    ? 'Too many attempts. Please wait a moment and try again.'
-                    : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
+                linkStatus >= 200 && linkStatus < 300
+                    ? 'Account linked. You can now log in with SSO.'
+                    : linkStatus === 429
+                        ? 'Too many attempts. Please wait a moment and try again.'
+                        : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
             return;
         }
     }

--- a/SSO-ONLY-LOGIN-DESIGN.md
+++ b/SSO-ONLY-LOGIN-DESIGN.md
@@ -1,0 +1,453 @@
+# SSO-only login (`DisablePasswordLogin`) — STRIDE threat model & design constraints
+
+**Status: NOT IMPLEMENTED.** This document is the mandatory pre-build design
+step for issue #165 (P4 — Feature parity). It threat-models an opt-in
+_SSO-only login_ mode — one that disables Jellyfin's native password login so
+users must authenticate through SSO — **before any code is written**, because
+the feature changes the authentication surface and, done naively, is a
+mass-lockout footgun. No `DisablePasswordLogin` setting, last-admin guard, or
+break-glass toggle exists in the plugin today. Building the feature is a
+separate work item; it must satisfy the acceptance criteria and conformance
+tests at the end of this document.
+
+The headline finding is in [§2](#2-can-the-plugin-even-enforce-this-the-honest-answer):
+**the plugin cannot flip a single global "password login off" switch, because
+Jellyfin core has none.** SSO-only can only be approximated per-user by
+repointing each account's `AuthenticationProviderId` away from the default
+password provider — the exact lever the plugin already pulls for the accounts it
+creates. That reframes the whole feature and its safety net.
+
+---
+
+## 1. How authentication works today (the grounding facts)
+
+Every claim below is anchored in current `4.3` code so the threat model rests on
+what the plugin actually does, not on how SSO plugins generally behave.
+
+### 1.1 SSO is a parallel path that bypasses password auth entirely
+
+The plugin does **not** implement `IAuthenticationProvider`. It never sits on
+Jellyfin's `/Users/AuthenticateByName` password path. Instead it exposes its own
+controller routes (`SSO-Auth/Api/SSOController.cs`) and, once a protocol response
+is verified, mints a session directly:
+
+- `SSO-Auth/Api/SessionMinter.cs:119` calls
+  `_sessionManager.AuthenticateDirect(authRequest)` — it hands Jellyfin an
+  already-authenticated request and receives an `AuthenticationResult`. No
+  password is ever presented to Jellyfin on the SSO path.
+
+Consequence: **native password login and SSO login are two independent doors.**
+Turning one off does nothing to the other. Disabling password login does not
+touch the SSO path; a broken SSO provider does not re-open the password path.
+This independence is precisely what makes "SSO-only" a lockout risk — if the SSO
+door jams and the password door is bolted, everyone is outside.
+
+### 1.2 The only lever the plugin has over password login is `AuthenticationProviderId`
+
+When the plugin **creates** an account for a first-time SSO user
+(`SSO-Auth/Api/Linking/CanonicalLinkService.cs:453-456`):
+
+```csharp
+var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
+user.AuthenticationProviderId = typeof(SSOController).FullName;
+user.Password = _cryptoProvider.CreatePasswordHash(
+    Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
+```
+
+Two things happen, and it matters which one is load-bearing:
+
+1. **`AuthenticationProviderId` is set to `SSOController`'s full type name** —
+   which is **not** a registered `IAuthenticationProvider`. Jellyfin routes a
+   user's password authentication to the provider whose type name equals their
+   `AuthenticationProviderId`; when that name resolves to no registered provider,
+   core substitutes its `InvalidAuthenticationProvider`, which rejects every
+   password. This is the same mechanism the SSO-revoke path relies on in reverse:
+   `CanonicalLinkService.cs:741` sets `user.AuthenticationProviderId = provider`
+   to switch an account **back** to a real (password) provider when SSO is
+   revoked. So `AuthenticationProviderId` **is** the plugin's password-login
+   on/off switch — per user.
+2. **A random 64-byte password is also set.** This is defence-in-depth: even if
+   core ever fell through to the default password provider for that account, the
+   password is unguessable. The plugin does not rely on (2) alone, and (2) is
+   destructive (it overwrites any existing password) — see the lockout analysis.
+
+**There is no server-wide equivalent.** `AuthenticationProviderId` is a
+per-`User` field. Jellyfin exposes no global "disable password authentication"
+setting, and the plugin cannot intercept core's `/Users/AuthenticateByName`
+endpoint. Any "SSO-only" mode is therefore an **iteration over users**, flipping
+each account's provider id — not a single toggle.
+
+### 1.3 Admin / permission model
+
+- Admin config endpoints are gated by Jellyfin's elevation policy:
+  `[Authorize(Policy = Policies.RequiresElevation)]` guards every mutating SSO
+  admin route (`SSOController.cs` — `OID/Add`, `OID/Del`, `SAML/Add`, `SAML/Del`,
+  `Config/Import`, `Unregister`, …). Only an authenticated **administrator** can
+  change plugin configuration.
+- Administrator status is a per-user permission,
+  `PermissionKind.IsAdministrator`, applied on the SSO path at
+  `SessionMinter.cs:63` from the resolved login's `IsAdmin` flag (which SSO
+  derives from the provider's admin-role claim, gated by the per-provider
+  `EnableAuthorization` master switch, `SessionMinter.cs:61`).
+- User enumeration for a guard is available: `IUserManager.Users` lists all
+  accounts, each carrying its `AuthenticationProviderId`, `HasPassword`, and
+  `IsAdministrator` permission.
+
+### 1.4 There is already a manual break-glass doctrine
+
+`providers.md` (the "Upgrading from a username-keyed version" runbook) already
+tells operators: **"Keep a break-glass admin that does _not_ depend on SSO …
+make sure at least one Jellyfin administrator has a normal password login
+(Dashboard → Users), or you will be left editing config on disk."** SSO-only
+mode makes that advice mandatory rather than advisory, and the feature must
+enforce it rather than merely document it.
+
+### 1.5 Configuration & audit substrate the feature will reuse
+
+- `DisablePasswordLogin` is a **server-wide** concern, so it belongs on the
+  top-level `PluginConfiguration` (`SSO-Auth/Config/PluginConfiguration.cs`),
+  alongside `EnableRateLimit` — not on a per-provider `OidConfig`/`SamlConfig`.
+- The plugin already has a **fail-closed refuse-to-save** precedent:
+  `SSO-Auth/Config/ProviderConfigValidator.cs` throws before anything is
+  persisted when an incoming config is invalid (`ProviderConfigStore.Save`
+  gates on it). The last-admin guard is a new predicate in that same style.
+- Audit entries go through `SSO-Auth/Api/SsoAudit.cs` (structured
+  `[SSO Audit]` log lines, line-ending-sanitised). This is Jellyfin's ordinary
+  log — **not** a tamper-evident hash chain — which bounds what Repudiation
+  mitigation can honestly claim (see S/R below).
+
+---
+
+## 2. Can the plugin even enforce this? The honest answer
+
+**Partially, and only per-user.** There is no global switch to own.
+
+| Question                                                            | Answer                                                                                                                                                                                                           |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Can the plugin disable password login with one server setting?      | **No.** Jellyfin core has no such setting, and the plugin does not sit on the password endpoint.                                                                                                                 |
+| Can the plugin disable password login for a given user?             | **Yes** — by setting that user's `AuthenticationProviderId` to a non-password provider (the `SSOController`-name lever it already uses for created accounts).                                                    |
+| Can the plugin guarantee an SSO-only account cannot use a password? | **Yes**, via `AuthenticationProviderId` → `InvalidAuthenticationProvider`. The random password is belt-and-braces, not the primary barrier.                                                                      |
+| Can the plugin re-enable password login without SSO?                | **Yes** — reverse the field back to `DefaultAuthenticationProvider` (the revoke path already does this at `CanonicalLinkService.cs:741`). This is the in-band break-glass.                                       |
+| Can the plugin _reach into every account_ to flip it?               | **Yes** for enumeration (`IUserManager.Users`), but flipping an existing password admin is destructive-ish (it changes how they log in) and must be explicit, reversible, and never applied to the exempt admin. |
+
+**Design consequence:** SSO-only mode is implemented as "for every user _except a
+protected break-glass admin set_, ensure `AuthenticationProviderId` is not the
+default password provider," plus a guard that **refuses to enter the mode unless
+a working login path for at least one admin is provable.** The feature is a
+managed per-user field flip with a safety interlock, not a global bolt.
+
+---
+
+## 3. The mass-lockout threat (risk #1) and the safety-net options
+
+**Threat.** Enabling `DisablePasswordLogin` removes the password door for admins.
+If the SSO door is then misconfigured, the IdP is down, the client secret
+rotates, the discovery URL breaks, a role claim stops mapping to admin, or a
+provider is deleted — **no one can obtain an administrator session.** The org is
+locked out of its own server. Recovery then means editing `config.xml`/the
+Jellyfin database on disk. For a self-hosted single-org tool this is the
+catastrophic-availability event; it dwarfs every other risk here.
+
+### Safety-net options considered
+
+- **(A) Always keep ≥1 local admin exempt (a break-glass admin that keeps its
+  password door).** The mode never flips the exempt admin's
+  `AuthenticationProviderId`; that account can always log in with a password. The
+  admin operating the toggle designates (or the plugin auto-selects) the exempt
+  account. Simple, always-available, and matches the doctrine already in
+  `providers.md`. Cost: one admin account is, by design, still password-reachable
+  — so SSO-only is "SSO-only for everyone _but_ the break-glass admin," which is
+  the honest and safe reading of the feature.
+- **(B) A break-glass / recovery path (reversible toggle without SSO).** Turning
+  `DisablePasswordLogin` **off** must not itself require SSO. It is a plain admin
+  config write (or, if fully locked out, a `config.xml` edit that the runbook
+  documents). Re-enabling restores each affected account's
+  `AuthenticationProviderId` to the default provider. This is recovery, and it
+  composes with (A) rather than replacing it.
+- **(C) Refuse to enable if it would strand the last admin (fail-closed
+  interlock).** Before persisting `DisablePasswordLogin = true`, prove that at
+  least one administrator retains a working login path — either the exempt
+  password admin of (A), or an admin with a live, enabled SSO canonical link on
+  an **enabled** provider. If neither is provable, **reject the save with a clear
+  message** and change nothing. Mirrors `ProviderConfigValidator`.
+- **(D) Auto re-enable password login on SSO failure.** _Rejected._ It is a
+  fail-**open** control: an attacker who can DoS the IdP (or forge a "provider
+  down" signal) would re-open the password door — turning an availability blip
+  into a security downgrade, and violating "fail closed." The break-glass admin
+  (A) + the reversible toggle (B) already give a safe, deliberate, human-driven
+  recovery. Availability is served by keeping a door that was **never** closed,
+  not by auto-unbolting one under duress.
+
+### Recommendation
+
+**Adopt (A) + (B) + (C) together; reject (D).**
+
+1. **(C) is the gate.** `DisablePasswordLogin` cannot be turned on unless the
+   guard proves a surviving admin login path. Default state is **off**
+   (fail-closed for upgrades: no existing install silently loses its password
+   door).
+2. **(A) is the guaranteed survivor.** Require an explicitly designated
+   **break-glass admin** whose password door the mode never touches. The guard in
+   (C) is satisfied most simply and most robustly by this account's continued
+   existence — it does not depend on any IdP being reachable, which is the entire
+   point. Refuse to enable if no such admin is designated (or if the designated
+   account is not actually an enabled administrator with a usable password).
+3. **(B) is the exit.** The toggle is reversible **without SSO**; the off-switch
+   restores password login for the affected accounts. Document the on-disk
+   `config.xml` recovery for the total-lockout case, exactly like the existing
+   `providers.md` runbook.
+
+The strongest, simplest guarantee is: **SSO-only never removes the last
+password-capable administrator; there is always a designated break-glass admin
+whose password login survives, and the mode refuses to activate otherwise.**
+Preferring the password-admin survivor over "an admin has an SSO link" for the
+guard is deliberate — an SSO link's usability depends on the IdP being up, which
+is exactly the thing that fails in the lockout scenario. An SSO-linked admin MAY
+count toward the guard as a secondary condition, but MUST NOT be the _only_
+thing standing between the org and a locked server.
+
+---
+
+## 4. STRIDE
+
+Scope of the change: a new server-wide `DisablePasswordLogin` config flag, an
+admin toggle to set it, a validation guard that refuses unsafe activation, and a
+routine that repoints affected users' `AuthenticationProviderId`. Threats below
+are specific to that surface.
+
+### S — Spoofing (SSO must become the _only_ path; no bypass survives)
+
+- **T-S1 — a residual password door.** If the flip misses any admin account
+  (race, new admin created after activation, an account whose provider id was not
+  repointed), that account still accepts a password — SSO-only is a fiction for
+  it. _Mitigation:_ the enforcement is **per-user and continuous**, not one-shot:
+  (a) apply on activation to all non-exempt users; (b) re-apply on the SSO login
+  path and on user-creation so a newly created/native account cannot linger on
+  the password provider while the mode is on; (c) a conformance test asserts no
+  non-exempt account keeps the default password provider while `DisablePasswordLogin`
+  is on.
+- **T-S2 — the exempt break-glass admin _is_ the intended residual door.** That
+  is by design, but it means the break-glass account is now the softest target.
+  _Mitigation:_ it must be an ordinary strong-password admin; document that its
+  password is the org's root-of-recovery and should be strong and stored offline.
+  The plugin does not weaken it and does not expose it via SSO.
+- **T-S3 — SSO path spoofing is out of scope here** — it is covered by the
+  existing verification stack (`OidcIdTokenValidator`, `SamlAssertionValidator`,
+  issuer/audience/replay checks). SSO-only does not relax any of it; note only
+  that SSO-only **raises the blast radius** of any SSO-auth bypass, because SSO
+  becomes the primary door. This argues for keeping (A)'s password admin as an
+  out-of-band check on a compromised IdP.
+
+### T — Tampering (the toggle is admin-only, integrity-checked)
+
+- **T-T1 — non-admin flips the flag.** _Mitigation:_ the toggle route carries
+  `[Authorize(Policy = Policies.RequiresElevation)]` like every other mutating
+  SSO admin endpoint. Fail-closed: no elevation → 403, no change.
+- **T-T2 — the flag is set in config to `true` while no safe admin exists**
+  (hand-edited `config.xml`, config import). _Mitigation:_ the guard (C) runs on
+  **every** persistence path, not just the UI toggle — `ProviderConfigStore.Save`
+  and `Config/Import` must both re-validate. A config that asserts SSO-only with
+  no surviving admin login path is rejected fail-closed, matching the existing
+  `ProviderConfigValidator` model.
+- **SoD note (honest limitation):** ECM-style separation-of-duties (author of a
+  record cannot approve it) **does not exist in Jellyfin** — any single admin can
+  both design and activate this. The feature cannot manufacture dual control on
+  top of Jellyfin's single-admin model. The mitigation is the fail-closed guard +
+  audit, not SoD. State this limitation in the feature's docs rather than
+  implying a control that is not there.
+
+### R — Repudiation (the toggle is audited)
+
+- **T-R1 — an admin enables/disables SSO-only and later denies it, or a lockout
+  has no forensic trail.** _Mitigation:_ emit an `SsoAudit` entry on **both**
+  transitions (enable and disable), recording actor (the elevated user), the new
+  state, and the guard outcome (which admin(s) satisfied the survivor check).
+  Add an entry when the guard **refuses** an activation, so a blocked lockout
+  attempt is visible.
+- **Honest limitation:** `SsoAudit` writes to Jellyfin's ordinary application
+  log — it is **not** a tamper-evident hash chain, so an attacker with host/log
+  access can alter it. Do not claim audit-grade non-repudiation; claim
+  operational traceability. (This is the plugin's standing audit posture, not a
+  regression introduced here.)
+
+### I — Information disclosure
+
+- **T-I1 — the guard's error message leaks which accounts are admins / their
+  login state.** _Mitigation:_ the refusal message states the _reason_ ("cannot
+  enable SSO-only: no administrator would retain a working login path; designate
+  a break-glass admin first") without enumerating usernames/emails. Follow the
+  plugin's existing `PublicReason` discipline — actionable, not a user roster.
+- **T-I2 — logs.** Reuse `SsoAudit`'s line-ending sanitisation; log the actor and
+  counts, not full account dumps. No secrets are involved in this feature.
+
+### D — Denial of service (mass lockout **is** the DoS; availability is paramount)
+
+- **T-D1 — the whole-org lockout of [§3].** This is the dominant threat of the
+  entire feature. _Mitigation:_ the (A)+(B)+(C) safety net — a guaranteed
+  password-capable break-glass admin, a reversible no-SSO off-switch, and a
+  fail-closed activation guard. The design's success criterion is that **no
+  reachable configuration of this feature can leave zero working admin logins.**
+- **T-D2 — self-inflicted lockout by deleting/disabling the break-glass admin
+  _after_ activation.** Activation-time proof is not enough; the exempt admin
+  could later be deleted, demoted, or password-cleared while SSO-only stays on.
+  _Mitigation:_ treat the survivor condition as an **invariant, re-checked at the
+  moments it can break** — at minimum, refuse to persist SSO-only if the guard no
+  longer holds, and (defence-in-depth) log a prominent warning if the last safe
+  admin path disappears while the mode is active. Full core-side interception of
+  "admin deleted" is a Jellyfin event the plugin may not receive; where the
+  plugin cannot observe the event, the runbook (B) is the backstop. Be honest in
+  docs about which transitions are enforced vs. documented.
+- **T-D3 — SSO provider outage with SSO-only on.** _Mitigation:_ the break-glass
+  password admin (A) is the by-design escape hatch; it does not depend on the
+  IdP. This is why the guard must not accept "an admin has an SSO link" as the
+  _sole_ survivor.
+- **T-D4 — availability of the login endpoints themselves** (rate-limit
+  lockout) is an existing concern governed by `SsoRateLimiter` /
+  `EnableRateLimit`; SSO-only does not change it, but note that with SSO-only on,
+  throttling the SSO endpoints has a larger blast radius (it is now the primary
+  door). Keep the limiter's "throttle, never permanently lock" posture.
+
+### E — Elevation of privilege (the safety net must not become a bypass)
+
+- **T-E1 — the break-glass exemption as a privilege backdoor.** The exempt admin
+  keeps a password door; if an attacker can get themselves _designated_ as the
+  break-glass admin, or point the exemption at an account they control, they mint
+  a permanent password-authenticable admin immune to SSO-only. _Mitigation:_
+  designating/changing the break-glass admin is itself an elevated,
+  `RequiresElevation` + audited operation; the exemption may only point at an
+  account that is **already** an administrator (it cannot _grant_ admin, only
+  spare an existing one's password door); changing it is logged.
+- **T-E2 — the re-enable/off path as an elevation.** Turning SSO-only off
+  re-opens password login for many accounts at once. _Mitigation:_ it is an
+  elevated + audited operation; it restores `DefaultAuthenticationProvider` and
+  nothing more — it must **not** reset or reveal passwords, only restore the
+  provider routing, so no account gains a _known_ password from the toggle.
+- **T-E3 — repointing `AuthenticationProviderId` must never grant rights.** The
+  enforcement routine only changes the auth-provider routing field; it must not
+  touch `IsAdministrator`, folder, or Live TV permissions. Keep it strictly
+  orthogonal to the permission-granting code in `SessionMinter` so a bug here
+  cannot escalate anyone.
+
+---
+
+## 5. Interaction with Jellyfin — how "disable password login" is actually enforced
+
+Restating [§1.2]/[§2] as the concrete enforcement contract the implementation
+must honor:
+
+1. **There is no Jellyfin-core global setting** to disable password
+   authentication, and the plugin cannot hook core's `/Users/AuthenticateByName`.
+   The feature is therefore **plugin-driven per-user enforcement**, not a core
+   setting the plugin merely toggles.
+2. **The enforced mechanism is `User.AuthenticationProviderId`.** For each
+   non-exempt account, the plugin sets it to a non-password provider id (the
+   `SSOController`-name lever already proven in
+   `CanonicalLinkService.cs:454`), which routes password attempts to core's
+   `InvalidAuthenticationProvider` and rejects them. Re-enabling restores
+   `DefaultAuthenticationProvider` (as the revoke path already does,
+   `CanonicalLinkService.cs:741`).
+3. **The plugin must _not_ rely on overwriting passwords** as the disabling
+   mechanism for existing accounts — that is destructive and irreversible (you
+   cannot restore the user's prior password on re-enable). Overwriting the
+   password is acceptable only for accounts the plugin itself creates (which never
+   had a user-chosen password); for pre-existing accounts, flip the provider id,
+   leave the stored password hash alone, so (B) re-enable is lossless.
+4. **Honesty in the UI/docs:** the config page must state that SSO-only is
+   enforced by the plugin per account and that a designated break-glass admin
+   retains password login by design — i.e. it is "SSO-only for all users except
+   the break-glass admin," not an absolute server-wide password kill-switch.
+   Overstating it would be a security-relevant misrepresentation.
+
+---
+
+## 6. Acceptance criteria
+
+Extends issue #165's list; each maps to a conformance test in [§7].
+
+1. `DisablePasswordLogin` is a **server-wide** opt-in on `PluginConfiguration`,
+   **default `false`** (upgrade-safe: no install silently loses its password
+   door).
+2. A **break-glass admin** is designatable; the mode never repoints that
+   account's `AuthenticationProviderId`, so it always retains password login.
+3. Enabling `DisablePasswordLogin` is **refused, fail-closed, with a clear
+   non-enumerating message**, unless the guard proves at least one administrator
+   retains a working login path — satisfied canonically by an enabled admin with
+   a usable password (the break-glass admin). The guard runs on **every**
+   persistence path (UI save, `Config/Import`, and re-validation on load).
+4. A **break-glass recovery path exists and is reversible without SSO**: turning
+   the flag off is a plain elevated admin write (documented `config.xml` edit for
+   the total-lockout case) and restores `DefaultAuthenticationProvider` for the
+   affected accounts **without** resetting or exposing any password.
+5. While the mode is on, **no non-exempt account retains the default password
+   provider** — enforced on activation and re-asserted on the SSO login and
+   user-creation paths (no residual password door, T-S1).
+6. Setting/changing the break-glass designation and toggling the mode are
+   **`RequiresElevation`-gated and audited** on both transitions (and on guard
+   refusal). The exemption can only point at an **already-administrator** account
+   (it never grants admin).
+7. The enforcement routine changes **only** `AuthenticationProviderId`; it never
+   alters `IsAdministrator`, folder, or Live-TV permissions (T-E3).
+8. Docs state honestly that (a) there is no global Jellyfin kill-switch, (b) the
+   break-glass admin is a deliberate residual password door, and (c) Jellyfin
+   offers no SoD, so a single admin can both design and activate the mode.
+
+## 7. Conformance / negative tests the implementation must ship
+
+Every fail-closed branch gets a negative test (repo rule). Mirror the existing
+suites (`ProviderConfigValidatorTests`, `SessionMinterTests`,
+`SSOControllerUnregisterTests`).
+
+- **`Enable_refused_when_no_admin_would_retain_a_login_path`** — guard rejects
+  activation and persists nothing when the only admin(s) would lose password
+  login and have no live SSO admin link. (The central lockout branch.)
+- **`Enable_allowed_when_a_break_glass_password_admin_exists`** — positive path:
+  designated password admin present → activation succeeds; that admin's
+  `AuthenticationProviderId` is unchanged.
+- **`Enabling_does_not_strand_via_config_import`** — the same guard fires on
+  `Config/Import` (and on config load), not only the UI toggle; an imported
+  config asserting SSO-only with no safe admin is rejected.
+- **`Break_glass_admin_provider_id_never_repointed`** — after activation, the
+  exempt admin still routes to the password provider.
+- **`No_nonexempt_account_keeps_password_provider_while_mode_on`** — invariant
+  check across `IUserManager.Users` after activation and after a subsequent SSO
+  login / user creation (T-S1).
+- **`Disable_restores_default_provider_without_touching_password_hash`** —
+  re-enable is lossless: provider id restored to `DefaultAuthenticationProvider`,
+  stored password hash byte-for-byte unchanged (T-E2, criterion 4).
+- **`Toggle_and_designation_require_elevation`** — non-elevated caller gets 403,
+  no state change, for both the mode toggle and the break-glass designation.
+- **`Break_glass_designation_rejects_non_admin_target`** — exemption cannot point
+  at a non-administrator (T-E1); it cannot grant admin.
+- **`Enable_and_disable_and_refusal_are_audited`** — an `SsoAudit` entry is
+  emitted on enable, on disable, and on guard refusal, with actor + outcome and
+  no username enumeration.
+- **`Enforcement_routine_touches_only_authentication_provider_id`** — property/
+  unit test that the repoint routine leaves `IsAdministrator`, folder, and
+  Live-TV permissions untouched (T-E3).
+- **`Guard_does_not_count_sso_link_on_disabled_or_deleted_provider`** — an admin
+  whose only path is an SSO link on a **disabled/deleted** provider does **not**
+  satisfy the survivor guard (reuses the `IsIdentityStillLinked` /
+  `requireEnabled` semantics from `CanonicalLinkService.cs:731-736`).
+
+---
+
+## 8. Summary for the reviewer
+
+- **Can the plugin enforce SSO-only?** Only **per-user**, by repointing
+  `AuthenticationProviderId` (the lever it already uses at
+  `CanonicalLinkService.cs:454`). **No global Jellyfin password kill-switch
+  exists**, and the plugin cannot intercept core's password endpoint — so the
+  honest framing is "SSO-only for every account except a designated break-glass
+  admin."
+- **Recommended safety net:** **(A) a mandatory designated break-glass password
+  admin + (B) a reversible, no-SSO off-switch + (C) a fail-closed activation
+  guard** that refuses to enable the mode unless a working admin login path is
+  provable. **Reject (D) auto-re-enable-on-SSO-failure** — it is fail-open.
+- **#1 risk:** whole-org mass lockout (a DoS). The design's success criterion is
+  that **no reachable configuration can leave zero working admin logins**, and
+  the break-glass admin — which does not depend on the IdP — is the guaranteed
+  survivor.
+- **Honest limitations to carry into the docs:** no SoD in Jellyfin (single
+  admin can self-approve), `SsoAudit` is a plain log (not tamper-evident), and
+  post-activation deletion of the break-glass admin is only partially
+  observable by the plugin — the runbook is the backstop.

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -1,0 +1,138 @@
+# Threat model
+
+STRIDE-style threat model for this repository. It has two parts:
+
+- **The product / login path** — the SSO login flow the plugin implements.
+  The published writeup is the wiki
+  [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model)
+  page, with the controls condensed in [`SECURITY.md`](SECURITY.md) and the
+  code structure in [`ARCHITECTURE.md`](ARCHITECTURE.md). A detailed working
+  model is kept internally and refreshed when the attack surface changes
+  (`SECURE-SDLC.md` phase 1).
+- **The AI delivery pipeline** — the agent-assisted process that _produces_ the
+  plugin. This is the part documented in full below, because it is not covered
+  by the product-facing docs above and is specific to how this repository is
+  built.
+
+## The AI delivery pipeline
+
+Development here is **AI-assisted under solo governance**: an AI agent (Claude)
+carries out individual process steps — generating and analysing code, running
+the adversarial security reviews, running the git/GitHub flow — and a human
+maintainer reviews, edits, and signs off on every one (see the README's
+"AI-assisted, human-owned" note). That makes the agent, the configuration that
+steers it, and the CI/release pipeline a **trust boundary that sits upstream of
+every shipped line**: a compromise of the pipeline is a supply-chain compromise
+of the delivered login-path code, without any bug in the login path itself.
+
+This is not hypothetical. Anthropic's Git MCP advisories
+(CVE-2025-68143..68145, Jan 2026) showed that a poisoned `README` or issue body
+_alone_ could trigger agent-side code execution; the Cloud Security Alliance's
+AI-coding-assistant attack-surface note (2026-04) catalogues the broader
+surface. The threats below are modelled against that reality.
+
+### Assets
+
+- The **delivered artifact** — the plugin `.zip` its users install — and its
+  build provenance.
+- The **agent-steering configuration**: everything that tells the agent what to
+  do or how to review — `.claude/` commands, agents, hooks, and settings;
+  `CLAUDE.md` / `AGENTS.md`; any prompt or instruction files; and, if ever
+  added, an AI-reviewer config such as `.github/copilot-instructions.md` or
+  `.coderabbit.yaml`.
+- The **maintainer's git/GitHub session** the agent operates with.
+- **Branch protection** and the **release-tag publish trigger** (a version-tag
+  push is what ships a release to all users).
+
+### Trust boundaries
+
+1. **Untrusted content the agent reads → the agent.** Issue and PR bodies,
+   review comments, external SAML metadata/XML pasted into an issue, vendored
+   JavaScript, `README`-class files, and any fetched web page are
+   attacker-influenceable. They are **data, never instructions**.
+2. **Agent-config files → the agent's behaviour.** A malicious edit to a hook,
+   command, or instruction file silently re-steers the agent and is therefore a
+   supply-chain vector into the shipped code. These files are **security-
+   sensitive** (see the classification below).
+3. **The agent's own actions.** The agent runs `git`/`gh` with real privilege,
+   so an over-privileged or injected action can rewrite history, delete a
+   branch, or publish a release.
+4. **CI / release pipeline.** The workflows, the third-party actions they call,
+   and the tag→publish trigger are release-critical.
+
+### STRIDE — threat → control that exists today
+
+| Threat                                                                                 | Vector                                                                            | Mitigation (in place)                                                                                                                                                                                                                                                                                                                                                                                                         |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **S**poofing — injected text poses as the maintainer or as a legitimate task           | untrusted issue / PR / review / web content read as if it were an instruction     | The agent operates under an **instruction-source boundary** — its operating manual treats observed content as data, not commands. Every step is a proposal the **maintainer signs off** (README disclosure); `CODEOWNERS` auto-requests maintainer-team review.                                                                                                                                                               |
+| **T**ampering — malicious edit to agent-config or to shipped code                      | `.claude/` hooks/commands, `CLAUDE.md`, prompt files; vendored JS; hidden Unicode | Agent-config is **classified security-sensitive** and reviewed like auth-surface code; the local `security-reminder` hook nudges `/security-review` on edits to those files; the **adversarial multi-lens review** reads full touched files; `--warnaserror` + analyzers + CodeQL + Opengrep + fitness tests gate the code; the **Trojan-Source / Unicode guard** rejects bidi/invisible control characters (CVE-2021-42574). |
+| **R**epudiation — an untraceable change slips in                                       | direct-to-branch change; ambiguous authorship                                     | PR-only flow with **branch protection** and required checks; the **internal-only merge gate** (`REVIEW-GATE.md`); the AI-assistance disclosure fixes human accountability ("a human stays responsible for every line").                                                                                                                                                                                                       |
+| **I**nformation disclosure — exfiltrate a secret through the agent                     | injected data-exfil instruction; secret in a log/diff                             | **Secret scanning with push protection** blocks a credential before it lands; secrets are never logged and are redacted on config export; `guard-git` blocks `gh auth logout`; workflow tokens are least-privilege and SHA-pinned.                                                                                                                                                                                            |
+| **D**enial / destruction — mass-destructive git/gh action                              | injected or over-broad `git`/`gh` command                                         | The `guard-git` hook blocks protected-branch **force-push**, ambiguous force-push, **history rewrites** (`filter-branch`/`filter-repo`), protected-branch **deletion**, and `gh release` / `gh repo` mutations.                                                                                                                                                                                                               |
+| **E**levation — the agent ships a release or writes to a protected branch unauthorized | over-privileged agent action                                                      | The **`SSO_RELEASE_GO` gate**: a release-tag push _and_ a manual `publish` workflow dispatch are blocked unless the maintainer's explicit go is present as the marker. Branch protection + required status checks; **SLSA build-provenance** (#147) ties each release to this repository's pipeline so a side-channel build cannot pass as genuine.                                                                           |
+
+### Untrusted-content-as-instructions (prompt injection)
+
+The failure mode is a single one: content the agent reads while doing its job —
+an issue it is asked to work, a PR diff it is reviewing, SAML metadata a user
+pasted for debugging, a web page it fetched — contains text _addressed to the
+agent_ ("ignore your instructions", "add this dependency", "approve this PR").
+The defence is that **only the maintainer, in the chat interface, issues
+instructions**; everything reached through a tool is data. When observed content
+contains agent-directed text, the agent surfaces it to the maintainer rather
+than acting on it. The compensating controls above (guard hooks, the sign-off
+gate, the adversarial review reading the _real_ diff, the hidden-Unicode guard,
+CODEOWNERS review) are what catch an injection that nonetheless changes a file.
+
+### Agent-configuration files are security-sensitive
+
+Because the agent-config steers everything the agent produces, a change to it
+warrants the **same review scrutiny as a change on the login/auth surface**.
+The following are classified security-sensitive:
+
+- `.claude/` — commands, agents, **hooks** (`guard-git.ps1`,
+  `security-reminder.ps1`, `format-changed.ps1`), and settings;
+- `CLAUDE.md` and `AGENTS.md` (the agent operating manuals);
+- any other prompt or instruction file added later;
+- an AI-reviewer config if one is ever introduced —
+  `.github/copilot-instructions.md`, `.coderabbit.yaml`.
+
+**How the classification is enforced.** The local `security-reminder` hook's
+sensitive-file list is extended to include `.github/copilot-instructions.md`,
+`.coderabbit.yaml`, and `CLAUDE.md`, so an edit to a file that steers the AI
+fires the same `/security-review` nudge as an edit to login-path code (the hook
+already covers the `.claude/` tooling it lives beside).
+
+**An honest residual.** `.claude/`, `CLAUDE.md`, `AGENTS.md`, and the internal
+`docs/` are **maintained locally and are git-ignored** — they are not published
+and never appear in a pull request. Their protection is therefore the **local
+guard/reminder hooks plus this written classification and the maintainer's
+own review**, not a CI status check or a `CODEOWNERS` rule (a `CODEOWNERS` entry
+for an un-tracked path would never fire). This is a deliberate consequence of
+keeping the tooling local; it is recorded here so the control is understood, not
+assumed.
+
+### Provenance
+
+- **SLSA build-provenance attestation** (SLSA v1.1, Build L3) on every stable
+  release zip (#147) — a downloader can verify the artifact came from this
+  repository's release pipeline and was not tampered with (`SECURITY.md`).
+- **SHA-pinned actions** — every workflow `uses:` is pinned to a full commit
+  SHA; **zizmor** audits the workflow YAML and **Scorecard** audits the pinning
+  and token posture weekly.
+- **Locked-mode restore** — committed `packages.lock.json` fails the build on
+  dependency drift or tampering.
+- The **internal-only merge gate** — no external review/quality/analysis
+  service is trusted with this repository; the gate is CI + the adversarial
+  lens review + the maintainer (`REVIEW-GATE.md`).
+
+## Pointers
+
+- [`SECURITY.md`](SECURITY.md) — the condensed control set and the private
+  vulnerability-reporting path.
+- [`REVIEW-GATE.md`](REVIEW-GATE.md) — what the review gate covers, class by
+  class, and its one accepted residual.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — where each login-path concern lives in
+  the code.
+- `.claude/hooks/guard-git.ps1`, `.claude/hooks/security-reminder.ps1` — the
+  local pipeline guards named above.

--- a/scripts/dora-metrics.sh
+++ b/scripts/dora-metrics.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# DORA four-key delivery metrics for jellyfin-plugin-sso (issue #175).
+#
+# Derives the four DORA keys (deployment frequency, lead time for changes, change-failure
+# rate, mean time to restore) plus two cheap AI-risk indicators (revert rate, rework signal)
+# from THIS repo's actual delivery data: `*-stable` release tags, git commit history, and —
+# when the `gh` CLI is authenticated — the `bug`-labelled issue timeline. No new tooling.
+#
+# The operational definitions, and where a metric is only an approximation given the small
+# dataset, are documented in DORA-METRICS.md at the repo root. Read that first.
+#
+# The script is READ-ONLY and deterministic: it only reads local git objects and (optionally)
+# makes read-only `gh` queries. It never writes to git or GitHub. Re-running it on the same
+# repo state produces the same report.
+#
+# Usage:  scripts/dora-metrics.sh
+# Requires: git (mandatory), gh (optional — enriches the change-failure signal).
+#
+set -euo pipefail
+
+# --- Configuration (repo-specific delivery conventions) ---------------------------------------
+# A production "deployment" for this plugin is a stable release, tagged `X.Y.Z-stable`.
+# Beta / JF12-beta / nightly tags are pre-production and are deliberately excluded.
+STABLE_GLOB='*-stable'
+# A patch-level (Z) bump on the same X.Y line is treated as a hotfix / remediation of the
+# preceding release on that line — the standard DORA change-failure proxy. HOTFIX_WINDOW_DAYS
+# only annotates the report (fast hotfix vs. long-planned patch); it does NOT gate the CFR count.
+HOTFIX_WINDOW_DAYS=7
+
+# --- Preconditions ----------------------------------------------------------------------------
+command -v git >/dev/null 2>&1 || { echo "error: git is required" >&2; exit 1; }
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "error: not a git repo" >&2; exit 1; }
+
+GH_AVAILABLE=0
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  GH_AVAILABLE=1
+fi
+
+now_epoch=$(date +%s)
+
+# --- Helpers ----------------------------------------------------------------------------------
+# Render a duration in seconds as a compact human string (e.g. "2d 3h", "41m").
+human_duration() {
+  local s=$1 d h m
+  if (( s < 0 )); then s=0; fi
+  d=$(( s / 86400 )); s=$(( s % 86400 ))
+  h=$(( s / 3600 ));  s=$(( s % 3600 ))
+  m=$(( s / 60 ))
+  if   (( d > 0 )); then printf '%dd %dh' "$d" "$h"
+  elif (( h > 0 )); then printf '%dh %dm' "$h" "$m"
+  else                   printf '%dm' "$m"
+  fi
+}
+
+# Median of the numbers on stdin (one per line). Empty input -> empty string.
+median() {
+  sort -n | awk '{ a[NR]=$1 } END {
+    if (NR==0) { exit }
+    if (NR%2==1) { printf "%d", a[(NR+1)/2] }
+    else         { printf "%d", int((a[NR/2]+a[NR/2+1])/2) }
+  }'
+}
+
+# p90 (nearest-rank) of the numbers on stdin. Empty input -> empty string.
+p90() {
+  sort -n | awk '{ a[NR]=$1 } END {
+    if (NR==0) { exit }
+    r=int(0.9*NR + 0.9999); if (r<1) r=1; if (r>NR) r=NR
+    printf "%d", a[r]
+  }'
+}
+
+# --- Collect stable releases (chronological) --------------------------------------------------
+# Each row: <epoch>\t<iso-date>\t<tag>   sorted oldest -> newest by tag creation date.
+mapfile -t STABLE_ROWS < <(
+  git for-each-ref --sort=creatordate \
+    --format='%(creatordate:unix)%09%(creatordate:short)%09%(refname:short)' \
+    "refs/tags/${STABLE_GLOB}"
+)
+
+echo "=================================================================="
+echo " DORA delivery metrics — jellyfin-plugin-sso"
+echo " generated: $(date -u +'%Y-%m-%dT%H:%M:%SZ')  (read-only, deterministic)"
+echo " gh enrichment: $([ "$GH_AVAILABLE" = 1 ] && echo 'available' || echo 'unavailable (git-only)')"
+echo "=================================================================="
+
+if (( ${#STABLE_ROWS[@]} == 0 )); then
+  echo
+  echo "No ${STABLE_GLOB} tags found — no production deployments to measure yet."
+  exit 0
+fi
+
+# Parse the rows into parallel arrays.
+declare -a TAG_EPOCH TAG_DATE TAG_NAME TAG_MAJOR TAG_MINOR TAG_PATCH
+for row in "${STABLE_ROWS[@]}"; do
+  IFS=$'\t' read -r ep dt nm <<<"$row"
+  ver=${nm%-stable}                       # 4.2.1-stable -> 4.2.1
+  IFS='.' read -r maj min pat <<<"$ver"
+  TAG_EPOCH+=("$ep"); TAG_DATE+=("$dt"); TAG_NAME+=("$nm")
+  TAG_MAJOR+=("${maj:-0}"); TAG_MINOR+=("${min:-0}"); TAG_PATCH+=("${pat:-0}")
+done
+N=${#TAG_NAME[@]}
+
+# --- 1. Deployment frequency ------------------------------------------------------------------
+first_ep=${TAG_EPOCH[0]}
+last_ep=${TAG_EPOCH[$((N-1))]}
+span_days=$(( (last_ep - first_ep) / 86400 ))
+echo
+echo "1) DEPLOYMENT FREQUENCY"
+echo "   Definition: count of ${STABLE_GLOB} release tags (pre-prod beta/nightly excluded)."
+echo "   Stable releases: $N"
+printf '   Window: %s -> %s' "${TAG_DATE[0]}" "${TAG_DATE[$((N-1))]}"
+if (( span_days > 0 )); then
+  # Use awk for fractional rates.
+  awk -v n="$N" -v days="$span_days" 'BEGIN {
+    printf "  (%d days)\n", days
+    printf "   Rate: %.2f releases/week, %.2f releases/month\n", (n-1)/days*7, (n-1)/days*30
+  }'
+else
+  echo "  (all releases within a single day)"
+  echo "   Rate: n/a — release history spans <1 day; frequency not yet meaningful."
+fi
+echo "   Releases:"
+for ((i=0;i<N;i++)); do printf '     %s  %s\n' "${TAG_DATE[i]}" "${TAG_NAME[i]}"; done
+
+# --- 2. Lead time for changes -----------------------------------------------------------------
+# For every stable release that has a predecessor stable release, take each non-merge commit in
+# (predecessor..release] and measure release_date - commit_author_date. Aggregate across all such
+# intervals. The earliest stable tag has no predecessor and is skipped (documented limitation).
+echo
+echo "2) LEAD TIME FOR CHANGES"
+echo "   Definition: per non-merge commit, time from author date to the ${STABLE_GLOB} tag that"
+echo "   first shipped it. Aggregated over intervals that have a predecessor stable tag."
+lead_tmp=$(mktemp)
+intervals=0
+for ((i=1;i<N;i++)); do
+  prev=${TAG_NAME[$((i-1))]}; cur=${TAG_NAME[i]}; cur_ep=${TAG_EPOCH[i]}
+  cnt=0
+  while IFS= read -r cae; do
+    [ -z "$cae" ] && continue
+    echo $(( cur_ep - cae )) >>"$lead_tmp"
+    cnt=$((cnt+1))
+  done < <(git log --no-merges --format='%at' "${prev}..${cur}")
+  intervals=$((intervals+1))
+  printf '   %s -> %s: %d change-commits\n' "$prev" "$cur" "$cnt"
+done
+if (( intervals == 0 )); then
+  echo "   Only one stable release exists — no predecessor interval; lead time not computable yet."
+elif [ ! -s "$lead_tmp" ]; then
+  echo "   No non-merge commits between stable tags."
+else
+  med=$(median <"$lead_tmp"); p90v=$(p90 <"$lead_tmp")
+  mn=$(sort -n "$lead_tmp" | head -1); mx=$(sort -n "$lead_tmp" | tail -1)
+  echo "   Median: $(human_duration "$med")   p90: $(human_duration "$p90v")   min: $(human_duration "$mn")   max: $(human_duration "$mx")"
+fi
+rm -f "$lead_tmp"
+
+# --- 3. Change-failure rate -------------------------------------------------------------------
+# A stable release R is counted as a failure if the next stable release on the same X.Y line is a
+# patch (Z) bump — i.e. a remediation was needed. The newest release cannot yet be judged (nothing
+# follows it) and is excluded from the denominator. Reverts and bug-labelled issues are reported as
+# corroborating signal but do not change the primary count.
+echo
+echo "3) CHANGE-FAILURE RATE (CFR)"
+echo "   Definition: fraction of judgeable stable releases followed by a same-line patch hotfix."
+failures=0
+declare -a FAIL_IDX HOTFIX_IDX
+for ((i=0;i<N-1;i++)); do
+  # Find the immediate next stable release (chronological successor is index i+1).
+  j=$((i+1))
+  if [ "${TAG_MAJOR[i]}" = "${TAG_MAJOR[j]}" ] && [ "${TAG_MINOR[i]}" = "${TAG_MINOR[j]}" ] \
+     && (( 10#${TAG_PATCH[j]} > 10#${TAG_PATCH[i]} )); then
+    failures=$((failures+1))
+    FAIL_IDX+=("$i"); HOTFIX_IDX+=("$j")
+    gap=$(( TAG_EPOCH[j] - TAG_EPOCH[i] ))
+    fast=""
+    (( gap <= HOTFIX_WINDOW_DAYS*86400 )) && fast=" (within ${HOTFIX_WINDOW_DAYS}d window: fast hotfix)"
+    printf '   FAIL: %s -> hotfixed by %s after %s%s\n' \
+      "${TAG_NAME[i]}" "${TAG_NAME[j]}" "$(human_duration "$gap")" "$fast"
+  fi
+done
+judgeable=$((N-1))   # every release except the newest can, in principle, be judged
+if (( judgeable > 0 )); then
+  awk -v f="$failures" -v d="$judgeable" 'BEGIN { printf "   CFR: %d/%d = %.0f%%\n", f, d, f/d*100 }'
+else
+  echo "   CFR: n/a — only one stable release; no release can yet be judged."
+fi
+
+# Corroborating signal: explicit git reverts across the stable window.
+revert_count=$(git log --no-merges --grep='^Revert' -i -E --format='%h' \
+  "${TAG_NAME[0]}..${TAG_NAME[$((N-1))]}" 2>/dev/null | wc -l | tr -d ' ')
+echo "   Signal: $revert_count explicit revert commit(s) between first and latest stable tag."
+
+if (( GH_AVAILABLE == 1 )); then
+  bug_closed=$(gh issue list --label bug --state closed --limit 200 \
+    --json closedAt --jq "[.[] | select(.closedAt != null)] | length" 2>/dev/null || echo "?")
+  echo "   Signal: $bug_closed closed \`bug\`-labelled issue(s) total (production-defect corpus)."
+else
+  echo "   Signal: bug-issue corpus skipped (gh unavailable)."
+fi
+
+# --- 4. Mean time to restore ------------------------------------------------------------------
+# For each failure (release -> its hotfix), restore time = hotfix_date - failed_release_date. This
+# measures release-to-release recovery; it is an UPPER bound on user-facing downtime since the
+# defect is usually discovered after the release, not at it (documented limitation).
+echo
+echo "4) MEAN TIME TO RESTORE (MTTR)"
+echo "   Definition: time from a failing stable release to the stable release that fixes it."
+if (( ${#FAIL_IDX[@]} == 0 )); then
+  echo "   No failure->hotfix pairs detected; MTTR not applicable."
+else
+  mttr_tmp=$(mktemp)
+  for k in "${!FAIL_IDX[@]}"; do
+    fi=${FAIL_IDX[k]}; hi=${HOTFIX_IDX[k]}
+    echo $(( TAG_EPOCH[hi] - TAG_EPOCH[fi] )) >>"$mttr_tmp"
+  done
+  total=0; cnt=0
+  while IFS= read -r v; do total=$((total+v)); cnt=$((cnt+1)); done <"$mttr_tmp"
+  mean=$(( total / cnt ))
+  med=$(median <"$mttr_tmp")
+  echo "   Pairs: $cnt   Mean: $(human_duration "$mean")   Median: $(human_duration "$med")"
+  rm -f "$mttr_tmp"
+fi
+
+# --- 5. Supplementary AI-risk indicators (cheap, git-derived) ---------------------------------
+# The DORA 2025/26 guidance flags instability in agent-authored change as the leading risk; revert
+# rate and a rework signal are the cheapest leading indicators derivable from git. Review-finding
+# density needs /security-review output and is tracked manually (see DORA-METRICS.md).
+echo
+echo "5) AI-RISK / DELIVERY-STABILITY INDICATORS (supplementary)"
+range="${TAG_NAME[0]}..${TAG_NAME[$((N-1))]}"
+total_commits=$(git log --no-merges --format='%h' "$range" 2>/dev/null | wc -l | tr -d ' ')
+if (( total_commits > 0 )); then
+  awk -v r="$revert_count" -v t="$total_commits" 'BEGIN {
+    printf "   Revert rate: %d/%d non-merge commits = %.1f%% (across the stable window)\n", r, t, r/t*100
+  }'
+else
+  echo "   Revert rate: n/a — no commits in the stable window."
+fi
+# Rework signal: fixup/amend-style subjects landing on top of recent work.
+rework=$(git log --no-merges -i -E --grep='^(fixup|amend|re-?fix|follow-?up)' --format='%h' "$range" 2>/dev/null | wc -l | tr -d ' ')
+echo "   Rework signal: $rework fixup/follow-up commit subject(s) in the stable window (heuristic)."
+echo "   Review-finding density: manually tracked per /security-review — see DORA-METRICS.md."
+
+echo
+echo "=================================================================="
+echo " Small-dataset caveat: with $N stable release(s), rates are indicative,"
+echo " not statistically stable. Interpret trend, not absolute value."
+echo "=================================================================="


### PR DESCRIPTION
Brings all the completed milestone-branch work onto main so it lives on the canonical branch (no more divergent long-lived branches). No release, no version bump, build.yaml stays 4.2.1.

**Merges (all conflict-free):**
- **4.6 (P6):** DORA-METRICS.md + scripts/dora-metrics.sh (#175), ROLLBACK.md (#151).
- **4.5 (P5b):** REVIEW-GATE.md (#101), THREAT-MODEL.md (#152), + SECURITY.md/CONTRIBUTING.md cross-refs.
- **4.4 (P5):** the artifacts↔publish-closure conformance test (#608), publish-jf12-stable.yml (#607).
- **4.3 (P4):** SLO-DESIGN.md (#154), SSO-ONLY-LOGIN-DESIGN.md (#165 threat model), the account-link success-UX fix + tests (#614).

After this merges green, the 4.3/4.4/4.5/4.6 branches are retired. Remaining milestone work continues as short-lived PRs to main.

## Verification
- [x] No merge conflicts; version unchanged (4.2.1); all milestone docs present.
- [ ] CI green on the combined tree (esp. the #608 conformance test + #614 WebResponse change together).