### PR TITLE
Rewrite the catalog listing copy

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -9,11 +9,17 @@ version: "4.3.0"
 targetAbi: "10.11.0.0"
 framework: "net9.0"
 owner: "iderex"
-overview: "Authenticate users against an SSO provider."
+overview: "Sign in to Jellyfin through OpenID Connect or SAML 2.0 identity providers."
 description: |
-  This plugin allows users to sign in through an SSO provider (such as Google, Facebook, or your own provider). This enables one-click signin.
-  SSO sign-in works in the Jellyfin Web UI and in clients that support Quick Connect.
-  Review documentation at https://github.com/iderex/jellyfin-plugin-sso
+  Single sign-on for Jellyfin via OpenID Connect and SAML 2.0 — works with self-hosted and
+  managed identity providers such as Authelia, Authentik, Keycloak, Pocket ID and Kanidm,
+  with multiple providers side by side.
+  Role-based access from provider claims (login, administrator, library folders, Live TV),
+  avatar sync, self-service account linking, and an optional SSO-only mode that disables
+  password login for every account except a designated break-glass admin.
+  Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
+  A security-first continuation of the archived 9p4/jellyfin-plugin-sso.
+  Documentation and provider setup guides: https://github.com/iderex/jellyfin-plugin-sso
 category: "Authentication"
 artifacts:
   - "SSO-Auth.dll"


### PR DESCRIPTION
# What & why

The `overview`/`description` shown in Jellyfin's plugin catalog was inherited 9p4 boilerplate, "Google, Facebook" social-login framing that misdescribes an OIDC/SAML IdP plugin. Replaced with an honest capability summary: the two protocols, typical self-hosted providers (Authelia, Authentik, Keycloak, Pocket ID, Kanidm), role-based access, avatar sync, self-service linking, the SSO-only mode with break-glass admin, Quick Connect reach for native clients, and the continuation-of-9p4 positioning.

Closes #730

## Type of change
- [x] Documentation / metadata only (no code, no version change, CHANGELOG rule not triggered)

## Security checklist
- [x] No functional change; `targetAbi`, `version`, `artifacts` untouched.
- [x] Copy makes no capability claim the plugin does not implement today (matrix: OIDC+SAML, roles, avatars, linking, SSO-only, Quick Connect, all shipped).

## Verification
- [x] YAML parses (the JPRM packaging job in this PR's CI consumes exactly this file).