### PR TITLE
Bound the untrusted SAML DOM with MaxCharactersInDocument

### DIFF
--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -33,6 +33,20 @@ public class SamlResponseParsingTests
     }
 
     [Fact]
+    public void TryLoad_OversizedResponse_IsRejectedFailClosed_BeforeDecoding()
+    {
+        // A body longer than the pre-decode cap is an unauthenticated pre-signature DoS attempt (#249/#754):
+        // it must be refused fail-closed BEFORE any base64 decode / DOM build, spending no crypto or bulk
+        // allocation on the untrusted input. The exact bytes are irrelevant — the length gate fires first —
+        // so a plainly over-length string is enough; the result is a clean rejection, never an unmapped throw.
+        var fixture = SamlTestFactory.Create();
+        var oversized = new string('A', SamlResponseLoader.MaxEncodedResponseLength + 1);
+
+        Assert.False(SamlResponseLoader.TryParse(fixture.CertificateBase64, oversized, out var response));
+        Assert.Null(response);
+    }
+
+    [Fact]
     public void TryLoad_MalformedXmlBody_ReturnsFalse()
     {
         var fixture = SamlTestFactory.Create();

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -146,6 +146,15 @@ internal sealed class SamlResponse : IDisposable
         {
             DtdProcessing = DtdProcessing.Prohibit,
             XmlResolver = null,
+
+            // Bound the DOM the reader materializes (#754). The untrusted body is already length-capped
+            // before decoding by SamlResponseLoader.MaxEncodedResponseLength (256 KB of base64), so this
+            // parser-layer cap normally never bites — a legitimate SAML response is single-digit KB, and
+            // the pre-decode cap keeps any accepted body well under this. It is the belt to the loader's
+            // suspenders: if that pre-decode cap were ever raised or bypassed, the reader still refuses to
+            // build a multi-megabyte document on the unauthenticated, pre-signature path (a cheap CPU/
+            // memory amplifier the DTD prohibition above does not stop, since it bounds entities, not bulk).
+            MaxCharactersInDocument = 256 * 1024,
         };
         using (var stringReader = new StringReader(xml))
         using (var reader = XmlReader.Create(stringReader, settings))


### PR DESCRIPTION
# What & why

The SAML response is attacker-controlled, unauthenticated input that is base64-decoded and loaded into an `XmlDocument` **before any signature is trusted** (`Saml.cs` `ParseResponseXml`).

**Already in place (not changed here):** `SamlResponseLoader` caps the base64 body at **256 KB before decoding** (#249), so the decoded document is already bounded, and `ParseResponseXml` prohibits DTDs and nulls the resolver (XXE / billion-laughs). So the multi-MB DoS the analysis worried about is largely already mitigated.

**This PR completes the layered bound (#754 AC 1/3/4):**
- Add `XmlReaderSettings.MaxCharactersInDocument = 256 KB`, the parser-layer echo of the pre-decode cap. It never bites a legitimate response (single-digit KB), but if the pre-decode cap were ever raised or bypassed, the reader itself refuses to build a multi-megabyte DOM on the unauthenticated pre-signature path (the DTD prohibition bounds entities, not raw bulk).
- Add a test asserting an over-length body is rejected **fail-closed before any decode/parse**.
- Document the layered bound beside the existing DTD/XXE reasoning.

No behaviour change for any legitimate response; a size cap can only reject more, never accept more.

Closes #754

## Type of change

- [x] Security hardening / vulnerability fix

## Security checklist

- [x] Fail-closed preserved: an over-length body is refused (no decode/crypto spent); `MaxCharactersInDocument` is a strict upper bound only.
- [x] No secrets logged.
- [x] Reviewed: the bound (256 KB chars) is >= the maximum a body accepted by the existing 256 KB base64 pre-decode cap can decode to (~192 KB), so it cannot reject a legitimate response; it is pure defense-in-depth beneath the effective cap.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings) and the ABI-floor build (10.11.0) green.
- [x] `dotnet test` green, 1559/1559 on both TFMs (incl. the new oversize test).