### PR TITLE
Correct the ProviderConfigValidator doc and tighten RequestHelpers visibility

### DIFF
--- a/SSO-Auth/Api/RequestHelpers.cs
+++ b/SSO-Auth/Api/RequestHelpers.cs
@@ -17,9 +17,10 @@ using Microsoft.AspNetCore.Http;
 namespace Jellyfin.Plugin.SSO_Auth.Helpers;
 
 /// <summary>
-/// Request Extensions.
+/// Request Extensions. Internal like the rest of the helper surface — its only member is internal, so
+/// nothing public was ever exposed either way (#671).
 /// </summary>
-public static class RequestHelpers
+internal static class RequestHelpers
 {
     /// <summary>
     /// Checks if the user can update an entry.

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -6,11 +6,19 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>
 /// Rejects invalid provider configuration fail-closed before anything is persisted. The whole-config
-/// <see cref="Validate"/> gates the admin config-page save inside <see cref="ProviderConfigStore.Save"/>;
-/// the per-provider methods apply the same predicates to a single incoming provider, so every admin
-/// write path can share one validation rule (#318). Delegates to the existing
-/// <see cref="CanonicalBaseUrl.IsInvalidOverride"/>, <see cref="SamlCertificate.IsInvalid"/>, and
-/// <see cref="ProviderNameValidator.IsInvalid"/> predicates.
+/// <see cref="Validate"/> gates the admin config-page save inside <see cref="ProviderConfigStore.Save"/>
+/// by composing the per-provider checks below; those per-provider methods are also exercised directly,
+/// one predicate at a time, by the unit tests (hence internal, not private). The single source of truth
+/// is the underlying <see cref="CanonicalBaseUrl.IsInvalidOverride"/>,
+/// <see cref="SamlCertificate.IsInvalid"/>, <see cref="SamlSigningKey.IsInvalid"/>, and
+/// <see cref="ProviderNameValidator.IsInvalid"/> predicates — the SAME ones the Add endpoints' own
+/// guards (<c>SSOController.RejectInvalid*</c>) delegate to. The two admin write paths keep separate
+/// throwing wrappers on purpose (#671): the config-page messages here embed the provider name and
+/// protocol for the admin UI, whereas the Add-endpoint messages stay generic and input-independent (they
+/// never echo the caller's provider name back), and <c>RejectInvalidNewProviderName</c> resolves
+/// existence under the config lock. So a new provider-config rule is one shared base predicate plus the
+/// two context-appropriate wrappers — the validation logic is not duplicated, only the messaging is
+/// deliberately parallel.
 /// </summary>
 internal static class ProviderConfigValidator
 {


### PR DESCRIPTION
# What & why

**#671** flagged two parallel copies of the provider-config validation and a class doc that claimed a shared rule that was never realized.

On investigation the substantive validation is **already** shared: both the config-page `ProviderConfigValidator.Validate*` methods and the Add-endpoint `SSOController.RejectInvalid*` wrappers delegate to the **same base predicates** (`CanonicalBaseUrl.IsInvalidOverride`, `SamlCertificate.IsInvalid`, `SamlSigningKey.IsInvalid`, `ProviderNameValidator.IsInvalid`). Only the thin throwing wrappers differ, and they differ **deliberately**:

- config-page messages embed the provider name/protocol for the admin UI;
- Add-endpoint messages stay generic and never echo the caller's provider name back into the exception;
- `RejectInvalidNewProviderName` resolves existence under the config lock, which the config-page path does differently.

So this is a **reasoned decline** of full unification (fully unifying would couple two intentionally separate error-message postures and change user-facing Add-endpoint messages for no real gain, since the logic is already shared) plus the doc fix the issue explicitly sanctioned:

- Rewrite the `ProviderConfigValidator` class doc to describe reality, `Validate` composes the per-provider checks, the per-provider methods stay `internal` because the unit tests exercise each predicate directly, and the genuine single source of truth is the base predicate set shared with the Add path's own wrappers.
- The four per-provider methods **cannot** be made `private` (the issue's other option): `ProviderConfigValidatorTests` / `ConfigPreservationTests` exercise them directly via `InternalsVisibleTo`.
- Fold the minor nit: `RequestHelpers` was a `public static class` whose only member is `internal`, so it exposed nothing publicly, made `internal`.

Closes #671

## Type of change

- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no validation behaviour changes, this is a doc correction plus a class-visibility reduction. The base predicates and both write paths' wrappers are untouched.
- [x] No secrets logged.
- [x] Reviewed: making `RequestHelpers` internal keeps it reachable by the test assembly (InternalsVisibleTo); its only member `AssertCanUpdateUser` (the admin-or-self fail-closed guard) is unchanged.

## Quality checklist

- [x] No duplicated logic introduced; the doc now states where the single source of truth actually lives.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; the decline rationale is in the class doc.
- [x] Architecture-conformance tests pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1535/1535 on both TFMs.
- [x] No `.js/.html/.css/.md` touched (prettier N/A).

## Notes

The duplication the issue worried about ("a new guard must be added in both places") is bounded: a new rule is one shared base predicate plus two thin context-appropriate wrappers, the validation logic itself is not duplicated.