### PR TITLE
Stop repointing third-party-provider accounts under SSO-only login

### DIFF
--- a/SSO-Auth.Tests/SsoOnlyLoginGuardTests.cs
+++ b/SSO-Auth.Tests/SsoOnlyLoginGuardTests.cs
@@ -129,17 +129,50 @@ public class SsoOnlyLoginGuardTests
         // login strips their door and the whole org is locked out once the IdP is down.
         var config = new PluginConfiguration { DisablePasswordLogin = true, BreakGlassAdminUsername = "root" };
 
-        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(config, "root", SsoAuthenticationProviders.SsoProviderId);
+        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(
+            config, "root", SsoAuthenticationProviders.DefaultPasswordProviderId, SsoAuthenticationProviders.SsoProviderId);
 
         Assert.Equal(SsoAuthenticationProviders.DefaultPasswordProviderId, resolved);
     }
 
     [Fact]
-    public void ResolveLoginProvider_ModeOn_NonExemptAccount_ForcedToSsoProvider()
+    public void ResolveLoginProvider_ModeOn_NonExemptPasswordAccount_ForcedToSsoProvider()
     {
         var config = new PluginConfiguration { DisablePasswordLogin = true, BreakGlassAdminUsername = "root" };
 
-        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(config, "alice", configuredDefaultProvider: null);
+        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(
+            config, "alice", SsoAuthenticationProviders.DefaultPasswordProviderId, configuredDefaultProvider: null);
+
+        Assert.Equal(SsoAuthenticationProviders.SsoProviderId, resolved);
+    }
+
+    [Fact]
+    public void ResolveLoginProvider_ModeOn_ThirdPartyProviderAccount_KeepsItsProvider()
+    {
+        // #690: an account whose CURRENT provider is neither the built-in password provider nor the SSO
+        // provider (a third-party IAuthenticationProvider — e.g. LDAP) already has NO password door, and the
+        // enable sweep skips it via the same IsDefaultPasswordProvider test. The login path must skip it too:
+        // keep it on its current provider rather than repoint it to SSO. Repointing here would be
+        // repointed-but-UNTRACKED (the tracking write is gated on IsDefaultPasswordProvider), which the
+        // off-switch/reconcile could never reverse — the exact path-disagreement #690 fixes.
+        const string thirdPartyProvider = "Some.ThirdParty.LdapAuthenticationProvider";
+        var config = new PluginConfiguration { DisablePasswordLogin = true, BreakGlassAdminUsername = "root" };
+
+        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(
+            config, "alice", thirdPartyProvider, configuredDefaultProvider: null);
+
+        Assert.Equal(thirdPartyProvider, resolved);
+    }
+
+    [Fact]
+    public void ResolveLoginProvider_ModeOn_AlreadySsoAccount_KeepsSsoProvider()
+    {
+        // An account already on the SSO provider (a plugin-created natively-SSO account) is left on it — the
+        // return is a no-op write to the same provider, unchanged from before #690.
+        var config = new PluginConfiguration { DisablePasswordLogin = true, BreakGlassAdminUsername = "root" };
+
+        var resolved = SsoOnlyLoginGuard.ResolveLoginProvider(
+            config, "carol", SsoAuthenticationProviders.SsoProviderId, configuredDefaultProvider: null);
 
         Assert.Equal(SsoAuthenticationProviders.SsoProviderId, resolved);
     }
@@ -149,8 +182,10 @@ public class SsoOnlyLoginGuardTests
     {
         var config = new PluginConfiguration { DisablePasswordLogin = false, BreakGlassAdminUsername = "root" };
 
-        Assert.Equal("some-provider", SsoOnlyLoginGuard.ResolveLoginProvider(config, "alice", "some-provider"));
-        Assert.Null(SsoOnlyLoginGuard.ResolveLoginProvider(config, "root", null));
+        Assert.Equal(
+            "some-provider",
+            SsoOnlyLoginGuard.ResolveLoginProvider(config, "alice", SsoAuthenticationProviders.DefaultPasswordProviderId, "some-provider"));
+        Assert.Null(SsoOnlyLoginGuard.ResolveLoginProvider(config, "root", SsoAuthenticationProviders.DefaultPasswordProviderId, null));
     }
 
     // --- Hardening (bypass-lens): pin the core default-provider identifier so a rename can't silently fail-open ---

--- a/SSO-Auth.Tests/SsoOnlyLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SsoOnlyLoginServiceTests.cs
@@ -40,6 +40,19 @@ public class SsoOnlyLoginServiceTests
         return user;
     }
 
+    // A third-party IAuthenticationProvider id (e.g. an LDAP plugin) — neither Jellyfin's built-in password
+    // provider nor this plugin's SSO provider. Named once so the #690 skip tests read intent.
+    private const string ThirdPartyProviderId = "Some.ThirdParty.LdapAuthenticationProvider";
+
+    private static User ThirdPartyUser(string name, Guid id)
+    {
+        // An account already routed to a third-party auth provider: it has no built-in-password door, so the
+        // enable sweep skips it and (post-#690) the login path must skip it too — keep its current provider.
+        var user = new User(name, "SSO-Auth", "Default") { Id = id, Password = "hash-" + name };
+        user.AuthenticationProviderId = ThirdPartyProviderId;
+        return user;
+    }
+
     private static User SsoOnlyUser(string name, Guid id)
     {
         // The shape CanonicalLinkService gives every account it creates: routed to the plugin's SSO provider
@@ -456,6 +469,31 @@ public class SsoOnlyLoginServiceTests
 
         Assert.Equal(SsoAuthenticationProviders.SsoProviderId, decision.DefaultProvider);
         Assert.DoesNotContain(SsoUserId, config.SsoOnlyRepointedUserIds);
+    }
+
+    [Fact]
+    public void ResolveLoginEnforcement_ModeOn_ThirdPartyProviderAccount_NotRepointed_AndNeverTracked()
+    {
+        // #690: an account currently on a THIRD-PARTY provider (neither the built-in password provider nor the
+        // SSO provider) already has no password door, and the enable sweep skips it. The login path must skip
+        // it too — keep it on its current provider and never track it. Before the fix the login path repointed
+        // it to SSO while the tracking write (gated on IsDefaultPasswordProvider) left it UNTRACKED, so
+        // DisableAsync/ReconcileOnStartupAsync could never reverse the move. This pins the two paths in
+        // agreement, mirroring the natively-SSO sweep-skip assertion above.
+        var root = PasswordAdmin("root", RootId);
+        var ldap = ThirdPartyUser("alice", AliceId);
+        var (service, config, _) = Build(new[] { root, ldap }, c =>
+        {
+            c.DisablePasswordLogin = true;
+            c.BreakGlassAdminUsername = "root";
+        });
+
+        var decision = service.ResolveLoginEnforcement(AliceId, configuredDefaultProvider: null);
+
+        // Kept on its third-party provider (NOT repointed to SSO), not the break-glass admin, and not tracked.
+        Assert.Equal(ThirdPartyProviderId, decision.DefaultProvider);
+        Assert.False(decision.IsBreakGlassAdmin);
+        Assert.DoesNotContain(AliceId, config.SsoOnlyRepointedUserIds);
     }
 
     [Fact]

--- a/SSO-Auth/Api/SsoOnlyLoginService.cs
+++ b/SSO-Auth/Api/SsoOnlyLoginService.cs
@@ -100,8 +100,11 @@ internal sealed class SsoOnlyLoginService
     /// reconciliation restore exactly the accounts the mode moved (Finding B); the break-glass admin and an
     /// account already on the SSO provider (plugin-created natively-SSO accounts included) are never tracked.
     /// The returned <see cref="SsoOnlyLoginDecision.IsBreakGlassAdmin"/> lets the mint keep the recovery
-    /// account admin/enabled (Finding H1). When the mode is off, the configured default is returned unchanged
-    /// and nothing is tracked (a read only, no config write).
+    /// account admin/enabled (Finding H1). An account already on a THIRD-PARTY provider (neither the built-in
+    /// password provider nor the SSO provider) is left on it and never tracked — matching the sweep, which
+    /// skips it, so the two enforcement paths agree and no account is repointed-but-untracked (#690). When the
+    /// mode is off, the configured default is returned unchanged and nothing is tracked (a read only, no
+    /// config write).
     /// </summary>
     /// <param name="userId">The Jellyfin user id the login resolved to.</param>
     /// <param name="configuredDefaultProvider">The provider config's own <c>DefaultProvider</c> (already trimmed), used unchanged while the mode is off.</param>
@@ -121,7 +124,7 @@ internal sealed class SsoOnlyLoginService
                 return (new SsoOnlyLoginDecision(configuredDefaultProvider, false), false);
             }
 
-            var provider = SsoOnlyLoginGuard.ResolveLoginProvider(configuration, resolved.Username, configuredDefaultProvider);
+            var provider = SsoOnlyLoginGuard.ResolveLoginProvider(configuration, resolved.Username, resolved.AuthenticationProviderId, configuredDefaultProvider);
             var modeOn = configuration is { DisablePasswordLogin: true };
             var isBreakGlass = modeOn && SsoOnlyLoginGuard.IsBreakGlass(configuration, resolved.Username);
 

--- a/SSO-Auth/Config/SsoOnlyLoginGuard.cs
+++ b/SSO-Auth/Config/SsoOnlyLoginGuard.cs
@@ -134,27 +134,44 @@ internal static class SsoOnlyLoginGuard
 
     /// <summary>
     /// Decides the authentication provider id an SSO login should write for the given account (#165,
-    /// Finding 1/2 fixes). When SSO-only is OFF, the provider's own configured default is used unchanged.
-    /// When it is ON, a non-exempt account is forced onto the SSO (non-password) provider so no residual
-    /// password door survives, and the break-glass admin is PINNED to the built-in password provider so an
-    /// SSO login can never strip its password door (operators often set a provider's DefaultProvider to the
-    /// SSO provider id; without this pin the break-glass admin could lock the whole org out when the IdP
-    /// later fails). Pure: the caller reads it under the config lock and passes the result to the minter.
+    /// Finding 1/2 fixes, #690). When SSO-only is OFF, the provider's own configured default is used
+    /// unchanged. When it is ON, the break-glass admin is PINNED to the built-in password provider so an SSO
+    /// login can never strip its password door (operators often set a provider's DefaultProvider to the SSO
+    /// provider id; without this pin the break-glass admin could lock the whole org out when the IdP later
+    /// fails). A non-exempt account is forced onto the SSO (non-password) provider ONLY when it currently
+    /// routes to the built-in password provider — the exact <see cref="SsoAuthenticationProviders.IsDefaultPasswordProvider"/>
+    /// test the enable sweep uses. An account already on a THIRD-PARTY provider (neither the built-in password
+    /// provider nor the SSO provider) keeps its current provider, matching the sweep, which skips it: SSO-only
+    /// closes the PASSWORD door, and such an account already has none (#690). Repointing it here would be
+    /// repointed-but-UNTRACKED — the caller's tracking write is gated on the same password-provider test — so
+    /// the off-switch and boot reconcile could never reverse it. An account already on the SSO provider keeps
+    /// the SSO provider (a no-op write). Pure: the caller reads it under the config lock and passes the result
+    /// to the minter.
     /// </summary>
     /// <param name="configuration">The live plugin configuration.</param>
     /// <param name="username">The account username completing the SSO login.</param>
+    /// <param name="currentProviderId">The account's CURRENT <c>AuthenticationProviderId</c>, used to leave a third-party-provider account untouched exactly as the sweep does.</param>
     /// <param name="configuredDefaultProvider">The provider config's own <c>DefaultProvider</c> (already trimmed), applied only while the mode is off.</param>
     /// <returns>The provider id to write, or the configured default when the mode is off.</returns>
-    internal static string ResolveLoginProvider(PluginConfiguration configuration, string username, string configuredDefaultProvider)
+    internal static string ResolveLoginProvider(PluginConfiguration configuration, string username, string currentProviderId, string configuredDefaultProvider)
     {
         if (configuration is not { DisablePasswordLogin: true })
         {
             return configuredDefaultProvider;
         }
 
-        return IsBreakGlass(configuration, username)
-            ? SsoAuthenticationProviders.DefaultPasswordProviderId
-            : SsoAuthenticationProviders.SsoProviderId;
+        if (IsBreakGlass(configuration, username))
+        {
+            return SsoAuthenticationProviders.DefaultPasswordProviderId;
+        }
+
+        // Match the enable sweep's skip exactly (SweepEnableAsync gates its repoint on this same test): only an
+        // account still on the built-in password provider is moved to the SSO provider. An account on any other
+        // provider — the SSO provider (no-op) or a third-party provider (kept) — is left on it, so the login
+        // path and the sweep can never disagree and no account is repointed-but-untracked (#690).
+        return SsoAuthenticationProviders.IsDefaultPasswordProvider(currentProviderId)
+            ? SsoAuthenticationProviders.SsoProviderId
+            : currentProviderId;
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

**#690** (surfaced by the adversarial re-review of SSO-only #165; pre-existing to that design, not a regression). Under SSO-only mode the per-login enforcement repointed **any** non-exempt account to the SSO provider, including an account on a **third-party** auth provider (neither the built-in password provider nor the SSO provider). But the `SsoOnlyRepointedUserIds` tracking write is gated on the built-in-password-provider test, and the enable **sweep already skips** third-party accounts, so such an account was **repointed-but-untracked**, and `DisableAsync`/`ReconcileOnStartupAsync` (which only restore the tracked set) could never reverse it.

Fix: the login path now moves a non-exempt account to the SSO provider **only when it currently routes to the built-in password provider**, using the exact `SsoAuthenticationProviders.IsDefaultPasswordProvider` test the sweep uses. An account on the SSO provider (no-op) or a third-party provider (kept) is left alone. SSO-only closes the **password** door, and a third-party-provider account already has none, so all four enforcement paths (sweep skip, login repoint, tracking write, disable/reconcile restore) now key off the same predicate and agree.

Closes #690

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix

## Security checklist

- [x] Fail-closed preserved: an account genuinely on the built-in password provider is still moved off it (door closed), decided from the DB's real `AuthenticationProviderId` under the config lock, never from IdP input.
- [x] No secrets logged.
- [x] Security review performed, adversarial availability/mass-lockout + bypass lenses over the full files, callers, sweep/disable/reconcile, and originals; both PASS. Confirmed: the break-glass password-provider pin runs first and is unchanged (recovery door never at risk); the activation interlock (`AssertCanActivate`) is untouched; the change **removes** a lockout vector (a third-party admin was previously stripped of its non-SSO door, untracked and unrecoverable, when logging in via SSO); leaving a third-party account on its provider is **not** a bypass because SSO-only's documented scope is closing the built-in password door, which the sweep has always enforced by the same skip.
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new logging.)

## Quality checklist

- [x] Reuses the existing `IsDefaultPasswordProvider` predicate, no new/parallel rule invented.
- [x] Minimal change (the guard gains the account's current provider id).
- [x] Self-documenting; the guard doc explains the third-party skip and why.
- [x] Architecture-conformance tests pass; two guard pins + one login-path pin added.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1538/1538 on both TFMs.
- [x] No `.js/.html/.css/.md` touched (prettier N/A).

## Notes

Two out-of-scope observations from the review, neither a fix for this PR:
1. Accounts the pre-fix code already moved to SSO-untracked would remain stranded, but SSO-only has **not shipped in any release**, so there are no field deployments carrying the bug; it is fixed before first release.
2. A defense-in-depth residual: a null/empty `AuthenticationProviderId` (which Jellyfin core treats as password-capable) is skipped by **both** the sweep and the login path. Pre-existing in the sweep, unreachable via normal user creation (the `User` constructor requires a concrete provider id), so left as-is to keep this change consistent with the sweep.