### PR TITLE
Constrain the Flows and Shared module import lists in the DAG test

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -207,6 +207,8 @@ public class ArchitectureConformanceTests
     [InlineData("Oidc", "Authz", "Avatar", "Identity", "Net", "Provider", "RateLimit", "Routing")] // OIDC flow — mints the keystone (Identity), orchestrates roles, avatar, net, provider, throttle; reads its callback path through the Routing suffix reader
     [InlineData("Identity", "Authz", "Provider")] // the identity keystone — grants (Authz) + link mode (Provider); decoupled from the protocols by #790
     [InlineData("Session", "Authz", "Avatar", "Linking")] // session mint + login outcomes — applies grants (Authz), sets avatars (Avatar), reconciles links (Linking)
+    [InlineData("Shared", "Avatar", "Linking", "RateLimit", "Routing", "Session")] // shared served-page / flow-response + rate-limit-gate helpers — depend downward on the session/linking/avatar/throttle/route tiers, never on a protocol or the boundary
+    [InlineData("Flows", "Audit", "Identity", "Linking", "Net", "Oidc", "Provider", "RateLimit", "Saml", "Session", "Shared")] // per-protocol login orchestration — drives both protocol modules (Oidc/Saml) and the downstream mint/link/session tiers; nothing above the boundary imports it
     [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide; nothing imports it back (#790/#807)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,24 +34,24 @@ case declaring its allowed edges; an import to any other Api module fails the
 test. Importing non-`Api` namespaces (e.g. `Config`) is permitted; there is no
 longer a flat `Api` core to import (see _The kernel is dissolved_ below).
 
-| Module      | Purpose                                                                             | May depend on                                                                     |
-| ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `Net`       | Networking / SSRF / URL primitives                                                  | — (leaf)                                                                          |
-| `Secrets`   | Secrets at rest (envelope, store, config wrapping)                                  | — (leaf)                                                                          |
-| `Audit`     | Append-only SSO audit logging                                                       | — (leaf)                                                                          |
-| `Authz`     | Role → permission mapping                                                           | — (leaf)                                                                          |
-| `Routing`   | Route-shape contract (suffix reader, path classifier)                               | — (leaf)                                                                          |
-| `Avatar`    | Avatar fetch + SSRF-gated validation                                                | `Net`, `RateLimit`                                                                |
-| `RateLimit` | Login throttling (buckets, gates, keys)                                             | `Net`                                                                             |
-| `Provider`  | Provider config / naming / test-result                                              | `Net`, `RateLimit`                                                                |
-| `Linking`   | Account link resolution / adoption / revocation                                     | `Audit`, `Provider`, `RateLimit`                                                  |
-| `Identity`  | The protocol-validated identity keystone                                            | `Authz`, `Provider`                                                               |
-| `Session`   | Session mint + login outcomes + SSO-only                                            | `Authz`, `Avatar`, `Linking`                                                      |
-| `Saml`      | SAML core, validators, caches, metadata                                             | `Authz`, `Identity`, `RateLimit`, `Session`                                       |
-| `Oidc`      | OIDC flow, discovery, id_token, state                                               | `Authz`, `Avatar`, `Identity`, `Net`, `Provider`, `RateLimit`, `Routing`          |
-| `Flows`     | Per-protocol login orchestration services                                           | (orchestration — depends downward)                                                |
-| `Shared`    | Shared served-page / flow-response helpers                                          | (shared — depends downward)                                                       |
-| `Http`      | The web boundary: `SSOController`, request helpers, the admin test-connection probe | the composition top — fronts every flow (wide by design); nothing imports it back |
+| Module      | Purpose                                                                             | May depend on                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Net`       | Networking / SSRF / URL primitives                                                  | — (leaf)                                                                                            |
+| `Secrets`   | Secrets at rest (envelope, store, config wrapping)                                  | — (leaf)                                                                                            |
+| `Audit`     | Append-only SSO audit logging                                                       | — (leaf)                                                                                            |
+| `Authz`     | Role → permission mapping                                                           | — (leaf)                                                                                            |
+| `Routing`   | Route-shape contract (suffix reader, path classifier)                               | — (leaf)                                                                                            |
+| `Avatar`    | Avatar fetch + SSRF-gated validation                                                | `Net`, `RateLimit`                                                                                  |
+| `RateLimit` | Login throttling (buckets, gates, keys)                                             | `Net`                                                                                               |
+| `Provider`  | Provider config / naming / test-result                                              | `Net`, `RateLimit`                                                                                  |
+| `Linking`   | Account link resolution / adoption / revocation                                     | `Audit`, `Provider`, `RateLimit`                                                                    |
+| `Identity`  | The protocol-validated identity keystone                                            | `Authz`, `Provider`                                                                                 |
+| `Session`   | Session mint + login outcomes + SSO-only                                            | `Authz`, `Avatar`, `Linking`                                                                        |
+| `Saml`      | SAML core, validators, caches, metadata                                             | `Authz`, `Identity`, `RateLimit`, `Session`                                                         |
+| `Oidc`      | OIDC flow, discovery, id_token, state                                               | `Authz`, `Avatar`, `Identity`, `Net`, `Provider`, `RateLimit`, `Routing`                            |
+| `Flows`     | Per-protocol login orchestration services                                           | `Audit`, `Identity`, `Linking`, `Net`, `Oidc`, `Provider`, `RateLimit`, `Saml`, `Session`, `Shared` |
+| `Shared`    | Shared served-page / flow-response helpers                                          | `Avatar`, `Linking`, `RateLimit`, `Routing`, `Session`                                              |
+| `Http`      | The web boundary: `SSOController`, request helpers, the admin test-connection probe | the composition top — fronts every flow (wide by design); nothing imports it back                   |
 
 `Saml` and `Oidc` are **sibling protocol modules**: neither imports the other.
 Dependencies point _into_ the low-level leaves (`Net`, `Secrets`, `Audit`,


### PR DESCRIPTION
# What & why

The DAG fitness function `ApiModule_ImportsOnlyItsAllowedApiModules` had an `InlineData` case for every Api module **except `Flows` and `Shared`**, so those two were unconstrained; a wrong-direction or cyclic import from either would not be caught. Surfaced during the #807 architecture review.

Adds both cases, pinning the real edges (`Shared` → Avatar/Linking/RateLimit/Routing/Session; `Flows` → Audit/Identity/Linking/Net/Oidc/Provider/RateLimit/Saml/Session/Shared) and replaces the "depends downward" prose in `docs/ARCHITECTURE.md` with the enumerated edges. Every Api module folder is now DAG-constrained.

Closes #844

## Type of change
- [x] Refactor / code quality (test + doc only)

## Security checklist
- [x] No production code change; a conformance-test tightening + doc.
- [x] The DAG theory passes with the new cases (no cycle, no undeclared import), 1594 both TFMs.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs).
- [x] `dotnet test` green (1594 both TFMs; DAG theory now covers Flows + Shared).