### PR TITLE
Route the OpenID discovery/JWKS/token fetches through the SSRF-hardened transport

### DIFF
--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using NSubstitute;
 using Xunit;
@@ -8,27 +7,46 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// Tests for <see cref="SsoHttp"/> — the single home for the plugin's outbound HTTP policy (#318, #378).
-/// <see cref="SsoHttp.CreateClient"/> must return the factory's client (over the factory's pooled handler
-/// stack, not a fresh standalone client) with the plugin User-Agent applied, so every server-to-provider
-/// call is identifiable from one definition.
+/// <see cref="SsoHttp.CreateClient"/> must resolve the SSRF-hardened <see cref="SsoHttp.OutboundClientName"/>
+/// named client from the factory (whose primary handler is the hardened transport in production, #755) with
+/// the plugin User-Agent applied, so every server-to-provider call is identifiable and transport-guarded from
+/// one definition.
 /// </summary>
 public class SsoHttpTests
 {
     [Fact]
-    public void CreateClient_AppliesThePluginUserAgentToTheFactoryClient()
+    public void CreateClient_ResolvesTheNamedHardenedClient_AndAppliesTheUserAgent()
     {
         using var factoryClient = new HttpClient();
         var factory = Substitute.For<IHttpClientFactory>();
-        // factory.CreateClient() is the HttpClientFactoryExtensions extension method, which forwards to
-        // the interface's CreateClient(Options.DefaultName) — NSubstitute latches onto that forwarded
-        // interface call, so this Returns covers the parameterless extension too.
-        factory.CreateClient().Returns(factoryClient);
+        // CreateClient must ask for the SSRF-hardened OUTBOUND client by name (#755): in production that name
+        // is registered with the hardened SocketsHttpHandler, so requesting the default client instead would
+        // silently bypass the connect-time guard. A test's stub/loopback factory returns its own client for
+        // this name, keeping an in-process IdP reachable.
+        factory.CreateClient(SsoHttp.OutboundClientName).Returns(factoryClient);
 
         var client = SsoHttp.CreateClient(factory);
 
-        Assert.Same(factoryClient, client); // the factory's client is used, not a fresh one
-        // The whole User-Agent must round-trip against the single-sourced constant — a wrong version or
-        // URL would slip past a substring check.
+        Assert.Same(factoryClient, client); // the named client is used, not the default and not a fresh one
+        factory.Received(1).CreateClient(SsoHttp.OutboundClientName);
+        // The whole User-Agent must round-trip against the single-sourced constant — a wrong version or URL
+        // would slip past a substring check.
         Assert.Equal(SsoHttp.UserAgent, client.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public void CreateHardenedHandler_IsConfiguredWithTheSsrfConnectGuardAndNoProxy()
+    {
+        // The transport guard cannot be exercised at unit level (it fires only on a real socket connect, and
+        // the higher-level tests stub the message handler, #385) — so pin its CONFIGURATION here, so a
+        // regression that drops the ConnectCallback, re-enables the system proxy (which would make the guard
+        // validate the proxy instead of the host), or unbounds redirects fails this test rather than silently
+        // reopening the SSRF / DNS-rebinding vector (#755, #370).
+        using var handler = SsoHttp.CreateHardenedHandler();
+
+        Assert.NotNull(handler.ConnectCallback);
+        Assert.False(handler.UseProxy);
+        Assert.True(handler.AllowAutoRedirect);
+        Assert.Equal(5, handler.MaxAutomaticRedirections);
     }
 }

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -4,7 +4,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
@@ -364,77 +363,7 @@ internal sealed class AvatarService
     // deadline (see TrySetAsync), so this Timeout bounds only connect + header wait. Never disposed —
     // it lives for the process, the intended lifetime of a shared HttpClient.
     private static HttpClient CreateHardenedClient() =>
-        new HttpClient(CreateHardenedHandler(), disposeHandler: true) { Timeout = TimeSpan.FromSeconds(10) };
-
-    // The production handler: routes every connection (including redirect targets) through a callback
-    // that rejects private/loopback addresses, closing the SSRF and DNS-rebinding vectors. Redirects
-    // stay enabled (many avatar URLs redirect) but are bounded, each hop is IP-validated, and both the
-    // request and the download are bounded. Built once for the shared client above.
-    private static SocketsHttpHandler CreateHardenedHandler() => new SocketsHttpHandler
-    {
-        AllowAutoRedirect = true,
-        MaxAutomaticRedirections = 5,
-        ConnectCallback = ConnectToAllowedAddressAsync,
-
-        // A system proxy would be the connection target, so the connect callback would validate the
-        // proxy's address rather than the avatar host's - bypassing the guard.
-        UseProxy = false,
-
-        // The handler is reused across logins, so bound how long a pooled connection lives — after this
-        // the connection is recycled and the host re-resolved, so DNS changes are honored despite reuse.
-        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
-    };
-
-    // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that
-    // resolves to an internal address - including via DNS rebinding on a redirect hop - cannot be reached.
-    private static async ValueTask<Stream> ConnectToAllowedAddressAsync(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
-    {
-        var addresses = await Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
-
-        // Try every non-blocked address in turn (a per-address connect fallback for dual-stack /
-        // multi-record hosts, since supplying a ConnectCallback replaces the handler's built-in one),
-        // connecting to the validated IP rather than the hostname so a DNS rebind cannot redirect the
-        // connection to an internal address.
-        Exception? lastError = null;
-        var attempted = false;
-        foreach (var address in addresses)
-        {
-            if (IpAddressClassifier.IsBlockedAddress(address))
-            {
-                continue;
-            }
-
-            attempted = true;
-            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
-            var connected = false;
-            try
-            {
-                await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
-                connected = true;
-                return new NetworkStream(socket, ownsSocket: true);
-            }
-            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-            {
-                lastError = ex;
-            }
-            finally
-            {
-                // Dispose unless ownership passed to the returned NetworkStream. Runs on the
-                // cancellation path too, where the catch filter is skipped and the socket would leak.
-                if (!connected)
-                {
-                    socket.Dispose();
-                }
-            }
-        }
-
-        if (attempted)
-        {
-            throw new HttpRequestException("Could not connect to any allowed address for the avatar host.", lastError);
-        }
-
-        throw new HttpRequestException("Avatar host resolves only to blocked addresses.");
-    }
+        new HttpClient(SsoHttp.CreateHardenedHandler(), disposeHandler: true) { Timeout = TimeSpan.FromSeconds(10) };
 
     // Copies the response body into memory, aborting if it exceeds the cap, so a hostile endpoint cannot
     // exhaust resources with an unbounded (or Content-Length-lying) download. Internal so the streamed

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -1,20 +1,34 @@
 #nullable enable
 
+using System;
 using System.Diagnostics;
+using System.IO;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 /// <summary>
-/// The one home for the plugin's outbound HTTP policy: the User-Agent value and the factory-client
-/// creation it is applied to, so every server-to-provider call (OpenID discovery, the PKCE-support
-/// probe) is identifiable and configured in one place. The SSRF-guarded avatar fetch builds its own
-/// hardened handler and does not go through <see cref="CreateClient"/>, but consumes
-/// <see cref="UserAgent"/> so the identity stays single-sourced. Enforced by the opengrep rule
-/// no-raw-outbound-httpclient.
+/// The one home for the plugin's outbound HTTP policy: the User-Agent, and the single SSRF-hardened
+/// transport every server-to-provider call is built on. Both the OpenID discovery / token / JWKS backchannel
+/// (through <see cref="CreateClient"/>, which resolves the named <see cref="OutboundClientName"/> client) and
+/// the avatar fetch (which builds its own long-lived client on <see cref="CreateHardenedHandler"/>) share the
+/// same connect-time guard, so a provider or avatar URL resolving to a private/loopback address is rejected
+/// at the transport layer in one place (#370, #755). The named client's hardened handler is registered in the
+/// composition root; a test's stub/loopback factory supplies its own handler for that name, so integration
+/// tests reach their in-process IdP while production stays fail-closed.
 /// </summary>
 internal static class SsoHttp
 {
+    /// <summary>
+    /// The <see cref="IHttpClientFactory"/> name of the plugin's SSRF-hardened outbound client. The
+    /// composition root registers this name with <see cref="CreateHardenedHandler"/>; production
+    /// server-to-provider calls resolve it through <see cref="CreateClient"/>.
+    /// </summary>
+    internal const string OutboundClientName = "sso-outbound";
+
     /// <summary>
     /// The plugin's outbound User-Agent: product token, assembly file version, and project URL.
     /// </summary>
@@ -22,14 +36,91 @@ internal static class SsoHttp
         $"Jellyfin-Plugin-SSO-Auth +{FileVersionInfo.GetVersionInfo(typeof(SsoHttp).Assembly.Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
 
     /// <summary>
-    /// Returns a factory client (over the factory's pooled handler stack) with <see cref="UserAgent"/> applied.
+    /// Returns the SSRF-hardened outbound client (the named <see cref="OutboundClientName"/> client from the
+    /// factory, whose primary handler is <see cref="CreateHardenedHandler"/> in production) with
+    /// <see cref="UserAgent"/> applied. Used for the OpenID discovery / token / JWKS fetches, so a provider
+    /// endpoint that resolves to a private/loopback address cannot be reached (#755).
     /// </summary>
     /// <param name="factory">The shared HTTP client factory.</param>
-    /// <returns>A client with the plugin User-Agent applied.</returns>
+    /// <returns>A client with the plugin User-Agent applied over the hardened transport.</returns>
     internal static HttpClient CreateClient(IHttpClientFactory factory)
     {
-        var client = factory.CreateClient();
+        var client = factory.CreateClient(OutboundClientName);
         client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
         return client;
+    }
+
+    /// <summary>
+    /// The SSRF-hardened transport handler: routes every connection (including redirect targets) through a
+    /// callback that resolves the host and connects only to a non-blocked (public) address, closing the SSRF
+    /// and DNS-rebinding vectors. Redirects stay enabled but bounded; the system proxy is disabled so the
+    /// guard validates the real host, not a proxy; and a pooled connection is recycled periodically so DNS
+    /// changes are honoured despite reuse. The one implementation shared by the OpenID backchannel (via the
+    /// named outbound client) and the avatar fetch.
+    /// </summary>
+    /// <returns>A hardened <see cref="SocketsHttpHandler"/>.</returns>
+    internal static SocketsHttpHandler CreateHardenedHandler() => new()
+    {
+        AllowAutoRedirect = true,
+        MaxAutomaticRedirections = 5,
+        ConnectCallback = ConnectToAllowedAddressAsync,
+
+        // A system proxy would be the connection target, so the connect callback would validate the proxy's
+        // address rather than the real host's — bypassing the guard.
+        UseProxy = false,
+
+        // The handler is reused, so bound how long a pooled connection lives — after this the connection is
+        // recycled and the host re-resolved, so DNS changes are honored despite reuse.
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+    };
+
+    // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that
+    // resolves to an internal address — including via DNS rebinding on a redirect hop — cannot be reached.
+    private static async ValueTask<Stream> ConnectToAllowedAddressAsync(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    {
+        var addresses = await System.Net.Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
+
+        // Try every non-blocked address in turn (a per-address connect fallback for dual-stack / multi-record
+        // hosts, since supplying a ConnectCallback replaces the handler's built-in one), connecting to the
+        // validated IP rather than the hostname so a DNS rebind cannot redirect the connection internally.
+        Exception? lastError = null;
+        var attempted = false;
+        foreach (var address in addresses)
+        {
+            if (IpAddressClassifier.IsBlockedAddress(address))
+            {
+                continue;
+            }
+
+            attempted = true;
+            var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+            var connected = false;
+            try
+            {
+                await socket.ConnectAsync(address, context.DnsEndPoint.Port, cancellationToken).ConfigureAwait(false);
+                connected = true;
+                return new NetworkStream(socket, ownsSocket: true);
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                lastError = ex;
+            }
+            finally
+            {
+                // Dispose unless ownership passed to the returned NetworkStream. Runs on the cancellation path
+                // too, where the catch filter is skipped and the socket would otherwise leak.
+                if (!connected)
+                {
+                    socket.Dispose();
+                }
+            }
+        }
+
+        if (attempted)
+        {
+            throw new HttpRequestException("Could not connect to any allowed address for the outbound host.", lastError);
+        }
+
+        throw new HttpRequestException("The outbound host resolves only to blocked addresses.");
     }
 }

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -1,4 +1,5 @@
-using Jellyfin.Plugin.SSO_Auth.Api;
+using System.Threading;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
@@ -9,9 +10,10 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// <summary>
 /// Registers the plugin's host-side services with Jellyfin's DI container (#165). Jellyfin discovers
 /// <see cref="IPluginServiceRegistrator"/> implementations in plugin assemblies (via a parameterless
-/// constructor) and calls <see cref="RegisterServices"/> while building the generic host. The one service
-/// registered is the boot-time SSO-only reconciliation (<see cref="SsoOnlyReconciliationService"/>), which
-/// makes the documented <c>config.xml</c> total-lockout recovery genuinely restore password login.
+/// constructor) and calls <see cref="RegisterServices"/> while building the generic host. Two things are
+/// registered: the boot-time SSO-only reconciliation (<see cref="SsoOnlyReconciliationService"/>), which
+/// makes the documented <c>config.xml</c> total-lockout recovery genuinely restore password login; and the
+/// SSRF-hardened outbound HTTP client the OpenID backchannel uses (#755).
 /// </summary>
 public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
 {
@@ -21,5 +23,20 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
     /// <param name="serviceCollection">The service collection.</param>
     /// <param name="applicationHost">The server application host.</param>
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
-        => serviceCollection.AddHostedService<SsoOnlyReconciliationService>();
+    {
+        serviceCollection.AddHostedService<SsoOnlyReconciliationService>();
+
+        // The plugin's SSRF-hardened outbound client (#755). The OpenID discovery / token / JWKS fetches
+        // resolve this named client through SsoHttp.CreateClient, so a provider endpoint that resolves to a
+        // private/loopback address is rejected at the transport layer — the same connect-time guard the
+        // avatar fetch uses (SsoHttp.CreateHardenedHandler). A test's stub or loopback factory supplies its
+        // own handler for this name, so an in-process test IdP stays reachable while production is fail-closed.
+        serviceCollection.AddHttpClient(SsoHttp.OutboundClientName)
+            .ConfigurePrimaryHttpMessageHandler(SsoHttp.CreateHardenedHandler)
+            // The hardened handler manages its own connection freshness via PooledConnectionLifetime, so the
+            // factory need not also rotate (and rebuild) the handler on its default 2-minute cadence — the
+            // documented pattern when you own PooledConnectionLifetime. Keeps one long-lived hardened handler
+            // (the ConnectCallback still fires on every connect) instead of churning a new one every 2 minutes.
+            .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+    }
 }

--- a/tools/opengrep/rules.yml
+++ b/tools/opengrep/rules.yml
@@ -125,13 +125,14 @@ rules:
       include:
         - "SSO-Auth/**/*.cs"
 
-  # Invariant (architecture, #318/#378 outbound policy): factory-based outbound
-  # HTTP clients are created only through SsoHttp.CreateClient, so the
-  # User-Agent and any future outbound policy (timeouts, headers) stay in one
-  # place. The SSRF-guarded avatar fetch is the documented exception and builds
-  # its own hardened SocketsHttpHandler (it never uses the factory). SsoHttp
-  # itself receives the factory as a parameter named `factory`, so the clean
-  # tree has zero findings for the controller-field pattern below.
+  # Invariant (architecture, #318/#378 outbound policy; SSRF #755): factory-based
+  # outbound HTTP clients are created only through SsoHttp.CreateClient, which
+  # resolves the SSRF-hardened named "sso-outbound" client, so the User-Agent and
+  # the transport-level SSRF guard stay in one place. The avatar fetch builds its
+  # own long-lived client but on SsoHttp.CreateHardenedHandler (the same shared
+  # guard), and never uses the factory. SsoHttp itself receives the factory as a
+  # parameter named `factory`, so the clean tree has zero findings for the
+  # controller-field pattern below.
   - id: no-raw-outbound-httpclient
     languages: [generic]
     severity: ERROR


### PR DESCRIPTION
# What & why

Closes #755. The avatar fetch is transport-SSRF-guarded; the **OpenID backchannel (discovery / JWKS / token / userinfo) was not**, `OidcLoginService` and `OidcDiscoveryReader` built their client from `SsoHttp.CreateClient`, a plain factory client with no connect-time guard, so a provider endpoint (or a discovery redirect) resolving to a private/loopback address could be reached.

**Approach (the clean seam):** consolidate the SSRF-safe transport into `Net/SsoHttp`, the one hardened `SocketsHttpHandler` (`CreateHardenedHandler` + `ConnectToAllowedAddressAsync`, moved verbatim from `AvatarService`, using the `Net` `IpAddressClassifier`) and a named `"sso-outbound"` client. The composition root registers that named client with the hardened handler, so `SsoHttp.CreateClient`, **unchanged at its two OIDC call sites**, now returns the hardened client in production. The avatar drops its private copies and shares `SsoHttp.CreateHardenedHandler` (dedup: one SSRF implementation, two consumers).

**Test seam = the named client.** A stub `IHttpClientFactory` (the controller harness) returns its stub for any name; a loopback fixture returns a default (unhardened) client for `"sso-outbound"`, so an in-process test IdP stays reachable while production is fail-closed. No `OidcLoginService`/`OidcDiscoveryReader`/fixture code changed.

Closes #755

## Type of change
- [x] Security hardening

## Security checklist
- [x] Fail-closed: the OpenID backchannel now rejects a connection to a private/loopback/blocked address at the transport layer, incl. redirect hops and DNS rebinding, sharing the exact avatar guard (`IpAddressClassifier.IsBlockedAddress`).
- [x] No behaviour change for a correctly-configured public IdP; the stub/loopback test factories are unaffected (they own the handler for the named client).
- [x] Proxy disabled on the hardened handler (so the guard validates the real host, not a proxy); redirects bounded; new test pins this configuration against regression.
- [x] Touches the OIDC login-critical HTTP path → adversarial `/security-review` on this diff before merge.

## Verification
- [x] `dotnet build --warnaserror` green (both TFMs, 0 warnings).
- [x] `dotnet test` green (1595 both TFMs; +2 SsoHttp tests, avatar + OIDC endpoint tests unchanged and green).
- [x] ABI-floor build (10.11.0) green.
- [x] opengrep `no-raw-outbound-httpclient` invariant preserved (its comment updated to reflect the shared hardened transport).

## Docs impact
- [ ] After merge: flip the [Security Conformance](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Conformance) V12 row from **Partial** to **Met** and note the OIDC parity on the Security-Model SSRF section.