### PR TITLE
Correct stale version references in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
-All notable changes to this plugin are documented here. Versions follow the
-four-part `X.Y.Z.W` scheme described in the release policy (breaking / feature /
-bug-fix / security).
+All notable changes to this plugin are documented here. Versions are three-part
+`X.Y.Z` as described in the release policy — **X** a breaking / Jellyfin-ABI
+change, **Y** a feature, **Z** a bug-fix or security patch (the two share the
+digit and differ by release cadence). The channel and Jellyfin generation are a
+suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
+`-JF12-*`), never part of the installed numeric version.
 
-## 4.2.1.0
+## 4.2.1
 
 A bug-fix release.
 
@@ -19,7 +22,7 @@ A bug-fix release.
   eliminates the internal-error surface. A masked test that had tolerated the
   old exception was corrected to assert the explicit deny.
 
-## 4.2.0.0
+## 4.2.0
 
 A breaking release.
 
@@ -41,7 +44,7 @@ A breaking release.
   since #251. Callers that scripted the legacy direct-assertion POST must switch
   to the callback-plus-token round-trip.
 
-## 4.1.1.0
+## 4.1.1
 
 A bug-fix release that restores plugin loading on Jellyfin 10.11. No
 configuration changes.
@@ -74,7 +77,7 @@ configuration changes.
   referenced above the .NET 9 host ABI, so a future dependency bump that
   re-crosses the floor is caught before release instead of in the field.
 
-## 4.1.0.0
+## 4.1.0
 
 The first feature release of the revived plugin. It folds in a full
 security-parity pass over the SAML and OpenID login path, encrypts provider

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 >
 > This is a revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continues from the last upstream release (**4.0.0.x**, Jellyfin 10.11 / .NET 9) and is taken forward **security-first**. Its hardened sibling project, **`jellyfin-plugin-sso-V2`** (private), is the reference this repository draws on — ported across deliberately, one reviewed change at a time. Huge thanks to the original author and contributors for the foundation.
 >
-> **Status:** **Alpha** — the second stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — a packaged release (**4.1.0.0**) is now installable from the Jellyfin plugin catalog, with build-from-source as the alternative.
+> **Status:** **Alpha** — the second stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — a packaged release is now installable from the Jellyfin plugin catalog, with build-from-source as the alternative.
 >
 > ### How this project is developed
 >


### PR DESCRIPTION
## What & why
Two documentation-accuracy fixes from the perfection audit (#684, #686 repo portion; the wiki portion of #686 is already live).

- **README (#684):** the Status line named a specific packaged version, **4.1.0.0**, which is both stale (latest stable is 4.2.1) and the specifically known-broken build that fails to load on JF 10.11 (#590). Dropped the literal; it now just says a packaged release is installable.
- **CHANGELOG (#686):** the intro described the **retired four-part `X.Y.Z.W`** scheme (breaking/feature/bug-fix/security). Rewrote it to the **three-part `X.Y.Z`** scheme the project actually uses (X = breaking / Jellyfin-ABI, Y = feature, Z = bug-fix or security; channel and generation are a tag / release-name suffix, never in the numeric version), matching the wiki Release Policy. Normalized the release headings to three-part (4.2.1, 4.2.0, 4.1.1, 4.1.0). Body prose keeps the exact historical build strings it references (e.g. the broken 4.1.0.0, the .NET assembly versions).

## Type of change
- [x] Documentation

## Security & quality checklist
- Docs only, no code, no security surface. Prettier gate passes on both files.

Closes #684
Closes #686