### PR TITLE
Publish the governance, support, CRA and privacy policy set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -469,3 +469,4 @@ AGENTS.md
 docs/*
 !docs/README.md
 !docs/ARCHITECTURE.md
+!docs/PRIVACY.md

--- a/.gitignore
+++ b/.gitignore
@@ -470,3 +470,4 @@ docs/*
 !docs/README.md
 !docs/ARCHITECTURE.md
 !docs/PRIVACY.md
+!docs/SECURITY-REMEDIATION-POLICY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Commit Messages](#commit-messages)
 - [Join The Project Team](#join-the-project-team)
 
+> Project governance — who holds access, how decisions are made, and the continuity model — is documented in [GOVERNANCE.md](GOVERNANCE.md).
+
 ## I Have a Question
 
 > If you want to ask a question, we assume that you have read the available [Documentation](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,64 @@
+# Governance
+
+How this project is run, who holds access, and how decisions are made. The
+guiding principle is honesty: this document describes the governance that
+actually exists, not the governance a larger project would have.
+
+## Roles and access
+
+This is a **single-maintainer project**. The maintainer — **@iderex** — holds
+admin access to the repository, write access to all branches, and control of
+the release pipeline (version tags, release publication, and the plugin
+manifest). There are no other people with commit, review, or release authority.
+
+Development is **AI-assisted** (see the README's "AI-assisted, human-owned"
+section): Claude (Anthropic) executes process steps under the maintainer's
+direction, and the maintainer reviews and signs off on what ships. The
+additional accounts named in `.github/CODEOWNERS` operate under the same
+AI-assisted model and are annotated as such there — their reviews are **not
+independent human auditing**, and this project does not claim otherwise. The
+quality gates that stand in for a review team are the CI gate (build with
+warnings-as-errors, the full test suite, conformance checks, CodeQL, supply-chain
+checks) and the adversarial multi-lens security review run on every change to
+the login path (see the [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)
+wiki page).
+
+## Decision-making
+
+- **Changes** follow the gated flow in [CONTRIBUTING.md](CONTRIBUTING.md):
+  issue → branch → tests → review gates → PR → CI-green merge.
+- **Scope and releases** are decided by the maintainer, guided by the public
+  [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) and its
+  maturity ladder; releases follow the
+  [Release Policy](https://github.com/iderex/jellyfin-plugin-sso/wiki/Release-Policy)
+  (channel/soak promotion).
+- **Security decisions outrank feature decisions.** Anything touching the login
+  path passes the adversarial review gate before merge.
+- Community input is welcome through issues and discussions; the maintainer has
+  the final say.
+
+## Granting elevated access
+
+No standing elevated access is granted to anyone beyond the maintainer. If that
+ever changes, the bar is: a track record of high-quality contributions here, a
+direct conversation with the maintainer, least-privilege scoping (write before
+admin, never release-signing), and a public update to this document in the same
+PR that grants the access. Elevated permissions are never granted implicitly or
+in bulk.
+
+## Continuity (bus factor)
+
+A solo project carries an honest bus factor of one. Mitigations in place:
+
+- Everything needed to build, test, and release is **in the repository** —
+  reproducible CI, documented release pipeline, no private build secrets beyond
+  standard GitHub tokens.
+- The license (GPL-3.0) guarantees the community can fork and continue at any
+  time; the archived upstream (`9p4/jellyfin-plugin-sso`) proves the model —
+  this project _is_ such a continuation.
+- If the project becomes unmaintained, the intent is to archive the repository
+  with a clear notice rather than leave it silently stale.
+
+Structural solo-maintainer limits (what badge levels this ceiling caps) are
+tracked openly in the maturity-map work
+([#749](https://github.com/iderex/jellyfin-plugin-sso/issues/749)).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 - [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Per-identity-provider setup: [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)
 - In-tree contributor map of the login flow and code layout: [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals)
+- Project policies: [Governance](GOVERNANCE.md) · [Privacy & data handling](docs/PRIVACY.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates)
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 - [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Per-identity-provider setup: [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)
 - In-tree contributor map of the login flow and code layout: [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals)
-- Project policies: [Governance](GOVERNANCE.md) · [Privacy & data handling](docs/PRIVACY.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates)
+- Project policies: [Governance](GOVERNANCE.md) · [Privacy & data handling](docs/PRIVACY.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,9 +23,31 @@ reporting.
 - Coordinated disclosure: please allow a fix to be released before public
   disclosure.
 
-## Supported versions
+## Supported versions & security updates
 
-The latest released version is the only supported version.
+**Support model (best-effort, volunteer):** this is a volunteer-maintained
+open-source project. The commitments below describe intent, applied
+consistently — they are not a contractual SLA.
+
+- **One active version line: 4.x.** Security fixes land in a **new latest
+  release** of that line; older releases are not patched in place. "Supported"
+  means: update to the latest release.
+- Each release is packaged for the server generations the manifests cover
+  (currently Jellyfin **10.11/11.x** on .NET 9 as the stable line, Jellyfin
+  **12.0** as beta until 12.0 itself is stable — see the README's install
+  matrix). A security fix ships for **all ABI builds of the latest release**
+  at the same time.
+- **When a future major line replaces 4.x** (the planned JF12-native 5.0 line —
+  [#743](https://github.com/iderex/jellyfin-plugin-sso/issues/743)), the intent
+  is to keep shipping **security fixes for the previous line for at least six
+  months** after the new line's first stable release.
+- **End of support is announced**, not silent: in `CHANGELOG.md` and the
+  release notes of the release that starts the clock, with at least three
+  months' notice before the final security update of a line.
+
+Release integrity, channels and the soak/promotion model are described in the
+[Release Policy](https://github.com/iderex/jellyfin-plugin-sso/wiki/Release-Policy)
+wiki page.
 
 ## Verifying a release download
 
@@ -53,3 +75,26 @@ replace the manifest MD5.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
 
 For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). For how they map onto the OpenSSF Best Practices passing-level criteria, see [OpenSSF Best Practices](https://github.com/iderex/jellyfin-plugin-sso/wiki/OpenSSF-Best-Practices).
+
+## EU Cyber Resilience Act (CRA) position
+
+- **This is a non-commercial FLOSS project.** It is developed and published
+  without monetization of any kind, which places it outside the CRA's
+  manufacturer obligations; the project also matches the spirit of the CRA's
+  **open-source software steward** role (Art. 24), whose obligations it meets
+  voluntarily: this document **is** the project's coordinated
+  vulnerability-handling and cybersecurity policy (reporting channel, response
+  expectations, supported versions above), and actively-exploited
+  vulnerabilities would be handled through the private-advisory process
+  described here.
+- **No conformity claim.** The project does **not** claim CRA conformity or CE
+  marking, and nothing here should be read as such — the statements above
+  describe only which obligations are voluntarily met.
+- **Commercial redistributors carry their own obligations.** Anyone who
+  integrates or redistributes this plugin **commercially** becomes responsible
+  for the CRA manufacturer obligations for their product; this project's
+  artifacts help (release provenance and checksums above, a dependency SBOM is
+  planned — [#763](https://github.com/iderex/jellyfin-plugin-sso/issues/763)
+  tracks OpenVEX), but do not transfer that responsibility.
+- Data-handling transparency for operators lives in
+  [docs/PRIVACY.md](docs/PRIVACY.md).

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,54 @@
+# Privacy & data handling
+
+What personal data this plugin touches, why, and where it lives — written for
+the **self-hosting operator**, who is the GDPR **data controller** for their
+Jellyfin server. This document exists so an operator can meet their own
+transparency (Art. 13/14) and records-of-processing (Art. 30) duties.
+
+**Scope honesty:** this plugin is a self-hosted, single-tenant component. The
+project (its maintainer, its repository, its CI) is **not a processor** and has
+**no access of any kind** to any deployment's data. Nothing the plugin
+processes ever leaves the operator's server except the operator's own traffic
+to their chosen identity provider. This document does **not** claim GDPR
+compliance on the operator's behalf — it supports the operator's compliance.
+
+## Data inventory
+
+| Data element                                                                         | Category                                  | Purpose                                                              | Where it lives                                                                                                                   | Retention                                                                                                                   |
+| ------------------------------------------------------------------------------------ | ----------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| IdP subject identifier (`sub` / SAML `NameID`), with the OpenID issuer bound to it   | Pseudonymous identifier (GDPR Recital 26) | Stable account linking — maps the IdP identity to a Jellyfin user id | Plugin configuration (`SSO-Auth.xml` in the Jellyfin config directory), as a canonical link keyed per provider                   | Until unlinked (self-service linking page or admin), the link is revoked, or the operator removes it from the configuration |
+| Jellyfin user id (GUID)                                                              | Pseudonymous identifier                   | The Jellyfin-side half of each link                                  | Plugin configuration (as above); also appears in **log lines** for login events                                                  | Links: as above. Logs: per the operator's Jellyfin log retention                                                            |
+| Username / `preferred_username` / `name` claims                                      | Identity data                             | Account provisioning and display-name selection at login             | Transient during login; the resulting username is stored by **Jellyfin's own user store** (Jellyfin is then the store of record) | Transient in the plugin; in Jellyfin until the operator deletes the user                                                    |
+| Email claim (if the IdP sends it)                                                    | Identity data                             | Available to identity resolution during login                        | Transient during login only — the plugin does not persist it                                                                     | Request-scoped                                                                                                              |
+| Role / group claims                                                                  | Authorization data                        | Mapped to Jellyfin permissions (login, admin, folders, Live TV)      | Transient during login; the **resulting permissions** are stored by Jellyfin                                                     | Transient in the plugin; permissions in Jellyfin until changed                                                              |
+| Avatar image (if avatar sync is enabled for a provider)                              | Identity data                             | Profile-image sync from the IdP                                      | Fetched from the IdP (SSRF-guarded) and stored as the user's **Jellyfin profile image**                                          | In Jellyfin until replaced/removed; disable per provider to avoid it                                                        |
+| Client IP address                                                                    | Network identifier                        | Rate-limiting of the anonymous SSO endpoints (opt-in feature)        | **In-memory only** (rate-limit buckets); never persisted by the plugin                                                           | Evicted with the rate-limit window; gone on restart                                                                         |
+| Login flow state (state, nonce, one-time outcome tokens, SAML request/replay caches) | Protocol data                             | CSRF/replay protection and flow integrity                            | In-memory only, single-use, short-lived                                                                                          | Minutes (single-use, expiring)                                                                                              |
+| OpenID client secret / SAML signing keys                                             | Operator secrets (not personal data)      | Provider authentication                                              | Plugin configuration, AES-256-GCM-encrypted at rest (`ssoenc:v1:`) with a separate key file                                      | Until the operator changes them                                                                                             |
+
+## Data minimization
+
+- The plugin persists **only** the subject-keyed link (plus the bound issuer)
+  — no email, no display name, no claims are stored by the plugin itself.
+- **Avatar sync is per-provider** — leave it off and no image is fetched.
+- Role/group claims can be scoped at the IdP: send only the groups the mapping
+  actually uses.
+- The IdP consent screen (where supported) is the right place to make the data
+  flow visible to end users; the plugin only ever sees what the IdP releases.
+
+## Data-subject rights (operator runbook)
+
+- **Access / erasure of the link:** the self-service linking page
+  (`/SSOViews/linking`) shows and removes a user's own links; an admin can
+  remove any link. Erasing the Jellyfin account itself is a Jellyfin-core
+  operation. A dedicated export path for link data is tracked in
+  [#760](https://github.com/iderex/jellyfin-plugin-sso/issues/760).
+- **Everything else the login produced** (username, permissions, avatar) lives
+  in Jellyfin's own user store and follows Jellyfin's user deletion.
+- **Logs** follow the operator's Jellyfin log rotation/retention.
+
+## Third parties
+
+The only external party in the flow is the **operator's own identity
+provider**. The plugin makes no telemetry, update-check, or analytics calls of
+any kind.

--- a/docs/SECURITY-REMEDIATION-POLICY.md
+++ b/docs/SECURITY-REMEDIATION-POLICY.md
@@ -1,0 +1,67 @@
+# Security remediation & secrets policy
+
+The written policy behind the gates CI already enforces. Rule of this document:
+it describes **what the tooling actually does** — if enforcement and policy
+ever drift, the policy is corrected or the gate is fixed, never papered over.
+
+## SCA — dependency vulnerabilities
+
+- **Merge gate:** a pull request that introduces or upgrades to a dependency
+  with a known vulnerability of **any severity (low and up)** is blocked
+  (`dependency-review` runs with `fail-on-severity: low`), transitive
+  dependencies included. The build itself also fails on known-vulnerable
+  dependencies, so the gate holds even outside PR context.
+- **Release gate:** a release is cut from a green `main`; the same checks make
+  a release with a known-vulnerable dependency impossible without an explicit,
+  documented exception (see _Accepted residuals_).
+- **Remediation timeframe** (for a vulnerability newly published against an
+  already-merged dependency): critical/high — patch or mitigate in the **next
+  release, expedited if exploitation is likely** (target: days, not weeks);
+  medium — next regular release; low — next regular release or batched with
+  the following one. Dependabot PRs for security updates are prioritized over
+  feature work (security before features).
+- **Dependabot** watches both ecosystems (NuGet and GitHub Actions); its
+  security PRs run the full gate like any other change.
+
+## SAST — static analysis
+
+- **Merge gate:** CodeQL (with the `security-extended` query pack) and the
+  repository-specific Opengrep invariant ruleset run on every pull request;
+  **any Opengrep finding fails the check outright** (`--error`), and CodeQL
+  alerts on the PR block merge until dispositioned. The .NET build runs with
+  warnings-as-errors, which promotes analyzer findings to build failures.
+- **Disposition of findings:** a finding is either **fixed before merge** or
+  **explicitly accepted** with a written rationale (a code comment at the site
+  or a note in the PR) — silent dismissal is not an option. False positives in
+  the Opengrep ruleset are fixed in the ruleset itself, never waived ad hoc.
+- **Accepted residuals** are documented where they live: the
+  [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)
+  wiki page records the known accepted residual(s) of the overall gate stack.
+
+## Secrets management
+
+- **No plaintext secrets in version control — enforced, not aspirational:**
+  GitHub secret scanning with **push protection** blocks a credential push
+  before it lands; there are no committed credentials, and the repository
+  history is clean of them.
+- **CI credentials are least-privilege:** workflows start from an explicit
+  deny-all (`permissions: {}`) and grant per-job read-only scopes; publishing
+  jobs use the ephemeral `GITHUB_TOKEN` with only the scopes the job needs.
+  There are no long-lived cloud credentials in this repository; if a cloud
+  integration is ever added, it uses **OIDC federation, not stored secrets**.
+- **Runtime secrets** (the operator's OIDC client secret, SAML signing keys)
+  never appear in the repository or CI at all — they live in the operator's
+  plugin configuration, AES-256-GCM-encrypted at rest with a separate key file
+  (see [SECURITY.md](../SECURITY.md) and
+  [docs/PRIVACY.md](PRIVACY.md)), are write-only in the admin API, and are
+  redacted from configuration exports.
+- **Rotation:** the maintainer's GitHub credentials use the platform's
+  strong-auth features; a leaked or suspected-leaked credential is rotated
+  immediately and the incident is noted in the affected release notes if any
+  artifact could have been touched.
+
+## Scope
+
+This policy covers the repository, its CI, and its release artifacts. Server
+operators' deployment secrets are covered by their own operational practices —
+the plugin's contribution is that it never logs, exports, or returns them.


### PR DESCRIPTION
# What & why

Four audit-grade policy documents the RC positioning was missing, published together as one coherent set:

| Doc | Issue | Substance |
|---|---|---|
| `GOVERNANCE.md` | #745 | Honest one-person roles/access (AI-assisted model, CODEOWNERS cross-ref, **no implied independent team**), decision-making, elevated-access vetting bar, bus-factor/continuity stance |
| `SECURITY.md` - support policy | #744 | One active 4.x line; fixes land in a new latest release for all ABI builds; ≥6 months security fixes for the previous line once a new major goes stable; EOL announced in CHANGELOG with 3 months notice; **best-effort volunteer framing, no SLA over-claim** |
| `SECURITY.md`, CRA position | #761 | Non-commercial FLOSS placement; voluntary Art. 24 steward-style commitments mapped to the existing policy; **explicit no-conformity/no-CE claim**; commercial-redistributor responsibility boundary; links the OpenVEX/SBOM track (#763) |
| `docs/PRIVACY.md` | #728 | Full data inventory (subject links, transient claims, in-memory IPs, GUIDs in logs, avatars, flow state, secrets) with purpose/location/retention; controller/processor honesty; minimization guidance; operator DSR runbook; links the export-path issue (#760). Un-ignored in `.gitignore` per the docs/ policy |

README links the set from *Documentation*; CONTRIBUTING links GOVERNANCE.

Closes #745, Closes #744, Closes #761, Closes #728

## Type of change
- [x] Documentation only

## Security checklist
- [x] **No over-claims anywhere:** no independent-review claim (GOVERNANCE), no SLA (support), no CRA-conformity/CE claim (CRA), no "GDPR-compliant" claim (PRIVACY, supports the operator's compliance).
- [x] Every factual statement checked against the code/repo (link key shape, encrypted-secret format, in-memory-only rate limiting, no telemetry).

## Verification
- [x] Prettier 3.9.5 clean on all five files.
- [x] All internal links/anchors verified.

---

**Second commit [#748]:** adds `docs/SECURITY-REMEDIATION-POLICY.md`, the written SCA/SAST remediation-threshold and secrets-management policy behind the existing gates (OSPS-VM-05.01/VM-06.01/BR-07.02). Policy strictly matches current enforcement (dependency-review `fail-on-severity: low`, Opengrep `--error`, deny-all workflow permissions); no overclaim. Closes #748
