### PR TITLE
Enable nullable reference types across the leaf modules

### DIFF
--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 

--- a/SSO-Auth/Api/Authz/PermissionGrant.cs
+++ b/SSO-Auth/Api/Authz/PermissionGrant.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Jellyfin.Database.Implementations.Enums;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Avatar/AvatarContentType.cs
+++ b/SSO-Auth/Api/Avatar/AvatarContentType.cs
@@ -1,3 +1,7 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 
 /// <summary>
@@ -18,7 +22,7 @@ internal static class AvatarContentType
     /// a bare form produced dotless filenames like <c>profilepng</c> (#384).
     /// </param>
     /// <returns><c>true</c> when the media type is an allowed raster image; otherwise <c>false</c>.</returns>
-    internal static bool TryResolveExtension(string mediaType, out string extension)
+    internal static bool TryResolveExtension(string? mediaType, [NotNullWhen(true)] out string? extension)
     {
         extension = (mediaType ?? string.Empty).ToLowerInvariant() switch
         {

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using System.Net;
@@ -97,8 +99,8 @@ internal sealed class AvatarService
         ILogger logger,
         string userAgent,
         HttpClient httpClient,
-        KeyedLockStore userStoreLocks = null,
-        Func<string, bool> fileExists = null,
+        KeyedLockStore? userStoreLocks = null,
+        Func<string, bool>? fileExists = null,
         TimeSpan? storeLockAcquireTimeout = null)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
@@ -120,7 +122,7 @@ internal sealed class AvatarService
     /// <param name="user">The user whose profile image is set.</param>
     /// <param name="avatarUrl">The provider-supplied avatar URL, or null to skip.</param>
     /// <returns>A <see cref="Task"/> that completes when the avatar has been set or skipped.</returns>
-    internal async Task TrySetAsync(User user, string avatarUrl)
+    internal async Task TrySetAsync(User user, string? avatarUrl)
     {
         if (avatarUrl is null)
         {
@@ -202,7 +204,9 @@ internal sealed class AvatarService
 
             using var stream = await ReadCappedAsync(avatarResponse, MaxAvatarBytes, timeout.Token).ConfigureAwait(false);
 
-            await StoreAsync(user, stream, mediaType, extension).ConfigureAwait(false);
+            // mediaType is non-null here: TryResolveExtension above returns false (and this method throws)
+            // for a null or unresolvable media type, so reaching this line proves it matched the allow-list.
+            await StoreAsync(user, stream, mediaType!, extension).ConfigureAwait(false);
         }
         catch (Exception e)
         {
@@ -391,7 +395,7 @@ internal sealed class AvatarService
         // multi-record hosts, since supplying a ConnectCallback replaces the handler's built-in one),
         // connecting to the validated IP rather than the hostname so a DNS rebind cannot redirect the
         // connection to an internal address.
-        Exception lastError = null;
+        Exception? lastError = null;
         var attempted = false;
         foreach (var address in addresses)
         {

--- a/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
@@ -20,7 +23,7 @@ internal static class AvatarUrlValidator
     /// <param name="url">The candidate avatar URL.</param>
     /// <param name="uri">The parsed URI when allowed; otherwise null.</param>
     /// <returns>True when the URL is allowed to be fetched.</returns>
-    internal static bool IsAllowedUrl(string url, out Uri uri)
+    internal static bool IsAllowedUrl(string url, [NotNullWhen(true)] out Uri? uri)
     {
         uri = null;
         if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var parsed))

--- a/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
@@ -23,7 +26,7 @@ internal static class CanonicalBaseUrl
     /// <param name="raw">The configured override value.</param>
     /// <param name="normalized">The normalized base URL when the value is a valid override.</param>
     /// <returns><see langword="true"/> if <paramref name="raw"/> is a valid absolute http/https base URL.</returns>
-    internal static bool TryNormalize(string raw, out string normalized)
+    internal static bool TryNormalize(string? raw, [NotNullWhen(true)] out string? normalized)
     {
         normalized = null;
         if (string.IsNullOrWhiteSpace(raw))
@@ -59,7 +62,7 @@ internal static class CanonicalBaseUrl
     /// </summary>
     /// <param name="raw">The configured override value.</param>
     /// <returns><see langword="true"/> if the value is set but not a valid base URL.</returns>
-    internal static bool IsInvalidOverride(string raw)
+    internal static bool IsInvalidOverride(string? raw)
         => !string.IsNullOrWhiteSpace(raw) && !TryNormalize(raw, out _);
 
     /// <summary>
@@ -81,7 +84,7 @@ internal static class CanonicalBaseUrl
     /// <param name="schemeOverride">The per-provider scheme override, or null.</param>
     /// <param name="portOverride">The per-provider port override, or null.</param>
     /// <returns>The external base URL, without a trailing slash.</returns>
-    internal static string Resolve(string baseUrlOverride, string scheme, string host, int? port, string pathBase, string schemeOverride, int? portOverride)
+    internal static string Resolve(string? baseUrlOverride, string scheme, string host, int? port, string pathBase, string? schemeOverride, int? portOverride)
     {
         if (!string.IsNullOrWhiteSpace(baseUrlOverride))
         {

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -1,3 +1,6 @@
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
 
@@ -52,7 +55,7 @@ internal static class IpAddressClassifier
     /// <param name="bytes">The 16 bytes of the IPv6 address.</param>
     /// <param name="embedded">The embedded IPv4 address when one is present; otherwise null.</param>
     /// <returns>True when an embedded IPv4 address was extracted.</returns>
-    internal static bool TryExtractEmbeddedIPv4(byte[] bytes, out IPAddress embedded)
+    internal static bool TryExtractEmbeddedIPv4(byte[] bytes, [NotNullWhen(true)] out IPAddress? embedded)
     {
         embedded = null;
 

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Diagnostics;
 using System.Net.Http;
 

--- a/SSO-Auth/Api/RateLimit/IntervalGate.cs
+++ b/SSO-Auth/Api/RateLimit/IntervalGate.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Threading;
 

--- a/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
+++ b/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -56,7 +58,7 @@ internal sealed class PerClientBudgetLimiter
     /// </summary>
     /// <param name="clientKey">The normalized client key, or null for an unattributable/exempt source.</param>
     /// <returns>True if a slot was reserved (or the key is exempt); false when the key is at its share.</returns>
-    internal bool TryReserve(string clientKey)
+    internal bool TryReserve(string? clientKey)
     {
         if (clientKey is null)
         {
@@ -96,7 +98,7 @@ internal sealed class PerClientBudgetLimiter
     /// under-count and let the bucket admit past its cap.
     /// </summary>
     /// <param name="clientKey">The client key whose slot is freed, or null (a no-op).</param>
-    internal void Release(string clientKey)
+    internal void Release(string? clientKey)
     {
         if (clientKey is null)
         {

--- a/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
@@ -10,6 +12,6 @@ internal static class ProviderScopedKey
 {
     // The newline separator cannot occur in a Guid-based AuthnRequest id, and both parts come from the
     // same trusted config/flow, so it partitions the key space by provider without collision.
-    internal static string For(string provider, string id) =>
+    internal static string? For(string provider, string? id) =>
         string.IsNullOrEmpty(id) ? id : provider + "\n" + id;
 }

--- a/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;
@@ -81,7 +83,7 @@ internal sealed class SsoRateLimiter
     /// value visible here is client-supplied and spoofable — keying on it would let an attacker
     /// rotate keys to evade or pin a victim's address to lock them out.</param>
     /// <returns>The rate-limit key, or null when the client cannot be attributed.</returns>
-    internal static string NormalizeClientKey(IPAddress remoteIp)
+    internal static string? NormalizeClientKey(IPAddress? remoteIp)
     {
         var ip = remoteIp;
         if (ip == null)
@@ -149,7 +151,7 @@ internal sealed class SsoRateLimiter
     /// <param name="nowUtc">The current time.</param>
     /// <param name="retryAfterSeconds">Whole seconds until the window expires, when refused.</param>
     /// <returns>True when the hit is allowed; false when the client is over the limit.</returns>
-    internal bool IsAllowed(string key, int maxAttempts, TimeSpan window, DateTime nowUtc, out int retryAfterSeconds)
+    internal bool IsAllowed(string? key, int maxAttempts, TimeSpan window, DateTime nowUtc, out int retryAfterSeconds)
     {
         retryAfterSeconds = 0;
         if (string.IsNullOrEmpty(key) || maxAttempts < 1)

--- a/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;

--- a/SSO-Auth/Api/Secrets/SecretEnvelope.cs
+++ b/SSO-Auth/Api/Secrets/SecretEnvelope.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -30,7 +33,7 @@ internal static class SecretEnvelope
     /// </summary>
     /// <param name="value">The stored value.</param>
     /// <returns>True when the value carries the envelope prefix.</returns>
-    internal static bool IsProtected(string value)
+    internal static bool IsProtected([NotNullWhen(true)] string? value)
         => value != null && value.StartsWith(Prefix, StringComparison.Ordinal);
 
     /// <summary>
@@ -41,7 +44,7 @@ internal static class SecretEnvelope
     /// </summary>
     /// <param name="value">The stored value.</param>
     /// <returns>True when the value is a structurally valid envelope.</returns>
-    internal static bool IsWellFormedEnvelope(string value)
+    internal static bool IsWellFormedEnvelope(string? value)
     {
         if (!IsProtected(value))
         {
@@ -147,7 +150,7 @@ internal static class SecretEnvelope
     /// <param name="value">The envelope string.</param>
     /// <param name="plaintext">The recovered plaintext when successful; otherwise null.</param>
     /// <returns>True when the value decrypted and its tag verified.</returns>
-    internal static bool TryUnprotect(byte[] key, string value, out string plaintext)
+    internal static bool TryUnprotect(byte[] key, string value, [NotNullWhen(true)] out string? plaintext)
     {
         try
         {

--- a/SSO-Auth/Api/Secrets/SecretStore.cs
+++ b/SSO-Auth/Api/Secrets/SecretStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.IO;
 using System.Security.Cryptography;
@@ -20,7 +22,7 @@ internal sealed class SecretStore
 {
     private readonly string _keyFilePath;
     private readonly System.Threading.Lock _lock = new();
-    private byte[] _cachedKey;
+    private byte[]? _cachedKey;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SecretStore"/> class.
@@ -53,7 +55,7 @@ internal sealed class SecretStore
     /// <exception cref="CryptographicException">
     /// <paramref name="configHasEnvelopes"/> is true and the key file is missing (a key existed and was lost).
     /// </exception>
-    internal string Protect(string storedValue, bool configHasEnvelopes = false)
+    internal string? Protect(string? storedValue, bool configHasEnvelopes = false)
     {
         // Skip only a genuinely-encrypted value (idempotency); a plaintext that merely starts with the
         // envelope prefix is not a well-formed envelope and is still encrypted here rather than stored raw.
@@ -73,7 +75,7 @@ internal sealed class SecretStore
     /// <param name="storedValue">The secret as read from configuration.</param>
     /// <returns>The plaintext secret.</returns>
     /// <exception cref="CryptographicException">The key file is missing/corrupt, or the value did not decrypt.</exception>
-    internal string Reveal(string storedValue)
+    internal string? Reveal(string? storedValue)
     {
         if (string.IsNullOrEmpty(storedValue) || !SecretEnvelope.IsProtected(storedValue))
         {


### PR DESCRIPTION
# What & why

First step of the project-wide NRT rollout (#799). Turns on `#nullable enable` for every file in the six **leaf** modules, Net, Secrets, Audit, Authz, Avatar, RateLimit (17 files that lacked it), and annotates the resulting contracts to their real nullability.

**Annotations only, no runtime behaviour change.** The full suite passes identically (**1589** both TFMs), and the guards themselves are untouched; only the type annotations now state what the code already did.

Highlights:
- Try-family out params carry `[NotNullWhen(true)]` (non-null on success).
- Methods whose existing guards already handle null take `string?` (SecretEnvelope, SecretStore, SsoRateLimiter, PerClientBudgetLimiter, ProviderScopedKey, CanonicalBaseUrl, AvatarService).
- `SecretEnvelope.IsProtected` gains `[NotNullWhen(true)]` on its parameter, documenting the guarantee `IsWellFormedEnvelope` relies on.
- One documented `!` (AvatarService.mediaType), provably non-null past the `TryResolveExtension` gate.

Refs #799

## Type of change
- [x] Refactor / code quality

## Security checklist
- [x] **Touches the Secrets (crypto) and RateLimit modules** → adversarial `/security-review` run on this diff before merge (see the review comment).
- [x] Fail-closed preserved: every null-guard (`ArgumentNullException.ThrowIfNull`, `IsNullOrEmpty`, `value != null`, the SSRF/rate-limit exemptions) is byte-identical; only annotations changed.
- [x] No secret logged; no crypto logic altered (AES-GCM protect/unprotect bodies untouched).

## Quality checklist
- [x] No lazy `!`-spam: exactly one `!`, documented, at a proven-non-null site.
- [x] `[NotNullWhen]` used to express real invariants rather than silence warnings.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1589 both TFMs, unchanged count).

## Notes
Next NRT PRs: Provider/Linking/Session, then Saml, Oidc, Shared/Flows, then the final csproj flip to `<Nullable>enable</Nullable>` + pragma removal.