### PR TITLE
Polish the served auth and self-service linking pages

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -949,6 +949,27 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void RawServedLinkingPage_ContainsNoDashboardLocalizationPlaceholders()
+    {
+        // The self-service linking page is served raw by SSOViewsController.GetView (route
+        // /SSOViews/linking) — no Jellyfin dashboard, so no localization pass runs. A ${...} token the
+        // dashboard would substitute therefore leaks to the end user verbatim (the ${Help} button label
+        // was the live case, #666). Scan the raw-served page for such placeholders, ignoring inline
+        // <script> blocks where ${...} is a legitimate JS template-literal interpolation, not a
+        // dashboard token.
+        var html = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "linking.html"));
+        var withoutScripts = Regex.Replace(html, "<script.*?</script>", string.Empty, RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+        var placeholders = Regex.Matches(withoutScripts, "\\$\\{[^}]*\\}", RegexOptions.Singleline)
+            .Select(m => m.Value)
+            .ToList();
+
+        Assert.True(
+            placeholders.Count == 0,
+            "The raw-served linking page must not carry dashboard ${...} localization placeholders (they are not substituted off the dashboard, #666); found: " + string.Join(", ", placeholders));
+    }
+
+    [Fact]
     public void ProviderFormFieldIds_MatchOidConfigProperties()
     {
         // The provider settings form's save contract (#365), locked in as a fitness function. config.js

--- a/SSO-Auth.Tests/WebResponseTests.cs
+++ b/SSO-Auth.Tests/WebResponseTests.cs
@@ -158,4 +158,46 @@ public class WebResponseTests
         Assert.Contains("Too many attempts. Please wait a moment and try again.", html);
         Assert.Contains("Could not link this account. The provider may be disabled, or linking is not permitted.", html);
     }
+
+    [Fact]
+    public void Generator_AnnouncesStatusToAssistiveTech_AndDeclaresLanguage()
+    {
+        // #667: the served page is reached directly by end users. The status line must be an
+        // aria-live region so its message swap after the async login attempt is announced, and the
+        // document must declare its language.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "OID", "n0nce");
+
+        Assert.Contains("<html lang='en'>", html);
+        Assert.Contains("role='status'", html);
+        Assert.Contains("aria-live='polite'", html);
+    }
+
+    [Fact]
+    public void Generator_TerminalFailure_OffersReturnToLoginLink()
+    {
+        // #667: a failed or throttled attempt must not dead-end. Both terminal-failure branches call
+        // showReturnLink(), which builds a "Return to login" anchor to the known-safe base URL.
+        var html = WebResponse.Generator("ZGF0YQ==", "keycloak", "https://jf.example.com", "OID", "n0nce", isLinking: true);
+
+        Assert.Contains("function showReturnLink()", html);
+        Assert.Contains("'Return to login'", html);
+        Assert.Contains("ssoBaseUrl + '/web/index.html'", html);
+        // The login-failure branch and the rejected-link branch both invoke it; success paths do not.
+        Assert.Contains("showReturnLink();", html);
+        // Pin that the linking branch guards the call behind the failure condition, so a successful
+        // (2xx) link does not offer a "return to login" as if it had failed. Deleting the `if (!linked)`
+        // guard (which would make the link appear on a successful link too) must fail this test.
+        Assert.Contains("if (!linked) {", html);
+    }
+
+    [Theory]
+    [InlineData("jf.example.com")]
+    [InlineData("")]
+    public void Generator_BaseUrlWithoutProtocolSeparator_ThrowsInsteadOfMisSplitting(string baseUrl)
+    {
+        // #679: a baseUrl lacking the "//" separator would otherwise silently mis-split via
+        // Substring(0, 1) / Substring(1) and build a corrupt ssoBaseUrl; it must fail closed.
+        Assert.Throws<System.ArgumentException>(
+            () => WebResponse.Generator("ZGF0YQ==", "keycloak", baseUrl, "OID", "n0nce"));
+    }
 }

--- a/SSO-Auth/Config/linking.html
+++ b/SSO-Auth/Config/linking.html
@@ -43,7 +43,7 @@
               target="_blank"
               rel="noopener noreferrer"
               href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
-              >${Help}</a
+              >Help</a
             >
           </div>
           <div

--- a/SSO-Auth/Config/linking.js
+++ b/SSO-Auth/Config/linking.js
@@ -39,6 +39,20 @@ const ssoConfigLinking = {
         .catch(() => ssoConfigLinking.showError());
     });
   },
+  // When a protocol section ends up with no rows — no enabled providers to offer and no existing
+  // link the user still holds — show a placeholder instead of a bare heading over blank space
+  // (#669), so a single-protocol or fresh install does not look broken. Called only after both the
+  // enabled-provider list and the existing-links feed have resolved, since a disabled provider the
+  // user still holds a link to is rendered from the links feed and keeps the section non-empty.
+  maybeShowSectionEmptyState: (container, provider_mode) => {
+    if (container.children.length > 0) {
+      return;
+    }
+    const placeholder = document.createElement("p");
+    placeholder.classList.add("sso-provider-empty");
+    placeholder.textContent = `No ${provider_mode.toUpperCase()} providers are available.`;
+    container.appendChild(placeholder);
+  },
   loadProviderList: (container, providers, provider_mode) => {
     // The server only offers enabled providers for new links (#344), so every name here gets an
     // add button. A link the user still holds to a since-disabled provider is rendered separately
@@ -95,10 +109,15 @@ const ssoConfigLinking = {
               provider_map[provider_name],
             );
           });
+          ssoConfigLinking.maybeShowSectionEmptyState(container, provider_mode);
         })
         // ApiClient.fetch rejects on a non-2xx status (auth expiry, a server error, ...), so a failed
         // existing-links load surfaces the banner instead of silently leaving the list empty (#536).
         .catch(() => ssoConfigLinking.showError());
+    } else {
+      // No signed-in user to fetch existing links for: the section is complete once the enabled
+      // providers are rendered, so decide the empty state now.
+      ssoConfigLinking.maybeShowSectionEmptyState(container, provider_mode);
     }
   },
 

--- a/SSO-Auth/WebResponse.cs
+++ b/SSO-Auth/WebResponse.cs
@@ -12,13 +12,16 @@ internal static class WebResponse
     /// The shared HTML between all of the responses.
     /// </summary>
     internal static readonly string Base = @"<!DOCTYPE html>
-<html><head>
+<html lang='en'><head>
 <meta name='viewport' content='width=device-width, initial-scale=1'>
 <style nonce=""{{NONCE}}"">
   body {
     background: #101010;
     color: #d1cfce;
     font-family: Noto Sans, Noto Sans HK, Noto Sans JP, Noto Sans KR, Noto Sans SC, Noto Sans TC, sans-serif;
+  }
+  a {
+    color: #00a4dc;
   }
   #iframe-main {
     position: absolute;
@@ -28,7 +31,7 @@ internal static class WebResponse
   }
 </style>
 </head><body>
-<p>Logging in...</p>
+<p role='status' aria-live='polite'>Logging in...</p>
 <noscript>Please enable Javascript to complete the login</noscript>
 <script nonce=""{{NONCE}}"">
 
@@ -221,6 +224,19 @@ const sleep = (milliseconds) => {
     return new Promise(resolve => setTimeout(resolve, milliseconds))
 }
 
+// On a terminal failure the page must not dead-end (#667): offer an obvious way back to the login
+// screen. ssoBaseUrl is a JSON-encoded safe constant; the link is built via DOM APIs (never
+// innerHTML) and appended once after the status line, which carries role='status' aria-live='polite'
+// so its message swap is announced to assistive tech.
+function showReturnLink() {
+    if (document.getElementById('sso-return-link')) return;
+    const link = document.createElement('a');
+    link.id = 'sso-return-link';
+    link.textContent = 'Return to login';
+    link.href = ssoBaseUrl + '/web/index.html';
+    document.querySelector('p').insertAdjacentElement('afterend', link);
+}
+
 ";
 
     /// <summary>
@@ -240,6 +256,15 @@ const sleep = (milliseconds) => {
         // Strip out the protocol (http:// or https://) and convert the domain to Punycode
         var idnMapping = new IdnMapping();
         var protocolSeparatorIndex = baseUrl.IndexOf("//", System.StringComparison.Ordinal);
+
+        // baseUrl is server-derived and normally carries a scheme, so "//" is expected. A missing
+        // separator would otherwise silently mis-split (Substring(0, 1) / Substring(1)); fail closed
+        // instead of building a corrupt ssoBaseUrl the whole page then posts back to.
+        if (protocolSeparatorIndex < 0)
+        {
+            throw new System.ArgumentException("baseUrl must contain a protocol separator ('//').", nameof(baseUrl));
+        }
+
         var protocol = baseUrl.Substring(0, protocolSeparatorIndex + 2);
         var domain = baseUrl.Substring(protocolSeparatorIndex + 2);
         var punycodeDomain = idnMapping.GetAscii(domain);
@@ -319,12 +344,16 @@ async function main() {
         //     behavior of proceeding to the auth leg, since that outcome cannot be told apart from success.
         var linkStatus = await link(request);
         if (linkStatus !== undefined) {
+            const linked = linkStatus >= 200 && linkStatus < 300;
             document.querySelector('p').textContent =
-                linkStatus >= 200 && linkStatus < 300
+                linked
                     ? 'Account linked. You can now log in with SSO.'
                     : linkStatus === 429
                         ? 'Too many attempts. Please wait a moment and try again.'
                         : 'Could not link this account. The provider may be disabled, or linking is not permitted.';
+            if (!linked) {
+                showReturnLink();
+            }
             return;
         }
     }
@@ -357,6 +386,7 @@ async function main() {
             response && response.status === 429
                 ? 'Too many login attempts. Please wait a moment and try again.'
                 : 'Login failed. Please try again.';
+        showReturnLink();
         return;
     }
     var userId = 'user-' + responseJson['User']['Id'] + '-' + responseJson['User']['ServerId'];


### PR DESCRIPTION
# What & why

The auth-completion page and the self-service linking page are served raw to end users off the Jellyfin dashboard, so dashboard-only affordances (localization, styled shells) do not apply. This sweeps the P7 UX/robustness findings on that surface.

- **#666**, `linking.html` showed the literal `${Help}` because the dashboard localization placeholder is never substituted on the raw `/SSOViews/linking` route. Replaced with a literal `Help`, and locked in with a conformance test that scans the raw-served page for `${...}` tokens (inline `<script>` blocks excluded, where `${...}` is a legitimate JS template literal).
- **#667**, the auth-completion status line is now an `aria-live` status region, the document declares `lang='en'`, and a terminal failure/throttle renders a **Return to login** link instead of dead-ending. The link is built via DOM APIs from the already-encoded `ssoBaseUrl` constant; its color rule lives inside the existing nonce'd `<style>` block (no CSP relaxation).
- **#679**, `WebResponse.Generator` now fails closed when `baseUrl` carries no `//` separator, instead of silently mis-splitting into a corrupt `ssoBaseUrl`. (The ordinal `IndexOf` and JS-boolean emission this issue also flagged had already landed; this closes the residual guard.)
- **#669**, the linking page shows a per-protocol empty-state placeholder when a section has no enabled providers and no existing links, so a single-protocol or fresh install no longer renders a bare heading over blank space.

Closes #666
Closes #667
Closes #669
Closes #679

## Type of change

- [x] Bug fix
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the new `baseUrl` guard throws rather than building a corrupt URL; no auth decision is affected (callers do not catch it into a default-accept).
- [x] No secrets logged; secrets are redacted on config export. (Not touched.)
- [x] A security review was performed, adversarial bypass/XSS + correctness lenses over the full touched files and their callers; both PASS. The `Return to login` link and empty-state DOM use `.href`/`textContent`/`createElement` only (no `innerHTML`), with values from the already-encoded `ssoBaseUrl` constant and trusted literal `provider_mode`.
- [x] Log inputs from the IdP are sanitized inline at the log call. (Not touched.)

## Quality checklist

- [x] No duplicated logic; the empty-state and return-link helpers are small single-purpose units.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why.
- [x] Architecture-conformance tests pass; #666 is locked in as a new `ArchitectureConformanceTests` rule.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1540/1540 on both TFMs.
- [x] Prettier clean for the `.js` / `.html` changes.

## Notes

Split out from the broader served-pages work: the error-page styling for browser-navigated rejections (#668) is a separate PR because it changes the `LoginStatusMapper` response content-type and touches the CSP-nonce surface, warranting its own focused review.