### PR TITLE
Extract the Audit module (audit logging) into Api/Audit

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -156,6 +156,7 @@ public class ArchitectureConformanceTests
     [Theory]
     [InlineData("Net")] // networking / URL / SSRF primitives: IpAddressClassifier, CanonicalBaseUrl, SsoHttp
     [InlineData("Secrets")] // secrets at rest: SecretStore, SecretEnvelope, ConfigSecretProtection
+    [InlineData("Audit")] // append-only audit logging: SsoAudit
     public void ApiModule_IsALeaf_ImportsNoOtherApiModule(string module)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/SsoAuditTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Microsoft.Extensions.Logging;
 using Xunit;
 

--- a/SSO-Auth.Tests/SsoOnlyAuditTests.cs
+++ b/SSO-Auth.Tests/SsoOnlyAuditTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
 using Xunit;

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Audit;
 
 /// <summary>
 /// Emits consistent, structured audit-log entries for security-relevant SSO events that exist today:

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
# What & why

Third module of the #777 folder migration (option B, folders with matching namespaces). Moves the append-only SSO audit logger into `Jellyfin.Plugin.SSO_Auth.Api.Audit`.

- `SsoAudit` → `Api/Audit/` (namespace `Api.Audit`), import added at each call site. `SsoAudit` is a leaf, it depends only on the logging abstraction and its own event strings.

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: pure mechanical move, no behavior change. The audit-log structural rules (append-only, same-transaction) are unaffected and stay green.
- [x] No secrets logged; no logging behavior changed.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; the Audit leaf case is one new `InlineData` on the shared theory.
- [x] Adds no more code than required.
- [x] Self-documenting; named folder/namespace.
- [x] New structural property locked in (Audit leaf case).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1574/1574; net10.0 1574/1574).
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A (no js/html/md/css).

## Notes
Diff is the single file move (1-line namespace), one `using …Api.Audit;` per call site (ordering fixed via scoped `dotnet format --include`), and the theory `InlineData`. Nothing else.