### PR TITLE
Restyle browser-navigated SSO error responses and reword the denial

### DIFF
--- a/SSO-Auth.Tests/BrowserErrorPageTests.cs
+++ b/SSO-Auth.Tests/BrowserErrorPageTests.cs
@@ -1,0 +1,126 @@
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="BrowserErrorPage"/> — the re-render of a browser-navigated login rejection (#668).
+/// A plain-text error reached by a browser becomes a styled HTML page with a return link; the XHR Auth leg
+/// (Accept: application/json) and every non-error result pass through unchanged.
+/// </summary>
+public class BrowserErrorPageTests
+{
+    private static HttpContext Context(string accept)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Accept = accept;
+        return ctx;
+    }
+
+    private static ContentResult PlainError(int status, string message) => new ContentResult
+    {
+        Content = message,
+        ContentType = "text/plain",
+        StatusCode = status,
+    };
+
+    [Fact]
+    public void Wrap_PlainTextError_BrowserAccept_RendersStyledHtmlPreservingStatus()
+    {
+        var ctx = Context("text/html,application/xhtml+xml");
+
+        var result = Assert.IsType<ContentResult>(
+            BrowserErrorPage.Wrap(PlainError(400, "Invalid or expired state"), ctx.Request, ctx.Response));
+
+        Assert.Equal("text/html", result.ContentType);
+        Assert.Equal(400, result.StatusCode);
+        Assert.Contains("Invalid or expired state", result.Content);
+        Assert.Contains("Return to login", result.Content);
+        Assert.Contains("href='/web/index.html'", result.Content);
+        Assert.Contains("#101010", result.Content); // the dark shell
+    }
+
+    [Fact]
+    public void Wrap_HtmlEncodesTheMessage_SoIdpSuppliedTextCannotInjectMarkup()
+    {
+        // A callback error body can interpolate an identity-provider error_description; a hostile value
+        // must be encoded, never break out of the <p>.
+        var ctx = Context("text/html");
+        var hostile = "Error preparing login: </p><script>alert(1)</script>";
+
+        var result = Assert.IsType<ContentResult>(
+            BrowserErrorPage.Wrap(PlainError(400, hostile), ctx.Request, ctx.Response));
+
+        Assert.DoesNotContain("<script>alert(1)</script>", result.Content);
+        Assert.Contains("&lt;script&gt;", result.Content);
+    }
+
+    [Fact]
+    public void Wrap_SetsScriptlessCspNonceAndDefensiveHeaders_NonceMatchesTheStyleTag()
+    {
+        var ctx = Context("text/html");
+
+        var result = Assert.IsType<ContentResult>(
+            BrowserErrorPage.Wrap(PlainError(401, "Login denied."), ctx.Request, ctx.Response));
+
+        var csp = ctx.Response.Headers.ContentSecurityPolicy.ToString();
+        Assert.Contains("default-src 'none'", csp);
+        Assert.DoesNotContain("script-src", csp); // no script on this page
+        Assert.Equal("DENY", ctx.Response.Headers["X-Frame-Options"].ToString());
+        Assert.Equal("nosniff", ctx.Response.Headers["X-Content-Type-Options"].ToString());
+        Assert.Equal("no-store", ctx.Response.Headers.CacheControl.ToString());
+
+        // The nonce authorizing the inline <style> must be the exact nonce bound in the CSP.
+        var nonce = Regex.Match(csp, "style-src 'nonce-([^']+)'").Groups[1].Value;
+        Assert.NotEqual(string.Empty, nonce);
+        Assert.Contains("<style nonce='" + nonce + "'>", result.Content);
+    }
+
+    [Fact]
+    public void Wrap_XhrJsonAccept_PassesThroughUnchanged()
+    {
+        // The XHR Auth leg reads the status, not the body; it must keep the plain-text shape.
+        var ctx = Context("application/json");
+        var original = PlainError(401, "Login denied.");
+
+        var result = BrowserErrorPage.Wrap(original, ctx.Request, ctx.Response);
+
+        Assert.Same(original, result);
+        Assert.True(ctx.Response.Headers.ContentSecurityPolicy.Count == 0);
+    }
+
+    [Fact]
+    public void Wrap_StringObjectResultError_BrowserAccept_IsRestyled()
+    {
+        var ctx = Context("text/html");
+
+        var result = Assert.IsType<ContentResult>(
+            BrowserErrorPage.Wrap(new BadRequestObjectResult("No matching provider found"), ctx.Request, ctx.Response));
+
+        Assert.Equal("text/html", result.ContentType);
+        Assert.Equal(400, result.StatusCode);
+        Assert.Contains("No matching provider found", result.Content);
+    }
+
+    [Fact]
+    public void Wrap_SuccessResult_PassesThroughUnchanged()
+    {
+        var ctx = Context("text/html");
+        var ok = new OkObjectResult(new { session = "x" });
+
+        Assert.Same(ok, BrowserErrorPage.Wrap(ok, ctx.Request, ctx.Response));
+    }
+
+    [Fact]
+    public void Wrap_AlreadyHtmlResult_PassesThroughUnchanged()
+    {
+        // The auth-completion page is text/html; it is not a plain-text error and must not be re-wrapped.
+        var ctx = Context("text/html");
+        var authPage = new ContentResult { Content = "<html></html>", ContentType = "text/html" };
+
+        Assert.Same(authPage, BrowserErrorPage.Wrap(authPage, ctx.Request, ctx.Response));
+    }
+}

--- a/SSO-Auth.Tests/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/LoginStatusMapperTests.cs
@@ -88,7 +88,7 @@ public class LoginStatusMapperTests
         var result = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Denied()));
 
         Assert.Equal(401, result.StatusCode);
-        Assert.Equal("Error. Check permissions.", result.Content);
+        Assert.Equal("Login denied. Your account is not permitted to sign in through this provider.", result.Content);
         Assert.Equal("text/plain", result.ContentType);
     }
 
@@ -137,7 +137,7 @@ public class LoginStatusMapperTests
 
         var denied = Assert.IsType<ContentResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Denied(), response));
         Assert.Equal(401, denied.StatusCode);
-        Assert.Equal("Error. Check permissions.", denied.Content);
+        Assert.Equal("Login denied. Your account is not permitted to sign in through this provider.", denied.Content);
 
         var session = new AuthenticationResult();
         var success = Assert.IsType<OkObjectResult>(LoginStatusMapper.ToActionResult(new LoginOutcome.Success(session), response));

--- a/SSO-Auth/Api/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/LoginStatusMapper.cs
@@ -15,8 +15,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// </summary>
 internal static class LoginStatusMapper
 {
-    /// <summary>The uniform denial body for any rejected login — deliberately uninformative.</summary>
-    internal const string PermissionDeniedMessage = "Error. Check permissions.";
+    /// <summary>
+    /// The uniform denial body for any rejected login. Actionable without enumerating (#668): it tells the
+    /// user their account is not permitted through this provider — the most common trigger is the role
+    /// allow-list not matching — without revealing which accounts or roles are allowed. The server log
+    /// disambiguates the exact reason.
+    /// </summary>
+    internal const string PermissionDeniedMessage = "Login denied. Your account is not permitted to sign in through this provider.";
 
     /// <summary>
     /// The body for an unresolved provider — one wording for both the unknown and the disabled case,

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -140,13 +140,14 @@ public class SSOController : ControllerBase
     {
         if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
-            return throttled;
+            return BrowserErrorPage.Wrap(throttled, Request, Response);
         }
 
         // The OpenID redirect callback lives in the flow service (#160, #318): it validates the
         // browser-bound state, exchanges the code, validates the id_token and RFC 9207 response issuer,
         // applies the role gate, and renders the security-headered intermediate auth page on the response.
-        return await _oidc.CallbackAsync(provider, state, Request, Response).ConfigureAwait(false);
+        // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
+        return BrowserErrorPage.Wrap(await _oidc.CallbackAsync(provider, state, Request, Response).ConfigureAwait(false), Request, Response);
     }
 
     /// <summary>
@@ -161,13 +162,14 @@ public class SSOController : ControllerBase
     {
         if (RateLimitCheck(SsoRateLimitClass.Challenge) is { } throttled)
         {
-            return throttled;
+            return BrowserErrorPage.Wrap(throttled, Request, Response);
         }
 
         // The OpenID challenge lives in the flow service (#160, #318): it reads discovery, applies the
         // PKCE gate, prepares the authorization request, registers the browser-bound authorize state, and
         // redirects to the identity provider (setting the binding cookie on the response).
-        return await _oidc.ChallengeAsync(provider, isLinking, Request, Response).ConfigureAwait(false);
+        // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
+        return BrowserErrorPage.Wrap(await _oidc.ChallengeAsync(provider, isLinking, Request, Response).ConfigureAwait(false), Request, Response);
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
@@ -461,13 +463,14 @@ public class SSOController : ControllerBase
     {
         if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
-            return throttled;
+            return BrowserErrorPage.Wrap(throttled, Request, Response);
         }
 
         // The SAML assertion-consumer callback lives in the flow service (#160, #318): it validates the
         // signed response and, on a passing role gate, renders the security-headered intermediate auth
         // page on the response.
-        return _saml.Callback(provider, relayState, formSamlResponse, Request, Response);
+        // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
+        return BrowserErrorPage.Wrap(_saml.Callback(provider, relayState, formSamlResponse, Request, Response), Request, Response);
     }
 
     /// <summary>
@@ -482,13 +485,14 @@ public class SSOController : ControllerBase
     {
         if (RateLimitCheck(SsoRateLimitClass.Challenge) is { } throttled)
         {
-            return throttled;
+            return BrowserErrorPage.Wrap(throttled, Request, Response);
         }
 
         // The SAML challenge lives in the flow service (#160, #318): it builds the AuthnRequest, binds it
         // to the initiating browser (setting the binding cookie on the response), signs it when the
         // provider opts in (#167), and redirects to the identity provider.
-        return _saml.Challenge(provider, isLinking, Request, Response);
+        // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
+        return BrowserErrorPage.Wrap(_saml.Challenge(provider, isLinking, Request, Response), Request, Response);
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Net.Mime;
+using System.Security.Cryptography;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
+
+/// <summary>
+/// Re-renders a plain-text rejection from a browser-navigated login endpoint — the OpenID/SAML
+/// challenge and callback routes, which the user reaches by direct navigation — as a minimal dark HTML
+/// page (matching the auth-completion page's shell) with a "Return to login" link, instead of dumping
+/// raw text onto what looks like a broken page (#668). Applied ONLY when the client accepts text/html:
+/// the XHR <c>/sso/*/Auth</c> leg (Accept: application/json) reads the response status, not the body, so
+/// it keeps the plain-text shape and is unaffected. Success, redirect, and already-HTML results (the
+/// challenge redirect, the auth-completion page) carry no plain-text error and pass through untouched.
+/// </summary>
+internal static class BrowserErrorPage
+{
+    /// <summary>
+    /// Restyles <paramref name="result"/> as an HTML error page when it is a plain-text rejection and the
+    /// caller is a browser; otherwise returns it unchanged.
+    /// </summary>
+    /// <param name="result">The flow result to possibly restyle.</param>
+    /// <param name="request">The request, whose Accept header decides browser vs XHR/API.</param>
+    /// <param name="response">The response the page's CSP nonce and defensive headers are written to.</param>
+    /// <returns>The styled HTML result, or the original result unchanged.</returns>
+    internal static ActionResult Wrap(ActionResult result, HttpRequest request, HttpResponse response)
+    {
+        if (!AcceptsHtml(request) || !TryExtractPlainTextError(result, out var status, out var message))
+        {
+            return result;
+        }
+
+        var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+
+        // A script-less page: only the nonce'd <style> is authorized, default-src 'none' denies scripts,
+        // fetch, frames and everything else. Same defensive headers the auth-completion page sets.
+        response.Headers.ContentSecurityPolicy =
+            "default-src 'none'; style-src 'nonce-" + nonce + "'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
+        response.Headers["X-Frame-Options"] = "DENY";
+        response.Headers["X-Content-Type-Options"] = "nosniff";
+        response.Headers["Referrer-Policy"] = "no-referrer";
+        response.Headers.CacheControl = "no-store";
+
+        return new ContentResult
+        {
+            Content = Render(nonce, message),
+            ContentType = MediaTypeNames.Text.Html,
+            StatusCode = status,
+        };
+    }
+
+    // A browser top-level navigation advertises "text/html" in Accept; the XHR Auth/Link legs send
+    // "application/json". Ordinal-ignore-case substring match over every Accept value.
+    private static bool AcceptsHtml(HttpRequest request) =>
+        request.Headers.Accept.Any(v => v != null && v.Contains("text/html", StringComparison.OrdinalIgnoreCase));
+
+    // A rejection worth restyling is a 4xx/5xx carrying a plain-text body: either a text/plain
+    // ContentResult (FlowResponses.PlainTextError, LoginStatusMapper) or a string-valued ObjectResult
+    // (BadRequestObjectResult). A success, a redirect, or the already-HTML auth page yields no message.
+    private static bool TryExtractPlainTextError(ActionResult result, out int status, out string message)
+    {
+        switch (result)
+        {
+            case ContentResult { StatusCode: >= 400 } cr
+                when cr.ContentType != null
+                     && cr.ContentType.StartsWith(MediaTypeNames.Text.Plain, StringComparison.OrdinalIgnoreCase):
+                status = cr.StatusCode.Value;
+                message = cr.Content ?? string.Empty;
+                return true;
+            case ObjectResult { StatusCode: >= 400, Value: string s } or:
+                status = or.StatusCode.Value;
+                message = s;
+                return true;
+            default:
+                status = 0;
+                message = null;
+                return false;
+        }
+    }
+
+    // The message is HTML-encoded because a few plain-text errors interpolate identity-provider-supplied
+    // text (an OpenID error/error_description on the callback), which must not break out of the markup.
+    // The "Return to login" link is a same-origin relative path, so no request-host derivation is needed.
+    private static string Render(string nonce, string message) =>
+        "<!DOCTYPE html>\n"
+        + "<html lang='en'><head>\n"
+        + "<meta name='viewport' content='width=device-width, initial-scale=1'>\n"
+        + "<style nonce='" + nonce + "'>\n"
+        + "  body { background: #101010; color: #d1cfce; font-family: Noto Sans, Noto Sans HK, Noto Sans JP, Noto Sans KR, Noto Sans SC, Noto Sans TC, sans-serif; margin: 2rem; }\n"
+        + "  a { color: #00a4dc; }\n"
+        + "</style>\n"
+        + "</head><body>\n"
+        + "<p>" + HtmlEncoder.Default.Encode(message) + "</p>\n"
+        + "<a href='/web/index.html'>Return to login</a>\n"
+        + "</body></html>";
+}


### PR DESCRIPTION
# What & why

**#668**, the OpenID/SAML **challenge and callback** routes are reached by direct browser navigation, so a rejection dumped raw `text/plain` onto what looked like a broken page (no theme, no way forward), inconsistent with the dark auth-completion page. And the `LoginOutcome.Denied` body `"Error. Check permissions."` was cryptic and undocumented, its most common trigger is the role allow-list not matching.

- New `BrowserErrorPage.Wrap`: when a browser (`Accept: text/html`) hits a plain-text rejection on those endpoints, it is re-rendered as a minimal dark HTML page matching the auth page's shell, with a **Return to login** link (a same-origin relative path, no request-host derivation needed). The message is **HTML-encoded** (a few error bodies interpolate identity-provider-supplied text), and the page carries a **script-less nonce CSP** (`default-src 'none'; style-src 'nonce-…'`) plus the same `X-Frame-Options`/`nosniff`/`Referrer-Policy`/`no-store` headers as the auth page.
- The XHR `/sso/*/Auth` leg (`Accept: application/json`) reads the status, not the body, so it is left on the plain-text path; success, redirect, and the already-HTML auth page pass through untouched.
- Applied at the four browser-navigated endpoints (OpenID/SAML challenge + callback), covering both the rate-limit 429 and the flow rejection.
- Reworded `PermissionDeniedMessage` to *"Login denied. Your account is not permitted to sign in through this provider."*, actionable without enumerating.

Closes #668

## Type of change

- [x] Bug fix
- [x] Security hardening (adds a strict CSP + defensive headers to responses that previously had none)

## Security checklist

- [x] Fail-closed preserved: the wrapper only restyles 4xx/5xx plain-text errors for browsers; success/redirect/HTML results and XHR/API clients pass through unchanged (verified, a false positive would break login). No auth decision changes.
- [x] No secrets logged; the message is HTML-encoded at its single `<p>` sink, so identity-provider-supplied `error_description` text cannot inject markup.
- [x] Security review performed, adversarial bypass/XSS/CSP + correctness lenses, both PASS. Confirmed: single encoded sink (`HtmlEncoder.Default`, correct for element-text context); per-response CSPRNG nonce that base64 cannot break out of; CSP is complete and tighter than the auth page's (no script/fetch/img needed); `frame-ancestors 'none'` + `X-Frame-Options: DENY`; the relative return link is not blocked by `default-src 'none'` (top-level navigation); the 429's `Retry-After` is preserved; the reworded denial stays non-enumerating.
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new logging.)

## Quality checklist

- [x] No duplicated logic; one small helper, applied at the four endpoints.
- [x] Minimal; contained to the browser-navigated endpoints, the ~30 emission sites and the XHR path are untouched.
- [x] Self-documenting; comments explain the content-negotiation and the HTML-encoding reason.
- [x] Architecture-conformance tests pass; the new renderer has its own test suite (encoding, CSP-nonce match, pass-through, status preservation).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1552/1552 on both TFMs.
- [x] No `.js/.html/.css/.md` touched (the page is server-rendered in C#; prettier N/A).

## Notes

The issue's Troubleshooting wiki entry (mapping the role-gate denial) will be added in the 4.3 wiki sweep, updated to the reworded message.

A follow-up was flagged (separate issue): the challenge/callback errors still echo the IdP `error`/`error_description` (now HTML-encoded, on an on-brand page), a marginal, pre-existing content-spoofing consideration worth deciding separately (show a fixed generic body, log the IdP detail server-side).