### PR TITLE
List SSO-only login in the README feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 - **OpenID Connect and SAML 2.0** — either or both, multiple providers side by side. See the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup).
 - **Role-based access control** — map identity-provider groups/roles to login, administrator, library folders, and Live TV.
 - **Hardened, fail-closed login path** — identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches. Details on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) page.
+- **Optional SSO-only login** — disable password login for every account except a designated break-glass admin, behind a fail-closed last-admin guard so no configuration can strand a server without a working admin login. Runbook on the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#sso-only-login-disable-password-login) page.
 - **Avatar sync, Quick Connect, and self-service account linking**.
 - **Tested** — a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
 


### PR DESCRIPTION
# What & why

The README's Features section states it reflects what is implemented today, but it omitted **SSO-only login** (`DisablePasswordLogin`), which shipped in #665, an operator-facing, security-relevant capability. This adds the missing Features bullet, naming the fail-closed last-admin guard and the break-glass admin, and links the wiki runbook that the plugin settings page already points to. The wiki side (Provider Setup runbook, Security Model summary, Troubleshooting recovery entry, design-page status) was updated separately in the wiki repository. Closes #699

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable, a README-only change; no login path, crypto, config persistence, or release-pipeline code is touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

(Build and tests are unaffected by a README-only change; CI runs them regardless. Prettier check passes on the changed file.)

## Notes

The bullet's claims are taken from the shipped implementation (the last-admin guard in `SsoOnlyLoginGuard`, the break-glass exemption, and the recovery paths), not from the design document, so the README stays truthful about what is implemented today.