### PR TITLE
Show the real OpenSSF badges and a release badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,20 @@
 <a href="https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt">
 <img alt="GPL 3.0 License" src="https://img.shields.io/github/license/iderex/jellyfin-plugin-sso.svg"/>
 </a>
+<a href="https://github.com/iderex/jellyfin-plugin-sso/releases">
+<img alt="Latest release" src="https://img.shields.io/github/v/release/iderex/jellyfin-plugin-sso?display_name=tag&label=release"/>
+</a>
 <a href="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
 <img alt="Build Status" src="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>
 </a>
 <a href="https://github.com/iderex/jellyfin-plugin-sso/wiki">
 <img alt="Documentation" src="https://img.shields.io/badge/docs-wiki-blue"/>
 </a>
-<!-- OpenSSF Best Practices badge. The project meets the passing-level criteria
-     (see the OpenSSF-Best-Practices wiki page); the badge goes live once the maintainer
-     registers at bestpractices.dev and swaps PROJECT_ID below for the real id.
-     Until then this links to the readiness mapping. -->
-<a href="https://github.com/iderex/jellyfin-plugin-sso/wiki/OpenSSF-Best-Practices">
-<img alt="OpenSSF Best Practices" src="https://img.shields.io/badge/OpenSSF_Best_Practices-passing_criteria_met-informational"/>
+<a href="https://www.bestpractices.dev/projects/13660">
+<img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13660/badge"/>
+</a>
+<a href="https://securityscorecards.dev/viewer/?uri=github.com/iderex/jellyfin-plugin-sso">
+<img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/iderex/jellyfin-plugin-sso/badge"/>
 </a>
 </p>
 


### PR DESCRIPTION
# What & why

The OpenSSF Best Practices project is now **registered (13660) and passes** at the passing level, and the OpenSSF **Scorecard** action publishes a public score (6.5), so the honest placeholder can be replaced with the real badges.

- Swap the OpenSSF Best Practices placeholder (and its "until registered" comment) for the live `bestpractices.dev/projects/13660` badge.
- Add the real **OpenSSF Scorecard** badge (`publish_results: true` is set; the public score is live).
- Add a **latest-release** badge linking to the releases page (shows the latest stable, honestly).

All badges reflect real, published state, no green for anything not actually passing.

Closes #765

## Type of change

- [x] Refactor / code quality / docs

## Verification

- [x] Prettier clean for `README.md`.
- [x] Badge endpoints verified live: bestpractices.dev/projects/13660 (passing), the Scorecard public API returns a real score, the release badge resolves.
- [x] No source/build change.