### PR TITLE
Share the publish-manifest-release concurrency group (#655)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,17 @@ on:
 permissions:
   contents: read
 
+# Serialize with the JF12 stable leg (#655): both this JF10.11 stable publish and
+# publish-jf12-stable.yml regenerate the SHARED manifest-release branch, so they must
+# not run concurrently or their reader-vs-pusher regenerations race (a TOCTOU that
+# could transiently drop the other generation's just-published build from the stable
+# manifest — the same hazard the shared publish-manifest-beta group fixes for the beta
+# legs). cancel-in-progress is false — a publish holding contents:write must never be
+# killed mid-run.
+concurrency:
+  group: publish-manifest-release
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build package


### PR DESCRIPTION
Closes #655. publish-jf12-stable.yml (#607) added `concurrency: group: publish-manifest-release` to serialize manifest-release regenerations, but publish.yml (JF10.11 stable) did not share it, so a JF10.11 and a JF12 stable publish could race the shared stable manifest (the same TOCTOU the beta legs fixed with publish-manifest-beta). Adds the same group here, cancel-in-progress:false.

## Type of change
- [x] CI hardening (one-line concurrency group)

Closes #655