### PR TITLE
Fall back to the standard OIDC picture claim for avatars

### DIFF
--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -545,6 +545,34 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void NoAvatarUrlFormat_PictureFallbackDisabled_YieldsNull()
+    {
+        // The admin opt-out (#723): with the picture fallback disabled and no template, no candidate is
+        // produced even when the IdP sends a picture claim — nothing is fetched.
+        var config = Config(c => c.DisableAvatarFromPictureClaim = true);
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("picture", "https://idp.example.com/alice.jpg")),
+            config);
+
+        Assert.Null(result.AvatarUrl);
+    }
+
+    [Fact]
+    public void AvatarUrlFormat_TemplateUnaffectedByPictureFallbackToggle()
+    {
+        // The opt-out only gates the no-template picture fallback; a configured template still resolves,
+        // so disabling the fallback never silently drops an explicitly-configured avatar.
+        var config = Config(c =>
+        {
+            c.AvatarUrlFormat = "https://avatars.example.com/@{sub}.png";
+            c.DisableAvatarFromPictureClaim = true;
+        });
+        var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice"), ("sub", "123")), config);
+
+        Assert.Equal("https://avatars.example.com/123.png", result.AvatarUrl);
+    }
+
+    [Fact]
     public void NoAvatarUrlFormat_EmptyPictureClaim_YieldsNull()
     {
         // An empty picture value is treated as absent, so the caller skips the fetch rather than handing

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -488,9 +488,71 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
-    public void NoAvatarUrlFormat_YieldsNull()
+    public void AvatarUrlFormat_ConfiguredTemplateWinsOverPictureClaim()
     {
+        // The template always wins when configured; the picture-claim fallback is only for the no-template
+        // case (#723), so a configured format is never silently overridden by a picture claim.
+        var config = Config(c => c.AvatarUrlFormat = "https://avatars.example.com/@{sub}.png");
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("sub", "123"), ("picture", "https://idp.example.com/pic.jpg")),
+            config);
+
+        Assert.Equal("https://avatars.example.com/123.png", result.AvatarUrl);
+    }
+
+    [Fact]
+    public void NoAvatarUrlFormat_FallsBackToStandardPictureClaim()
+    {
+        // Zero-config parity (#723): with no template the resolver uses the standard OIDC `picture` claim,
+        // so a standards-compliant IdP yields an avatar candidate without any configuration.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("picture", "https://idp.example.com/alice.jpg")),
+            Config(_ => { }));
+
+        Assert.Equal("https://idp.example.com/alice.jpg", result.AvatarUrl);
+    }
+
+    [Fact]
+    public void EmptyAvatarUrlFormat_FallsBackToStandardPictureClaim()
+    {
+        // An empty template is treated the same as no template (null/empty → picture fallback, #723),
+        // rather than resolving to an empty URL the way the pre-#723 aggregate did.
+        var config = Config(c => c.AvatarUrlFormat = string.Empty);
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("picture", "https://idp.example.com/alice.jpg")),
+            config);
+
+        Assert.Equal("https://idp.example.com/alice.jpg", result.AvatarUrl);
+    }
+
+    [Fact]
+    public void NoAvatarUrlFormat_LastPictureClaimWins()
+    {
+        // Last wins, matching the subject/username/email_verified derivations.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("picture", "https://idp.example.com/old.jpg"), ("picture", "https://idp.example.com/new.jpg")),
+            Config(_ => { }));
+
+        Assert.Equal("https://idp.example.com/new.jpg", result.AvatarUrl);
+    }
+
+    [Fact]
+    public void NoAvatarUrlFormat_NoPictureClaim_YieldsNull()
+    {
+        // No template and no picture claim: nothing to fetch, so the candidate is null (no fetch attempted).
         var result = OidcAuthorizeStateBuilder.Build(Claims(("preferred_username", "alice")), Config(_ => { }));
+        Assert.Null(result.AvatarUrl);
+    }
+
+    [Fact]
+    public void NoAvatarUrlFormat_EmptyPictureClaim_YieldsNull()
+    {
+        // An empty picture value is treated as absent, so the caller skips the fetch rather than handing
+        // an empty URL to AvatarUrlValidator.
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("picture", string.Empty)),
+            Config(_ => { }));
+
         Assert.Null(result.AvatarUrl);
     }
 

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -138,15 +138,17 @@ internal static class OidcAuthorizeStateBuilder
     // Resolves the avatar URL. With a configured format the template wins: @{claimType} tokens are
     // substituted (for a duplicate claim type the first occurrence wins — after the first Replace the
     // token is gone, and Replace on an absent token returns the instance unchanged). With no format
-    // (null or empty) the resolver falls back to the standard OIDC `picture` claim verbatim (#723), so
-    // a standards-compliant IdP yields an avatar with zero configuration. Either way this only produces
-    // a CANDIDATE URL: AvatarService.TrySetAsync still gates the fetch through AvatarUrlValidator, so a
-    // `picture` (or templated) URL to a private/loopback host is refused exactly the same.
+    // (null or empty) the resolver falls back to the standard OIDC `picture` claim verbatim (#723) so a
+    // standards-compliant IdP yields an avatar with zero configuration — UNLESS the admin has opted out
+    // via DisableAvatarFromPictureClaim, in which case no candidate is produced and nothing is fetched.
+    // Either way this only produces a CANDIDATE URL: AvatarService.TrySetAsync still gates the fetch
+    // through AvatarUrlValidator, so a `picture` (or templated) URL to a private/loopback host is refused
+    // exactly the same.
     private static string? ResolveAvatarUrl(IReadOnlyList<Claim> claims, OidConfig config)
     {
         if (string.IsNullOrEmpty(config.AvatarUrlFormat))
         {
-            return ResolvePictureClaim(claims);
+            return config.DisableAvatarFromPictureClaim ? null : ResolvePictureClaim(claims);
         }
 
         return claims.Aggregate(
@@ -227,7 +229,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="EnableLiveTv">Whether the login grants Live TV access.</param>
     /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
-    /// <param name="AvatarUrl">The resolved avatar URL, or null when no avatar format is configured.</param>
+    /// <param name="AvatarUrl">The resolved avatar candidate URL: the configured AvatarUrlFormat template with @{claim} tokens substituted, or — when no template is configured (null/empty) — the standard OIDC "picture" claim (#723); null when neither yields a value. Only a candidate: the fetch is still gated by AvatarUrlValidator.</param>
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -135,19 +135,40 @@ internal static class OidcAuthorizeStateBuilder
         return emailVerified;
     }
 
-    // Resolves the avatar URL by substituting @{claimType} tokens in the configured format, or null
-    // when no format is configured. For a duplicate claim type the first occurrence wins: after the
-    // first Replace the token is gone, and Replace on an absent token returns the instance unchanged.
+    // Resolves the avatar URL. With a configured format the template wins: @{claimType} tokens are
+    // substituted (for a duplicate claim type the first occurrence wins — after the first Replace the
+    // token is gone, and Replace on an absent token returns the instance unchanged). With no format
+    // (null or empty) the resolver falls back to the standard OIDC `picture` claim verbatim (#723), so
+    // a standards-compliant IdP yields an avatar with zero configuration. Either way this only produces
+    // a CANDIDATE URL: AvatarService.TrySetAsync still gates the fetch through AvatarUrlValidator, so a
+    // `picture` (or templated) URL to a private/loopback host is refused exactly the same.
     private static string? ResolveAvatarUrl(IReadOnlyList<Claim> claims, OidConfig config)
     {
-        if (config.AvatarUrlFormat is null)
+        if (string.IsNullOrEmpty(config.AvatarUrlFormat))
         {
-            return null;
+            return ResolvePictureClaim(claims);
         }
 
         return claims.Aggregate(
             config.AvatarUrlFormat,
             (s, claim) => s.Replace($"@{{{claim.Type}}}", claim.Value));
+    }
+
+    // The last non-empty "picture" claim value, or null when none is present (#723). Last wins, matching
+    // the subject/username/email_verified derivations; an empty value is treated as absent so the caller
+    // skips the fetch rather than handing an empty URL to the validator.
+    private static string? ResolvePictureClaim(IReadOnlyList<Claim> claims)
+    {
+        string? picture = null;
+        foreach (var claim in claims)
+        {
+            if (string.Equals(claim.Type, "picture", StringComparison.Ordinal) && !string.IsNullOrEmpty(claim.Value))
+            {
+                picture = claim.Value;
+            }
+        }
+
+        return picture;
     }
 
     // Splits the configured role-claim path on unescaped dots; escaped "\." are normalized to ".".

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -502,6 +502,18 @@ public class OidConfig : ProviderConfigBase
     public string AvatarUrlFormat { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the zero-config fallback to the standard OIDC
+    /// <c>picture</c> claim is disabled (#723). Off by default (the fallback is on), so a
+    /// standards-compliant IdP yields an avatar with no <see cref="AvatarUrlFormat"/> template. Set it
+    /// to opt an admin out of the IdP-driven avatar fetch entirely — with no template and this set, no
+    /// avatar candidate is produced and nothing is fetched. A configured template is unaffected either
+    /// way. The negative name keeps the safe/parity default at <see langword="false"/>, matching the
+    /// other <c>Disable…</c>/<c>DoNot…</c> toggles and surviving deserialization of configs saved before
+    /// this field existed.
+    /// </summary>
+    public bool DisableAvatarFromPictureClaim { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether HTTPS in the discovery endpoint is required.
     /// </summary>
     public bool DisableHttps { get; set; }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -615,6 +615,26 @@
                     </div>
                   </div>
 
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="DisableAvatarFromPictureClaim"
+                        name="DisableAvatarFromPictureClaim"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Disable avatar from the OIDC picture claim</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      With no avatar url format above, the standard OIDC
+                      <code>picture</code> claim is used automatically. Check
+                      this to opt out of that fetch entirely.
+                    </div>
+                  </div>
+
                   <div class="inputContainer">
                     <label
                       class="inputLabel inputLabelUnfocused"


### PR DESCRIPTION
# What & why

Avatar sync only worked when an admin hand-wrote an `AvatarUrlFormat` template with `@{claim}` tokens. With no template, `ResolveAvatarUrl` returned null and the plugin ignored the **standard OIDC `picture` claim** entirely, even when the IdP published a usable avatar URL, every operator had to discover the template syntax to get what OIDC gives for free. This is a concrete V2 parity gap (V2 already ships the fallback) and the kind of zero-config "it just works with a standards-compliant IdP" polish the RC bar expects.

When `AvatarUrlFormat` is null or empty, resolve the `picture` claim (last non-empty value wins, matching the subject/username/email_verified derivations); a configured template still wins, unchanged. An empty template now also falls back to the picture claim rather than resolving to an empty URL as the prior aggregate did.

Closes #723

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the resolver only produces a **candidate** URL. `AvatarService.TrySetAsync` still gates every fetch through `AvatarUrlValidator.IsAllowedUrl`, so a `picture` URL to a private/loopback host is refused exactly like a templated one, the fallback adds no SSRF surface. An empty picture value is treated as absent (no fetch).
- [x] No secrets logged; the disallowed-URL warning already line-sanitizes the URL.
- [x] A security review was performed (adversarial lenses: SSRF/bypass + correctness).
- [x] Log inputs from the IdP are sanitized inline at the log call (unchanged path).

## Quality checklist

- [x] No duplicated logic; the picture lookup is one small last-wins helper mirroring the sibling claim resolvers.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; the comment explains why (zero-config parity) and that the SSRF guard is downstream.
- [x] Architecture-conformance tests pass.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` green (net9.0 1569/1569; net10.0 1569/1569).
- [x] ABI-floor build (net9.0 against targetAbi 10.11.0) green, 0 warnings.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` changed, N/A.

## Notes

Tests mirror V2: template path, template-wins-over-picture, picture fallback, empty-template fallback, last-picture-wins, none-available (null, no fetch), and empty-picture (null, no fetch).