### PR TITLE
Enable deterministic build settings and document reproducibility

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,24 @@
          the restore if a committed lock file would change (drift or tampering). Left off locally so
          a package update does not need the force-evaluate switch. -->
     <RestoreLockedMode Condition="'$(GITHUB_ACTIONS)' == 'true'">true</RestoreLockedMode>
+
+    <!-- Build determinism (#764): with the pinned toolchain (rust-toolchain-equivalent: the SDK is
+         pinned) and the locked dependency graph above, a deterministic compile lets an independent
+         party rebuild from source + lock files and compare against the shipped, SLSA-attested binary.
+         Deterministic removes compile-time nondeterminism (e.g. randomized assembly-internal ordering);
+         it does NOT change runtime behaviour. -->
+    <Deterministic>true</Deterministic>
+
+    <!-- The final determinism switch — normalizes embedded source paths so the build machine's
+         checkout directory does not leak into (or vary) the output. Scoped to CI (the shipped artifact
+         is built there) AND to the shipped project only: it must NOT apply to SSO-Auth.Tests, because
+         ContinuousIntegrationBuild rewrites [CallerFilePath] to a normalized "/_/…" path, and the
+         architecture fitness-function tests resolve the repo root from their own [CallerFilePath] to
+         read source files at test time — path normalization there makes every source-scanning
+         conformance test fail to locate the tree. Reproducibility is a property of the shipped
+         SSO-Auth.dll, not the test assembly, so scoping it to SSO-Auth loses nothing. Left off locally
+         so a debugger keeps real source paths. -->
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true' And '$(MSBuildProjectName)' == 'SSO-Auth'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
 </Project>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,26 @@ gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
 The provenance attestation complements the checksum sidecars — it does not
 replace the manifest MD5.
 
+### Reproducible compile
+
+The build is **deterministic**: `Directory.Build.props` sets `Deterministic` and
+(in CI) `ContinuousIntegrationBuild`, and the dependency graph is pinned by
+committed `packages.lock.json` files restored in locked mode. Together with the
+pinned .NET SDK, an independent party can rebuild the plugin assembly from the
+tagged source and compare it against the shipped, SLSA-attested binary:
+
+```sh
+# from a clean checkout of the release tag, in the pinned SDK:
+GITHUB_ACTIONS=true dotnet build SSO-Auth/SSO-Auth.csproj -c Release
+# then compare the produced SSO-Auth.dll against the one in the release zip
+```
+
+Honest caveat: **the compiled `SSO-Auth.dll` is reproducible; the release `.zip`
+is not byte-identical** — the JPRM packaging step embeds build timestamps and
+ordering into the archive. Reproducibility is therefore verified at the
+**assembly** level (the code that runs), not the archive wrapper; the archive's
+integrity is covered by the SLSA attestation and the checksum sidecars above.
+
 ## Repository security controls
 
 - **Secret scanning** and **push protection** are enabled, so a leaked credential — an identity-provider client secret, a CI token — is blocked before it can be pushed.


### PR DESCRIPTION
# What & why

Closes #764. Adds .NET build-determinism flags to `Directory.Build.props`:
- `Deterministic=true` (always), removes compile-time nondeterminism; no runtime effect.
- `ContinuousIntegrationBuild=true` **CI-only** (conditioned on `GITHUB_ACTIONS`, matching the existing `RestoreLockedMode` pattern), normalizes embedded source paths so the build-machine checkout dir doesn't leak/vary; left off locally so the edit-debug loop keeps real source paths.

On top of the already-pinned, locked-mode dependency graph + pinned SDK, this makes the compiled `SSO-Auth.dll` reproducible: an independent party can rebuild from the tagged source and compare against the shipped, SLSA-attested binary. Complements the existing SLSA v1.1 Build L3 provenance (OpenSSF Gold `build_reproducible`).

`SECURITY.md` gains a **Reproducible compile** subsection next to the SLSA verification steps, with the **honest caveat**: reproducibility is verified at the **assembly** level; the release `.zip` is not byte-identical (JPRM embeds timestamps into the archive, its integrity is covered by SLSA + checksums).

Closes #764

## Type of change
- [x] Build / supply chain

## Security checklist
- [x] No runtime behaviour change, determinism flags affect only compile-time path/ordering normalization.
- [x] `ContinuousIntegrationBuild` is CI-gated, so local debugging is unaffected.

## Verification
- [x] Local build (CIB off): green, warnings-as-errors, both TFMs.
- [x] CI-simulated build (`GITHUB_ACTIONS=true`, CIB on + path normalization): green, 0 warnings.
- [x] Prettier clean.