### PR TITLE
Map IdP groups to a parental-rating ceiling (MaxParentalRatingScore) [#736]

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia,
 ## Features
 
 - **OpenID Connect and SAML 2.0** — either or both, multiple providers side by side. See the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup).
-- **Role-based access control** — map identity-provider groups/roles to login, administrator, library folders, and Live TV.
+- **Role-based access control** — map identity-provider groups/roles to login, administrator, library folders, Live TV, generic permissions, and a per-group parental-rating (content) ceiling.
 - **Hardened, fail-closed login path** — identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches. Details on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) page.
 - **Optional SSO-only login** — disable password login for every account except a designated break-glass admin, behind a fail-closed last-admin guard so no configuration can strand a server without a working admin login. Runbook on the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup#sso-only-login-disable-password-login) page.
 - **Avatar sync, Quick Connect, and self-service account linking**.

--- a/SSO-Auth.Tests/Authz/ParentalRatingPolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/ParentalRatingPolicyTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="ParentalRatingPolicy"/> — the role → parental-rating-score reducer (#736). Fail
+/// closed toward the LESS permissive outcome: the feature off, no mapping matched, or an empty allow-list
+/// all yield null (leave the existing ceiling), and when several mappings match the MINIMUM (most
+/// restrictive) score wins, never the loosest.
+/// </summary>
+public class ParentalRatingPolicyTests
+{
+    private static OidConfig Config(bool enabled, params ParentalRatingRoleMap[] maps) => new OidConfig
+    {
+        EnableParentalRatingRoles = enabled,
+        ParentalRatingRoleMappings = new List<ParentalRatingRoleMap>(maps),
+    };
+
+    private static ParentalRatingRoleMap Map(int score, params string[] roles) => new ParentalRatingRoleMap { Score = score, Roles = roles };
+
+    [Fact]
+    public void Resolve_FeatureOff_ReturnsNull()
+        => Assert.Null(ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: false, Map(5, "kids"))));
+
+    [Fact]
+    public void Resolve_NullMappings_ReturnsNull()
+        => Assert.Null(ParentalRatingPolicy.Resolve(new[] { "kids" }, new OidConfig { EnableParentalRatingRoles = true, ParentalRatingRoleMappings = null }));
+
+    [Fact]
+    public void Resolve_NoRoleMatches_ReturnsNull()
+        => Assert.Null(ParentalRatingPolicy.Resolve(new[] { "adults" }, Config(enabled: true, Map(5, "kids"))));
+
+    [Fact]
+    public void Resolve_SingleMatch_ReturnsItsScore()
+        => Assert.Equal(5, ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, Map(5, "kids"))));
+
+    [Fact]
+    public void Resolve_MultipleMatches_ReturnsTheMinimumMostRestrictive()
+        => Assert.Equal(3, ParentalRatingPolicy.Resolve(new[] { "a", "b" }, Config(enabled: true, Map(10, "a"), Map(3, "b"), Map(7, "c"))));
+
+    [Fact]
+    public void Resolve_MatchAcrossSeparateEntries_TakesTheStricter_EvenWhenTheLooserComesFirst()
+        => Assert.Equal(2, ParentalRatingPolicy.Resolve(new[] { "teens", "littles" }, Config(enabled: true, Map(9, "teens"), Map(2, "littles"))));
+
+    [Fact]
+    public void Resolve_ZeroScore_IsRespected()
+        => Assert.Equal(0, ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, Map(0, "kids"))));
+
+    [Fact]
+    public void Resolve_NullEntry_IsSkipped_OtherMatchesStillApply()
+        => Assert.Equal(5, ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, null!, Map(5, "kids"))));
+
+    [Fact]
+    public void Resolve_MappingWithNoRoles_NeverMatches()
+        => Assert.Null(ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, Map(5))));
+
+    [Fact]
+    public void Resolve_ConfiguredRoleIsTrimmed()
+        => Assert.Equal(5, ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, Map(5, "  kids  "))));
+
+    [Fact]
+    public void Resolve_MatchingIsOrdinalCaseSensitive()
+        => Assert.Null(ParentalRatingPolicy.Resolve(new[] { "kids" }, Config(enabled: true, Map(5, "Kids"))));
+}

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -36,6 +36,47 @@ public class ProviderConfigValidatorTests
         => Assert.Null(Record.Exception(() =>
             ProviderConfigValidator.ValidateAcrRequirement("kc", new OidConfig { RequireAcr = requireAcr, AcrValues = acrValues })));
 
+    // --- ValidateParentalRatingMappings (#736): reject a negative score or an entry with no roles ---
+
+    [Fact]
+    public void ValidateParentalRatingMappings_NegativeScore_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateParentalRatingMappings(
+            "OpenID", "kc", new[] { new ParentalRatingRoleMap { Score = -1, Roles = new[] { "kids" } } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("kc", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("score", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateParentalRatingMappings_NullRoles_Throws()
+        => AssertNoRolesRejected(null);
+
+    [Fact]
+    public void ValidateParentalRatingMappings_EmptyRoles_Throws()
+        => AssertNoRolesRejected(Array.Empty<string>());
+
+    private static void AssertNoRolesRejected(string[]? roles)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateParentalRatingMappings(
+            "SAML", "idp", new[] { new ParentalRatingRoleMap { Score = 5, Roles = roles! } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("no roles", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateParentalRatingMappings_ValidOrNullOrEmpty_DoesNotThrow()
+    {
+        Assert.Null(Record.Exception(() =>
+        {
+            ProviderConfigValidator.ValidateParentalRatingMappings("OpenID", "kc", new[] { new ParentalRatingRoleMap { Score = 0, Roles = new[] { "kids" } } });
+            ProviderConfigValidator.ValidateParentalRatingMappings("OpenID", "kc", new ParentalRatingRoleMap[] { null! }); // a null entry is tolerated
+            ProviderConfigValidator.ValidateParentalRatingMappings("OpenID", "kc", null); // no mappings at all
+        }));
+    }
+
     // --- ValidateProviderName (#336, #360): reject a NEW round-trip-breaking name; exempt existing names ---
 
     [Theory]

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -57,7 +57,7 @@ public class LoginCompletionServiceTests
     private static AuthResponse Response() =>
         new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
 
-    private static VerifiedIdentity OidcIdentity(string provider, string subject, string username) =>
+    private static VerifiedIdentity OidcIdentity(string provider, string subject, string username, int? maxParentalRatingScore = null) =>
         TestIdentities.Oidc(provider, new OidcAuthorizeStateBuilder.OidcAuthorizeState(
             Username: username,
             Subject: subject,
@@ -68,7 +68,8 @@ public class LoginCompletionServiceTests
             EnableLiveTv: false,
             EnableLiveTvManagement: false,
             Folders: new List<string>(),
-            AvatarUrl: null));
+            AvatarUrl: null,
+            MaxParentalRatingScore: maxParentalRatingScore));
 
     private static VerifiedIdentity SamlIdentity(string provider, string nameId) =>
         TestIdentities.Saml(provider, nameId, new SamlAuthorizeStateBuilder.SamlAuthorizeState(
@@ -97,6 +98,29 @@ public class LoginCompletionServiceTests
         Assert.NotNull(captured);
         Assert.Equal(Created, captured!.UserId);
         Assert.Equal("203.0.113.9", captured.RemoteEndPoint);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_ThreadsTheParentalRatingCeilingFromTheIdentityOntoTheMintedUser()
+    {
+        // #736 end-to-end through the whole keystone thread (VerifiedIdentity -> SessionParameters ->
+        // SessionMinter): a resolved ceiling on the identity lands on the user's MaxParentalRatingScore. Guards
+        // the middle of the threading — every hop is optional/defaulted, so a dropped copy line would compile
+        // and pass the per-unit tests while silently failing to reach the mint; this fails if it does.
+        var config = new OidConfig { Enabled = true, EnableAuthorization = true };
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
+        var created = UserNamed("alice", Created);
+        created.MaxParentalRatingScore = 100; // a looser existing value the resolved ceiling must overwrite
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Created).Returns(created);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice", maxParentalRatingScore: 3), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(3, created.MaxParentalRatingScore);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -232,6 +232,50 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void ParentalRating_MatchedRole_CarriesTheMinimumCeilingOnTheState()
+    {
+        // #736 wiring: the role→parental-rating ceiling derived from the login's roles is carried on the
+        // derived state (and thence to the mint). The login matches two mappings; the minimum (most
+        // restrictive) wins.
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnableParentalRatingRoles = true;
+            c.ParentalRatingRoleMappings = new System.Collections.Generic.List<ParentalRatingRoleMap>
+            {
+                new ParentalRatingRoleMap { Score = 10, Roles = new[] { "teens" } },
+                new ParentalRatingRoleMap { Score = 3, Roles = new[] { "kids" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "teens"), ("role", "kids")),
+            config);
+
+        Assert.Equal(3, result.MaxParentalRatingScore);
+    }
+
+    [Fact]
+    public void ParentalRating_FeatureOff_LeavesTheCeilingNull()
+    {
+        var config = Config(c =>
+        {
+            c.RoleClaim = "role";
+            c.EnableParentalRatingRoles = false;
+            c.ParentalRatingRoleMappings = new System.Collections.Generic.List<ParentalRatingRoleMap>
+            {
+                new ParentalRatingRoleMap { Score = 3, Roles = new[] { "kids" } },
+            };
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("role", "kids")),
+            config);
+
+        Assert.Null(result.MaxParentalRatingScore);
+    }
+
+    [Fact]
     public void AdminRole_GrantsAdmin_ViaNestedJsonRoleClaim()
     {
         var config = Config(c =>

--- a/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
@@ -92,6 +92,43 @@ public class SamlAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void ParentalRating_MatchedRole_CarriesTheMinimumCeilingOnTheState()
+    {
+        // #736 wiring on the SAML side: the role→parental-rating ceiling is carried on the derived state; the
+        // minimum (most restrictive) matched score wins.
+        var config = Config(c =>
+        {
+            c.EnableParentalRatingRoles = true;
+            c.ParentalRatingRoleMappings = new List<ParentalRatingRoleMap>
+            {
+                new ParentalRatingRoleMap { Score = 10, Roles = new[] { "teens" } },
+                new ParentalRatingRoleMap { Score = 3, Roles = new[] { "kids" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "teens", "kids" }, config);
+
+        Assert.Equal(3, result.MaxParentalRatingScore);
+    }
+
+    [Fact]
+    public void ParentalRating_FeatureOff_LeavesTheCeilingNull()
+    {
+        var config = Config(c =>
+        {
+            c.EnableParentalRatingRoles = false;
+            c.ParentalRatingRoleMappings = new List<ParentalRatingRoleMap>
+            {
+                new ParentalRatingRoleMap { Score = 3, Roles = new[] { "kids" } },
+            };
+        });
+
+        var result = SamlAuthorizeStateBuilder.Build(new List<string> { "kids" }, config);
+
+        Assert.Null(result.MaxParentalRatingScore);
+    }
+
+    [Fact]
     public void NonMatchingRole_GrantsNothing()
     {
         var config = Config(c =>

--- a/SSO-Auth.Tests/Session/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/Session/SessionMinterTests.cs
@@ -49,21 +49,23 @@ public class SessionMinterTests
         bool enableLiveTvManagement = false,
         string? avatarUrl = null,
         string? defaultProvider = null,
-        IReadOnlyList<PermissionGrant>? permissionGrants = null) => new SessionParameters
-    {
-        UserId = UserId,
-        IsAdmin = isAdmin,
-        IsBreakGlassAdmin = isBreakGlassAdmin,
-        EnableAuthorization = enableAuthorization,
-        EnableAllFolders = enableAllFolders,
-        EnabledFolders = enabledFolders ?? Array.Empty<string>(),
-        EnableLiveTv = enableLiveTv,
-        EnableLiveTvManagement = enableLiveTvManagement,
-        PermissionGrants = permissionGrants ?? Array.Empty<PermissionGrant>(),
-        AvatarUrl = avatarUrl,
-        DefaultProvider = defaultProvider,
-        AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
-    };
+        IReadOnlyList<PermissionGrant>? permissionGrants = null,
+        int? maxParentalRatingScore = null) => new SessionParameters
+        {
+            UserId = UserId,
+            IsAdmin = isAdmin,
+            IsBreakGlassAdmin = isBreakGlassAdmin,
+            EnableAuthorization = enableAuthorization,
+            EnableAllFolders = enableAllFolders,
+            EnabledFolders = enabledFolders ?? Array.Empty<string>(),
+            EnableLiveTv = enableLiveTv,
+            EnableLiveTvManagement = enableLiveTvManagement,
+            PermissionGrants = permissionGrants ?? Array.Empty<PermissionGrant>(),
+            MaxParentalRatingScore = maxParentalRatingScore,
+            AvatarUrl = avatarUrl,
+            DefaultProvider = defaultProvider,
+            AuthResponse = new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
+        };
 
     [Fact]
     public async Task MintAsync_ResolvedAccountDeleted_ThrowsAndMintsNoSession()
@@ -330,5 +332,49 @@ public class SessionMinterTests
         Assert.True(states[^1].Written); // the final gate ran after the user write
         Assert.False(states[^1].Minted); // and before the mint
         Assert.True(mintCalled); // with both gates true, the mint proceeded
+    }
+
+    [Fact]
+    public async Task MintAsync_EnableAuthorization_AppliesTheParentalRatingCeiling()
+    {
+        // #736: with the master switch on, the resolved parental-rating-score ceiling is written to the user.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, MaxParentalRatingScore = 100 };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: true, maxParentalRatingScore: 7), () => "203.0.113.7", () => true);
+
+        Assert.Equal(7, user.MaxParentalRatingScore);
+    }
+
+    [Fact]
+    public async Task MintAsync_NoAuthorization_LeavesTheParentalRatingCeilingUntouched()
+    {
+        // The ceiling respects the same EnableAuthorization master switch (#215/#736): with it off, a resolved
+        // ceiling is NOT applied — the account's existing value survives.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, MaxParentalRatingScore = 3 };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: false, maxParentalRatingScore: 7), () => "203.0.113.7", () => true);
+
+        Assert.Equal(3, user.MaxParentalRatingScore); // seed left untouched
+    }
+
+    [Fact]
+    public async Task MintAsync_NullCeiling_LeavesTheExistingValueUntouched()
+    {
+        // #736 fail-safe: a null ceiling (no mapping matched) never raises or clears the existing value — an
+        // unmapped or malformed claim leaves MaxParentalRatingScore exactly as it was, even with RBAC on.
+        var (minter, users, sessions) = Build();
+        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId, MaxParentalRatingScore = 3 };
+        users.GetUserById(UserId).Returns(user);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await minter.MintAsync(Params(enableAuthorization: true, maxParentalRatingScore: null), () => "203.0.113.7", () => true);
+
+        Assert.Equal(3, user.MaxParentalRatingScore); // existing ceiling untouched
     }
 }

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -30,6 +30,7 @@ internal static class TestIdentities
             EnableLiveTvManagement = derived.EnableLiveTvManagement,
             AvatarUrl = derived.AvatarUrl,
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+            MaxParentalRatingScore = derived.MaxParentalRatingScore,
         });
 
     internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
@@ -46,5 +47,6 @@ internal static class TestIdentities
             EnableLiveTvManagement = privileges.EnableLiveTvManagement,
             AvatarUrl = null,
             PermissionGrants = privileges.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+            MaxParentalRatingScore = privileges.MaxParentalRatingScore,
         });
 }

--- a/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
+++ b/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+/// <summary>
+/// Reduces a login's roles to a maximum parental-rating-score ceiling (#736), the scalar-policy counterpart
+/// of the boolean <see cref="PermissionRolePolicy"/>. When <c>EnableParentalRatingRoles</c> is on, each
+/// configured mapping whose roles the login holds contributes its score, and the MOST RESTRICTIVE (minimum)
+/// wins — never the loosest. A login that matches no mapping (or the feature being off) yields null, so the
+/// mint leaves the account's existing ceiling untouched: an unmapped or malformed claim never raises it.
+/// </summary>
+internal static class ParentalRatingPolicy
+{
+    /// <summary>
+    /// The parental-rating-score ceiling the login's roles resolve to, or null when the feature is off or no
+    /// mapping matched (leave the existing ceiling untouched).
+    /// </summary>
+    /// <param name="roles">The login's role values.</param>
+    /// <param name="config">The provider configuration carrying the mappings.</param>
+    /// <returns>The minimum matched score, or null when nothing applies.</returns>
+    internal static int? Resolve(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        // Master switch off (the default) or no mappings configured: SSO manages no ceiling, so the mint
+        // leaves MaxParentalRatingScore exactly as it was — byte-for-byte the pre-#736 behavior.
+        if (!config.EnableParentalRatingRoles || config.ParentalRatingRoleMappings is null)
+        {
+            return null;
+        }
+
+        var loginRoles = roles as IReadOnlyCollection<string> ?? new List<string>(roles);
+
+        int? ceiling = null;
+        foreach (var mapping in config.ParentalRatingRoleMappings)
+        {
+            // Fail closed toward the LESS permissive outcome: a null entry contributes nothing (it is
+            // rejected at config-save validation; at runtime we skip rather than throw so a single bad entry
+            // cannot 500 the login). A negative score is likewise rejected on save.
+            if (mapping is null || !MatchesAnyRole(mapping.Roles, loginRoles))
+            {
+                continue;
+            }
+
+            // Minimum-wins: the smallest matched ceiling is the most restrictive, so a login matching several
+            // groups never ends up looser than the strictest group allows.
+            ceiling = ceiling is { } current ? Math.Min(current, mapping.Score) : mapping.Score;
+        }
+
+        return ceiling;
+    }
+
+    // A login holding any of the mapping's roles matches. The configured role is trimmed and compared
+    // ordinally to the (verbatim) login roles, null-safe — the same matching the boolean policy uses.
+    private static bool MatchesAnyRole(string[]? mappingRoles, IReadOnlyCollection<string> loginRoles)
+    {
+        if (mappingRoles is null)
+        {
+            return false;
+        }
+
+        foreach (var role in mappingRoles)
+        {
+            var trimmed = role?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var loginRole in loginRoles)
+            {
+                if (string.Equals(loginRole, trimmed, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -120,6 +120,7 @@ internal sealed class LoginCompletionService
             EnableLiveTv = identity.EnableLiveTv,
             EnableLiveTvManagement = identity.EnableLiveTvManagement,
             PermissionGrants = identity.PermissionGrants,
+            MaxParentalRatingScore = identity.MaxParentalRatingScore,
             AuthResponse = response,
             DefaultProvider = enforcement.DefaultProvider,
             AvatarUrl = identity.AvatarUrl,

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -277,6 +277,9 @@ public class SSOController : ControllerBase
         // the config-page save-time validation. Reuses the one shared validator so every admin write path
         // agrees on what a valid mapping is.
         ProviderConfigValidator.ValidatePermissionRoleMappings(OpenIdProtocol, provider, config.PermissionRoleMappings);
+        // Reject an invalid parental-rating mapping (#736) at the door too (negative score / no roles), like
+        // the permission-role guard above — the Add endpoints bypass the config-page save-time validation.
+        ProviderConfigValidator.ValidateParentalRatingMappings(OpenIdProtocol, provider, config.ParentalRatingRoleMappings);
         // Reject RequireAcr with no acr_values at the door too (#757): an empty allow-list would refuse every
         // login for the provider (a silent single-provider lockout). Mirrors the config-page/import validation
         // so this Add path — which persists through MutateConfiguration and bypasses the save-time Validate —
@@ -550,6 +553,7 @@ public class SSOController : ControllerBase
         RejectInvalidSamlSigningKey(newConfig.SamlRolloverSigningKeyPfx);
         // Reject a malformed generic permission-role mapping (#164) at the door, as OidAdd does.
         ProviderConfigValidator.ValidatePermissionRoleMappings(SamlProtocol, provider, newConfig.PermissionRoleMappings);
+        ProviderConfigValidator.ValidateParentalRatingMappings(SamlProtocol, provider, newConfig.ParentalRatingRoleMappings);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -51,4 +51,7 @@ internal sealed record ValidatedLogin
 
     /// <summary>Gets the generic role→permission grants the login resolves (#164), or empty when the feature is off.</summary>
     internal required IReadOnlyList<PermissionGrant> PermissionGrants { get; init; }
+
+    /// <summary>Gets the parental-rating-score ceiling the login resolves (#736), or null when the feature is off or no mapping matched (leave the existing ceiling untouched).</summary>
+    internal int? MaxParentalRatingScore { get; init; }
 }

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -53,7 +53,8 @@ internal sealed record VerifiedIdentity
         bool enableLiveTv,
         bool enableLiveTvManagement,
         string? avatarUrl,
-        IReadOnlyList<PermissionGrant> permissionGrants)
+        IReadOnlyList<PermissionGrant> permissionGrants,
+        int? maxParentalRatingScore)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -68,6 +69,7 @@ internal sealed record VerifiedIdentity
         EnableLiveTvManagement = enableLiveTvManagement;
         AvatarUrl = avatarUrl;
         PermissionGrants = permissionGrants;
+        MaxParentalRatingScore = maxParentalRatingScore;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -118,6 +120,13 @@ internal sealed record VerifiedIdentity
     internal IReadOnlyList<PermissionGrant> PermissionGrants { get; }
 
     /// <summary>
+    /// Gets the parental-rating-score ceiling the login resolves (#736): the minimum (most restrictive) of
+    /// the matched role→ceiling mappings, applied at the mint under EnableAuthorization. Null when the feature
+    /// is off or no mapping matched, so the account's existing ceiling is left untouched.
+    /// </summary>
+    internal int? MaxParentalRatingScore { get; }
+
+    /// <summary>
     /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
     /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
     /// promoted (role-gate-passed) state — so a raw or unvalidated login can never reach it.
@@ -153,5 +162,6 @@ internal sealed record VerifiedIdentity
             login.EnableLiveTv,
             login.EnableLiveTvManagement,
             login.AvatarUrl,
-            login.PermissionGrants);
+            login.PermissionGrants,
+            login.MaxParentalRatingScore);
 }

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -129,6 +129,7 @@ internal abstract class AuthorizeSession
                 EnableLiveTvManagement = derived.EnableLiveTvManagement,
                 AvatarUrl = derived.AvatarUrl,
                 PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+                MaxParentalRatingScore = derived.MaxParentalRatingScore,
             });
         }
 

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -79,6 +79,10 @@ internal static class OidcAuthorizeStateBuilder
         // Default-deny and empty when the feature is off, so it changes nothing for existing deployments.
         var permissionGrants = PermissionRolePolicy.Map(roles, config);
 
+        // Reduce the roles to a parental-rating-score ceiling (#736): null when the feature is off or no
+        // mapping matched, so the mint leaves the account's existing ceiling untouched.
+        var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
+
         // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
         // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning
         // the claims a second time. Faithful to the original: unlike the preferred-username branch, this
@@ -99,7 +103,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -233,6 +237,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
     /// <param name="AvatarUrl">The resolved avatar candidate URL: the configured AvatarUrlFormat template with @{claim} tokens substituted, or — when no template is configured (null/empty) — the standard OIDC "picture" claim (#723); null when neither yields a value. Only a candidate: the fetch is still gated by AvatarUrlValidator.</param>
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
+    /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -244,5 +249,6 @@ internal static class OidcAuthorizeStateBuilder
         bool EnableLiveTvManagement,
         List<string> Folders,
         string? AvatarUrl,
-        IReadOnlyList<PermissionGrant>? PermissionGrants = null);
+        IReadOnlyList<PermissionGrant>? PermissionGrants = null,
+        int? MaxParentalRatingScore = null);
 }

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -216,6 +216,7 @@ internal sealed class SamlAssertionValidator
             EnableLiveTvManagement = derived.EnableLiveTvManagement,
             AvatarUrl = null,
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
+            MaxParentalRatingScore = derived.MaxParentalRatingScore,
         });
         return true;
     }

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -34,7 +34,11 @@ internal static class SamlAuthorizeStateBuilder
         // Default-deny and empty when the feature is off, so it changes nothing for existing deployments.
         var permissionGrants = PermissionRolePolicy.Map(roles, config);
 
-        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants);
+        // Reduce the roles to a parental-rating-score ceiling (#736): null when the feature is off or no
+        // mapping matched, so the mint leaves the account's existing ceiling untouched.
+        var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
+
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore);
     }
 
     /// <summary>
@@ -45,10 +49,12 @@ internal static class SamlAuthorizeStateBuilder
     /// <param name="EnableLiveTvManagement">Whether the login grants Live TV management.</param>
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
+    /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     internal readonly record struct SamlAuthorizeState(
         bool Admin,
         bool EnableLiveTv,
         bool EnableLiveTvManagement,
         List<string> Folders,
-        IReadOnlyList<PermissionGrant>? PermissionGrants = null);
+        IReadOnlyList<PermissionGrant>? PermissionGrants = null,
+        int? MaxParentalRatingScore = null);
 }

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -101,6 +101,15 @@ internal sealed class SessionMinter
             {
                 user.SetPermission(grant.Kind, grant.Granted);
             }
+
+            // Parental-rating-score ceiling (#736): applied only when the login resolved one (a role matched a
+            // configured mapping); a null leaves the account's existing MaxParentalRatingScore untouched, so an
+            // unmapped or malformed claim never raises the ceiling. Under the same EnableAuthorization master
+            // switch as the grants above, so turning RBAC off leaves the ceiling untouched too.
+            if (parameters.MaxParentalRatingScore.HasValue)
+            {
+                user.MaxParentalRatingScore = parameters.MaxParentalRatingScore;
+            }
         }
 
         await _avatarService.TrySetAsync(user, parameters.AvatarUrl).ConfigureAwait(false);

--- a/SSO-Auth/Api/Session/SessionParameters.cs
+++ b/SSO-Auth/Api/Session/SessionParameters.cs
@@ -67,6 +67,13 @@ internal sealed class SessionParameters
     public required IReadOnlyList<PermissionGrant> PermissionGrants { get; init; }
 
     /// <summary>
+    /// Gets the parental-rating-score ceiling to apply at the mint (#736), or null to leave the account's
+    /// existing ceiling untouched. Applied only when <see cref="EnableAuthorization"/> is on, exactly like the
+    /// other role-derived grants. Optional (defaults null) so an unconfigured provider changes nothing.
+    /// </summary>
+    public int? MaxParentalRatingScore { get; init; }
+
+    /// <summary>
     /// Gets the client identity (app, version, device) the session is bound to.
     /// </summary>
     public required AuthResponse AuthResponse { get; init; }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -251,6 +251,28 @@ public abstract class ProviderConfigBase
     public List<PermissionRoleMap> PermissionRoleMappings { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the role-to-parental-rating mapping
+    /// (<see cref="ParentalRatingRoleMappings"/>) is applied at login (#736). Off by default (fail closed):
+    /// a deployment that does not set it sees no change on upgrade. Gated additionally by
+    /// <see cref="EnableAuthorization"/> at the mint, exactly like the other role-derived grants, so turning
+    /// RBAC off leaves the ceiling untouched.
+    /// </summary>
+    public bool EnableParentalRatingRoles { get; set; }
+
+    /// <summary>
+    /// Gets or sets the role-to-parental-rating-ceiling mappings applied at login when
+    /// <see cref="EnableParentalRatingRoles"/> is on (#736): each entry names a maximum parental-rating
+    /// score and the roles it applies to (e.g. a <c>kids</c> group → a content-rating ceiling). When a login
+    /// matches several entries the MOST RESTRICTIVE (minimum) ceiling wins, never the loosest. A login that
+    /// matches no entry leaves the account's existing ceiling untouched — an unmapped or malformed claim
+    /// never raises the ceiling. Validated fail-closed on save (a negative score, or an entry with no roles,
+    /// is rejected before it is persisted).
+    /// </summary>
+    [XmlArray("ParentalRatingRoleMappings")]
+    [XmlArrayItem(typeof(ParentalRatingRoleMap), ElementName = "ParentalRatingRoleMappings")]
+    public List<ParentalRatingRoleMap> ParentalRatingRoleMappings { get; set; }
+
+    /// <summary>
     /// Gets or sets the authentication provider id written to the user's Jellyfin account
     /// (<c>User.AuthenticationProviderId</c>) after a successful SSO login. This is a Jellyfin-native
     /// user attribute; SSO logins themselves always resolve through the per-provider canonical-link maps,
@@ -636,6 +658,27 @@ public class PermissionRoleMap
     /// <summary>
     /// Gets or sets the roles that grant the permission. A login holding any of these roles is granted
     /// the permission; a login holding none has it explicitly revoked.
+    /// </summary>
+    public string[] Roles { get; set; }
+}
+
+/// <summary>
+/// Maps a set of provider roles to a maximum parental-rating score ceiling (#736): a login holding any of
+/// the listed roles has its Jellyfin <c>MaxParentalRatingScore</c> capped at <see cref="Score"/>. When a
+/// login matches several entries the minimum (most restrictive) score wins. The score is validated
+/// fail-closed on save (non-negative; the role list must be non-empty).
+/// </summary>
+public class ParentalRatingRoleMap
+{
+    /// <summary>
+    /// Gets or sets the maximum parental-rating score granted to the listed roles. A smaller value is more
+    /// restrictive; when several mappings match a login the smallest wins.
+    /// </summary>
+    public int Score { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles the ceiling applies to. A login holding any of these roles is capped at
+    /// <see cref="Score"/>; a login holding none is left untouched.
     /// </summary>
     public string[] Roles { get; set; }
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -265,8 +265,10 @@ public abstract class ProviderConfigBase
     /// score and the roles it applies to (e.g. a <c>kids</c> group → a content-rating ceiling). When a login
     /// matches several entries the MOST RESTRICTIVE (minimum) ceiling wins, never the loosest. A login that
     /// matches no entry leaves the account's existing ceiling untouched — an unmapped or malformed claim
-    /// never raises the ceiling. Validated fail-closed on save (a negative score, or an entry with no roles,
-    /// is rejected before it is persisted).
+    /// never raises the ceiling. A login that DOES match is authoritative, exactly like the admin/folder/Live
+    /// TV grants: the matched (minimum) ceiling is written even if it is looser than a value an administrator
+    /// set by hand, so keep the mappings in sync with the intended policy. Validated fail-closed on save (a
+    /// negative score, or an entry with no roles, is rejected before it is persisted).
     /// </summary>
     [XmlArray("ParentalRatingRoleMappings")]
     [XmlArrayItem(typeof(ParentalRatingRoleMap), ElementName = "ParentalRatingRoleMappings")]

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -45,6 +45,7 @@ internal static class ProviderConfigValidator
                 ValidateProviderName("OpenID", kvp.Key, isNew: live?.OidConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
                 ValidatePermissionRoleMappings("OpenID", kvp.Key, kvp.Value?.PermissionRoleMappings);
+                ValidateParentalRatingMappings("OpenID", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
                 ValidateAcrRequirement(kvp.Key, kvp.Value);
             }
         }
@@ -63,6 +64,7 @@ internal static class ProviderConfigValidator
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
                 ValidatePermissionRoleMappings("SAML", kvp.Key, kvp.Value?.PermissionRoleMappings);
+                ValidateParentalRatingMappings("SAML", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
             }
         }
     }
@@ -182,6 +184,42 @@ internal static class ProviderConfigValidator
             throw new ArgumentException(
                 $"{protocol} provider '{echoName}' has an invalid permission-role mapping: it {reason}. Each mapping's Permission must be the exact name of a Jellyfin PermissionKind (for example EnableContentDownloading) other than IsAdministrator, EnableAllFolders, EnableLiveTvAccess, EnableLiveTvManagement, or IsDisabled.",
                 nameof(mappings));
+        }
+    }
+
+    // A parental-rating mapping (#736) with a negative score or no roles would be persisted and then either
+    // never apply (no roles) or be a nonsensical ceiling — reject both fail-closed at save so a mis-set is
+    // caught before it takes effect. A null entry maps nothing and is tolerated (it contributes nothing at
+    // runtime). Both the config-page save and the Add endpoints run this. The provider name is control-
+    // stripped in case it reaches a log through the thrown exception.
+    internal static void ValidateParentalRatingMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<ParentalRatingRoleMap> mappings)
+    {
+        if (mappings == null)
+        {
+            return;
+        }
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping == null)
+            {
+                continue;
+            }
+
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            if (mapping.Score < 0)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has an invalid parental-rating mapping: the score must be zero or greater (a smaller value is more restrictive; null/unmapped leaves the ceiling untouched).",
+                    nameof(mappings));
+            }
+
+            if (mapping.Roles == null || mapping.Roles.Length == 0)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has a parental-rating mapping with no roles: each mapping must list at least one role the ceiling applies to.",
+                    nameof(mappings));
+            }
         }
     }
 


### PR DESCRIPTION
# What & why

The plugin mapped IdP roles to boolean `PermissionKind` flags but not to **scalar** policy, chiefly `MaxParentalRatingScore`, so an operator could not say "the `kids` group gets a content-rating ceiling" from SSO, the single most-requested parental control. This finishes the scalar piece #164 left open, for both OpenID and SAML.

- **Config (`ProviderConfigBase`):** `EnableParentalRatingRoles` (bool) + a new `ParentalRatingRoleMappings` list of `{Score, Roles}`, both **XML / config-API only** (mirroring the #164 `PermissionRoleMappings`), default off, no change on upgrade.
- **Reducer:** `ParentalRatingPolicy.Resolve` reduces the login's roles to a single `int?` ceiling, the **minimum (most restrictive)** matched score, or null when the feature is off or no mapping matched. Minimum-wins, so several matched groups never end up looser than the strictest allows.
- **Threaded** as an `int?` through the identity keystone (`OidcAuthorizeState`/`SamlAuthorizeState` → `ValidatedLogin` → `VerifiedIdentity` → `SessionParameters`) and applied in `SessionMinter` under the `EnableAuthorization` master switch by direct assignment to `user.MaxParentalRatingScore`. A null leaves the account's existing ceiling untouched, so an unmapped or malformed claim **never raises** it.
- **Validation:** a negative score or a mapping with no roles is rejected at save, on the config-page save/import **and** the `OidAdd`/`SamlAdd` door-guards.

Closes #736

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed *toward the less-permissive outcome*: minimum-wins, and a null (no match) never raises the ceiling; the write is gated by `EnableAuthorization` like the other role-derived grants. The value is a restrictive content ceiling, never an access grant.
- [x] No secrets logged (no new logging).
- [x] A security review was performed (adversarial authz/correctness lenses, see below).
- [x] Log inputs from the IdP are sanitized inline at the log call (the validator control-strips the echoed provider name; no IdP claim is logged).

## Quality checklist

- [x] No duplicated logic; one pure reducer mirroring `PermissionRolePolicy`, threaded through the same six sites the boolean list uses (as init-only/optional properties, so no existing construction site or test broke).
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; comments explain the minimum-wins and never-raise rationale.
- [x] Architecture-conformance tests pass (no form field added, XML/config-API only, like #164, so the provider-form rosters are unaffected).
- [x] Docs impact included: README RBAC line + a Provider-Setup wiki example (pushed with merge).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0 + the JF 10.11.0 ABI floor).
- [x] `dotnet test` green, 1686 tests (both TFMs), +20 new.
- [x] Prettier clean for the `.md` change (the local CRLF `--check` warning is a Windows-working-tree artifact CI does not see).

## Notes

Modelled as a NEW list field rather than folding into `PermissionRoleMappings`, because that type's runtime `Map` returns boolean `PermissionGrant(Kind, bool)`, a scalar `int?` ceiling cannot ride it. `MaxParentalRatingSubScore` and `Preference` fields are deferred as follow-ups, per the issue.