### PR TITLE
Add one-click provider templates to the config page [#726]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1617,6 +1617,151 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void ProviderPresets_OidcFieldsAndTogglesAreRenderedMarkedFields()
+    {
+        // #726 provider templates: applying a preset writes into the editor field whose id equals the
+        // preset's `fields` key (and pre-checks the toggle whose id equals the toggle name). If a key does
+        // not match a marked field in the OpenID form, the apply silently no-ops (a broken preset) — and the
+        // separate save-contract test already guarantees every marked field id is a real OidConfig property,
+        // so this pins the composition: every OIDC preset field/toggle targets a real persisting field, so
+        // applying a preset always respects the save contract.
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+        var (fieldKeys, toggles) = ParsePresetCatalog(js, "OIDC_PRESETS");
+        Assert.True(fieldKeys.Count > 0, "OIDC_PRESETS parsed to zero field keys — broken parse or empty catalog.");
+
+        var markedIds = MarkedFieldIds(OidcProviderFormMarkup(
+            File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html"))));
+
+        var missing = fieldKeys.Concat(toggles).Where(k => !markedIds.Contains(k)).ToList();
+        Assert.True(
+            missing.Count == 0,
+            "These OIDC preset field/toggle keys do not match a marked field id in #sso-new-oidc-provider (a preset would silently fill nothing): " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void ProviderPresets_SamlFieldsAndTogglesAreRenderedMarkedFields()
+    {
+        // The SAML counterpart: a SAML preset's field/toggle key K targets the id "saml-"+K, so each must
+        // exist as a marked field in #sso-new-saml-provider.
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+        var (fieldKeys, toggles) = ParsePresetCatalog(js, "SAML_PRESETS");
+        Assert.True(fieldKeys.Count > 0, "SAML_PRESETS parsed to zero field keys — broken parse or empty catalog.");
+
+        var markedIds = MarkedFieldIds(SamlProviderFormMarkup(
+            File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "configPage.html"))));
+
+        var missing = fieldKeys.Concat(toggles).Where(k => !markedIds.Contains("saml-" + k)).ToList();
+        Assert.True(
+            missing.Count == 0,
+            "These SAML preset field/toggle keys do not match a marked \"saml-\"+key field id in #sso-new-saml-provider: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void ProviderPresets_NeverFillSecrets()
+    {
+        // A preset pre-fills only NON-secret fields (#726 acceptance). Pin it: no preset's `fields` may carry
+        // a write-only secret property, so a template can never place a secret value in the form (or, worse,
+        // a plausible-looking wrong one the admin trusts).
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+        var secrets = new[] { "OidSecret", "SamlSigningKeyPfx", "SamlRolloverSigningKeyPfx" };
+
+        foreach (var catalog in new[] { "OIDC_PRESETS", "SAML_PRESETS" })
+        {
+            var (fieldKeys, _) = ParsePresetCatalog(js, catalog);
+            var offending = fieldKeys.Where(k => secrets.Contains(k, StringComparer.Ordinal)).ToList();
+            Assert.True(
+                offending.Count == 0,
+                $"{catalog} must never pre-fill a secret field; found: " + string.Join(", ", offending));
+        }
+    }
+
+    [Fact]
+    public void ProviderPresets_OnlyPreCheckKnownCompatToggles()
+    {
+        // A preset may pre-check ONLY a known compatibility/insecure toggle, never a fail-closed hardening
+        // toggle (#726): silently enabling a hardening toggle could lock out a not-yet-ready IdP, and
+        // enabling an unrelated toggle is a downgrade the admin did not choose. Pin both directions: every
+        // preset toggle is in the protocol's managed-toggle allow-list, and every allow-list entry is a real
+        // config property that is NOT one of the hardening toggles.
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+
+        var oidcProps = typeof(OidConfig).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+        var samlProps = typeof(SamlConfig).GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+        var hardening = new[]
+        {
+            "RequirePkce", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin", "RequireAcr",
+            "ValidateRecipient", "ValidateInResponseTo", "SignAuthnRequests",
+        };
+
+        var oidcManaged = ParseJsStringArrayConst(js, "OIDC_PRESET_MANAGED_TOGGLES");
+        var samlManaged = ParseJsStringArrayConst(js, "SAML_PRESET_MANAGED_TOGGLES");
+
+        // Allow-list entries are real properties and are not hardening toggles.
+        foreach (var (managed, props, name) in new[]
+        {
+            (oidcManaged, oidcProps, "OIDC_PRESET_MANAGED_TOGGLES"),
+            (samlManaged, samlProps, "SAML_PRESET_MANAGED_TOGGLES"),
+        })
+        {
+            var notProp = managed.Where(t => !props.Contains(t)).ToList();
+            Assert.True(notProp.Count == 0, $"{name} contains non-properties: " + string.Join(", ", notProp));
+            var isHardening = managed.Where(t => hardening.Contains(t, StringComparer.Ordinal)).ToList();
+            Assert.True(isHardening.Count == 0, $"{name} must not include a hardening toggle: " + string.Join(", ", isHardening));
+        }
+
+        // Every preset toggle is within its protocol's allow-list.
+        var oidcToggles = ParsePresetCatalog(js, "OIDC_PRESETS").toggles;
+        var samlToggles = ParsePresetCatalog(js, "SAML_PRESETS").toggles;
+        var oidcStray = oidcToggles.Where(t => !oidcManaged.Contains(t)).ToList();
+        var samlStray = samlToggles.Where(t => !samlManaged.Contains(t)).ToList();
+        Assert.True(oidcStray.Count == 0, "OIDC presets pre-check a toggle outside the allow-list: " + string.Join(", ", oidcStray));
+        Assert.True(samlStray.Count == 0, "SAML presets pre-check a toggle outside the allow-list: " + string.Join(", ", samlStray));
+    }
+
+    [Fact]
+    public void ProviderPresets_OidcPresetsShareTheSameFieldKeySet()
+    {
+        // #726 idempotency invariant: applyOidcPreset overwrites only the fields the newly chosen preset
+        // sets (after clearing the managed toggles), so if two presets set DIFFERENT field-key sets,
+        // switching from a richer to a poorer one would leave a stale value behind — e.g. a preset that
+        // dropped RoleClaim would keep the previous provider's claim path. Every OIDC preset must therefore
+        // set EXACTLY the same four fields; this locks that in so a future preset cannot silently reintroduce
+        // the state-bleed (a review follow-up on #726).
+        var js = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Config", "config.js"));
+        var start = js.IndexOf("const OIDC_PRESETS = {", StringComparison.Ordinal);
+        Assert.True(start >= 0, "OIDC_PRESETS was not found in config.js.");
+        var end = js.IndexOf("};", start, StringComparison.Ordinal);
+        Assert.True(end > start, "OIDC_PRESETS has no closing }};.");
+        var region = js[start..end];
+
+        var required = new[] { "OidEndpoint", "OidScopes", "RoleClaim", "DefaultUsernameClaim" };
+        var blocks = Regex.Matches(region, @"fields:\s*\{([^}]*)\}", RegexOptions.Singleline)
+            .Select(m => m.Groups[1].Value)
+            .ToList();
+        Assert.True(
+            blocks.Count >= 9,
+            $"Expected at least 9 OIDC preset field blocks, found {blocks.Count} — broken parse or shrunken catalog.");
+
+        foreach (var block in blocks)
+        {
+            var keys = Regex.Matches(block, "(\\w+)\\s*:\\s*\"")
+                .Select(m => m.Groups[1].Value)
+                .ToHashSet(StringComparer.Ordinal);
+            var missing = required.Where(r => !keys.Contains(r)).ToList();
+            var extra = keys.Where(k => !required.Contains(k)).ToList();
+            Assert.True(
+                missing.Count == 0,
+                "An OIDC preset omits a shared field key (switching templates would leave a stale value): " + string.Join(", ", missing));
+            Assert.True(
+                extra.Count == 0,
+                "An OIDC preset sets a field key outside the shared set (breaks idempotent switching): " + string.Join(", ", extra));
+        }
+    }
+
+    [Fact]
     public void OpenProvider_ResetsEditorBeforeLoadingTheProvider()
     {
         // #689 (provider-switch state bleed): the editor is a single reused form, so opening a provider must
@@ -2031,6 +2176,89 @@ public class ArchitectureConformanceTests
         var end = html.IndexOf("</form>", start, StringComparison.Ordinal);
         Assert.True(end > start, "The #sso-new-saml-provider form has no closing </form> tag.");
         return html[start..end];
+    }
+
+    // The set of persisting (marker-classed) field ids in a provider form's markup — the ids the save
+    // contract reads. Shared by the #726 preset tests to prove every preset field/toggle targets one.
+    private static HashSet<string> MarkedFieldIds(string formMarkup)
+    {
+        var markerClasses = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match tag in Regex.Matches(formMarkup, "<[a-zA-Z][^>]*>", RegexOptions.Singleline))
+        {
+            var classAttr = Regex.Match(tag.Value, "class=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (!classAttr.Success)
+            {
+                continue;
+            }
+
+            var classes = classAttr.Groups[1].Value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            if (!classes.Any(c => markerClasses.Contains(c, StringComparer.Ordinal)))
+            {
+                continue;
+            }
+
+            var idMatch = Regex.Match(tag.Value, "(?<![-\\w])id=\"([^\"]*)\"", RegexOptions.Singleline);
+            if (idMatch.Success)
+            {
+                ids.Add(idMatch.Groups[1].Value);
+            }
+        }
+
+        return ids;
+    }
+
+    // Parse a preset catalog object literal (const <name> = { … };) from config.js into the set of `fields`
+    // keys and the set of `toggles` entries across all its presets. The catalog contains no nested "};", so
+    // the first "};" after the declaration is its terminator; a `fields:{…}` block contains no nested "}"
+    // and a `toggles:[…]` no nested "]", so the per-block regexes are exact. A field key is matched only in
+    // key position (`word:` immediately followed by a quote), so a ':' inside a URL value is never mistaken
+    // for a key.
+    private static (HashSet<string> fieldKeys, HashSet<string> toggles) ParsePresetCatalog(string js, string constName)
+    {
+        var start = js.IndexOf("const " + constName + " = {", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"{constName} was not found in config.js.");
+        var end = js.IndexOf("};", start, StringComparison.Ordinal);
+        Assert.True(end > start, $"{constName} has no closing }};.");
+        var region = js[start..end];
+
+        var fieldKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match block in Regex.Matches(region, @"fields:\s*\{([^}]*)\}", RegexOptions.Singleline))
+        {
+            foreach (Match key in Regex.Matches(block.Groups[1].Value, "(\\w+)\\s*:\\s*\""))
+            {
+                fieldKeys.Add(key.Groups[1].Value);
+            }
+        }
+
+        var toggles = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match block in Regex.Matches(region, @"toggles:\s*\[([^\]]*)\]", RegexOptions.Singleline))
+        {
+            foreach (Match t in Regex.Matches(block.Groups[1].Value, "\"(\\w+)\""))
+            {
+                toggles.Add(t.Groups[1].Value);
+            }
+        }
+
+        return (fieldKeys, toggles);
+    }
+
+    // Parse a flat JS string-array const (const <name> = [ "a", "b" ];) from config.js into a set.
+    private static HashSet<string> ParseJsStringArrayConst(string js, string constName)
+    {
+        var start = js.IndexOf("const " + constName + " = [", StringComparison.Ordinal);
+        Assert.True(start >= 0, $"{constName} was not found in config.js.");
+        var end = js.IndexOf("];", start, StringComparison.Ordinal);
+        Assert.True(end > start, $"{constName} has no closing ];.");
+        var region = js[start..end];
+
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(region, "\"(\\w+)\""))
+        {
+            set.Add(m.Groups[1].Value);
+        }
+
+        return set;
     }
 
     // A configuration type for the facade rule: the plugin configuration itself or any provider config

--- a/SSO-Auth/Config/config.js
+++ b/SSO-Auth/Config/config.js
@@ -1,3 +1,150 @@
+// Provider templates (#726) — the single source of truth for the "Start from a template" pickers.
+// Applying a preset writes ONLY into existing marker-classed fields by their id (OpenID: the property
+// name; SAML: "saml-" + the property name) and pre-checks ONLY the compatibility toggles a given IdP
+// genuinely needs. Presets are plain data so they are trivial to extend and to lock in with a fitness
+// test (ProviderPresets_* in ArchitectureConformanceTests): every `fields` key / `toggles` entry must be
+// a real config property, no preset may fill a secret, and toggles may only pre-check a known
+// compatibility toggle. `fields` values are non-secret placeholders — endpoints use an example host and
+// UPPERCASE tokens the admin replaces (realm/tenant/domain), never a hard-coded production host, so they
+// never go stale. OidScopes holds the ADDITIONAL scopes only (one per line) — the server always prepends
+// "openid profile", so a preset lists just what a provider needs on top (e.g. "email", or "email\ngroups"
+// where roles ride a groups scope), never "openid"/"profile" again. Every OpenID preset sets the SAME four
+// fields (blank where a provider has none), so switching templates is idempotent — no stale value survives;
+// ProviderPresets_OidcPresetsShareTheSameFieldKeySet locks that shared-key-set invariant in.
+const OIDC_PRESETS = {
+  keycloak: {
+    label: "Keycloak",
+    note: "Keycloak realm client with the default mappers. Roles come from realm_access.roles (or resource_access.<clientId>.roles for client roles). Replace YOUR_REALM in the endpoint.",
+    fields: {
+      OidEndpoint:
+        "https://keycloak.example.com/realms/YOUR_REALM/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "realm_access.roles",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+  authelia: {
+    label: "Authelia",
+    note: "Authelia OpenID Connect provider. Groups are exposed via the `groups` claim (add the `groups` scope in Authelia). Pushed Authorization Requests are disabled here because some Authelia versions do not support them.",
+    fields: {
+      OidEndpoint: "https://auth.example.com/.well-known/openid-configuration",
+      OidScopes: "email\ngroups",
+      RoleClaim: "groups",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: ["DisablePushedAuthorization"],
+  },
+  authentik: {
+    label: "Authentik",
+    note: "Authentik OAuth2/OpenID provider application. Groups are exposed via the `groups` claim. Replace YOUR_APP_SLUG in the endpoint with the application slug.",
+    fields: {
+      OidEndpoint:
+        "https://authentik.example.com/application/o/YOUR_APP_SLUG/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "groups",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+  entra: {
+    label: "Microsoft Entra ID (Azure AD)",
+    note: "Entra ID app registration. App roles come from the `roles` claim (assign them under the app registration). Replace YOUR_TENANT_ID in the endpoint.",
+    fields: {
+      OidEndpoint:
+        "https://login.microsoftonline.com/YOUR_TENANT_ID/v2.0/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "roles",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+  google: {
+    label: "Google",
+    note: "Google issues no group or role claim, so Roles is left blank — grant access with folder/role mapping or leave it open. Endpoint validation is relaxed because Google's discovery document does not list every endpoint the strict check expects.",
+    fields: {
+      OidEndpoint:
+        "https://accounts.google.com/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "",
+      DefaultUsernameClaim: "email",
+    },
+    toggles: ["DoNotValidateEndpoints"],
+  },
+  auth0: {
+    label: "Auth0",
+    note: "Auth0 application. Roles require a custom claim added by an Auth0 Action/Rule under a namespace you choose — set RoleClaim to that namespaced claim (e.g. https://your-app/roles). Replace YOUR_TENANT in the endpoint.",
+    fields: {
+      OidEndpoint:
+        "https://YOUR_TENANT.us.auth0.com/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "",
+      DefaultUsernameClaim: "nickname",
+    },
+    toggles: [],
+  },
+  okta: {
+    label: "Okta",
+    note: "Okta OIDC app. Groups come from the `groups` claim (add a groups claim + the `groups` scope in the Okta authorization server). Replace YOUR_DOMAIN in the endpoint.",
+    fields: {
+      OidEndpoint:
+        "https://YOUR_DOMAIN.okta.com/.well-known/openid-configuration",
+      OidScopes: "email\ngroups",
+      RoleClaim: "groups",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+  gitlab: {
+    label: "GitLab",
+    note: "GitLab as an OpenID provider. Direct group paths come from the `groups_direct` claim. For self-managed GitLab, replace gitlab.com in the endpoint with your host.",
+    fields: {
+      OidEndpoint: "https://gitlab.com/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "groups_direct",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+  "generic-oidc": {
+    label: "Generic OpenID Connect",
+    note: "A standards-compliant OpenID provider. Point the endpoint at its discovery document and set the role claim to whatever your IdP issues (often `groups` or `roles`).",
+    fields: {
+      OidEndpoint: "https://idp.example.com/.well-known/openid-configuration",
+      OidScopes: "email",
+      RoleClaim: "",
+      DefaultUsernameClaim: "preferred_username",
+    },
+    toggles: [],
+  },
+};
+
+const SAML_PRESETS = {
+  "generic-saml": {
+    label: "Generic SAML 2.0",
+    note: "A generic SAML 2.0 identity provider. Use the metadata import below to fill the SSO endpoint and signing certificate from your IdP's metadata, then set the SAML Client ID (this service provider's entity id) and review before saving.",
+    fields: {
+      SamlEndpoint: "https://idp.example.com/sso/saml",
+    },
+    toggles: [],
+  },
+};
+
+// The compatibility/insecure toggles a preset is ALLOWED to pre-check. A preset never pre-checks a
+// fail-closed HARDENING toggle (RequirePkce, RequireVerifiedEmail*, RequireAcr, SAML ValidateRecipient/
+// ValidateInResponseTo/SignAuthnRequests) — enabling those is a deliberate admin decision, and silently
+// turning them on could lock out a not-yet-ready IdP. This set is also what applyOidcPreset/applySamlPreset
+// clear before applying, so switching templates never leaves a previous preset's toggle checked.
+const OIDC_PRESET_MANAGED_TOGGLES = [
+  "DisablePushedAuthorization",
+  "DoNotValidateEndpoints",
+  "DoNotValidateIssuerName",
+  "DoNotValidateResponseIssuer",
+  "DisableHttps",
+  "DoNotLoadProfile",
+];
+const SAML_PRESET_MANAGED_TOGGLES = ["DoNotValidateAudience"];
+
 const ssoConfigurationPage = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
   // Toggles that disable an OpenID Connect security defense. An active one is a downgrade the admin must
@@ -188,6 +335,12 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.syncDependentFields(page);
     // Clear the computed redirect URI back to its placeholder for the fresh/blank editor (#724).
     ssoConfigurationPage.updateRedirectUri(page);
+    // Reset the template picker + its note so opening/adding a provider never shows a stale template (#726).
+    const oidPreset = page.querySelector("#OidPreset");
+    if (oidPreset) {
+      oidPreset.value = "";
+    }
+    ssoConfigurationPage.renderPresetNote(page, "OidPreset-note", "");
   },
   // Return every accordion section INSIDE the editor to its authored default collapse state (the sections
   // with data-expanded="true" open, the rest — including "Security & hardening" — collapsed). Scoped to
@@ -1055,6 +1208,107 @@ const ssoConfigurationPage = {
     view.appendChild(style);
   },
 
+  // ---- Provider templates (#726) ----
+  // Fill a preset picker's options from its catalog (createElement/textContent — the labels are our own
+  // fixed strings, but building them inertly keeps the one-DOM-construction idiom). The leading blank
+  // "Choose a template" option authored in the HTML is preserved.
+  populatePresetPicker: (page, selectId, presets) => {
+    const select = page.querySelector("#" + selectId);
+    if (!select) {
+      return;
+    }
+    Object.keys(presets).forEach((key) => {
+      const option = document.createElement("option");
+      option.value = key;
+      option.textContent = presets[key].label;
+      select.appendChild(option);
+    });
+  },
+  renderPresetNote: (page, noteId, message) => {
+    const box = page.querySelector("#" + noteId);
+    if (box) {
+      box.textContent = message || "";
+    }
+  },
+  // Apply an OpenID preset onto the editor. Writes ONLY into existing marker-classed fields by their id
+  // (every field key is a real OidConfig property, pinned by ProviderPresets_ReferenceOnlyRealOidcProperties)
+  // and pre-checks ONLY the listed compatibility toggles. It first clears every preset-managed toggle so
+  // switching templates cannot leave a previous preset's toggle checked, never touches the secret, and
+  // never saves. syncDependentFields then surfaces any pre-enabled insecure toggle in the auto-expanded
+  // danger zone. The provider name and client secret the admin may have typed are left untouched.
+  applyOidcPreset: (page, key) => {
+    OIDC_PRESET_MANAGED_TOGGLES.forEach((prop) => {
+      const el = page.querySelector("#" + prop);
+      if (el) {
+        el.checked = false;
+      }
+    });
+
+    const preset = OIDC_PRESETS[key];
+    if (!preset) {
+      // The blank "choose a template" option: clear the note and re-sync (so a just-cleared toggle
+      // collapses its danger-zone surfacing) without altering the admin's fields.
+      ssoConfigurationPage.renderPresetNote(page, "OidPreset-note", "");
+      ssoConfigurationPage.syncDependentFields(page);
+      return;
+    }
+
+    Object.keys(preset.fields).forEach((prop) => {
+      const el = page.querySelector("#" + prop);
+      if (el) {
+        el.value = preset.fields[prop];
+      }
+    });
+    preset.toggles.forEach((prop) => {
+      const el = page.querySelector("#" + prop);
+      if (el) {
+        el.checked = true;
+      }
+    });
+
+    ssoConfigurationPage.syncDependentFields(page);
+    ssoConfigurationPage.updateRedirectUri(page);
+    ssoConfigurationPage.renderPresetNote(page, "OidPreset-note", preset.note);
+  },
+  // The SAML counterpart. Field ids are "saml-" + the SamlConfig property; toggles likewise. Same
+  // clear-then-apply discipline, and syncSamlDependentFields surfaces a pre-enabled insecure toggle.
+  applySamlPreset: (page, key) => {
+    SAML_PRESET_MANAGED_TOGGLES.forEach((prop) => {
+      const el = page.querySelector("#saml-" + prop);
+      if (el) {
+        el.checked = false;
+      }
+    });
+
+    const preset = SAML_PRESETS[key];
+    if (!preset) {
+      ssoConfigurationPage.renderPresetNote(page, "saml-Preset-note", "");
+      ssoConfigurationPage.syncSamlDependentFields(page);
+      return;
+    }
+
+    Object.keys(preset.fields).forEach((prop) => {
+      const el = page.querySelector("#saml-" + prop);
+      if (el) {
+        el.value = preset.fields[prop];
+      }
+    });
+    preset.toggles.forEach((prop) => {
+      const el = page.querySelector("#saml-" + prop);
+      if (el) {
+        el.checked = true;
+      }
+    });
+
+    ssoConfigurationPage.syncSamlDependentFields(page);
+    ssoConfigurationPage.updateSamlUrls(page);
+    ssoConfigurationPage.renderPresetNote(
+      page,
+      "saml-Preset-note",
+      preset.note,
+    );
+  },
+
   // ============================================================================
   // SAML provider workspace (#725)
   // ----------------------------------------------------------------------------
@@ -1205,6 +1459,12 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.resetSamlEditorSections(page);
     ssoConfigurationPage.syncSamlDependentFields(page);
     ssoConfigurationPage.updateSamlUrls(page);
+    // Reset the template picker + its note so opening/adding a provider never shows a stale template (#726).
+    const samlPreset = page.querySelector("#saml-Preset");
+    if (samlPreset) {
+      samlPreset.value = "";
+    }
+    ssoConfigurationPage.renderPresetNote(page, "saml-Preset-note", "");
   },
   // Return every accordion INSIDE the SAML editor to its authored default; scoped to #saml-editor so the
   // OpenID editor and the page-level collapses are untouched.
@@ -2176,4 +2436,14 @@ export default function initSsoConfigurationPage(view) {
 
   // Populate the computed URLs once at init (blank editor shows the placeholders until a name is typed).
   ssoConfigurationPage.updateSamlUrls(view);
+
+  // ---- Provider template pickers (#726) ----
+  ssoConfigurationPage.populatePresetPicker(view, "OidPreset", OIDC_PRESETS);
+  ssoConfigurationPage.populatePresetPicker(view, "saml-Preset", SAML_PRESETS);
+  view.querySelector("#OidPreset").addEventListener("change", (e) => {
+    ssoConfigurationPage.applyOidcPreset(view, e.target.value);
+  });
+  view.querySelector("#saml-Preset").addEventListener("change", (e) => {
+    ssoConfigurationPage.applySamlPreset(view, e.target.value);
+  });
 }

--- a/SSO-Auth/Config/configPage.html
+++ b/SSO-Auth/Config/configPage.html
@@ -330,6 +330,45 @@
                 are required.
               </p>
 
+              <!--
+                Start from a template (#726): a NON-persisting picker (no marker class, so it is never
+                saved and the conformance scan ignores it). Choosing a provider pre-fills only the
+                non-secret provider-specific fields (scopes, role-claim path, username claim, an endpoint
+                PLACEHOLDER) and pre-checks only the compatibility toggles that identity provider genuinely
+                needs. It never fills a secret and never auto-saves; any pre-enabled insecure/compatibility
+                toggle surfaces in the auto-expanded danger zone. The options are populated from
+                OIDC_PRESETS in config.js so the catalog is the single source of truth.
+              -->
+              <div class="inputContainer sso-preset-picker">
+                <label class="inputLabel inputLabelUnfocused" for="OidPreset"
+                  >Start from a template
+                  <span class="sso-optional">(optional)</span></label
+                >
+                <select
+                  is="emby-select"
+                  id="OidPreset"
+                  name="OidPreset"
+                  class="emby-select-withcolor emby-select"
+                >
+                  <option value="">
+                    &mdash; Choose a provider template &mdash;
+                  </option>
+                </select>
+                <div
+                  id="OidPreset-note"
+                  class="sso-preset-note fieldDescription"
+                  role="status"
+                  aria-live="polite"
+                ></div>
+                <div class="fieldDescription">
+                  Pre-fills the scopes, role-claim path, username claim, and an
+                  endpoint placeholder for a known identity provider, and
+                  enables only the compatibility options it needs. Review every
+                  field &mdash; especially the endpoint &mdash; and enter your
+                  client secret before saving. Nothing is saved automatically.
+                </div>
+              </div>
+
               <!-- Section 1: Connection -->
               <div
                 is="emby-collapse"
@@ -1624,6 +1663,40 @@
                 <span class="sso-required" aria-hidden="true">*</span>
                 are required.
               </p>
+
+              <!--
+                Start from a template (#726) — the SAML counterpart of the OpenID picker above.
+                Non-persisting (no marker class); options populated from SAML_PRESETS in config.js.
+                Pre-fills only the non-secret endpoint placeholder; never a signing key, never auto-saves.
+              -->
+              <div class="inputContainer sso-preset-picker">
+                <label class="inputLabel inputLabelUnfocused" for="saml-Preset"
+                  >Start from a template
+                  <span class="sso-optional">(optional)</span></label
+                >
+                <select
+                  is="emby-select"
+                  id="saml-Preset"
+                  name="saml-Preset"
+                  class="emby-select-withcolor emby-select"
+                >
+                  <option value="">
+                    &mdash; Choose a provider template &mdash;
+                  </option>
+                </select>
+                <div
+                  id="saml-Preset-note"
+                  class="sso-preset-note fieldDescription"
+                  role="status"
+                  aria-live="polite"
+                ></div>
+                <div class="fieldDescription">
+                  Pre-fills an endpoint placeholder for a SAML identity
+                  provider. Use the metadata import below to fill the endpoint
+                  and signing certificate from your IdP, then review and save.
+                  Nothing is saved automatically.
+                </div>
+              </div>
 
               <!-- SAML Section 1: Connection -->
               <div

--- a/SSO-Auth/Config/style.css
+++ b/SSO-Auth/Config/style.css
@@ -316,6 +316,20 @@
   min-height: 4em;
 }
 
+/* Provider template picker (#726): a prominent "start from a template" entry point at the top of each
+   editor. Grouped like the metadata-import block; the note shows the selected preset's assumptions. */
+.sso-preset-picker {
+  margin-bottom: 1em;
+  padding: 0.75em 1em;
+  border: 1px solid rgba(255, 255, 255, 0.135);
+  border-radius: 0.25em;
+}
+
+.sso-preset-note:not(:empty) {
+  margin-top: 0.4em;
+  font-style: italic;
+}
+
 /* Callout (promotes the former inline-red BaseUrlOverride warning) */
 .sso-callout {
   margin-top: 0.5em;


### PR DESCRIPTION
# What & why

Every provider was configured from a blank ~20-field form, with the provider-specific values (extra scopes, the role-claim JSON path, the endpoint shape, which compatibility toggle an IdP needs) only available as field-description prose to transcribe by hand. This adds a **"Start from a template"** picker to each editor (OpenID + SAML) that pre-fills those non-secret values for a known identity provider.

Presets are plain data, `OIDC_PRESETS` / `SAML_PRESETS` in `config.js`, the single source of truth the pickers populate from and the fitness tests validate. OIDC: Keycloak, Authelia, Authentik, Entra ID, Google, Auth0, Okta, GitLab, Generic OIDC. SAML: Generic SAML. Each carries a one-line "what this preset assumes" note.

Applying a preset writes **only** into existing marker-classed fields by their id (so it respects the save contract), pre-checks **only** the compatibility toggles that IdP genuinely needs, and never fills a secret and never auto-saves. It first clears every preset-managed toggle so switching templates is idempotent (no stale toggle survives), and every OIDC preset sets the same four fields so no stale value survives either. A pre-enabled insecure toggle (Google's endpoint relaxation, Authelia's pushed-authorization opt-out) surfaces through the existing danger-zone auto-expansion, nothing insecure is enabled invisibly. The picker carries no marker class, so it is never persisted; opening/adding a provider resets it. Endpoints are placeholders (example host + UPPERCASE tokens the admin replaces), never a hard-coded production host.

`OidScopes` is the "Additional Scopes" field (the server always prepends `openid profile`), so presets list only the extra scopes, one per line (`email`, or `email` + `groups` where roles ride a groups scope).

Closes #726.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: presets pre-fill an editor for review and never auto-save; the server stays the authority. No preset pre-checks a fail-closed hardening toggle (a fitness test forbids it), so a preset can never strand a not-yet-ready IdP.
- [x] No secrets logged; secrets are redacted on config export: presets never fill a secret field (`ProviderPresets_NeverFillSecrets`); no logging touched.
- [x] A security review was performed: 3-lens adversarial review (correctness, security/secret-leak/downgrade, availability + integration/regression), all PASS. Two non-blocking review notes were fixed (scope format; a shared-field-key-set fitness test). Primary verification given no JS runtime harness.
- [x] Log inputs from the IdP are sanitized inline at the log call: n/a, no server-side change; preset labels/notes are our own static data rendered inert (`textContent`).

## Quality checklist

- [x] No duplicated logic; the apply step reuses `syncDependentFields` / `updateRedirectUri` / `updateSamlUrls`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain the save-contract and idempotency rationale.
- [x] Architecture-conformance tests pass, and the new structural properties are locked in (`ProviderPresets_*`, real-field targeting, no-secret, compat-toggle-only, shared-field-key-set).
- [x] Docs impact considered: a wiki note on the template picker will fold into the #856 SAML doc refresh / a provider-setup update; filed as a follow-up rather than expanding this PR (see Notes).

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 + net10.0 (0 warnings).
- [x] `dotnet test` green: 1732/1732 on both TFMs.
- [x] Prettier 3.9.5 clean for `configPage.html`, `config.js`, `style.css`.

## Notes

- **Reasoned scope:** presets pre-fill only the four provider-specific OIDC fields (endpoint, additional scopes, role claim, username claim) + a SAML endpoint. Secrets, provider name, and every hardening/opt-in toggle stay the admin's to enter, by design.
- **Follow-up:** a wiki/README note showing the template picker will be folded into the current-milestone documentation refresh (alongside #856).