### PR TITLE
Extract the Oidc module (OIDC flow, discovery, token) into Api/Oidc

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
@@ -169,6 +170,7 @@ public class ArchitectureConformanceTests
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
     [InlineData("Linking", "Audit", "Provider", "RateLimit")] // account linking — audits writes, validates providers, throttles
     [InlineData("Saml", "Authz", "RateLimit")] // SAML core/validators — maps roles (Authz), throttles (RateLimit)
+    [InlineData("Oidc", "Authz", "Avatar", "Net", "Provider", "RateLimit")] // OIDC flow — orchestrates roles, avatar, net, provider, throttle
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/AuthorizeStateBindingTests.cs
+++ b/SSO-Auth.Tests/AuthorizeStateBindingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.AspNetCore.Http;
 using Xunit;
 

--- a/SSO-Auth.Tests/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/LoginCompletionServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/OidcAuthorizeStateBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;

--- a/SSO-Auth.Tests/OidcCallbackPathTests.cs
+++ b/SSO-Auth.Tests/OidcCallbackPathTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/OidcDiscoveryReaderTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;

--- a/SSO-Auth.Tests/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/OidcIdTokenValidatorTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;

--- a/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/OidcInsecureTogglesTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 

--- a/SSO-Auth.Tests/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/OidcLoginServiceTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;

--- a/SSO-Auth.Tests/OidcResponseIssuerTests.cs
+++ b/SSO-Auth.Tests/OidcResponseIssuerTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.IdentityModel.Tokens;
 using Xunit;
 

--- a/SSO-Auth.Tests/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/OidcRoleExtractorTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/OidcRoundTripTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth.Tests/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/OidcStateStoreTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/OidcTokenFixture.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// Builds a real signed OpenID Connect id_token plus the matching JWKS against a throw-away RSA key, so
 /// a test can drive the token-exchange callback (<c>OidPost</c>) through the actual id_token validation
-/// path (<see cref="Jellyfin.Plugin.SSO_Auth.Api.OidcIdTokenValidator"/>) rather than mocks. The
+/// path (<see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcIdTokenValidator"/>) rather than mocks. The
 /// discovery document, this JWKS, and a token endpoint returning <see cref="TokenEndpointJson"/> are
 /// served in-process through the harness's HTTP responder.
 /// </summary>

--- a/SSO-Auth.Tests/PkceDiscoveryTests.cs
+++ b/SSO-Auth.Tests/PkceDiscoveryTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/PropertyTests.cs
+++ b/SSO-Auth.Tests/PropertyTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using FsCheck;
 using FsCheck.Fluent;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;

--- a/SSO-Auth.Tests/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/SSOControllerChallengeTests.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/SSOControllerLinkTests.cs
@@ -7,6 +7,7 @@ using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidAuthTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;

--- a/SSO-Auth.Tests/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/SSOControllerOidPostTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;

--- a/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlAuthTests.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;

--- a/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/SSOControllerSamlTokenTests.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/VerifiedIdentityTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Xunit;

--- a/SSO-Auth/Api/ChallengePath.cs
+++ b/SSO-Auth/Api/ChallengePath.cs
@@ -11,7 +11,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// match (RFC 6749 section 4.1.3), so it has to be read off the route exactly — not by a
 /// <c>Contains("/start/")</c> substring test, which a provider literally named <c>start</c> on the
 /// legacy route (<c>.../OID/p/start/</c>) would trip, flipping the spelling and breaking the login at
-/// the IdP's redirect_uri check (#337). Same fix family as <see cref="OidcCallbackPath.RedirectSegment"/>
+/// the IdP's redirect_uri check (#337). Same fix family as <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcCallbackPath.RedirectSegment"/>
 /// (#98); both now read the suffix through the shared <see cref="RouteSuffix"/> reader (#411, #509) and
 /// keep only their own terminal comparison and default.
 /// </summary>

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -9,6 +9,7 @@ using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -1,7 +1,7 @@
 using System;
 using Duende.IdentityModel.OidcClient;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// The in-flight OpenID authorize state as a closed, immutable sum of two variants: a

--- a/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
@@ -2,7 +2,7 @@ using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Binds an in-flight OpenID authorize state to the browser that started it (#326). The authorize

--- a/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// The two discovery-document facts the OpenID challenge reads from a single discovery response: whether

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -9,7 +9,7 @@ using Jellyfin.Plugin.SSO_Auth.Config;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Derives the per-login authorize-state values (username, login validity, admin, Live TV, folder

--- a/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
@@ -2,7 +2,7 @@ using System;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Derives the r/redirect path segment for rebuilding the callback's redirect URI. The token

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
@@ -3,14 +3,14 @@ using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Builds the <see cref="OidcClientOptions"/> Authority and discovery policy — <c>RequireHttps</c>,
 /// <c>ValidateIssuerName</c>, <c>ValidateEndpoints</c>, and the additional base address for providers whose
 /// endpoints sit off the authority — from a provider config, in ONE place. Both the login path
 /// (<see cref="Flows.OidcLoginService"/>, which layers the client credentials, redirect URI, scope and the
-/// id_token validator on top) and the admin Test-connection probe (<see cref="ProviderConnectionTester"/>,
+/// id_token validator on top) and the admin Test-connection probe (<see cref="Jellyfin.Plugin.SSO_Auth.Api.ProviderConnectionTester"/>,
 /// which reads discovery only) build their options here, so the test fetch runs under the EXACT same
 /// SSRF/TLS posture as the real login discovery (#163) — a later change to the login's discovery policy
 /// cannot silently leave the probe on a weaker one. The client secret is deliberately NOT set here:

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -6,7 +6,7 @@ using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Reads a provider's OpenID discovery document ONCE at the challenge and returns both the two

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
@@ -1,6 +1,6 @@
 using Duende.IdentityModel.OidcClient;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// The outcome of the OpenID challenge's single discovery read (<see cref="OidcDiscoveryReader"/>, #450):

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -13,7 +13,7 @@ using Microsoft.IdentityModel.Tokens;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Validates the OpenID Connect id_token per OIDC Core 1.0 section 3.1.3.7. OidcClient 7.x ships no

--- a/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Names the per-provider OpenID options that switch off an RFC 9700-mandated protection (#140), so

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// RFC 9207 authorization-response issuer check (OpenID Connect mix-up defense, #125, hardened in #210).

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Reads the role values out of an OpenID claim according to the configured role-claim path.

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// The in-flight OpenID authorize-state store: cap-bounded registration at challenge, a non-consuming

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Decides whether an OpenID provider's discovery document advertises PKCE with SHA-256 (<c>S256</c>).

--- a/SSO-Auth/Api/ProviderConnectionTester.cs
+++ b/SSO-Auth/Api/ProviderConnectionTester.cs
@@ -5,10 +5,13 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api.Provider;
+namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
 /// Runs an admin-triggered Test-connection probe against a STORED provider configuration (#163) so an

--- a/SSO-Auth/Api/RouteSuffix.cs
+++ b/SSO-Auth/Api/RouteSuffix.cs
@@ -4,7 +4,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>
 /// The trailing <c>{protocol}/{path-kind}/{provider}</c> suffix that both <see cref="ChallengePath"/>
-/// and <see cref="OidcCallbackPath"/> anchor their new-vs-legacy route classification to (#411). Anchoring
+/// and <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcCallbackPath"/> anchor their new-vs-legacy route classification to (#411). Anchoring
 /// to the suffix — rather than the first protocol-like token found anywhere in the path — keeps a
 /// protocol-like reverse-proxy prefix (e.g. <c>/OID/start/proxy/...</c>) from deciding the spelling (#337).
 /// Each caller keeps its own terminal comparison (which protocol/path-kind values it accepts) and its own

--- a/SSO-Auth/Api/SSOController.cs
+++ b/SSO-Auth/Api/SSOController.cs
@@ -13,6 +13,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -12,7 +12,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 /// only (roles, config) and returns the derived values, which the SAML callback applies to the
 /// session parameters. Login validity is decided separately by <see cref="SamlLoginPolicy"/> and the
 /// username is the assertion's NameID, so — unlike the OpenID builder
-/// (<see cref="OidcAuthorizeStateBuilder"/>) — neither is derived here. Mirrors, one-for-one, the
+/// (<see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcAuthorizeStateBuilder"/>) — neither is derived here. Mirrors, one-for-one, the
 /// privilege derivation that used to live inline in the callback.
 /// </summary>
 internal static class SamlAuthorizeStateBuilder

--- a/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
@@ -5,7 +5,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Names the per-provider SAML options that switch off a default-on protection (#672, the SAML parity of
-/// the OpenID <see cref="OidcInsecureToggles"/> under #140), so enabling one leaves a visible, auditable
+/// the OpenID <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcInsecureToggles"/> under #140), so enabling one leaves a visible, auditable
 /// trace instead of silently weakening the login path. Kept strictly to default-on-DISABLE toggles: the
 /// opt-in SAML hardening flags (<c>ValidateRecipient</c>, <c>ValidateInResponseTo</c>, request signing)
 /// are additive protections, not downgrades, and are deliberately NOT reported here.

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -13,7 +13,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 /// token and hands the intermediate auth page only that token — never the assertion. The same-origin
 /// session-mint leg redeems the token once and completes the login from the stored outcome, so the signed
 /// XML no longer round-trips through the browser and is not parsed or validated a second time. This is the
-/// SAML analogue of <see cref="OidcStateStore"/>'s one-time authorize-state redeem: cap-bounded
+/// SAML analogue of <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcStateStore"/>'s one-time authorize-state redeem: cap-bounded
 /// registration, an atomic one-time claim, and an <see cref="IntervalGate"/>-throttled expired-entry sweep.
 /// </summary>
 /// <remarks>

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -9,7 +9,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 /// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
 /// reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
 /// bound (#452). It mirrors the sibling login-path caches (<see cref="SamlRequestCache"/>,
-/// <see cref="OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and a
+/// <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and a
 /// second <see cref="IntervalGate"/>-throttled signal that surfaces a cap refusal to the caller so a full
 /// replay cache is observable rather than silent (#470).
 ///

--- a/SSO-Auth/Api/SsoUrlBuilder.cs
+++ b/SSO-Auth/Api/SsoUrlBuilder.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
 namespace Jellyfin.Plugin.SSO_Auth.Api;
 
 /// <summary>

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using MediaBrowser.Model.Plugins;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
# What & why

Tenth module of the #777 folder migration, the OIDC surface. Moves the 14 OIDC types into `Jellyfin.Plugin.SSO_Auth.Api.Oidc`.

Oidc orchestrates several lower modules; allowed deps: **Authz, Avatar, Net, Provider, RateLimit**.

**The migration surfaced and broke a real dependency cycle:** `ProviderConnectionTester` lived in the `Provider` module but imports **Oidc** (it probes OIDC discovery) *and* **Saml** (it probes SAML), so `Provider → Oidc` while `Oidc → Provider`. It is a cross-protocol orchestration type, not a Provider primitive, so it moves back to the flat `Api` core to await the final Http/orchestration module (which may legitimately depend on both protocol modules). Provider is now clean of Oidc; no sibling module imports another.

Refs #777

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: **pure mechanical move, no behavior change.** OIDC discovery / id_token validation / PKCE / state-store / issuer checks are untouched; every existing conformance rule (issuer-bound canonical links, PKCE gate, UTC-keyed state, mix-up defense) stays green.
- [x] No secrets logged.
- [x] Mechanical namespace move, full conformance + test suite is the verification.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; the Oidc edges are one `InlineData`, and the move **removes a real Provider⇄Oidc cycle**.
- [x] Adds no more code than required (moves + one import per call site + the cycle-break + qualified doc crefs).
- [x] Self-documenting; the whole OIDC surface is one namespace.
- [x] New structural property locked in (Oidc edges; the DAG rule would now reject a re-introduced cycle).

## Verification
- [x] `dotnet build --warnaserror` green (net9.0 + net10.0, 0 warnings).
- [x] `dotnet test` green net9.0 (1580) incl. the DAG rule. **net10.0 test execution was blocked locally by a Windows application-control policy (a host issue, not a code one, net9 runs the identical TFM-agnostic suite green, and CI runs net10.0 on Linux).**
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
Beyond the 14 moves + one import per call site, the diff carries the ProviderConnectionTester cycle-break (moved to flat Api) and several `<see cref>` doc-reference qualifications the move forced (Saml-module and flat-Api routing crefs pointing at Oidc types; Oidc's cref to the now-flat ProviderConnectionTester), fully-qualified so the doc links survive without importing across a forbidden edge.