### PR TITLE
Pin the persisted SSO AuthenticationProviderId, decoupled from the controller type

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -715,6 +715,32 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void SsoManagedProviderId_IsPinnedAndUsedByBothStampAndDetector()
+    {
+        // SECURITY / PERSISTENCE pin (#837). This exact string is written to User.AuthenticationProviderId
+        // and persisted in Jellyfin's user database: every SSO-managed account provisioned by any version
+        // carries it, the stamp (CanonicalLinkService) writes it, and the SSO-only detector
+        // (SsoAuthenticationProviders.IsSsoProvider) compares against it. It MUST NEVER change — a different
+        // value silently stops recognizing every existing SSO account — and it MUST stay decoupled from
+        // typeof(SSOController).FullName so a future move of that type (e.g. into an Api.Http module, #807)
+        // cannot orphan those accounts. The value equals the controller's historical full type name; that is
+        // a coincidence of history, not a live coupling.
+        Assert.Equal("Jellyfin.Plugin.SSO_Auth.Api.SSOController", SsoManagedProviderId.Value);
+
+        // The detector resolves to the same pinned value, so the stamp and the detector can never disagree.
+        Assert.Equal(SsoManagedProviderId.Value, SsoAuthenticationProviders.SsoProviderId);
+
+        // The stamp uses the pin, and neither the stamp nor the detector recomputes the id from the
+        // controller type. Source scans, so a regression to type-coupling fails here even if today's value
+        // still happens to match.
+        var stampSource = string.Join("\n", SourceFilesDeclaring(new[] { typeof(CanonicalLinkService) }).Select(File.ReadAllText));
+        var detectorSource = string.Join("\n", SourceFilesDeclaring(new[] { typeof(SsoAuthenticationProviders) }).Select(File.ReadAllText));
+        Assert.Contains("SsoManagedProviderId.Value", stampSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("typeof(SSOController)", stampSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("typeof(SSOController)", detectorSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Controller_DelegatesLoginCompletionToTheFlowService()
     {
         // Locked in by the login-completion extraction (#160, #318 step 11): the one shared completion tail —

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -458,7 +458,7 @@ internal sealed class CanonicalLinkService
         }
 
         var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
-        user.AuthenticationProviderId = typeof(SSOController).FullName!;
+        user.AuthenticationProviderId = SsoManagedProviderId.Value;
         // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
         user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
 

--- a/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
+++ b/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
@@ -1,0 +1,25 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// The single <c>User.AuthenticationProviderId</c> value the plugin stamps on the accounts it manages
+/// (#133) and that the SSO-only feature (#165) uses to detect them. It is a Jellyfin identifier that
+/// resolves to no registered <c>IAuthenticationProvider</c>, so core substitutes its
+/// <c>InvalidAuthenticationProvider</c> and every password attempt on such an account is rejected.
+/// </summary>
+internal static class SsoManagedProviderId
+{
+    /// <summary>
+    /// Gets the pinned provider-id string.
+    /// </summary>
+    /// <remarks>
+    /// SECURITY / PERSISTENCE: this exact string is written to <c>User.AuthenticationProviderId</c> and
+    /// persisted in Jellyfin's user database. It MUST NEVER change — every account provisioned by an
+    /// earlier version carries this literal, and both the stamp (<c>CanonicalLinkService</c>) and the
+    /// SSO-only detector (<c>SsoAuthenticationProviders.IsSsoProvider</c>) compare against it. It is
+    /// deliberately a fixed literal and NOT <c>typeof(SSOController).FullName</c>: coupling a persisted
+    /// value to the controller's namespace meant any future move of that type (e.g. into an Api.Http
+    /// module, #807) would silently stop recognizing every existing SSO-managed account. The value
+    /// happens to equal the controller's historical full type name; a conformance test pins it.
+    /// </remarks>
+    internal const string Value = "Jellyfin.Plugin.SSO_Auth.Api.SSOController";
+}

--- a/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
+++ b/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
@@ -12,11 +12,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 /// </summary>
 /// <remarks>
 /// Jellyfin has no server-wide "disable password login" switch (see SSO-ONLY-LOGIN-DESIGN.md §2); the only
-/// lever is the per-user provider id. Setting it to <see cref="SsoProviderId"/> — the plugin controller's
-/// full type name, which is NOT a registered <c>IAuthenticationProvider</c> — makes Jellyfin route that
-/// account's password attempts to its <c>InvalidAuthenticationProvider</c>, which rejects every password.
-/// This is the exact lever <see cref="CanonicalLinkService"/> already uses for the accounts it
-/// creates (<c>user.AuthenticationProviderId = typeof(SSOController).FullName</c>). Restoring
+/// lever is the per-user provider id. Setting it to <see cref="SsoProviderId"/> — a value that is NOT a
+/// registered <c>IAuthenticationProvider</c> — makes Jellyfin route that account's password attempts to its
+/// <c>InvalidAuthenticationProvider</c>, which rejects every password. This is the exact same pinned value
+/// (<see cref="SsoManagedProviderId"/>) that <see cref="CanonicalLinkService"/> stamps on the accounts it
+/// creates, so the stamp and this detector can never disagree. Restoring
 /// <see cref="DefaultPasswordProviderId"/> re-opens native password login, exactly as the Unregister revoke
 /// path does. Neither value is a secret; both are stable, documented Jellyfin identifiers.
 /// </remarks>
@@ -31,13 +31,14 @@ internal static class SsoAuthenticationProviders
     internal const string DefaultPasswordProviderId = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider";
 
     /// <summary>
-    /// Gets the provider id that disables native password login for an account: the SSO controller's full
-    /// type name, which resolves to no registered password provider (so core substitutes its
-    /// <c>InvalidAuthenticationProvider</c>). Computed from <see cref="SSOController"/> so a namespace/rename
-    /// tracks automatically rather than drifting from the value <see cref="CanonicalLinkService"/>
-    /// stamps on created accounts.
+    /// Gets the provider id that disables native password login for an account: a value that resolves to no
+    /// registered password provider (so core substitutes its <c>InvalidAuthenticationProvider</c>). It is the
+    /// pinned <see cref="SsoManagedProviderId.Value"/> — the exact string <see cref="CanonicalLinkService"/>
+    /// stamps on created accounts — so the stamp and this detector are guaranteed identical. Pinned to a
+    /// fixed literal (rather than derived from the controller's runtime type name) precisely so a future move
+    /// of that type never orphans the already-persisted accounts that carry this literal (#837).
     /// </summary>
-    internal static string SsoProviderId { get; } = typeof(SSOController).FullName!;
+    internal static string SsoProviderId => SsoManagedProviderId.Value;
 
     /// <summary>Whether the given provider id is the plugin's SSO (password-disabling) provider.</summary>
     /// <param name="authenticationProviderId">The account's <c>AuthenticationProviderId</c>.</param>


### PR DESCRIPTION
# What & why

The value stamped on `User.AuthenticationProviderId` to mark an SSO-managed / SSO-only account, and compared against to detect one, was `typeof(SSOController).FullName` in two places. That coupled a value **persisted in Jellyfin's user database** to the controller's namespace: any future move of that type (e.g. into an `Api.Http` module, #807) would change `FullName`, so the stamp + detector would move to the new string while **every already-persisted account kept the old one**, silently making existing SSO-only accounts invisible to the enforcement sweep, the break-glass guard, and status reporting.

Fix: pin it. A new `SsoManagedProviderId.Value` const holds the exact legacy literal `"Jellyfin.Plugin.SSO_Auth.Api.SSOController"`; both `CanonicalLinkService` (the stamp) and `SsoAuthenticationProviders` (the detector) reference it. The const lives in the Linking module (the stamp's home); Session already depends on Linking (existing DAG edge), so no new coupling.

Closes #837

## Type of change
- [x] Security hardening (removes a persisted-value / type-location coupling hazard)

## Security checklist
- [x] **No behaviour change: the persisted string is byte-identical** to what every prior version wrote (`"Jellyfin.Plugin.SSO_Auth.Api.SSOController"`), a new conformance test pins the exact literal, asserts the detector resolves to it, and **source-scans both sites to forbid a regression** to `typeof(SSOController)` coupling.
- [x] Fail-closed preserved: the SSO-only enforcement, break-glass and last-admin logic are untouched; only the source of the (identical) id changed.
- [x] Stamp and detector are now provably identical (both reference the one const).

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1590 both TFMs, +1 pin test).
- [x] ABI-floor build (10.11.0) green.
- [x] opengrep: no landmine referencing the moved token.

## Notes
This is the documented prerequisite that makes the `SSOController` → `Api/Http` move (#807, closing the #790 kernel-dissolution epic) a behaviour-preserving mechanical change.