### PR TITLE
Import SAML provider config from IdP metadata (URL or XML) [#735]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1104,7 +1104,7 @@ public class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 11;
+        const int expectedTypedCallSites = 12;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// End-to-end tests of the SAML metadata-import endpoint (#735) through the controller harness: pasted XML
+/// and a server-fetched URL both return the parsed values, and invalid input fails closed with a 400. The
+/// endpoint's elevation gate is asserted by the controller authorization suite that enumerates every
+/// [Authorize(RequiresElevation)] endpoint.
+/// </summary>
+[Collection("SSOController")]
+public class SamlImportMetadataEndpointTests
+{
+    private const string EntityId = "https://idp.example.com/e";
+    private const string Sso = "https://idp.example.com/sso";
+
+    private static string Metadata()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var cert = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+        return "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"" + EntityId + "\">" +
+               "<md:IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
+               $"<md:KeyDescriptor use=\"signing\"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>{cert}</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>" +
+               $"<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"{Sso}\" />" +
+               "</md:IDPSSODescriptor></md:EntityDescriptor>";
+    }
+
+    [Fact]
+    public async Task SamlImportMetadata_PastedXml_ReturnsParsedValues()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.SamlImportMetadata(new SamlMetadataImportRequest { Xml = Metadata() });
+
+        var import = Assert.IsType<SamlMetadataImport>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(EntityId, import.EntityId);
+        Assert.Equal(Sso, import.Endpoint);
+        Assert.NotNull(import.PrimaryCertificate);
+    }
+
+    [Fact]
+    public async Task SamlImportMetadata_FetchedUrl_ReturnsParsedValues()
+    {
+        var xml = Metadata();
+        var harness = new SsoControllerHarness(httpResponder: _ =>
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(xml) });
+
+        var result = await harness.Controller.SamlImportMetadata(new SamlMetadataImportRequest { Url = "https://idp.example.com/metadata" });
+
+        var import = Assert.IsType<SamlMetadataImport>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(EntityId, import.EntityId);
+        Assert.Equal(Sso, import.Endpoint);
+    }
+
+    [Fact]
+    public async Task SamlImportMetadata_MalformedXml_Returns400()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.SamlImportMetadata(new SamlMetadataImportRequest { Xml = "<not-metadata/>" });
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task SamlImportMetadata_NeitherUrlNorXml_Returns400()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.SamlImportMetadata(new SamlMetadataImportRequest());
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task SamlImportMetadata_NullBody_Returns400()
+    {
+        var harness = new SsoControllerHarness();
+
+        var result = await harness.Controller.SamlImportMetadata(null!);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+}

--- a/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
@@ -64,6 +64,25 @@ public class SamlImportMetadataEndpointTests
     }
 
     [Fact]
+    public async Task SamlImportMetadata_FetchedUtf8BomMetadata_Parses()
+    {
+        // ADFS serves FederationMetadata.xml UTF-8-with-BOM; the fetch must decode it (BOM stripped) rather
+        // than fail the marquee URL-import path.
+        var bom = System.Text.Encoding.UTF8.GetPreamble();
+        var body = System.Text.Encoding.UTF8.GetBytes(Metadata());
+        var withBom = new byte[bom.Length + body.Length];
+        Array.Copy(bom, withBom, bom.Length);
+        Array.Copy(body, 0, withBom, bom.Length, body.Length);
+        var harness = new SsoControllerHarness(httpResponder: _ =>
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent(withBom) });
+
+        var result = await harness.Controller.SamlImportMetadata(new SamlMetadataImportRequest { Url = "https://idp.example.com/FederationMetadata.xml" });
+
+        var import = Assert.IsType<SamlMetadataImport>(Assert.IsType<OkObjectResult>(result).Value);
+        Assert.Equal(EntityId, import.EntityId);
+    }
+
+    [Fact]
     public async Task SamlImportMetadata_MalformedXml_Returns400()
     {
         var harness = new SsoControllerHarness();

--- a/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
+++ b/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
@@ -66,4 +66,18 @@ public class SamlMetadataImporterTests
         await Assert.ThrowsAsync<SamlMetadataException>(() =>
             SamlMetadataImporter.ImportAsync(factory, null, "<not-metadata/>", CancellationToken.None));
     }
+
+    [Theory]
+    [InlineData("ftp://idp.example.com/metadata")]
+    [InlineData("file:///etc/passwd")]
+    [InlineData("not-a-url")]
+    public async Task ImportAsync_NonHttpUrl_FailsClosedBeforeFetching(string url)
+    {
+        // The scheme allow-list rejects a non-http(s) URL before any outbound client is created.
+        var factory = Substitute.For<IHttpClientFactory>();
+
+        await Assert.ThrowsAsync<SamlMetadataException>(() => SamlMetadataImporter.ImportAsync(factory, url, null, CancellationToken.None));
+
+        factory.DidNotReceive().CreateClient(Arg.Any<string>());
+    }
 }

--- a/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
+++ b/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the input dispatch of <see cref="SamlMetadataImporter"/> (#735): exactly one of a URL or pasted XML,
+/// and that the XML path parses without any outbound fetch. The URL-fetch path (SSRF-hardened) is exercised
+/// end-to-end through the controller harness; the parsing itself is covered by
+/// <see cref="SamlMetadataParserTests"/>.
+/// </summary>
+public class SamlMetadataImporterTests
+{
+    private static string ValidMetadata()
+    {
+        using var rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=Test IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        var cert = Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+        return "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"https://idp.example.com/e\">" +
+               "<md:IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
+               $"<md:KeyDescriptor use=\"signing\"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>{cert}</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>" +
+               "<md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" Location=\"https://idp.example.com/sso\" />" +
+               "</md:IDPSSODescriptor></md:EntityDescriptor>";
+    }
+
+    [Fact]
+    public async Task ImportAsync_NeitherUrlNorXml_FailsClosed()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        await Assert.ThrowsAsync<SamlMetadataException>(() => SamlMetadataImporter.ImportAsync(factory, null, "  ", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ImportAsync_BothUrlAndXml_FailsClosed()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        await Assert.ThrowsAsync<SamlMetadataException>(() =>
+            SamlMetadataImporter.ImportAsync(factory, "https://idp.example.com/metadata", ValidMetadata(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ImportAsync_Xml_ParsesWithoutFetching()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+
+        var result = await SamlMetadataImporter.ImportAsync(factory, null, ValidMetadata(), CancellationToken.None);
+
+        Assert.Equal("https://idp.example.com/e", result.EntityId);
+        Assert.Equal("https://idp.example.com/sso", result.Endpoint);
+        factory.DidNotReceive().CreateClient(Arg.Any<string>()); // the XML path never opens an outbound client
+    }
+
+    [Fact]
+    public async Task ImportAsync_MalformedXml_FailsClosed()
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        await Assert.ThrowsAsync<SamlMetadataException>(() =>
+            SamlMetadataImporter.ImportAsync(factory, null, "<not-metadata/>", CancellationToken.None));
+    }
+}

--- a/SSO-Auth.Tests/Kernel/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerAuthorizationTests.cs
@@ -36,7 +36,7 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     private static readonly string[] ExpectedElevationActions =
     {
         "OidAdd", "OidDel", "OidProviders", "OidTest", "OidStates",
-        "SamlAdd", "SamlDel", "SamlProviders", "SamlTest",
+        "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
         "ExportConfig", "ImportConfig", "Unregister",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",

--- a/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
@@ -128,6 +128,32 @@ public class SamlMetadataParserTests
         Assert.Equal(cert, result.PrimaryCertificate);
     }
 
+    [Fact]
+    public void Parse_LeadingByteOrderMark_IsStripped_AndParses()
+    {
+        // ADFS serves FederationMetadata.xml UTF-8-with-BOM; a surviving U+FEFF before the XML declaration
+        // must be stripped, not rejected as malformed.
+        var cert = Cert();
+        var withBom = ((char)0xFEFF).ToString() + Metadata(KeyDescriptor(cert), Sso(Redirect, RedirectSso));
+
+        var result = SamlMetadataParser.Parse(withBom);
+
+        Assert.Equal(EntityId, result.EntityId);
+        Assert.Equal(cert, result.PrimaryCertificate);
+    }
+
+    [Fact]
+    public void Parse_PreferredBindingWithEmptyLocation_FallsBackToTheNextUsableBinding()
+    {
+        // A Redirect SingleSignOnService with a blank Location must not short-circuit the fallback — a usable
+        // POST endpoint present in the same document is used.
+        var result = SamlMetadataParser.Parse(Metadata(
+            KeyDescriptor(Cert()),
+            Sso(Redirect, string.Empty) + Sso(Post, PostSso)));
+
+        Assert.Equal(PostSso, result.Endpoint);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData("   ")]

--- a/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlMetadataParser"/> (#735): it extracts the IdP entity id, the SSO endpoint, and
+/// the signing certificate(s) from SAML metadata, reusing the same fail-closed XML hardening the inbound
+/// response parser uses. Every malformed / oversized / incomplete document fails closed with a
+/// <see cref="SamlMetadataException"/> and no partial result.
+/// </summary>
+public class SamlMetadataParserTests
+{
+    private const string Md = "urn:oasis:names:tc:SAML:2.0:metadata";
+    private const string Ds = "http://www.w3.org/2000/09/xmldsig#";
+    private const string Redirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+    private const string Post = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+    private const string EntityId = "https://idp.example.com/entity";
+    private const string RedirectSso = "https://idp.example.com/sso/redirect";
+    private const string PostSso = "https://idp.example.com/sso/post";
+
+    private static string Cert(int keyBits = 2048)
+    {
+        using var rsa = RSA.Create(keyBits);
+        var request = new CertificateRequest("CN=Test IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        using var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        return Convert.ToBase64String(certificate.Export(X509ContentType.Cert));
+    }
+
+    private static string KeyDescriptor(string cert, string? use = "signing")
+    {
+        var useAttr = use is null ? string.Empty : $" use=\"{use}\"";
+        return $"<md:KeyDescriptor{useAttr}><ds:KeyInfo><ds:X509Data><ds:X509Certificate>{cert}</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>";
+    }
+
+    private static string Sso(string binding, string location) =>
+        $"<md:SingleSignOnService Binding=\"{binding}\" Location=\"{location}\" />";
+
+    private static string Metadata(string keyDescriptors, string ssoServices, string entityId = EntityId) =>
+        $"<?xml version=\"1.0\"?><md:EntityDescriptor xmlns:md=\"{Md}\" xmlns:ds=\"{Ds}\" entityID=\"{entityId}\">" +
+        $"<md:IDPSSODescriptor protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">{keyDescriptors}{ssoServices}</md:IDPSSODescriptor>" +
+        "</md:EntityDescriptor>";
+
+    [Fact]
+    public void Parse_ValidMetadata_ExtractsEntityIdEndpointAndCertificate()
+    {
+        var cert = Cert();
+        var result = SamlMetadataParser.Parse(Metadata(KeyDescriptor(cert), Sso(Redirect, RedirectSso)));
+
+        Assert.Equal(EntityId, result.EntityId);
+        Assert.Equal(RedirectSso, result.Endpoint);
+        Assert.Equal(cert, result.PrimaryCertificate);
+        Assert.Null(result.SecondaryCertificate);
+    }
+
+    [Fact]
+    public void Parse_PrefersRedirectBinding_OverPost()
+    {
+        var result = SamlMetadataParser.Parse(Metadata(
+            KeyDescriptor(Cert()),
+            Sso(Post, PostSso) + Sso(Redirect, RedirectSso)));
+
+        Assert.Equal(RedirectSso, result.Endpoint); // redirect wins even though POST appears first
+    }
+
+    [Fact]
+    public void Parse_OnlyPostBinding_UsesThePostLocation()
+    {
+        var result = SamlMetadataParser.Parse(Metadata(KeyDescriptor(Cert()), Sso(Post, PostSso)));
+
+        Assert.Equal(PostSso, result.Endpoint);
+    }
+
+    [Fact]
+    public void Parse_TwoSigningCertificates_MapsToPrimaryAndSecondary()
+    {
+        var first = Cert();
+        var second = Cert();
+        var result = SamlMetadataParser.Parse(Metadata(
+            KeyDescriptor(first) + KeyDescriptor(second),
+            Sso(Redirect, RedirectSso)));
+
+        Assert.Equal(first, result.PrimaryCertificate);
+        Assert.Equal(second, result.SecondaryCertificate);
+    }
+
+    [Fact]
+    public void Parse_KeyDescriptorWithNoUseAttribute_IsTreatedAsSigning()
+    {
+        var cert = Cert();
+        var result = SamlMetadataParser.Parse(Metadata(KeyDescriptor(cert, use: null), Sso(Redirect, RedirectSso)));
+
+        Assert.Equal(cert, result.PrimaryCertificate);
+    }
+
+    [Fact]
+    public void Parse_EncryptionOnlyKeyDescriptor_IsIgnored_ThenNoSigningCert_FailsClosed()
+    {
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(Metadata(
+            KeyDescriptor(Cert(), use: "encryption"),
+            Sso(Redirect, RedirectSso))));
+        Assert.Contains("signing certificate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_WhitespaceWrappedCertificate_IsStripped()
+    {
+        var cert = Cert();
+        var wrapped = "\n        " + cert.Substring(0, 40) + "\n        " + cert.Substring(40) + "\n      ";
+        var result = SamlMetadataParser.Parse(Metadata(KeyDescriptor(wrapped), Sso(Redirect, RedirectSso)));
+
+        Assert.Equal(cert, result.PrimaryCertificate); // whitespace removed, loads as a valid cert
+    }
+
+    [Fact]
+    public void Parse_EntitiesDescriptorAggregate_ResolvesTheIdpEntity()
+    {
+        var cert = Cert();
+        var inner = Metadata(KeyDescriptor(cert), Sso(Redirect, RedirectSso)).Replace("<?xml version=\"1.0\"?>", string.Empty);
+        var aggregate = $"<?xml version=\"1.0\"?><md:EntitiesDescriptor xmlns:md=\"{Md}\">{inner}</md:EntitiesDescriptor>";
+
+        var result = SamlMetadataParser.Parse(aggregate);
+
+        Assert.Equal(EntityId, result.EntityId);
+        Assert.Equal(cert, result.PrimaryCertificate);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void Parse_EmptyInput_FailsClosed(string? xml)
+        => Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(xml));
+
+    [Fact]
+    public void Parse_MalformedXml_FailsClosed()
+        => Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse("<md:EntityDescriptor>not closed"));
+
+    [Fact]
+    public void Parse_DoctypeDtd_IsRejected_NoXxeNoBillionLaughs()
+    {
+        // A DOCTYPE/DTD must be refused outright (XXE + entity-expansion DoS), like the inbound response parser.
+        var withDtd = "<?xml version=\"1.0\"?><!DOCTYPE foo [<!ENTITY x \"y\">]>" + Metadata(KeyDescriptor(Cert()), Sso(Redirect, RedirectSso)).Replace("<?xml version=\"1.0\"?>", string.Empty);
+
+        Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(withDtd));
+    }
+
+    [Fact]
+    public void Parse_OversizedDocument_IsRejected()
+    {
+        // A document past the character bound must be refused before a multi-megabyte DOM is built.
+        var filler = new string('a', SamlMetadataParser.MaxCharactersInDocument + 1024);
+        var oversized = Metadata(KeyDescriptor(Cert()), Sso(Redirect, RedirectSso), entityId: EntityId).Replace(
+            "</md:IDPSSODescriptor>",
+            $"<md:Organization><md:OrganizationName xml:lang=\"en\">{filler}</md:OrganizationName></md:Organization></md:IDPSSODescriptor>");
+
+        Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(oversized));
+    }
+
+    [Fact]
+    public void Parse_MissingIdpDescriptor_FailsClosed()
+    {
+        var spOnly = $"<?xml version=\"1.0\"?><md:EntityDescriptor xmlns:md=\"{Md}\" entityID=\"{EntityId}\"><md:SPSSODescriptor protocolSupportEnumeration=\"x\" /></md:EntityDescriptor>";
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(spOnly));
+        Assert.Contains("IDPSSODescriptor", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_MissingEntityId_FailsClosed()
+    {
+        var noEntityId = Metadata(KeyDescriptor(Cert()), Sso(Redirect, RedirectSso)).Replace($" entityID=\"{EntityId}\"", string.Empty);
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(noEntityId));
+        Assert.Contains("entityID", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_MissingSsoService_FailsClosed()
+    {
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(Metadata(KeyDescriptor(Cert()), string.Empty)));
+        Assert.Contains("SingleSignOnService", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_MissingSigningCertificate_FailsClosed()
+    {
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(Metadata(string.Empty, Sso(Redirect, RedirectSso))));
+        Assert.Contains("signing certificate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_UnloadableCertificate_FailsClosed()
+    {
+        // Valid base64 ("ABC") that is not an X.509 certificate — rejected like the config-save cert guard.
+        var ex = Assert.Throws<SamlMetadataException>(() => SamlMetadataParser.Parse(Metadata(KeyDescriptor("QUJD"), Sso(Redirect, RedirectSso))));
+        Assert.Contains("certificate", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -635,6 +635,50 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Parses SAML identity-provider metadata into the provider-configuration values an administrator would
+    /// otherwise hand-copy — the SSO endpoint and the signing certificate(s) — from EITHER a server-fetched
+    /// URL or pasted XML (#735). Requires administrator privileges and is deliberately elevation-gated: the
+    /// server fetches an admin-supplied URL, so — like <see cref="OidTest"/> — an unauthenticated caller must
+    /// not be able to drive it as an SSRF probe (the fetch also routes through the SSRF-hardened outbound
+    /// client, which refuses a private/loopback address). The metadata XML is parsed with fail-closed
+    /// hardening (no DTD/XXE, size-bounded). It RETURNS the parsed values for the admin to review and save; it
+    /// applies nothing itself, and returns the IdP entityID for reference only (it is NOT the SP SamlClientId).
+    /// The request body is size-capped and the endpoint is throttled after the elevation guard.
+    /// </summary>
+    /// <param name="request">Exactly one of a metadata URL or pasted metadata XML.</param>
+    /// <returns>The parsed import values, or 400 when the input or metadata is invalid.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("SAML/ImportMetadata")]
+    [RequestSizeLimit(ConfigImportMaxBytes)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public async Task<ActionResult> SamlImportMetadata([FromBody] SamlMetadataImportRequest request)
+    {
+        // Throttle after the elevation guard, before the outbound fetch (mirrors OidTest): the [Authorize]
+        // filter rejects a non-elevated caller before the body runs, so an unauthorized request never reaches
+        // the limiter or the fetch — no SSRF probe, no rate-limit oracle.
+        if (RateLimitCheck(SsoRateLimitClass.Test) is { } throttled)
+        {
+            return throttled;
+        }
+
+        if (request is null)
+        {
+            return BadRequest("The metadata-import request is missing or is not valid JSON.");
+        }
+
+        try
+        {
+            var import = await SamlMetadataImporter.ImportAsync(_httpClientFactory, request.Url, request.Xml, HttpContext.RequestAborted).ConfigureAwait(false);
+            return Ok(import);
+        }
+        catch (SamlMetadataException ex)
+        {
+            // The message is an admin-facing fixed string (no IdP/library detail); nothing was applied.
+            return BadRequest(ex.Message);
+        }
+    }
+
+    /// <summary>
     /// Exports the whole plugin configuration as a redacted, importable document (#161). Requires
     /// administrator privileges, like the other config endpoints — the document lists every provider's
     /// settings. The redaction is the config's OWN JSON-boundary withholding, reused: the provider secrets

--- a/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
+
+/// <summary>
+/// The request body for the SAML metadata-import endpoint (#735): exactly one of a metadata <see cref="Url"/>
+/// (fetched server-side, SSRF-hardened) or pasted metadata <see cref="Xml"/>. Both null/blank, or both set,
+/// is rejected.
+/// </summary>
+public sealed class SamlMetadataImportRequest
+{
+    /// <summary>Gets or sets the IdP metadata URL to fetch, or null when pasting XML.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>Gets or sets the pasted IdP metadata XML, or null when fetching a URL.</summary>
+    public string? Xml { get; set; }
+}

--- a/SSO-Auth/Api/Http/SamlMetadataImporter.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImporter.cs
@@ -1,0 +1,107 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
+
+/// <summary>
+/// Orchestrates a SAML IdP-metadata import (#735): it takes EITHER a metadata URL (fetched server-side) or
+/// pasted metadata XML, and returns the parsed <see cref="SamlMetadataImport"/>. The URL is fetched through
+/// the plugin's SSRF-hardened outbound client (<see cref="SsoHttp"/>) — the same transport the OpenID
+/// discovery fetch uses, so an admin-supplied URL that resolves to a private/loopback address cannot be used
+/// to probe internal services — with a hard body-size cap and timeout on top. The XML is then parsed with
+/// the fail-closed hardening in <see cref="SamlMetadataParser"/>. Any failure throws
+/// <see cref="SamlMetadataException"/> and nothing is applied.
+/// </summary>
+internal static class SamlMetadataImporter
+{
+    // The fetched body is capped at the same size the parser will accept, so an oversized document is refused
+    // before it is buffered, not after.
+    private const int MaxBytes = SamlMetadataParser.MaxCharactersInDocument;
+
+    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Imports SAML metadata from exactly one of a URL or pasted XML.
+    /// </summary>
+    /// <param name="factory">The shared HTTP client factory (resolves the SSRF-hardened outbound client).</param>
+    /// <param name="url">The metadata URL to fetch, or null/blank when pasting XML.</param>
+    /// <param name="xml">The pasted metadata XML, or null/blank when fetching a URL.</param>
+    /// <param name="cancellationToken">Cancels the outbound fetch.</param>
+    /// <returns>The parsed, validated import values.</returns>
+    /// <exception cref="SamlMetadataException">Neither or both inputs given, the fetch failed, or the metadata is invalid.</exception>
+    internal static async Task<SamlMetadataImport> ImportAsync(IHttpClientFactory factory, string? url, string? xml, CancellationToken cancellationToken)
+    {
+        var hasUrl = !string.IsNullOrWhiteSpace(url);
+        var hasXml = !string.IsNullOrWhiteSpace(xml);
+        if (hasUrl == hasXml)
+        {
+            throw new SamlMetadataException("Provide exactly one of a metadata URL or pasted metadata XML.");
+        }
+
+        var metadataXml = hasXml
+            ? xml!
+            : await FetchAsync(factory, url!.Trim(), cancellationToken).ConfigureAwait(false);
+
+        return SamlMetadataParser.Parse(metadataXml);
+    }
+
+    private static async Task<string> FetchAsync(IHttpClientFactory factory, string url, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (!string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                && !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
+        {
+            throw new SamlMetadataException("The metadata URL must be an absolute http(s) URL.");
+        }
+
+        using var client = SsoHttp.CreateClient(factory);
+        client.Timeout = FetchTimeout;
+
+        try
+        {
+            using var response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            return await ReadCappedAsync(response, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            // Unreachable host, a blocked (private/loopback) address rejected by the hardened transport, or a
+            // non-success status — all fail closed with an admin-facing message; no library detail is echoed.
+            throw new SamlMetadataException("The metadata URL could not be fetched (unreachable, blocked, or an error response).", ex);
+        }
+        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            throw new SamlMetadataException("The metadata URL fetch timed out.", ex);
+        }
+    }
+
+    // Reads the response body with a hard byte cap: the SSRF-hardened transport restricts WHERE the fetch
+    // connects, and this bounds HOW MUCH it will buffer, so a hostile or accidental multi-megabyte document
+    // cannot exhaust memory.
+    private static async Task<string> ReadCappedAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
+        using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var buffered = new MemoryStream();
+        var chunk = new byte[8192];
+        int read;
+        while ((read = await stream.ReadAsync(chunk, cancellationToken).ConfigureAwait(false)) > 0)
+        {
+            if (buffered.Length + read > MaxBytes)
+            {
+                throw new SamlMetadataException("The metadata document exceeds the size limit.");
+            }
+
+            buffered.Write(chunk, 0, read);
+        }
+
+        return Encoding.UTF8.GetString(buffered.ToArray());
+    }
+}

--- a/SSO-Auth/Api/Http/SamlMetadataImporter.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImporter.cs
@@ -65,11 +65,17 @@ internal static class SamlMetadataImporter
         using var client = SsoHttp.CreateClient(factory);
         client.Timeout = FetchTimeout;
 
+        // An overall deadline linked to the caller's token: client.Timeout with ResponseHeadersRead covers
+        // only the header fetch, so this also bounds the streamed body read — a slow-drip server cannot hold
+        // the fetch open past FetchTimeout.
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(FetchTimeout);
+
         try
         {
-            using var response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            using var response = await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, deadline.Token).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
-            return await ReadCappedAsync(response, cancellationToken).ConfigureAwait(false);
+            return await ReadCappedAsync(response, deadline.Token).ConfigureAwait(false);
         }
         catch (HttpRequestException ex)
         {
@@ -77,8 +83,14 @@ internal static class SamlMetadataImporter
             // non-success status — all fail closed with an admin-facing message; no library detail is echoed.
             throw new SamlMetadataException("The metadata URL could not be fetched (unreachable, blocked, or an error response).", ex);
         }
-        catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        catch (IOException ex)
         {
+            // A mid-stream connection reset while reading the body — fail closed as a clean 400, not a 500.
+            throw new SamlMetadataException("The metadata could not be read from the URL.", ex);
+        }
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The linked deadline (or the client timeout) fired, not the caller's own cancellation.
             throw new SamlMetadataException("The metadata URL fetch timed out.", ex);
         }
     }
@@ -102,6 +114,12 @@ internal static class SamlMetadataImporter
             buffered.Write(chunk, 0, read);
         }
 
-        return Encoding.UTF8.GetString(buffered.ToArray());
+        // Decode honouring the byte-order mark: ADFS (a very common IdP) serves FederationMetadata.xml as
+        // UTF-8-with-BOM, and a raw Encoding.UTF8.GetString would leave a U+FEFF before the XML declaration
+        // that the reader rejects. StreamReader with BOM detection strips a UTF-8 BOM and correctly decodes a
+        // UTF-16 (BOM'd) document; a plain UTF-8 body is unaffected.
+        buffered.Position = 0;
+        using var textReader = new StreamReader(buffered, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        return await textReader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/SSO-Auth/Api/Saml/SamlMetadataImport.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataImport.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// The values extracted from an identity provider's SAML metadata (#735): the IdP entity id, the Single
+/// Sign-On endpoint URL (→ <c>SamlEndpoint</c>), and the signing certificate(s) (→ <c>SamlCertificate</c>
+/// plus an optional <c>SamlSecondaryCertificate</c> for a rollover overlap). The importer only ever
+/// PRE-FILLS; the admin reviews and saves through the normal validated write path.
+/// <para>
+/// <see cref="EntityId"/> is the IDENTITY PROVIDER's own <c>entityID</c> (the issuer of its assertions), NOT
+/// the plugin's <c>SamlClientId</c> — that field is the SERVICE PROVIDER's own entity id (sent as the
+/// AuthnRequest issuer and used as the expected audience), which the admin sets and the IdP does not supply.
+/// The entity id is surfaced for the admin's reference only; it is deliberately not mapped onto
+/// <c>SamlClientId</c>, which would break the issuer/audience semantics.
+/// </para>
+/// </summary>
+/// <param name="EntityId">The IdP's <c>entityID</c> (its assertion issuer), for reference — not the SP <c>SamlClientId</c>.</param>
+/// <param name="Endpoint">The <c>SingleSignOnService</c> Location the browser is redirected to (→ <c>SamlEndpoint</c>).</param>
+/// <param name="PrimaryCertificate">The primary Base64 (DER) signing certificate (→ <c>SamlCertificate</c>).</param>
+/// <param name="SecondaryCertificate">The optional secondary signing certificate (→ <c>SamlSecondaryCertificate</c>), or null.</param>
+internal sealed record SamlMetadataImport(
+    string EntityId,
+    string Endpoint,
+    string PrimaryCertificate,
+    string? SecondaryCertificate);
+
+/// <summary>
+/// Thrown when SAML metadata cannot be parsed into a usable provider configuration (#735) — malformed or
+/// oversized XML, a prohibited DOCTYPE/DTD, a missing <c>IDPSSODescriptor</c>/entityID/endpoint, or no usable
+/// signing certificate. The message is admin-facing and free of internal detail; the import applies nothing
+/// on failure (never a partial result).
+/// </summary>
+internal sealed class SamlMetadataException : Exception
+{
+    internal SamlMetadataException(string message)
+        : base(message)
+    {
+    }
+
+    internal SamlMetadataException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/SSO-Auth/Api/Saml/SamlMetadataParser.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataParser.cs
@@ -1,0 +1,157 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// Parses an identity provider's SAML 2.0 metadata into the provider-configuration values an administrator
+/// would otherwise hand-copy (#735): the entity id, the Single Sign-On endpoint, and the signing
+/// certificate(s). The metadata is UNTRUSTED input, so it is parsed with the identical fail-closed hardening
+/// <see cref="SamlResponse"/> uses on inbound assertions — DTD/DOCTYPE prohibited (no XXE, no billion-laughs
+/// entity expansion), <c>XmlResolver = null</c> (no external-entity fetch / SSRF), and a bound on the DOM the
+/// reader materializes. Any malformed, oversized, or incomplete document throws
+/// <see cref="SamlMetadataException"/> with an admin-facing message; nothing is ever partially extracted.
+/// </summary>
+internal static class SamlMetadataParser
+{
+    private const string MetadataNamespace = "urn:oasis:names:tc:SAML:2.0:metadata";
+    private const string DsigNamespace = "http://www.w3.org/2000/09/xmldsig#";
+    private const string RedirectBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect";
+    private const string PostBinding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST";
+
+    /// <summary>
+    /// The maximum characters the metadata reader will materialize (#754), matching the inbound-response
+    /// parser. A legitimate IdP metadata document is single- to low-double-digit KB; this bounds a hostile or
+    /// accidental multi-megabyte document that DTD prohibition (which bounds entities, not bulk) would not.
+    /// </summary>
+    internal const int MaxCharactersInDocument = 256 * 1024;
+
+    /// <summary>
+    /// Parses IdP metadata XML into a <see cref="SamlMetadataImport"/>.
+    /// </summary>
+    /// <param name="xml">The raw metadata XML (fetched or pasted).</param>
+    /// <returns>The extracted, validated configuration values.</returns>
+    /// <exception cref="SamlMetadataException">The metadata is malformed, oversized, or incomplete.</exception>
+    internal static SamlMetadataImport Parse(string? xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml))
+        {
+            throw new SamlMetadataException("The metadata document was empty.");
+        }
+
+        var doc = ParseHardened(xml);
+
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("md", MetadataNamespace);
+        ns.AddNamespace("ds", DsigNamespace);
+
+        // The IdP role descriptor — anywhere in the tree, so a metadata aggregate (EntitiesDescriptor wrapping
+        // several EntityDescriptors) resolves to the first entity that actually plays the IdP role.
+        if (doc.SelectSingleNode("//md:EntityDescriptor/md:IDPSSODescriptor", ns) is not XmlElement idp)
+        {
+            throw new SamlMetadataException("No IDPSSODescriptor was found — this does not look like SAML identity-provider metadata.");
+        }
+
+        var entityId = ((XmlElement)idp.ParentNode!).GetAttribute("entityID").Trim();
+        if (string.IsNullOrEmpty(entityId))
+        {
+            throw new SamlMetadataException("The EntityDescriptor carries no entityID.");
+        }
+
+        var endpoint = PickSsoLocation(idp, ns)
+            ?? throw new SamlMetadataException("No SingleSignOnService with a usable HTTP-Redirect or HTTP-POST binding was found.");
+
+        var certificates = ExtractSigningCertificates(idp, ns);
+        if (certificates.Count == 0)
+        {
+            throw new SamlMetadataException("No signing certificate (a KeyDescriptor with use=\"signing\") was found in the metadata.");
+        }
+
+        // Every extracted certificate must load AND meet the minimum key-strength floor (#733), reusing the
+        // one predicate the SAML config-save path uses — so an import can never pre-fill a cert that the save
+        // would reject (or that would fail signature validation at login). Fail closed on the first bad one;
+        // no partial result.
+        foreach (var certificate in certificates)
+        {
+            if (SamlCertificate.IsInvalid(certificate))
+            {
+                throw new SamlMetadataException("A signing certificate in the metadata is not a loadable X.509 certificate or does not meet the minimum key strength.");
+            }
+        }
+
+        return new SamlMetadataImport(
+            entityId,
+            endpoint,
+            certificates[0],
+            certificates.Count > 1 ? certificates[1] : null);
+    }
+
+    // Parses the untrusted metadata with the same hardening SamlResponse applies to inbound assertions: no
+    // DTD/DOCTYPE (XXE + billion-laughs), no external-entity resolution, and a bound on the materialized DOM.
+    private static XmlDocument ParseHardened(string xml)
+    {
+        var doc = new XmlDocument { XmlResolver = null };
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = MaxCharactersInDocument,
+        };
+
+        try
+        {
+            using var stringReader = new StringReader(xml);
+            using var reader = XmlReader.Create(stringReader, settings);
+            doc.Load(reader);
+        }
+        catch (XmlException ex)
+        {
+            // Malformed XML, a prohibited DOCTYPE/DTD, or the character bound exceeded — all fail closed with
+            // an admin-facing message; the library's detail stays out of the response.
+            throw new SamlMetadataException("The metadata is not well-formed XML, exceeds the size limit, or contains a prohibited DTD/DOCTYPE.", ex);
+        }
+
+        return doc;
+    }
+
+    // The SSO endpoint URL: prefer HTTP-Redirect (the binding this SP drives the browser with), then
+    // HTTP-POST, then the first SingleSignOnService that carries any Location.
+    private static string? PickSsoLocation(XmlElement idp, XmlNamespaceManager ns)
+    {
+        var services = idp.SelectNodes("md:SingleSignOnService", ns)?.Cast<XmlElement>().ToList() ?? new List<XmlElement>();
+
+        string? ByBinding(string binding) => services
+            .FirstOrDefault(s => string.Equals(s.GetAttribute("Binding"), binding, StringComparison.Ordinal))
+            ?.GetAttribute("Location");
+
+        var location = ByBinding(RedirectBinding)
+            ?? ByBinding(PostBinding)
+            ?? services.Select(s => s.GetAttribute("Location")).FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+
+        return string.IsNullOrWhiteSpace(location) ? null : location.Trim();
+    }
+
+    // The signing certificates: every KeyDescriptor marked use="signing" OR with no use attribute (which by
+    // the SAML metadata schema serves both signing and encryption), in document order. Whitespace inside the
+    // Base64 (metadata is commonly pretty-printed with wrapped certificate text) is stripped so the value is a
+    // clean Base64 DER string the config fields and X509 loader accept.
+    private static List<string> ExtractSigningCertificates(XmlElement idp, XmlNamespaceManager ns)
+    {
+        return (idp.SelectNodes("md:KeyDescriptor", ns)?.Cast<XmlElement>() ?? Enumerable.Empty<XmlElement>())
+            .Where(k =>
+            {
+                var use = k.GetAttribute("use");
+                return string.IsNullOrEmpty(use) || string.Equals(use, "signing", StringComparison.Ordinal);
+            })
+            .Select(k => k.SelectSingleNode("ds:KeyInfo/ds:X509Data/ds:X509Certificate", ns)?.InnerText)
+            .Where(text => !string.IsNullOrWhiteSpace(text))
+            .Select(text => new string(text!.Where(c => !char.IsWhiteSpace(c)).ToArray()))
+            .Where(text => text.Length > 0)
+            .ToList();
+    }
+}

--- a/SSO-Auth/Api/Saml/SamlMetadataParser.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataParser.cs
@@ -95,6 +95,15 @@ internal static class SamlMetadataParser
     // DTD/DOCTYPE (XXE + billion-laughs), no external-entity resolution, and a bound on the materialized DOM.
     private static XmlDocument ParseHardened(string xml)
     {
+        // Strip a leading UTF-8 byte-order-mark: a BOM that survived into the string (a pasted document, or a
+        // fetch decoded without BOM handling) is a U+FEFF character before the XML declaration, which the
+        // reader rejects as "data at the root level is invalid" — so an otherwise-valid document (ADFS serves
+        // its FederationMetadata.xml UTF-8-with-BOM) would fail. The fetch path decodes with BOM detection too.
+        if (xml.Length > 0 && xml[0] == 0xFEFF)
+        {
+            xml = xml.Substring(1);
+        }
+
         var doc = new XmlDocument { XmlResolver = null };
         var settings = new XmlReaderSettings
         {
@@ -125,9 +134,16 @@ internal static class SamlMetadataParser
     {
         var services = idp.SelectNodes("md:SingleSignOnService", ns)?.Cast<XmlElement>().ToList() ?? new List<XmlElement>();
 
-        string? ByBinding(string binding) => services
-            .FirstOrDefault(s => string.Equals(s.GetAttribute("Binding"), binding, StringComparison.Ordinal))
-            ?.GetAttribute("Location");
+        // XmlElement.GetAttribute returns "" (not null) for a missing/empty Location, so normalize a blank to
+        // null — otherwise a matching-binding service with no Location would short-circuit the ?? fallback and
+        // skip a usable endpoint under another binding.
+        string? ByBinding(string binding)
+        {
+            var candidate = services
+                .FirstOrDefault(s => string.Equals(s.GetAttribute("Binding"), binding, StringComparison.Ordinal))
+                ?.GetAttribute("Location");
+            return string.IsNullOrWhiteSpace(candidate) ? null : candidate;
+        }
 
         var location = ByBinding(RedirectBinding)
             ?? ByBinding(PostBinding)


### PR DESCRIPTION
# What & why

Adding a SAML provider meant hand-copying the SSO endpoint and a Base64 signing certificate; a mis-wrapped or truncated cert breaks signature validation with an opaque failure. OIDC gets this free from its discovery URL, SAML now gets a metadata parser + an admin endpoint (#735).

- **`SamlMetadataParser` (pure):** parses `EntityDescriptor` → `IDPSSODescriptor` for the entityID, the `SingleSignOnService` Location (HTTP-Redirect preferred, else POST), and the signing certificate(s) (`KeyDescriptor use="signing"`, or use-less). It reuses the **identical fail-closed XML hardening `SamlResponse` applies to inbound assertions**, `DtdProcessing.Prohibit` (no XXE / no billion-laughs), `XmlResolver` null, `MaxCharactersInDocument = 256 KB`, and validates every extracted cert with the same `SamlCertificate.IsInvalid` the config-save path uses. Malformed / oversized / incomplete → `SamlMetadataException`, nothing partial.
- **`SAML/ImportMetadata` endpoint** (`[Authorize(RequiresElevation)]`, throttled, `[RequestSizeLimit]`): accepts a metadata **URL** (fetched via the **SSRF-hardened `SsoHttp` outbound client**, body-size-capped + timed out) OR pasted **XML**, and **returns** the parsed values for the admin to review and save. There is no SAML admin form yet (#725), so it **pre-fills, it does not auto-apply or lock**.
- **Correctness:** the IdP `entityID` is returned **for reference only** and is deliberately **not** mapped onto `SamlClientId`, which is the SERVICE PROVIDER's own entity id (sent as the AuthnRequest `Issuer` / expected audience), not the IdP's issuer.

STRIDE threat model posted on the issue before implementation.

Closes #735

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed: the metadata parser refuses a DTD/DOCTYPE (XXE, entity-expansion DoS), an oversized doc, and any incomplete/invalid metadata, applying nothing. The fetch is SSRF-hardened (reuses the `SsoHttp` outbound client) + body-capped; the endpoint is elevation-gated and throttled after the guard (no unauth SSRF probe, no rate-limit oracle).
- [x] No secrets logged; the endpoint returns only public metadata facts and echoes only fixed admin-facing error messages (no IdP/library detail).
- [x] A security review was performed (adversarial XXE/SSRF + correctness lenses, see below).
- [x] Log inputs from the IdP are not logged; the parser handles them as data only.

## Quality checklist

- [x] No duplicated hardening; the parser reuses the exact `SamlResponse` XML settings and the `SamlCertificate` validity predicate.
- [x] The change adds no more code than the problem requires (no new SSRF primitive, reuses `SsoHttp`; no new UI, returns values for #725's form).
- [x] Self-documenting; comments explain the entityID-vs-SamlClientId distinction and the reused hardening.
- [x] Architecture-conformance: the new module files sit in `Api/Saml` and `Api/Http` (both within the allowed DAG); the rate-limited-endpoint sentinel (11→12) and the known-elevation-surface list are updated in this PR.
- [x] Docs impact included: Provider-Setup wiki (endpoint + entityID note).

## Verification

- [x] `dotnet build --no-restore --warnaserror` green (net9.0 + net10.0 + the JF 10.11.0 ABI floor).
- [x] `dotnet test` green, 1718 tests (both TFMs), +28 new (parser 19, importer 4, endpoint 5).
- [x] opengrep clean, the fetch uses the approved `SsoHttp.CreateClient` wrapper, not a raw `CreateClient`.

## Notes

Client-side pre-fill UI lands with the SAML admin form (#725); this PR delivers the server-side parser + endpoint it will call. An admin can already use it directly (POST a URL or XML, copy the returned values into the SAML config XML).