### PR TITLE
Advance the plugin to Beta for the 4.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ digit and differ by release cadence). The channel and Jellyfin generation are a
 suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 `-JF12-*`), never part of the installed numeric version.
 
+## 4.3.0
+
+A feature release. This line advances the plugin's maturity to **Beta** on the
+back of a large login-hardening and code-quality pass: SSO-only login
+enforcement, full role-based access control, a redesigned configuration UI, and
+a broad security + perfection audit.
+
+### Added
+
+- **SSO-only login enforcement (#165).** An optional mode that closes the
+  built-in username/password door so accounts authenticate only through the
+  configured SSO provider. It is fail-closed by construction: activation is
+  refused unless a designated, enabled break-glass administrator keeps a working
+  password login, so no reachable configuration can strand the last admin. The
+  per-login enforcement and the enable sweep agree on which accounts are moved,
+  and the mode is fully reversible on disable.
+- **Full role-based access control (#164).** Providers can map identity-provider
+  roles to Jellyfin permissions through a generic permission-role mapping,
+  validated fail-closed at save so a malformed mapping is rejected at the door
+  rather than silently granting nothing at login.
+- **Redesigned configuration UI (#697).** The admin settings page was reworked
+  into clearer, native accordion sections.
+
+### Changed
+
+- **The self-service linking and auth-completion pages were polished
+  (#666, #667, #669).** The linking page renders a proper help label and an
+  empty-state placeholder instead of bare headings; the auth-completion status
+  line is an `aria-live` region that announces failures to assistive tech and
+  now offers a "Return to login" link instead of dead-ending.
+- **Browser-navigated login errors are now styled (#668).** A rejection reached
+  by direct navigation (the OpenID/SAML challenge and callback routes) is
+  rendered as a themed HTML page with a return link and a strict
+  Content-Security-Policy, instead of raw plain text on what looked like a broken
+  page. The uniform denial message was reworded to be actionable without
+  enumerating.
+- **Internal consolidation (#670, #671, #695).** The duplicated challenge
+  redirect-path resolver and a single-caller OpenID wrapper were unified, and the
+  provider-config validation doc was corrected to describe the single source of
+  truth — no behavioural change, locked in by conformance tests.
+
+### Security
+
+- **SAML parsing hardened (#698).**
+- **SAML `DoNotValidateAudience` is now audited (#672).** Enabling this default-on
+  protection's escape hatch leaves an `[SSO Audit]` trail on save and import, at
+  parity with the OpenID insecure toggles.
+- **Rate-limit endpoint-class bucket keys are typed (#694).** The per-client
+  limiter keys are named constants rather than bare string literals, so a typo
+  can no longer silently split a security budget; a conformance test forbids
+  regressions.
+- **SSO-only no longer strips a third-party provider account's login path (#690).**
+- **The OpenID authorize-state store is keyed on UTC (#696), and role-privilege
+  mapping guards null folder sets (#693).**
+
 ## 4.2.1
 
 A bug-fix release.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 <!-- markdownlint-disable MD041 -->
 
-> [!WARNING]
+> [!NOTE]
 >
-> ## 🟡 Alpha — for testing and evaluation only
->
-> This plugin is at the **Alpha** stage — the second rung of its maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). It is now installable, but **for testing and evaluation only** — do **not** put it in front of a real Jellyfin instance with real user accounts, and do **not** run it in production. This is a login path still being hardened, so you must expect **bugs, breaking changes, and security gaps that are still open**. Wait for a **Full Release** before using it anywhere that matters.
+> **Status: Beta** — the third rung of the maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). Installable from the Jellyfin plugin catalog.
 
 <h1 align="center">Jellyfin SSO Plugin</h1>
 
@@ -38,7 +36,7 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 >
 > This is a revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continues from the last upstream release (**4.0.0.x**, Jellyfin 10.11 / .NET 9) and is taken forward **security-first**. Its hardened sibling project, **`jellyfin-plugin-sso-V2`** (private), is the reference this repository draws on — ported across deliberately, one reviewed change at a time. Huge thanks to the original author and contributors for the foundation.
 >
-> **Status:** **Alpha** — the second stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — a packaged release is now installable from the Jellyfin plugin catalog, with build-from-source as the alternative.
+> **Status:** **Beta** — the third stage of the maturity ladder. See the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) for what each stage gates, and [Installing](#installing) — a packaged release is now installable from the Jellyfin plugin catalog, with build-from-source as the alternative.
 >
 > ### How this project is developed
 >

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -40,8 +40,8 @@
                 Making changes to this configuration requires a restart of
                 Jellyfin.
                 <br />
-                This plug-in is at the In-Development stage of its maturity
-                ladder (In-Development &rarr; Alpha &rarr; Beta &rarr; Release
+                This plug-in is at the Beta stage of its maturity ladder
+                (In-Development &rarr; Alpha &rarr; Beta &rarr; Release
                 Candidate &rarr; Full Release); not all configuration options
                 are exposed in the UI yet.
                 <br />

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -7,8 +7,8 @@
          publish pipeline builds each target into its own package with its own targetAbi. -->
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
-    <AssemblyVersion>4.2.1</AssemblyVersion>
-    <FileVersion>4.2.1</FileVersion>
+    <AssemblyVersion>4.3.0</AssemblyVersion>
+    <FileVersion>4.3.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- TreatWarningsAsErrors=true is set repo-wide in Directory.Build.props so a plain local
          build matches the CI warnaserror gate. -->

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 name: "SSO Authentication"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
-version: "4.2.1"
+version: "4.3.0"
 # The oldest Jellyfin server this plugin claims to load on. The shipping build compiles against a
 # newer 10.11.x SDK, so the CI `abi-floor` job also builds against this floor to prove every Jellyfin
 # API the plugin calls exists here — otherwise a newer member would throw MissingMethodException at


### PR DESCRIPTION
# What & why

Cuts the **4.3.0** release and promotes the plugin's maturity **Alpha → Beta**, on the back of this feature line: SSO-only login (#165), full RBAC (#164), the config-UI redesign (#697), SAML hardening (#698), and the P7 perfection-audit sweep (#666–672, #679, #690, #694, #695, #668).

- **README**, the fat `🟡 Alpha — for testing and evaluation only` warning block is removed for a concise **Status: Beta** note; the second status line becomes Beta.
- **configPage.html**, the in-app maturity banner now reads **Beta** (closes **#685**, whose wiki part already landed).
- **build.yaml**, version `4.2.1` → `4.3.0` (a feature line; three-part `X.Y.Z`, the channel/generation stays a suffix on the tag + release name only).
- **CHANGELOG**, a 4.3.0 entry covering the feature and security highlights.

Closes #685

## Type of change

- [x] Refactor / code quality / docs (release + maturity messaging)

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` green, 1557/1557 on both TFMs (the configPage banner text change does not affect the provider-form conformance scan).
- [x] Prettier clean for the `.md` / `.html` changes.

## Notes, release steps gated on my sign-off (NOT done here)

This PR is the release **preparation** only. Merging it bumps `build.yaml` to 4.3.0, so the next scheduled beta will publish `4.3.0.<run>` on the **beta** channel. The **stable** publish tag (`4.3.0-stable`) is gated on my sign-off (`SSO_RELEASE_GO=1`) and is **not** part of this PR, the exact version, channel, and tag are being confirmed with me before merge. The wiki (Roadmap/Home maturity Alpha→Beta, remove the Alpha warning block, add the #668 role-gate Troubleshooting entry) is updated separately at release time.
