### PR TITLE
Link the maturity map from README and SECURITY

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 - Per-identity-provider setup: [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)
 - In-tree contributor map of the login flow and code layout: [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals)
 - Project policies: [Governance](GOVERNANCE.md) · [Privacy & data handling](docs/PRIVACY.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
+- Honest maturity self-assessment (Silver/Gold + OSPS, incl. what a solo project structurally cannot meet): [Maturity Map](https://github.com/iderex/jellyfin-plugin-sso/wiki/Maturity-Map)
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,7 +74,7 @@ replace the manifest MD5.
 - **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
 
-For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). For how they map onto the OpenSSF Best Practices passing-level criteria, see [OpenSSF Best Practices](https://github.com/iderex/jellyfin-plugin-sso/wiki/OpenSSF-Best-Practices).
+For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). For how they map onto the OpenSSF Best Practices passing-level criteria, see [OpenSSF Best Practices](https://github.com/iderex/jellyfin-plugin-sso/wiki/OpenSSF-Best-Practices); for an honest Silver/Gold + OSPS-Baseline map — including the criteria a solo, AI-assisted project structurally cannot meet — see the [Maturity Map](https://github.com/iderex/jellyfin-plugin-sso/wiki/Maturity-Map).
 
 ## EU Cyber Resilience Act (CRA) position
 


### PR DESCRIPTION
# What & why

Closes #749. The new [Maturity Map](https://github.com/iderex/jellyfin-plugin-sso/wiki/Maturity-Map) wiki page, an honest Silver/Gold + OSPS-Baseline self-assessment with the **Structurally N/A** disclosures (Gold `bus_factor`, `contributors_unassociated`, `two_person_review`, OSPS-QA-07.01/AC-03.01) and named compensating controls, is now linked from the README policies row and the SECURITY.md repository-controls section.

The page itself is already live on the wiki (this PR only adds the two cross-links the issue's acceptance requires).

Closes #749

## Type of change
- [x] Documentation only

## Docs impact considered
- [x] This PR is the docs cross-link; the page is on the wiki.

## Verification
- [x] Prettier clean.