### PR TITLE
Advisory deterministic PR-hygiene checks (#171)

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,170 @@
+# Deterministic PR-hygiene checks (#171). A "Danger-style" gate implemented as a
+# plain workflow + one first-party github-script step — no external Danger runtime,
+# bot, or third-party review service (the merge gate is internal-only by policy;
+# see REVIEW-GATE.md). It complements, never duplicates, the build/test, Prettier,
+# CodeQL, Opengrep, zizmor, and Unicode-guard checks: those reason about the code;
+# this reasons about the *pull request* (its linkage, size, and changelog/test
+# co-changes) — a class none of them cover.
+#
+# This workflow is deliberately ADVISORY: it is NOT wired into the "Protect main"
+# required-status-check ruleset, so it never blocks a merge. It surfaces a
+# deterministic hygiene signal for the maintainer, who keeps the final say. The
+# checks are tiered by confidence so it does not red-flag reasonable PRs:
+#   - FAIL  (high confidence, near-zero false-positive):
+#       * PR body carries an issue reference (Closes/Refs #N) — skipped for bots.
+#       * a build.yaml version bump also touches CHANGELOG.md.
+#       * the diff is not enormous (>800 changed lines) unless `override:size` says so.
+#   - WARN  (soft convention, annotation only — never fails):
+#       * the diff is large (>=400 changed lines).
+#       * SSO-Auth code changed without a matching SSO-Auth.Tests change.
+#
+# Two acceptance-criteria items from #171 are intentionally NOT implemented here
+# (sensitive-path sign-off grep, and issue-open triage-lint); the rationale is
+# recorded in REVIEW-GATE.md so the decision is auditable, not silent.
+name: PR Hygiene
+
+on:
+  pull_request:
+    # labeled/unlabeled: so adding `override:size` re-runs and clears the check.
+    # edited: so editing the body to add the issue reference re-runs it.
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+# Explicit deny-all at workflow level; the job below grants only what it reads.
+permissions: {}
+
+# Cancel a superseded run on the same PR; this is an advisory lint, not a publish,
+# so cancelling an obsolete run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hygiene:
+    name: Deterministic PR-hygiene checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read # read build.yaml/CHANGELOG changes via the pulls API
+      pull-requests: read # read the PR body, labels, and changed-file list
+    steps:
+      # No checkout: every input is read from the PR metadata and the changed-file
+      # patches via the API, so there is no untrusted working tree to guard.
+      # Untrusted values (the PR body, labels, filenames) are only ever read from
+      # the JS `context`/API objects — never interpolated into a shell `run:` — so
+      # there is no template-injection surface (zizmor-clean by construction).
+      - name: Run PR-hygiene checks
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const warnings = [];
+            const failures = [];
+
+            // --- Changed files (paginated) -------------------------------------
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const changed = files.map((f) => f.filename);
+            const labels = (pr.labels || []).map((l) => l.name);
+            const isBot = pr.user && pr.user.type === "Bot";
+
+            // --- Check 1: PR body references an issue (Closes/Refs #N) ----------
+            // Directive: every change is issue-driven and linked. Bots (Dependabot)
+            // open PRs with no issue, so they are exempt. A bare `#123`, a keyword
+            // form (`Closes #123`), or a full issue URL all satisfy it — lenient on
+            // purpose so a legitimately-linked PR is never flagged on phrasing.
+            const body = pr.body || "";
+            const hasIssueRef =
+              /(^|[^\w])#\d+\b/.test(body) ||
+              /github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+/i.test(body);
+            if (!isBot && !hasIssueRef) {
+              failures.push(
+                "PR body has no issue reference. Link the issue it addresses " +
+                  "(e.g. `Closes #123` or `Refs #123`).",
+              );
+            }
+
+            // --- Check 2: a build.yaml version bump must touch CHANGELOG.md -----
+            // The version field only changes in a release PR, which must also record
+            // the release in CHANGELOG.md. Near-zero false-positive: a non-release PR
+            // never edits the `version:` line, so this stays silent for it.
+            const buildYaml = files.find((f) => f.filename === "build.yaml");
+            const versionBumped =
+              buildYaml &&
+              buildYaml.patch &&
+              /^\+\s*version:/m.test(buildYaml.patch);
+            if (versionBumped && !changed.includes("CHANGELOG.md")) {
+              failures.push(
+                "build.yaml `version:` changed but CHANGELOG.md was not updated. " +
+                  "Record the release in CHANGELOG.md.",
+              );
+            }
+
+            // --- Check 3: PR size (warn >=400, fail >800 unless overridden) -----
+            // Rationale (#171): reviewer effectiveness — human and AI — degrades on
+            // very large diffs. Generated/lock files are excluded so the count
+            // reflects human-authored change, and `override:size` is the escape
+            // hatch for a legitimately large change (a bulk rename, a vendored drop).
+            const isGenerated = (name) =>
+              name.endsWith("packages.lock.json") ||
+              name === "flake.lock" ||
+              name.endsWith(".min.js") ||
+              name.endsWith(".min.css");
+            const churn = files
+              .filter((f) => !isGenerated(f.filename))
+              .reduce((sum, f) => sum + f.additions + f.deletions, 0);
+            const WARN_AT = 400;
+            const FAIL_AT = 800;
+            const sizeOverridden = labels.includes("override:size");
+            if (churn > FAIL_AT && !sizeOverridden) {
+              failures.push(
+                `PR changes ${churn} lines (excluding generated/lock files), over ` +
+                  `the ${FAIL_AT}-line cap. Split it into smaller PRs, or add the ` +
+                  "`override:size` label with a reason if it is genuinely atomic.",
+              );
+            } else if (churn >= WARN_AT) {
+              warnings.push(
+                `PR changes ${churn} lines (excluding generated/lock files). ` +
+                  `Consider splitting it — reviews degrade past ~${WARN_AT} lines.`,
+              );
+            }
+
+            // --- Check 4: code changed without a matching test change (WARN) ----
+            // Soft convention: a behavioural change to SSO-Auth should move a test.
+            // Warn only — a docs/comment-only edit, a pure refactor, or a project-file
+            // tweak legitimately touches no test, and hard-failing those would be the
+            // exact false-positive friction #171 warns against.
+            const codeChanged = changed.some(
+              (n) => n.startsWith("SSO-Auth/") && n.endsWith(".cs"),
+            );
+            const testsChanged = changed.some((n) =>
+              n.startsWith("SSO-Auth.Tests/"),
+            );
+            if (codeChanged && !testsChanged) {
+              warnings.push(
+                "SSO-Auth/*.cs changed but no SSO-Auth.Tests/* change is in this PR. " +
+                  "Confirm the change is genuinely untestable (docs/refactor) or add a test.",
+              );
+            }
+
+            // --- Report --------------------------------------------------------
+            for (const w of warnings) core.warning(w);
+            const summary = core.summary.addHeading("PR-hygiene checks", 2);
+            if (failures.length === 0 && warnings.length === 0) {
+              summary.addRaw("All deterministic PR-hygiene checks passed.");
+            } else {
+              if (failures.length) {
+                summary.addHeading("Failures", 3).addList(failures);
+              }
+              if (warnings.length) {
+                summary.addHeading("Warnings (non-blocking)", 3).addList(warnings);
+              }
+            }
+            await summary.write();
+
+            if (failures.length) {
+              core.setFailed(failures.join(" | "));
+            }

--- a/REVIEW-GATE.md
+++ b/REVIEW-GATE.md
@@ -24,6 +24,17 @@ test`, Prettier, CodeQL (security-extended), Opengrep repo-invariant rules,
   the transitive vulnerable-dependency scan. `build`, `prettier`, and
   `dependency-review` are required status checks on the protected branch (see
   the comment in each workflow); CodeQL is intentionally a non-required check.
+- **Every pull request** (advisory, non-gating): the deterministic PR-hygiene
+  checks (`pr-hygiene.yml`) — a self-hosted "Danger-style" gate (plain workflow +
+  one first-party `github-script` step, no external Danger runtime or bot). It
+  checks the pull request _as an object_ rather than the code: that the body
+  carries an issue reference (Closes/Refs #N; bots exempt), that a `build.yaml`
+  version bump also touches `CHANGELOG.md`, that the diff is not enormous
+  (warn ≥400, fail >800 changed non-generated lines unless `override:size`), and
+  that an `SSO-Auth/*.cs` change moves a test (warn only). It is deliberately
+  **not** a required status check, so it never blocks a merge — it surfaces a
+  deterministic hygiene signal the maintainer acts on. See the header of
+  `pr-hygiene.yml` and the "Deterministic PR-hygiene" note below.
 - **On a weekly schedule** (not per-PR, non-gating by construction): Stryker.NET
   mutation testing (scoped to the SAML/OIDC core), SharpFuzz fuzzing (SAML/OIDC
   parse surface), OpenSSF Scorecard, and the CodeQL baseline re-scan.
@@ -185,11 +196,62 @@ The direction — an author-independent review perspective on every diff — is 
 standing goal; this document records how far the internal gate currently closes
 it.
 
+## Deterministic PR-hygiene (#171): what is checked, and what was declined
+
+`pr-hygiene.yml` implements the deterministic, mechanically-decidable subset of
+the PR-process checks scoped in #171 — the ones that add real value beyond the
+existing CI and do not red-flag a reasonable pull request. Two of the four
+acceptance-criteria items were deliberately **not** implemented; that is a
+reasoned decline, recorded here so the decision is auditable.
+
+**Implemented (high-confidence, in `pr-hygiene.yml`):**
+
+- **Issue reference** — a non-bot PR whose body carries no `#N` / issue-URL
+  reference fails. Closes the issue-driven-linkage gap; nothing else checked it.
+- **CHANGELOG on version bump** — a `build.yaml` `version:` change that does not
+  also touch `CHANGELOG.md` fails. Deterministic release hygiene; near-zero
+  false-positive because only a release PR edits the version line.
+- **PR size** — warn ≥400, fail >800 changed lines (generated/lock files
+  excluded), with an `override:size` label as the escape hatch for a genuinely
+  atomic large change. Reviewer effectiveness degrades on large diffs.
+- **Test co-change** — an `SSO-Auth/*.cs` change with no `SSO-Auth.Tests/*`
+  change **warns only**, never fails: a docs/comment/refactor edit legitimately
+  moves no test, and hard-failing those is exactly the false-positive friction
+  the issue warns against.
+
+**Declined, with rationale:**
+
+- **Sensitive-path diffs without a sign-off gate note (AC3).** A regex over the
+  PR body for a "security-review sign-off note" would be a fuzzy proxy for a
+  control that already exists and is stronger. The login / SAML-OIDC-crypto /
+  config-persistence / release-pipeline surface already gets the **mandatory
+  adversarial multi-lens review** (this document, above) plus the PR template's
+  security checklist; a body-grep cannot tell a genuinely-reviewed PR from one
+  that merely pattern-matches the expected wording, so it would produce
+  false confidence on the miss and false-positive friction on legitimately
+  reviewed PRs whose note is phrased differently. The human gate is the control;
+  a deterministic grep would add noise, not assurance.
+- **Issue-open triage-lint: type + area + priority + milestone (AC4).** These
+  facets are assigned by the maintainer **during triage**, not by the author at
+  open time — and community bug/feature issues are filed through the public
+  templates, which cannot set them. Enforcing them on `issues.opened` would
+  red-flag essentially every externally-filed issue the moment it is created,
+  penalising exactly the outside contributors the project wants to welcome, for
+  a step that is a maintainer responsibility rather than an author obligation.
+  Triage stays a manual maintainer action; automating it as an open-time gate
+  trades a small consistency gain for constant, unfair false-positive friction.
+
+If the declined items are ever revisited, the honest form of AC4 is a
+maintainer-scoped nudge (run only on issues opened by a maintainer, or as a
+periodic untriaged-issue report), not an open-time hard gate — and AC3's value
+is already delivered by the adversarial review, not a body-grep.
+
 ## Pointers
 
 - `SECURITY.md` — the repository security controls, condensed, and the private
   vulnerability-reporting path.
 - `CONTRIBUTING.md` — the build/test commands and the branch → PR flow.
 - `.github/workflows/` — the CI workflows named above.
+- `.github/workflows/pr-hygiene.yml` — the deterministic PR-hygiene checks (#171).
 - `tools/opengrep/rules.yml` — the greppable security invariants.
 - `SSO-Auth.Tests/ArchitectureConformanceTests.cs` — the fitness functions.


### PR DESCRIPTION
Closes #171 (P5b). Adds `.github/workflows/pr-hygiene.yml`, a self-hosted Danger-style gate (one SHA-pinned actions/github-script step, NO external Danger service, respects the internal-only-gate policy). **Advisory / non-blocking** (not in the required-check ruleset) so it never red-flags a reasonable PR:
- FAIL: PR body references an issue (#N/URL); bots exempt (Dependabot).
- FAIL: a build.yaml `version:` bump must also touch CHANGELOG.md.
- WARN ≥400 / FAIL >800 changed lines, excluding lock/generated files, with an `override:size` label escape.
- WARN-only: SSO-Auth/*.cs changed without a test change (warn, not fail, docs/refactor legitimately move no test).

Reasoned-declined AC3 (sensitive-path body-grep, the mandatory adversarial review is the stronger real control) + AC4 (issue-triage-lint, that's a manual triage action, would red-flag every community issue); rationale added to REVIEW-GATE.md.

zizmor-clean: `permissions:{}` + read-only grant, SHA-pinned, untrusted values via context objects (no template injection).

## Type of change
- [x] CI (advisory PR hygiene)

Closes #171