### PR TITLE
Advertise both SAML ACS spellings in SP metadata

### DIFF
--- a/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
@@ -120,6 +120,40 @@ public class SSOControllerSamlMetadataTests
     }
 
     [Fact]
+    public void SamlMetadata_PublishesBothAcsSpellings_NewDefaultThenLegacy_AnchoredToTheCanonicalBaseUrl()
+    {
+        // The SP honours either ACS spelling on the way back (SsoUrlBuilder.SamlExpectedAcsUrls), so the
+        // endpoint publishes both (#569): the new-path spelling as the default (index 0), the legacy spelling
+        // as a second, non-default endpoint (index 1). Both are anchored to the canonical Base URL, never the
+        // spoofable request host.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlClientId = "https://sp",
+            BaseUrlOverride = CanonicalBaseUrl,
+            SignAuthnRequests = false,
+        });
+
+        var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));
+
+        Assert.Equal(200, result.StatusCode);
+        var spDescriptor = XDocument.Parse(result.Content!).Root!.Element(Md + "SPSSODescriptor");
+        var acsElements = spDescriptor!.Elements(Md + "AssertionConsumerService").ToList();
+
+        Assert.Equal(2, acsElements.Count);
+
+        Assert.Equal(CanonicalBaseUrl + "/sso/SAML/post/adfs", (string?)acsElements[0].Attribute("Location"));
+        Assert.Equal("0", (string?)acsElements[0].Attribute("index"));
+        Assert.Equal("true", (string?)acsElements[0].Attribute("isDefault"));
+
+        Assert.Equal(CanonicalBaseUrl + "/sso/SAML/p/adfs", (string?)acsElements[1].Attribute("Location"));
+        Assert.Equal("1", (string?)acsElements[1].Attribute("index"));
+        Assert.Equal("false", (string?)acsElements[1].Attribute("isDefault"));
+
+        Assert.DoesNotContain(RequestHost, result.Content!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SamlMetadata_SigningOn_AdvertisesThePublicCertificate_WithoutThePrivateKey()
     {
         using var certificate = SamlSigningKeyFactory.CreateCertificate();

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -190,6 +190,65 @@ public class SamlSpMetadataBuilderTests
     }
 
     [Fact]
+    public void Build_WithLegacyAcs_AdvertisesBothAssertionConsumerServices_NewDefaultThenLegacy()
+    {
+        // The SP accepts either ACS spelling on the way back (SsoUrlBuilder.SamlExpectedAcsUrls), so the
+        // metadata lists both: the new spelling is the default at index 0, the legacy spelling follows as a
+        // non-default endpoint at index 1 (#569).
+        const string legacyAcs = "https://jellyfin.example.com/sso/SAML/p/adfs";
+
+        var document = XDocument.Parse(
+            SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null, legacyAssertionConsumerServiceUrl: legacyAcs));
+        var spDescriptor = document.Root!.Element(Md + "SPSSODescriptor");
+
+        var acsElements = spDescriptor!.Elements(Md + "AssertionConsumerService").ToList();
+        Assert.Equal(2, acsElements.Count);
+        Assert.All(acsElements, acs => Assert.Equal(HttpPostBinding, (string?)acs.Attribute("Binding")));
+
+        var primary = acsElements[0];
+        Assert.Equal(AcsUrl, (string?)primary.Attribute("Location"));
+        Assert.Equal("0", (string?)primary.Attribute("index"));
+        Assert.Equal("true", (string?)primary.Attribute("isDefault"));
+
+        var legacy = acsElements[1];
+        Assert.Equal(legacyAcs, (string?)legacy.Attribute("Location"));
+        Assert.Equal("1", (string?)legacy.Attribute("index"));
+        Assert.Equal("false", (string?)legacy.Attribute("isDefault"));
+    }
+
+    [Fact]
+    public void Build_WithoutLegacyAcs_EmitsExactlyOneAssertionConsumerService_PreservingSingleAcsBehavior()
+    {
+        // Legacy unset (the default) is byte-for-byte the pre-#569 single-ACS output.
+        var withDefault = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null);
+        var withExplicitNullLegacy = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null, legacyAssertionConsumerServiceUrl: null);
+
+        Assert.Equal(withDefault, withExplicitNullLegacy);
+        var acsElements = XDocument.Parse(withDefault).Root!
+            .Element(Md + "SPSSODescriptor")!
+            .Elements(Md + "AssertionConsumerService")
+            .ToList();
+        Assert.Single(acsElements);
+        Assert.Equal("0", (string?)acsElements[0].Attribute("index"));
+        Assert.Equal("true", (string?)acsElements[0].Attribute("isDefault"));
+    }
+
+    [Fact]
+    public void Build_LegacyAcsEqualToPrimary_EmitsExactlyOneAssertionConsumerService()
+    {
+        // A legacy URL identical to the primary is redundant — the SP already advertises that exact endpoint —
+        // so the second entry is dropped, leaving the single-ACS output unchanged (#569 dedup).
+        var withDuplicateLegacy = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null, legacyAssertionConsumerServiceUrl: AcsUrl);
+        var withoutLegacy = SamlSpMetadataBuilder.Build(EntityId, AcsUrl, signingCertificateBase64: null);
+
+        Assert.Equal(withoutLegacy, withDuplicateLegacy);
+        Assert.Single(
+            XDocument.Parse(withDuplicateLegacy).Root!
+                .Element(Md + "SPSSODescriptor")!
+                .Elements(Md + "AssertionConsumerService"));
+    }
+
+    [Fact]
     public void Build_DeclaresUtf8Encoding()
     {
         // A StringWriter is UTF-16 internally; the builder reports UTF-8 so the declaration matches the

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -249,6 +249,36 @@ public class SamlSpMetadataBuilderTests
     }
 
     [Fact]
+    public void Build_WithRolloverAndLegacyAcs_KeepsBothKeyDescriptorsBeforeBothAssertionConsumerServices()
+    {
+        // The combined worst case for XSD element order: signing-key rollover (#491) emits TWO KeyDescriptors
+        // and the legacy ACS (#569) emits TWO AssertionConsumerService entries in the SAME document. The
+        // metadata XSD requires every KeyDescriptor to precede every AssertionConsumerService, so pin that the
+        // last KeyDescriptor still comes before the first ACS when both features are on at once — a future edit
+        // that interleaves them (invalid for strict IdPs like ADFS/Azure AD) fails here, not only in the field.
+        using var primary = SamlSigningKeyFactory.CreateCertificate();
+        using var rollover = SamlSigningKeyFactory.CreateCertificate();
+        const string legacyAcs = "https://jellyfin.example.com/sso/SAML/p/adfs";
+
+        var spDescriptor = XDocument.Parse(
+                SamlSpMetadataBuilder.Build(
+                    EntityId,
+                    AcsUrl,
+                    Convert.ToBase64String(primary.RawData),
+                    Convert.ToBase64String(rollover.RawData),
+                    legacyAcs))
+            .Root!.Element(Md + "SPSSODescriptor")!;
+
+        Assert.Equal(2, spDescriptor.Elements(Md + "KeyDescriptor").Count());
+        Assert.Equal(2, spDescriptor.Elements(Md + "AssertionConsumerService").Count());
+
+        var childNames = spDescriptor.Elements().Select(e => e.Name).ToList();
+        var lastKeyDescriptorIndex = childNames.FindLastIndex(n => n == Md + "KeyDescriptor");
+        var firstAcsIndex = childNames.FindIndex(n => n == Md + "AssertionConsumerService");
+        Assert.True(lastKeyDescriptorIndex < firstAcsIndex, "Every KeyDescriptor must precede AssertionConsumerService (SAML metadata XSD order).");
+    }
+
+    [Fact]
     public void Build_DeclaresUtf8Encoding()
     {
         // A StringWriter is UTF-16 internally; the builder reports UTF-8 so the declaration matches the

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -454,9 +454,12 @@ internal sealed class SamlLoginService
                 "SAML metadata is unavailable: this provider has no client id (SP entity id) configured.");
         }
 
-        // Advertise the canonical new-path ACS spelling; the SP accepts either spelling on the way back
-        // (SsoUrlBuilder.SamlExpectedAcsUrls), so publishing one is unambiguous for the identity provider.
+        // Advertise BOTH ACS spellings the SP actually honours on the way back
+        // (SsoUrlBuilder.SamlExpectedAcsUrls): the canonical new-path spelling is the default (index 0), and
+        // the legacy spelling is published as a second, non-default endpoint (index 1) so metadata truthfully
+        // reflects that either POST target is accepted rather than silently omitting one the SP still serves.
         var acsUrl = SsoUrlBuilder.SamlAcsUrl(baseUrl, newPath: true, provider);
+        var legacyAcsUrl = SsoUrlBuilder.SamlAcsUrl(baseUrl, newPath: false, provider);
 
         if (!TryResolveSigningCertificates(config, out var signingCertificateBase64, out var rolloverSigningCertificateBase64))
         {
@@ -471,7 +474,7 @@ internal sealed class SamlLoginService
 
         return new ContentResult
         {
-            Content = SamlSpMetadataBuilder.Build(entityId, acsUrl, signingCertificateBase64, rolloverSigningCertificateBase64),
+            Content = SamlSpMetadataBuilder.Build(entityId, acsUrl, signingCertificateBase64, rolloverSigningCertificateBase64, legacyAcsUrl),
             ContentType = "application/samlmetadata+xml",
             StatusCode = StatusCodes.Status200OK,
         };

--- a/SSO-Auth/Api/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/SamlSpMetadataBuilder.cs
@@ -10,11 +10,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// Builds SAML 2.0 service-provider metadata — an <c>EntityDescriptor</c> carrying an
 /// <c>SPSSODescriptor</c> — that an administrator can hand to an identity provider so it registers this
 /// service provider by URL instead of by hand (#162). Pure and request-free: it emits exactly the entity
-/// id, the HTTP-POST assertion-consumer URL, and — only when request signing is enabled — the PUBLIC
-/// signing certificate(s) it is given. During a signing-key rollover (#491) it advertises BOTH the primary
+/// id, the HTTP-POST assertion-consumer URL(s), and — only when request signing is enabled — the PUBLIC
+/// signing certificate(s) it is given. This SP accepts BOTH ACS spellings on the way back — the new-path
+/// and the legacy one (<see cref="SsoUrlBuilder.SamlExpectedAcsUrls"/>) — so when a legacy ACS URL is
+/// supplied the metadata advertises both as two <c>AssertionConsumerService</c> entries: the new spelling
+/// stays the default at <c>index="0"</c>, the legacy spelling follows at <c>index="1"</c>
+/// (<c>isDefault="false"</c>). During a signing-key rollover (#491) it advertises BOTH the primary
 /// and the optional rollover PUBLIC certificate as two <c>KeyDescriptor use="signing"</c> entries, so the
 /// identity provider trusts either while the administrator swaps. It never touches a private key or any
-/// secret, and it never reads the request <c>Host</c>: the caller resolves the entity id and ACS URL from
+/// secret, and it never reads the request <c>Host</c>: the caller resolves the entity id and ACS URL(s) from
 /// the configured canonical Base URL (#139), so a spoofed or proxy-forwarded host cannot poison the ACS the
 /// identity provider is told to POST assertions to.
 /// </summary>
@@ -33,8 +37,8 @@ internal static class SamlSpMetadataBuilder
     /// (the configured client id), so the identity provider correlates the two.
     /// </param>
     /// <param name="assertionConsumerServiceUrl">
-    /// The absolute HTTP-POST assertion-consumer URL, built from the configured canonical Base URL (never
-    /// the request host).
+    /// The absolute HTTP-POST assertion-consumer URL — the new-path spelling — built from the configured
+    /// canonical Base URL (never the request host). This is the default ACS at <c>index="0"</c>.
     /// </param>
     /// <param name="signingCertificateBase64">
     /// The Base64 (DER) PUBLIC signing certificate to advertise under a <c>KeyDescriptor use="signing"</c>
@@ -49,8 +53,17 @@ internal static class SamlSpMetadataBuilder
     /// (no primary means signing is off, so there is nothing to roll over). Again only ever the public
     /// certificate — never a private key.
     /// </param>
+    /// <param name="legacyAssertionConsumerServiceUrl">
+    /// The OPTIONAL absolute HTTP-POST assertion-consumer URL for the LEGACY route spelling. This SP accepts
+    /// either spelling at runtime (<see cref="SsoUrlBuilder.SamlExpectedAcsUrls"/>), so when this is supplied
+    /// the metadata truthfully advertises both: the new spelling stays the default at <c>index="0"</c> and
+    /// this legacy spelling is emitted as a SECOND <c>AssertionConsumerService</c> at <c>index="1"</c>,
+    /// <c>isDefault="false"</c>. <see langword="null"/> (the default), or a value equal to
+    /// <paramref name="assertionConsumerServiceUrl"/>, emits a single ACS — byte-for-byte the pre-#569
+    /// output. Placed last so existing positional callers stay source-compatible.
+    /// </param>
     /// <returns>The metadata document as an XML string.</returns>
-    internal static string Build(string entityId, string assertionConsumerServiceUrl, string? signingCertificateBase64, string? rolloverSigningCertificateBase64 = null)
+    internal static string Build(string entityId, string assertionConsumerServiceUrl, string? signingCertificateBase64, string? rolloverSigningCertificateBase64 = null, string? legacyAssertionConsumerServiceUrl = null)
     {
         // A StringWriter is UTF-16 internally, which would make XmlWriter stamp encoding="utf-16" into the
         // XML declaration even though the bytes are served as UTF-8; report UTF-8 so the declaration matches
@@ -95,6 +108,23 @@ internal static class SamlSpMetadataBuilder
             xml.WriteAttributeString("index", "0");
             xml.WriteAttributeString("isDefault", "true");
             xml.WriteEndElement(); // md:AssertionConsumerService
+
+            // The SP accepts either ACS spelling on the way back (SsoUrlBuilder.SamlExpectedAcsUrls), so when a
+            // distinct legacy spelling is supplied the metadata lists it too — a SECOND, non-default endpoint at
+            // index="1". The new spelling above stays the default (index="0", isDefault="true"), so an identity
+            // provider that honours isDefault keeps posting to it; the legacy entry only widens what the IdP may
+            // pick to a URL this SP already honours. A null (the default) or duplicate legacy URL leaves the
+            // single-ACS output unchanged.
+            if (legacyAssertionConsumerServiceUrl is not null
+                && !string.Equals(legacyAssertionConsumerServiceUrl, assertionConsumerServiceUrl, System.StringComparison.Ordinal))
+            {
+                xml.WriteStartElement("md", "AssertionConsumerService", MetadataNamespace);
+                xml.WriteAttributeString("Binding", HttpPostBinding);
+                xml.WriteAttributeString("Location", legacyAssertionConsumerServiceUrl);
+                xml.WriteAttributeString("index", "1");
+                xml.WriteAttributeString("isDefault", "false");
+                xml.WriteEndElement(); // md:AssertionConsumerService
+            }
 
             xml.WriteEndElement(); // md:SPSSODescriptor
             xml.WriteEndElement(); // md:EntityDescriptor


### PR DESCRIPTION
# What & why

Published SAML SP metadata advertised only the canonical new-path assertion-consumer (ACS) URL, but the SP honours **both** spellings on the inbound POST, the new-path route and the deprecated `SAML/p/...` route, via `SsoUrlBuilder.SamlExpectedAcsUrls`. A strict IdP that pins a single ACS from metadata could therefore reject a POST to the legacy target the SP still serves.

The metadata now advertises both: the new spelling stays the default `AssertionConsumerService` at `index="0"` (`isDefault="true"`), and the legacy spelling is emitted as a second, non-default endpoint at `index="1"`. Both `Location`s are anchored to the configured canonical Base URL, never the request `Host`, so a spoofed or proxy-forwarded host cannot poison the ACS the IdP is told to POST to. A `null` or duplicate legacy URL leaves the output byte-for-byte identical to the prior single-ACS metadata.

This is **Part 1** of #569. **Part 2** (an admin-UI link to the metadata URL on the SAML provider config page) is already an explicit acceptance criterion of #725, which introduces that page, there is no SAML config form today to host the link.

Closes #569

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the change touches only published metadata; inbound assertion validation is unchanged, and both advertised ACS targets flow through the identical `SamlExpectedAcsUrls` acceptance the SP already enforced.
- [x] No secrets logged; secrets are redacted on config export. (No secret surface touched; only public ACS URLs, already derived from the canonical Base URL.)
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. (Adversarial lens review: bypass / correctness / SAML-integrity.)
- [x] Log inputs from the IdP are sanitized inline at the log call. (No new logging.)

## Quality checklist

- [x] No duplicated logic; the legacy ACS emission is a single guarded block in the pure builder.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why (both spellings honoured; anchored to canonical Base URL).
- [x] Architecture-conformance tests pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` is green (net9.0 1563/1563; net10.0 1563/1563).
- [x] ABI-floor build (net9.0 against targetAbi 10.11.0) green, 0 warnings.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` changed, N/A.

## Notes

Part 2 (metadata-URL link in the admin UI) is folded into #725 per that issue's acceptance criteria. Adds 4 tests: both-spellings emission, single-ACS byte-identical output when legacy unset, dedup when legacy equals primary, and a controller-level assertion that both ACS Locations anchor to the canonical Base URL (request host absent).