### PR TITLE
Extract the Net module (networking/SSRF/URL primitives) into Api/Net

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -148,6 +148,28 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void NetModule_IsALeaf_ImportsNoOtherApiModule()
+    {
+        // First module-boundary fitness function of the #777 folder migration. The Net module holds the
+        // low-level networking / URL / SSRF primitives (IpAddressClassifier, CanonicalBaseUrl, SsoHttp); it is
+        // a LEAF — dependencies point INTO it, never out. Enforced at the IMPORT level, which also catches
+        // method-body coupling (reflection over signatures would miss a body-only call): using any type from
+        // another Api module requires importing its namespace, so no source file under SSO-Auth/Api/Net may
+        // import a Jellyfin.Plugin.SSO_Auth.Api or Jellyfin.Plugin.SSO_Auth.Api.* namespace. As further modules
+        // land (#777), each adds its own allowed-direction rule; together they lock in the module DAG.
+        var netDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Net");
+        var offenders = Directory.EnumerateFiles(netDir, "*.cs")
+            .SelectMany(file => File.ReadLines(file)
+                .Where(line => Regex.IsMatch(line, @"^\s*using\s+Jellyfin\.Plugin\.SSO_Auth\.Api(\.|;)"))
+                .Select(line => Path.GetFileName(file) + ": " + line.Trim()))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "The Net module is a leaf: no file under Api/Net may import another Api module. Offending imports: " + string.Join(" | ", offenders));
+    }
+
+    [Fact]
     public void MutableKeyedState_LivesOnlyInsideStoreLikeTypes()
     {
         // Locked in by the OidcStateStore consolidation (#318): a raw dictionary holding runtime state

--- a/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/CanonicalBaseUrlTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/IpAddressClassifierTests.cs
+++ b/SSO-Auth.Tests/IpAddressClassifierTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlMetadataTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Jellyfin.Plugin.SSO_Auth.Config;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/SsoHttpTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using NSubstitute;
 using Xunit;
 

--- a/SSO-Auth.Tests/SsoUrlBuilderTests.cs
+++ b/SSO-Auth.Tests/SsoUrlBuilderTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth/Api/AvatarService.cs
+++ b/SSO-Auth/Api/AvatarService.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;

--- a/SSO-Auth/Api/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/AvatarUrlValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Providers;

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 /// <summary>
 /// Normalizes the per-provider canonical external base-URL override (#139). When an admin pins the

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 /// <summary>
 /// Classifies a client-supplied or connection IP address as public or blocked (loopback, private,

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using System.Net.Http;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 /// <summary>
 /// The one home for the plugin's outbound HTTP policy: the User-Agent value and the factory-client

--- a/SSO-Auth/Api/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/OidcDiscoveryReader.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Duende.IdentityModel.Client;
 using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/Api/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/ProviderNameValidator.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Buffers;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Helpers;

--- a/SSO-Auth/Api/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/SsoRateLimiter.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/SsoUrlBuilder.cs
+++ b/SSO-Auth/Api/SsoUrlBuilder.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 internal static class SsoUrlBuilder
 {
     /// <summary>Builds the challenge-time OIDC redirect_uri; the spelling follows the route the login started on.</summary>
-    /// <param name="baseUrl">The canonical base URL, trailing-slash free (from <see cref="CanonicalBaseUrl.Resolve"/>).</param>
+    /// <param name="baseUrl">The canonical base URL, trailing-slash free (from <see cref="Net.CanonicalBaseUrl.Resolve"/>).</param>
     /// <param name="newPath">Whether the login started on the new-path route, choosing "redirect" over "r".</param>
     /// <param name="provider">The route-decoded provider name, appended raw.</param>
     /// <returns>The absolute redirect_uri to register the authorization request under.</returns>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 


### PR DESCRIPTION
# What & why

First module of the #777 folder migration (option B, folders **with** matching namespaces). The flat `Api/` directory hides the module boundaries; this moves the low-level, dependency-free networking primitives into `Jellyfin.Plugin.SSO_Auth.Api.Net` so the module is visible in the tree and in every `using`.

- `IpAddressClassifier`, `CanonicalBaseUrl`, `SsoHttp` → `Api/Net/` (namespace `Api.Net`), import added at each call site.
- **`SsoUrlBuilder` deliberately stays in flat `Api`**: it is not a networking leaf, it composes SSO callback/ACS URLs and calls `OidcCallbackPath`, so it belongs with the routing/URL types that will form a later module. Surfacing that coupling is exactly why the migration runs one module at a time.

Refs #777

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: **pure mechanical move, no behavior change.** No logic, validation, or control flow is touched, only namespaces and imports. Every existing conformance rule (incl. the SSRF/`no-raw-sockets`, verified-identity, and audit-integrity structural rules) stays green, proving the security properties are intact.
- [x] No secrets logged; no secret surface touched.
- [x] A security review is not separately required for a mechanical namespace move; the full conformance + test suite is the verification (documented here).
- [x] Log inputs unchanged.

## Quality checklist

- [x] No duplicated logic; no logic changed at all.
- [x] The change adds no more code than the problem requires (moves + one import per call site).
- [x] Self-documenting; the module is now a named folder/namespace.
- [x] **New structural property locked in:** `NetModule_IsALeaf_ImportsNoOtherApiModule`, no file under `Api/Net` may import another `Api` module, enforced at the import level so it also catches method-body coupling (signature reflection would miss it). Each further module lands its own allowed-direction rule; together they pin the module DAG (directive 4).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` green (net9.0 1572/1572; net10.0 1572/1572, +1 the new conformance rule).
- [x] ABI-floor build (net9.0 against targetAbi 10.11.0) green, 0 warnings.
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed, N/A.

## Notes

Diff is purely the 3 file moves (each a 1-line namespace change), one `using Jellyfin.Plugin.SSO_Auth.Api.Net;` per call site, a doc-comment `cref` qualification in `SsoUrlBuilder`, and the new conformance rule. Nothing else. Next module in the sequence per the #777 plan: another leaf (`Secrets` / `Audit` / `Avatar`).