### PR TITLE
Auto-manage the login-page sign-in buttons (core) [#722]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -202,6 +202,8 @@ public class ArchitectureConformanceTests
     [InlineData("Authz")] // leaf — role→permission mapping: PermissionGrant, PermissionRolePolicy, RolePrivilegeMapper
     [InlineData("Routing")] // leaf — the plugin's route-shape contract: RouteSuffix ({protocol}/{path-kind}/{provider} reader), ChallengePath (new/legacy classifier)
     [InlineData("Crypto")] // leaf — the shared asymmetric signing-key strength policy (min RSA bits / approved EC curves), referenced by both protocol paths so they cannot drift (#733)
+    [InlineData("LoginButtons")] // leaf — login-page button rendering (#722): pure injector/builder over the config + a branding-sync hosted service; imports no other Api module
+
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
     [InlineData("Linking", "Audit", "Provider", "RateLimit")] // account linking — audits writes, validates providers, throttles
     [InlineData("Saml", "Authz", "Crypto", "Identity", "RateLimit", "Session")] // SAML core/validators — mints the keystone (Identity), returns login outcomes (Session), maps roles (Authz), throttles (RateLimit), enforces the signing-key floor (Crypto)

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonBuilderTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonBuilderTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="LoginButtonBuilder"/> — the pure selection rule that turns the configuration into the
+/// ordered login buttons (#722): management must be on, only enabled + non-hidden providers get a button,
+/// OpenID before SAML, and the label falls back from <c>LoginButtonText</c> to the provider name.
+/// </summary>
+public class LoginButtonBuilderTests
+{
+    private static PluginConfiguration Config(bool manage)
+    {
+        var config = new PluginConfiguration { ManageLoginPageButtons = manage };
+        return config;
+    }
+
+    [Fact]
+    public void Build_ManagementOff_IsEmptyEvenWithEnabledProviders()
+    {
+        var config = Config(manage: false);
+        config.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
+
+        Assert.Empty(LoginButtonBuilder.Build(config));
+    }
+
+    [Fact]
+    public void Build_ExcludesDisabledAndHiddenProviders()
+    {
+        var config = Config(manage: true);
+        config.OidConfigs["on"] = new OidConfig { Enabled = true };
+        config.OidConfigs["off"] = new OidConfig { Enabled = false };
+        config.OidConfigs["hidden"] = new OidConfig { Enabled = true, HideLoginButton = true };
+
+        var names = LoginButtonBuilder.Build(config).Select(b => b.Name).ToList();
+
+        Assert.Contains("on", names);
+        Assert.DoesNotContain("off", names);
+        Assert.DoesNotContain("hidden", names);
+    }
+
+    [Fact]
+    public void Build_LabelFallsBackFromTextToName()
+    {
+        var config = Config(manage: true);
+        config.OidConfigs["withText"] = new OidConfig { Enabled = true, LoginButtonText = "Sign in with Corp" };
+        config.OidConfigs["noText"] = new OidConfig { Enabled = true };
+        config.OidConfigs["blankText"] = new OidConfig { Enabled = true, LoginButtonText = "   " };
+
+        var byName = LoginButtonBuilder.Build(config).ToDictionary(b => b.Name, b => b.Text);
+
+        Assert.Equal("Sign in with Corp", byName["withText"]);
+        Assert.Equal("noText", byName["noText"]);
+        // Whitespace-only text falls back to the name too.
+        Assert.Equal("blankText", byName["blankText"]);
+    }
+
+    [Fact]
+    public void Build_OrdersOpenIdBeforeSaml_WithCorrectProtocol()
+    {
+        var config = Config(manage: true);
+        config.OidConfigs["oidc1"] = new OidConfig { Enabled = true };
+        config.SamlConfigs["saml1"] = new SamlConfig { Enabled = true };
+
+        var buttons = LoginButtonBuilder.Build(config);
+
+        Assert.Equal(2, buttons.Count);
+        Assert.Equal(LoginButtonProtocol.Oidc, buttons[0].Protocol);
+        Assert.Equal("oidc1", buttons[0].Name);
+        Assert.Equal(LoginButtonProtocol.Saml, buttons[1].Protocol);
+        Assert.Equal("saml1", buttons[1].Name);
+    }
+}

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="LoginButtonInjector"/> — the pure render/merge core of the managed login-page
+/// buttons (#722). The output is HTML rendered on the anonymous, pre-auth login page, so the encoding tests
+/// are the security pins: a hostile provider name or button label must never break out into markup.
+/// </summary>
+public class LoginButtonInjectorTests
+{
+    private static IReadOnlyList<LoginButton> One(string name, string text, LoginButtonProtocol protocol = LoginButtonProtocol.Oidc)
+        => new[] { new LoginButton(protocol, name, text) };
+
+    [Fact]
+    public void BuildBlock_NoButtons_IsEmpty()
+    {
+        Assert.Equal(string.Empty, LoginButtonInjector.BuildBlock(new List<LoginButton>()));
+    }
+
+    [Fact]
+    public void BuildBlock_IsFencedByTheMarkers()
+    {
+        var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+        Assert.StartsWith(LoginButtonInjector.BeginMarker, block, System.StringComparison.Ordinal);
+        Assert.EndsWith(LoginButtonInjector.EndMarker, block, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildBlock_LinksToTheProtocolStartRoute()
+    {
+        Assert.Contains("href=\"/sso/OID/start/keycloak\"", LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+        Assert.Contains(
+            "href=\"/sso/SAML/start/corp\"",
+            LoginButtonInjector.BuildBlock(One("corp", "Corp", LoginButtonProtocol.Saml)));
+    }
+
+    [Fact]
+    public void BuildBlock_HtmlEncodesAHostileLabel_NoScriptSurvives()
+    {
+        // The XSS pin: a label with markup must render inert. The raw < and " must not appear unencoded, and
+        // the literal <script> tag must be gone.
+        var block = LoginButtonInjector.BuildBlock(One("prov", "\"><script>alert(1)</script>"));
+
+        Assert.DoesNotContain("<script>", block, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("&lt;script&gt;", block, System.StringComparison.Ordinal);
+        // The label's leading quote+bracket is encoded, so it cannot close the href attribute or the anchor.
+        Assert.Contains("&quot;&gt;&lt;script&gt;", block, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildBlock_HtmlEncodesAHostileName_InBothHrefAndFallbackLabel()
+    {
+        // A name is both URL-encoded into the href and (when it is the label) HTML-encoded. Even though names
+        // are validated to exclude these characters (#336), the injector must not rely on that.
+        var block = LoginButtonInjector.BuildBlock(One("a\"b<c", "a\"b<c"));
+
+        Assert.DoesNotContain("<c", block, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\"b", block, System.StringComparison.Ordinal);
+        // URL-encoded in the href (double-encoded: Uri.EscapeDataString then HtmlEncode leaves %-escapes intact).
+        Assert.Contains("/sso/OID/start/a%22b%3Cc", block, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Merge_AppendsWhenNoRegionExists_PreservingAdminContent()
+    {
+        var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+        var merged = LoginButtonInjector.Merge("Welcome to our server.", block);
+
+        Assert.StartsWith("Welcome to our server.", merged, System.StringComparison.Ordinal);
+        Assert.Contains(LoginButtonInjector.BeginMarker, merged, System.StringComparison.Ordinal);
+        Assert.EndsWith(LoginButtonInjector.EndMarker, merged, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Merge_IsIdempotent_ReApplyReplacesOnlyTheManagedRegion()
+    {
+        var first = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+        var second = LoginButtonInjector.BuildBlock(One("authelia", "Authelia"));
+
+        var once = LoginButtonInjector.Merge("Admin note.", first);
+        var twice = LoginButtonInjector.Merge(once, second);
+        var thrice = LoginButtonInjector.Merge(twice, second);
+
+        // Re-applying the same block is a fixed point (no growth, no duplicate region).
+        Assert.Equal(twice, thrice);
+        // The managed region was REPLACED, not appended: the first provider is gone, the second present, once.
+        Assert.DoesNotContain("keycloak", twice, System.StringComparison.Ordinal);
+        Assert.Contains("authelia", twice, System.StringComparison.Ordinal);
+        Assert.Equal(1, CountOccurrences(twice, LoginButtonInjector.BeginMarker));
+        // Admin content outside the region survives every re-apply.
+        Assert.StartsWith("Admin note.", twice, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Merge_EmptyBlock_RemovesTheRegion_RestoringSurroundingContent()
+    {
+        var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+        var withRegion = LoginButtonInjector.Merge("Before.\n\nAfter.", block);
+
+        // Sanity: the region landed between the admin content.
+        Assert.Contains(LoginButtonInjector.BeginMarker, withRegion, System.StringComparison.Ordinal);
+
+        var removed = LoginButtonInjector.Merge(withRegion, string.Empty);
+        Assert.DoesNotContain(LoginButtonInjector.BeginMarker, removed, System.StringComparison.Ordinal);
+        Assert.DoesNotContain(LoginButtonInjector.EndMarker, removed, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("keycloak", removed, System.StringComparison.Ordinal);
+        // The surrounding admin content is preserved.
+        Assert.Contains("Before.", removed, System.StringComparison.Ordinal);
+        Assert.Contains("After.", removed, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Merge_EmptyBlock_OnDisclaimerWithNoRegion_IsUnchanged()
+    {
+        Assert.Equal("Just an admin disclaimer.", LoginButtonInjector.Merge("Just an admin disclaimer.", string.Empty));
+        Assert.Equal(string.Empty, LoginButtonInjector.Merge(null, string.Empty));
+    }
+
+    [Fact]
+    public void Merge_MalformedFence_IsTreatedAsNoRegion_NeverCorruptsContent()
+    {
+        // Only a BEGIN marker (END hand-deleted): not a well-formed region, so a fresh block appends rather
+        // than trying to parse the partial fence — the mangled content is preserved untouched.
+        var mangled = "Note.\n" + LoginButtonInjector.BeginMarker + "\nleftover";
+        var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+        var merged = LoginButtonInjector.Merge(mangled, block);
+
+        Assert.Contains("leftover", merged, System.StringComparison.Ordinal);
+        Assert.EndsWith(LoginButtonInjector.EndMarker, merged, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildBlock_HostilePayload_LeavesNoUnescapedMarkupFromInput()
+    {
+        // Stronger inertness proof than a per-payload substring check: after removing the ONLY markup the
+        // template itself emits (the marker comments, the wrapping div, and the fixed anchor tags), no '<'
+        // from the input survives — so no provider name or label can introduce an element on the login page.
+        var block = LoginButtonInjector.BuildBlock(One("<x>", "<img src=x onerror=alert(1)>"));
+
+        var stripped = block
+            .Replace(LoginButtonInjector.BeginMarker, string.Empty, System.StringComparison.Ordinal)
+            .Replace(LoginButtonInjector.EndMarker, string.Empty, System.StringComparison.Ordinal)
+            .Replace("<div class=\"sso-login-buttons\">", string.Empty, System.StringComparison.Ordinal)
+            .Replace("</div>", string.Empty, System.StringComparison.Ordinal)
+            .Replace("</a>", string.Empty, System.StringComparison.Ordinal);
+        // The anchor open tag's href value is encoded (contains no quote), so [^"]* matches it exactly.
+        stripped = Regex.Replace(stripped, "<a class=\"[^\"]*\" href=\"[^\"]*\">", string.Empty);
+
+        Assert.DoesNotContain("<", stripped, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Merge_StrayEndMarkerBeforeARegion_ConvergesWithoutUnboundedGrowth()
+    {
+        // A hand-mangled disclaimer with a stray END marker BEFORE a real region must not make Merge re-append
+        // a fresh block on every sync (which would grow the login disclaimer once per login, as a login's
+        // canonical-link write also raises the config-changed event). The closing fence is searched only after
+        // the opener, so the real region is replaced in place and the result is a fixed point.
+        var region = LoginButtonInjector.Merge("Admin.", LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+        var mangled = LoginButtonInjector.EndMarker + "\nstray\n" + region;
+
+        var next = LoginButtonInjector.BuildBlock(One("authelia", "Authelia"));
+        var once = LoginButtonInjector.Merge(mangled, next);
+        var twice = LoginButtonInjector.Merge(once, next);
+
+        Assert.Equal(once, twice); // converges — no per-sync growth
+        Assert.Equal(1, CountOccurrences(once, LoginButtonInjector.BeginMarker));
+        Assert.Contains("authelia", once, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("keycloak", once, System.StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = haystack.IndexOf(needle, index, System.StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/SSO-Auth/Api/LoginButtons/LoginButton.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButton.cs
@@ -1,0 +1,23 @@
+namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+
+/// <summary>
+/// The SSO protocol a <see cref="LoginButton"/> starts, choosing the anonymous start route it links to.
+/// </summary>
+public enum LoginButtonProtocol
+{
+    /// <summary>OpenID Connect — links to <c>/sso/OID/start/{name}</c>.</summary>
+    Oidc,
+
+    /// <summary>SAML 2.0 — links to <c>/sso/SAML/start/{name}</c>.</summary>
+    Saml,
+}
+
+/// <summary>
+/// A single "Sign in with …" button to render on the Jellyfin login page (#722). Immutable value type: the
+/// display <see cref="Text"/> and the provider <see cref="Name"/> are admin/provider-controlled strings that
+/// are HTML/URL-encoded at render time by <see cref="LoginButtonInjector"/>, never trusted as markup.
+/// </summary>
+/// <param name="Protocol">The provider protocol, selecting the start route segment (OID or SAML).</param>
+/// <param name="Name">The provider name (its config-dictionary key), used to build the start URL.</param>
+/// <param name="Text">The button label shown to the visitor.</param>
+public readonly record struct LoginButton(LoginButtonProtocol Protocol, string Name, string Text);

--- a/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+
+/// <summary>
+/// Turns the plugin configuration into the ordered list of login-page buttons (#722): one button per ENABLED
+/// provider that does not set <see cref="ProviderConfigBase.HideLoginButton"/>, OpenID providers first then
+/// SAML, each in the provider dictionaries' order. Pure — no I/O — so the selection rule is unit-testable.
+/// Disabled providers are omitted (a disabled provider's start route rejects the login anyway), matching the
+/// enabled-only rule the anonymous <c>GetNames</c> endpoints already use (#344).
+/// </summary>
+internal static class LoginButtonBuilder
+{
+    /// <summary>
+    /// Builds the button list for the given configuration. Returns an empty list when button management is
+    /// off, so the caller renders (and merges) an empty managed block that removes any prior region.
+    /// </summary>
+    /// <param name="configuration">The plugin configuration.</param>
+    /// <returns>The ordered buttons; empty when management is off or no provider qualifies.</returns>
+    public static IReadOnlyList<LoginButton> Build(PluginConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var buttons = new List<LoginButton>();
+        if (!configuration.ManageLoginPageButtons)
+        {
+            return buttons;
+        }
+
+        foreach (var (name, config) in configuration.OidConfigs)
+        {
+            AddIfVisible(buttons, LoginButtonProtocol.Oidc, name, config);
+        }
+
+        foreach (var (name, config) in configuration.SamlConfigs)
+        {
+            AddIfVisible(buttons, LoginButtonProtocol.Saml, name, config);
+        }
+
+        return buttons;
+    }
+
+    private static void AddIfVisible(List<LoginButton> buttons, LoginButtonProtocol protocol, string name, ProviderConfigBase config)
+    {
+        if (!config.Enabled || config.HideLoginButton)
+        {
+            return;
+        }
+
+        var text = string.IsNullOrWhiteSpace(config.LoginButtonText) ? name : config.LoginButtonText;
+        buttons.Add(new LoginButton(protocol, name, text));
+    }
+}

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -1,0 +1,137 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+
+/// <summary>
+/// Pure string logic that renders the SSO "Sign in with …" buttons and splices them into Jellyfin's
+/// login-page branding disclaimer (#722). No I/O — <see cref="LoginButtonManager"/> owns the read/write of
+/// the server's <c>BrandingOptions.LoginDisclaimer</c>; this type only transforms strings, so it is
+/// exhaustively unit-testable, which matters because the output is rendered into an anonymous, pre-auth page.
+/// </summary>
+/// <remarks>
+/// SECURITY — this output is HTML rendered on the login page for every visitor, so it is an XSS sink. Every
+/// interpolated value is <see cref="WebUtility.HtmlEncode(string)"/>d and every provider name placed in a URL
+/// is additionally <see cref="Uri.EscapeDataString(string)"/>d; the markup is assembled only from a fixed
+/// template plus those encoded values — no admin string is ever passed through as raw HTML. The managed block
+/// is fenced between unique marker comments so <see cref="Merge"/> can replace or remove exactly its own
+/// region and never disturb an admin's surrounding disclaimer content, idempotently.
+/// </remarks>
+public static class LoginButtonInjector
+{
+    /// <summary>The opening fence of the plugin-managed region inside the login disclaimer.</summary>
+    internal const string BeginMarker = "<!-- SSO-LOGIN-BUTTONS:BEGIN (managed by jellyfin-plugin-sso — do not edit inside) -->";
+
+    /// <summary>The closing fence of the plugin-managed region.</summary>
+    internal const string EndMarker = "<!-- SSO-LOGIN-BUTTONS:END -->";
+
+    /// <summary>
+    /// Renders the managed button block, or the empty string when there are no buttons. The returned string,
+    /// when non-empty, always begins with <see cref="BeginMarker"/> and ends with <see cref="EndMarker"/>.
+    /// </summary>
+    /// <param name="buttons">The buttons to render, in order.</param>
+    /// <returns>The fenced HTML block, or an empty string when <paramref name="buttons"/> is empty.</returns>
+    public static string BuildBlock(IReadOnlyList<LoginButton> buttons)
+    {
+        ArgumentNullException.ThrowIfNull(buttons);
+        if (buttons.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(BeginMarker).Append('\n');
+        sb.Append("<div class=\"sso-login-buttons\">").Append('\n');
+        foreach (var button in buttons)
+        {
+            // Route segment is a fixed literal chosen by the enum — never interpolated from input.
+            var segment = button.Protocol == LoginButtonProtocol.Saml ? "SAML" : "OID";
+
+            // The provider name in the href is URL-encoded (path segment). Provider names are already
+            // validated to exclude URI-reserved and control characters (#336), but encode regardless so a
+            // future relaxation cannot turn this into an injection or a broken link.
+            var href = "/sso/" + segment + "/start/" + Uri.EscapeDataString(button.Name);
+
+            // Both the href attribute value and the visible label are HTML-encoded, so a name/label such as
+            // `"><script>…` renders as inert text, never markup. HtmlEncode also encodes the quotes that
+            // would otherwise break out of the attribute.
+            sb.Append("  <a class=\"raised block emby-button sso-login-button\" href=\"")
+                .Append(WebUtility.HtmlEncode(href))
+                .Append("\">")
+                .Append(WebUtility.HtmlEncode(button.Text))
+                .Append("</a>")
+                .Append('\n');
+        }
+
+        sb.Append("</div>").Append('\n');
+        sb.Append(EndMarker);
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Splices <paramref name="block"/> into <paramref name="existingDisclaimer"/> idempotently: an existing
+    /// managed region (between the markers) is replaced; when none is present the block is appended; and an
+    /// empty <paramref name="block"/> removes the managed region entirely, restoring the surrounding admin
+    /// content. Content outside the markers — an admin's own disclaimer — is preserved, aside from the
+    /// blank-line separator the managed region introduces, which is collapsed on removal so repeated
+    /// enable/disable cycles cannot accumulate whitespace.
+    /// </summary>
+    /// <param name="existingDisclaimer">The current login disclaimer (may be null/empty).</param>
+    /// <param name="block">The managed block from <see cref="BuildBlock"/> (empty to remove the region).</param>
+    /// <returns>The merged disclaimer.</returns>
+    public static string Merge(string? existingDisclaimer, string block)
+    {
+        ArgumentNullException.ThrowIfNull(block);
+        var current = existingDisclaimer ?? string.Empty;
+
+        var begin = current.IndexOf(BeginMarker, StringComparison.Ordinal);
+
+        // Search for the CLOSING fence only AFTER the opener. Searching from 0 would let a stray END that a
+        // hand-edited disclaimer placed BEFORE the BEGIN make the region look malformed on every sync, so a
+        // fresh block would be re-appended each time — and because a login's canonical-link write also raises
+        // the config-changed event, that would grow the disclaimer without bound, once per login. Anchoring
+        // the END search past the BEGIN ignores the stray marker and converges instead.
+        var end = begin >= 0
+            ? current.IndexOf(EndMarker, begin + BeginMarker.Length, StringComparison.Ordinal)
+            : -1;
+
+        // A well-formed existing region is BEGIN then END-after-BEGIN. Anything else (only one marker) is
+        // treated as "no managed region": we never parse a partial fence, so we cannot corrupt surrounding
+        // content. A fresh block then appends cleanly.
+        var hasRegion = begin >= 0 && end >= 0;
+
+        if (!hasRegion)
+        {
+            if (block.Length == 0)
+            {
+                return current;
+            }
+
+            // Append with a single blank-line separator only when there is prior content to separate from.
+            return current.Length == 0 ? block : current.TrimEnd('\n') + "\n\n" + block;
+        }
+
+        var before = current[..begin];
+        var after = current[(end + EndMarker.Length)..];
+
+        if (block.Length == 0)
+        {
+            // Remove the region and heal the seam: collapse the blank-line separator the insert introduced so
+            // repeated enable/disable cycles do not accumulate whitespace, then trim a now-trailing gap.
+            var healed = before.TrimEnd('\n');
+            var tail = after.TrimStart('\n');
+            if (healed.Length == 0)
+            {
+                return tail;
+            }
+
+            return tail.Length == 0 ? healed : healed + "\n\n" + tail;
+        }
+
+        return before + block + after;
+    }
+}

--- a/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
@@ -1,0 +1,125 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Branding;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+
+/// <summary>
+/// Keeps Jellyfin's login-page branding disclaimer in sync with the configured providers (#722). Registered
+/// as a hosted service (by <see cref="SsoOnlyServiceRegistrator"/>), where <see cref="IServerConfigurationManager"/>
+/// is available. At host start and on every plugin-configuration change it rebuilds the managed "Sign in with …"
+/// button block (<see cref="LoginButtonBuilder"/> + <see cref="LoginButtonInjector"/>) and splices it into the
+/// server's <c>BrandingOptions.LoginDisclaimer</c>, or removes the managed region when button management is off.
+/// </summary>
+/// <remarks>
+/// The change hook uses the plugin's <c>ConfigurationChanged</c> event, whose argument is the just-saved
+/// configuration — so the sync reads that object directly and never re-enters the plugin's config lock (which
+/// may still be held while the event fires). Writing the branding configuration touches a DIFFERENT
+/// configuration store, so it cannot re-trigger this handler (no loop). Everything is fail-safe: any error is
+/// logged and swallowed, so a branding-sync problem can never block a config save, a login (canonical-link
+/// writes also raise the event), or host startup. The write is guarded — the branding is saved only when the
+/// merge actually changes the disclaimer — so an unrelated config change performs no branding write.
+/// </remarks>
+internal sealed class LoginButtonManager : IHostedService
+{
+    private const string BrandingConfigKey = "branding";
+
+    private readonly IServerConfigurationManager _serverConfigurationManager;
+    private readonly ILogger<LoginButtonManager> _logger;
+    private EventHandler<BasePluginConfiguration>? _handler;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginButtonManager"/> class.
+    /// </summary>
+    /// <param name="serverConfigurationManager">The server configuration manager (owns the branding config).</param>
+    /// <param name="logger">The logger.</param>
+    public LoginButtonManager(IServerConfigurationManager serverConfigurationManager, ILogger<LoginButtonManager> logger)
+    {
+        _serverConfigurationManager = serverConfigurationManager ?? throw new ArgumentNullException(nameof(serverConfigurationManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Subscribes to configuration changes and runs an initial sync at host start.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token (unused; the sync is short and idempotent).</param>
+    /// <returns>A completed task.</returns>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var plugin = SSOPlugin.Instance;
+        if (plugin is null)
+        {
+            return Task.CompletedTask;
+        }
+
+        _handler = (_, configuration) => Sync(configuration as PluginConfiguration);
+        plugin.ConfigurationChanged += _handler;
+
+        // Initial reconciliation at startup: read once under the config lock (no save is in progress here, so
+        // there is no reentrancy) so a disclaimer left stale by an out-of-band config.xml edit is corrected.
+        try
+        {
+            Sync(plugin.ReadConfiguration(configuration => configuration));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Initial login-page button sync at startup failed; skipping.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Unsubscribes from configuration changes on shutdown.
+    /// </summary>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A completed task.</returns>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        var plugin = SSOPlugin.Instance;
+        if (plugin is not null && _handler is not null)
+        {
+            plugin.ConfigurationChanged -= _handler;
+            _handler = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void Sync(PluginConfiguration? configuration)
+    {
+        if (configuration is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var block = LoginButtonInjector.BuildBlock(LoginButtonBuilder.Build(configuration));
+
+            var branding = (BrandingOptions)_serverConfigurationManager.GetConfiguration(BrandingConfigKey);
+            var current = branding.LoginDisclaimer;
+            var merged = LoginButtonInjector.Merge(current, block);
+
+            // Guard the write: an unrelated config change (or a login's canonical-link write) whose button set
+            // is unchanged leaves the disclaimer identical, so no branding save happens.
+            if (!string.Equals(current ?? string.Empty, merged, StringComparison.Ordinal))
+            {
+                branding.LoginDisclaimer = merged;
+                _serverConfigurationManager.SaveConfiguration(BrandingConfigKey, branding);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to sync the managed login-page buttons into the branding login disclaimer.");
+        }
+    }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -58,6 +58,17 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     public int RateLimitWindowSeconds { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the plugin manages the "Sign in with …" buttons on the
+    /// Jellyfin login page (#722), by splicing a marker-fenced block into the server's branding login
+    /// disclaimer. Off by default (fail safe): a deployment that does not opt in never has its branding
+    /// mutated. When on, the managed block lists one button per ENABLED provider that does not set
+    /// <see cref="ProviderConfigBase.HideLoginButton"/>; turning it off removes only the managed region,
+    /// preserving any surrounding admin disclaimer content. The button labels/names are HTML-encoded into the
+    /// disclaimer (an anonymous, pre-auth page), so a hostile provider name or label renders inert.
+    /// </summary>
+    public bool ManageLoginPageButtons { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether SSO-only login is on (#165): native password login is
     /// disabled per account by repointing each non-exempt user's <c>AuthenticationProviderId</c> away from
     /// Jellyfin's password provider, EXCEPT a designated break-glass admin whose password door is always
@@ -143,6 +154,21 @@ public abstract class ProviderConfigBase
     /// Gets or sets a value indicating whether the provider is enabled.
     /// </summary>
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
+    /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
+    /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a
+    /// button on the login page. No effect while managed buttons are off.
+    /// </summary>
+    public bool HideLoginButton { get; set; }
+
+    /// <summary>
+    /// Gets or sets the label for this provider's managed login-page button (#722). Blank uses the provider
+    /// name. The value is HTML-encoded into the login disclaimer, so any text is safe. No effect while
+    /// <see cref="PluginConfiguration.ManageLoginPageButtons"/> is off or <see cref="HideLoginButton"/> is on.
+    /// </summary>
+    public string LoginButtonText { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether RBAC is enabled.

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using MediaBrowser.Controller;
@@ -25,6 +26,10 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
         serviceCollection.AddHostedService<SsoOnlyReconciliationService>();
+
+        // Keeps the login-page "Sign in with …" buttons (#722) in sync with the configured providers by
+        // splicing a managed block into the server's branding login disclaimer on every config change.
+        serviceCollection.AddHostedService<LoginButtonManager>();
 
         // The plugin's SSRF-hardened outbound client (#755). The OpenID discovery / token / JWKS fetches
         // resolve this named client through SsoHttp.CreateClient, so a provider endpoint that resolves to a


### PR DESCRIPTION
# What & why

A configured provider surfaced no button on the Jellyfin login page, admins hand-crafted branding HTML or shared a raw `/sso/OID/start/PROVIDER` URL (the largest recurring support cluster). This adds an **opt-in** feature that keeps a "Sign in with …" button block in the server's branding **login disclaimer** in sync with the enabled providers.

This PR is the **server-side core** (per the "Kern jetzt" scope): the pure render/merge logic, the config, the branding-sync hosted service, and exhaustive unit tests. The admin-page toggles, the live-server verification with wiki screenshots, and the hide-password / auto-redirect recipes follow separately (they need a running Jellyfin instance).

## Design

- **`LoginButtonInjector` (pure, the security core):** `BuildBlock` renders a marker-fenced block where every value is **context-encoded**, labels HTML-encoded into element text; provider names URL-encoded into a fixed-scheme `/sso/{OID,SAML}/start/` path then HTML-encoded into the double-quoted `href`, so a hostile provider name or label renders inert on the anonymous, pre-auth login page. `Merge` splices idempotently: replaces only its own marker region, appends when absent, removes it (restoring surrounding admin content) when empty, and searches the closing fence **only after the opener** so a hand-mangled disclaimer cannot drive an unbounded re-append.
- **`LoginButtonManager` (hosted service):** on startup and every plugin-config change, rebuilds the block and writes `BrandingOptions.LoginDisclaimer`, **guarded** so an unchanged button set performs no write (a login's canonical-link write raises the same event but never changes the block). It reads the change event's config argument rather than re-entering the plugin config lock, writes a **separate** config store (so it cannot re-trigger itself), and is **fail-safe**, any error is logged and swallowed, never blocking a config save, a login, or host startup.
- **Config:** `ManageLoginPageButtons` (global, **default off**, branding is never mutated without consent); per-provider `HideLoginButton` + `LoginButtonText`.

Refs #722.

## Type of change

- [x] Security hardening / vulnerability fix (the output is a login-page XSS sink; encoding is the control)
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed / fail-safe: the feature is off by default; every sync path swallows errors and can never block a config save, a login, or host start; a login never triggers a branding write.
- [x] No secrets logged / exposed: only enabled-provider display names (already public via the anonymous `GetNames`) reach the disclaimer.
- [x] A security review was performed: STRIDE threat-model before building; a 3-lens adversarial review (XSS/injection, merge correctness, integration/availability). XSS = PASS, integration = PASS; the merge lens's one real finding (END-before-BEGIN unbounded append) is fixed and pinned by a convergence test. Primary verification, as there is no live Jellyfin/JS runtime here.
- [x] IdP input sanitized at the sink: provider names/labels are context-encoded (`Uri.EscapeDataString` + `WebUtility.HtmlEncode`), proven inert by unit tests.

## Quality checklist

- [x] No duplicated logic; the hosted-service pattern mirrors `SsoOnlyReconciliationService`.
- [x] Minimal; illegal states avoided (the protocol is an enum, the route segment a fixed literal).
- [x] Self-documenting; comments explain the encoding contract and the lock/loop reasoning.
- [x] Architecture-conformance: the new `LoginButtons` module is registered in the import DAG (leaf, imports no Api module); the `Builder` helper is `internal`.
- [x] Docs impact considered: admin-page toggles + wiki are the tracked follow-up on #722 (this PR does not touch the wiki).

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 + net10.0 (0 warnings).
- [x] `dotnet test` green: 1749/1749 on both TFMs (incl. the XSS-inertness and merge-convergence pins).
- [ ] Prettier: n/a, no `.js` / `.html` / `.css` / `.md` change.

## Notes

- **Scope / follow-up (tracked on #722):** the admin-page controls for `ManageLoginPageButtons` / `HideLoginButton` / `LoginButtonText`, the end-to-end live-server verification with wiki screenshots, and the documented hide-password (cross-referencing the enforced `DisablePasswordLogin`) and auto-redirect (`?password=1` escape-hatch) recipes, all need a running Jellyfin 10.11 instance and land next.
- **Consistency:** `ManageLoginPageButtons` is XML/config-settable like the existing `EnableRateLimit` global toggle (no admin-page control yet).