### PR TITLE
Add a docs/ pointer to the Wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -463,6 +463,8 @@ AGENTS.md
 # Internal project-process docs are maintained LOCALLY, not published. Public
 # user documentation lives in README.md and the GitHub wiki; if
 # a genuinely public doc is ever added under docs/, un-ignore it explicitly
-# (e.g. `!docs/CONFIGURATION.md`).
-docs/
+# (e.g. `!docs/CONFIGURATION.md`). Ignore the CONTENTS of docs/ (docs/*) rather
+# than the directory itself, so such an exception can re-include a file — a
+# `!` rule cannot re-include a file whose parent directory is excluded.
+docs/*
 !docs/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -465,3 +465,4 @@ AGENTS.md
 # a genuinely public doc is ever added under docs/, un-ignore it explicitly
 # (e.g. `!docs/CONFIGURATION.md`).
 docs/
+!docs/README.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation
+
+The full documentation for this plugin lives in the project
+**[Wiki](https://github.com/iderex/jellyfin-plugin-sso/wiki)**. It is maintained
+as a separate Git repository, so it is not mirrored into this folder.
+
+Start there for:
+
+- **[Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation)**
+- **[Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)**
+  — OpenID Connect and SAML
+- **[Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow)**
+- **[Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model)**
+  and **[Threat Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Threat-Model)**
+- **[Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)**
+- **[Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)**
+
+The [README](../README.md) has the overview and quick start; the Wiki is the
+reference documentation.


### PR DESCRIPTION
# What & why

Documentation for this plugin lives in the GitHub **Wiki** (a separate repository), so a repo-folder documentation scan, including the OpenSSF Best Practices `documentation_basics` auto-check, finds nothing under `docs/` and reports it unmet.

Add a short, public `docs/README.md` that points to the Wiki's key pages (Installation, Provider Setup, Login Flow, Security/Threat Model, Troubleshooting, Roadmap), so the documentation is discoverable from the source tree.

`docs/` was git-ignored (local process notes). A `!docs/README.md` exception cannot re-include a file while its parent directory is excluded, so the ignore is changed from `docs/` to `docs/*` (ignore the contents, not the directory) with the `!docs/README.md` exception, matching the convention the `.gitignore` comment already describes.

## Type of change

- [x] Refactor / code quality / docs

## Verification

- [x] Prettier clean for `docs/README.md`.
- [x] No source/build change; `docs/` is not compiled.