### PR TITLE
Full RBAC mapping: SSO claims -> PermissionKind (default-deny) (#164)

### DIFF
--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -183,6 +183,53 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void PermissionRoles_AreThreadedFromClaimsOntoTheDerivedState()
+    {
+        // #164 wiring: the generic role→permission grants derived from the login's role claims and the
+        // provider configuration are carried on the derived state (and thence to the mint). Here the login
+        // carries the mapped role, so the permission is granted; another configured-but-unmatched permission
+        // is explicitly revoked.
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnablePermissionRoles = true;
+            c.PermissionRoleMappings = new System.Collections.Generic.List<PermissionRoleMap>
+            {
+                new PermissionRoleMap { Permission = "EnableContentDownloading", Roles = new[] { "downloaders" } },
+                new PermissionRoleMap { Permission = "EnableContentDeletion", Roles = new[] { "deleters" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "downloaders")),
+            config);
+
+        Assert.NotNull(result.PermissionGrants);
+        Assert.Contains(result.PermissionGrants!, g => g.Kind == Jellyfin.Database.Implementations.Enums.PermissionKind.EnableContentDownloading && g.Granted);
+        Assert.Contains(result.PermissionGrants!, g => g.Kind == Jellyfin.Database.Implementations.Enums.PermissionKind.EnableContentDeletion && !g.Granted);
+    }
+
+    [Fact]
+    public void PermissionRoles_FeatureOff_LeavesTheGrantsEmpty()
+    {
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnablePermissionRoles = false;
+            c.PermissionRoleMappings = new System.Collections.Generic.List<PermissionRoleMap>
+            {
+                new PermissionRoleMap { Permission = "EnableContentDownloading", Roles = new[] { "downloaders" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "downloaders")),
+            config);
+
+        Assert.Empty(result.PermissionGrants!);
+    }
+
+    [Fact]
     public void AdminRole_GrantsAdmin_ViaNestedJsonRoleClaim()
     {
         var config = Config(c =>

--- a/SSO-Auth.Tests/PermissionRolePolicyTests.cs
+++ b/SSO-Auth.Tests/PermissionRolePolicyTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="PermissionRolePolicy"/> — the generic role→permission mapping (#164) that extends
+/// the dedicated admin/folder/Live TV surface to the full boolean <see cref="PermissionKind"/> surface.
+/// These pin the security-load-bearing guarantees: the mapping is default-deny and authoritative (a
+/// configured permission is granted only when a matching role is present and otherwise EXPLICITLY revoked,
+/// so a missing/empty/unmapped claim never grants), the feature is off by default, the dedicated
+/// permissions (notably IsAdministrator) cannot be granted through the generic map, and role matching is
+/// ordinal. Each grant/deny case would flip to a failing assertion if the policy were loosened.
+/// </summary>
+public class PermissionRolePolicyTests
+{
+    private static OidConfig Config(bool enable, params PermissionRoleMap[] mappings) => new OidConfig
+    {
+        EnablePermissionRoles = enable,
+        PermissionRoleMappings = mappings.ToList(),
+    };
+
+    private static PermissionRoleMap Map(string permission, params string[] roles) => new PermissionRoleMap
+    {
+        Permission = permission,
+        Roles = roles,
+    };
+
+    private static bool? GrantFor(IReadOnlyList<PermissionGrant> grants, PermissionKind kind)
+    {
+        var matches = grants.Where(g => g.Kind == kind).ToList();
+        return matches.Count == 0 ? null : matches[0].Granted;
+    }
+
+    // --- Feature gate: off by default, nothing is managed ---
+
+    [Fact]
+    public void Map_FeatureOff_EvenWithAMatchingRole_ReturnsEmpty()
+    {
+        // The master switch is the fail-closed default: with it off, SSO manages no extra permission even
+        // when a mapping would match — byte-for-byte the pre-#164 behavior.
+        var config = Config(enable: false, Map("EnableContentDownloading", "media"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "media" }, config);
+
+        Assert.Empty(grants);
+    }
+
+    [Fact]
+    public void Map_FeatureOn_NoMappings_ReturnsEmpty()
+    {
+        var grants = PermissionRolePolicy.Map(new[] { "media" }, Config(enable: true));
+
+        Assert.Empty(grants);
+    }
+
+    // --- Grant / default-deny core ---
+
+    [Fact]
+    public void Map_MatchingRole_GrantsThePermission()
+    {
+        var config = Config(enable: true, Map("EnableContentDownloading", "downloaders"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "downloaders" }, config);
+
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_ConfiguredPermissionButNoMatchingRole_ExplicitlyRevokes()
+    {
+        // Default-deny AND authoritative: a permission the admin listed is still emitted when no role
+        // matches, as an explicit REVOKE (false). A missing claim never leaves a stale grant in place and
+        // never silently grants.
+        var config = Config(enable: true, Map("EnableContentDownloading", "downloaders"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "someone-else" }, config);
+
+        Assert.Equal(false, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_UnmappedPermission_IsNeverEmitted()
+    {
+        // A permission not listed at all is not in the result, so the mint leaves it untouched (Jellyfin's
+        // own default governs it). Only EXPLICITLY configured permissions are managed by SSO.
+        var config = Config(enable: true, Map("EnableContentDownloading", "downloaders"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "downloaders" }, config);
+
+        Assert.Null(GrantFor(grants, PermissionKind.EnableContentDeletion));
+        Assert.Null(GrantFor(grants, PermissionKind.EnableMediaConversion));
+    }
+
+    // --- No privilege escalation through the generic map ---
+
+    [Theory]
+    [InlineData("IsAdministrator")]
+    [InlineData("EnableAllFolders")]
+    [InlineData("EnableLiveTvAccess")]
+    [InlineData("EnableLiveTvManagement")]
+    public void Map_DedicatedPermission_IsNeverGrantedThroughTheGenericMap_EvenWithAMatchingRole(string permission)
+    {
+        // The four permissions with their own dedicated config fields/flows cannot be granted here — this is
+        // the anti-escalation guarantee: an admin cannot mint IsAdministrator (or all-folders / Live TV)
+        // through the generic map, even when the login carries the mapped role. They resolve to no grant.
+        var config = Config(enable: true, Map(permission, "privileged"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "privileged" }, config);
+
+        Assert.Empty(grants);
+    }
+
+    [Fact]
+    public void Map_UnknownPermissionName_GrantsNothing()
+    {
+        // Fail closed: an unknown permission name resolves to no grant (it is also rejected at config-save
+        // validation, but the runtime path must not throw on it either).
+        var config = Config(enable: true, Map("NotARealPermission", "any"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "any" }, config);
+
+        Assert.Empty(grants);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Map_BlankPermissionName_GrantsNothing(string? permission)
+    {
+        var config = Config(enable: true, Map(permission!, "any"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "any" }, config);
+
+        Assert.Empty(grants);
+    }
+
+    // --- Ordinal role matching, config-side trim, null-safety ---
+
+    [Fact]
+    public void Map_RoleMatchingIsOrdinalCaseSensitive()
+    {
+        // Deterministic ordinal matching (consistent with the auth-path comparison hardening): a differently
+        // cased login role is NOT a match, so the permission is explicitly revoked rather than granted.
+        var config = Config(enable: true, Map("EnableContentDownloading", "Downloaders"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "downloaders" }, config);
+
+        Assert.Equal(false, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_ConfiguredRoleIsTrimmedBeforeComparison_LoginRoleComparedRaw()
+    {
+        // The configured (trusted, admin-authored) role is trimmed; the IdP-supplied role is compared raw
+        // and ordinal — mirroring the folder-role comparison hardening (#367), so stray config whitespace is
+        // not a mismatch while an IdP role cannot inject whitespace to force a match.
+        var config = Config(enable: true, Map("EnableContentDownloading", "  downloaders  "));
+
+        var grants = PermissionRolePolicy.Map(new[] { "downloaders" }, config);
+
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_NullRolesArray_DoesNotThrow_Revokes()
+    {
+        var config = Config(enable: true, new PermissionRoleMap { Permission = "EnableContentDownloading", Roles = null });
+
+        var grants = PermissionRolePolicy.Map(new[] { "media" }, config);
+
+        Assert.Equal(false, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_NullEntryAmongMappings_IsSkipped()
+    {
+        var config = new OidConfig
+        {
+            EnablePermissionRoles = true,
+            PermissionRoleMappings = new List<PermissionRoleMap> { null!, Map("EnableContentDownloading", "media") },
+        };
+
+        var grants = PermissionRolePolicy.Map(new[] { "media" }, config);
+
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    // --- Determinism: duplicates OR-ed, emitted once ---
+
+    [Fact]
+    public void Map_SamePermissionInSeveralEntries_IsOredAndEmittedOnce()
+    {
+        // A permission named in several entries is granted iff ANY entry's roles match (OR), and it is
+        // emitted exactly once so the mint never applies it twice with conflicting values.
+        var config = Config(
+            enable: true,
+            Map("EnableContentDownloading", "no-match"),
+            Map("EnableContentDownloading", "yes-match"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "yes-match" }, config);
+
+        Assert.Single(grants, g => g.Kind == PermissionKind.EnableContentDownloading);
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_MultipleDistinctPermissions_AllEmitted()
+    {
+        var config = Config(
+            enable: true,
+            Map("EnableContentDownloading", "media"),
+            Map("EnableContentDeletion", "editors"),
+            Map("EnableCollectionManagement", "editors"));
+
+        var grants = PermissionRolePolicy.Map(new[] { "media", "editors" }, config);
+
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDownloading));
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableContentDeletion));
+        Assert.Equal(true, GrantFor(grants, PermissionKind.EnableCollectionManagement));
+    }
+
+    // --- Classify: the validation predicate ---
+
+    [Theory]
+    [InlineData("EnableContentDownloading")]
+    [InlineData("EnableContentDeletion")]
+    [InlineData("EnableSubtitleManagement")]
+    public void Classify_KnownNonDedicatedPermission_IsValid(string permission)
+    {
+        Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Valid, PermissionRolePolicy.Classify(permission));
+    }
+
+    [Theory]
+    [InlineData("IsAdministrator")]
+    [InlineData("EnableAllFolders")]
+    [InlineData("EnableLiveTvAccess")]
+    [InlineData("EnableLiveTvManagement")]
+    public void Classify_DedicatedPermission_IsDedicated(string permission)
+    {
+        Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Dedicated, PermissionRolePolicy.Classify(permission));
+    }
+
+    [Theory]
+    [InlineData("NotARealPermission")]
+    [InlineData("enablecontentdownloading")] // mis-cased: canonical name comparison is ordinal
+    [InlineData("11")] // a numeric string must not resolve to a permission by ordinal value
+    [InlineData("EnableContentDownloading ")] // trailing space is trimmed, so this is actually valid — see below
+    public void Classify_UnknownOrMiscasedName_IsUnknown_ExceptTrimmedValid(string permission)
+    {
+        var status = PermissionRolePolicy.Classify(permission);
+
+        // The trimmed-but-otherwise-valid name is Valid (leading/trailing whitespace is trimmed); every
+        // other case here is Unknown.
+        if (permission.Trim() == "EnableContentDownloading")
+        {
+            Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Valid, status);
+        }
+        else
+        {
+            Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Unknown, status);
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Classify_BlankName_IsEmpty(string? permission)
+    {
+        Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Empty, PermissionRolePolicy.Classify(permission));
+    }
+}

--- a/SSO-Auth.Tests/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigValidatorTests.cs
@@ -243,4 +243,84 @@ public class ProviderConfigValidatorTests
 
         Assert.Null(ex);
     }
+
+    // --- ValidatePermissionRoleMappings (#164): reject a malformed generic permission-role mapping ---
+
+    private static System.Collections.Generic.List<PermissionRoleMap> Mappings(string permission) =>
+        new() { new PermissionRoleMap { Permission = permission, Roles = new[] { "role" } } };
+
+    [Theory]
+    [InlineData("OpenID", "kc")]
+    [InlineData("SAML", "adfs")]
+    public void ValidatePermissionRoleMappings_UnknownPermission_ThrowsNamingProtocolProviderAndPermission(string protocol, string provider)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePermissionRoleMappings(protocol, provider, Mappings("NotARealPermission")));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains(protocol, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(provider, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("NotARealPermission", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("not a known Jellyfin permission", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("IsAdministrator")]
+    [InlineData("EnableAllFolders")]
+    [InlineData("EnableLiveTvAccess")]
+    [InlineData("EnableLiveTvManagement")]
+    public void ValidatePermissionRoleMappings_DedicatedPermission_IsRejected_NoDoubleMapping(string permission)
+    {
+        // The anti-escalation / single-source guarantee at the admin write boundary: a dedicated permission
+        // (notably IsAdministrator) cannot be persisted into the generic map, so it can never be granted
+        // through it.
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", Mappings(permission)));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("dedicated setting", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ValidatePermissionRoleMappings_EmptyPermissionName_IsRejected(string? permission)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", Mappings(permission!)));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("empty permission name", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidatePermissionRoleMappings_ControlCharacterInPermission_IsStrippedFromTheEchoedMessage()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", Mappings("Enable\nDownloading")));
+
+        Assert.DoesNotContain('\n', ex.Message);
+        Assert.DoesNotContain('\r', ex.Message);
+    }
+
+    [Fact]
+    public void ValidatePermissionRoleMappings_ValidPermission_DoesNotThrow()
+    {
+        var ex = Record.Exception(() =>
+            ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", Mappings("EnableContentDownloading")));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ValidatePermissionRoleMappings_NullMappingsOrNullEntry_DoesNotThrow()
+    {
+        // A null list means "no mappings"; a null entry maps nothing and is tolerated (it grants nothing at
+        // runtime) — the same fail-closed-but-not-fatal posture as the runtime mapper.
+        Assert.Null(Record.Exception(() => ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", null)));
+
+        var withNullEntry = new System.Collections.Generic.List<PermissionRoleMap> { null! };
+        Assert.Null(Record.Exception(() => ProviderConfigValidator.ValidatePermissionRoleMappings("OpenID", "kc", withNullEntry)));
+    }
 }

--- a/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
@@ -171,4 +171,49 @@ public class SamlAuthorizeStateBuilderTests
 
         Assert.False(result.EnableLiveTv);
     }
+
+    [Fact]
+    public void PermissionRoles_AreThreadedFromRolesOntoTheDerivedState()
+    {
+        // #164 wiring (SAML side, symmetric with the OIDC builder): the generic role→permission grants
+        // are derived from the assertion's roles and the provider config and carried on the derived state
+        // (thence to the mint). The matched role grants its permission; a configured-but-unmatched
+        // permission is explicitly revoked. Pins the SAML grant-threading branch so a regression that drops
+        // it (silently losing all SAML grants AND default-deny revokes) fails here.
+        var config = Config(c =>
+        {
+            c.EnablePermissionRoles = true;
+            c.PermissionRoleMappings = new List<PermissionRoleMap>
+            {
+                new PermissionRoleMap { Permission = "EnableContentDownloading", Roles = new[] { "downloaders" } },
+                new PermissionRoleMap { Permission = "EnableContentDeletion", Roles = new[] { "deleters" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "downloaders" }, config);
+
+        Assert.NotNull(result.PermissionGrants);
+        Assert.Contains(result.PermissionGrants!, g => g.Kind == Jellyfin.Database.Implementations.Enums.PermissionKind.EnableContentDownloading && g.Granted);
+        Assert.Contains(result.PermissionGrants!, g => g.Kind == Jellyfin.Database.Implementations.Enums.PermissionKind.EnableContentDeletion && !g.Granted);
+    }
+
+    [Fact]
+    public void PermissionRoles_FeatureOff_LeavesTheGrantsEmpty()
+    {
+        // With the master switch off, no generic grants are derived even when a mapping and a matching role
+        // are present (default-deny; Jellyfin's own defaults govern).
+        var config = Config(c =>
+        {
+            c.EnablePermissionRoles = false;
+            c.PermissionRoleMappings = new List<PermissionRoleMap>
+            {
+                new PermissionRoleMap { Permission = "EnableContentDownloading", Roles = new[] { "downloaders" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "downloaders" }, config);
+
+        Assert.NotNull(result.PermissionGrants);
+        Assert.Empty(result.PermissionGrants!);
+    }
 }

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -43,7 +44,8 @@ public class SessionMinterTests
         bool enableLiveTv = false,
         bool enableLiveTvManagement = false,
         string? avatarUrl = null,
-        string? defaultProvider = null) => new SessionParameters
+        string? defaultProvider = null,
+        IReadOnlyList<PermissionGrant>? permissionGrants = null) => new SessionParameters
     {
         UserId = UserId,
         IsAdmin = isAdmin,
@@ -52,6 +54,7 @@ public class SessionMinterTests
         EnabledFolders = enabledFolders ?? Array.Empty<string>(),
         EnableLiveTv = enableLiveTv,
         EnableLiveTvManagement = enableLiveTvManagement,
+        PermissionGrants = permissionGrants ?? Array.Empty<PermissionGrant>(),
         AvatarUrl = avatarUrl,
         DefaultProvider = defaultProvider,
         AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
@@ -158,6 +161,56 @@ public class SessionMinterTests
         await minter.MintAsync(Params(enableAuthorization: false, isAdmin: false), () => "203.0.113.7", () => true);
 
         Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.IsAdministrator && perm.Value); // seeded admin left untouched
+    }
+
+    [Fact]
+    public async Task MintAsync_EnableAuthorization_AppliesGenericPermissionGrants_GrantAndRevoke()
+    {
+        // #164: with the master switch on, each generic role→permission grant is applied authoritatively —
+        // a granted permission is set true and a revoked one set false. Seed the OPPOSITE of each so the
+        // assertions prove the mint flipped them, not that a fresh user happened to match.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        user.SetPermission(PermissionKind.EnableContentDownloading, false); // grant must flip to true
+        user.SetPermission(PermissionKind.EnableContentDeletion, true); // revoke must flip to false
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(
+            Params(
+                enableAuthorization: true,
+                permissionGrants: new[]
+                {
+                    new PermissionGrant(PermissionKind.EnableContentDownloading, true),
+                    new PermissionGrant(PermissionKind.EnableContentDeletion, false),
+                }),
+            () => "203.0.113.7",
+            () => true);
+
+        Assert.Contains(user.Permissions, perm => perm.Kind == PermissionKind.EnableContentDownloading && perm.Value);
+        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableContentDeletion && perm.Value);
+    }
+
+    [Fact]
+    public async Task MintAsync_NoAuthorization_LeavesGenericPermissionGrantsUntouched()
+    {
+        // The generic grants respect the same EnableAuthorization master switch as the admin/Live TV grants
+        // (#215): with it off, a mapped permission is NOT applied. Seed the opposite of the grant and pass
+        // the master switch off — a correct skip leaves the seed intact.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        user.SetPermission(PermissionKind.EnableContentDownloading, false);
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(
+            Params(
+                enableAuthorization: false,
+                permissionGrants: new[] { new PermissionGrant(PermissionKind.EnableContentDownloading, true) }),
+            () => "203.0.113.7",
+            () => true);
+
+        Assert.DoesNotContain(user.Permissions, perm => perm.Kind == PermissionKind.EnableContentDownloading && perm.Value); // seed left untouched
     }
 
     [Fact]

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -85,6 +85,7 @@ internal sealed class LoginCompletionService
             EnabledFolders = identity.Folders.ToArray(),
             EnableLiveTv = identity.EnableLiveTv,
             EnableLiveTvManagement = identity.EnableLiveTvManagement,
+            PermissionGrants = identity.PermissionGrants,
             AuthResponse = response,
             DefaultProvider = config.DefaultProvider?.Trim(),
             AvatarUrl = identity.AvatarUrl,

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -73,6 +73,10 @@ internal static class OidcAuthorizeStateBuilder
         var enableLiveTvManagement = privileges.EnableLiveTvManagement;
         var folders = privileges.Folders;
 
+        // Assemble the generic role→permission grants for the full boolean PermissionKind surface (#164).
+        // Default-deny and empty when the feature is off, so it changes nothing for existing deployments.
+        var permissionGrants = PermissionRolePolicy.Map(roles, config);
+
         // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
         // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning
         // the claims a second time. Faithful to the original: unlike the preferred-username branch, this
@@ -93,7 +97,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -203,6 +207,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
     /// <param name="AvatarUrl">The resolved avatar URL, or null when no avatar format is configured.</param>
+    /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -213,5 +218,6 @@ internal static class OidcAuthorizeStateBuilder
         bool EnableLiveTv,
         bool EnableLiveTvManagement,
         List<string> Folders,
-        string? AvatarUrl);
+        string? AvatarUrl,
+        IReadOnlyList<PermissionGrant>? PermissionGrants = null);
 }

--- a/SSO-Auth/Api/PermissionGrant.cs
+++ b/SSO-Auth/Api/PermissionGrant.cs
@@ -1,0 +1,12 @@
+using Jellyfin.Database.Implementations.Enums;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// A single generic permission grant a login resolves: the Jellyfin permission and whether it is granted
+/// (true) or explicitly revoked (false). Produced by <see cref="PermissionRolePolicy"/> and applied
+/// authoritatively at the session mint (#164).
+/// </summary>
+/// <param name="Kind">The Jellyfin permission this grant sets.</param>
+/// <param name="Granted">Whether the permission is granted (true) or explicitly revoked (false).</param>
+internal readonly record struct PermissionGrant(PermissionKind Kind, bool Granted);

--- a/SSO-Auth/Api/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/PermissionRolePolicy.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Maps the roles carried by a verified login to the generic Jellyfin permission grants they produce
+/// under the provider configuration (#164), extending the mapping beyond the dedicated admin / folder /
+/// Live TV surface handled by <see cref="RolePrivilegeMapper"/> to the full boolean
+/// <see cref="PermissionKind"/> surface. Pure: it derives the grants from (roles, config) and decides
+/// nothing about the session itself.
+/// </summary>
+/// <remarks>
+/// The mapping is <b>default-deny and authoritative</b>: for every permission an administrator explicitly
+/// listed (and only those), the grant is <c>true</c> when the login carries a matching role and <c>false</c>
+/// otherwise — so a missing or unmapped claim never silently grants a permission, and SSO explicitly revokes
+/// a listed permission the login no longer qualifies for. A permission that is not listed at all is never
+/// emitted, so the mint leaves it untouched and Jellyfin's own default governs it.
+///
+/// The four permissions with their own dedicated configuration fields/flows —
+/// <see cref="PermissionKind.IsAdministrator"/>, <see cref="PermissionKind.EnableAllFolders"/>,
+/// <see cref="PermissionKind.EnableLiveTvAccess"/>, <see cref="PermissionKind.EnableLiveTvManagement"/> —
+/// are refused here (see <see cref="DedicatedPermissions"/>) so each permission has exactly one
+/// authoritative source and two sources can never disagree. That refusal is enforced fail-closed at
+/// config-save validation; at login an entry that still names one (or an unknown/blank name) simply grants
+/// nothing rather than throwing.
+/// </remarks>
+internal static class PermissionRolePolicy
+{
+    // The permissions that already have a dedicated configuration surface and are therefore not allowed in
+    // the generic map — mapping them here would create a second, conflicting authoritative source.
+    private static readonly HashSet<PermissionKind> DedicatedPermissions = new()
+    {
+        PermissionKind.IsAdministrator,
+        PermissionKind.EnableAllFolders,
+        PermissionKind.EnableLiveTvAccess,
+        PermissionKind.EnableLiveTvManagement,
+    };
+
+    /// <summary>
+    /// The validity of a configured permission name.
+    /// </summary>
+    internal enum PermissionNameStatus
+    {
+        /// <summary>A known, mappable permission.</summary>
+        Valid,
+
+        /// <summary>The name is null, empty, or whitespace.</summary>
+        Empty,
+
+        /// <summary>The name does not name any <see cref="PermissionKind"/> (or is mis-cased / numeric).</summary>
+        Unknown,
+
+        /// <summary>The name is a dedicated permission managed by its own configuration field/flow.</summary>
+        Dedicated,
+    }
+
+    /// <summary>
+    /// Evaluates the generic permission grants the given roles produce under the given configuration.
+    /// </summary>
+    /// <param name="roles">The roles extracted from the verified login (OpenID claims or SAML attributes).</param>
+    /// <param name="config">The provider configuration.</param>
+    /// <returns>
+    /// One grant per configured, resolvable permission — deterministic (first-appearance order), each
+    /// permission emitted at most once (an entry repeated for a permission is OR-ed), with
+    /// <see cref="PermissionGrant.Granted"/> true iff a matching role is present. Empty when the master
+    /// switch is off or nothing is configured, so nothing is applied.
+    /// </returns>
+    internal static IReadOnlyList<PermissionGrant> Map(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        // Master switch off (the default) or no mappings configured: SSO manages no extra permissions, so
+        // the mint touches none of them — byte-for-byte the pre-#164 behavior.
+        if (!config.EnablePermissionRoles || config.PermissionRoleMappings is null)
+        {
+            return Array.Empty<PermissionGrant>();
+        }
+
+        var loginRoles = roles as IReadOnlyCollection<string> ?? roles.ToList();
+
+        // Accumulate OR-ing duplicates while preserving first-appearance order, so the result is
+        // deterministic and never applies the same permission twice with conflicting values.
+        var granted = new Dictionary<PermissionKind, bool>();
+        var order = new List<PermissionKind>();
+        foreach (var mapping in config.PermissionRoleMappings)
+        {
+            // Fail closed: a null entry, a blank/unknown name, or a dedicated permission grants nothing.
+            // These are rejected at config-save validation; at runtime we still skip rather than throw so a
+            // single bad entry cannot 500 the whole login path.
+            if (mapping is null || !TryResolvePermission(mapping.Permission, out var kind))
+            {
+                continue;
+            }
+
+            var matches = MatchesAnyRole(mapping.Roles, loginRoles);
+            if (granted.TryGetValue(kind, out var existing))
+            {
+                granted[kind] = existing || matches;
+            }
+            else
+            {
+                granted[kind] = matches;
+                order.Add(kind);
+            }
+        }
+
+        var result = new List<PermissionGrant>(order.Count);
+        foreach (var kind in order)
+        {
+            result.Add(new PermissionGrant(kind, granted[kind]));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Classifies a configured permission name for fail-closed validation.
+    /// </summary>
+    /// <param name="permissionName">The configured permission name.</param>
+    /// <returns>Whether the name is valid, and if not, why.</returns>
+    internal static PermissionNameStatus Classify(string? permissionName)
+    {
+        if (string.IsNullOrWhiteSpace(permissionName))
+        {
+            return PermissionNameStatus.Empty;
+        }
+
+        var trimmed = permissionName.Trim();
+
+        // Ordinal, case-sensitive, name-exact parse: Enum.TryParse alone would also accept a numeric string
+        // ("11") or a mis-cased name, so require the parsed value's canonical name to equal the input. That
+        // makes an unknown, numeric, or mis-cased name fail closed (grants nothing) and the mapping
+        // deterministic.
+        if (!Enum.TryParse(trimmed, out PermissionKind parsed)
+            || !string.Equals(Enum.GetName(parsed), trimmed, StringComparison.Ordinal))
+        {
+            return PermissionNameStatus.Unknown;
+        }
+
+        return DedicatedPermissions.Contains(parsed)
+            ? PermissionNameStatus.Dedicated
+            : PermissionNameStatus.Valid;
+    }
+
+    /// <summary>
+    /// Resolves a configured permission name to its <see cref="PermissionKind"/> when it is valid and
+    /// mappable, failing closed (returns false, grants nothing) for a blank, unknown, or dedicated name.
+    /// </summary>
+    /// <param name="permissionName">The configured permission name.</param>
+    /// <param name="kind">The resolved permission when valid; otherwise the enum default.</param>
+    /// <returns>Whether the name resolved to a mappable permission.</returns>
+    internal static bool TryResolvePermission(string? permissionName, out PermissionKind kind)
+    {
+        if (Classify(permissionName) == PermissionNameStatus.Valid
+            && Enum.TryParse(permissionName!.Trim(), out PermissionKind parsed))
+        {
+            kind = parsed;
+            return true;
+        }
+
+        kind = default;
+        return false;
+    }
+
+    // Whether the login carries any of the configured roles. The configured (trusted, admin-authored) role
+    // is trimmed before comparison; the IdP-supplied role is compared raw and ordinal, so there is no
+    // whitespace-injection vector — mirroring the folder-role comparison hardening (#367). Null-safe both
+    // ways: a null role array or a null entry is simply not a match, never a NullReferenceException, so an
+    // admin misconfiguration fails closed (grants nothing) instead of throwing.
+    private static bool MatchesAnyRole(string[]? configuredRoles, IReadOnlyCollection<string> loginRoles)
+    {
+        if (configuredRoles is null)
+        {
+            return false;
+        }
+
+        foreach (var configured in configuredRoles)
+        {
+            if (configured is null)
+            {
+                continue;
+            }
+
+            var trimmed = configured.Trim();
+            foreach (var role in loginRoles)
+            {
+                if (string.Equals(role, trimmed, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -256,6 +256,11 @@ public class SSOController : ControllerBase
     {
         RejectNullProviderBody(config);
         RejectInvalidBaseUrlOverride(config.BaseUrlOverride);
+        // Reject a malformed generic permission-role mapping (#164) at the door, exactly like the base-URL
+        // and certificate guards above: the Add endpoints persist through MutateConfiguration and so bypass
+        // the config-page save-time validation. Reuses the one shared validator so every admin write path
+        // agrees on what a valid mapping is.
+        ProviderConfigValidator.ValidatePermissionRoleMappings(OpenIdProtocol, provider, config.PermissionRoleMappings);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,
@@ -520,6 +525,8 @@ public class SSOController : ControllerBase
         RejectInvalidSamlSecondaryCertificate(newConfig.SamlSecondaryCertificate);
         RejectInvalidSamlSigningKey(newConfig.SamlSigningKeyPfx);
         RejectInvalidSamlSigningKey(newConfig.SamlRolloverSigningKeyPfx);
+        // Reject a malformed generic permission-role mapping (#164) at the door, as OidAdd does.
+        ProviderConfigValidator.ValidatePermissionRoleMappings(SamlProtocol, provider, newConfig.PermissionRoleMappings);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
@@ -29,7 +29,11 @@ internal static class SamlAuthorizeStateBuilder
         // ignored here.
         var privileges = RolePrivilegeMapper.AssemblePrivileges(roles, config);
 
-        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders);
+        // Assemble the generic role→permission grants for the full boolean PermissionKind surface (#164).
+        // Default-deny and empty when the feature is off, so it changes nothing for existing deployments.
+        var permissionGrants = PermissionRolePolicy.Map(roles, config);
+
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants);
     }
 
     /// <summary>
@@ -39,9 +43,11 @@ internal static class SamlAuthorizeStateBuilder
     /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
     /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
+    /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     internal readonly record struct SamlAuthorizeState(
         bool Admin,
         bool EnableLiveTv,
         bool EnableLiveTvManagement,
-        List<string> Folders);
+        List<string> Folders,
+        IReadOnlyList<PermissionGrant>? PermissionGrants = null);
 }

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -73,6 +73,19 @@ internal sealed class SessionMinter
             // management off (#215).
             user.SetPermission(PermissionKind.EnableLiveTvAccess, parameters.EnableLiveTv);
             user.SetPermission(PermissionKind.EnableLiveTvManagement, parameters.EnableLiveTvManagement);
+
+            // Generic role→permission grants for the full boolean PermissionKind surface (#164): apply each
+            // permission the admin explicitly mapped, authoritatively and default-deny — granted when a
+            // login role matched, revoked otherwise. Empty unless the feature is on, so this touches nothing
+            // for existing deployments. The permissions with dedicated fields above (admin, all-folders,
+            // Live TV) are excluded from this set at config validation, so there is exactly one authoritative
+            // writer per permission and no grant here can silently override an admin/folder/Live TV decision.
+            // Under the same EnableAuthorization master switch as those grants (#215), so turning SSO
+            // permission management off leaves the whole permission surface untouched.
+            foreach (var grant in parameters.PermissionGrants)
+            {
+                user.SetPermission(grant.Kind, grant.Granted);
+            }
         }
 
         await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);

--- a/SSO-Auth/Api/SessionParameters.cs
+++ b/SSO-Auth/Api/SessionParameters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 #nullable enable
 
@@ -47,6 +48,13 @@ internal sealed class SessionParameters
     /// Gets a value indicating whether the user may manage Live TV.
     /// </summary>
     public required bool EnableLiveTvManagement { get; init; }
+
+    /// <summary>
+    /// Gets the generic role→permission grants to apply at the mint (#164): one authoritative grant per
+    /// permission the administrator explicitly mapped, applied only when <see cref="EnableAuthorization"/>
+    /// is on. Required (no default) so a mint path cannot silently omit it; an empty list applies nothing.
+    /// </summary>
+    public required IReadOnlyList<PermissionGrant> PermissionGrants { get; init; }
 
     /// <summary>
     /// Gets the client identity (app, version, device) the session is bound to.

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 #nullable enable
@@ -45,7 +46,8 @@ internal sealed record VerifiedIdentity
         IReadOnlyList<string> folders,
         bool enableLiveTv,
         bool enableLiveTvManagement,
-        string? avatarUrl)
+        string? avatarUrl,
+        IReadOnlyList<PermissionGrant> permissionGrants)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -59,6 +61,7 @@ internal sealed record VerifiedIdentity
         EnableLiveTv = enableLiveTv;
         EnableLiveTvManagement = enableLiveTvManagement;
         AvatarUrl = avatarUrl;
+        PermissionGrants = permissionGrants;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -102,6 +105,13 @@ internal sealed record VerifiedIdentity
     internal string? AvatarUrl { get; }
 
     /// <summary>
+    /// Gets the generic role→permission grants the login resolves (#164): one authoritative grant per
+    /// permission the administrator explicitly mapped, applied at the mint (default-deny). Empty when the
+    /// feature is off, so no extra permission is touched.
+    /// </summary>
+    internal IReadOnlyList<PermissionGrant> PermissionGrants { get; }
+
+    /// <summary>
     /// Builds the verified identity of an OpenID login from the role-gate result. Called from inside
     /// <see cref="AuthorizeSession.Ready"/>, which the store produces only for a promoted (role-gate-passed)
     /// state and hands out only through the one-time atomic redeem — so this can never run before that claim.
@@ -125,7 +135,8 @@ internal sealed record VerifiedIdentity
             derived.Folders,
             derived.EnableLiveTv,
             derived.EnableLiveTvManagement,
-            derived.AvatarUrl);
+            derived.AvatarUrl,
+            derived.PermissionGrants ?? Array.Empty<PermissionGrant>());
 
     /// <summary>
     /// Builds the verified identity of a SAML login. Called only at the SAML session-minting endpoint after
@@ -152,5 +163,6 @@ internal sealed record VerifiedIdentity
             privileges.Folders,
             privileges.EnableLiveTv,
             privileges.EnableLiveTvManagement,
-            null);
+            null,
+            privileges.PermissionGrants ?? Array.Empty<PermissionGrant>());
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -165,6 +165,31 @@ public abstract class ProviderConfigBase
     public List<FolderRoleMap> FolderRoleMapping { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the generic role-to-permission mapping
+    /// (<see cref="PermissionRoleMappings"/>) is applied at login (#164). Off by default (fail closed):
+    /// a deployment that does not set it sees no change on upgrade, and the extra permission surface is
+    /// only ever managed by SSO when an administrator opts in AND lists explicit mappings. Gated
+    /// additionally by <see cref="EnableAuthorization"/> at the mint, exactly like the admin/folder/Live TV
+    /// grants, so turning RBAC off leaves every permission untouched.
+    /// </summary>
+    public bool EnablePermissionRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the generic role-to-permission mappings applied at login when
+    /// <see cref="EnablePermissionRoles"/> is on (#164): each entry names a single Jellyfin
+    /// <c>PermissionKind</c> and the roles that grant it. The mapping is authoritative and default-deny —
+    /// a listed permission is granted only when the login carries a matching role and is otherwise
+    /// explicitly revoked, so a missing or unmapped claim never silently grants a permission. Permissions
+    /// with their own dedicated configuration (administrator, all-folders, Live TV access/management) are
+    /// rejected here so each permission has exactly one authoritative source. A permission not listed at all
+    /// is never touched by SSO — Jellyfin's own default governs it. Validated fail-closed on save (an
+    /// unknown or dedicated permission name is rejected before it is persisted).
+    /// </summary>
+    [XmlArray("PermissionRoleMappings")]
+    [XmlArrayItem(typeof(PermissionRoleMap), ElementName = "PermissionRoleMappings")]
+    public List<PermissionRoleMap> PermissionRoleMappings { get; set; }
+
+    /// <summary>
     /// Gets or sets the authentication provider id written to the user's Jellyfin account
     /// (<c>User.AuthenticationProviderId</c>) after a successful SSO login. This is a Jellyfin-native
     /// user attribute; SSO logins themselves always resolve through the per-provider canonical-link maps,
@@ -482,4 +507,26 @@ public class FolderRoleMap
     /// Gets or sets the folders that are allowed from the given role.
     /// </summary>
     public List<string> Folders { get; set; }
+}
+
+/// <summary>
+/// Maps a single Jellyfin permission (by its <c>PermissionKind</c> name) to the roles that grant it,
+/// for the generic role-to-permission RBAC mapping (#164). The permission name is validated fail-closed
+/// on save; at login the permission is granted only when a matching role is present and otherwise
+/// explicitly revoked (default-deny).
+/// </summary>
+public class PermissionRoleMap
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin permission this mapping grants, as the exact <c>PermissionKind</c>
+    /// enum name (e.g. <c>EnableContentDownloading</c>). An unknown name, or one of the dedicated
+    /// permissions managed elsewhere (administrator, all-folders, Live TV), is rejected on save.
+    /// </summary>
+    public string Permission { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles that grant the permission. A login holding any of these roles is granted
+    /// the permission; a login holding none has it explicitly revoked.
+    /// </summary>
+    public string[] Roles { get; set; }
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -32,6 +32,7 @@ internal static class ProviderConfigValidator
             {
                 ValidateProviderName("OpenID", kvp.Key, isNew: live?.OidConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
+                ValidatePermissionRoleMappings("OpenID", kvp.Key, kvp.Value?.PermissionRoleMappings);
             }
         }
 
@@ -48,6 +49,7 @@ internal static class ProviderConfigValidator
                 ValidateSamlSecondaryCertificate(kvp.Key, kvp.Value?.SamlSecondaryCertificate);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
+                ValidatePermissionRoleMappings("SAML", kvp.Key, kvp.Value?.PermissionRoleMappings);
             }
         }
     }
@@ -110,6 +112,49 @@ internal static class ProviderConfigValidator
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
                 nameof(certificate));
+        }
+    }
+
+    // A malformed generic permission-role mapping (#164) would be persisted and then silently grant
+    // nothing for the offending entry at login (fail-closed at runtime), leaving the admin's intended
+    // permission un-applied with no feedback. Reject it at the door instead: every entry's Permission must
+    // name a known Jellyfin PermissionKind that is not one of the dedicated permissions managed by their
+    // own fields (administrator, all-folders, Live TV access/management) — those have exactly one
+    // authoritative source and may not be double-mapped here. A null entry maps nothing and is tolerated
+    // (it grants nothing at runtime). Both the config-page save and the Add endpoints run this. The
+    // provider name and the echoed permission are control-stripped in case they reach a log through the
+    // thrown exception.
+    internal static void ValidatePermissionRoleMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<PermissionRoleMap> mappings)
+    {
+        if (mappings == null)
+        {
+            return;
+        }
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping == null)
+            {
+                continue;
+            }
+
+            var status = PermissionRolePolicy.Classify(mapping.Permission);
+            if (status == PermissionRolePolicy.PermissionNameStatus.Valid)
+            {
+                continue;
+            }
+
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            var echoPerm = string.Concat((mapping.Permission ?? string.Empty).Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            var reason = status switch
+            {
+                PermissionRolePolicy.PermissionNameStatus.Empty => "has an empty permission name",
+                PermissionRolePolicy.PermissionNameStatus.Dedicated => $"names '{echoPerm}', which is managed by its own dedicated setting (administrator, all-folders, or Live TV) and may not be mapped here",
+                _ => $"names '{echoPerm}', which is not a known Jellyfin permission",
+            };
+            throw new ArgumentException(
+                $"{protocol} provider '{echoName}' has an invalid permission-role mapping: it {reason}. Each mapping's Permission must be the exact name of a Jellyfin PermissionKind (for example EnableContentDownloading) other than IsAdministrator, EnableAllFolders, EnableLiveTvAccess, or EnableLiveTvManagement.",
+                nameof(mappings));
         }
     }
 


### PR DESCRIPTION
Closes #164 (P4). A config-driven, **default-deny**, typed mapping from verified roles/claims to the full boolean Jellyfin `PermissionKind` surface, extending (not replacing) the existing admin/folder/LiveTV handling.

- New pure `PermissionRolePolicy` mapper → `PermissionGrant` list; config on `ProviderConfigBase`: `EnablePermissionRoles` (off by default) + `PermissionRoleMappings`.
- Grants derived in the Oidc/Saml AuthorizeStateBuilders from the VERIFIED identity, carried on the unforgeable `VerifiedIdentity`, threaded through `SessionParameters` as a `required` field (no mint path can omit it), applied in `SessionMinter` inside the existing `EnableAuthorization` block before the revocation gate (ordering conformance test still passes).
- Covers all ~20 boolean PermissionKind flags EXCEPT the 4 with dedicated config sources (IsAdministrator, EnableAllFolders, EnableLiveTvAccess/Management), one authoritative writer per permission.

## Security (fail-closed / default-deny)
- A listed permission is granted ONLY with a matching role, explicitly revoked otherwise; missing/empty/unmapped claim never grants; unlisted permission untouched.
- **No privilege escalation:** IsAdministrator (+ dedicated flags) cannot be granted via the generic map, rejected at validation AND ignored at runtime.
- Malformed mapping rejected fail-closed at every elevation-gated admin write; runtime fail-closed-but-not-fatal.
- Ordinal deterministic matching.

## Deferred (documented)
Scalar policies (max sessions, bitrate, parental score) + list preferences, need value-conflict resolution; separate design. Boolean surface delivered in full, no stubs.

## Verification
- [x] build --warnaserror 0/0 + test 1439/1439 on net9.0 + net10.0.
- [ ] Adversarial authz + bypass review (this PR).

Closes #164