### PR TITLE
Stop reflecting IdP error text into the OpenID browser error page

### DIFF
--- a/SSO-Auth.Tests/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/OidcRoundTripTests.cs
@@ -86,13 +86,15 @@ public class OidcRoundTripTests
 
         // The callback must fail closed: the signature does not verify against the advertised JWKS, so the
         // real validator rejects and CallbackAsync returns the plain-text 400 login error (never the
-        // text/html auth page). Asserting the invalid_signature reason pins the 400 to the signature check
-        // specifically, not an unrelated token-exchange failure.
+        // text/html auth page). The body is the fixed generic message — the library's error detail
+        // (invalid_signature) is logged server-side, not reflected into the browser page (#708) — so this
+        // asserts the generic body and that the detail is absent rather than pinning on the reflected reason.
         RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
         Assert.Equal(400, callback.StatusCode);
         Assert.Equal("text/plain", callback.ContentType);
-        Assert.Contains("invalid_signature", callback.Content);
+        Assert.Equal("Error logging in.", callback.Content);
+        Assert.DoesNotContain("invalid_signature", callback.Content);
 
         // End-to-end fail-closed: because the callback never promoted the state to a redeemable Ready, the
         // authenticate leg finds no state to redeem and provisions nothing — no login is minted from a token

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -239,6 +239,28 @@ public class SSOControllerOidPostTests
     }
 
     [Fact]
+    public async Task OidPost_IdpErrorRedirect_DoesNotReflectAttackerText_ReturnsGenericMessage()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // #708: the authorization server returns an error redirect, whose error / error_description are
+        // parsed from the callback query and are therefore attacker-controllable via a crafted callback URL.
+        // The callback must NOT echo that text into the browser-navigated page (a content-spoofing primitive
+        // that, on the on-brand error page, would display attacker-chosen text). The body is the fixed
+        // generic message; neither the error code nor the attacker-planted description marker appears.
+        const string attackerMarker = "PHISHED-CONTENT-MARKER-708";
+        var harness = ArrangeCallback(fixture, query: $"?error=access_denied&error_description={attackerMarker}&state=state-1");
+
+        var result = await harness.Controller.OidCallback("kc", "state-1");
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("text/plain", content.ContentType);
+        Assert.Equal("Error logging in.", content.Content);
+        Assert.DoesNotContain(attackerMarker, content.Content, StringComparison.Ordinal);
+        Assert.DoesNotContain("access_denied", content.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task OidPost_IdTokenWithoutSub_Returns401()
     {
         using var fixture = new OidcTokenFixture(Authority, "jf");

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -182,7 +182,17 @@ internal sealed class OidcLoginService
 
         if (state.IsError)
         {
-            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, $"Error preparing login: {state.Error} - {state.ErrorDescription}");
+            // Keep the library's error detail out of the browser-navigated page (#708): log it server-side
+            // for the operator, return a fixed generic message. This challenge-side detail is plugin-local
+            // (PrepareLoginAsync builds the authorize request), not attacker-reflected, but the callback
+            // sibling below IS reflected — genericize both so no IdP/library error string ever renders on
+            // the user-facing error page. Sanitized against log forging. Fail-closed is unchanged (400).
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: preparing the authorization request failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty), state.Error?.ReplaceLineEndings(string.Empty), state.ErrorDescription?.ReplaceLineEndings(string.Empty));
+            }
+
+            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error preparing login.");
         }
 
         // Bind this authorize state to the browser that started it (#326): record a fresh random id on
@@ -271,7 +281,18 @@ internal sealed class OidcLoginService
 
         if (result.IsError)
         {
-            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, $"Error logging in: {result.Error} - {result.ErrorDescription}");
+            // result.Error / result.ErrorDescription are parsed from the callback query — an authorization
+            // server returns them on an error redirect, so they are attacker-controllable via a crafted
+            // callback URL. Echoing them into this browser-navigated page is a content-spoofing primitive
+            // (the on-brand error page would display attacker-chosen text). Log the detail server-side for
+            // troubleshooting, return a fixed generic message (#708). Sanitized against log forging;
+            // fail-closed is unchanged (400, no session minted).
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID login refused for provider {Provider}: the authorization-response processing failed ({Error} - {ErrorDescription}).", provider?.ReplaceLineEndings(string.Empty), result.Error?.ReplaceLineEndings(string.Empty), result.ErrorDescription?.ReplaceLineEndings(string.Empty));
+            }
+
+            return FlowResponses.PlainTextError(StatusCodes.Status400BadRequest, "Error logging in.");
         }
 
         // RFC 9207 (#125, hardened #210): the library parses the authorization-response `iss` but never


### PR DESCRIPTION
# What & why

The browser-navigated OpenID error responses echoed identity-provider-supplied text straight into the response body:

- `ChallengeAsync`: `"Error preparing login: {state.Error} - {state.ErrorDescription}"`
- `CallbackAsync`: `"Error logging in: {result.Error} - {result.ErrorDescription}"`, `result.Error`/`result.ErrorDescription` are parsed from the callback query (the `error`/`error_description` an authorization server returns on an error redirect), so they are attacker-controllable via a crafted callback URL.

An attacker who lures a victim to `.../sso/OID/redirect/{provider}?error=...&error_description=<attacker text>&state=<valid state>` could make the plugin's own error page display attacker-chosen text, a content-spoofing primitive on a first-party path. The text is HTML-encoded (no XSS) and the only link is a hardcoded same-origin path, so severity is low; the uplift comes from the on-brand error page lending the spoof legitimacy.

This replaces both reflected messages with a fixed generic user-facing message and logs the provider/library detail server-side at `Warning` (sanitized against log forging), keeping the operator's troubleshooting value off the victim-facing page. The challenge-side message is plugin-local rather than reflected, but is genericized too for consistency, there is no reason to surface internal library error strings to the browser.

Closes #708

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: both paths still return `400` and mint no session; the change only alters the message body, not any auth decision.
- [x] No secrets logged; secrets are redacted on config export. (Only the IdP-supplied `error`/`error_description` are logged, sanitized.)
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [x] Log inputs from the IdP are sanitized inline at the log call (`ReplaceLineEndings`).

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`. (No new structural property.)

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (Debug and Release).
- [x] `dotnet test` is green (1551 tests, 0 failures).
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. (No such files changed.)

## Notes

Pre-existing reflection, not introduced by a recent change. Scope is the OpenID flow only; the SAML sibling does not reflect IdP error text on this surface. A new callback test proves an attacker-supplied `error_description` is not reflected into the body; the wrong-key round-trip test now asserts the generic body rather than the formerly reflected `invalid_signature` reason (that detail is now server-side only).
