### PR TITLE
Add a restrictive Permissions-Policy to the served auth and error pages

### DIFF
--- a/SSO-Auth.Tests/BrowserErrorPageTests.cs
+++ b/SSO-Auth.Tests/BrowserErrorPageTests.cs
@@ -72,6 +72,7 @@ public class BrowserErrorPageTests
         Assert.Equal("DENY", ctx.Response.Headers["X-Frame-Options"].ToString());
         Assert.Equal("nosniff", ctx.Response.Headers["X-Content-Type-Options"].ToString());
         Assert.Equal("no-store", ctx.Response.Headers.CacheControl.ToString());
+        Assert.Contains("camera=()", ctx.Response.Headers["Permissions-Policy"].ToString());
 
         // The nonce authorizing the inline <style> must be the exact nonce bound in the CSP.
         var nonce = Regex.Match(csp, "style-src 'nonce-([^']+)'").Groups[1].Value;

--- a/SSO-Auth.Tests/FlowResponsesTests.cs
+++ b/SSO-Auth.Tests/FlowResponsesTests.cs
@@ -59,6 +59,11 @@ public class FlowResponsesTests
         Assert.Equal("nosniff", response.Headers["X-Content-Type-Options"]);
         Assert.Equal("no-referrer", response.Headers["Referrer-Policy"]);
         Assert.Equal("no-store", response.Headers.CacheControl.ToString());
+        // A restrictive Permissions-Policy denies powerful features the login-completion page never uses.
+        var permissionsPolicy = response.Headers["Permissions-Policy"].ToString();
+        Assert.Contains("camera=()", permissionsPolicy);
+        Assert.Contains("geolocation=()", permissionsPolicy);
+        Assert.Contains("microphone=()", permissionsPolicy);
         Assert.False(string.IsNullOrEmpty(response.Headers.ContentSecurityPolicy.ToString()));
     }
 

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -44,6 +44,7 @@ internal static class BrowserErrorPage
         response.Headers["X-Content-Type-Options"] = "nosniff";
         response.Headers["Referrer-Policy"] = "no-referrer";
         response.Headers.CacheControl = "no-store";
+        response.Headers["Permissions-Policy"] = FlowResponses.ServedPagePermissionsPolicy;
 
         return new ContentResult
         {

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -19,6 +19,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 /// </summary>
 internal static class FlowResponses
 {
+    // The restrictive Permissions-Policy applied to both served HTML pages — the auth-completion page and
+    // the browser-navigated error page in BrowserErrorPage — shared as one constant so the two cannot drift.
+    // These pages run only a tiny inline script and need no powerful browser feature, so every listed feature
+    // is denied with an empty allowlist. HSTS is deliberately NOT set per page: transport security for the
+    // whole origin is the operator's reverse proxy / Jellyfin global responsibility (#756), not a per-response
+    // plugin header.
+    internal const string ServedPagePermissionsPolicy =
+        "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), display-capture=()";
+
     /// <summary>
     /// A plain-text error result (<c>text/plain</c> with the given status), reproducing the controller's
     /// former <c>ReturnError</c> shape exactly so the non-outcome flow errors — a SAML signing-key failure,
@@ -52,6 +61,7 @@ internal static class FlowResponses
         response.Headers["X-Content-Type-Options"] = "nosniff";
         response.Headers["Referrer-Policy"] = "no-referrer";
         response.Headers.CacheControl = "no-store";
+        response.Headers["Permissions-Policy"] = ServedPagePermissionsPolicy;
         return new ContentResult
         {
             Content = render(nonce),


### PR DESCRIPTION
# What & why

The intermediate auth-completion page (`FlowResponses.AuthPage`) and the browser-navigated error page (`BrowserErrorPage`) send a strong defensive header set (nonce CSP, `X-Frame-Options: DENY`, `nosniff`, `Referrer-Policy: no-referrer`, `Cache-Control: no-store`) but omitted **`Permissions-Policy`**. Both pages run only a tiny inline script and have no legitimate use for any powerful browser feature.

- Add a restrictive `Permissions-Policy` denying camera, microphone, geolocation, payment, usb, and the common sensor/media features (empty allowlists) to **both** served pages (consistency, they are the same class of served HTML).
- Share the policy as **one constant** so the two pages cannot drift.
- Document that **HSTS is intentionally not set per page**, origin-wide transport security is the operator's reverse-proxy / Jellyfin global responsibility (a scanner HSTS finding here is a documented decline, to be recorded in the ASVS self-assessment #734).

No behaviour change to either page's inline script.

Closes #756

## Type of change

- [x] Security hardening / vulnerability fix

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0) and the ABI-floor build green.
- [x] `dotnet test` green, 1559/1559 both TFMs (Permissions-Policy asserted on both pages in FlowResponsesTests + BrowserErrorPageTests).