### PR TITLE
Type the rate-limit endpoint-class bucket keys

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -788,6 +788,48 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void RateLimitEndpointClass_UsesTypedConstants_NotLiterals()
+    {
+        // Locked in by #694: the per-client rate-limit bucket key is built as `class + ":" + clientKey` in
+        // SsoRateLimitGate.Check, so the endpoint-class string IS the limiter grouping. Passed as a bare
+        // literal at each call site, a single typo ("challange") compiles cleanly and silently mints a
+        // separate, empty bucket — weakening the rate limit undetectably, with nothing to fail. Every call
+        // site now references a SsoRateLimitClass member instead, so a typo is a compile error; this rule
+        // forbids a raw literal from creeping back in. Call-level property, so it is a source scan like the
+        // other controller rules above. The scan covers BOTH the controller's RateLimitCheck wrapper and any
+        // direct SsoRateLimitGate.Check invocation (belt-and-braces: a future controller could call the gate
+        // straight, bypassing the wrapper), and flags a string-literal FIRST argument to either — never the
+        // typed SsoRateLimitClass member reference.
+        var literalCall = new Regex("(?:RateLimitCheck|SsoRateLimitGate\\.Check)\\(\\s*\"");
+        var offenders = ControllerSourceFiles()
+            .SelectMany(path => File.ReadAllLines(path)
+                .Select((line, index) => (File: Path.GetFileName(path), Text: line.Trim(), Number: index + 1)))
+            .Where(l => literalCall.IsMatch(l.Text))
+            .Select(l => $"{l.File} line {l.Number}: {l.Text}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "A rate-limited endpoint must pass its endpoint class as a SsoRateLimitClass member, never a raw string literal — a literal typo silently mints a separate empty limiter bucket (#694). Found: " + string.Join(" | ", offenders));
+
+        // Sentinel against a vacuous pass: the scan only means something while the typed call sites exist. A
+        // rename of the wrapper or a restructure that dropped every RateLimitCheck call would make the
+        // offender scan match nothing and pass for the wrong reason, so pin the count of typed call sites. All
+        // rate-limited endpoints route through the RateLimitCheck(SsoRateLimitClass.X) wrapper today; extend
+        // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
+        // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
+        // drift the offender scan cannot see.
+        const int expectedTypedCallSites = 11;
+        var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
+        var typedCallSites = ControllerSourceFiles()
+            .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);
+
+        Assert.True(
+            typedCallSites == expectedTypedCallSites,
+            $"Expected {expectedTypedCallSites} typed RateLimitCheck(SsoRateLimitClass.X) call sites (#694); found {typedCallSites}. A rate-limited endpoint was added or removed — update this sentinel in the same PR so the literal scan cannot pass vacuously.");
+    }
+
+    [Fact]
     public void Controller_HoldsNoMutableStaticState()
     {
         // Locked in by the rate-limit-gate extraction (#160, #318): after the OpenID (#500), SAML (#501) and

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -138,7 +138,7 @@ public class SSOController : ControllerBase
         [FromRoute] string provider,
         [FromQuery] string state)
     {
-        if (RateLimitCheck("callback") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
             return throttled;
         }
@@ -159,7 +159,7 @@ public class SSOController : ControllerBase
     [HttpGet("OID/start/{provider}")]
     public async Task<ActionResult> OidChallenge(string provider, [FromQuery] bool isLinking = false)
     {
-        if (RateLimitCheck("challenge") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Challenge) is { } throttled)
         {
             return throttled;
         }
@@ -387,7 +387,7 @@ public class SSOController : ControllerBase
         // [Authorize] filter rejects a non-elevated caller before the body runs, so an unauthorized request
         // never reaches the limiter (no rate-limit oracle). Once past it, the shared "test" budget caps how
         // fast an authorized admin can drive the probe's outbound discovery fetch.
-        if (RateLimitCheck("test") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Test) is { } throttled)
         {
             return throttled;
         }
@@ -426,7 +426,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult> OidAuth(string provider, [FromBody] AuthResponse response)
     {
-        if (RateLimitCheck("auth") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Auth) is { } throttled)
         {
             return throttled;
         }
@@ -459,7 +459,7 @@ public class SSOController : ControllerBase
     [HttpPost("SAML/post/{provider}")]
     public ActionResult SamlCallback(string provider, [FromQuery] string relayState = null, [FromForm(Name = "SAMLResponse")] string formSamlResponse = null)
     {
-        if (RateLimitCheck("callback") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
             return throttled;
         }
@@ -480,7 +480,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/start/{provider}")]
     public ActionResult SamlChallenge(string provider, [FromQuery] bool isLinking = false)
     {
-        if (RateLimitCheck("challenge") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Challenge) is { } throttled)
         {
             return throttled;
         }
@@ -504,7 +504,7 @@ public class SSOController : ControllerBase
     [HttpGet("SAML/metadata/{provider}")]
     public ActionResult SamlMetadata(string provider)
     {
-        if (RateLimitCheck("metadata") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Metadata) is { } throttled)
         {
             return throttled;
         }
@@ -697,7 +697,7 @@ public class SSOController : ControllerBase
     [Produces(MediaTypeNames.Application.Json)]
     public async Task<ActionResult> SamlAuth(string provider, [FromBody] AuthResponse response)
     {
-        if (RateLimitCheck("auth") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Auth) is { } throttled)
         {
             return throttled;
         }
@@ -732,7 +732,7 @@ public class SSOController : ControllerBase
         // everywhere, persists a provider switch, and revokes the user's active sessions (#440). Its own
         // "unregister" class carries an independent budget, so it neither starves nor is starved by the
         // link/unlink write surface's "link" bucket (#382) or the anonymous login flows.
-        if (RateLimitCheck("unregister") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Unregister) is { } throttled)
         {
             return throttled;
         }
@@ -905,7 +905,7 @@ public class SSOController : ControllerBase
         // refused before the limiter is consulted (no rate-limit oracle), then the shared gate caps how fast
         // an authorized caller can drive the config-XML disk writes this write surface performs. "link" is a
         // distinct endpoint class, so its budget is independent of the anonymous login flows.
-        if (RateLimitCheck("link") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
         {
             return throttled;
         }
@@ -940,7 +940,7 @@ public class SSOController : ControllerBase
         // Throttle after the caller-authz guard (#382): a name-miss DELETE still runs a full persist under the
         // global config lock, so this endpoint is capped too. It shares the "link" budget with AddCanonicalLink
         // — one bucket per client for the whole link/unlink write surface — while the 403 stays first.
-        if (RateLimitCheck("link") is { } throttled)
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
         {
             return throttled;
         }

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -1,0 +1,26 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
+
+/// <summary>
+/// The endpoint-class bucket keys the per-client rate-limit gate keys on (#694). <see cref="SsoRateLimitGate.Check"/>
+/// folds the class into the limiter key as <c>class + ":" + clientKey</c>, so each value here names one
+/// independent budget: the anonymous login stages (<see cref="Challenge"/>/<see cref="Callback"/>/<see cref="Auth"/>),
+/// the elevation-gated Test-connection probe (<see cref="Test"/>), the anonymous SP-metadata read
+/// (<see cref="Metadata"/>), the admin SSO-revoke (<see cref="Unregister"/>, #516), and the authenticated
+/// link/unlink write surface (<see cref="Link"/>, #382). These are named constants rather than bare string
+/// literals at the call sites precisely because the value is LOAD-BEARING on the limiter grouping: a typo in a
+/// literal ("challange") compiles cleanly and silently mints a separate, empty bucket, weakening the rate limit
+/// undetectably. Referencing a member instead makes a typo a compile error, and the
+/// <c>RateLimitEndpointClass_UsesTypedConstants_NotLiterals</c> conformance test forbids a raw literal from
+/// creeping back in. The values are the exact lowercase strings the wire keys have always carried, so this is a
+/// readability/safety change with no behavioural or persisted-state effect.
+/// </summary>
+internal static class SsoRateLimitClass
+{
+    internal const string Challenge = "challenge";
+    internal const string Callback = "callback";
+    internal const string Auth = "auth";
+    internal const string Test = "test";
+    internal const string Metadata = "metadata";
+    internal const string Unregister = "unregister";
+    internal const string Link = "link";
+}


### PR DESCRIPTION
# What & why

**#694**, the per-client rate-limit bucket key is built as `class + ":" + clientKey` in `SsoRateLimitGate.Check`, so the endpoint-class string is **load-bearing on the limiter grouping**, yet it was passed as a bare string literal at 11 controller call sites (`"challenge"`, `"callback"`, `"auth"`, `"test"`, `"metadata"`, `"unregister"`, `"link"`). A typo (`"challange"`) compiles cleanly and silently mints a separate, empty bucket, weakening a security control undetectably.

- New `SSO-Auth/Api/Shared/SsoRateLimitClass.cs` holds the seven classes as named `const string` members; every call site now references a member, so a typo is a **compile error**.
- The const values are the **exact** lowercase strings the wire keys have always carried, so the built keys are **byte-for-byte identical**, no behaviour or persisted-state change.
- New conformance test `RateLimitEndpointClass_UsesTypedConstants_NotLiterals` forbids a raw string literal as the first argument to `RateLimitCheck` / `SsoRateLimitGate.Check` in the controller, with a sentinel pinning the 11 typed call sites so the scan can't pass vacuously after a wrapper rename.

Closes #694

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Refactor / code quality

## Security checklist

- [x] Fail-closed preserved: the limiter grouping is unchanged, wire keys are byte-identical (verified per call site) and `SsoRateLimitGate.Check`'s key-building line is untouched.
- [x] No secrets logged.
- [x] Reviewed: each of the 11 literals maps to the correct member with an identical value; the paired login legs (`challenge`/`callback`/`auth`) remain distinct budgets exactly as before.

## Quality checklist

- [x] No duplicated logic; one holder replaces 11 scattered literals.
- [x] Minimal change.
- [x] Self-documenting; the holder doc explains why the value is load-bearing.
- [x] Architecture-conformance test added and locks the invariant in.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1536/1536 on both TFMs.
- [x] No `.js/.html/.css/.md` touched (prettier N/A).

## Notes

The only `SsoRateLimitGate.Check` call outside the controller is in a test (passes a variable, not a literal); the conformance scan is scoped to controller source, where the production call sites live.