### PR TITLE
Show and copy the exact OIDC redirect URI on the provider form [#724]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -714,6 +714,37 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void OidcRedirectUriField_IsReadOnlyAndUnmarked_AndDerivesFromTheSameBaseTheLoginUses()
+    {
+        // #724: the config page shows the exact redirect_uri the login uses so an admin registers it verbatim
+        // (a mismatch is the most common OIDC setup failure). Structural properties a JS runtime test cannot
+        // pin (no JS harness exists), locked as a source scan:
+        //  - the field is READ-ONLY and carries NO sso-* marker class, so it never becomes a persisting field
+        //    (it is not an OidConfig property; ProviderFormFieldIds_MatchOidConfigProperties stays green);
+        //  - its value is set via .value, never innerHTML (#221);
+        //  - it derives from the Base URL Override (the same canonical base the server's OidcRedirectUriBuilder
+        //    uses) plus the fixed /sso/OID/redirect/ path — deriving from anything else would display a URI the
+        //    login does not actually send;
+        //  - the copy confirmation is announced through an aria-live region (not colour-only).
+        var html = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html"));
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+
+        var field = Regex.Match(html, "<input\\b[^>]*id=\"OidRedirectUri\"[^>]*>", RegexOptions.Singleline);
+        Assert.True(field.Success, "The read-only #OidRedirectUri field must exist in configPage.html (#724).");
+        Assert.Contains("readonly", field.Value, StringComparison.Ordinal);
+        Assert.DoesNotMatch(new Regex("class=\"[^\"]*sso-(text|line-list|toggle|folder-list|role-map)"), field.Value);
+
+        // The copy confirmation is a live region, not a colour-only signal.
+        Assert.Matches(new Regex("id=\"OidRedirectUri-copied\"[^>]*aria-live", RegexOptions.Singleline), html);
+
+        // config.js derives from the base-URL override + the fixed server path, and writes via .value.
+        Assert.Contains("/sso/OID/redirect/", js, StringComparison.Ordinal);
+        Assert.Matches(new Regex("computeRedirectUri[\\s\\S]{0,400}BaseUrlOverride", RegexOptions.Singleline), js);
+        Assert.Matches(new Regex("#OidRedirectUri\"\\)[\\s\\S]{0,200}\\.value\\s*=", RegexOptions.Singleline), js);
+        Assert.DoesNotMatch(new Regex("OidRedirectUri[\\s\\S]{0,200}innerHTML", RegexOptions.Singleline), js);
+    }
+
+    [Fact]
     public void OidcStepUpGate_ReadsAcrFromTheSignatureVerifiedIdToken_NotTheUserInfoMergedPrincipal()
     {
         // Locked in by #757. With LoadProfile on (the default), OidcClient merges the UNSIGNED UserInfo

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -739,7 +739,13 @@ public class ArchitectureConformanceTests
 
         // config.js derives from the base-URL override + the fixed server path, and writes via .value.
         Assert.Contains("/sso/OID/redirect/", js, StringComparison.Ordinal);
-        Assert.Matches(new Regex("computeRedirectUri[\\s\\S]{0,400}BaseUrlOverride", RegexOptions.Singleline), js);
+        Assert.Matches(new Regex("computeRedirectUri[\\s\\S]{0,500}BaseUrlOverride", RegexOptions.Singleline), js);
+        // It normalizes the base through the URL parser so the shown value matches the server's System.Uri
+        // canonicalization (lowercased scheme/host, default port elided) — deriving from the raw override
+        // string would display a URI the login does not send (a redirect_uri mismatch). Pinned on the exact
+        // origin+pathname derivation, which is unique to computeRedirectUri.
+        Assert.Contains("new URL(raw)", js, StringComparison.Ordinal);
+        Assert.Matches(new Regex("\\.origin\\s*\\+\\s*[A-Za-z_$][\\w$]*\\.pathname", RegexOptions.Singleline), js);
         Assert.Matches(new Regex("#OidRedirectUri\"\\)[\\s\\S]{0,200}\\.value\\s*=", RegexOptions.Singleline), js);
         Assert.DoesNotMatch(new Regex("OidRedirectUri[\\s\\S]{0,200}innerHTML", RegexOptions.Singleline), js);
     }

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -701,10 +701,21 @@ const ssoConfigurationPage = {
   // appends the route-decoded name without re-encoding so the string equals the login's byte-for-byte.
   computeRedirectUri: (page, providerName) => {
     const override = page.querySelector("#BaseUrlOverride").value.trim();
-    const base = (override || ApiClient.serverAddress() || "").replace(
-      /\/+$/,
-      "",
-    );
+    const raw = override || ApiClient.serverAddress() || "";
+    let base;
+    try {
+      // Mirror the server's CanonicalBaseUrl (System.Uri.GetLeftPart(UriPartial.Path)) so the shown value
+      // equals what the login sends: `origin` lowercases scheme + host AND elides the default port
+      // (443/80) — exactly as System.Uri does — while pathname keeps any sub-path; query/fragment are
+      // dropped and the trailing slash trimmed. A raw string strip alone would show a non-canonical override
+      // (e.g. `https://X.COM:443`) that the login then normalizes away, causing a redirect_uri mismatch.
+      const u = new URL(raw);
+      base = u.origin + u.pathname.replace(/\/+$/, "");
+    } catch (e) {
+      // Not a parseable absolute URL yet (admin mid-typing, or a bare host): best-effort fall back to the
+      // raw value with only trailing slashes stripped so the field still shows something.
+      base = raw.replace(/\/+$/, "");
+    }
     return base + "/sso/OID/redirect/" + providerName;
   },
   // Live-updates the read-only redirect-URI field; empty (placeholder) until a provider name is entered. Sets

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -175,6 +175,8 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.setInsecureOptionsExpanded(page, false);
     ssoConfigurationPage.resetEditorSections(page);
     ssoConfigurationPage.syncDependentFields(page);
+    // Clear the computed redirect URI back to its placeholder for the fresh/blank editor (#724).
+    ssoConfigurationPage.updateRedirectUri(page);
   },
   // Return every accordion section INSIDE the editor to its authored default collapse state (the sections
   // with data-expanded="true" open, the rest — including "Security & hardening" — collapsed). Scoped to
@@ -687,7 +689,77 @@ const ssoConfigurationPage = {
         // active insecure option. Runs after the check_fields above are set from the loaded provider, so a
         // hidden-but-checked box is never left behind for the next save.
         ssoConfigurationPage.syncDependentFields(page);
+        // Reflect the loaded provider's name + base-URL override in the computed redirect URI (#724).
+        ssoConfigurationPage.updateRedirectUri(page);
       },
+    );
+  },
+  // Computes the exact redirect_uri the login uses, so the admin can register it verbatim at the IdP (#724).
+  // Mirrors the server-side build (OidcRedirectUriBuilder): the canonical base — the Base URL Override when
+  // set, else this server's address — plus the fixed /sso/OID/redirect/<provider> path. The provider name is
+  // appended raw (names are validated to exclude URI-reserved characters, #336), matching the server, which
+  // appends the route-decoded name without re-encoding so the string equals the login's byte-for-byte.
+  computeRedirectUri: (page, providerName) => {
+    const override = page.querySelector("#BaseUrlOverride").value.trim();
+    const base = (override || ApiClient.serverAddress() || "").replace(
+      /\/+$/,
+      "",
+    );
+    return base + "/sso/OID/redirect/" + providerName;
+  },
+  // Live-updates the read-only redirect-URI field; empty (placeholder) until a provider name is entered. Sets
+  // .value only (never innerHTML, #221). Called on name/override input, on load, on reset, and at init.
+  updateRedirectUri: (page) => {
+    const field = page.querySelector("#OidRedirectUri");
+    if (!field) {
+      return;
+    }
+    const name = page.querySelector("#OidProviderName").value.trim();
+    field.value = name
+      ? ssoConfigurationPage.computeRedirectUri(page, name)
+      : "";
+    field.placeholder = name
+      ? ""
+      : "Enter a provider name above to see the redirect URI";
+    // A name/override change invalidates any previous "copied" confirmation.
+    const status = page.querySelector("#OidRedirectUri-copied");
+    if (status) {
+      status.textContent = "";
+    }
+  },
+  copyRedirectUri: (page) => {
+    const field = page.querySelector("#OidRedirectUri");
+    const status = page.querySelector("#OidRedirectUri-copied");
+    const value = field && field.value;
+    if (!value) {
+      return;
+    }
+    const announce = (message) => {
+      if (status) {
+        status.textContent = message;
+      }
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(
+        () => announce("Redirect URI copied to the clipboard."),
+        () => announce("Copy failed — select the field and copy it manually."),
+      );
+      return;
+    }
+    // Fallback for a non-secure context without the async Clipboard API.
+    field.removeAttribute("readonly");
+    field.select();
+    let ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (e) {
+      ok = false;
+    }
+    field.setAttribute("readonly", "");
+    announce(
+      ok
+        ? "Redirect URI copied to the clipboard."
+        : "Copy failed — select the field and copy it manually.",
     );
   },
   deleteProvider: (page, provider_name) => {
@@ -1102,6 +1174,26 @@ export default function initSsoConfigurationPage(view) {
   view
     .querySelector("#BaseUrlOverride")
     .addEventListener("blur", () => ssoConfigurationPage.validateBaseUrl(view));
+
+  // Live-update the computed redirect URI (#724) as the provider name or the base-URL override changes, so
+  // the value shown always matches what the login will send. `input` (per-keystroke) not `blur`, since the
+  // field is purely informational — reflecting immediately is the point.
+  ["OidProviderName", "BaseUrlOverride"].forEach((id) => {
+    view
+      .querySelector("#" + id)
+      .addEventListener("input", () =>
+        ssoConfigurationPage.updateRedirectUri(view),
+      );
+  });
+
+  view.querySelector("#CopyRedirectUri").addEventListener("click", (e) => {
+    ssoConfigurationPage.copyRedirectUri(view);
+    e.preventDefault();
+    return false;
+  });
+
+  // Populate the redirect URI once at init (the blank editor shows its placeholder until a name is typed).
+  ssoConfigurationPage.updateRedirectUri(view);
 
   view.querySelector("#ExportConfig").addEventListener("click", (e) => {
     ssoConfigurationPage.exportConfig(view);

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -377,6 +377,56 @@
                     </div>
                   </div>
 
+                  <!--
+                    Read-only computed redirect URI (#724): shows the exact redirect_uri the login uses, so an
+                    admin can register it verbatim at the identity provider (a wrong value is the most common
+                    OIDC setup failure). NO sso-* marker class and read-only, so it is not a persisting field
+                    (listArgumentsByType must not pick it up, and it stays out of the
+                    ProviderFormFieldIds_MatchOidConfigProperties contract, like OidProviderName). Its value is
+                    set via .value in config.js (never innerHTML, #221). It mirrors the server-side build:
+                    Base URL Override when set, else this server's address, + /sso/OID/redirect/<name>.
+                  -->
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="OidRedirectUri"
+                      >Redirect URI (register this at your provider):</label
+                    >
+                    <div class="sso-redirect-uri-row">
+                      <input
+                        is="emby-input"
+                        id="OidRedirectUri"
+                        type="text"
+                        readonly
+                        aria-describedby="OidRedirectUri-help"
+                      />
+                      <button
+                        is="emby-button"
+                        type="button"
+                        id="CopyRedirectUri"
+                        class="raised button-alt"
+                      >
+                        <span>Copy</span>
+                      </button>
+                    </div>
+                    <div
+                      id="OidRedirectUri-copied"
+                      class="sso-copied-status"
+                      role="status"
+                      aria-live="polite"
+                    ></div>
+                    <div class="fieldDescription" id="OidRedirectUri-help">
+                      The exact redirect URI the login uses — register it
+                      verbatim at your identity provider. It updates as you type
+                      the provider name above. Derived from the
+                      <strong>Base URL Override</strong> (in the Advanced
+                      section) when set, otherwise this server's address; if you
+                      sit behind a reverse proxy, set that override so this
+                      matches what the login actually sends. The legacy spelling
+                      <code>/sso/OID/r/&lt;name&gt;</code> also works.
+                    </div>
+                  </div>
+
                   <div class="inputContainer">
                     <label
                       class="inputLabel inputLabelUnfocused"

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -263,6 +263,33 @@
   font-weight: 700;
 }
 
+/* Computed redirect URI (#724): the read-only field and its copy button on one row */
+.sso-redirect-uri-row {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.sso-redirect-uri-row input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.sso-redirect-uri-row button {
+  flex: 0 0 auto;
+}
+
+.sso-copied-status {
+  margin-top: 0.35em;
+  min-height: 1.2em;
+  color: inherit;
+}
+
+.sso-copied-status:not(:empty)::before {
+  content: "✓ ";
+  font-weight: 700;
+}
+
 /* Sub-groups inside a section */
 .sso-subgroup {
   margin-top: 0.75em;


### PR DESCRIPTION
# What & why

Registering the plugin's `redirect_uri` at the IdP is the highest-friction, highest-error OIDC setup step, the config page never showed it, so an admin had to mentally concatenate base URL + fixed path + provider name, and a wrong value (`redirect_uri` mismatch) is the most common failure. This shows it directly (#724).

- A **read-only, always-visible field** in the OIDC Connection section shows the exact redirect URI, **updating live** as the provider name is typed (placeholder when empty), with a **copy-to-clipboard** button whose success is announced through an **aria-live** region (not colour-only).
- The value derives from the **same canonical base the login uses**, Base URL Override when set, else this server's address, plus the fixed `/sso/OID/redirect/<name>` path, so what is shown equals what the login sends. The help text states which base is shown, notes the reverse-proxy caveat, and surfaces the legacy `/sso/OID/r/<name>` spelling.
- The field carries **no `sso-*` marker** and is read-only, so it never becomes a persisting field (not an `OidConfig` property; `ProviderFormFieldIds_MatchOidConfigProperties` stays green); its value is set via `.value`, **never `innerHTML`** (#221).
- A **conformance test** locks these structural properties (read-only + unmarked, derives from `BaseUrlOverride` + the fixed path, value-not-innerHTML, aria-live confirmation), since no JS runtime harness exists.

Closes #724

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] No new server surface (client-side display only; no new endpoint). The value is set via `.value`, never `innerHTML`, the provider name is not injected as markup (#221), pinned by the conformance test.
- [x] No secrets shown (the redirect URI is public).
- [x] A security review was performed (adversarial correctness/UX + injection lenses, see below).
- [x] N/A, no IdP-supplied input is logged.

## Quality checklist

- [x] No duplicated logic; one resolver mirrors the server-side `OidcRedirectUriBuilder` base + path.
- [x] The change adds no more code than the problem requires (no new endpoint; the existing `BaseUrlOverride` field + `ApiClient.serverAddress()` suffice).
- [x] Self-documenting; comments explain why it must match the server-side base.
- [x] Architecture-conformance: a new fitness test locks the read-only/unmarked/value-not-innerHTML/derives-from-override properties; the `ProviderFormFieldIds` contract is unaffected (the field is unmarked).
- [x] Docs impact included: Provider-Setup wiki notes the form now shows/copies the URI.

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0 + the JF 10.11.0 ABI floor).
- [x] `dotnet test` green, 1690 tests (both TFMs), +1 conformance test.
- [x] Prettier clean for the `.js` / `.html` / `.css` change (content-identical to Prettier output; the local CRLF `--check` warning is a Windows-working-tree artifact CI does not see).

## Notes

Client-side only, I deliberately did not add the optional elevation-gated endpoint the issue floated, because the browser already has both inputs the server uses (the `BaseUrlOverride` field and `ApiClient.serverAddress()`), so the resolver reproduces the server's base without a round-trip. Manual browser verification of the live-update + copy is not automatable here (no JS runtime harness), so the structural conformance test is the CI guard.