### PR TITLE
Invert VerifiedIdentity's dependency on the protocol modules

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -448,7 +448,7 @@ public class ArchitectureConformanceTests
         //    instance clones a valid identity verbatim; every property is get-only, so it can neither
         //    mutate nor forge one.) A future `public`/`internal` ctor added to the type would reopen that
         //    hole and fail HERE.
-        // 2. Source scan: each factory is INVOKED only from its protocol's validator. FromOidcRedemption
+        // 2. Source scan: each factory is INVOKED only from its protocol's validator. FromValidatedOidc
         //    belongs to the OpenID redeem path — built inside AuthorizeSession.Ready, which the store hands
         //    out only through the one-time atomic redeem — and FromValidatedSaml only at the SAML
         //    session-minting endpoint after full response validation. A call from anywhere else (a link
@@ -471,7 +471,7 @@ public class ArchitectureConformanceTests
         // role-gate result); the SAML factory is invoked from the dedicated SamlAssertionValidator, the
         // single home the SAML inbound validation moved into (#496) — downstream of every gate, so the
         // "constructed only after complete validation" invariant is local to the validator.
-        const string oidcFactory = "FromOidcRedemption";
+        const string oidcFactory = "FromValidatedOidc";
         const string samlFactory = "FromValidatedSaml";
         var factoryMethods = typeof(VerifiedIdentity)
             .GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -56,7 +56,7 @@ public class LoginCompletionServiceTests
         new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
 
     private static VerifiedIdentity OidcIdentity(string provider, string subject, string username) =>
-        VerifiedIdentity.FromOidcRedemption(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+        TestIdentities.Oidc(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: username,
             Subject: subject,
             Issuer: null,
@@ -69,7 +69,7 @@ public class LoginCompletionServiceTests
             AvatarUrl: null));
 
     private static VerifiedIdentity SamlIdentity(string provider, string nameId) =>
-        VerifiedIdentity.FromValidatedSaml(provider, nameId, new SamlAuthorizeStateBuilder.SamlAuthorizeState(
+        TestIdentities.Saml(provider, nameId, new SamlAuthorizeStateBuilder.SamlAuthorizeState(
             Admin: false,
             EnableLiveTv: false,
             EnableLiveTvManagement: false,

--- a/SSO-Auth.Tests/Kernel/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerSamlTokenTests.cs
@@ -109,7 +109,7 @@ public class SSOControllerSamlTokenTests
 
         // Seed an outcome whose lifetime has already elapsed (Created well in the past): the redeem rejects
         // it as out of its window, so it cannot mint even though its token is otherwise well-formed.
-        var identity = VerifiedIdentity.FromValidatedSaml("adfs", "alice", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
+        var identity = TestIdentities.Saml("adfs", "alice", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
         var token = SamlOutcomeStore.NewToken();
         SamlLoginService.SeedSamlOutcomeForTests(new SamlLoginOutcome(token, "adfs", identity, string.Empty, null, DateTime.UtcNow.AddHours(-1)));
 
@@ -175,7 +175,7 @@ public class SSOControllerSamlTokenTests
         var store = new SamlOutcomeStore(1, TimeSpan.FromMinutes(15), TimeSpan.FromMinutes(1));
         SamlLoginService.SetSamlOutcomeStoreForTests(store);
         var filler = SamlOutcomeStore.NewToken();
-        var fillerIdentity = VerifiedIdentity.FromValidatedSaml("adfs", "filler", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
+        var fillerIdentity = TestIdentities.Saml("adfs", "filler", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
         Assert.True(store.TryAdd(new SamlLoginOutcome(filler, "adfs", fillerIdentity, string.Empty, null, DateTime.UtcNow), out _));
 
         // The callback is refused at the store cap — a fail-closed 500 — and the assertion's one-time replay

--- a/SSO-Auth.Tests/Kernel/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/Kernel/VerifiedIdentityTests.cs
@@ -1,9 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Jellyfin.Plugin.SSO_Auth.Api;
-using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
-using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Xunit;
 
@@ -23,29 +23,32 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class VerifiedIdentityTests
 {
     [Fact]
-    public void FromOidcRedemption_MapsEveryFieldFromTheRoleGateResult()
+    public void FromValidatedOidc_SetsTheOpenIdLabels_AndCopiesEveryValidatedField()
     {
-        var derived = new OidcAuthorizeStateBuilder.OidcAuthorizeState(
-            Username: "alice",
-            Subject: "sub-123",
-            Issuer: "https://issuer.example",
-            EmailVerified: true,
-            Valid: true,
-            Admin: true,
-            EnableLiveTv: true,
-            EnableLiveTvManagement: false,
-            Folders: new List<string> { "movies", "shows" },
-            AvatarUrl: "https://idp.example/a.png");
+        var login = new ValidatedLogin
+        {
+            Provider = "keycloak",
+            Subject = "sub-123",
+            Issuer = "https://issuer.example",
+            Username = "alice",
+            EmailVerified = true,
+            Admin = true,
+            Folders = new List<string> { "movies", "shows" },
+            EnableLiveTv = true,
+            EnableLiveTvManagement = false,
+            AvatarUrl = "https://idp.example/a.png",
+            PermissionGrants = Array.Empty<PermissionGrant>(),
+        };
 
-        var identity = VerifiedIdentity.FromOidcRedemption("keycloak", derived);
+        var identity = VerifiedIdentity.FromValidatedOidc(login);
 
-        // The two protocol-facing labels drive the link namespace and the audit line.
+        // The factory sets the two protocol-facing labels that drive the link namespace and the audit line...
         Assert.Equal(ProviderMode.Oid, identity.LinkMode);
         Assert.Equal("OpenID", identity.AuditProtocol);
-        Assert.Equal("keycloak", identity.Provider);
 
-        // OpenID keys the link on the stable subject; the username is derived independently. The issuer is
-        // carried onto the identity to issuer-bind the canonical link (#186).
+        // ...and copies every validated field verbatim. OpenID keys the link on the stable subject; the
+        // issuer is carried onto the identity to issuer-bind the canonical link (#186).
+        Assert.Equal("keycloak", identity.Provider);
         Assert.Equal("sub-123", identity.Subject);
         Assert.Equal("https://issuer.example", identity.Issuer);
         Assert.Equal("alice", identity.Username);
@@ -58,30 +61,33 @@ public class VerifiedIdentityTests
     }
 
     [Fact]
-    public void FromValidatedSaml_KeysSubjectAndUsernameOnTheNameId_AndCarriesNoEmailOrAvatar()
+    public void FromValidatedSaml_SetsTheSamlLabels_AndCopiesEveryValidatedField()
     {
-        var privileges = new SamlAuthorizeStateBuilder.SamlAuthorizeState(
-            Admin: true,
-            EnableLiveTv: false,
-            EnableLiveTvManagement: true,
-            Folders: new List<string> { "movies" });
+        var login = new ValidatedLogin
+        {
+            Provider = "okta",
+            Subject = "alice@example.com",
+            Issuer = null,
+            Username = "alice@example.com",
+            EmailVerified = null,
+            Admin = true,
+            Folders = new List<string> { "movies" },
+            EnableLiveTv = false,
+            EnableLiveTvManagement = true,
+            AvatarUrl = null,
+            PermissionGrants = Array.Empty<PermissionGrant>(),
+        };
 
-        var identity = VerifiedIdentity.FromValidatedSaml("okta", "alice@example.com", privileges);
+        var identity = VerifiedIdentity.FromValidatedSaml(login);
 
         Assert.Equal(ProviderMode.Saml, identity.LinkMode);
         Assert.Equal("SAML", identity.AuditProtocol);
         Assert.Equal("okta", identity.Provider);
-
-        // SAML keys the link directly on the NameID: subject and username are the same value.
         Assert.Equal("alice@example.com", identity.Subject);
         Assert.Equal("alice@example.com", identity.Username);
-
-        // SAML carries no email_verified claim, no avatar, and no issuer binding (#186), so the adoption
-        // gate, avatar step, and issuer check are all inert.
         Assert.Null(identity.EmailVerified);
         Assert.Null(identity.AvatarUrl);
         Assert.Null(identity.Issuer);
-
         Assert.True(identity.Admin);
         Assert.Equal(new[] { "movies" }, identity.Folders);
         Assert.False(identity.EnableLiveTv);

--- a/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
@@ -25,7 +25,7 @@ public class SamlOutcomeStoreTests
     // A verified identity is opaque to the store; any real one will do. Built through the SAML factory so
     // the test does not forge one (its constructor is private).
     private static VerifiedIdentity Identity(string provider = "adfs") =>
-        VerifiedIdentity.FromValidatedSaml(provider, "alice", SamlAuthorizeStateBuilder.Build(new List<string>(), new SamlConfig()));
+        TestIdentities.Saml(provider, "alice", SamlAuthorizeStateBuilder.Build(new List<string>(), new SamlConfig()));
 
     private static SamlLoginOutcome Outcome(string token, string provider = "adfs", string inResponseTo = "", string? clientKey = null, DateTime? created = null) =>
         new SamlLoginOutcome(token, provider, Identity(provider), inResponseTo, clientKey, created ?? Now);

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -1,0 +1,49 @@
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Test fixtures that mint a <see cref="VerifiedIdentity"/> from a protocol authorize-state, mirroring the
+/// production destructuring in <c>AuthorizeSession.Ready</c> (OpenID) and <c>SamlAssertionValidator</c>
+/// (SAML). Kept in one place so the #790 dependency inversion — protocol state → <see cref="ValidatedLogin"/>
+/// → the keystone factory — is applied identically wherever a test needs a ready-made verified identity,
+/// without each test repeating the field mapping.
+/// </summary>
+internal static class TestIdentities
+{
+    internal static VerifiedIdentity Oidc(string provider, OidcAuthorizeStateBuilder.OidcAuthorizeState derived) =>
+        VerifiedIdentity.FromValidatedOidc(new ValidatedLogin
+        {
+            Provider = provider,
+            Subject = derived.Subject!,
+            Issuer = derived.Issuer,
+            Username = derived.Username!,
+            EmailVerified = derived.EmailVerified,
+            Admin = derived.Admin,
+            Folders = derived.Folders,
+            EnableLiveTv = derived.EnableLiveTv,
+            EnableLiveTvManagement = derived.EnableLiveTvManagement,
+            AvatarUrl = derived.AvatarUrl,
+            PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+        });
+
+    internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
+        VerifiedIdentity.FromValidatedSaml(new ValidatedLogin
+        {
+            Provider = provider,
+            Subject = nameId,
+            Issuer = null,
+            Username = nameId,
+            EmailVerified = null,
+            Admin = privileges.Admin,
+            Folders = privileges.Folders,
+            EnableLiveTv = privileges.EnableLiveTv,
+            EnableLiveTvManagement = privileges.EnableLiveTvManagement,
+            AvatarUrl = null,
+            PermissionGrants = privileges.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+        });
+}

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -1,5 +1,6 @@
 using System;
 using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
@@ -110,7 +111,24 @@ internal abstract class AuthorizeSession
             // VerifiedIdentity the mint path is keyed on. Building it here — inside the variant the store
             // only ever produces for a promoted state and only hands out through the one-time atomic
             // redeem — is what makes this the OpenID construction site the keystone's contract names.
-            Identity = VerifiedIdentity.FromOidcRedemption(pending.Provider, derived);
+            // Destructure the role-gate result into the protocol-agnostic ValidatedLogin the keystone takes
+            // (#790). The subject and username are non-null by this point: the callback rejects a valid login
+            // that resolved no subject (#155) or no username (#95) before the state is promoted, so the
+            // null-forgiving reads preserve that upstream fail-closed guarantee rather than re-deciding it.
+            Identity = VerifiedIdentity.FromValidatedOidc(new ValidatedLogin
+            {
+                Provider = pending.Provider,
+                Subject = derived.Subject!,
+                Issuer = derived.Issuer,
+                Username = derived.Username!,
+                EmailVerified = derived.EmailVerified,
+                Admin = derived.Admin,
+                Folders = derived.Folders,
+                EnableLiveTv = derived.EnableLiveTv,
+                EnableLiveTvManagement = derived.EnableLiveTvManagement,
+                AvatarUrl = derived.AvatarUrl,
+                PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+            });
         }
 
         /// <summary>

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
@@ -196,7 +197,24 @@ internal sealed class SamlAssertionValidator
         // and carries no email_verified claim, so the verified-email gate is not applicable at the caller
         // (AdoptionGate.None); the resolver's unconditional admin-adoption refusal (#218) still applies.
         rejection = null;
-        identity = VerifiedIdentity.FromValidatedSaml(provider, nameId, derived);
+        // Destructure the validated assertion into the protocol-agnostic ValidatedLogin the keystone takes
+        // (#790). SAML keys the link directly on the NameID (subject and username are the same value) and
+        // carries no email_verified claim, avatar, or issuer binding (all null — issuer binding is OpenID
+        // only, #186).
+        identity = VerifiedIdentity.FromValidatedSaml(new ValidatedLogin
+        {
+            Provider = provider,
+            Subject = nameId,
+            Issuer = null,
+            Username = nameId,
+            EmailVerified = null,
+            Admin = derived.Admin,
+            Folders = derived.Folders,
+            EnableLiveTv = derived.EnableLiveTv,
+            EnableLiveTvManagement = derived.EnableLiveTvManagement,
+            AvatarUrl = null,
+            PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+        });
         return true;
     }
 

--- a/SSO-Auth/Api/ValidatedLogin.cs
+++ b/SSO-Auth/Api/ValidatedLogin.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api;
+
+/// <summary>
+/// The protocol-agnostic result of a completed login validation — the primitive facts a protocol validator
+/// has resolved, from which <see cref="VerifiedIdentity"/>'s protocol factories mint the keystone identity
+/// (#790, dependency inversion). It carries only BCL / <see cref="PermissionGrant"/> values and no protocol
+/// identity of its own (the protocol label and link mode are set by the protocol-named factory), so the
+/// identity keystone no longer depends on the OpenID or SAML modules. Each validator destructures its own
+/// state into this named bundle (init-only properties, so a caller cannot transpose a positional argument)
+/// and hands it to its factory. Holding a <see cref="ValidatedLogin"/> is NOT the keystone — it is a plain,
+/// in-principle-forgeable data carrier; the un-forgeable proof of a completed validation stays
+/// <see cref="VerifiedIdentity"/> (private constructor, two factories, and the conformance rule pinning each
+/// factory's call site to its validator).
+/// </summary>
+internal sealed record ValidatedLogin
+{
+    /// <summary>Gets the provider that verified this login.</summary>
+    internal required string Provider { get; init; }
+
+    /// <summary>Gets the stable subject identifier keying the account link (OpenID "sub"; the SAML NameID).</summary>
+    internal required string Subject { get; init; }
+
+    /// <summary>Gets the id_token issuer the account link is bound to, or null (SAML, and a token that carried none) (#186).</summary>
+    internal string? Issuer { get; init; }
+
+    /// <summary>Gets the username the login resolves (the OpenID username; the SAML NameID).</summary>
+    internal required string Username { get; init; }
+
+    /// <summary>Gets the login's <c>email_verified</c> claim (true/false), or null when absent — SAML always null (#218).</summary>
+    internal bool? EmailVerified { get; init; }
+
+    /// <summary>Gets a value indicating whether the login grants administrator rights.</summary>
+    internal required bool Admin { get; init; }
+
+    /// <summary>Gets the folders the login grants access to (statically enabled plus role-granted).</summary>
+    internal required IReadOnlyList<string> Folders { get; init; }
+
+    /// <summary>Gets a value indicating whether the login may view live TV.</summary>
+    internal required bool EnableLiveTv { get; init; }
+
+    /// <summary>Gets a value indicating whether the login may manage live TV.</summary>
+    internal required bool EnableLiveTvManagement { get; init; }
+
+    /// <summary>Gets the avatar URL the login resolves, or null when none — SAML always null.</summary>
+    internal string? AvatarUrl { get; init; }
+
+    /// <summary>Gets the generic role→permission grants the login resolves (#164), or empty when the feature is off.</summary>
+    internal required IReadOnlyList<PermissionGrant> PermissionGrants { get; init; }
+}

--- a/SSO-Auth/Api/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/VerifiedIdentity.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
-using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
-using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 #nullable enable
 
@@ -18,20 +16,24 @@ namespace Jellyfin.Plugin.SSO_Auth.Api;
 /// unvalidated response because there is no other way to obtain one.
 /// </summary>
 /// <remarks>
-/// The constructor is PRIVATE, so the type is unforgeable from outside: the only way to obtain an
-/// instance is one of the two named factories, each of which represents a completed protocol validation.
+/// The constructor is PRIVATE, so the type is unforgeable from outside: the only way to obtain an instance
+/// is one of the two protocol factories (<see cref="FromValidatedOidc"/>, <see cref="FromValidatedSaml"/>),
+/// each of which takes a protocol-agnostic
+/// <see cref="ValidatedLogin"/> — the primitive facts a completed validation resolved. Each protocol builds
+/// that bundle and calls the factory ONLY once its validation has passed:
 /// <list type="bullet">
-/// <item><see cref="FromOidcRedemption"/>, built inside <see cref="AuthorizeSession.Ready"/> and handed
-/// out only by <see cref="OidcStateStore.TryRedeem"/> after the atomic one-time claim of a promoted
-/// (role-gate-passed) state.</item>
-/// <item><see cref="FromValidatedSaml"/>, called only at the SAML session-minting endpoint after the
-/// response has passed signature, time-bound, audience, recipient and replay validation.</item>
+/// <item>OpenID: inside <c>AuthorizeSession.Ready</c>, handed out only by <c>OidcStateStore.TryRedeem</c>
+/// after the atomic one-time claim of a promoted (role-gate-passed) state.</item>
+/// <item>SAML: at the session-minting validator (<c>SamlAssertionValidator</c>) after the response has
+/// passed signature, time-bound, audience, recipient and replay validation.</item>
 /// </list>
-/// This construction lock is pinned as a fitness function
-/// (<c>ArchitectureConformanceTests.VerifiedIdentity_IsConstructedOnlyByProtocolValidators</c>). The two
-/// protocol-facing labels (<see cref="LinkMode"/>, <see cref="AuditProtocol"/>) are the only branch the
-/// completion path needs; a richer protocol abstraction is deferred to a later #318 step rather than
-/// pre-empted here.
+/// The construction lock is pinned as a fitness function
+/// (<c>ArchitectureConformanceTests.VerifiedIdentity_IsConstructedOnlyByProtocolValidators</c>): the private
+/// constructor keeps <c>new VerifiedIdentity(...)</c> inside this file, and the source scan keeps
+/// each factory's call site to its own validator. Taking a
+/// <see cref="ValidatedLogin"/> instead of the protocol state types is the #790 dependency inversion — the
+/// keystone no longer depends on the OpenID or SAML modules. The two protocol-facing labels
+/// (<see cref="LinkMode"/>, <see cref="AuditProtocol"/>) are the only branch the completion path needs.
 /// </remarks>
 internal sealed record VerifiedIdentity
 {
@@ -116,57 +118,40 @@ internal sealed record VerifiedIdentity
     internal IReadOnlyList<PermissionGrant> PermissionGrants { get; }
 
     /// <summary>
-    /// Builds the verified identity of an OpenID login from the role-gate result. Called from inside
-    /// <see cref="AuthorizeSession.Ready"/>, which the store produces only for a promoted (role-gate-passed)
-    /// state and hands out only through the one-time atomic redeem — so this can never run before that claim.
-    /// The subject and username are non-null by that point: the callback rejects a valid login that resolved
-    /// no subject (#155) and no username (#95) before the state is promoted, so the null-forgiving reads
-    /// preserve that upstream fail-closed guarantee rather than re-deciding it here.
+    /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
+    /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
+    /// promoted (role-gate-passed) state — so a raw or unvalidated login can never reach it.
     /// </summary>
-    /// <param name="provider">The provider that verified the login.</param>
-    /// <param name="derived">The passed role-gate result carrying the resolved identity and privileges.</param>
+    /// <param name="login">The primitive facts the OpenID role-gate resolved for the completed login.</param>
     /// <returns>The verified OpenID identity.</returns>
-    internal static VerifiedIdentity FromOidcRedemption(string provider, OidcAuthorizeStateBuilder.OidcAuthorizeState derived) =>
-        new(
-            ProviderMode.Oid,
-            "OpenID",
-            provider,
-            derived.Subject!,
-            derived.Issuer,
-            derived.Username!,
-            derived.EmailVerified,
-            derived.Admin,
-            derived.Folders,
-            derived.EnableLiveTv,
-            derived.EnableLiveTvManagement,
-            derived.AvatarUrl,
-            derived.PermissionGrants ?? Array.Empty<PermissionGrant>());
+    internal static VerifiedIdentity FromValidatedOidc(ValidatedLogin login) => Build(ProviderMode.Oid, "OpenID", login);
 
     /// <summary>
-    /// Builds the verified identity of a SAML login. Called only at the SAML session-minting endpoint after
-    /// the response has passed signature, time-bound, audience, recipient and replay validation, the login
-    /// allow-list, and the non-empty-NameID guard (#95) — so a raw or unvalidated response can never reach
-    /// this factory. SAML keys the link directly on the NameID (subject and username are the same value) and
-    /// carries no <c>email_verified</c> claim, avatar, or issuer binding (all null — issuer binding is
-    /// OpenID-only, #186).
+    /// Mints the verified identity of a SAML login. Called only from the SAML session-minting validator
+    /// (<c>SamlAssertionValidator</c>), reached only after the response has passed signature, time-bound,
+    /// audience, recipient and replay validation, the login allow-list, and the non-empty-NameID guard (#95).
     /// </summary>
-    /// <param name="provider">The provider that verified the login.</param>
-    /// <param name="nameId">The validated, non-empty NameID; the link key and the username.</param>
-    /// <param name="privileges">The privileges derived from the assertion's roles and the provider configuration.</param>
+    /// <param name="login">The primitive facts the SAML validation resolved for the completed login.</param>
     /// <returns>The verified SAML identity.</returns>
-    internal static VerifiedIdentity FromValidatedSaml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
+    internal static VerifiedIdentity FromValidatedSaml(ValidatedLogin login) => Build(ProviderMode.Saml, "SAML", login);
+
+    // The two protocol factories set the protocol label + link mode (the only protocol-facing branch, #369)
+    // and fold in the protocol-agnostic ValidatedLogin. Taking that neutral bundle rather than the OpenID /
+    // SAML state types is the #790 dependency inversion — the keystone no longer references either protocol
+    // module; the arrow points from each protocol INTO the keystone.
+    private static VerifiedIdentity Build(ProviderMode linkMode, string auditProtocol, ValidatedLogin login) =>
         new(
-            ProviderMode.Saml,
-            "SAML",
-            provider,
-            nameId,
-            null,
-            nameId,
-            null,
-            privileges.Admin,
-            privileges.Folders,
-            privileges.EnableLiveTv,
-            privileges.EnableLiveTvManagement,
-            null,
-            privileges.PermissionGrants ?? Array.Empty<PermissionGrant>());
+            linkMode,
+            auditProtocol,
+            login.Provider,
+            login.Subject,
+            login.Issuer,
+            login.Username,
+            login.EmailVerified,
+            login.Admin,
+            login.Folders,
+            login.EnableLiveTv,
+            login.EnableLiveTvManagement,
+            login.AvatarUrl,
+            login.PermissionGrants);
 }


### PR DESCRIPTION
# What & why

Third step of #790 (approved): **break the kernel cycle at the identity keystone.** `VerifiedIdentity`'s two factories took the OpenID/SAML authorize-state **types** (`OidcAuthorizeState`, `SamlAuthorizeState`), so the keystone imported both protocol modules while the protocols also depend on it, the `VerifiedIdentity ⇄ Oidc/Saml` cycle documented in `ARCHITECTURE.md` that kept it (and the session/web kernel around it) from modularising.

**Invert it** with a protocol-agnostic **`ValidatedLogin`** (the primitive facts a completed validation resolves, BCL / `ProviderMode` / `PermissionGrant` only; named init-only properties so a caller cannot transpose a positional argument):

- `FromValidatedOidc` / `FromValidatedSaml` now take `ValidatedLogin`, set the protocol label + link mode, and fold in the neutral bundle. **`VerifiedIdentity` no longer references the OpenID or SAML modules, its imports drop to `Authz` + `Provider`.** The arrow points one way, from each protocol INTO the keystone.
- Each protocol validator destructures its own state into `ValidatedLogin` at the existing construction site (`AuthorizeSession.Ready` for OpenID, `SamlAssertionValidator` for SAML) and calls its factory.

Refs #790

## Type of change
- [x] Refactor / code quality / docs

## Security checklist
- [x] **The unforgeable-construction invariant is fully preserved.** The constructor stays PRIVATE, so `new VerifiedIdentity(...)` can appear only inside `VerifiedIdentity.cs` via the two factories (the reflection pin is unchanged); the source-scan pin still confines each factory's invocation to its one validator (`AuthorizeSession` / `SamlAssertionValidator`), the rule updated for the `FromOidcRedemption`→`FromValidatedOidc` rename. `VerifiedIdentity_IsConstructedOnlyByProtocolValidators` is green.
- [x] Fail-closed preserved: same fields mapped, same labels, same null-forgiving reads guarded by the same upstream fail-closed rejections (#95/#155). Holding a `ValidatedLogin` is NOT the keystone, it is a plain data carrier; the proof of validation stays `VerifiedIdentity`.
- [x] No secrets logged; no crypto/validation path changed.
- [x] **Full adversarial `/security-review`** run (bypass · correctness · keystone-integrity), identity-construction surface.

## Quality checklist
- [x] No duplicated logic; the destructuring moves to the two validators, shared for tests via a `TestIdentities` helper.
- [x] Composition-first inversion, a neutral DTO, no deep inheritance.
- [x] Self-documenting; `ValidatedLogin` and the factories document the inverted flow.
- [x] The construction-lock fitness function is preserved and updated.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (net9.0 1583; net10.0 1583) incl. the keystone invariant and every e2e login flow.
- [x] ABI-floor build green, 0 warnings.
- [x] Goal confirmed: `VerifiedIdentity` imports drop to `Authz` + `Provider` (Oidc/Saml gone).

## Notes
This breaks the last hard cycle blocking the kernel: with `VerifiedIdentity` decoupled, a follow-up can extract it (and the session types) into an `Identity`/`Session` module and advance the "flat `Api` is empty" rule. Behaviour is unchanged, a pure dependency inversion.