### PR TITLE
Extract the Saml module (SAML core, validators, caches) into Api/Saml

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
@@ -167,6 +168,7 @@ public class ArchitectureConformanceTests
     [InlineData("Authz")] // leaf — role→permission mapping: PermissionGrant, PermissionRolePolicy, RolePrivilegeMapper
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
     [InlineData("Linking", "Audit", "Provider", "RateLimit")] // account linking — audits writes, validates providers, throttles
+    [InlineData("Saml", "Authz", "RateLimit")] // SAML core/validators — maps roles (Authz), throttles (RateLimit)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/LoginCompletionServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;

--- a/SSO-Auth.Tests/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/ProviderScopedKeyTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Xunit;
 

--- a/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;

--- a/SSO-Auth.Tests/SamlAssertionValidatorTests.cs
+++ b/SSO-Auth.Tests/SamlAssertionValidatorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;

--- a/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlAuthorizeStateBuilderTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlCertificateTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/SamlInsecureTogglesTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlLoginPolicyTests.cs
+++ b/SSO-Auth.Tests/SamlLoginPolicyTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/SamlOutcomeStoreTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/SamlRecipientValidatorTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlRedirectSignerTests.cs
+++ b/SSO-Auth.Tests/SamlRedirectSignerTests.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/SamlReplayCacheTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;

--- a/SSO-Auth.Tests/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/SamlRequestCacheTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/SamlResponseParsingTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography.Xml;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
+++ b/SSO-Auth.Tests/SamlSecondaryCertificateTests.cs
@@ -195,7 +195,7 @@ public class SamlSecondaryCertificateTests
         // front; a hand-edited config is caught here.
         var fixture = SamlTestFactory.Create();
 
-        Assert.False(Jellyfin.Plugin.SSO_Auth.Api.SamlResponseLoader.TryParse(
+        Assert.False(Jellyfin.Plugin.SSO_Auth.Api.Saml.SamlResponseLoader.TryParse(
             fixture.CertificateBase64, "QUJD", fixture.EncodeResponse(), out var response));
         Assert.Null(response);
     }

--- a/SSO-Auth.Tests/SamlSigningKeyTests.cs
+++ b/SSO-Auth.Tests/SamlSigningKeyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/SamlSpMetadataBuilderTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Xml.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/SsoControllerHarness.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/ValidateSamlTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;

--- a/SSO-Auth.Tests/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/VerifiedIdentityTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Xunit;
 

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -12,7 +12,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 /// result into the authorize state (OR-ing the booleans, appending the folders). One mapper for both
 /// protocols, since every member it reads lives on <see cref="ProviderConfigBase"/> (#367). The SAML
 /// caller ignores <see cref="RoleGrants.Valid"/> — SAML login validity is decided by
-/// <see cref="SamlLoginPolicy"/>, not here.
+/// <see cref="Jellyfin.Plugin.SSO_Auth.Api.Saml.SamlLoginPolicy"/>, not here.
 /// </summary>
 internal static class RolePrivilegeMapper
 {
@@ -81,7 +81,7 @@ internal static class RolePrivilegeMapper
     /// merge that used to be duplicated, byte-identical, in the OpenID and SAML authorize-state builders
     /// (#508). The OpenID builder OR-s the returned <see cref="AssembledPrivileges.Valid"/> into its own
     /// running validity; the SAML builder ignores it — validity there is decided by
-    /// <see cref="SamlLoginPolicy"/>, not here.
+    /// <see cref="Jellyfin.Plugin.SSO_Auth.Api.Saml.SamlLoginPolicy"/>, not here.
     /// </summary>
     /// <param name="roles">The roles extracted from the verified login (OpenID claims or SAML attributes).</param>
     /// <param name="config">The provider configuration.</param>
@@ -114,7 +114,7 @@ internal static class RolePrivilegeMapper
     /// <summary>
     /// The privileges a set of roles grants under a provider configuration.
     /// </summary>
-    /// <param name="Valid">Whether any role is on the login allow-list (<see cref="ProviderConfigBase.Roles"/>). Ignored by the SAML caller, whose validity is decided by <see cref="SamlLoginPolicy"/>.</param>
+    /// <param name="Valid">Whether any role is on the login allow-list (<see cref="ProviderConfigBase.Roles"/>). Ignored by the SAML caller, whose validity is decided by <see cref="Jellyfin.Plugin.SSO_Auth.Api.Saml.SamlLoginPolicy"/>.</param>
     /// <param name="Admin">Whether any role is on the admin list (<see cref="ProviderConfigBase.AdminRoles"/>).</param>
     /// <param name="EnableLiveTv">Whether any role grants Live TV (only when role-based Live TV is enabled).</param>
     /// <param name="EnableLiveTvManagement">Whether any role grants Live TV management (only when role-based Live TV is enabled).</param>
@@ -129,7 +129,7 @@ internal static class RolePrivilegeMapper
     /// <summary>
     /// The assembled authorize-state privileges for a login, produced by <see cref="AssemblePrivileges"/>.
     /// </summary>
-    /// <param name="Valid">Whether any role is on the login allow-list. Ignored by the SAML caller, whose validity is decided by <see cref="SamlLoginPolicy"/>.</param>
+    /// <param name="Valid">Whether any role is on the login allow-list. Ignored by the SAML caller, whose validity is decided by <see cref="Jellyfin.Plugin.SSO_Auth.Api.Saml.SamlLoginPolicy"/>.</param>
     /// <param name="Admin">Whether the login grants administrator rights.</param>
     /// <param name="EnableLiveTv">Whether the login grants Live TV access (config default OR role grant).</param>
     /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management (config default OR role grant).</param>

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -9,6 +9,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -14,6 +14,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Jellyfin.Plugin.SSO_Auth.Helpers;

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -4,7 +4,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// The single home for inbound SAML assertion validation (#496, #318): parse plus signature, time-bound,

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -4,7 +4,7 @@ using Jellyfin.Plugin.SSO_Auth.Config;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Derives the per-login authorize-state privileges (admin, Live TV, Live TV management, folder

--- a/SSO-Auth/Api/Saml/SamlCertificate.cs
+++ b/SSO-Auth/Api/Saml/SamlCertificate.cs
@@ -2,7 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Validates the per-provider SAML signing certificate (#206). A non-blank but unloadable

--- a/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Names the per-provider SAML options that switch off a default-on protection (#672, the SAML parity of

--- a/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Pure login-authorization gate for SAML: decides whether an assertion's roles satisfy the

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// The in-flight SAML login-outcome store (#251): the assertion-consumer callback validates the signed

--- a/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Pure endpoint-binding check for a SAML response (#156): the bearer SubjectConfirmationData

--- a/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
+++ b/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
@@ -3,7 +3,7 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Signs an outgoing SAML message for the HTTP-Redirect binding (SAML Bindings 3.4.4.1, #167). The plugin

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Tracks SAML assertion IDs that have already been used to mint a session, so a captured assertion

--- a/SSO-Auth/Api/Saml/SamlRequestCache.cs
+++ b/SSO-Auth/Api/Saml/SamlRequestCache.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Tracks the IDs of SAML AuthnRequests this service provider has issued but not yet seen answered,

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -2,7 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Xml;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Safely constructs a <see cref="SamlResponse"/> from an untrusted SAML response string (#199). The

--- a/SSO-Auth/Api/Saml/SamlSigningKey.cs
+++ b/SSO-Auth/Api/Saml/SamlSigningKey.cs
@@ -2,7 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Loads this service provider's SAML signing key (#167). The key is supplied by the operator as a

--- a/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Text;
 using System.Xml;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Builds SAML 2.0 service-provider metadata — an <c>EntityDescriptor</c> carrying an

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 #nullable enable
 

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;
 

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -4,6 +4,7 @@ using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Saml.cs
+++ b/SSO-Auth/Saml.cs
@@ -17,6 +17,7 @@ using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Web;
 using System.Xml;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 namespace Jellyfin.Plugin.SSO_Auth;
 
@@ -716,6 +717,6 @@ internal sealed class SamlAuthnRequest
     {
         ArgumentNullException.ThrowIfNull(samlEndpoint);
 
-        return Api.SamlRedirectSigner.BuildSignedRedirectUrl(samlEndpoint, "SAMLRequest", GetRequest(), relayState, signingKey);
+        return SamlRedirectSigner.BuildSignedRedirectUrl(samlEndpoint, "SAMLRequest", GetRequest(), relayState, signingKey);
     }
 }


### PR DESCRIPTION
# What & why

Ninth module of the #777 folder migration, the SAML surface. Moves the 13 `Saml*` types into `Jellyfin.Plugin.SSO_Auth.Api.Saml` so the SAML module is visible in the tree and every `using`.

Allowed deps: **Authz** (role mapping), **RateLimit** (throttling); plus the still-flat `Api` core (`SsoUrlBuilder`, `VerifiedIdentity`), permitted during the migration.

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: **pure mechanical move, no behavior change**, only namespaces/imports. The SAML assertion/recipient/replay validation, signing, and metadata logic is untouched; every existing conformance rule (SAML replay-cap gate, one-time outcome, recipient binding, etc.) stays green.
- [x] No secrets logged; no signing-key handling changed.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; the Saml→{Authz,RateLimit} edges are one `InlineData` on the DAG theory.
- [x] Adds no more code than required (moves + one import per call site + three qualified-reference fixes the move required).
- [x] Self-documenting; the whole SAML surface is now one namespace.
- [x] New structural property locked in (Saml edges).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1579/1579; net10.0 1579/1579).
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
Beyond the 13 moves + one import per call site, the diff carries three necessary reference fixes the move forced: `Saml.cs`'s `Api.SamlRedirectSigner` → unqualified; a test's fully-qualified `…Api.SamlResponseLoader` → `…Api.Saml.SamlResponseLoader`; and four `<see cref="SamlLoginPolicy"/>` doc refs in the Authz leaf `RolePrivilegeMapper` fully-qualified so the doc link survives without importing Saml into a leaf (which the DAG rule forbids).