### PR TITLE
Extract the Secrets module (secrets at rest) into Api/Secrets

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -147,26 +147,29 @@ public class ArchitectureConformanceTests
         Assert.True(outside.Count == 0, "All plugin types must live under the " + Root + " root namespace: " + string.Join(", ", outside));
     }
 
-    [Fact]
-    public void NetModule_IsALeaf_ImportsNoOtherApiModule()
+    // Module-boundary fitness function of the #777 folder migration: each extracted module is a LEAF — no
+    // source file under SSO-Auth/Api/<module> may import ANOTHER Api module. Enforced at the IMPORT level,
+    // which also catches method-body coupling (reflection over signatures would miss a body-only call): using a
+    // type from another Api module requires importing its namespace. Importing NON-Api namespaces (e.g. the
+    // Config persistence model) stays allowed, and a file never imports its own module namespace. As each
+    // module lands (#777) it registers a case here; together the cases lock in the module DAG.
+    [Theory]
+    [InlineData("Net")] // networking / URL / SSRF primitives: IpAddressClassifier, CanonicalBaseUrl, SsoHttp
+    [InlineData("Secrets")] // secrets at rest: SecretStore, SecretEnvelope, ConfigSecretProtection
+    public void ApiModule_IsALeaf_ImportsNoOtherApiModule(string module)
     {
-        // First module-boundary fitness function of the #777 folder migration. The Net module holds the
-        // low-level networking / URL / SSRF primitives (IpAddressClassifier, CanonicalBaseUrl, SsoHttp); it is
-        // a LEAF — dependencies point INTO it, never out. Enforced at the IMPORT level, which also catches
-        // method-body coupling (reflection over signatures would miss a body-only call): using any type from
-        // another Api module requires importing its namespace, so no source file under SSO-Auth/Api/Net may
-        // import a Jellyfin.Plugin.SSO_Auth.Api or Jellyfin.Plugin.SSO_Auth.Api.* namespace. As further modules
-        // land (#777), each adds its own allowed-direction rule; together they lock in the module DAG.
-        var netDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Net");
-        var offenders = Directory.EnumerateFiles(netDir, "*.cs")
+        var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);
+        var selfImport = "Jellyfin.Plugin.SSO_Auth.Api." + module + ";";
+        var offenders = Directory.EnumerateFiles(moduleDir, "*.cs")
             .SelectMany(file => File.ReadLines(file)
-                .Where(line => Regex.IsMatch(line, @"^\s*using\s+Jellyfin\.Plugin\.SSO_Auth\.Api(\.|;)"))
+                .Where(line => Regex.IsMatch(line, @"^\s*using\s+Jellyfin\.Plugin\.SSO_Auth\.Api(\.|;)")
+                    && !line.TrimEnd().EndsWith(selfImport, StringComparison.Ordinal))
                 .Select(line => Path.GetFileName(file) + ": " + line.Trim()))
             .ToList();
 
         Assert.True(
             offenders.Count == 0,
-            "The Net module is a leaf: no file under Api/Net may import another Api module. Offending imports: " + string.Join(" | ", offenders));
+            $"The {module} module is a leaf: no file under Api/{module} may import another Api module. Offending imports: " + string.Join(" | ", offenders));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/ConfigSecretProtectionTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/ConfigXmlLifecycleTests.cs
+++ b/SSO-Auth.Tests/ConfigXmlLifecycleTests.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Xml;
 using System.Xml.Serialization;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;

--- a/SSO-Auth.Tests/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/SSOControllerAddTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;

--- a/SSO-Auth.Tests/SecretEnvelopeTests.cs
+++ b/SSO-Auth.Tests/SecretEnvelopeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SecretStoreTests.cs
+++ b/SSO-Auth.Tests/SecretStoreTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
@@ -1,6 +1,6 @@
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 
 /// <summary>
 /// Encrypts the at-rest secrets carried in a <see cref="PluginConfiguration"/> - the OpenID client secrets

--- a/SSO-Auth/Api/Secrets/SecretEnvelope.cs
+++ b/SSO-Auth/Api/Secrets/SecretEnvelope.cs
@@ -2,7 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 
 /// <summary>
 /// Authenticated envelope encryption for the plugin's at-rest secrets (the OpenID client secret and the

--- a/SSO-Auth/Api/Secrets/SecretStore.cs
+++ b/SSO-Auth/Api/Secrets/SecretStore.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 
 /// <summary>
 /// Owns the plugin's data-encryption key (DEK) and turns config secrets into (and back out of) at-rest

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Duende.IdentityModel.OidcClient.Infrastructure;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;


### PR DESCRIPTION
# What & why

Second module of the #777 folder migration (option B, folders **with** matching namespaces). Moves the at-rest secret handling into `Jellyfin.Plugin.SSO_Auth.Api.Secrets` so the module is visible in the tree and every `using`.

- `SecretStore`, `SecretEnvelope`, `ConfigSecretProtection` → `Api/Secrets/` (namespace `Api.Secrets`), import added at each call site.
- `ConfigSecretProtection` keeps its dependency on the `Config` persistence model (the `SamlConfig` signing-key fields), a non-`Api` namespace, which the leaf rule allows; the two crypto primitives depend on nothing but the BCL.

Refs #777

## Type of change

- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: **pure mechanical move, no behavior change**, only namespaces/imports. The crypto/secrets surface is unchanged; every existing conformance rule (incl. the `Secret<T>`-redaction / secrets-at-rest structural rules) stays green, proving the properties are intact.
- [x] No secrets logged; no secret value handling touched.
- [x] A separate adversarial review is not required for a mechanical namespace move; the full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist

- [x] No duplicated logic, the per-module leaf rule is now a **parameterised theory** `ApiModule_IsALeaf_ImportsNoOtherApiModule` (Net, Secrets), so each further module adds one `InlineData` case instead of copying the body.
- [x] Adds no more code than required (moves + one import per call site).
- [x] Self-documenting; the module is a named folder/namespace.
- [x] New structural property locked in (the Secrets leaf case; directive 4).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` green (net9.0 1573/1573; net10.0 1573/1573).
- [x] ABI-floor build (net9.0 against targetAbi 10.11.0) green, 0 warnings.
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` changed, N/A.

## Notes

Diff is the 3 file moves (1-line namespace each), one `using …Api.Secrets;` per call site, and the conformance-rule generalisation (Net's `[Fact]` → a `[Theory]` with Net + Secrets cases). Nothing else.