### PR TITLE
Add a SAML provider configuration admin UI [#725]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1444,6 +1444,179 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void ProviderFormFieldIds_MatchSamlConfigProperties()
+    {
+        // The SAML provider form's save contract (#725), locked in as the SamlConfig-side twin of
+        // ProviderFormFieldIds_MatchOidConfigProperties. config.js saveSamlProvider persists each marked
+        // input as current_config[samlPropOf(element.id)] = value, where samlPropOf strips the mandatory
+        // "saml-" id prefix (the prefix keeps every SAML field id unique in a document the OpenID form already
+        // populated). So every input bearing a persisting marker class MUST (a) have a "saml-"-prefixed id and
+        // (b) once stripped, equal a real SamlConfig property — otherwise it renders but silently never saves,
+        // because the server drops JSON members that are not SamlConfig properties. The scan is scoped to
+        // #sso-new-saml-provider so it is checked against SamlConfig, never OidConfig. Paired below with a
+        // reverse security-critical pin so neither a mistyped id nor a dropped marker class can silently break
+        // a SAML security setting's save.
+        var markerClasses = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
+
+        var form = SamlProviderFormMarkup(
+            File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html")));
+
+        var samlConfigProperties = typeof(SamlConfig)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // matchedProps holds the STRIPPED property names (samlPropOf) so the sentinel/security pins below read
+        // as plain SamlConfig property names, mirroring the OpenID test.
+        var matchedProps = new HashSet<string>(StringComparer.Ordinal);
+        var offenders = new List<string>();
+        foreach (Match tag in Regex.Matches(form, "<[a-zA-Z][^>]*>", RegexOptions.Singleline))
+        {
+            var classAttr = Regex.Match(tag.Value, "class=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (!classAttr.Success)
+            {
+                continue;
+            }
+
+            var classes = classAttr.Groups[1].Value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (!classes.Any(c => markerClasses.Contains(c, StringComparer.Ordinal)))
+            {
+                continue;
+            }
+
+            var idMatch = Regex.Match(tag.Value, "(?<![-\\w])id=\"([^\"]*)\"", RegexOptions.Singleline);
+            var id = idMatch.Success ? idMatch.Groups[1].Value : "(no id)";
+
+            // The prefix itself is part of the contract: a marked SAML field without it would collide with the
+            // OpenID field of the same name AND be mis-saved, so flag it rather than silently stripping nothing.
+            if (!id.StartsWith("saml-", StringComparison.Ordinal))
+            {
+                offenders.Add($"{id} (missing the required saml- id prefix; classes: {classAttr.Groups[1].Value.Trim()})");
+                continue;
+            }
+
+            var prop = id.Substring("saml-".Length);
+            matchedProps.Add(prop);
+            if (!samlConfigProperties.Contains(prop))
+            {
+                offenders.Add($"{id} -> {prop} (classes: {classAttr.Groups[1].Value.Trim()})");
+            }
+        }
+
+        // Guard against a vacuous pass: one sentinel per marker class must have been scanned.
+        var sentinels = new[] { "SamlEndpoint", "Roles", "Enabled", "EnabledFolders", "FolderRoleMapping" };
+        var missingSentinels = sentinels.Where(s => !matchedProps.Contains(s)).ToList();
+        Assert.True(
+            missingSentinels.Count == 0,
+            "The SAML provider-form scan did not reach expected fields (broken parse or renamed marker class?); missing sentinels: " + string.Join(", ", missingSentinels));
+
+        // Reverse direction: pin the SAML security-critical settings — each MUST remain a marked, correctly
+        // "saml-"-prefixed persisting field, so dropping its marker class (fail-open: the server keeps the
+        // stored value and the admin can no longer change it in the form) fails here. DoNotValidateAudience is
+        // the SAML insecure toggle; ValidateRecipient/ValidateInResponseTo/SignAuthnRequests are the opt-in
+        // hardening toggles; the signing keys are the write-only secrets; AllowExistingAccountLink and
+        // ProvisionNewUsersDisabled govern account adoption/provisioning. Extend in the same PR that surfaces a
+        // new SAML security setting.
+        var securityCritical = new[]
+        {
+            "EnableAuthorization", "DoNotValidateAudience", "ValidateRecipient", "ValidateInResponseTo",
+            "SignAuthnRequests", "SamlSigningKeyPfx", "SamlRolloverSigningKeyPfx",
+            "AllowExistingAccountLink", "ProvisionNewUsersDisabled",
+        };
+        var unsaved = securityCritical.Where(p => !matchedProps.Contains(p)).ToList();
+        Assert.True(
+            unsaved.Count == 0,
+            "These SAML security-critical settings must remain persisting provider-form fields (a marked input whose id is \"saml-\" + the SamlConfig property); missing or unmarked: " + string.Join(", ", unsaved));
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every persisting SAML provider-form field (sso-text/sso-line-list/sso-toggle/sso-folder-list/sso-role-map) must have an id equal to \"saml-\" + a SamlConfig property; these do not: " + string.Join(" | ", offenders));
+    }
+
+    [Fact]
+    public void SamlProviderForm_RendersEveryPersistingFieldId()
+    {
+        // The exhaustive reverse pin for the SAML save contract (#725), the twin of
+        // ProviderForm_RendersEveryPersistingFieldId: every one of the 30 persisting SAML fields must render
+        // as a marked input with its exact "saml-"-prefixed id, so a field silently dropped or unmarked during
+        // a future re-layout — which would stop it persisting — fails here rather than shipping as silent data
+        // loss. The provider-name KEY input (saml-provider-name) is deliberately unmarked (it supplies the
+        // SamlConfigs dictionary key, not a SamlConfig property) and is asserted present separately.
+        var markerClasses = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
+        var form = SamlProviderFormMarkup(
+            File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html")));
+
+        var markedProps = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match tag in Regex.Matches(form, "<[a-zA-Z][^>]*>", RegexOptions.Singleline))
+        {
+            var classAttr = Regex.Match(tag.Value, "class=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (!classAttr.Success)
+            {
+                continue;
+            }
+
+            var classes = classAttr.Groups[1].Value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (!classes.Any(c => markerClasses.Contains(c, StringComparer.Ordinal)))
+            {
+                continue;
+            }
+
+            var idMatch = Regex.Match(tag.Value, "(?<![-\\w])id=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (idMatch.Success && idMatch.Groups[1].Value.StartsWith("saml-", StringComparison.Ordinal))
+            {
+                markedProps.Add(idMatch.Groups[1].Value.Substring("saml-".Length));
+            }
+        }
+
+        var expected = new[]
+        {
+            "SamlEndpoint", "SamlClientId", "SamlCertificate", "SamlSecondaryCertificate", "SamlAudience",
+            "DoNotValidateAudience", "ValidateRecipient", "ValidateInResponseTo", "SignAuthnRequests",
+            "SamlSigningKeyPfx", "SamlRolloverSigningKeyPfx",
+            "Enabled", "EnableAuthorization", "DefaultProvider", "AllowExistingAccountLink", "ProvisionNewUsersDisabled",
+            "Roles", "AdminRoles", "EnableAllFolders", "EnabledFolders", "EnableFolderRoles", "FolderRoleMapping",
+            "EnableLiveTvRoles", "LiveTvRoles", "LiveTvManagementRoles", "EnableLiveTv", "EnableLiveTvManagement",
+            "SchemeOverride", "PortOverride", "BaseUrlOverride",
+        };
+
+        Assert.Equal(30, expected.Length);
+        var missing = expected.Where(p => !markedProps.Contains(p)).ToList();
+        Assert.True(
+            missing.Count == 0,
+            "These persisting SAML provider-form fields are missing their marked \"saml-\"-prefixed input in configPage.html (a re-layout dropped or unmarked them, so they would stop persisting): " + string.Join(", ", missing));
+
+        // The provider-name KEY input must still be present (unmarked by design).
+        Assert.Contains("id=\"saml-provider-name\"", form, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OpenSamlProvider_ResetsEditorBeforeLoadingTheProvider()
+    {
+        // #689/#725 (provider-switch state bleed) for the SAML editor: the SAML editor is a single reused
+        // form, so opening a provider must start from a clean slate or a field the target provider does not
+        // set keeps the PREVIOUS provider's value and a later save silently persists it. No JS runtime harness
+        // exists, so this pins the ordering statically: within openSamlProvider, resetSamlEditor(page) must run
+        // BEFORE loadSamlProvider(page, provider_name), the same clean-slate-first order OpenProvider enforces.
+        var js = File.ReadAllText(
+            Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+
+        var open = js.IndexOf("openSamlProvider:", StringComparison.Ordinal);
+        Assert.True(open >= 0, "openSamlProvider was not found in config.js.");
+
+        var nextMethod = js.IndexOf("addSamlProvider:", open, StringComparison.Ordinal);
+        Assert.True(nextMethod > open, "addSamlProvider (the method after openSamlProvider) was not found in config.js.");
+        var body = js[open..nextMethod];
+
+        var reset = body.IndexOf("resetSamlEditor(page)", StringComparison.Ordinal);
+        var load = body.IndexOf("loadSamlProvider(page, provider_name)", StringComparison.Ordinal);
+        Assert.True(reset >= 0, "openSamlProvider must call resetSamlEditor(page) to clear the previous provider's state before loading.");
+        Assert.True(load >= 0, "openSamlProvider must call loadSamlProvider(page, provider_name).");
+        Assert.True(
+            reset < load,
+            "openSamlProvider must call resetSamlEditor(page) BEFORE loadSamlProvider(page, provider_name); otherwise the previous provider's unset fields bleed into the loaded provider and can be silently saved (#689/#725).");
+    }
+
+    [Fact]
     public void OpenProvider_ResetsEditorBeforeLoadingTheProvider()
     {
         // #689 (provider-switch state bleed): the editor is a single reused form, so opening a provider must
@@ -1847,6 +2020,16 @@ public class ArchitectureConformanceTests
         Assert.True(start >= 0, "The #sso-new-oidc-provider form was not found in configPage.html.");
         var end = html.IndexOf("</form>", start, StringComparison.Ordinal);
         Assert.True(end > start, "The #sso-new-oidc-provider form has no closing </form> tag.");
+        return html[start..end];
+    }
+
+    private static string SamlProviderFormMarkup(string html)
+    {
+        const string marker = "id=\"sso-new-saml-provider\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "The #sso-new-saml-provider form was not found in configPage.html.");
+        var end = html.IndexOf("</form>", start, StringComparison.Ordinal);
+        Assert.True(end > start, "The #sso-new-saml-provider form has no closing </form> tag.");
         return html[start..end];
     }
 

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -23,11 +23,22 @@ const ssoConfigurationPage = {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
         ssoConfigurationPage.populateProviders(page, config.OidConfigs);
+        // Refresh the SAML workspace from the same configuration load (#725), so a SAML save/delete/import
+        // reloads its provider list exactly as the OpenID one does.
+        ssoConfigurationPage.populateSamlProviders(
+          page,
+          config.SamlConfigs || {},
+        );
       },
     );
 
     const folder_container = page.querySelector("#EnabledFolders");
     ssoConfigurationPage.populateFolders(folder_container);
+    // The SAML editor has its own available-folders checklist; populate it too (#725).
+    const saml_folder_container = page.querySelector("#saml-EnabledFolders");
+    if (saml_folder_container) {
+      ssoConfigurationPage.populateFolders(saml_folder_container);
+    }
   },
   populateProviders: (page, providers) => {
     const select = page.querySelector("#selectProvider");
@@ -1043,6 +1054,766 @@ const ssoConfigurationPage = {
       ApiClient.getUrl("web/configurationpage") + "?name=SSO-Auth.css";
     view.appendChild(style);
   },
+
+  // ============================================================================
+  // SAML provider workspace (#725)
+  // ----------------------------------------------------------------------------
+  // A lifecycle parallel to the OpenID one above, kept entirely separate so the OpenID workspace and its
+  // JS are untouched (there is no JS runtime test harness — the adversarial review is the primary
+  // verification, so isolation is the cheapest correctness guarantee). Every SAML persisting field id is
+  // its SamlConfig property spelled with a "saml-" PREFIX (ids must be unique across the whole document,
+  // and the OpenID fields already own the unprefixed spellings); the property is the id minus that prefix,
+  // computed by samlPropOf. ProviderFormFieldIds_MatchSamlConfigProperties fails the build if any
+  // saml-*-marked field id (after stripping the prefix) is not a real SamlConfig property, so a field that
+  // would silently never save cannot land. The generic element-argument helpers above (setFieldError,
+  // populateFolders / populateEnabledFolders / serializeEnabledFolders, populateRoleMappings /
+  // serializeRoleMappings, fillTextList / parseTextList, setCollapseExpanded, setDependent,
+  // setSectionExpanded, renderTestMessage / renderTestResult) are protocol-agnostic and reused as-is.
+  // ============================================================================
+
+  // Toggles/settings whose ENABLED state is a security downgrade the admin must not miss (mirrors
+  // insecureFieldIds/sensitiveFieldIds for OpenID). DoNotValidateAudience disables the AudienceRestriction
+  // check; AllowExistingAccountLink widens account adoption. Property names (no prefix): the flag is read
+  // from the saved config (provider[prop]) and, when checking the live checkbox, queried as "#saml-"+prop.
+  // ProvisionNewUsersDisabled is deliberately NOT flagged — it is a fail-closed hardening toggle (ON is
+  // MORE secure), so surfacing it would be backwards and cause alert fatigue, exactly as for OpenID.
+  samlInsecureFieldIds: ["DoNotValidateAudience"],
+  samlSensitiveFieldIds: ["AllowExistingAccountLink"],
+  samlPropOf: (id) => id.slice("saml-".length),
+  populateSamlProviders: (page, providers) => {
+    const select = page.querySelector("#saml-selectProvider");
+    select.querySelectorAll("option").forEach((option) => option.remove());
+    Object.keys(providers).forEach((provider_name) => {
+      select.appendChild(new Option(provider_name, provider_name));
+    });
+    ssoConfigurationPage.renderSamlProviderCards(page, providers);
+  },
+  // SAML provider cards — same inert createElement/textContent construction as renderProviderCards (#221):
+  // a provider name is never interpolated as markup, so a hostile name stays inert on the page.
+  renderSamlProviderCards: (page, providers) => {
+    const list = page.querySelector("#saml-provider-list");
+    const empty = page.querySelector("#saml-provider-empty");
+    list.replaceChildren();
+
+    const names = Object.keys(providers);
+    empty.hidden = names.length !== 0;
+
+    names.forEach((provider_name) => {
+      const provider = providers[provider_name] || {};
+
+      const card = document.createElement("button");
+      card.type = "button";
+      card.classList.add("sso-provider-card");
+      card.dataset.provider = provider_name;
+      card.setAttribute("role", "listitem");
+
+      const name = document.createElement("span");
+      name.classList.add("sso-provider-card-name");
+      name.textContent = provider_name;
+
+      const badge = document.createElement("span");
+      badge.classList.add("sso-badge", "sso-badge-type");
+      badge.textContent = "SAML";
+
+      const enabled = Boolean(provider.Enabled);
+      const pill = document.createElement("span");
+      pill.classList.add(
+        "sso-pill",
+        enabled ? "sso-pill-enabled" : "sso-pill-disabled",
+      );
+      pill.textContent = enabled ? "Enabled" : "Disabled";
+
+      card.append(name, badge, pill);
+
+      const flagged = ssoConfigurationPage.samlInsecureFieldIds
+        .concat(ssoConfigurationPage.samlSensitiveFieldIds)
+        .some((id) => Boolean(provider[id]));
+      if (flagged) {
+        card.classList.add("sso-provider-card-flagged");
+        const warn = document.createElement("span");
+        warn.classList.add("sso-badge", "sso-badge-warn");
+        warn.textContent = "Review";
+        warn.title =
+          "This provider has an active insecure or sensitive setting.";
+        card.append(warn);
+      }
+
+      list.appendChild(card);
+    });
+  },
+  showSamlEditor: (page) => {
+    page.querySelector("#saml-editor").hidden = false;
+  },
+  hideSamlEditor: (page) => {
+    page.querySelector("#saml-editor").hidden = true;
+  },
+  setSamlEditorTitle: (page, title) => {
+    page.querySelector("#saml-editor-title").textContent = title;
+  },
+  // Load a SAML card into the editor. resetSamlEditor gives a clean slate FIRST (same discipline as
+  // openProvider) so no field, toggle, or collapse state from the previously loaded provider bleeds into
+  // this one and gets silently re-saved.
+  openSamlProvider: (page, provider_name) => {
+    page.querySelector("#saml-selectProvider").value = provider_name;
+    ssoConfigurationPage.resetSamlEditor(page);
+    ssoConfigurationPage.clearSamlValidationErrors(page);
+    ssoConfigurationPage.renderSamlSaveStatus(page, "");
+    ssoConfigurationPage.setSamlEditorTitle(page, provider_name);
+    ssoConfigurationPage.showSamlEditor(page);
+    ssoConfigurationPage.loadSamlProvider(page, provider_name);
+    page.querySelector("#saml-editor").scrollIntoView({ block: "start" });
+  },
+  addSamlProvider: (page) => {
+    page.querySelector("#saml-selectProvider").value = "";
+    ssoConfigurationPage.resetSamlEditor(page);
+    ssoConfigurationPage.clearSamlValidationErrors(page);
+    ssoConfigurationPage.renderSamlSaveStatus(page, "");
+    ssoConfigurationPage.setSamlEditorTitle(page, "New provider");
+    ssoConfigurationPage.syncSamlDependentFields(page);
+    ssoConfigurationPage.showSamlEditor(page);
+    page.querySelector("#saml-editor").scrollIntoView({ block: "start" });
+    page.querySelector("#saml-provider-name").focus();
+  },
+  resetSamlEditor: (page) => {
+    const form_elements = ssoConfigurationPage.listSamlArgumentsByType(page);
+
+    page.querySelector("#saml-provider-name").value = "";
+
+    form_elements.text_fields.forEach((id) => {
+      page.querySelector("#" + id).value = "";
+    });
+    form_elements.text_list_fields.forEach((id) => {
+      page.querySelector("#" + id).value = "";
+    });
+    form_elements.check_fields.forEach((id) => {
+      page.querySelector("#" + id).checked = false;
+    });
+    form_elements.folder_list_fields.forEach((id) => {
+      ssoConfigurationPage.populateEnabledFolders(
+        [],
+        page.querySelector("#" + id),
+      );
+    });
+    form_elements.role_map_fields.forEach((id) => {
+      ssoConfigurationPage.populateRoleMappings(
+        [],
+        page.querySelector("#" + id),
+      );
+    });
+
+    ssoConfigurationPage.setSamlInsecureOptionsExpanded(page, false);
+    ssoConfigurationPage.resetSamlEditorSections(page);
+    ssoConfigurationPage.syncSamlDependentFields(page);
+    ssoConfigurationPage.updateSamlUrls(page);
+  },
+  // Return every accordion INSIDE the SAML editor to its authored default; scoped to #saml-editor so the
+  // OpenID editor and the page-level collapses are untouched.
+  resetSamlEditorSections: (page) => {
+    const editor = page.querySelector("#saml-editor");
+    if (!editor) {
+      return;
+    }
+    editor.querySelectorAll('[is="emby-collapse"]').forEach((section) => {
+      ssoConfigurationPage.setCollapseExpanded(
+        section,
+        section.getAttribute("data-expanded") === "true",
+      );
+    });
+  },
+  syncSamlDependentFields: (page) => {
+    ssoConfigurationPage.setDependent(
+      page,
+      "saml-EnableAllFolders",
+      "saml-EnabledFolders-group",
+      false,
+    );
+    ssoConfigurationPage.setDependent(
+      page,
+      "saml-EnableFolderRoles",
+      "saml-FolderRoleMapping-group",
+      true,
+    );
+    ssoConfigurationPage.setDependent(
+      page,
+      "saml-EnableLiveTvRoles",
+      "saml-LiveTvRoles-group",
+      true,
+    );
+
+    // Surface active insecure / sensitive settings behind the collapsed "Security & hardening" accordion
+    // (and, for the insecure subset, its inner list) — expand-only, exactly like syncDependentFields.
+    const isChecked = (id) => {
+      const el = page.querySelector("#saml-" + id);
+      return Boolean(el && el.checked);
+    };
+    const anyInsecure =
+      ssoConfigurationPage.samlInsecureFieldIds.some(isChecked);
+    const anySensitive =
+      anyInsecure || ssoConfigurationPage.samlSensitiveFieldIds.some(isChecked);
+    if (anyInsecure) {
+      ssoConfigurationPage.setSamlInsecureOptionsExpanded(page, true);
+    }
+    if (anySensitive) {
+      ssoConfigurationPage.setSectionExpanded(
+        page,
+        "saml-security-section",
+        true,
+      );
+    }
+  },
+  setSamlInsecureOptionsExpanded: (page, expanded) => {
+    const button = page.querySelector("#saml-ShowInsecureOptions");
+    const options = page.querySelector("#saml-insecure-options");
+    if (!button || !options) {
+      return;
+    }
+    options.hidden = !expanded;
+    button.setAttribute("aria-expanded", String(expanded));
+    button.querySelector("span").textContent = expanded
+      ? "Hide insecure options"
+      : "Show insecure options";
+  },
+  // The SAML save contract, made explicit (mirrors listArgumentsByType): every input in
+  // #sso-new-saml-provider that persists carries an sso-* marker class AND a "saml-"+property id. The
+  // folder-list and role-map ids are the two that are not plain inputs, listed explicitly like the OpenID
+  // side. saveSamlProvider/loadSamlProvider map id->property with samlPropOf.
+  listSamlArgumentsByType: (page) => {
+    const folder_list_fields = ["saml-EnabledFolders"];
+    const role_map_fields = ["saml-FolderRoleMapping"];
+
+    const form = page.querySelector("#sso-new-saml-provider");
+
+    const text_fields = [...form.querySelectorAll(".sso-text")].map(
+      (e) => e.id,
+    );
+    const text_list_fields = [...form.querySelectorAll(".sso-line-list")].map(
+      (e) => e.id,
+    );
+    const check_fields = [...form.querySelectorAll(".sso-toggle")].map(
+      (e) => e.id,
+    );
+
+    return {
+      text_list_fields,
+      text_fields,
+      check_fields,
+      folder_list_fields,
+      role_map_fields,
+    };
+  },
+  loadSamlProvider: (page, provider_name) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        const provider = (config.SamlConfigs || {})[provider_name] || {};
+
+        const form_elements =
+          ssoConfigurationPage.listSamlArgumentsByType(page);
+
+        page.querySelector("#saml-provider-name").value = provider_name;
+
+        form_elements.text_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          // The write-only signing keys (SamlSigningKeyPfx / SamlRolloverSigningKeyPfx) are serialized back
+          // as null by the server (WriteOnlySecretConverter), so provider[prop] is falsy and the field stays
+          // blank — its "leave blank to keep" placeholder governs, exactly like the OpenID OidSecret.
+          if (provider[prop]) {
+            page.querySelector("#" + id).value = provider[prop];
+          }
+        });
+
+        form_elements.text_list_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          if (provider[prop]) {
+            ssoConfigurationPage.fillTextList(
+              provider[prop],
+              page.querySelector("#" + id),
+            );
+          }
+        });
+
+        form_elements.folder_list_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          if (provider[prop]) {
+            ssoConfigurationPage.populateEnabledFolders(
+              provider[prop],
+              page.querySelector("#" + id),
+            );
+          }
+        });
+
+        form_elements.check_fields.forEach((id) => {
+          // Always set from the loaded provider (not only when truthy) so a stale insecure toggle from a
+          // previously loaded provider is never left checked to be silently re-saved — the exact reason the
+          // OpenID loadProvider sets Boolean(provider[id]) unconditionally.
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          page.querySelector("#" + id).checked = Boolean(provider[prop]);
+        });
+
+        form_elements.role_map_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          const elem = page.querySelector("#" + id);
+          if (provider[prop]) {
+            ssoConfigurationPage.populateRoleMappings(provider[prop], elem);
+          }
+        });
+
+        ssoConfigurationPage.syncSamlDependentFields(page);
+        ssoConfigurationPage.updateSamlUrls(page);
+      },
+    );
+  },
+  // Canonical external base for the computed SAML URLs (mirrors the inline logic in computeRedirectUri,
+  // #724): the Base URL Override when set, else this server's address, normalized the way the server's
+  // CanonicalBaseUrl (System.Uri.GetLeftPart) is — origin lowercases scheme+host and elides the default
+  // port, pathname keeps any sub-path, and the trailing slash is trimmed. When the override is blank the
+  // shown URL reflects the browser's server address; the scheme/port overrides are a legacy mechanism the
+  // Base URL Override supersedes (its callout steers the admin there).
+  samlCanonicalBase: (page) => {
+    const override = page.querySelector("#saml-BaseUrlOverride").value.trim();
+    const raw = override || ApiClient.serverAddress() || "";
+    try {
+      const u = new URL(raw);
+      return u.origin + u.pathname.replace(/\/+$/, "");
+    } catch (e) {
+      return raw.replace(/\/+$/, "");
+    }
+  },
+  // Live-update the read-only ACS + SP-metadata URLs (#725/#569). The IdP POSTs to the new-path ACS
+  // spelling the SP metadata advertises at index 0 (SamlAcsUrlBuilder.AcsUrl newPath=true => "post"); the
+  // metadata document is served at /sso/SAML/metadata/<provider>. The provider name is appended raw, as the
+  // server does (names exclude URI-reserved characters, #336). Sets .value only, never innerHTML (#221).
+  updateSamlUrls: (page) => {
+    const acs = page.querySelector("#saml-AcsUrl");
+    const metadata = page.querySelector("#saml-MetadataUrl");
+    const name = page.querySelector("#saml-provider-name").value.trim();
+    const base = ssoConfigurationPage.samlCanonicalBase(page);
+
+    if (acs) {
+      acs.value = name ? base + "/sso/SAML/post/" + name : "";
+      acs.placeholder = name
+        ? ""
+        : "Enter a provider name above to see the ACS URL";
+    }
+    if (metadata) {
+      metadata.value = name ? base + "/sso/SAML/metadata/" + name : "";
+      metadata.placeholder = name
+        ? ""
+        : "Enter a provider name above to see the metadata URL";
+    }
+    const status = page.querySelector("#saml-url-copied");
+    if (status) {
+      status.textContent = "";
+    }
+  },
+  // Copy a read-only computed SAML URL to the clipboard, with the same secure-context/execCommand fallback
+  // and inert status announcement as copyRedirectUri (#724). fieldId/label identify which URL was copied.
+  copySamlUrl: (page, fieldId, label) => {
+    const field = page.querySelector("#" + fieldId);
+    const status = page.querySelector("#saml-url-copied");
+    const value = field && field.value;
+    if (!value) {
+      return;
+    }
+    const announce = (message) => {
+      if (status) {
+        status.textContent = message;
+      }
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(value).then(
+        () => announce(label + " copied to the clipboard."),
+        () => announce("Copy failed — select the field and copy it manually."),
+      );
+      return;
+    }
+    field.removeAttribute("readonly");
+    field.select();
+    let ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch (e) {
+      ok = false;
+    }
+    field.setAttribute("readonly", "");
+    announce(
+      ok
+        ? label + " copied to the clipboard."
+        : "Copy failed — select the field and copy it manually.",
+    );
+  },
+  // Import IdP metadata (#735) from a URL (fetched server-side through the SSRF-hardened outbound client) or
+  // pasted XML, and pre-fill the endpoint + signing certificate(s) for the admin to review and save. The
+  // server returns the parsed values; NOTHING is applied server-side by this call. The IdP EntityId is
+  // shown for reference only — it is NOT the SP SamlClientId, which the admin chooses.
+  importSamlMetadata: (page, source) => {
+    const status = page.querySelector("#saml-metadata-status");
+    const url =
+      source === "url"
+        ? page.querySelector("#saml-metadata-url").value.trim()
+        : "";
+    const xml =
+      source === "xml"
+        ? page.querySelector("#saml-metadata-xml").value.trim()
+        : "";
+    if (!url && !xml) {
+      ssoConfigurationPage.renderTransferMessage(
+        status,
+        source === "url"
+          ? "Enter a metadata URL first."
+          : "Paste the metadata XML first.",
+      );
+      return Promise.resolve();
+    }
+
+    ssoConfigurationPage.renderTransferMessage(status, "Importing metadata…");
+    return ApiClient.fetch({
+      type: "POST",
+      url: ApiClient.getUrl("sso/SAML/ImportMetadata"),
+      data: JSON.stringify({ Url: url || null, Xml: xml || null }),
+      contentType: "application/json",
+      dataType: "json",
+    }).then(
+      (result) => {
+        if (result && result.Endpoint) {
+          page.querySelector("#saml-SamlEndpoint").value = result.Endpoint;
+        }
+        if (result && result.PrimaryCertificate) {
+          page.querySelector("#saml-SamlCertificate").value =
+            result.PrimaryCertificate;
+        }
+        if (result && result.SecondaryCertificate) {
+          page.querySelector("#saml-SamlSecondaryCertificate").value =
+            result.SecondaryCertificate;
+        }
+        // The endpoint/certificate are now filled; re-run their on-blur validation so a bad imported value
+        // surfaces immediately rather than only on the next focus change.
+        ssoConfigurationPage.validateSamlEndpoint(page);
+        ssoConfigurationPage.validateSamlCertificate(
+          page,
+          "saml-SamlCertificate",
+          "IdP Signing Certificate",
+        );
+        // EntityId is reference-only: shown as inert text, never written into a field.
+        const entity = result && result.EntityId ? result.EntityId : "";
+        ssoConfigurationPage.renderTransferMessage(
+          status,
+          entity
+            ? "Imported the endpoint and certificate. The provider's entity id is " +
+                entity +
+                " (reference only — set the SAML Client ID yourself). Review the fields and Save."
+            : "Imported the endpoint and certificate. Review the fields and Save.",
+        );
+      },
+      () =>
+        ssoConfigurationPage.renderTransferMessage(
+          status,
+          "Could not import the metadata. Check the URL or XML, make sure you are signed in as an administrator, and that the address is reachable and not a private/loopback host.",
+        ),
+    );
+  },
+  clearSamlValidationErrors: (page) => {
+    [
+      "saml-provider-name",
+      "saml-SamlEndpoint",
+      "saml-SamlClientId",
+      "saml-SamlCertificate",
+      "saml-SamlSecondaryCertificate",
+      "saml-BaseUrlOverride",
+    ].forEach((id) => ssoConfigurationPage.setFieldError(page, id, ""));
+  },
+  renderSamlSaveStatus: (page, message, ok) => {
+    const box = page.querySelector("#saml-save-status");
+    if (!box) {
+      return;
+    }
+    box.textContent = message || "";
+    box.classList.remove("sso-status-ok", "sso-status-fail");
+    if (message) {
+      box.classList.add(ok ? "sso-status-ok" : "sso-status-fail");
+    }
+  },
+  // Mirror the server's fail-closed provider-name checks (#336/#360) before the round-trip, keeping the
+  // source ASCII-only (control chars detected by code point, not a regex escape) as validateProviderName does.
+  validateSamlProviderName: (page) => {
+    const value = page.querySelector("#saml-provider-name").value;
+    if (!value.trim()) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-provider-name",
+        "A provider name is required.",
+      );
+      return;
+    }
+    const hasControlChar = [...value].some((ch) => {
+      const code = ch.charCodeAt(0);
+      return code < 0x20 || code === 0x7f;
+    });
+    if (hasControlChar) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-provider-name",
+        "Remove control characters (such as a tab or newline, often introduced by copy-paste) from the name.",
+      );
+      return;
+    }
+    const reserved = ["\\", "/", "?", "#", "%"];
+    if (reserved.some((c) => value.includes(c))) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-provider-name",
+        "Remove backslash and URI-reserved characters (\\ / ? # %) from the name.",
+      );
+      return;
+    }
+    ssoConfigurationPage.setFieldError(page, "saml-provider-name", "");
+  },
+  validateSamlRequired: (page, id, label) => {
+    const value = page.querySelector("#" + id).value.trim();
+    ssoConfigurationPage.setFieldError(
+      page,
+      id,
+      value ? "" : label + " is required.",
+    );
+  },
+  validateSamlEndpoint: (page) => {
+    const value = page.querySelector("#saml-SamlEndpoint").value.trim();
+    if (!value) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-SamlEndpoint",
+        "SAML SSO Endpoint is required.",
+      );
+      return;
+    }
+    let url;
+    try {
+      url = new URL(value);
+    } catch (e) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-SamlEndpoint",
+        "Enter an absolute URL, e.g. https://idp.example.com/sso",
+      );
+      return;
+    }
+    if (url.protocol === "http:") {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-SamlEndpoint",
+        "Uses http:// — the redirect would be unencrypted. Prefer an https:// endpoint.",
+      );
+      return;
+    }
+    if (url.protocol !== "https:") {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-SamlEndpoint",
+        "Use an https:// URL for the SAML endpoint.",
+      );
+      return;
+    }
+    ssoConfigurationPage.setFieldError(page, "saml-SamlEndpoint", "");
+  },
+  validateSamlBaseUrl: (page) => {
+    const value = page.querySelector("#saml-BaseUrlOverride").value.trim();
+    if (!value) {
+      ssoConfigurationPage.setFieldError(page, "saml-BaseUrlOverride", "");
+      return;
+    }
+    let url;
+    try {
+      url = new URL(value);
+    } catch (e) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-BaseUrlOverride",
+        "Enter a full origin such as https://jellyfin.example.com (scheme + host only).",
+      );
+      return;
+    }
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-BaseUrlOverride",
+        "Enter a full origin such as https://jellyfin.example.com",
+      );
+      return;
+    }
+    if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        "saml-BaseUrlOverride",
+        "Enter the base URL only (no path) — e.g. https://jellyfin.example.com, not the /sso/... ACS URL.",
+      );
+      return;
+    }
+    ssoConfigurationPage.setFieldError(page, "saml-BaseUrlOverride", "");
+  },
+  // Pre-emptive certificate shape check (WARNING only, never blocks the save — the server stays the
+  // authority, so a false positive cannot lock an admin out). Accepts an empty optional field, a PEM block,
+  // or a bare Base64 body; only an obviously malformed value (non-Base64 characters once PEM armor and
+  // whitespace are stripped) is flagged. label/id let it serve both the primary and secondary certificate.
+  validateSamlCertificate: (page, id, label) => {
+    const raw = page.querySelector("#" + id).value.trim();
+    if (!raw) {
+      // Optional (the secondary) or required-checked elsewhere (the primary) — an empty value is not a
+      // SHAPE error here; requiredness for the primary is enforced by the server on save.
+      ssoConfigurationPage.setFieldError(page, id, "");
+      return;
+    }
+    const body = raw
+      .replace(/-----BEGIN CERTIFICATE-----/g, "")
+      .replace(/-----END CERTIFICATE-----/g, "")
+      .replace(/\s+/g, "");
+    if (!body || !/^[A-Za-z0-9+/]+={0,2}$/.test(body)) {
+      ssoConfigurationPage.setFieldError(
+        page,
+        id,
+        label +
+          " is not valid Base64 — paste the certificate body (the text between the PEM BEGIN/END lines) or the whole PEM block.",
+      );
+      return;
+    }
+    ssoConfigurationPage.setFieldError(page, id, "");
+  },
+  deleteSamlProvider: (page, provider_name) => {
+    if (
+      !window.confirm(
+        `Are you sure you want to delete the provider ${provider_name}?`,
+      )
+    ) {
+      return;
+    }
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        if (
+          !config.SamlConfigs ||
+          !config.SamlConfigs.hasOwnProperty(provider_name)
+        ) {
+          return;
+        }
+
+        delete config.SamlConfigs[provider_name];
+        ApiClient.updatePluginConfiguration(
+          ssoConfigurationPage.pluginUniqueId,
+          config,
+        ).then(
+          function (result) {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+            ssoConfigurationPage.loadConfiguration(page);
+            ssoConfigurationPage.hideSamlEditor(page);
+            Dashboard.alert("Provider removed");
+          },
+          function () {
+            Dashboard.alert({
+              title: "Delete failed",
+              message:
+                "Could not remove the provider. The saved configuration was rejected by the server; reload the page and try again.",
+            });
+          },
+        );
+      },
+    );
+  },
+  saveSamlProvider: (page, provider_name) => {
+    return new Promise((resolve, reject) => {
+      const form_elements = ssoConfigurationPage.listSamlArgumentsByType(page);
+
+      ApiClient.getPluginConfiguration(
+        ssoConfigurationPage.pluginUniqueId,
+      ).then((config) => {
+        if (!config.SamlConfigs) {
+          config.SamlConfigs = {};
+        }
+        let current_config = {};
+        if (config.SamlConfigs.hasOwnProperty(provider_name)) {
+          current_config = config.SamlConfigs[provider_name];
+        }
+
+        form_elements.text_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          current_config[prop] = page.querySelector("#" + id).value || null;
+        });
+
+        form_elements.check_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          current_config[prop] = page.querySelector("#" + id).checked;
+        });
+
+        form_elements.text_list_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          current_config[prop] = ssoConfigurationPage.parseTextList(
+            page.querySelector("#" + id),
+          );
+        });
+
+        form_elements.folder_list_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          const elem = page.querySelector("#" + id);
+          current_config[prop] =
+            ssoConfigurationPage.serializeEnabledFolders(elem);
+        });
+
+        form_elements.role_map_fields.forEach((id) => {
+          const prop = ssoConfigurationPage.samlPropOf(id);
+          const elem = page.querySelector("#" + id);
+          current_config[prop] =
+            ssoConfigurationPage.serializeRoleMappings(elem);
+        });
+
+        config.SamlConfigs[provider_name] = current_config;
+
+        ApiClient.updatePluginConfiguration(
+          ssoConfigurationPage.pluginUniqueId,
+          config,
+        ).then(
+          function (result) {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+            ssoConfigurationPage.loadConfiguration(page);
+            ssoConfigurationPage.loadSamlProvider(page, provider_name);
+
+            page.querySelector("#saml-selectProvider").value = provider_name;
+            Dashboard.alert("Settings saved.");
+            resolve();
+          },
+          function () {
+            Dashboard.alert({
+              title: "Save failed",
+              message:
+                "Could not save the provider. Check that the provider name has no control characters (such as a tab or newline, often introduced by copy-paste), no backslash, and none of the URI-reserved characters such as / ? # %, and that the Base URL Override is a full URL such as https://jellyfin.example.com (or blank).",
+            });
+            reject(new Error("Provider save failed"));
+          },
+        );
+      });
+    });
+  },
+  // Test-connection for a SAVED SAML provider (#163). Calls the elevation-gated SAML/Test endpoint, which
+  // parses the stored IdP signing certificate server-side and returns only its non-secret facts (never the
+  // SP signing key). Reuses the OpenID renderTestResult/renderTestMessage (same Ok/Message/Details shape).
+  testSamlProvider: (page, provider_name) => {
+    const container = page.querySelector("#saml-TestResult");
+    if (!provider_name) {
+      ssoConfigurationPage.renderTestMessage(
+        container,
+        "Enter a provider name and save it first, then test.",
+      );
+      return Promise.resolve();
+    }
+
+    ssoConfigurationPage.renderTestMessage(container, "Testing…");
+
+    return ApiClient.getJSON(
+      ApiClient.getUrl("sso/SAML/Test/" + encodeURIComponent(provider_name)),
+    ).then(
+      (result) => ssoConfigurationPage.renderTestResult(container, result),
+      () =>
+        ssoConfigurationPage.renderTestMessage(
+          container,
+          "Could not run the test. Make sure the provider is saved and that you are signed in as an administrator, then try again.",
+        ),
+    );
+  },
 };
 
 export default function initSsoConfigurationPage(view) {
@@ -1228,4 +1999,181 @@ export default function initSsoConfigurationPage(view) {
 
   view.querySelector("#sso-self-service-link").href =
     ApiClient.getUrl("/SSOViews/linking");
+
+  // ---- SAML workspace bindings (#725) — the exact parallel of the OpenID bindings above ----
+  view.querySelector("#saml-SaveProvider").addEventListener("click", (e) => {
+    const target_provider = view.querySelector("#saml-provider-name").value;
+
+    ssoConfigurationPage.saveSamlProvider(view, target_provider).then(
+      () => {
+        ssoConfigurationPage.renderSamlSaveStatus(
+          view,
+          "Settings saved.",
+          true,
+        );
+        ssoConfigurationPage.setSamlEditorTitle(view, target_provider);
+      },
+      () =>
+        ssoConfigurationPage.renderSamlSaveStatus(
+          view,
+          "Save failed — see the details in the alert.",
+          false,
+        ),
+    );
+
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#saml-TestProvider").addEventListener("click", (e) => {
+    const target_provider = view.querySelector("#saml-provider-name").value;
+    ssoConfigurationPage.testSamlProvider(view, target_provider);
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#saml-provider-list").addEventListener("click", (e) => {
+    const card = e.target.closest(".sso-provider-card");
+    if (!card) {
+      return;
+    }
+    ssoConfigurationPage.openSamlProvider(view, card.dataset.provider);
+  });
+
+  view.querySelector("#saml-AddProvider").addEventListener("click", (e) => {
+    ssoConfigurationPage.addSamlProvider(view);
+    e.preventDefault();
+    return false;
+  });
+
+  view
+    .querySelector("#saml-AddProviderEmpty")
+    .addEventListener("click", (e) => {
+      ssoConfigurationPage.addSamlProvider(view);
+      e.preventDefault();
+      return false;
+    });
+
+  view.querySelector("#saml-DeleteProvider").addEventListener("click", (e) => {
+    const target_provider = view.querySelector("#saml-provider-name").value;
+    if (target_provider) {
+      ssoConfigurationPage.deleteSamlProvider(view, target_provider);
+    } else {
+      ssoConfigurationPage.hideSamlEditor(view);
+    }
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#saml-AddRoleMapping").addEventListener("click", (e) => {
+    const container = view.querySelector("#saml-FolderRoleMapping");
+    const current_mappings =
+      ssoConfigurationPage.serializeRoleMappings(container);
+    current_mappings.push({ Role: "", Folders: [] });
+    ssoConfigurationPage.populateRoleMappings(current_mappings, container);
+    e.preventDefault();
+    return false;
+  });
+
+  view
+    .querySelector("#saml-ShowInsecureOptions")
+    .addEventListener("click", (e) => {
+      const collapsed = view.querySelector("#saml-insecure-options").hidden;
+      ssoConfigurationPage.setSamlInsecureOptionsExpanded(view, collapsed);
+      e.preventDefault();
+      return false;
+    });
+
+  [
+    "saml-EnableAllFolders",
+    "saml-EnableFolderRoles",
+    "saml-EnableLiveTvRoles",
+  ].forEach((id) => {
+    view
+      .querySelector("#" + id)
+      .addEventListener("change", () =>
+        ssoConfigurationPage.syncSamlDependentFields(view),
+      );
+  });
+
+  view
+    .querySelector("#saml-provider-name")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlProviderName(view),
+    );
+  view
+    .querySelector("#saml-SamlEndpoint")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlEndpoint(view),
+    );
+  view
+    .querySelector("#saml-SamlClientId")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlRequired(
+        view,
+        "saml-SamlClientId",
+        "SAML Client ID",
+      ),
+    );
+  view
+    .querySelector("#saml-SamlCertificate")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlCertificate(
+        view,
+        "saml-SamlCertificate",
+        "IdP Signing Certificate",
+      ),
+    );
+  view
+    .querySelector("#saml-SamlSecondaryCertificate")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlCertificate(
+        view,
+        "saml-SamlSecondaryCertificate",
+        "Secondary IdP Signing Certificate",
+      ),
+    );
+  view
+    .querySelector("#saml-BaseUrlOverride")
+    .addEventListener("blur", () =>
+      ssoConfigurationPage.validateSamlBaseUrl(view),
+    );
+
+  // Live-update the computed ACS + SP-metadata URLs as the provider name or base-URL override changes.
+  ["saml-provider-name", "saml-BaseUrlOverride"].forEach((id) => {
+    view
+      .querySelector("#" + id)
+      .addEventListener("input", () =>
+        ssoConfigurationPage.updateSamlUrls(view),
+      );
+  });
+
+  view.querySelector("#saml-CopyAcsUrl").addEventListener("click", (e) => {
+    ssoConfigurationPage.copySamlUrl(view, "saml-AcsUrl", "ACS URL");
+    e.preventDefault();
+    return false;
+  });
+  view.querySelector("#saml-CopyMetadataUrl").addEventListener("click", (e) => {
+    ssoConfigurationPage.copySamlUrl(view, "saml-MetadataUrl", "Metadata URL");
+    e.preventDefault();
+    return false;
+  });
+
+  view
+    .querySelector("#saml-ImportMetadataUrl")
+    .addEventListener("click", (e) => {
+      ssoConfigurationPage.importSamlMetadata(view, "url");
+      e.preventDefault();
+      return false;
+    });
+  view
+    .querySelector("#saml-ImportMetadataXml")
+    .addEventListener("click", (e) => {
+      ssoConfigurationPage.importSamlMetadata(view, "xml");
+      e.preventDefault();
+      return false;
+    });
+
+  // Populate the computed URLs once at init (blank editor shows the placeholders until a name is typed).
+  ssoConfigurationPage.updateSamlUrls(view);
 }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -1534,6 +1534,1047 @@
               </div>
             </div>
           </form>
+
+          <!--
+            SAML provider workspace (#725) — a second, independent workspace parallel to the OpenID one above.
+            To keep every element id unique in the document (an HTML requirement) while still driving the save
+            contract off the id, every SAML persisting field carries a "saml-" PREFIXED id AND the marker class:
+            config.js's SAML save path writes current_config[id.slice("saml-".length)] = value, so the property
+            name is the id minus the prefix (e.g. id="saml-SamlEndpoint" -> SamlConfig.SamlEndpoint). This leaves
+            the OpenID workspace and its JS completely untouched. Pinned by
+            ArchitectureConformanceTests.ProviderFormFieldIds_MatchSamlConfigProperties.
+          -->
+          <form id="sso-load-saml-config" class="esqConfigurationForm">
+            <div class="verticalSection">
+              <div class="sso-workspace-header">
+                <h3 class="sso-workspace-title">SAML providers</h3>
+                <button
+                  id="saml-AddProvider"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit sso-add-provider emby-button"
+                >
+                  <span class="material-icons add" aria-hidden="true"></span>
+                  <span>Add SAML provider</span>
+                </button>
+              </div>
+
+              <div id="saml-provider-empty" class="sso-empty-state" hidden>
+                <p class="sso-empty-state-title">No SAML providers yet</p>
+                <p class="fieldDescription">
+                  Add a SAML 2.0 provider to let users sign in through your
+                  identity provider. You can import the endpoint and signing
+                  certificate straight from your IdP's metadata below.
+                </p>
+                <button
+                  id="saml-AddProviderEmpty"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit sso-add-provider emby-button"
+                >
+                  <span class="material-icons add" aria-hidden="true"></span>
+                  <span>Add SAML provider</span>
+                </button>
+              </div>
+
+              <div
+                id="saml-provider-list"
+                class="sso-provider-list"
+                role="list"
+              ></div>
+
+              <label for="saml-selectProvider" class="sso-visually-hidden"
+                >Loaded SAML provider</label
+              >
+              <select
+                is="emby-select"
+                id="saml-selectProvider"
+                name="saml-selectProvider"
+                class="emby-select-withcolor emby-select sso-visually-hidden"
+              ></select>
+            </div>
+          </form>
+
+          <form id="sso-new-saml-provider" class="esqConfigurationForm">
+            <div class="sso-editor" id="saml-editor" hidden>
+              <div class="sso-editor-header">
+                <h3 class="sso-editor-title" id="saml-editor-title">
+                  New provider
+                </h3>
+                <div class="sso-editor-header-actions">
+                  <div
+                    id="saml-save-status"
+                    class="sso-save-status"
+                    role="status"
+                    aria-live="polite"
+                  ></div>
+                  <button
+                    id="saml-DeleteProvider"
+                    is="emby-button"
+                    type="button"
+                    class="raised button-delete sso-btn-deemphasized emby-button"
+                  >
+                    <span>Delete</span>
+                  </button>
+                </div>
+              </div>
+
+              <p class="fieldDescription sso-required-legend">
+                Fields marked
+                <span class="sso-required" aria-hidden="true">*</span>
+                are required.
+              </p>
+
+              <!-- SAML Section 1: Connection -->
+              <div
+                is="emby-collapse"
+                data-expanded="true"
+                title="Connection"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-provider-name"
+                      >Name of SAML Provider:
+                      <span class="sso-required" aria-hidden="true"
+                        >*</span
+                      ></label
+                    >
+                    <!-- No marker class: this input's value is the SamlConfigs dictionary KEY, not a property. -->
+                    <input
+                      is="emby-input"
+                      id="saml-provider-name"
+                      required=""
+                      type="text"
+                      aria-describedby="saml-provider-name-error"
+                    />
+                    <div
+                      class="sso-inline-error"
+                      id="saml-provider-name-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="fieldDescription">
+                      The name Jellyfin uses to identify this SAML provider. A
+                      new provider is created if the name is new; an existing
+                      one is updated.
+                    </div>
+                  </div>
+
+                  <!--
+                    Import from IdP metadata (#735): fetch a metadata URL server-side (SSRF-hardened) or paste
+                    the XML, and pre-fill the endpoint + signing certificate below. Read-only result via
+                    textContent (#221). These inputs/buttons are NOT persisting fields (no marker class).
+                  -->
+                  <div class="inputContainer sso-metadata-import">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-metadata-url"
+                      >Import from IdP metadata
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <div class="sso-redirect-uri-row">
+                      <input
+                        is="emby-input"
+                        id="saml-metadata-url"
+                        type="text"
+                        placeholder="https://idp.example.com/metadata"
+                      />
+                      <button
+                        is="emby-button"
+                        type="button"
+                        id="saml-ImportMetadataUrl"
+                        class="raised button-alt"
+                      >
+                        <span>Import URL</span>
+                      </button>
+                    </div>
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-metadata-xml"
+                      class="emby-textarea"
+                      placeholder="…or paste the metadata XML here"
+                    ></textarea>
+                    <button
+                      is="emby-button"
+                      type="button"
+                      id="saml-ImportMetadataXml"
+                      class="raised button-alt"
+                    >
+                      <span>Import pasted XML</span>
+                    </button>
+                    <div
+                      id="saml-metadata-status"
+                      class="sso-copied-status"
+                      role="status"
+                      aria-live="polite"
+                    ></div>
+                    <div class="fieldDescription">
+                      Fetches the SSO endpoint and signing certificate(s) from
+                      your identity provider's SAML metadata and fills them in
+                      below for review. It never fills the SAML Client ID (that
+                      is this service provider's own entity id, which you
+                      choose).
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-SamlEndpoint"
+                      >SAML SSO Endpoint:
+                      <span class="sso-required" aria-hidden="true"
+                        >*</span
+                      ></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-SamlEndpoint"
+                      required=""
+                      type="text"
+                      class="sso-text"
+                      aria-describedby="saml-SamlEndpoint-error"
+                    />
+                    <div
+                      class="sso-inline-error"
+                      id="saml-SamlEndpoint-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="fieldDescription">
+                      The identity provider's Single Sign-On URL — where the
+                      browser is redirected to authenticate.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-SamlClientId"
+                      >SAML Client ID (SP entity id):
+                      <span class="sso-required" aria-hidden="true"
+                        >*</span
+                      ></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-SamlClientId"
+                      required=""
+                      type="text"
+                      class="sso-text"
+                      aria-describedby="saml-SamlClientId-error"
+                    />
+                    <div
+                      class="sso-inline-error"
+                      id="saml-SamlClientId-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="fieldDescription">
+                      This service provider's entity id — the value the plugin
+                      sends as the AuthnRequest issuer and expects as the
+                      audience. You choose it and register it at the IdP; it is
+                      also the SP entityID shown below.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-SamlCertificate"
+                      >IdP Signing Certificate:
+                      <span class="sso-required" aria-hidden="true"
+                        >*</span
+                      ></label
+                    >
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-SamlCertificate"
+                      class="sso-text emby-textarea"
+                      aria-describedby="saml-SamlCertificate-error"
+                    ></textarea>
+                    <div
+                      class="sso-inline-error"
+                      id="saml-SamlCertificate-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="fieldDescription">
+                      The identity provider's PUBLIC signing certificate as
+                      Base64 (DER) — the value between the PEM
+                      <code>BEGIN/END CERTIFICATE</code> lines, or the whole
+                      PEM. Used to verify the SAML response signature.
+                    </div>
+                  </div>
+
+                  <!--
+                    Read-only computed SP URLs (#569/#725): the ACS and metadata URLs the IdP must be told
+                    about, plus the SP entityID. Derived client-side from the Base URL Override (else the
+                    server address) exactly like the login builds them; set via .value/textContent, never
+                    innerHTML (#221). Not persisting fields (no marker class, read-only).
+                  -->
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-AcsUrl"
+                      >ACS URL (register this at your IdP):</label
+                    >
+                    <div class="sso-redirect-uri-row">
+                      <input
+                        is="emby-input"
+                        id="saml-AcsUrl"
+                        type="text"
+                        readonly
+                      />
+                      <button
+                        is="emby-button"
+                        type="button"
+                        id="saml-CopyAcsUrl"
+                        class="raised button-alt"
+                      >
+                        <span>Copy</span>
+                      </button>
+                    </div>
+                    <div class="fieldDescription">
+                      The Assertion Consumer Service URL the IdP POSTs the SAML
+                      response to. Updates as you type the provider name.
+                      Derived from the Base URL Override (Advanced section) when
+                      set, else this server's address. The legacy spelling
+                      <code>/sso/SAML/p/&lt;name&gt;</code> also works.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-MetadataUrl"
+                      >SP metadata URL (hand this to your IdP):</label
+                    >
+                    <div class="sso-redirect-uri-row">
+                      <input
+                        is="emby-input"
+                        id="saml-MetadataUrl"
+                        type="text"
+                        readonly
+                      />
+                      <button
+                        is="emby-button"
+                        type="button"
+                        id="saml-CopyMetadataUrl"
+                        class="raised button-alt"
+                      >
+                        <span>Copy</span>
+                      </button>
+                    </div>
+                    <div
+                      id="saml-url-copied"
+                      class="sso-copied-status"
+                      role="status"
+                      aria-live="polite"
+                    ></div>
+                    <div class="fieldDescription">
+                      This service provider's metadata document — many IdPs can
+                      import it by URL instead of hand-configuring the ACS and
+                      entityID. The SP entityID it advertises is the SAML Client
+                      ID above.
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-Enabled"
+                        name="saml-Enabled"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Enabled</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <!-- SAML Section 2: User provisioning -->
+              <div
+                is="emby-collapse"
+                data-expanded="true"
+                title="User provisioning"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-EnableAuthorization"
+                        name="saml-EnableAuthorization"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Enable Authorization by Plugin</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      Determines if the plugin sets permissions for the user. If
+                      off, the user starts with no permissions and an
+                      administrator adds them. Existing users' permissions are
+                      not rewritten on later logins.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-DefaultProvider"
+                      >Set default Provider:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-DefaultProvider"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      Assigned to the user after they log in. If unset, nothing
+                      changes and the user can still log in via other providers.
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-AllowExistingAccountLink"
+                        name="saml-AllowExistingAccountLink"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Allow Adopting Existing Accounts (Sensitive)</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      ⚠ Sensitive: lets a first SAML login adopt a pre-existing,
+                      unlinked Jellyfin account whose username matches the SAML
+                      NameID, instead of rejecting it. Off by default. A
+                      name-matched administrator account is never adopted.
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-ProvisionNewUsersDisabled"
+                        name="saml-ProvisionNewUsersDisabled"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span
+                        >Provision New Users Disabled (Pending Approval)</span
+                      >
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      An unknown identity's first login creates its account
+                      disabled, with no permissions, and is refused with an
+                      "awaiting administrator approval" message until an admin
+                      enables it. Off by default. Never disables an existing or
+                      adopted account, and each deferral is audited.
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- SAML Section 3: Roles & access -->
+              <div
+                is="emby-collapse"
+                data-expanded="true"
+                title="Roles &amp; access"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-Roles"
+                      >Roles:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-Roles"
+                      type="text"
+                      class="sso-line-list emby-textarea"
+                    ></textarea>
+                    <div class="fieldDescription">
+                      One role per line. A login must carry at least one of
+                      these roles (in the assertion's Role attribute) to be
+                      allowed in. Leave blank to allow any authenticated user.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-AdminRoles"
+                      >Admin Roles:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-AdminRoles"
+                      type="text"
+                      class="sso-line-list emby-textarea"
+                    ></textarea>
+                    <div class="fieldDescription">
+                      One role per line. A login carrying any of these roles is
+                      granted administrator rights.
+                    </div>
+                  </div>
+
+                  <div class="sso-subgroup">
+                    <p class="sso-subgroup-title">Library access</p>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
+                          id="saml-EnableAllFolders"
+                          name="saml-EnableAllFolders"
+                          type="checkbox"
+                          class="sso-toggle"
+                          aria-controls="saml-EnabledFolders-group"
+                        />
+                        <span>Enable All Folders</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        If enabled, all libraries are accessible to any user
+                        that logs in through this provider.
+                      </div>
+                    </div>
+
+                    <div
+                      class="inputContainer sso-dependent"
+                      id="saml-EnabledFolders-group"
+                    >
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-EnabledFolders"
+                        >Enabled Folders:</label
+                      >
+                      <div
+                        id="saml-EnabledFolders"
+                        class="checkboxList paperList checkboxList-paperList sso-folder-list sso-bordered-list"
+                      ></div>
+                      <div class="fieldDescription">
+                        Which libraries are accessible to a user that logs in
+                        through this provider. No effect when "Enable All
+                        Folders" is checked.
+                      </div>
+                    </div>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
+                          id="saml-EnableFolderRoles"
+                          name="saml-EnableFolderRoles"
+                          type="checkbox"
+                          class="sso-toggle"
+                          aria-controls="saml-FolderRoleMapping-group"
+                        />
+                        <span>Enable Role-Based Folder Access:</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        Determines if user roles should control library access.
+                      </div>
+                    </div>
+
+                    <div
+                      class="inputContainer sso-dependent"
+                      id="saml-FolderRoleMapping-group"
+                    >
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-FolderRoleMapping"
+                        >Folder Role Mapping:</label
+                      >
+                      <button
+                        is="emby-button"
+                        id="saml-AddRoleMapping"
+                        type="button"
+                        class="fab btnAddFolder submit"
+                        title="${Add}"
+                        aria-label="Add role mapping"
+                      >
+                        <span
+                          class="material-icons add"
+                          aria-hidden="true"
+                        ></span>
+                      </button>
+                      <div
+                        id="saml-FolderRoleMapping"
+                        class="sso-role-map"
+                      ></div>
+                      <div class="fieldDescription">
+                        Map roles to lists of libraries. A user holding a given
+                        role gets access to its mapped libraries.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- SAML Section 4: Live TV -->
+              <div
+                is="emby-collapse"
+                title="Live TV"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-EnableLiveTvRoles"
+                        name="saml-EnableLiveTvRoles"
+                        type="checkbox"
+                        class="sso-toggle"
+                        aria-controls="saml-LiveTvRoles-group"
+                      />
+                      <span>Enable Role-Based Live TV Access</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      Determines if user roles should control Live TV access.
+                    </div>
+                  </div>
+
+                  <div
+                    class="inputContainer sso-dependent"
+                    id="saml-LiveTvRoles-group"
+                  >
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-LiveTvRoles"
+                      >Live TV Roles:</label
+                    >
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-LiveTvRoles"
+                      type="text"
+                      class="sso-line-list emby-textarea"
+                    ></textarea>
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-LiveTvManagementRoles"
+                      >Live TV Management Roles:</label
+                    >
+                    <textarea
+                      is="emby-textarea"
+                      id="saml-LiveTvManagementRoles"
+                      type="text"
+                      class="sso-line-list emby-textarea"
+                    ></textarea>
+                    <div class="fieldDescription">
+                      One role per line. Grants Live TV access / management to
+                      logins carrying a listed role.
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-EnableLiveTv"
+                        name="saml-EnableLiveTv"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Enable Live TV Access (all users)</span>
+                    </label>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-EnableLiveTvManagement"
+                        name="saml-EnableLiveTvManagement"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Enable Live TV Management (all users)</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              <!-- SAML Section 5: Compatibility & overrides -->
+              <div
+                is="emby-collapse"
+                title="Compatibility &amp; overrides"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-SchemeOverride"
+                      >Scheme Override:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-SchemeOverride"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      Force the scheme (http/https) used when building the ACS
+                      and metadata URLs. Prefer the Base URL Override below.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-PortOverride"
+                      >Port Override:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-PortOverride"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      Force the port used when building the ACS and metadata
+                      URLs. Prefer the Base URL Override below.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-BaseUrlOverride"
+                      >Base URL Override:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-BaseUrlOverride"
+                      type="text"
+                      class="sso-text"
+                      aria-describedby="saml-BaseUrlOverride-error"
+                    />
+                    <div
+                      class="sso-inline-error"
+                      id="saml-BaseUrlOverride-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="sso-callout sso-callout-warning" role="note">
+                      ⚠ Recommended. The canonical external base URL of this
+                      server, e.g. <code>https://jellyfin.example.com</code>.
+                      When set, the ACS and SP metadata URLs are built from it
+                      instead of the request host, so a spoofed or
+                      proxy-forwarded host cannot redirect the login elsewhere.
+                      Overrides the scheme and port overrides above.
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- SAML Section 6: Security & hardening -->
+              <div
+                is="emby-collapse"
+                id="saml-security-section"
+                title="Security &amp; hardening"
+                class="verticalSection verticalSection-extrabottompadding"
+              >
+                <div class="collapseContent">
+                  <div class="sso-security-block">
+                    <p class="sso-subgroup-title">Assertion validation</p>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
+                          id="saml-ValidateRecipient"
+                          name="saml-ValidateRecipient"
+                          type="checkbox"
+                          class="sso-toggle"
+                        />
+                        <span>Validate Recipient</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        Additionally require the assertion's
+                        <code>Recipient</code> to equal this SP's ACS URL (a
+                        token-redirection defense). Off by default so an
+                        existing deployment is not locked out; enable once your
+                        IdP sets the recipient correctly.
+                      </div>
+                    </div>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
+                          id="saml-ValidateInResponseTo"
+                          name="saml-ValidateInResponseTo"
+                          type="checkbox"
+                          class="sso-toggle"
+                        />
+                        <span>Validate InResponseTo</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        Require the response's <code>InResponseTo</code> to
+                        match an AuthnRequest this SP issued (rejects
+                        unsolicited assertions). Off by default; enable for
+                        solicited-only SSO.
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="sso-security-block">
+                    <p class="sso-subgroup-title">Audience</p>
+
+                    <div class="inputContainer">
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-SamlAudience"
+                        >SAML Audience:
+                        <span class="sso-optional">(optional)</span></label
+                      >
+                      <input
+                        is="emby-input"
+                        id="saml-SamlAudience"
+                        type="text"
+                        class="sso-text"
+                      />
+                      <div class="fieldDescription">
+                        The expected <code>AudienceRestriction</code> in the
+                        assertion. When blank, the SAML Client ID is used.
+                        Ignored when "Do Not Validate Audience" is set.
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="sso-security-block">
+                    <p class="sso-subgroup-title">Request signing</p>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
+                          id="saml-SignAuthnRequests"
+                          name="saml-SignAuthnRequests"
+                          type="checkbox"
+                          class="sso-toggle"
+                        />
+                        <span>Sign AuthnRequests</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        Sign outgoing SAML AuthnRequests with the SP signing key
+                        below. Off by default; when on, a valid Signing Key must
+                        be configured.
+                      </div>
+                    </div>
+
+                    <div class="inputContainer">
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-SamlSigningKeyPfx"
+                        >SP Signing Key (PFX/PKCS#12, Base64):
+                        <span class="sso-optional">(optional)</span></label
+                      >
+                      <input
+                        is="emby-input"
+                        id="saml-SamlSigningKeyPfx"
+                        type="password"
+                        autocomplete="off"
+                        placeholder="Leave blank to keep the current key"
+                        class="sso-text"
+                      />
+                      <div class="fieldDescription">
+                        This service provider's PRIVATE signing key, as a Base64
+                        PKCS#12 (PFX) blob. For security it is never sent back
+                        to this page: leave blank to keep the stored key, or
+                        enter a new one to replace it.
+                      </div>
+                    </div>
+
+                    <div class="inputContainer">
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-SamlRolloverSigningKeyPfx"
+                        >SP Rollover Signing Key (PFX/PKCS#12, Base64):
+                        <span class="sso-optional">(optional)</span></label
+                      >
+                      <input
+                        is="emby-input"
+                        id="saml-SamlRolloverSigningKeyPfx"
+                        type="password"
+                        autocomplete="off"
+                        placeholder="Leave blank to keep the current key"
+                        class="sso-text"
+                      />
+                      <div class="fieldDescription">
+                        An OPTIONAL second SP signing key for a rollover
+                        overlap: the SP metadata advertises both public
+                        certificates so the IdP trusts either. AuthnRequests are
+                        always signed with the primary key. Write-only, like the
+                        primary key.
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="sso-security-block sso-sensitive-region">
+                    <p class="sso-subgroup-title">
+                      Inbound certificate rotation
+                    </p>
+
+                    <div class="inputContainer">
+                      <label
+                        class="inputLabel inputLabelUnfocused"
+                        for="saml-SamlSecondaryCertificate"
+                        >Secondary IdP Signing Certificate:
+                        <span class="sso-optional">(optional)</span></label
+                      >
+                      <textarea
+                        is="emby-textarea"
+                        id="saml-SamlSecondaryCertificate"
+                        class="sso-text emby-textarea"
+                        aria-describedby="saml-SamlSecondaryCertificate-error"
+                      ></textarea>
+                      <div
+                        class="sso-inline-error"
+                        id="saml-SamlSecondaryCertificate-error"
+                        role="alert"
+                        hidden
+                      ></div>
+                      <div class="fieldDescription">
+                        An OPTIONAL second IdP PUBLIC signing certificate
+                        accepted during an inbound signing-key rotation: a
+                        response verifying against EITHER this or the primary
+                        certificate is accepted. Base64 (DER) or PEM, like the
+                        primary.
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="sso-security-block sso-danger-zone">
+                    <p class="sso-subgroup-title sso-danger-title">
+                      Insecure options
+                    </p>
+                    <div class="fieldDescription">
+                      These options disable SAML security defenses. Enable one
+                      only if your provider genuinely requires it; each is
+                      recorded as an audit warning.
+                    </div>
+                    <button
+                      is="emby-button"
+                      type="button"
+                      id="saml-ShowInsecureOptions"
+                      class="raised button-alt sso-insecure-toggle emby-button"
+                      aria-expanded="false"
+                      aria-controls="saml-insecure-options"
+                    >
+                      <span>Show insecure options</span>
+                    </button>
+
+                    <div
+                      id="saml-insecure-options"
+                      class="sso-insecure-options"
+                      hidden
+                    >
+                      <div
+                        class="checkboxContainer checkboxContainer-withDescription"
+                      >
+                        <label>
+                          <input
+                            is="emby-checkbox"
+                            id="saml-DoNotValidateAudience"
+                            name="saml-DoNotValidateAudience"
+                            type="checkbox"
+                            class="sso-toggle"
+                          />
+                          <span>Do Not Validate Audience (Insecure)</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                          ⚠ Insecure: disables the
+                          <code>AudienceRestriction</code> check, so an
+                          assertion minted for a different service provider
+                          could be replayed here. Only if your IdP cannot set
+                          the audience correctly. Enabling it is recorded as an
+                          audit warning.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="sso-test-block">
+                <button
+                  id="saml-TestProvider"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-alt block emby-button"
+                >
+                  <span>Test Connection</span>
+                </button>
+                <div class="fieldDescription">
+                  Validates the <strong>saved</strong> provider: parses the
+                  stored IdP signing certificate and reports its non-secret
+                  facts (subject, issuer, validity, thumbprint). Save the
+                  provider first. Requires administrator privileges; no signing
+                  key is shown.
+                </div>
+                <div id="saml-TestResult"></div>
+              </div>
+
+              <div class="sso-save-footer">
+                <div class="fieldDescription sso-restart-reminder">
+                  Saving requires a restart of Jellyfin to take effect.
+                </div>
+                <button
+                  id="saml-SaveProvider"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button sso-save-button"
+                >
+                  <span>Save</span>
+                </button>
+              </div>
+            </div>
+          </form>
         </div>
       </div>
     </div>

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -302,6 +302,20 @@
   margin: 0.25em 0 0.5em;
 }
 
+/* SAML metadata-import affordance (#725/#735): groups the URL/XML import controls above the endpoint and
+   certificate fields they pre-fill. */
+.sso-metadata-import {
+  margin-bottom: 1em;
+  padding: 0.75em 1em;
+  border: 1px solid rgba(255, 255, 255, 0.135);
+  border-radius: 0.25em;
+}
+
+.sso-metadata-import textarea {
+  margin-top: 0.5em;
+  min-height: 4em;
+}
+
 /* Callout (promotes the former inline-red BaseUrlOverride warning) */
 .sso-callout {
   margin-top: 0.5em;


### PR DESCRIPTION
# What & why

The config page could add and edit OpenID providers but not SAML ones, so every SAML setting had to be hand-edited in the configuration XML. This adds a full SAML provider workspace parallel to the OpenID one, covering the whole `SamlConfig` surface: connection (endpoint, client id / SP entity id, IdP signing certificate), an IdP-metadata import affordance (URL or pasted XML, via the #735 endpoint) that pre-fills the endpoint and certificate for review, read-only copyable computed ACS and SP-metadata URLs plus the SP entityID for registration at the IdP, user provisioning, roles & folder / Live TV access, compatibility overrides, and a Security & hardening section (assertion validation, audience, request signing with write-only SP keys, inbound certificate rotation) with a danger zone for `DoNotValidateAudience`.

The two workspaces share one document, so every SAML persisting field carries a `saml-`-PREFIXED id together with its marker class; `config.js` maps the id back to the `SamlConfig` property by stripping that prefix (`samlPropOf`). This keeps the proven OpenID form and its JavaScript completely untouched, there is no JS runtime test harness, so isolation is the cheapest correctness guarantee, while the id still drives the save contract. The server drops JSON members that are not `SamlConfig` properties, so a mistyped id or a dropped marker class would make a field render but silently never save; two fitness tests lock that out.

The SP signing keys (`SamlSigningKeyPfx` / `SamlRolloverSigningKeyPfx`) are write-only password fields (blank keeps the stored key), exactly like the OpenID client secret. All server-echoed values (provider names, imported endpoint / certificate / entityID, test-result details) reach the DOM as text, never markup (#221). Every client validation is a warning that never blocks a save, so a false positive cannot lock the sole administrator out.

Closes #725. Refs #569, #735.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: unchanged, this is admin-facing UI over the existing config-persistence path; the server stays the sole authority (validation is client-side warning only) and the fail-closed SAML validation defaults are untouched.
- [x] No secrets logged; secrets are redacted on config export: the SP signing keys stay write-only (never echoed to the browser); blank-keeps-stored via `ServerManagedFields.Preserve`.
- [x] A security review was performed: 4-lens adversarial review (correctness / silent-data-loss, security-bypass / XSS / secret leak, availability / lockout, integration / OpenID regression), all PASS, every attack path refuted. This is the primary verification given no JS runtime harness.
- [x] Log inputs from the IdP are sanitized inline at the log call: no new server-side logging; imported IdP values are rendered inert client-side.

## Quality checklist

- [x] No duplicated logic; the SAML lifecycle reuses the generic element-argument helpers (folder/role serialization, `setFieldError`, collapse/dependent helpers, test-result rendering).
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why (the id-prefix save contract, the write-only-secret and inert-DOM rationale).
- [x] Architecture-conformance tests pass, and the new save-contract properties are locked in (`ProviderFormFieldIds_MatchSamlConfigProperties`, `SamlProviderForm_RendersEveryPersistingFieldId`, `OpenSamlProvider_ResetsEditorBeforeLoadingTheProvider`).
- [x] Docs impact considered: the wiki Provider-Setup documents SAML config partly as "edit on disk"; that becomes partly outdated with this UI. Filed as a follow-up `documentation` issue (see Notes) rather than expanding this PR.

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 and net10.0 (0 warnings).
- [x] `dotnet test` green: 1727/1727 on both TFMs.
- [x] Prettier 3.9.5 clean for `configPage.html`, `config.js`, `style.css`.

## Notes

- **Scope / parity:** the SAML form matches the OpenID form's editable field set exactly. The four XML-only base properties (`EnablePermissionRoles`, `PermissionRoleMappings`, `EnableParentalRatingRoles`, `ParentalRatingRoleMappings`) are absent from **both** forms, consistent, not a SAML gap.
- **Reasoned DECLINE (review, non-blocking):** the forward conformance test's property set includes server-managed props (`NewPath`/`CanonicalLinks`), inherited unchanged from the OpenID test. Excluding them would mean touching the proven OpenID test too, scope creep beyond #725, and the exhaustive 30-field roster already pins the exact field set. Left at parity.
- **Follow-up:** a `documentation` issue to refresh the wiki SAML setup for the new UI will be filed against the current milestone.