### PR TITLE
Audit SAML DoNotValidateAudience as an insecure toggle

### DIFF
--- a/SSO-Auth.Tests/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/ProviderConfigStoreTests.cs
@@ -157,6 +157,27 @@ public class ProviderConfigStoreTests
     }
 
     [Fact]
+    public void Save_FreshConfigWithInsecureSamlOptions_PersistsAndAuditsThem()
+    {
+        // The #672 SAML parity of the #140 audit: saving a SAML provider with DoNotValidateAudience set
+        // emits a warning naming the provider and the option (protocol SAML), the same trace the OpenID
+        // escape hatches leave.
+        var logger = new CapturingLogger();
+        var (store, _, persisted) = CreateStore(logger);
+        var incoming = new PluginConfiguration();
+        incoming.SamlConfigs["corp"] = new SamlConfig { DoNotValidateAudience = true };
+
+        store.Save(incoming);
+
+        Assert.Single(persisted);
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("corp", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("DoNotValidateAudience", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("SAML", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Save_WithoutALogger_StillPersistsInsecureOptions_WithoutThrowing()
     {
         // The audit is best-effort: a missing logger must never turn a valid save into a failure.

--- a/SSO-Auth.Tests/SamlInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/SamlInsecureTogglesTests.cs
@@ -1,0 +1,42 @@
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlInsecureToggles"/> — the helper that names the enabled default-on-disable
+/// options on a SAML provider (#672, the SAML parity of #140), so a save/import with one set can be
+/// audit-logged.
+/// </summary>
+public class SamlInsecureTogglesTests
+{
+    [Fact]
+    public void Enabled_FullyValidatedProvider_ReturnsEmpty()
+    {
+        Assert.Empty(SamlInsecureToggles.Enabled(new SamlConfig()));
+    }
+
+    [Fact]
+    public void Enabled_NullConfig_ReturnsEmpty()
+    {
+        Assert.Empty(SamlInsecureToggles.Enabled(null));
+    }
+
+    [Fact]
+    public void Enabled_DoNotValidateAudience_ReportsIt()
+    {
+        Assert.Equal(
+            new[] { "DoNotValidateAudience" },
+            SamlInsecureToggles.Enabled(new SamlConfig { DoNotValidateAudience = true }));
+    }
+
+    [Fact]
+    public void Enabled_AdditiveHardeningFlags_AreNotReported()
+    {
+        // ValidateRecipient / ValidateInResponseTo are opt-in ADDITIVE protections, not downgrades of a
+        // default-on check, so enabling them is not an insecure toggle and must not be audited here (#672).
+        var config = new SamlConfig { ValidateRecipient = true, ValidateInResponseTo = true };
+        Assert.Empty(SamlInsecureToggles.Enabled(config));
+    }
+}

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -551,6 +551,15 @@ public class SSOController : ControllerBase
             configuration.SamlConfigs[provider] = newConfig;
         });
         SsoAudit.ProviderConfigured(_logger, SamlProtocol, provider);
+
+        // Mirror OidAdd (#140/#672): a SAML provider added with a default-on protection disabled
+        // (DoNotValidateAudience) leaves the same auditable [SSO Audit] trace an OpenID escape hatch does.
+        var insecure = SamlInsecureToggles.Enabled(newConfig);
+        if (insecure.Count > 0)
+        {
+            SsoAudit.InsecureOptionsEnabled(_logger, SamlProtocol, provider, insecure);
+        }
+
         return Ok();
     }
 
@@ -679,6 +688,26 @@ public class SSOController : ControllerBase
                 if (insecure.Count > 0)
                 {
                     SsoAudit.InsecureOptionsEnabled(_logger, OpenIdProtocol, kvp.Key, insecure);
+                }
+            }
+        }
+
+        // A mistaken or hostile import that disables a default-on SAML protection (DoNotValidateAudience)
+        // must leave the same [SSO Audit] trace the OpenID escape hatches above do (#672) — the import path
+        // is exactly one of the failure scenarios that issue calls out.
+        if (document.Configuration?.SamlConfigs is { } samlConfigs)
+        {
+            foreach (var kvp in samlConfigs)
+            {
+                if (kvp.Value is null)
+                {
+                    continue;
+                }
+
+                var insecure = SamlInsecureToggles.Enabled(kvp.Value);
+                if (insecure.Count > 0)
+                {
+                    SsoAudit.InsecureOptionsEnabled(_logger, SamlProtocol, kvp.Key, insecure);
                 }
             }
         }

--- a/SSO-Auth/Api/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/SamlInsecureToggles.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// Names the per-provider SAML options that switch off a default-on protection (#672, the SAML parity of
+/// the OpenID <see cref="OidcInsecureToggles"/> under #140), so enabling one leaves a visible, auditable
+/// trace instead of silently weakening the login path. Kept strictly to default-on-DISABLE toggles: the
+/// opt-in SAML hardening flags (<c>ValidateRecipient</c>, <c>ValidateInResponseTo</c>, request signing)
+/// are additive protections, not downgrades, and are deliberately NOT reported here.
+/// </summary>
+internal static class SamlInsecureToggles
+{
+    /// <summary>
+    /// Lists the insecure options currently enabled on a SAML provider, by their configuration-key names
+    /// (stable and greppable). Empty when the provider keeps every default-on protection.
+    /// </summary>
+    /// <param name="config">The SAML provider configuration.</param>
+    /// <returns>The enabled insecure option names.</returns>
+    internal static IReadOnlyList<string> Enabled(SamlConfig config)
+    {
+        var enabled = new List<string>();
+        if (config == null)
+        {
+            return enabled;
+        }
+
+        // DoNotValidateAudience drops the AudienceRestriction binding: with it on, an assertion minted for
+        // a DIFFERENT service provider that shares this IdP is accepted, so it is a genuine audience/SP
+        // confusion downgrade of a default-on check — exactly the class #140 audits for OpenID.
+        if (config.DoNotValidateAudience)
+        {
+            enabled.Add(nameof(SamlConfig.DoNotValidateAudience));
+        }
+
+        return enabled;
+    }
+}

--- a/SSO-Auth/Api/SsoAudit.cs
+++ b/SSO-Auth/Api/SsoAudit.cs
@@ -188,7 +188,7 @@ internal static class SsoAudit
             breakGlassAdmin?.ReplaceLineEndings(string.Empty));
     }
 
-    /// <summary>Records a provider being saved with one or more security checks disabled (#140).</summary>
+    /// <summary>Records a provider being saved with one or more default-on security checks disabled (#140, #672).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>
     /// <param name="provider">The provider name.</param>
@@ -200,8 +200,12 @@ internal static class SsoAudit
             return;
         }
 
+        // Shared by OpenID (#140) and SAML (#672), so the wording stays protocol-neutral: each named option
+        // switches off a protection that is on by default (OpenID transport/issuer/endpoint binding, SAML
+        // audience binding). Naming the exact options is what the audit trail needs; the per-option detail
+        // lives in each toggle's config doc.
         logger.LogWarning(
-            "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. These weaken RFC 9700 transport/issuer/endpoint validation; keep them only if the provider genuinely requires it. DisableHttps in particular exposes the id_token signing keys (JWKS) to a man-in-the-middle.",
+            "[SSO Audit] {Protocol} provider '{Provider}' saved with security checks disabled: {Options}. Each switches off a default-on protection on the login path (such as transport, issuer/audience, or endpoint binding); keep them only if the provider genuinely requires it.",
             protocol,
             provider?.ReplaceLineEndings(string.Empty),
             string.Join(", ", options));

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -110,7 +110,7 @@ internal sealed class ProviderConfigStore
     public void Save(BasePluginConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        List<(string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
+        List<(string Protocol, string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
         lock (Sync)
         {
             if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))
@@ -141,31 +141,42 @@ internal sealed class ProviderConfigStore
         // provider can neither block config reads/writes nor turn a completed save into a failure.
         if (insecureToAudit != null && _logger != null)
         {
-            foreach (var (provider, options) in insecureToAudit)
+            foreach (var (protocol, provider, options) in insecureToAudit)
             {
-                SsoAudit.InsecureOptionsEnabled(_logger, "OpenID", provider, options);
+                SsoAudit.InsecureOptionsEnabled(_logger, protocol, provider, options);
             }
         }
     }
 
-    // Snapshots, under the caller's lock, the OpenID providers saved with a security check disabled
-    // (#140), as (provider, enabled-option-names) pairs. Pure read: it does not log, so the audit
-    // warnings can be emitted after the config lock is released. Only the admin save path reaches
-    // here (a fresh incoming config), so it fires once per save, not per login.
-    private static List<(string Provider, IReadOnlyList<string> Options)> CollectInsecureOptions(PluginConfiguration incoming)
+    // Snapshots, under the caller's lock, the OpenID and SAML providers saved with a default-on security
+    // check disabled (#140, #672), as (protocol, provider, enabled-option-names) triples. Pure read: it
+    // does not log, so the audit warnings can be emitted after the config lock is released. Only the admin
+    // save path reaches here (a fresh incoming config), so it fires once per save, not per login.
+    private static List<(string Protocol, string Provider, IReadOnlyList<string> Options)> CollectInsecureOptions(PluginConfiguration incoming)
     {
-        var records = new List<(string, IReadOnlyList<string>)>();
-        if (incoming.OidConfigs == null)
+        var records = new List<(string, string, IReadOnlyList<string>)>();
+
+        if (incoming.OidConfigs != null)
         {
-            return records;
+            foreach (var kvp in incoming.OidConfigs)
+            {
+                var insecure = OidcInsecureToggles.Enabled(kvp.Value);
+                if (insecure.Count > 0)
+                {
+                    records.Add(("OpenID", kvp.Key, insecure));
+                }
+            }
         }
 
-        foreach (var kvp in incoming.OidConfigs)
+        if (incoming.SamlConfigs != null)
         {
-            var insecure = OidcInsecureToggles.Enabled(kvp.Value);
-            if (insecure.Count > 0)
+            foreach (var kvp in incoming.SamlConfigs)
             {
-                records.Add((kvp.Key, insecure));
+                var insecure = SamlInsecureToggles.Enabled(kvp.Value);
+                if (insecure.Count > 0)
+                {
+                    records.Add(("SAML", kvp.Key, insecure));
+                }
             }
         }
 


### PR DESCRIPTION
# What & why

**#672**, `SamlConfig.DoNotValidateAudience` disables a default-on protection: off (the default), `SamlAssertionValidator.ValidateSaml` requires the assertion's `AudienceRestriction` to name this SP; on, an assertion minted for a **different SP sharing the same IdP** is accepted. This is the SAML equivalent of the OpenID escape hatches audited under #140 via `SsoAudit.InsecureOptionsEnabled`, but the SAML toggle produced **no `[SSO Audit]` trail** on save or import, so a reviewer auditing the trail had no record it was turned off.

- New `SamlInsecureToggles.Enabled(SamlConfig)`, mirroring `OidcInsecureToggles`, reporting `DoNotValidateAudience`. Kept strictly to default-on-disable toggles, the opt-in additive flags (`ValidateRecipient`, `ValidateInResponseTo`, `SignAuthnRequests`) are extra protections, not downgrades, and are not reported.
- Wired into the **same three** admin write paths that already audit the OpenID toggles: `SamlAdd` (mirrors `OidAdd`), `ProviderConfigStore.CollectInsecureOptions` (config-page save, now carries the protocol and iterates both maps), and the **config-import** path (the issue's own "mistaken/hostile import" failure scenario).
- Generalized the shared `SsoAudit.InsecureOptionsEnabled` warning to protocol-neutral wording: reused verbatim it printed OpenID-specific claims (`DisableHttps ... JWKS`) on a SAML audience line.

Closes #672

## Type of change

- [x] Security hardening / vulnerability fix

## Security checklist

- [x] Fail-closed preserved: additive change, it only emits audit lines. No auth/validation decision is altered; `DoNotValidateAudience`'s runtime effect is unchanged.
- [x] No secrets logged; the provider name is sanitized with `ReplaceLineEndings` at the log call (unchanged), and the option names are `nameof(...)` config keys, not user input.
- [x] Security review performed, adversarial audit-integrity + correctness lenses, both PASS. Confirmed empirically (from the login code, not doc comments): `DoNotValidateAudience` is the **only** default-on-disable toggle on `SamlConfig`; the three additive flags are correctly excluded; SAML is wired at exactly the OpenID audit's three sites (Add / config-save / import) with no path left unaudited (Mutate- vs Save-based writes both covered); the OpenID audit output is byte-identical; sanitization intact.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; `SamlInsecureToggles` mirrors `OidcInsecureToggles` and reuses the shared `SsoAudit.InsecureOptionsEnabled` (no audit-API signature change).
- [x] Minimal; the change adds no more than the problem requires.
- [x] Self-documenting; comments explain why the additive flags are excluded and why the message is protocol-neutral.
- [x] Architecture-conformance tests pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1550/1550 on both TFMs (merged onto current main).
- [x] No `.js/.html/.css/.md` touched (prettier N/A).

## Notes

The config UI does not expose `DoNotValidateAudience` as a field, so there is no UI danger-zone change here; this is purely the audit trail the issue asks for. Generalizing the shared warning drops the OpenID-specific `DisableHttps`/JWKS-MITM annotation from the log line, deliberate, since the message is shared with SAML; that per-option guidance still lives in the admin UI and each toggle's config doc, and the audit line still names the exact options.