### PR TITLE
Widen unicode-guard to all branches; tidy publish-pipeline config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,3 @@
-# These are supported funding model platforms
-
-github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
+# Sponsor button shown on the repository. Only the platforms actually in use are listed;
+# see https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 buy_me_a_coffee: iderex
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -28,10 +28,9 @@ permissions: {}
 
 # Serialize manifest-release regenerations so two stable publishes never race the pages branch (the same
 # reader-vs-pusher TOCTOU #135 fixed for manifest-beta). cancel-in-progress is false: a publish holding
-# contents:write must never be killed mid-run. NOTE: publish.yml (JF10.11 stable) predates this pattern
-# and does not yet share this group, so today this only serializes JF12-stable runs against each other;
-# a follow-up should add the same group name to publish.yml so the two stable legs are serialized against
-# each other as well.
+# contents:write must never be killed mid-run. publish.yml (JF10.11 stable) shares this same group name,
+# so the two stable legs are serialized against each other as well — a JF10.11 and a JF12 stable publish
+# can never regenerate manifest-release concurrently.
 concurrency:
   group: publish-manifest-release
   cancel-in-progress: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       attestations: write
     uses: ./.github/workflows/build.yml
     with:
-      dotnet-version: "9.0.*"
+      dotnet-version: "9.0.x"
       dotnet-target:  "net9.0"
       attest: true
   upload:

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -1,10 +1,12 @@
 name: unicode-guard
 
 on:
+  # Every branch and every PR: the guard is a cheap read-only scan and must cover
+  # the shipping release branches (e.g. 4.2, which ships JF12 betas), not just main.
   push:
-    branches: [main]
+    branches: ["**"]
   pull_request:
-    branches: [main]
+    branches: ["**"]
 
 # Read-only: the guard only greps the tracked tree, it never writes.
 permissions:


### PR DESCRIPTION
## What & why
Four small CI/repo-config hygiene fixes surfaced by the perfection audit. None touch application code.

- **unicode-guard.yml (#680, hardening/medium):** the Trojan Source (CVE-2021-42574) scan triggered only on `main`, leaving the shipping `4.2` branch (which builds JF12 betas installed by users) unscanned. Widened both `push` and `pull_request` to `['**']`, the scan is a cheap read-only `git grep`, so covering every branch/PR is free and closes the gap.
- **publish.yml (#681):** `dotnet-version` was `"9.0.*"` while every other workflow (codeql, dotnet, publish-beta) uses `"9.0.x"`. Normalized for consistency (functionally equivalent for setup-dotnet).
- **publish-jf12-stable.yml (#681):** the concurrency comment claimed publish.yml "does not yet share this group" and a follow-up should add it, but #655 already added the shared `publish-manifest-release` group to publish.yml. Corrected the stale comment; no behaviour change.
- **FUNDING.yml (#682):** dropped the default-template placeholder lines, keeping only the active platform.

## Type of change
- [x] CI / build / repo config
- [x] Documentation / comment (stale-comment correction)

## Security & quality checklist
- **Release-pipeline surface (directive 1):** adversarial review run, see below. The only behavioural change is *widening* a fail-closed security scan's coverage; the publish changes are a version-string normalization and a comment correction (no permission, trigger, or logic change to the release path).
- No application code touched; no new permissions granted; workflow `permissions:` blocks unchanged.
- unicode-guard remains fail-closed (scanner error → exit 1).

## Review gate
Adversarial integration-lens review on the pipeline diff: results appended as a comment before merge.

Closes #680
Closes #681
Closes #682