### PR TITLE
Enforce bracketed issue references in every commit subject

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -90,6 +90,44 @@ jobs:
               );
             }
 
+            // --- Check 1b: every commit subject carries [#N] refs (#817) ---------
+            // Maintainer rule: traceability must survive down to the single commit —
+            // blame/bisect/log show a commit's SUBJECT line without its PR, so the
+            // PR-body link (check 1) is not enough. The reference lives in the
+            // subject, bracketed, one bracket per issue: `Fix the thing [#12][#34]`.
+            // (GitHub's auto-close keywords still go in the body — `[#N]` in a
+            // subject does not close anything.) Bots and merge commits (subject
+            // starts with "Merge ") are exempt; merge commits are machine-generated
+            // and inherit the merged PR's own linkage.
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const subjectHasBracketedRef = (message) =>
+              /\[#\d+\]/.test(message.split("\n")[0]);
+            const unlinked = commits.filter((c) => {
+              const authorIsBot =
+                (c.author && c.author.type === "Bot") ||
+                /\[bot\]/.test((c.commit.author && c.commit.author.name) || "");
+              const isMerge =
+                c.parents.length > 1 || c.commit.message.startsWith("Merge ");
+              return (
+                !authorIsBot && !isMerge && !subjectHasBracketedRef(c.commit.message)
+              );
+            });
+            if (!isBot && unlinked.length > 0) {
+              const list = unlinked
+                .map((c) => `${c.sha.slice(0, 7)} ("${c.commit.message.split("\n")[0]}")`)
+                .join(", ");
+              failures.push(
+                `Commit subject(s) without a bracketed issue reference: ${list}. ` +
+                  "Every commit subject must end with its issue reference(s) in " +
+                  "the form `[#N]` (multiple issues: `[#N][#M]`).",
+              );
+            }
+
             // --- Check 2: a build.yaml version bump must touch CHANGELOG.md -----
             // The version field only changes in a release PR, which must also record
             // the release in CHANGELOG.md. Near-zero false-positive: a non-release PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ We are always open to better docs! The main place documentation could be improve
 
 ### Commit Messages
 
-Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); explain the _why_ in the body and reference the issue it closes.
+Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); explain the _why_ in the body. **Every commit subject ends with its issue reference(s) in brackets** — `Add SAML replay cache [#123]`, multiple issues as `[#123][#456]` — so the link survives `git blame`/`bisect`/`log`, which show only the subject. GitHub's auto-close keywords (`Closes #N`) additionally go in the body when the commit resolves the issue. The PR-hygiene gate enforces the bracketed subject reference per commit (bots and merge commits exempt).
 
 ### C#
 


### PR DESCRIPTION
# What & why

Re-opened replacement for #818, which GitHub auto-closed during the outage when the `ci/` → `chore/` branch rename (branch-prefix convention) lost its PR retarget server-side. Identical content, rebased on current `main`.

A rule I am adding: **every commit subject must carry its issue reference(s) in brackets**, `Fix the thing [#12]`, multiple as `[#12][#34]`, so traceability survives `git blame`/`bisect`/`log`, which show only the subject line. GitHub's auto-close keywords (`Closes #N`) still go in the body when the commit resolves the issue.

The PR-hygiene gate now lists the PR's commits and **fails** on any commit subject without a `[#N]` reference. Bots and merge commits are exempt. CONTRIBUTING.md documents the format; the merge-gate line is reworded to first person while there.

Closes #817

## Type of change
- [x] CI / process

## Security checklist
- [x] Read-only (`pulls.listCommits` under the existing `pull-requests: read` grant); no new permissions.
- [x] Untrusted values stay inside the JS context, nothing interpolated into a shell `run:`; zizmor-clean construction preserved.

## Docs impact considered
- [x] CONTRIBUTING.md updated in this PR.

## Verification
- [x] Prettier 3.9.5 clean; workflow JS parses; the check dogfoods itself (this PR's own commit subject carries `[#817]`).