### PR TITLE
Give the remaining root types their module homes

### DIFF
--- a/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
+++ b/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Xml;
 using System.Xml.Serialization;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/Flows/WebResponseTests.cs
+++ b/SSO-Auth.Tests/Flows/WebResponseTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/Saml/SamlAssertionTimeTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAssertionTimeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth.Tests/Saml/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlSignatureAlgorithmsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;

--- a/SSO-Auth/Api/Flows/WebResponse.cs
+++ b/SSO-Auth/Api/Flows/WebResponse.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 
-namespace Jellyfin.Plugin.SSO_Auth;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 
 /// <summary>
 /// A helper class to return HTML for the client's auth flow.

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// stub, so signature, issuer, audience and lifetime all went unchecked. This validator restores the
 /// mandatory checks — signature against the discovery JWKS, iss against the discovery issuer,
 /// aud/azp against the client id, exp/nbf with the client's clock skew — under an asymmetric-only
-/// signature-algorithm allowlist (the posture of the SAML side's <see cref="SamlSignatureAlgorithms"/>).
+/// signature-algorithm allowlist (the posture of the SAML side's SamlSignatureAlgorithms).
 /// Every failure rejects the login (fail closed).
 /// </summary>
 internal sealed class OidcIdTokenValidator : IIdentityTokenValidator

--- a/SSO-Auth/Api/Saml/SamlAssertionTime.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionTime.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Xml;
 
-namespace Jellyfin.Plugin.SSO_Auth;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Pure, fail-closed validation of a SAML assertion's time bounds.

--- a/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Jellyfin.Plugin.SSO_Auth;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>
 /// Allowlist of acceptable XML-DSig signature and digest algorithms for a SAML response. .NET's

--- a/SSO-Auth/Config/SerializableDictionary.cs
+++ b/SSO-Auth/Config/SerializableDictionary.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
-namespace Jellyfin.Plugin.SSO_Auth;
+namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>
 /// For some reason, the generic Dictionary in .net 2.0 is not XML serializable. The following code snippet is a xml serializable generic dictionary. The dictionary is serializable by implementing the IXmlSerializable interface.


### PR DESCRIPTION
# What & why

Four types still lived at the project root although each belongs to a module or the Config namespace (discovery follow-up to #800/#803):

| Type | New home | Note |
|---|---|---|
| `SamlAssertionTime` | `Api/Saml` | consumed only inside the Saml module |
| `SamlSignatureAlgorithms` | `Api/Saml` | the Oidc validator's reference was a doc `cref`, not code, becomes plain text per the cross-module doc rule, so **no Oidc→Saml edge appears** |
| `WebResponse` | `Api/Flows` | consumed only by the two flow login services |
| `SerializableDictionary` | `Config` | the XML-serialization primitive backing the persisted configuration |

`WebResponseTests` moves to `Tests/Flows/` (test mirror). The root now holds only genuinely-root types: `AssemblyInfo`, `SSOPlugin`, and the host-discovered `SsoOnlyServiceRegistrator`.

Closes #804

## Type of change
- [x] Refactor / code quality

## Security checklist
- [x] **No behavior change**, pure moves + namespace changes; the SAML algorithm allowlist, assertion-time policy and served-page renderer are byte-identical (their existing tests pass unchanged).
- [x] No new module dependency edges (verified: no new cross-module `using` in production `Api/`).

## Quality checklist
- [x] Root is now minimal and intentional.
- [x] Test mirror preserved.
- [x] Cross-module doc references as plain text (established rule).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1588 both TFMs).
- [x] ABI-floor build (10.11.0) green.