### PR TITLE
Enable nullable reference types across the Shared module

### DIFF
--- a/SSO-Auth.Tests/Shared/SsoRateLimitGateTests.cs
+++ b/SSO-Auth.Tests/Shared/SsoRateLimitGateTests.cs
@@ -48,7 +48,7 @@ public class SsoRateLimitGateTests
     // remoteIp is nullable here on purpose: the no-attributable-address case (a null connection peer) is one
     // of the fail-open inputs under test. The gate's own NormalizeClientKey handles null (returns no key), so
     // forwarding it is the behavior being exercised, not a defect — hence the deliberate null-forgiving pass.
-    private static ActionResult Check(string endpointClass, IPAddress? remoteIp, HttpResponse response) =>
+    private static ActionResult? Check(string endpointClass, IPAddress? remoteIp, HttpResponse response) =>
         SsoRateLimitGate.Check(endpointClass, remoteIp!, Substitute.For<ILogger>(), response);
 
     [Fact]

--- a/SSO-Auth/Api/Shared/AuthPageCsp.cs
+++ b/SSO-Auth/Api/Shared/AuthPageCsp.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net.Mime;
 using System.Security.Cryptography;
@@ -62,7 +65,7 @@ internal static class BrowserErrorPage
     // A rejection worth restyling is a 4xx/5xx carrying a plain-text body: either a text/plain
     // ContentResult (FlowResponses.PlainTextError, LoginStatusMapper) or a string-valued ObjectResult
     // (BadRequestObjectResult). A success, a redirect, or the already-HTML auth page yields no message.
-    private static bool TryExtractPlainTextError(ActionResult result, out int status, out string message)
+    private static bool TryExtractPlainTextError(ActionResult result, out int status, [NotNullWhen(true)] out string? message)
     {
         switch (result)
         {

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Net.Mime;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -47,7 +49,7 @@ internal static class SsoRateLimitGate
     /// <param name="logger">The caller's logger, for the bounded throttle-engaged observability signal (#195).</param>
     /// <param name="response">The response whose Retry-After header a throttled outcome sets (#474).</param>
     /// <returns>Null when the request may proceed, or the throttled 429 outcome otherwise.</returns>
-    internal static ActionResult Check(string endpointClass, IPAddress remoteIp, ILogger logger, HttpResponse response)
+    internal static ActionResult? Check(string endpointClass, IPAddress remoteIp, ILogger logger, HttpResponse response)
     {
         var (enabled, maxAttempts, windowSeconds) = SSOPlugin.Instance.ReadConfiguration(
             c => (c.EnableRateLimit, c.RateLimitMaxAttempts, c.RateLimitWindowSeconds));


### PR DESCRIPTION
# What & why

Third NRT step (#799): `#nullable enable` for the six Shared (served-page / flow-response) files. Three annotations, no runtime behaviour change (suite 1589 both TFMs):

- `BrowserErrorPage.TryExtractPlainTextError` out `message` → `[NotNullWhen(true)] out string?`.
- `SsoRateLimitGate.Check` → `ActionResult?`, null already meant "allowed, no rejection" at runtime; this states it. The rate-limit / mass-lockout logic is untouched.
- Test helper mirrors the nullable `Check` return.

Refs #799

## Type of change
- [x] Refactor / code quality

## Security checklist
- [x] **Touches `SsoRateLimitGate`** (the per-client rate-limit / mass-lockout defense) → focused availability review on the diff before merge.
- [x] Fail-open-on-unattributable preserved: `Check` returning null = allowed is the pre-existing contract; `NormalizeClientKey`'s null-exemption and `IsAllowed` are unchanged.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1589 both TFMs).

## Notes
Remaining NRT (the crypto/auth core, Saml, Oidc, Flows) deferred to an unhurried session given the SAML validator's ~37 annotation sites and the stakes; then the csproj flip + pragma removal.