### PR TITLE
Correct the actions/checkout pin comment to its exact tag [#858]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       attestations: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # JPRM builds the plugin; nothing pushes via git, so drop the persisted token.
           persist-credentials: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Dependency review

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         # No step pushes via git, so do not leave the GITHUB_TOKEN persisted in
         # .git/config (zizmor "artipacked" hardening — shrinks the credential blast radius).
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
     - name: Setup .NET

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -71,7 +71,7 @@ jobs:
       LIBFUZZER_DOTNET_REF: c33d28305eba24261ce1945a39576e659f437b90
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -44,7 +44,7 @@ jobs:
       OPENGREP_SHA256: "9ac4aebb47ba3f7b0d8fc641ac8749cb6c2f253f616131a67d9631e00d4bea33"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         # Default checkout (the PR merge commit) — it is what should be linted,
         # and checking out head_ref made the job an untrusted-checkout finding.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Prettify code

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -87,7 +87,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         # The release/manifest steps authenticate with GITHUB_TOKEN via their action
         # inputs, not the git remote, so the persisted checkout token is unneeded.

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -82,7 +82,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
     - name: Setup .NET

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -45,7 +45,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
     - name: Setup .NET

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/stryker-mutation.yml
+++ b/.github/workflows/stryker-mutation.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -48,7 +48,7 @@ jobs:
       ZIZMOR_VERSION: "1.26.1"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
# What & why

The `Audit workflows (zizmor)` merge gate fails with 15 `ref-version-mismatch` findings: every `actions/checkout@9c091bb…dddfe3e0 # v7` pin has a stale comment. The pinned SHA is the immutable tag `v7.0.0`, but upstream moved the `v7` major tag to a newer commit, so `# v7` no longer matches the SHA. This is a main regression that blocks every PR's merge gate (CI was green on the same pins before the upstream tag moved).

Correct the comment to the exact tag the SHA resolves to, `# v7.0.0`, across all 15 occurrences (zizmor's own auto-fix). The reviewed SHA is unchanged; only the comment is corrected, which is the more precise supply-chain practice (pin + exact-version comment, not a moving major).

Closes #858.

## Type of change

- [x] Security hardening / vulnerability fix (supply-chain / CI hardening)
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] No pin SHA changed, only the version comment is corrected to the exact immutable tag; no action is re-pointed.
- [x] The zizmor gate becomes deterministically green.

## Verification

- [x] 15 comments corrected across 14 workflow files; `actions/setup-dotnet@… # v5` pins deliberately untouched (their `v5` tag still resolves to the pinned SHA, not flagged).
- [x] The `Audit workflows (zizmor)` check will confirm on this PR.

## Notes

- RCA/adaptation: bare-major comments (`# v7`) go stale silently when upstream moves the major tag. Exact-tag comments avoid this; Dependabot (github-actions) keeps them fresh on bump. The `setup-dotnet # v5` pins share the pattern and can be aligned when `v5` next moves.