### PR TITLE
Extract the Avatar module (avatar fetch) into Api/Avatar

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
@@ -147,30 +148,32 @@ public class ArchitectureConformanceTests
         Assert.True(outside.Count == 0, "All plugin types must live under the " + Root + " root namespace: " + string.Join(", ", outside));
     }
 
-    // Module-boundary fitness function of the #777 folder migration: each extracted module is a LEAF — no
-    // source file under SSO-Auth/Api/<module> may import ANOTHER Api module. Enforced at the IMPORT level,
-    // which also catches method-body coupling (reflection over signatures would miss a body-only call): using a
-    // type from another Api module requires importing its namespace. Importing NON-Api namespaces (e.g. the
-    // Config persistence model) stays allowed, and a file never imports its own module namespace. As each
-    // module lands (#777) it registers a case here; together the cases lock in the module DAG.
+    // Module-boundary fitness function of the #777 folder migration: each extracted module may import ONLY the
+    // Api modules explicitly allowed for it (a leaf allows none), pinning the module dependency DAG. Enforced at
+    // the IMPORT level, which also catches method-body coupling (reflection over signatures would miss a
+    // body-only call): using a type from another Api module requires importing its namespace. Importing NON-Api
+    // namespaces (e.g. the Config persistence model or the still-unmigrated flat Api core) stays allowed, and a
+    // file never imports its own module namespace. As each module lands (#777) it registers a case here with its
+    // allowed dependencies; together the cases lock in the DAG and forbid a cycle.
     [Theory]
-    [InlineData("Net")] // networking / URL / SSRF primitives: IpAddressClassifier, CanonicalBaseUrl, SsoHttp
-    [InlineData("Secrets")] // secrets at rest: SecretStore, SecretEnvelope, ConfigSecretProtection
-    [InlineData("Audit")] // append-only audit logging: SsoAudit
-    public void ApiModule_IsALeaf_ImportsNoOtherApiModule(string module)
+    [InlineData("Net")] // leaf — networking / URL / SSRF primitives: IpAddressClassifier, CanonicalBaseUrl, SsoHttp
+    [InlineData("Secrets")] // leaf — secrets at rest: SecretStore, SecretEnvelope, ConfigSecretProtection
+    [InlineData("Audit")] // leaf — append-only audit logging: SsoAudit
+    [InlineData("Avatar", "Net")] // avatar fetch — validates targets through the Net SSRF classifier
+    public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);
-        var selfImport = "Jellyfin.Plugin.SSO_Auth.Api." + module + ";";
+        var permitted = new HashSet<string>(allowed) { module };
         var offenders = Directory.EnumerateFiles(moduleDir, "*.cs")
             .SelectMany(file => File.ReadLines(file)
-                .Where(line => Regex.IsMatch(line, @"^\s*using\s+Jellyfin\.Plugin\.SSO_Auth\.Api(\.|;)")
-                    && !line.TrimEnd().EndsWith(selfImport, StringComparison.Ordinal))
-                .Select(line => Path.GetFileName(file) + ": " + line.Trim()))
+                .Select(line => Regex.Match(line, @"^\s*using\s+Jellyfin\.Plugin\.SSO_Auth\.Api\.(?<mod>[A-Za-z0-9_]+)\s*;"))
+                .Where(m => m.Success && !permitted.Contains(m.Groups["mod"].Value))
+                .Select(m => Path.GetFileName(file) + ": " + m.Value.Trim()))
             .ToList();
 
         Assert.True(
             offenders.Count == 0,
-            $"The {module} module is a leaf: no file under Api/{module} may import another Api module. Offending imports: " + string.Join(" | ", offenders));
+            $"The {module} module may import only [{string.Join(", ", allowed)}] among Api modules; these imports break that: " + string.Join(" | ", offenders));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/AvatarContentTypeTests.cs
+++ b/SSO-Auth.Tests/AvatarContentTypeTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/AvatarServiceTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;

--- a/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
+++ b/SSO-Auth.Tests/AvatarUrlValidatorTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/LoginCompletionServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Authentication;

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth.Tests/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/SamlLoginServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -5,6 +5,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;

--- a/SSO-Auth/Api/Avatar/AvatarContentType.cs
+++ b/SSO-Auth/Api/Avatar/AvatarContentType.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 
 /// <summary>
 /// Resolves the stored file extension for an avatar HTTP content type, restricted to an allow-list of

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -12,7 +12,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Providers;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 
 /// <summary>
 /// Fetches an SSO provider's avatar over an SSRF-safe transport and stores it as the user's profile

--- a/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 
 /// <summary>
 /// Validation helpers that constrain the server-side avatar fetch to public http(s) targets,

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -8,7 +8,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 /// carrier-grade NAT, link-local, unique/site-local, unspecified, reserved, or multicast), and unwraps the
 /// IPv4 address embedded in an IPv4-in-IPv6 transition form (6to4, NAT64, the deprecated IPv4-compatible
 /// form). Two unrelated callers share this one definition so they can never disagree on what counts as a
-/// public address: the avatar-fetch SSRF guard (<see cref="AvatarUrlValidator"/>) rejects a blocked target
+/// public address: the avatar-fetch SSRF guard (AvatarUrlValidator) rejects a blocked target
 /// before fetching it, and the login rate limiter (<see cref="SsoRateLimiter.NormalizeClientKey"/>) exempts a
 /// blocked/non-public connection address from throttling entirely. Neither caller's own file is the right
 /// home for this shared invariant — tuning the avatar SSRF policy must never silently change which clients

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 #nullable enable

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -9,6 +9,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
# What & why

Fourth module of the #777 folder migration. Moves avatar resolution/fetch into `Jellyfin.Plugin.SSO_Auth.Api.Avatar`.

- `AvatarService`, `AvatarUrlValidator`, `AvatarContentType` → `Api/Avatar/` (namespace `Api.Avatar`), import added at each call site.
- **First non-leaf module:** `AvatarUrlValidator` validates fetch targets through the Net SSRF classifier, so Avatar may depend on **Net and only Net**.

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: pure mechanical move, no behavior change. The avatar SSRF guard and its wiring are unchanged; every existing conformance rule stays green.
- [x] No secrets logged.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic, the leaf rule is generalised to `ApiModule_ImportsOnlyItsAllowedApiModules(module, params allowed)`, so a leaf lists no allowed modules and Avatar lists `Net`. This locks in the module **dependency DAG** and forbids a cycle (e.g. a Net→Avatar edge is rejected).
- [x] Adds no more code than required.
- [x] Self-documenting; named folder/namespace.
- [x] New structural property locked in (Avatar→Net allowed edge; directive 4).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1575/1575; net10.0 1575/1575).
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
Diff is the 3 file moves (1-line namespace each), one `using …Api.Avatar;` per call site, the conformance-rule generalisation, and a 1-line change dropping a cross-module `<see cref>` in the Net `IpAddressClassifier` doc comment (it would otherwise couple the Net leaf to Avatar). Nothing else.