### PR TITLE
Add a supported-providers matrix and an honest comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,38 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 
 > The feature set from the sibling project is being ported here one reviewed change at a time; this list reflects what is implemented today.
 
+## Supported providers
+
+Any OIDC-conformant or SAML 2.0 identity provider should work. These have verified, step-by-step guides on the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) wiki page:
+
+| Provider                                                                                                                                                                                    | OIDC | SAML | Role mapping (RBAC) |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--: | :--: | :-----------------: |
+| [Authelia](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#authelia)                                                                                                      |  ✔   |  —   |          ✔          |
+| [authentik](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#authentik)                                                                                                    |  ✔   |  —   |          ✔          |
+| Keycloak ([OIDC](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#keycloak-oidc), [SAML](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#keycloak-saml)) |  ✔   |  ✔   |          ✔          |
+| [Pocket ID](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#pocket-id)                                                                                                    |  ✔   |  —   |          ✔          |
+| [Kanidm](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#kanidm)                                                                                                          |  ✔   |  —   |          ✔          |
+| Google                                                                                                                                                                                      |  ✔   |  —   |          —          |
+
+"—" under SAML means no verified guide yet, not that it cannot work. Google works without role mapping and with caveats (numeric usernames; endpoint validation must be relaxed) — see the wiki. A guide for a provider you use is a welcome contribution.
+
+## How it compares
+
+Honest positioning against the alternatives — pick what fits your setup:
+
+|                                  | This plugin                                                                                                              | Jellyfin built-in auth | Official [LDAP plugin](https://github.com/jellyfin/jellyfin-plugin-ldapauth) | Archived [9p4 plugin](https://github.com/9p4/jellyfin-plugin-sso)                               |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Sign-in model                    | Delegated to your IdP (OIDC / SAML)                                                                                      | Local passwords        | Directory bind (LDAP/AD)                                                     | Delegated to your IdP (OIDC / SAML)                                                             |
+| Passwords touch Jellyfin         | No (optional SSO-only mode)                                                                                              | Yes                    | Yes (bind credentials)                                                       | No                                                                                              |
+| Role / permission mapping        | ✔ from IdP claims (admin, folders, Live TV)                                                                              | Manual per user        | ✔ from LDAP attributes                                                       | ✔ from IdP claims                                                                               |
+| Account linking (existing users) | ✔ self-service                                                                                                           | n/a                    | ✔ (by username)                                                              | ✔                                                                                               |
+| Maintenance status               | Active (Beta)                                                                                                            | Active (core)          | Active (official)                                                            | Archived, unmaintained                                                                          |
+| Security process                 | Adversarial review + CI gates per change ([Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)) | Jellyfin core process  | Jellyfin org process                                                         | —                                                                                               |
+| Native clients                   | Via Quick Connect                                                                                                        | ✔ everywhere           | ✔ everywhere                                                                 | Via Quick Connect                                                                               |
+| Best when                        | You run an IdP (or want one) and want passwords out of Jellyfin                                                          | Small setups, no IdP   | You have AD/LDAP but no web IdP                                              | (migrate here — [guide](https://github.com/iderex/jellyfin-plugin-sso/wiki/Migrating-from-9p4)) |
+
+The LDAP plugin and this one solve different problems and can even coexist; if you already run Authelia/authentik/Keycloak, this plugin is the direct path. Coming from the archived 9p4 plugin, migration is an in-place upgrade.
+
 ## Installing
 
 > **This is an independent plugin repository.** Jellyfin's built-in catalog only lists plugins that live in the [`jellyfin`](https://github.com/jellyfin) GitHub org, and there is currently no official SSO plugin there (the LDAP plugin is the only official auth plugin). You install this plugin by adding **its** repository (below) under **Plugins → Repositories**; it then appears in your in-app catalog. The project is independent for now.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Honest positioning against the alternatives — pick what fits your setup:
 
 The LDAP plugin and this one solve different problems and can even coexist; if you already run Authelia/authentik/Keycloak, this plugin is the direct path. Coming from the archived 9p4 plugin, migration is an in-place upgrade.
 
+Jellyfin upstream is building [native OIDC](https://github.com/jellyfin/jellyfin/pull/17271) (13.0 at the earliest). This plugin **complements** it rather than competing: it remains the option for **SAML 2.0, folder/Live-TV role mapping, account linking, avatar sync and SSO-only mode** — and for every current server release. Full stance: [Native OIDC Coexistence](https://github.com/iderex/jellyfin-plugin-sso/wiki/Native-OIDC-Coexistence).
+
 ## Installing
 
 > **This is an independent plugin repository.** Jellyfin's built-in catalog only lists plugins that live in the [`jellyfin`](https://github.com/jellyfin) GitHub org, and there is currently no official SSO plugin there (the LDAP plugin is the only official auth plugin). You install this plugin by adding **its** repository (below) under **Plugins → Repositories**; it then appears in your in-app catalog. The project is independent for now.


### PR DESCRIPTION
# What & why

Two README gaps from the P8 marketing polish, bundled as one coherent README change:

- **Supported providers (#732):** verified-guide matrix (provider × OIDC/SAML × RBAC) sourced from the wiki's tested-providers section, plus the generic any-conformant-IdP statement and the Google caveats. A dash means "no verified guide yet", not incompatibility, and invites guide contributions.
- **How it compares (#750):** honest positioning vs built-in auth, the official LDAP plugin, and the archived 9p4 upstream, sign-in model, password exposure, RBAC, linking, maintenance status, security process, native-client reach, and a "best when" row. States explicitly that the LDAP plugin and this one solve different problems and can coexist, and points 9p4 users at the migration guide.

Closes #732
Closes #750

## Type of change
- [x] Documentation only

## Security checklist
- [x] Every capability claim maps to a shipped feature or a linked wiki guide; no overclaiming (Quick Connect reach stated as the native-client path, LDAP positioned fairly as the AD answer).

## Verification
- [x] Prettier 3.9.5 clean (tables formatted by it).
- [x] All wiki anchors verified against the current Provider-Setup page headings.

---

**Second commit [#721]:** adds the native-OIDC positioning paragraph to the comparison section (complements, not competes; the wiki's new [Native OIDC Coexistence](https://github.com/iderex/jellyfin-plugin-sso/wiki/Native-OIDC-Coexistence) page carries the full stance, upstream watch, capability table vs the native draft, link-model migration honesty). Together with the wiki work this completes the issue.

Closes #721