### PR TITLE
Extract the Authz module (role to permission mapping) into Api/Authz

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -162,6 +162,7 @@ public class ArchitectureConformanceTests
     [InlineData("Audit")] // leaf — append-only audit logging: SsoAudit
     [InlineData("Avatar", "Net")] // avatar fetch — validates targets through the Net SSRF classifier
     [InlineData("RateLimit", "Net")] // login throttling — keys buckets by the Net client-IP classifier
+    [InlineData("Authz")] // leaf — role→permission mapping: PermissionGrant, PermissionRolePolicy, RolePrivilegeMapper
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/PermissionRolePolicyTests.cs
+++ b/SSO-Auth.Tests/PermissionRolePolicyTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/PropertyTests.cs
+++ b/SSO-Auth.Tests/PropertyTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using FsCheck;
 using FsCheck.Fluent;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/RolePrivilegeMapperTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/SessionMinterTests.cs
@@ -5,6 +5,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Configuration;

--- a/SSO-Auth/Api/Authz/PermissionGrant.cs
+++ b/SSO-Auth/Api/Authz/PermissionGrant.cs
@@ -1,6 +1,6 @@
 using Jellyfin.Database.Implementations.Enums;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 /// <summary>
 /// A single generic permission grant a login resolves: the Jellyfin permission and whether it is granted

--- a/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
@@ -6,7 +6,7 @@ using Jellyfin.Plugin.SSO_Auth.Config;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 /// <summary>
 /// Maps the roles carried by a verified login to the generic Jellyfin permission grants they produce

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 /// <summary>
 /// Maps the roles carried by a verified login (OpenID or SAML) to the privileges they grant, according

--- a/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/OidcAuthorizeStateBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/SamlAuthorizeStateBuilder.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 #nullable enable

--- a/SSO-Auth/Api/SessionMinter.cs
+++ b/SSO-Auth/Api/SessionMinter.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;

--- a/SSO-Auth/Api/SessionParameters.cs
+++ b/SSO-Auth/Api/SessionParameters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 #nullable enable
 

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 #nullable enable
 

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;


### PR DESCRIPTION
# What & why

Sixth module of the #777 folder migration. Moves the generic role→permission types into `Jellyfin.Plugin.SSO_Auth.Api.Authz`.

- `PermissionGrant`, `PermissionRolePolicy`, `RolePrivilegeMapper` → `Api/Authz/` (namespace `Api.Authz`), import added at each call site. **Leaf**, no Api-module dependency.
- `OidcRoleExtractor` is intentionally left in flat `Api`: it is OIDC-flavoured claim extraction and moves with the Oidc module.

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: pure mechanical move, no behavior change. The authorization structural rules (permission-grant shapes, role mapping) are unchanged and every conformance rule stays green.
- [x] No secrets logged.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; the Authz leaf case is one new `InlineData` on the DAG theory.
- [x] Adds no more code than required.
- [x] Self-documenting; named folder/namespace.
- [x] New structural property locked in (Authz leaf).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1577/1577; net10.0 1577/1577).
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
Diff is the 3 file moves (1-line namespace each), one `using …Api.Authz;` per call site, and the theory `InlineData`. Nothing else.