### PR TITLE
Fail closed on a null FolderRoleMap.Folders in RolePrivilegeMapper

### DIFF
--- a/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
@@ -231,6 +231,28 @@ public class RolePrivilegeMapperTests
         Assert.Empty(RolePrivilegeMapper.Evaluate(new[] { "media" }, config).Folders);
     }
 
+    [Fact]
+    public void FolderRolesEnabled_NullFoldersOnMatchingEntry_DoesNotThrow_GrantsNoFoldersForIt()
+    {
+        // #675: a matching FolderRoleMap whose Folders list is null (a config/deserialization edge)
+        // formerly threw an ArgumentNullException on AddRange(null) — a 500. It is now null-guarded, so
+        // the entry grants nothing (fail closed) and other valid entries are unaffected.
+        var config = Oid(c =>
+        {
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = "media", Folders = null! },
+                new FolderRoleMap { Role = "music", Folders = new List<string> { "songs" } },
+            };
+        });
+
+        var grants = RolePrivilegeMapper.Evaluate(new[] { "media", "music" }, config);
+
+        // The null-Folders "media" entry contributes nothing; the valid "music" entry still grants.
+        Assert.Equal(new List<string> { "songs" }, grants.Folders);
+    }
+
     // --- Null-safe comparison (reconciled) ---
 
     [Fact]

--- a/SSO-Auth/Api/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/RolePrivilegeMapper.cs
@@ -48,8 +48,10 @@ internal static class RolePrivilegeMapper
                 {
                     // The configured (trusted, admin-authored) map-role is trimmed before comparison; the
                     // IdP-supplied role is compared raw, so there is no whitespace-injection vector (#367).
-                    if (string.Equals(role, folderRoleMap.Role?.Trim(), StringComparison.Ordinal))
+                    if (string.Equals(role, folderRoleMap.Role?.Trim(), StringComparison.Ordinal) && folderRoleMap.Folders != null)
                     {
+                        // A null Folders on a matching entry (a config/deserialization edge) grants nothing
+                        // for it rather than throwing an ArgumentNullException — fail closed, like IsOnList (#675).
                         folders.AddRange(folderRoleMap.Folders);
                     }
                 }


### PR DESCRIPTION
## What & why
Fixes #675. `RolePrivilegeMapper.Evaluate` dereferenced `FolderRoleMap.Folders` with no null guard, `folders.AddRange(folderRoleMap.Folders)` throws `ArgumentNullException` (surfacing as a 500) when a matching entry has a null `Folders` list (a config/deserialization edge: the property is an un-initialized auto-property). This was the one unguarded null hazard in a method whose every other one already fails closed (`FolderRoleMapping != null`, `Role?.Trim()`, and `IsOnList` is explicitly documented null-safe).

Added `&& folderRoleMap.Folders != null` to the match branch so a null `Folders` grants nothing for that entry (fail closed) rather than throwing, consistent with the method's contract, plus a load-bearing why-comment.

## Type of change
- [x] Bug fix (fail-closed hardening)

## Security & quality checklist
- Fail-closed: a null grants nothing rather than 500ing; other valid entries unaffected.
- Negative test added (`FolderRolesEnabled_NullFoldersOnMatchingEntry_DoesNotThrow_GrantsNoFoldersForIt`) per the repo's negative-test-per-fail-closed-branch rule, 1512 tests green both TFMs.

Closes #675