### PR TITLE
Extract the route-shape primitives into a Routing leaf module

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;
@@ -199,10 +200,11 @@ public class ArchitectureConformanceTests
     [InlineData("Avatar", "Net", "RateLimit")] // avatar fetch — validates targets through the Net SSRF classifier, per-user store locks via KeyedLockStore (RateLimit)
     [InlineData("RateLimit", "Net")] // login throttling — keys buckets by the Net client-IP classifier
     [InlineData("Authz")] // leaf — role→permission mapping: PermissionGrant, PermissionRolePolicy, RolePrivilegeMapper
+    [InlineData("Routing")] // leaf — the plugin's route-shape contract: RouteSuffix ({protocol}/{path-kind}/{provider} reader), ChallengePath (new/legacy classifier)
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
     [InlineData("Linking", "Audit", "Provider", "RateLimit")] // account linking — audits writes, validates providers, throttles
     [InlineData("Saml", "Authz", "Identity", "RateLimit", "Session")] // SAML core/validators — mints the keystone (Identity), returns login outcomes (Session), maps roles (Authz), throttles (RateLimit)
-    [InlineData("Oidc", "Authz", "Avatar", "Identity", "Net", "Provider", "RateLimit")] // OIDC flow — mints the keystone (Identity), orchestrates roles, avatar, net, provider, throttle
+    [InlineData("Oidc", "Authz", "Avatar", "Identity", "Net", "Provider", "RateLimit", "Routing")] // OIDC flow — mints the keystone (Identity), orchestrates roles, avatar, net, provider, throttle; reads its callback path through the Routing suffix reader
     [InlineData("Identity", "Authz", "Provider")] // the identity keystone — grants (Authz) + link mode (Provider); decoupled from the protocols by #790
     [InlineData("Session", "Authz", "Avatar", "Linking")] // session mint + login outcomes — applies grants (Authz), sets avatars (Avatar), reconciles links (Linking)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)

--- a/SSO-Auth.Tests/Routing/ChallengePathTests.cs
+++ b/SSO-Auth.Tests/Routing/ChallengePathTests.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth.Tests/Routing/RouteSuffixTests.cs
+++ b/SSO-Auth.Tests/Routing/RouteSuffixTests.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth.Tests/Shared/AuthPageCspTests.cs
+++ b/SSO-Auth.Tests/Shared/AuthPageCspTests.cs
@@ -1,3 +1,4 @@
+using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;
 

--- a/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
@@ -1,4 +1,5 @@
 using System;
+using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 #nullable enable
 

--- a/SSO-Auth/Api/Routing/ChallengePath.cs
+++ b/SSO-Auth/Api/Routing/ChallengePath.cs
@@ -2,7 +2,7 @@ using System;
 
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 /// <summary>
 /// Decides whether a challenge arrived on the "new", descriptive route

--- a/SSO-Auth/Api/Routing/RouteSuffix.cs
+++ b/SSO-Auth/Api/Routing/RouteSuffix.cs
@@ -1,6 +1,6 @@
 #nullable enable
 
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 /// <summary>
 /// The trailing <c>{protocol}/{path-kind}/{provider}</c> suffix that both <see cref="ChallengePath"/>

--- a/SSO-Auth/Api/Shared/AuthPageCsp.cs
+++ b/SSO-Auth/Api/Shared/AuthPageCsp.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.SSO_Auth.Api;
+namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>
 /// Builds the Content-Security-Policy for the rendered auth-completion page. The page runs a single

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -2,6 +2,7 @@ using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
+using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;


### PR DESCRIPTION
# What & why

Kernel dissolution, penultimate step (Refs #790, Closes #806). `RouteSuffix` and `ChallengePath` are the plugin's route-shape contract and are **real code dependencies of registered modules** (`Oidc/OidcCallbackPath` calls `RouteSuffix.TryRead`; `Shared/ChallengeNewPathResolver` calls `ChallengePath.IsNewPath`), so they cannot move into the upcoming Http boundary module (module edges must never point at the boundary). They become a leaf:

- **`Api/Routing`**: `RouteSuffix`, `ChallengePath`. DAG: `Routing` leaf; `Oidc` gains the `Routing` edge.
- **`AuthPageCsp` → `Api/Shared`**, sole consumer is `Shared/FlowResponses`; a served-page helper is exactly Shared's charter.
- Tests mirror: `Tests/Routing/`, `AuthPageCspTests` → `Tests/Shared/`.

**Why a dedicated 2-file leaf instead of Net:** Net is generic networking/SSRF infrastructure; the route shape is the plugin's own URL contract, separate concerns, documented in the module map.

After this, flat `Api/` holds only the web boundary (SSOController, RequestHelpers, ProviderConnectionTester), the Http module (#807) finishes the dissolution.

## Type of change
- [x] Refactor / code quality

## Security checklist
- [x] **No behavior change**, pure moves + namespace changes; route parsing and the auth-page CSP are byte-identical (existing tests pass unchanged, +1 conformance case).
- [x] New module edges are exactly the two declared ones (verified via production `using` diff: only `Oidc` and `Shared` gained `Api.Routing`).

## Quality checklist
- [x] DAG case added for the Routing leaf; Oidc's allowed list extended with rationale comments.
- [x] Test mirror preserved.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1589 both TFMs).
- [x] ABI-floor build (10.11.0) green.