### PR TITLE
Key the OpenID authorize-state store on UTC, not machine-local time

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -544,6 +544,60 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void OidcAuthorizeState_IsKeyedOnUtc_NotMachineLocalTime()
+    {
+        // Locked in by #676: the in-flight OpenID authorize-state store keys its lifetime/expiry on the
+        // instant the challenge stamps (the Pending's Created) and the callback/redeem legs compare against
+        // (PruneExpired / PeekCurrent / TryRedeem). That instant MUST be UTC (DateTime.UtcNow), never
+        // machine-LOCAL wall-clock (DateTime.Now): on a DST transition or a clock step local time jumps, so
+        // a machine-local basis can expire a valid authorize state early — or shift its window — and
+        // spuriously fail an otherwise-valid login. The SAML flow already keeps a UTC basis; this pins the
+        // OpenID side to the same one. Call-level property, so it is a source scan like the controller /
+        // SessionMinter rules above — the store TAKES `now` as a parameter, so the clock choice lives
+        // entirely at these call sites and is invisible to a store-level unit test (which injects its own
+        // clock and so passes with EITHER basis). The production code passes the clock inline at each site.
+        //
+        // Deliberately NOT in scope: the _newPathPersistGate.TryEnter(DateTime.Now) throttle in the same
+        // file (and its SAML twin) — a best-effort config-persist throttle, not the authorize-state
+        // lifetime; its clock jitter is harmless and it stays symmetric with the SAML side. The markers
+        // below are scoped to the store's clock-bearing calls, so that line is out of scope by construction.
+        var oidcSource = SourceFilesDeclaring(new[] { typeof(OidcLoginService) });
+        Assert.True(
+            oidcSource.Count == 1,
+            "OidcLoginService's source file was not found (renamed/moved); point OidcAuthorizeState_IsKeyedOnUtc_NotMachineLocalTime at its new location so the UTC-basis scan keeps guarding #676.");
+
+        var lines = File.ReadAllLines(oidcSource[0]);
+        var storeClockMarkers = new[]
+        {
+            "StateStore.PruneExpired(", "StateStore.PeekCurrent(", "StateStore.TryRedeem(", "new AuthorizeSession.Pending(",
+        };
+
+        foreach (var marker in storeClockMarkers)
+        {
+            var markerLines = lines
+                .Select((line, index) => (Text: line.Trim(), Number: index + 1))
+                .Where(l => l.Text.Contains(marker, StringComparison.Ordinal))
+                .ToList();
+
+            // Liveness against a vacuous pass: the store's clock-bearing call site must still exist, or the
+            // scan guards nothing — a rename/restructure of the flow fails HERE and forces a conscious
+            // update of this rule (as the other source scans' sentinels do). "DateTime.Now" is not a
+            // substring of "DateTime.UtcNow", so a correct UtcNow site never trips the machine-local check.
+            Assert.True(
+                markerLines.Count > 0,
+                $"The OIDC authorize-state call site \"{marker}\" was not found in OidcLoginService; it was renamed or restructured, so update OidcAuthorizeState_IsKeyedOnUtc_NotMachineLocalTime so the UTC-basis scan keeps guarding #676.");
+
+            var offenders = markerLines
+                .Where(l => l.Text.Contains("DateTime.Now", StringComparison.Ordinal) || !l.Text.Contains("DateTime.UtcNow", StringComparison.Ordinal))
+                .Select(l => $"line {l.Number}: {l.Text}")
+                .ToList();
+            Assert.True(
+                offenders.Count == 0,
+                $"Every OIDC authorize-state \"{marker}\" call must key on DateTime.UtcNow, never machine-local DateTime.Now, so a DST transition or clock step cannot expire a valid login early (#676). Found: " + string.Join(" | ", offenders));
+        }
+    }
+
+    [Fact]
     public void Controller_DelegatesLoginCompletionToTheFlowService()
     {
         // Locked in by the login-completion extraction (#160, #318 step 11): the one shared completion tail —

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -87,7 +87,7 @@ public class OidcLoginServiceTests
     {
         var (service, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = "seed-1" }, "kc", isLinking: false, DateTime.Now, "binding", clientKey: null, providerInformation: null, responseIssuerRequired: false);
+        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = "seed-1" }, "kc", isLinking: false, DateTime.UtcNow, "binding", clientKey: null, providerInformation: null, responseIssuerRequired: false);
         OidcLoginService.SeedOidStateForTests("seed-1", pending);
 
         Assert.Contains(service.StateSummaries(), s => s.Provider == "kc" && !s.Valid);

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -444,6 +444,60 @@ public class OidcStateStoreTests
         Assert.Null(store.TryRedeem("tok", "p", Now, Binding));
     }
 
+    // --- UTC-consistent lifetime boundary (#676): expiry keys on the SAME basis the challenge stamped
+    // Created with. The production call sites now pass DateTime.UtcNow (matching the SAML flow), never the
+    // machine-LOCAL DateTime.Now — so a DST transition or a clock step cannot shift an in-flight state's
+    // window and expire a valid login early. These drive the whole basis off a real DateTime.UtcNow to pin
+    // the read predicates' lifetime edge and the challenge -> peek -> promote -> redeem round-trip on one
+    // consistent UTC clock, the invariant the call-site fix restores. ---
+
+    [Fact]
+    public void ReadPredicates_OnAConsistentUtcBasis_HonorTheStateThroughItsLifetime_ThenRejectPastIt()
+    {
+        // T is a real UTC instant — the same DateTime.UtcNow the production challenge stamps Created with;
+        // every comparison below is measured on that one basis, so the boundary is exact and clock-anomaly
+        // free.
+        var t = DateTime.UtcNow;
+
+        // PeekCurrent (the callback precondition) keys on the still-pending variant: valid just inside and
+        // exactly at the lifetime ('<= lifetime' acceptance edge), rejected one tick past it.
+        var peekStore = Store();
+        peekStore.Seed("s", Pending("p", "s", t));
+        Assert.NotNull(peekStore.PeekCurrent("s", "p", t + Lifetime - TimeSpan.FromTicks(1), Binding));
+        Assert.NotNull(peekStore.PeekCurrent("s", "p", t + Lifetime, Binding));
+        Assert.Null(peekStore.PeekCurrent("s", "p", t + Lifetime + TimeSpan.FromTicks(1), Binding));
+
+        // TryRedeem (the mint/link claim) shares IsCurrentFor over the promoted variant: one tick past the
+        // lifetime is rejected WITHOUT consuming the state (fail closed, non-consuming) — then it still
+        // redeems within the lifetime, single-use.
+        var redeemStore = Store();
+        redeemStore.Seed("tok", Ready("p", "tok", t));
+        Assert.Null(redeemStore.TryRedeem("tok", "p", t + Lifetime + TimeSpan.FromTicks(1), Binding));
+        Assert.Equal(1, redeemStore.Count);
+        Assert.NotNull(redeemStore.TryRedeem("tok", "p", t + Lifetime - TimeSpan.FromTicks(1), Binding));
+        Assert.Equal(0, redeemStore.Count);
+    }
+
+    [Fact]
+    public void ChallengeToRedeem_RoundTripsOnOneUtcBasis()
+    {
+        // The full production path on a single UTC basis (the regression #676 guards): register at UtcNow,
+        // peek + promote at UtcNow, redeem at UtcNow — one session minted, the replay rejected. A state
+        // created and consumed on the same UTC clock round-trips exactly as it did on a same-local-clock
+        // basis, but now without the DST/clock-step window shift a machine-local basis carried.
+        var t = DateTime.UtcNow;
+        var store = Store();
+        Assert.True(store.TryAdd(Pending("p", "tok", t), out _));
+
+        var pending = store.PeekCurrent("tok", "p", t, Binding);
+        Assert.NotNull(pending);
+        Assert.True(store.Promote(pending, FullDerived()));
+
+        Assert.NotNull(store.TryRedeem("tok", "p", t, Binding));
+        Assert.Null(store.TryRedeem("tok", "p", t, Binding));
+        Assert.Equal(0, store.Count);
+    }
+
     // --- Single-use / invalidate-immediately (#138: upstream 9p4 v4.0.0.4 fix) ---
     // Upstream v4.0.0.3 invalidated the OpenID authorize state only by expiry after a successful
     // auth, leaving the consumed state redeemable again within its ~15-min lifetime — a replay. The
@@ -612,7 +666,7 @@ public class OidcStateStoreTests
     {
         // The warning signal is bounded exactly like the sweeps: the first refusal signals, further
         // refusals inside the interval stay silent, so a flood cannot amplify into log volume. The gate
-        // is driven by the Pending's Created instant (which is the challenge's DateTime.Now).
+        // is driven by the Pending's Created instant (which is the challenge's DateTime.UtcNow).
         var store = Store(maxEntries: 1);
         Assert.True(store.TryAdd(Pending("p", "a", Now), out _));
 

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -304,7 +304,7 @@ public class SSOControllerLinkTests
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         // The OID link path redeems an authorize state the redirect leg validated; seed a redeemable one.
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -323,7 +323,7 @@ public class SSOControllerLinkTests
         // the two cases cannot be probed apart.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = false });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -346,7 +346,7 @@ public class SSOControllerLinkTests
         // remove — the state is NOT consumed, so the browser that started the flow can still link.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
         // A wrong-browser callback: overwrite the matching cookie ForCaller set with a different id.
         harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}=other-browser";

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -226,7 +226,7 @@ public class SSOControllerOidAuthTests
     // the verified-email login gate (#166).
     private static void SeedValidState(SsoControllerHarness harness, string token, bool? emailVerified = null)
     {
-        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = token }, "kc", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false);
+        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = token }, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false);
         var ready = new AuthorizeSession.Ready(
             pending,
             new OidcAuthorizeStateBuilder.OidcAuthorizeState(

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -456,7 +456,7 @@ public class SSOControllerOidPostTests
         // parameter (#210), so the callback must require iss; false is the tolerant default (the challenge
         // capture path itself is pinned end-to-end by OidChallengeToCallback_* below). Seeded as a Pending:
         // the callback derives the login and promotes it to a Ready (#341).
-        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.Now, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: responseIssuerRequired));
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: responseIssuerRequired));
 
         return harness;
     }

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -122,7 +122,7 @@ internal sealed class OidcLoginService
     /// <returns>A redirect to the authorization server, or a fail-closed rejection/error.</returns>
     internal async Task<ActionResult> ChallengeAsync(string provider, bool isLinking, HttpRequest request, HttpResponse response)
     {
-        StateStore.PruneExpired(DateTime.Now);
+        StateStore.PruneExpired(DateTime.UtcNow);
         var config = FindOidConfig(provider);
         if (config is not { Enabled: true })
         {
@@ -218,8 +218,11 @@ internal sealed class OidcLoginService
         // advertised the RFC 9207 response-`iss` parameter (so the callback requires `iss`, its absence
         // being a downgrade, #210). Both come from the one response (#450). Folded in at construction so
         // registration is one atomic insert and the stored Pending is never mutated after it enters the
-        // store (#341).
-        var pending = new AuthorizeSession.Pending(state, provider, isLinking, DateTime.Now, bindingId, clientKey, discovery.ProviderInformation, discovery.Facts.ResponseIssuerAdvertised);
+        // store (#341). The Created instant — and every expiry comparison the store makes against it
+        // (PruneExpired / PeekCurrent / TryRedeem) — is UTC, not machine-local wall-clock, so a DST
+        // transition or a clock step cannot expire an in-flight authorize state early or shift its window
+        // and spuriously fail a login; this matches the UTC basis the SAML flow already keeps (#676).
+        var pending = new AuthorizeSession.Pending(state, provider, isLinking, DateTime.UtcNow, bindingId, clientKey, discovery.ProviderInformation, discovery.Facts.ResponseIssuerAdvertised);
         if (!StateStore.TryAdd(pending, out var shouldWarnCapacity))
         {
             if (shouldWarnCapacity)
@@ -266,7 +269,7 @@ internal sealed class OidcLoginService
             return new BadRequestObjectResult("Missing state");
         }
 
-        if (StateStore.PeekCurrent(state, provider, DateTime.Now, request.Cookies[AuthorizeStateBinding.CookieName]) is not { } pending)
+        if (StateStore.PeekCurrent(state, provider, DateTime.UtcNow, request.Cookies[AuthorizeStateBinding.CookieName]) is not { } pending)
         {
             // Unknown, expired, minted for a different provider, or from a different browser than the
             // one that started the flow (#326) — reject (details on PeekCurrent / AuthorizeStateBinding).
@@ -389,7 +392,7 @@ internal sealed class OidcLoginService
         // is a client-caused rejection, not a server fault: one uniform body, so a replay is
         // indistinguishable from an expiry and replay stays hidden. A binding mismatch does not consume
         // the state (the check precedes the atomic remove), so it cannot burn a legitimate user's state.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, bindingCookie) is not { } redeemed)
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.UtcNow, bindingCookie) is not { } redeemed)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }
@@ -451,7 +454,7 @@ internal sealed class OidcLoginService
         // (unknown, expired, provider-mismatched, already-redeemed, or from a different browser than
         // started the flow, #326) is a client-caused 400 in the same uniform body as the login path,
         // not a 500. The linking challenge sets the same binding cookie, carried on this same-origin POST.
-        if (StateStore.TryRedeem(response.Data, provider, DateTime.Now, bindingCookie) is not { } redeemed)
+        if (StateStore.TryRedeem(response.Data, provider, DateTime.UtcNow, bindingCookie) is not { } redeemed)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.InvalidState));
         }


### PR DESCRIPTION
## What & why
Fixes #676. The OpenID authorize-state store keyed its lifetime/expiry on `DateTime.Now` (machine-LOCAL wall-clock) while the SAML flow uses `DateTime.UtcNow`. On a DST transition or clock step, local time jumps, so a valid in-flight authorize state could expire early (spurious login failure) or its window shift. Switched all five authorize-state call sites in `OidcLoginService.cs` (PruneExpired, the `Pending` Created stamp, PeekCurrent, and both TryRedeem legs) to `DateTime.UtcNow` so create and all expiry comparisons share one monotonic UTC basis.

Deliberately left on local time (documented): the best-effort config-persist *throttle* gates (`OidcLoginService`/`SamlLoginService`, jitter is harmless and symmetric) and `Saml.cs`'s request issue-instant (already `.ToUniversalTime()`d).

## Type of change
- [x] Bug fix (correctness / availability, DST/clock-step)

## Security & quality checklist
- No security regression: UTC is strictly more consistent than local (no DST jump extending or truncating a state's life); the state's replay/CSRF window is now exact.
- **Regression guard:** a new conformance test (`OidcAuthorizeState_IsKeyedOnUtc_NotMachineLocalTime`) source-scans every authorize-state call site to `DateTime.UtcNow`, the store takes `now` as a parameter, so a store unit test cannot catch a call-site revert; the scan can. Plus store-level boundary + round-trip tests.
- 1514 tests green both TFMs. (Fixed timezone-coupled test seeds that a UTC+2 host surfaced.)

Closes #676