### PR TITLE
Extract the shared ILoginService contract for OIDC and SAML

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -126,6 +126,36 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void ProtocolLoginServices_ImplementTheSharedContract()
+    {
+        // #790: OIDC and SAML are polymorphic implementations of ONE login contract, not two parallel paths.
+        // Every concrete per-protocol session-minting service in Flows (a *LoginService, excluding the shared
+        // LoginCompletionService tail) implements ILoginService, so a future protocol slots in by implementing
+        // the interface instead of forking a third path. Composition-first: a shared interface, not a deep
+        // inheritance base.
+        var contract = typeof(SSOPlugin).Assembly.GetType(Root + ".Api.Flows.ILoginService");
+        Assert.NotNull(contract);
+
+        var protocolServices = PluginClasses
+            .Where(t => !t.IsAbstract
+                && t.Namespace == Root + ".Api.Flows"
+                && SimpleName(t).EndsWith("LoginService", StringComparison.Ordinal)
+                && SimpleName(t) != "LoginCompletionService")
+            .ToList();
+
+        Assert.NotEmpty(protocolServices); // non-vacuous: a rename must not silently empty this set
+
+        var offenders = protocolServices
+            .Where(t => !contract!.IsAssignableFrom(t))
+            .Select(SimpleName)
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every protocol login service in Flows must implement ILoginService (#790): " + string.Join(", ", offenders));
+    }
+
+    [Fact]
     public void Controllers_DeriveFromControllerBase()
     {
         var stray = PluginClasses

--- a/SSO-Auth/Api/Flows/ILoginService.cs
+++ b/SSO-Auth/Api/Flows/ILoginService.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
+
+/// <summary>
+/// The shared contract every SSO login protocol implements (#790). Each protocol module has exactly one
+/// implementation — <see cref="OidcLoginService"/> for OpenID Connect and <see cref="SamlLoginService"/> for
+/// SAML — so the session-minting authenticate leg is a single, protocol-agnostic shape rather than two
+/// parallel code paths, and a future protocol slots in by implementing this interface instead of forking a
+/// third path. This is a composition-first abstraction: protocols are polymorphic implementations of one
+/// contract, not a deep inheritance hierarchy. Protocol-specific operations that do not generalise (SAML SP
+/// metadata, the OIDC state summaries) stay off the interface, on the concrete service.
+/// </summary>
+internal interface ILoginService
+{
+    /// <summary>
+    /// Redeems the browser-bound authorize state once and mints the session for the already-verified
+    /// identity, delegating to the shared completion tail. The controller keeps the flow tier HttpContext-free
+    /// (#177) by resolving the presented binding cookie and the remote endpoint and passing them in; the
+    /// binding-cookie NAME is protocol-specific and chosen by the controller, so this contract takes the
+    /// resolved cookie value.
+    /// </summary>
+    /// <param name="provider">The configured provider name.</param>
+    /// <param name="response">The client-presented one-time exchange payload.</param>
+    /// <param name="bindingCookie">The presented browser-binding cookie value (or null when absent).</param>
+    /// <param name="remoteEndPointResolver">Resolves the caller's normalized remote IP, lazily.</param>
+    /// <returns>The session result, or a fail-closed rejection.</returns>
+    Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver);
+}

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -45,7 +45,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// <see cref="LoginCompletionService"/>: the authenticate leg takes only the redeemed model, the presented
 /// binding cookie value, and the remote-endpoint resolver (#177).
 /// </remarks>
-internal sealed class OidcLoginService
+internal sealed class OidcLoginService : ILoginService
 {
     // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal all
     // live inside; see OidcStateStore). One process-wide instance, like the SAML caches the controller keeps.
@@ -383,7 +383,7 @@ internal sealed class OidcLoginService
     /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#326).</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177).</param>
     /// <returns>The minted session, or a fail-closed rejection.</returns>
-    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
+    public async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
     {
         if (string.IsNullOrEmpty(response?.Data))
         {

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -45,7 +45,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// two response shapes both flows share — the security-headered auth page and the manual-link write mapping —
 /// are rendered from the shared <see cref="FlowResponses"/> home rather than a controller delegate (#160).
 /// </remarks>
-internal sealed class SamlLoginService
+internal sealed class SamlLoginService : ILoginService
 {
     // Outstanding SAML AuthnRequest IDs, for InResponseTo correlation of solicited responses (#156) and the
     // browser binding (#415). One process-wide instance.
@@ -572,7 +572,7 @@ internal sealed class SamlLoginService
     /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#415).</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177).</param>
     /// <returns>The minted session, or a fail-closed rejection.</returns>
-    internal async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
+    public async Task<ActionResult> AuthenticateAsync(string provider, AuthResponse response, string bindingCookie, Func<string> remoteEndPointResolver)
     {
         // Unknown and disabled providers share one rejection so neither can be probed apart — this
         // unifies the previously JSON unknown-provider body and the disabled provider's 500.


### PR DESCRIPTION
# What & why

First step of #790 (approved design): OIDC and SAML become **polymorphic implementations of one login contract** rather than two parallel code paths, the composition-first shared abstraction.

- New internal interface `Flows/ILoginService` with `AuthenticateAsync`, the one operation whose signature is **already identical** in both services (the session-minting authenticate leg).
- `OidcLoginService` and `SamlLoginService` implement it; their `AuthenticateAsync` changes `internal` → `public` to satisfy the interface (the classes stay `internal sealed`, so **no wider exposure**). **No behaviour change.**
- Protocol-specific operations that don't generalise (`SamlLoginService.Metadata`, `OidcLoginService.StateSummaries`) stay off the interface.

Refs #790

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] Fail-closed preserved: **no behaviour change**, an interface both services already satisfy, plus a visibility change (`internal`→`public`) on `internal sealed` classes (no wider reachability). The full auth-boundary conformance suite (VerifiedIdentity construction, controller delegation, immutable states) stays green.
- [x] No secrets logged.
- [x] Adversarial review run (bypass / correctness), structural change on the login-service surface.
- [x] Log inputs unchanged.

## Quality checklist
- [x] No duplicated logic; establishes a shared contract, composition-first (interface, not a deep base).
- [x] Adds no more code than required (one interface + `: ILoginService` on each service).
- [x] Self-documenting; the interface documents the shared shape.
- [x] **New fitness function** `ProtocolLoginServices_ImplementTheSharedContract`, every concrete Flows `*LoginService` (except the shared `LoginCompletionService` tail) implements `ILoginService`; non-vacuous, so a future protocol must implement it.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green net9.0 (1583 incl. the new rule); CI runs net10.0 on Linux.
- [x] ABI-floor build green, 0 warnings.
- [x] Prettier: N/A.

## Notes
Next in the #790 sequence: `IProviderProbe` (split the cross-protocol `ProviderConnectionTester`), then the `VerifiedIdentity` dependency inversion (with a full `/security-review`, since it touches identity construction) that lets the flat-`Api` kernel modularise.