### PR TITLE
Extract the RateLimit module (login throttling) into Api/RateLimit

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
@@ -160,6 +161,7 @@ public class ArchitectureConformanceTests
     [InlineData("Secrets")] // leaf — secrets at rest: SecretStore, SecretEnvelope, ConfigSecretProtection
     [InlineData("Audit")] // leaf — append-only audit logging: SsoAudit
     [InlineData("Avatar", "Net")] // avatar fetch — validates targets through the Net SSRF classifier
+    [InlineData("RateLimit", "Net")] // login throttling — keys buckets by the Net client-IP classifier
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/CanonicalLinkServiceTests.cs
@@ -5,6 +5,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
 using NSubstitute;

--- a/SSO-Auth.Tests/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/IntervalGateTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/KeyedLockStoreTests.cs
+++ b/SSO-Auth.Tests/KeyedLockStoreTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/PerClientBudgetLimiterTests.cs
+++ b/SSO-Auth.Tests/PerClientBudgetLimiterTests.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/ProviderNameValidatorTests.cs
+++ b/SSO-Auth.Tests/ProviderNameValidatorTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth.Tests/SsoRateLimitGateTests.cs
+++ b/SSO-Auth.Tests/SsoRateLimitGateTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/SSO-Auth.Tests/SsoRateLimiterTests.cs
+++ b/SSO-Auth.Tests/SsoRateLimiterTests.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -8,6 +8,7 @@ using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Providers;

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth/Api/KeyedLockStore.cs
+++ b/SSO-Auth/Api/KeyedLockStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -7,6 +7,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.Cryptography;

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 /// IPv4 address embedded in an IPv4-in-IPv6 transition form (6to4, NAT64, the deprecated IPv4-compatible
 /// form). Two unrelated callers share this one definition so they can never disagree on what counts as a
 /// public address: the avatar-fetch SSRF guard (AvatarUrlValidator) rejects a blocked target
-/// before fetching it, and the login rate limiter (<see cref="SsoRateLimiter.NormalizeClientKey"/>) exempts a
+/// before fetching it, and the login rate limiter (SsoRateLimiter.NormalizeClientKey) exempts a
 /// blocked/non-public connection address from throttling entirely. Neither caller's own file is the right
 /// home for this shared invariant — tuning the avatar SSRF policy must never silently change which clients
 /// the login rate limiter exempts, and vice versa (#370).
@@ -45,7 +45,7 @@ internal static class IpAddressClassifier
     /// NAT64 well-known prefix <c>64:ff9b::/96</c>, or the deprecated IPv4-compatible <c>::/96</c> form). Both
     /// callers of this classifier share this single definition so they cannot disagree on what an embedded
     /// IPv4 is: the SSRF classifier unwraps it so a blocked internal IPv4 cannot be reached by wrapping it in
-    /// one of these formats, and the rate limiter (<see cref="SsoRateLimiter.NormalizeClientKey"/>) keys a
+    /// one of these formats, and the rate limiter (SsoRateLimiter.NormalizeClientKey) keys a
     /// transition source on its embedded IPv4 instead of collapsing every such client into one shared /64
     /// bucket.
     /// </summary>

--- a/SSO-Auth/Api/OidcStateStore.cs
+++ b/SSO-Auth/Api/OidcStateStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/ProviderNameValidator.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Buffers;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/RateLimit/IntervalGate.cs
+++ b/SSO-Auth/Api/RateLimit/IntervalGate.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
 /// A once-per-interval throttle cursor shared by the anonymous-path sweeps and log signals that must

--- a/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
 /// A per-client occupancy sub-cap shared by the in-flight state stores (#327). Each store owns one

--- a/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
 /// Forms the provider-scoped one-time-use key for the SAML replay and outstanding-AuthnRequest caches,

--- a/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
@@ -6,7 +6,7 @@ using System.Net.Sockets;
 using System.Threading;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
 /// Opt-in fixed-window rate limiter for the anonymous SSO flow endpoints (#128), keyed on the

--- a/SSO-Auth/Api/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/SamlAssertionValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
 

--- a/SSO-Auth/Api/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/SamlOutcomeStore.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/SamlReplayCache.cs
+++ b/SSO-Auth/Api/SamlReplayCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/SamlRequestCache.cs
+++ b/SSO-Auth/Api/SamlRequestCache.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,6 +1,7 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -103,7 +103,7 @@ rules:
       include:
         - "SSO-Auth/**/*.cs"
       exclude:
-        - "SSO-Auth/Api/IntervalGate.cs"
+        - "SSO-Auth/Api/RateLimit/IntervalGate.cs"
 
   # Invariant (architecture, #318 config boundary): every configuration access
   # goes through ProviderConfigStore behind SSOPlugin's facade (ReadConfiguration


### PR DESCRIPTION
# What & why

Fifth module of the #777 folder migration. Moves the login-throttling primitives into `Jellyfin.Plugin.SSO_Auth.Api.RateLimit`.

- `SsoRateLimiter`, `PerClientBudgetLimiter`, `IntervalGate`, `ProviderScopedKey` → `Api/RateLimit/` (namespace `Api.RateLimit`), import added at each call site.
- Depends on **Net and only Net** (buckets keyed by the Net client-IP classifier).

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: pure mechanical move, no behavior change. The rate limiter's throttle-never-lock behavior and every existing conformance rule stay green.
- [x] No secrets logged.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; the RateLimit→Net edge is one new `InlineData` on the DAG theory.
- [x] Adds no more code than required.
- [x] Self-documenting; named folder/namespace.
- [x] New structural property locked in (RateLimit→Net edge).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1576/1576; net10.0 1576/1576).
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
The module-DAG conformance rule caught a real coupling during this move: the Net leaf `IpAddressClassifier` picked up an `Api.RateLimit` import via two `<see cref="SsoRateLimiter.NormalizeClientKey"/>` doc references. Those crefs are dropped to plain text (2 lines) so the Net leaf stays decoupled, same treatment the Avatar move gave its `AvatarUrlValidator` cref. Rest of the diff is the 4 moves + one import per call site + the theory `InlineData`.