### PR TITLE
Unify the challenge NewPath resolver and inline a single-caller OIDC wrapper

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -722,6 +722,42 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void FlowServices_DoNotDuplicateChallengeNewPathResolution()
+    {
+        // Locked in by #670: the near-identical ResolveChallengeNewPath resolver — and its
+        // _newPathPersistGate persist-throttle — that OidcLoginService and SamlLoginService each carried
+        // (~40 lines apiece, differing only in which provider map the Mutate delegate re-resolved against)
+        // are now ONE generic helper in ChallengeNewPathResolver (Api/Shared), with a single shared gate. Pin
+        // by reflection that NEITHER flow service re-declares its own copy of either member, so the
+        // duplication (and a second, divergent throttle) cannot silently reappear.
+        const BindingFlags all = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        var flowServices = new[] { typeof(OidcLoginService), typeof(SamlLoginService) };
+
+        var offenders = flowServices
+            .SelectMany(t => t.GetMethods(all)
+                .Where(m => m.Name == "ResolveChallengeNewPath")
+                .Select(m => $"{SimpleName(t)}.{m.Name} (method)")
+                .Concat(t.GetFields(all)
+                    .Where(f => f.Name == "_newPathPersistGate")
+                    .Select(f => $"{SimpleName(t)}.{f.Name} (field)")))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "Neither flow service may declare its own ResolveChallengeNewPath method or _newPathPersistGate field; the single generic resolver and its one shared throttle live in ChallengeNewPathResolver (Api/Shared) (#670). Found: " + string.Join(", ", offenders));
+
+        // Liveness against a vacuous pass: the shared resolver must actually own both — a move, not a silent
+        // removal — so ChallengeNewPathResolver must declare the resolver method and the single gate field.
+        var resolver = typeof(ChallengeNewPathResolver);
+        Assert.True(
+            resolver.GetMethods(all).Any(m => m.Name == "ResolveChallengeNewPath"),
+            "ChallengeNewPathResolver must own the ResolveChallengeNewPath resolver; otherwise the flow-service scan passes vacuously (#670).");
+        Assert.True(
+            resolver.GetFields(all).Any(f => f.Name == "_newPathPersistGate" && f.FieldType == typeof(IntervalGate)),
+            "ChallengeNewPathResolver must own the single _newPathPersistGate IntervalGate; otherwise the flow-service scan passes vacuously (#670).");
+    }
+
+    [Fact]
     public void SharedFlowResponses_OwnTheAuthPageErrorAndLinkWriteResults()
     {
         // Locked in by the shared-helper consolidation (#160, #500): the three HTTP result shapes both flow

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
@@ -100,7 +101,8 @@ public class OidcLoginServiceTests
     [Fact]
     public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
     {
-        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside the shared
+        // ChallengeNewPathResolver (unified across both flows in #670), driven with the OpenID map selector.
         // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
         // (FindOidConfig) before its own Enabled check passed; something then disables the provider in the
         // LIVE store before this write attempt runs — a race the outer check cannot see. The current
@@ -111,7 +113,7 @@ public class OidcLoginServiceTests
         SSOPlugin.Instance.MutateConfiguration(c => c.OidConfigs["kc"].Enabled = false);
         context.Request.Path = "/sso/OID/start/kc";
 
-        var result = OidcLoginService.ResolveChallengeNewPath("kc", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+        var result = ChallengeNewPathResolver.ResolveChallengeNewPath("kc", config, isLinking: false, context.Request, Substitute.For<ILogger>(), c => c.OidConfigs);
 
         Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["kc"].NewPath)); // stored value untouched

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -208,7 +208,7 @@ public class OidcStateStoreTests
     public void PeekWithoutProviderInformation_ExposesNull_SoTheCallbackFallsBackToDiscovery()
     {
         // A state whose challenge captured no discovery (a flow that predates the capture) exposes null,
-        // so the callback's CreateOidcClient runs a fresh discovery — never a broken login.
+        // so the callback's client build runs a fresh discovery — never a broken login.
         var store = Store();
         Assert.True(store.TryAdd(Pending("p", "s", Now), out _));
 

--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -198,7 +198,7 @@ public class ProviderConfigStoreTests
     [Fact]
     public async Task Mutate_ConcurrentChallengeStyleReadThenWrite_NeverThrows_AndSettlesOnADerivedSpelling()
     {
-        // Mirrors OidcLoginService/SamlLoginService.ResolveChallengeNewPath's shape (#412): a fast Read,
+        // Mirrors ChallengeNewPathResolver.ResolveChallengeNewPath's shape (#412, unified in #670): a fast Read,
         // then a Mutate only when the derived spelling differs from what is stored — never a bare field
         // write outside the lock. Concurrent callers alternate between the two derivable spellings for
         // "kc" while OTHER concurrent callers add and remove UNRELATED provider entries — a genuine

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
@@ -116,7 +117,8 @@ public class SamlLoginServiceTests
     [Fact]
     public void ResolveChallengeNewPath_ProviderDisabledInTheRaceWindow_SkipsThePersist_ButStillReturnsThisRequestsDerivedSpelling()
     {
-        // #412 review follow-up: exercises the Mutate delegate's own re-check inside ResolveChallengeNewPath.
+        // #412 review follow-up: exercises the Mutate delegate's own re-check inside the shared
+        // ChallengeNewPathResolver (unified across both flows in #670), driven with the SAML map selector.
         // `config` mirrors the reference the real caller already captured under ReadConfiguration's lock
         // (FindSamlConfig) before its own Enabled check passed; something then disables the provider in the
         // LIVE store before this write attempt runs — a race the outer check cannot see. The current
@@ -127,7 +129,7 @@ public class SamlLoginServiceTests
         SSOPlugin.Instance.MutateConfiguration(c => c.SamlConfigs["adfs"].Enabled = false);
         context.Request.Path = "/sso/SAML/start/adfs";
 
-        var result = SamlLoginService.ResolveChallengeNewPath("adfs", config, isLinking: false, context.Request, Substitute.For<ILogger>());
+        var result = ChallengeNewPathResolver.ResolveChallengeNewPath("adfs", config, isLinking: false, context.Request, Substitute.For<ILogger>(), c => c.SamlConfigs);
 
         Assert.True(result); // this request's own redirect still uses the freshly-derived spelling
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].NewPath)); // stored value untouched

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -58,20 +58,6 @@ internal sealed class OidcLoginService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
 
-    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
-    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
-    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
-    // logins — SamlAssertionValidator's ExpectedAcsUrls already treats a flip as routine, not a rare edge
-    // case. Without a cap, that ordinary traffic shape would turn every such login into a synchronous
-    // config persist under the process-wide config lock, serializing every OID/SAML login on the server
-    // (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER, separate
-    // linking challenge — never this request's own redirect, which always uses its own freshly-derived
-    // value regardless of whether a write lands — so bounding this to one persist attempt per interval,
-    // process-wide, is harmless: it only delays how soon a flapping spelling's latest value reaches disk.
-    // Not readonly: ResetOidStateForTests installs a fresh gate between tests, so one test's persisted
-    // change cannot throttle a genuine change in the next one.
-    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
-
     internal OidcLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -95,13 +81,13 @@ internal sealed class OidcLoginService
     // the same non-parallel collection. Internal and reachable only through InternalsVisibleTo; it is never
     // wired to an endpoint or DI, so it adds no runtime or security surface. Moved here with the statics from
     // the controller (#160, #289). The discovery read is stateless (#450), so there is nothing else to clear.
-    // Also installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness
+    // Also resets the shared NewPath persist-throttle gate (#412 review follow-up, #670): SsoControllerHarness
     // calls this for every test, so a change persisted in one test can never throttle a genuine change in
-    // the next one.
+    // the next one. The gate now lives on the shared ChallengeNewPathResolver, so the reset delegates there.
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
-        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
+        ChallengeNewPathResolver.ResetForTests();
     }
 
     // Test-only seed of a single authorize-state entry so a test can exercise the callback/authenticate legs
@@ -132,7 +118,7 @@ internal sealed class OidcLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        var newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
+        var newPath = ChallengeNewPathResolver.ResolveChallengeNewPath(provider, config, isLinking, request, _logger, c => c.OidConfigs);
 
         string redirectUri = SsoUrlBuilder.OidRedirectUri(RequestBaseUrl(request, config), newPath, provider);
 
@@ -485,66 +471,6 @@ internal sealed class OidcLoginService
     private static OidConfig FindOidConfig(string provider) =>
         SSOPlugin.Instance.ReadConfiguration(configuration => configuration.OidConfigs.TryGetValue(provider, out var config) ? config : null);
 
-    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that as
-    // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
-    // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
-    // flow — which cannot know which redirect path the identity provider has registered — reuses the last
-    // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
-    // reason this value is remembered across requests.) The SAML sibling keeps its own generic resolver
-    // because OidConfig and SamlConfig share no base with a NewPath setter.
-    //
-    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
-    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
-    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
-    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
-    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. A plain locked comparison with no write serves the case where the
-    // derived spelling already matches what is stored; an actual change is throttled by
-    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
-    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
-    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
-    // callers can exercise the race-window fallback branch directly and deterministically, the way
-    // ResetOidStateForTests/SeedOidStateForTests already do for other login-flow internals.
-    internal static bool ResolveChallengeNewPath(string provider, OidConfig config, bool isLinking, HttpRequest request, ILogger logger)
-    {
-        if (isLinking)
-        {
-            return config.NewPath;
-        }
-
-        var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
-        {
-            return derived;
-        }
-
-        try
-        {
-            return SSOPlugin.Instance.MutateConfiguration(configuration =>
-            {
-                if (configuration.OidConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
-                {
-                    liveConfig.NewPath = derived;
-                }
-
-                // The current redirect always uses `derived` regardless of whether the write above landed —
-                // it reflects this request's own path, exactly like a read-only resolution would have.
-                return derived;
-            });
-        }
-        catch (Exception ex)
-        {
-            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
-            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
-            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
-            // every persist failure is handled identically — but logged so a persistently failing config
-            // write stays observable rather than silently accepted forever (mirrors AvatarService's
-            // best-effort avatar fetch).
-            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
-            return derived;
-        }
-    }
-
     // Runs an options/client build step that reveals the at-rest client secret (#158), failing closed if
     // it cannot be decrypted. Secrets.Reveal (inside BuildOidcOptions) surfaces a missing or corrupt at-rest
     // key file, or a corrupt envelope, as a CryptographicException/FormatException; this catches it and
@@ -573,43 +499,15 @@ internal sealed class OidcLoginService
         }
     }
 
-    // Builds the OidcClient that both the challenge and the callback use. Pure mechanical assembly:
-    // the redirect URI and the scope string are the only two inputs the endpoints derive differently,
-    // so the caller supplies them. Constructed in the same order as before the extraction, so a null
-    // OidEndpoint still fails at the same point (the Uri constructor, after the options object).
-    private OidcClient CreateOidcClient(OidConfig config, string redirectUri, string scope, ProviderInformation providerInformation = null)
-    {
-        var options = BuildOidcOptions(config, redirectUri, scope);
-
-        // Reuse an already-fetched, policy-validated discovery metadata when the caller supplies it — the
-        // challenge feeds the single discovery read it performed (#450), and the callback feeds the metadata
-        // captured at the challenge (#247) so ProcessResponseAsync does not re-run discovery + JWKS.
-        // Pre-assigning ProviderInformation sets the client's internal _useDiscovery = false, which also
-        // disables the library's invalid_signature JWKS-refresh-and-retry. Two directions of key change,
-        // both bounded by the authorize state's ~15-minute lifetime: a key rotated IN during the window (the
-        // id_token signed by a key the challenge did not capture) fails this callback closed and self-heals
-        // on retry (the next challenge fetches fresh keys); a key rotated OUT / revoked during the window
-        // stays accepted until the state expires, since the callback validates against the captured set — a
-        // far tighter exposure than the platform-default 24-hour JWKS cache, and never wider than the state
-        // lifetime. Populated only from a validated fetch (never hand-filled), so the DiscoveryPolicy
-        // (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed.
-        if (providerInformation is not null)
-        {
-            options.ProviderInformation = providerInformation;
-        }
-
-        return new OidcClient(options);
-    }
-
     // Builds the OidcClient options both sites share — Authority, client credentials, redirect URI, scope,
     // the discovery policy (RequireHttps / ValidateIssuerName / ValidateEndpoints + the additional base
     // address for providers whose endpoints sit off the authority), and the required id_token signature
-    // validator (#134) — but WITHOUT ProviderInformation. Split out from CreateOidcClient so the challenge
-    // can configure the policy, read discovery ONCE under it, and only then construct the client with the
-    // resulting metadata pre-assigned (#450); the constructor's internal use-discovery flag is decided from
-    // whether ProviderInformation is set at construction, so the assignment must happen before `new
-    // OidcClient(options)`, not after. A null OidEndpoint still fails at the same point it did before (the
-    // Uri constructor, after the options object).
+    // validator (#134) — but WITHOUT ProviderInformation. Kept separate from the client construction so the
+    // challenge can configure the policy, read discovery ONCE under it, and only then construct the client
+    // with the resulting metadata pre-assigned (#450); the constructor's internal use-discovery flag is
+    // decided from whether ProviderInformation is set at construction, so the assignment must happen before
+    // `new OidcClient(options)`, not after. A null OidEndpoint still fails at the same point it did before
+    // (the Uri constructor, after the options object).
     private OidcClientOptions BuildOidcOptions(OidConfig config, string redirectUri, string scope)
     {
         // Authority and the discovery policy (RequireHttps / ValidateIssuerName / ValidateEndpoints + the
@@ -644,11 +542,32 @@ internal sealed class OidcLoginService
     // back on exactly the route the authorization request advertised), so the token request's
     // redirect_uri matches the authorization request's as RFC 6749 requires (#98). The scope string
     // is normalized the same way as the challenge side (BuildScopeString) — both tolerate a null
-    // OidScopes identically (#368).
+    // OidScopes identically (#368). The challenge leg builds its own client inline (BuildOidcOptions +
+    // new OidcClient with the discovery metadata pre-assigned, #450), so this is the sole client-assembly
+    // site left; the former CreateOidcClient wrapper folded in here (#695).
     private OidcClient CreateCallbackOidcClient(OidConfig config, string provider, HttpRequest request, ProviderInformation providerInformation)
     {
         var redirectUri = SsoUrlBuilder.OidCallbackRedirectUri(RequestBaseUrl(request, config), request.Path.Value, provider);
-        return CreateOidcClient(config, redirectUri, BuildScopeString(config), providerInformation);
+        var options = BuildOidcOptions(config, redirectUri, BuildScopeString(config));
+
+        // Reuse an already-fetched, policy-validated discovery metadata when the caller supplies it — the
+        // callback feeds the metadata captured at the challenge (#247) so ProcessResponseAsync does not
+        // re-run discovery + JWKS. Pre-assigning ProviderInformation sets the client's internal
+        // _useDiscovery = false, which also disables the library's invalid_signature JWKS-refresh-and-retry.
+        // Two directions of key change, both bounded by the authorize state's ~15-minute lifetime: a key
+        // rotated IN during the window (the id_token signed by a key the challenge did not capture) fails
+        // this callback closed and self-heals on retry (the next challenge fetches fresh keys); a key rotated
+        // OUT / revoked during the window stays accepted until the state expires, since the callback validates
+        // against the captured set — a far tighter exposure than the platform-default 24-hour JWKS cache, and
+        // never wider than the state lifetime. Populated only from a validated fetch (never hand-filled), so
+        // the DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed. The
+        // conditional is kept as-is (behaviour-preserving) though the sole caller always supplies non-null.
+        if (providerInformation is not null)
+        {
+            options.ProviderInformation = providerInformation;
+        }
+
+        return new OidcClient(options);
     }
 
     // Resolves the canonical base URL from the live request and the provider's overrides — the same pure

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -76,20 +76,6 @@ internal sealed class SamlLoginService
 
     private readonly ILogger _logger;
 
-    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
-    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
-    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
-    // logins — ExpectedAcsUrls (near ResolveChallengeNewPath below) already treats a flip as routine, not
-    // a rare edge case. Without a cap, that ordinary traffic shape would turn every such login into a
-    // synchronous config persist under the process-wide config lock, serializing every OID/SAML login on
-    // the server (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER,
-    // separate linking challenge — never this request's own redirect, which always uses its own
-    // freshly-derived value regardless of whether a write lands — so bounding this to one persist attempt
-    // per interval, process-wide, is harmless: it only delays how soon a flapping spelling's latest value
-    // reaches disk. Not readonly, for the same reason as _outcomes above: ResetSamlRequestsForTests
-    // installs a fresh gate between tests, so one test's persisted change cannot throttle a later test's.
-    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
-
     internal SamlLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -105,13 +91,13 @@ internal sealed class SamlLoginService
     // (e.g. one left behind by a signature-failing response that returns before the consume) cannot leak
     // into the next test. Same test-only surface as OidcLoginService.ResetOidStateForTests (internal,
     // InternalsVisibleTo, no endpoint/DI). Moved here with the statics from the controller (#160). Also
-    // installs a fresh NewPath persist-throttle gate (#412 review follow-up): SsoControllerHarness calls
-    // this for every test, so a change persisted in one test can never throttle a genuine change in the
-    // next one.
+    // resets the shared NewPath persist-throttle gate (#412 review follow-up, #670): SsoControllerHarness
+    // calls this for every test, so a change persisted in one test can never throttle a genuine change in
+    // the next one. The gate now lives on the shared ChallengeNewPathResolver, so the reset delegates there.
     internal static void ResetSamlRequestsForTests()
     {
         SamlRequests.Clear();
-        _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
+        ChallengeNewPathResolver.ResetForTests();
     }
 
     // Test-only: restores a fresh default in-flight login-outcome store (#251) between tests, the same
@@ -338,7 +324,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.UnknownProvider));
         }
 
-        bool newPath = ResolveChallengeNewPath(provider, config, isLinking, request, _logger);
+        bool newPath = ChallengeNewPathResolver.ResolveChallengeNewPath(provider, config, isLinking, request, _logger, c => c.SamlConfigs);
 
         string redirectUri = SsoUrlBuilder.SamlAcsUrl(GetRequestBase(request, config.SchemeOverride, config.PortOverride, config.BaseUrlOverride), newPath, provider);
         string relayState = isLinking ? "linking" : null;
@@ -714,66 +700,6 @@ internal sealed class SamlLoginService
     // controller with the SAML flow (#160); the OpenID twin lives on OidcLoginService.
     private static SamlConfig FindSamlConfig(string provider) =>
         SSOPlugin.Instance.ReadConfiguration(configuration => configuration.SamlConfigs.TryGetValue(provider, out var config) ? config : null);
-
-    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that as
-    // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
-    // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
-    // flow — which cannot know which redirect path the identity provider has registered — reuses the last
-    // login's spelling. A linking challenge only reads the stored value. (See SamlAssertionValidator's
-    // ExpectedAcsUrls for the same reason this value is remembered across requests.) Mirrors
-    // OidcLoginService.ResolveChallengeNewPath.
-    //
-    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
-    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
-    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
-    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
-    // provider by name instead of trusting the outer `config` reference, so one deleted/disabled in that
-    // race window is not written into. A plain locked comparison with no write serves the case where the
-    // derived spelling already matches what is stored; an actual change is throttled by
-    // _newPathPersistGate (see its comment) rather than persisted on every mismatched challenge, and a
-    // persist failure is swallowed — this write is best-effort bookkeeping for a later login, never a
-    // requirement for THIS one to succeed. Internal (not private) so ProviderConfigStoreTests-style
-    // callers can exercise the race-window fallback branch directly and deterministically, the way
-    // ResetSamlRequestsForTests-style hooks already do for other login-flow internals.
-    internal static bool ResolveChallengeNewPath(string provider, SamlConfig config, bool isLinking, HttpRequest request, ILogger logger)
-    {
-        if (isLinking)
-        {
-            return config.NewPath;
-        }
-
-        var derived = ChallengePath.IsNewPath(request.Path.Value);
-        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
-        {
-            return derived;
-        }
-
-        try
-        {
-            return SSOPlugin.Instance.MutateConfiguration(configuration =>
-            {
-                if (configuration.SamlConfigs.TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
-                {
-                    liveConfig.NewPath = derived;
-                }
-
-                // The current redirect always uses `derived` regardless of whether the write above landed —
-                // it reflects this request's own path, exactly like a read-only resolution would have.
-                return derived;
-            });
-        }
-        catch (Exception ex)
-        {
-            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
-            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
-            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
-            // every persist failure is handled identically — but logged so a persistently failing config
-            // write stays observable rather than silently accepted forever (mirrors AvatarService's
-            // best-effort avatar fetch).
-            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
-            return derived;
-        }
-    }
 
     // Builds the redirect URL to the identity provider, signing the outgoing AuthnRequest when the provider
     // opts in (#167). Fail-closed: signing enabled but the signing key missing/unloadable throws, so the

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,0 +1,111 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
+
+/// <summary>
+/// The one generic resolver both login-flow services share for the "new redirect path" spelling (#670): the
+/// OpenID and SAML sites carried near-identical ~40-line copies — each with its own
+/// <see cref="IntervalGate"/> persist-throttle — that differed only in which provider map the write
+/// re-resolves against (<c>OidConfigs</c> vs <c>SamlConfigs</c>). Every field it touches
+/// (<see cref="Config.ProviderConfigBase.NewPath"/>, <c>Enabled</c>) lives on the shared
+/// <see cref="Config.ProviderConfigBase"/>, so one method generic over the provider-config type, taking the
+/// map selector as a delegate, replaces both — with a SINGLE process-wide throttle gate rather than one per
+/// flow. The race-window re-resolve, the throttle semantics and the best-effort swallow are preserved
+/// verbatim from the pre-consolidation copies.
+/// </summary>
+internal static class ChallengeNewPathResolver
+{
+    // Throttles how often an actual NewPath change is persisted (#412 review follow-up). Both route
+    // spellings stay permanently live side by side (ChallengePath/SsoUrlBuilder never retire either one),
+    // so a provider used concurrently by clients on both is EXPECTED to flip this value on alternating
+    // logins — SamlAssertionValidator's ExpectedAcsUrls already treats a flip as routine, not a rare edge
+    // case. Without a cap, that ordinary traffic shape would turn every such login into a synchronous
+    // config persist under the process-wide config lock, serializing every OID/SAML login on the server
+    // (not just this provider's) behind disk I/O. NewPath is only ever consulted by a LATER, separate
+    // linking challenge — never this request's own redirect, which always uses its own freshly-derived
+    // value regardless of whether a write lands — so bounding this to one persist attempt per interval,
+    // process-wide, is harmless: it only delays how soon a flapping spelling's latest value reaches disk.
+    // ONE gate is shared by both flows now (#670): a single process-wide throttle over the one persist path.
+    // Not readonly: ResetForTests installs a fresh gate between tests, so one test's persisted change cannot
+    // throttle a genuine change in the next one.
+    private static IntervalGate _newPathPersistGate = new(TimeSpan.FromSeconds(5));
+
+    /// <summary>
+    /// Test-only reset of the shared NewPath persist-throttle gate (#412 review follow-up, #670): installs a
+    /// fresh gate so a change persisted in one test can never throttle a genuine change in the next one. The
+    /// flow services' own reset hooks (ResetOidStateForTests / ResetSamlRequestsForTests) call this, and
+    /// SsoControllerHarness calls both for every test. Internal and reachable only through InternalsVisibleTo;
+    /// never wired to an endpoint or DI, so it adds no runtime or security surface.
+    /// </summary>
+    internal static void ResetForTests() => _newPathPersistGate = new IntervalGate(TimeSpan.FromSeconds(5));
+
+    // Resolves whether this challenge uses the "new", more descriptive redirect path, and records that as
+    // server-managed runtime state on the provider config. A non-linking challenge derives the spelling
+    // from the request path (a `.../start/...` route means the new path) and stores it, so a later linking
+    // flow — which cannot know which redirect path the identity provider has registered — reuses the last
+    // login's spelling. A linking challenge only reads the stored value. (See ExpectedAcsUrls for the same
+    // reason this value is remembered across requests.)
+    //
+    // The record itself goes through MutateConfiguration rather than a bare field assignment (#412): the
+    // `config` the caller passes in was read under ReadConfiguration's lock, which is released before this
+    // runs, so writing straight into it raced a concurrent challenge for the same provider and never went
+    // through the write path every other config mutation uses. The Mutate delegate re-resolves the
+    // provider by name — against the map the caller selects (OidConfigs / SamlConfigs) — instead of trusting
+    // the outer `config` reference, so one deleted/disabled in that race window is not written into. A plain
+    // locked comparison with no write serves the case where the derived spelling already matches what is
+    // stored; an actual change is throttled by _newPathPersistGate (see its comment) rather than persisted on
+    // every mismatched challenge, and a persist failure is swallowed — this write is best-effort bookkeeping
+    // for a later login, never a requirement for THIS one to succeed. Internal (not private) so
+    // ProviderConfigStoreTests-style callers can exercise the race-window fallback branch directly and
+    // deterministically, the way the flow services' test hooks already do for other login-flow internals.
+    internal static bool ResolveChallengeNewPath<T>(
+        string provider,
+        T config,
+        bool isLinking,
+        HttpRequest request,
+        ILogger logger,
+        Func<PluginConfiguration, SerializableDictionary<string, T>> selectConfigs)
+        where T : ProviderConfigBase
+    {
+        if (isLinking)
+        {
+            return config.NewPath;
+        }
+
+        var derived = ChallengePath.IsNewPath(request.Path.Value);
+        if (derived == config.NewPath || !_newPathPersistGate.TryEnter(DateTime.Now))
+        {
+            return derived;
+        }
+
+        try
+        {
+            return SSOPlugin.Instance.MutateConfiguration(configuration =>
+            {
+                if (selectConfigs(configuration).TryGetValue(provider, out var liveConfig) && liveConfig is { Enabled: true })
+                {
+                    liveConfig.NewPath = derived;
+                }
+
+                // The current redirect always uses `derived` regardless of whether the write above landed —
+                // it reflects this request's own path, exactly like a read-only resolution would have.
+                return derived;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a config-persist failure here (full disk, permissions, a corrupt secret
+            // envelope surfacing mid-ProtectAll) must not turn an otherwise-valid login into a 500 over a
+            // value that only helps a LATER linking flow guess the right spelling. Broad on purpose —
+            // every persist failure is handled identically — but logged so a persistently failing config
+            // write stays observable rather than silently accepted forever (mirrors AvatarService's
+            // best-effort avatar fetch).
+            logger?.LogWarning(ex, "Could not record the NewPath redirect spelling for provider {Provider}; this login proceeds with its own derived value.", provider?.ReplaceLineEndings(string.Empty));
+            return derived;
+        }
+    }
+}


### PR DESCRIPTION
# What & why

Two behaviour-preserving reductions on the login-flow tier (directive 4: minimal, one architecture).

**#670**, `OidcLoginService` and `SamlLoginService` each carried a near-identical ~40-line `ResolveChallengeNewPath` plus its own `IntervalGate` persist-throttle, kept in lockstep by hand and differing only in which provider map the #412 race-window re-resolve targets (`OidConfigs` vs `SamlConfigs`). `NewPath` and `Enabled` both live on the shared `ProviderConfigBase`, so one generic helper, `Api/Shared/ChallengeNewPathResolver.ResolveChallengeNewPath<T>`, taking the map selector as a delegate and backed by a single process-wide throttle gate, replaces both. The race-window re-resolve, the throttle semantics, and the best-effort swallow are preserved verbatim. The stale justifying comment (claiming the two configs "share no base with a NewPath setter", false since #204) is removed. A new conformance test `FlowServices_DoNotDuplicateChallengeNewPathResolution` asserts neither flow service re-declares the method or the gate field, so the duplication cannot silently return.

**#695**, `CreateOidcClient` was a single-caller wrapper with a dead `= null` default and an always-true guard for its sole caller. Folded into `CreateCallbackOidcClient`, dropping the dead default and keeping the `is not null` assignment verbatim. The challenge leg never used it and is untouched.

Closes #670
Closes #695

## Type of change

- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the swallow still only affects best-effort `NewPath` bookkeeping and returns the request's own derived spelling; the `liveConfig is { Enabled: true }` race-window guard is byte-identical, so a provider disabled in the window is still never written/revived.
- [x] No secrets logged; the swallow's log line is copied verbatim and sanitizes the provider name with the codebase-wide `ReplaceLineEndings` convention.
- [x] A security review was performed, adversarial bypass/fail-open + correctness lenses, line-by-line against `origin/main`; both PASS. Confirmed: the type system makes a cross-map write a compile error; `NewPath` feeds no authz/ACS-validation decision (SAML `ExpectedAcsUrls` returns both spellings unconditionally); the shared gate is not a security lever; the internal helper adds no production-reachable surface; #695 leaves `BuildOidcOptions`, discovery policy, and the id_token signature validator (#134) unchanged.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; ~80 lines of hand-mirrored logic collapse to one generic unit (net −4 LOC with the conformance test added).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why.
- [x] Architecture-conformance tests pass; the dedup is locked in as a new `ArchitectureConformanceTests` rule.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1536/1536 on both TFMs.
- [x] No `.js/.html/.css/.md` touched (prettier N/A).

## Notes

The shared throttle gate now bounds both flows' `NewPath` persists together rather than each independently, a deliberate, documented consequence of one owner. `NewPath` is consulted only by a later linking challenge and never by the current request, so this only affects how soon a flapping redirect-path spelling reaches disk, and reduces synchronous config persists under the process-wide lock.