### PR TITLE
Add the Single Logout session-state store (SLO-1) [#727]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -203,6 +203,8 @@ public class ArchitectureConformanceTests
     [InlineData("Routing")] // leaf — the plugin's route-shape contract: RouteSuffix ({protocol}/{path-kind}/{provider} reader), ChallengePath (new/legacy classifier)
     [InlineData("Crypto")] // leaf — the shared asymmetric signing-key strength policy (min RSA bits / approved EC curves), referenced by both protocol paths so they cannot drift (#733)
     [InlineData("LoginButtons")] // leaf — login-page button rendering (#722): pure injector/builder over the config + a branding-sync hosted service; imports no other Api module
+    [InlineData("Logout")] // leaf — Single Logout session-state store (#727): pure bounded operations over the config's LogoutSessions map; imports no other Api module
+
 
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
     [InlineData("Linking", "Audit", "Provider", "RateLimit")] // account linking — audits writes, validates providers, throttles
@@ -303,8 +305,11 @@ public class ArchitectureConformanceTests
         //   wrong home; it is config state, not in-flight state.
         // - OidConfig._canonicalLinkIssuers: the per-link issuer binding (#186), the exact parallel of
         //   _canonicalLinks — serialized config mutated only under the config lock, same rationale.
+        // - PluginConfiguration._logoutSessions: the persisted Single Logout session map (#727) — serialized
+        //   config mutated only under the config lock via SessionLogoutStore, so it is config state, not
+        //   in-flight state; the store type (SessionLogoutStore) holds the bounding logic, not the field.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth.Api.Logout;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
@@ -865,5 +866,111 @@ public class ConfigPreservationTests
 
         var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(incoming, new PluginConfiguration()));
         Assert.Contains("secondary", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Preserve_ReinjectsLiveLogoutSessions_OverAnEmptyIncomingMap()
+    {
+        // The Single Logout session store (#727) is server-managed and JSON-ignored, so a config-page PUT
+        // arrives with it empty. Preserve must re-inject the live map, so a save never strands the captured
+        // sessions and a PUT can neither wipe nor forge them.
+        var live = new PluginConfiguration();
+        live.LogoutSessions["session-1"] = new LogoutSession { Provider = "keycloak", Subject = "sub-1", IdToken = "tok" };
+
+        var incoming = new PluginConfiguration(); // empty LogoutSessions, as a JSON round-trip produces
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Same(live.LogoutSessions, incoming.LogoutSessions);
+        Assert.True(incoming.LogoutSessions.ContainsKey("session-1"));
+    }
+
+    [Fact]
+    public void LogoutSessions_AreOmittedFromJson_UnderEveryNamingPolicy_SoTheIdTokenNeverLeaks()
+    {
+        // The captured id_token is a bearer secret; the whole map is [JsonIgnore] (#727). Pin that it — its
+        // key, its fields, and above all the raw id_token — never appears in a JSON response, under both the
+        // default and the camelCase policy, exactly as OidSecret/CanonicalLinks are pinned. The field-level
+        // [JsonIgnore] on IdToken is a second layer, checked by serializing a LogoutSession directly too.
+        var config = new PluginConfiguration();
+        config.LogoutSessions["session-key-1"] = new LogoutSession
+        {
+            Protocol = "OID",
+            Provider = "keycloak",
+            Subject = "sub-secret",
+            IdToken = "RAW-ID-TOKEN-SECRET",
+        };
+
+        foreach (var options in new[]
+        {
+            null,
+            new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase },
+        })
+        {
+            var json = System.Text.Json.JsonSerializer.Serialize(config, options);
+            Assert.DoesNotContain("LogoutSessions", json, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("session-key-1", json, StringComparison.Ordinal);
+            Assert.DoesNotContain("RAW-ID-TOKEN-SECRET", json, StringComparison.Ordinal);
+        }
+
+        // Serialize a LogoutSession directly: the field-level [JsonIgnore] keeps the id_token out even off the map.
+        var direct = System.Text.Json.JsonSerializer.Serialize(config.LogoutSessions["session-key-1"]);
+        Assert.DoesNotContain("RAW-ID-TOKEN-SECRET", direct, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogoutSessions_RoundTripThroughConfigXml_KeepingTheIdTokenAndFields()
+    {
+        // The load-bearing claim is that a captured session survives a restart with a usable id_token_hint, so
+        // pin the config XML round-trip (the id_token persists to disk as-is — encryption is layered on at the
+        // persist boundary and covered by ConfigSecretProtectionTests). Mirrors CanonicalLinks_...ButKeptInXml.
+        var config = new PluginConfiguration();
+        config.LogoutSessions["session-key-1"] = new LogoutSession
+        {
+            Protocol = "OID",
+            Provider = "keycloak",
+            Subject = "sub-1",
+            SessionIndex = "sid-1",
+            Issuer = "https://idp.example",
+            IdToken = "ssoenc:v1:PERSISTED-ENVELOPE",
+            UserId = User,
+            CapturedUtcTicks = 638000000000000000,
+        };
+
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("LogoutSessions", xml, StringComparison.Ordinal);
+        Assert.Contains("ssoenc:v1:PERSISTED-ENVELOPE", xml, StringComparison.Ordinal);
+
+        // Hardened reader (DTD prohibited, no resolver) so the round-trip deserialize is not itself an XXE
+        // sink (CA5369) — the same fail-closed XML posture the SAML parsers use.
+        using var reader = System.Xml.XmlReader.Create(
+            new System.IO.StringReader(xml),
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var restored = (PluginConfiguration)serializer.Deserialize(reader)!;
+
+        Assert.True(restored.LogoutSessions.ContainsKey("session-key-1"));
+        var entry = restored.LogoutSessions["session-key-1"];
+        Assert.Equal("keycloak", entry.Provider);
+        Assert.Equal("sub-1", entry.Subject);
+        Assert.Equal("sid-1", entry.SessionIndex);
+        Assert.Equal("https://idp.example", entry.Issuer);
+        Assert.Equal("ssoenc:v1:PERSISTED-ENVELOPE", entry.IdToken);
+        Assert.Equal(User, entry.UserId);
+        Assert.Equal(638000000000000000, entry.CapturedUtcTicks);
+    }
+
+    [Fact]
+    public void FindByProviderSubject_BlankSubject_MatchesNothing()
+    {
+        // A blank subject must not sweep every blank-subject entry (it feeds token revocation, #727): the store
+        // returns nothing rather than a broad match, independent of any caller guard.
+        var config = new PluginConfiguration();
+        config.LogoutSessions["a"] = new LogoutSession { Provider = "keycloak", Subject = string.Empty };
+
+        Assert.Empty(SessionLogoutStore.FindByProviderSubject(config, "keycloak", string.Empty, string.Empty));
+        Assert.Empty(SessionLogoutStore.FindByProviderSubject(config, "keycloak", null, string.Empty));
     }
 }

--- a/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
+++ b/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.Logout;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SessionLogoutStore"/> — the bounded, pure operations over the Single Logout session
+/// store (#727): capture with TTL + cap eviction, removal, and the by-subject lookup the SAML SLO path uses.
+/// </summary>
+public class SessionLogoutStoreTests
+{
+    private static readonly DateTime Now = new DateTime(2026, 7, 20, 12, 0, 0, DateTimeKind.Utc);
+
+    private static LogoutSession State(string provider, string subject, string sid = "", string idToken = "tok")
+        => new LogoutSession { Protocol = "OID", Provider = provider, Subject = subject, SessionIndex = sid, IdToken = idToken };
+
+    [Fact]
+    public void Capture_StoresTheEntryAndStampsCaptureTime()
+    {
+        var config = new PluginConfiguration();
+        SessionLogoutStore.Capture(config, "session-1", State("keycloak", "sub-1"), Now);
+
+        var stored = SessionLogoutStore.Find(config, "session-1");
+        Assert.NotNull(stored);
+        Assert.Equal("keycloak", stored.Provider);
+        Assert.Equal(Now.Ticks, stored.CapturedUtcTicks);
+    }
+
+    [Fact]
+    public void Capture_EmptyKey_IsIgnored()
+    {
+        var config = new PluginConfiguration();
+        SessionLogoutStore.Capture(config, string.Empty, State("keycloak", "sub-1"), Now);
+        Assert.Empty(config.LogoutSessions);
+    }
+
+    [Fact]
+    public void Capture_SameKey_ReplacesThePriorEntry()
+    {
+        var config = new PluginConfiguration();
+        SessionLogoutStore.Capture(config, "session-1", State("keycloak", "sub-1", idToken: "old"), Now);
+        SessionLogoutStore.Capture(config, "session-1", State("keycloak", "sub-1", idToken: "new"), Now);
+
+        Assert.Single(config.LogoutSessions);
+        Assert.Equal("new", SessionLogoutStore.Find(config, "session-1").IdToken);
+    }
+
+    [Fact]
+    public void Remove_DropsTheEntry_AndReportsWhether()
+    {
+        var config = new PluginConfiguration();
+        SessionLogoutStore.Capture(config, "session-1", State("keycloak", "sub-1"), Now);
+
+        Assert.True(SessionLogoutStore.Remove(config, "session-1"));
+        Assert.False(SessionLogoutStore.Remove(config, "session-1"));
+        Assert.Empty(config.LogoutSessions);
+    }
+
+    [Fact]
+    public void Capture_PrunesEntriesOlderThanTheTtl()
+    {
+        var config = new PluginConfiguration();
+        // An entry captured well beyond MaxAge in the past.
+        var stale = State("keycloak", "old");
+        stale.CapturedUtcTicks = Now.Ticks - SessionLogoutStore.MaxAge.Ticks - TimeSpan.FromDays(1).Ticks;
+        config.LogoutSessions["stale"] = stale;
+
+        // Any fresh capture triggers the TTL sweep.
+        SessionLogoutStore.Capture(config, "fresh", State("keycloak", "new"), Now);
+
+        Assert.False(config.LogoutSessions.ContainsKey("stale"));
+        Assert.True(config.LogoutSessions.ContainsKey("fresh"));
+    }
+
+    [Fact]
+    public void Capture_EnforcesTheHardCap_EvictingTheOldestFirst()
+    {
+        var config = new PluginConfiguration();
+        // Fill to the cap with entries of increasing capture time, all within the TTL.
+        for (var i = 0; i < SessionLogoutStore.MaxEntries; i++)
+        {
+            var s = State("keycloak", "sub-" + i);
+            s.CapturedUtcTicks = Now.Ticks + i; // strictly increasing, oldest = i=0
+            config.LogoutSessions["key-" + i] = s;
+        }
+
+        // One more capture pushes over the cap; the single oldest (key-0) must be evicted.
+        SessionLogoutStore.Capture(config, "newest", State("keycloak", "newest"), Now.AddTicks(SessionLogoutStore.MaxEntries));
+
+        Assert.Equal(SessionLogoutStore.MaxEntries, config.LogoutSessions.Count);
+        Assert.False(config.LogoutSessions.ContainsKey("key-0"));
+        Assert.True(config.LogoutSessions.ContainsKey("newest"));
+    }
+
+    [Fact]
+    public void FindByProviderSubject_MatchesProviderAndSubject_AndSessionIndexWhenGiven()
+    {
+        var config = new PluginConfiguration();
+        SessionLogoutStore.Capture(config, "a", State("keycloak", "alice", sid: "s1"), Now);
+        SessionLogoutStore.Capture(config, "b", State("keycloak", "alice", sid: "s2"), Now);
+        SessionLogoutStore.Capture(config, "c", State("keycloak", "bob", sid: "s1"), Now);
+        SessionLogoutStore.Capture(config, "d", State("authelia", "alice", sid: "s1"), Now);
+
+        // Blank session index matches every session for the (provider, subject).
+        var allAlice = SessionLogoutStore.FindByProviderSubject(config, "keycloak", "alice", string.Empty);
+        Assert.Equal(2, allAlice.Count);
+        Assert.All(allAlice, p => Assert.Equal("alice", p.Value.Subject));
+
+        // A given session index narrows to the exact session.
+        var oneAlice = SessionLogoutStore.FindByProviderSubject(config, "keycloak", "alice", "s2");
+        Assert.Single(oneAlice);
+        Assert.Equal("b", oneAlice[0].Key);
+
+        // A different provider or subject does not match.
+        Assert.Empty(SessionLogoutStore.FindByProviderSubject(config, "keycloak", "carol", string.Empty));
+        Assert.Single(SessionLogoutStore.FindByProviderSubject(config, "authelia", "alice", string.Empty));
+    }
+}

--- a/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
@@ -110,6 +110,57 @@ public class ConfigSecretProtectionTests
     }
 
     [Fact]
+    public void ProtectAll_EncryptsTheCapturedLogoutIdToken_AndRevealRecoversIt()
+    {
+        WithStore(store =>
+        {
+            // The Single Logout id_token (#727) is a bearer secret used as an id_token_hint at logout, so it
+            // must be encrypted at rest exactly like the provider secrets — a plaintext id_token in config.xml
+            // would be a secrets-at-rest regression.
+            var config = new PluginConfiguration();
+            config.LogoutSessions["session-1"] = new LogoutSession
+            {
+                Protocol = "OID",
+                Provider = "keycloak",
+                Subject = "sub-1",
+                IdToken = "raw.id.token",
+            };
+
+            ConfigSecretProtection.ProtectAll(config, store);
+
+            Assert.True(SecretEnvelope.IsProtected(config.LogoutSessions["session-1"].IdToken));
+            Assert.Equal("raw.id.token", store.Reveal(config.LogoutSessions["session-1"].IdToken));
+        });
+    }
+
+    [Fact]
+    public void HasAnyEnvelope_ALogoutIdTokenEnvelopeAlone_IsDetected_SoAMissingKeyFailsClosed()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        try
+        {
+            // An envelope living ONLY in a captured logout id_token must still be seen as "config holds an
+            // envelope", so a lost key fails closed (orphan-prevention must cover the logout store too).
+            var envelope = new SecretStore(path).Protect("old-id-token");
+            File.Delete(path);
+
+            var config = new PluginConfiguration();
+            config.LogoutSessions["s"] = new LogoutSession { Provider = "keycloak", Subject = "sub", IdToken = envelope };
+            config.OidConfigs["b"] = new OidConfig { OidSecret = "new-plaintext" };
+
+            Assert.Throws<CryptographicException>(() => ConfigSecretProtection.ProtectAll(config, new SecretStore(path)));
+            Assert.False(File.Exists(path)); // no replacement key minted
+        }
+        finally
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    [Fact]
     public void HasAnyEnvelope_ARolloverEnvelopeAlone_IsDetected_SoAMissingKeyFailsClosed()
     {
         var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");

--- a/SSO-Auth/Api/Logout/SessionLogoutStore.cs
+++ b/SSO-Auth/Api/Logout/SessionLogoutStore.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Logout;
+
+/// <summary>
+/// Pure operations over the per-session Single Logout store (#727) — the
+/// <see cref="PluginConfiguration.LogoutSessions"/> map. No I/O: the login path calls <see cref="Capture"/>
+/// and the logout path calls <see cref="Remove"/>/the query helpers inside a <c>MutateConfiguration</c>/
+/// <c>ReadConfiguration</c> lambda, so persistence and locking stay with the config store while the
+/// selection and bounding rules live here and are unit-testable.
+/// </summary>
+/// <remarks>
+/// The store is bounded two ways so it cannot grow without limit even if session-end pruning is missed: an
+/// absolute <see cref="MaxEntries"/> cap (the oldest capture is evicted first) and a <see cref="MaxAge"/>
+/// time-to-live (stale entries are swept on every capture). Both run at capture time, so a busy server keeps
+/// the map trimmed without a background timer.
+/// </remarks>
+internal static class SessionLogoutStore
+{
+    /// <summary>The hard cap on stored sessions; the oldest is evicted once exceeded.</summary>
+    internal const int MaxEntries = 10_000;
+
+    /// <summary>Entries older than this are swept at capture time (a session that outlives it re-captures on its next login).</summary>
+    internal static readonly TimeSpan MaxAge = TimeSpan.FromDays(30);
+
+    /// <summary>
+    /// Records the logout state for a freshly minted session, then prunes expired entries and enforces the
+    /// cap. A re-used key replaces the prior entry (a re-login on the same session refreshes its id_token).
+    /// </summary>
+    /// <param name="configuration">The live configuration (mutated in place under the config lock).</param>
+    /// <param name="sessionKey">The opaque per-session key (never a secret).</param>
+    /// <param name="state">The captured state; its <see cref="LogoutSession.CapturedUtcTicks"/> is set here.</param>
+    /// <param name="nowUtc">The current UTC time (supplied for determinism).</param>
+    internal static void Capture(PluginConfiguration configuration, string sessionKey, LogoutSession state, DateTime nowUtc)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(state);
+        if (string.IsNullOrEmpty(sessionKey))
+        {
+            return;
+        }
+
+        state.CapturedUtcTicks = nowUtc.Ticks;
+        configuration.LogoutSessions[sessionKey] = state;
+
+        Prune(configuration, nowUtc);
+    }
+
+    /// <summary>Removes the entry for a session (called when a logout terminates it). A no-op if absent.</summary>
+    /// <param name="configuration">The live configuration.</param>
+    /// <param name="sessionKey">The session key to drop.</param>
+    /// <returns><c>true</c> when an entry was removed.</returns>
+    internal static bool Remove(PluginConfiguration configuration, string sessionKey)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        return !string.IsNullOrEmpty(sessionKey) && configuration.LogoutSessions.Remove(sessionKey);
+    }
+
+    /// <summary>Looks up a session by its key.</summary>
+    /// <param name="configuration">The live configuration.</param>
+    /// <param name="sessionKey">The session key.</param>
+    /// <returns>The state, or <c>null</c> when absent.</returns>
+    internal static LogoutSession Find(PluginConfiguration configuration, string sessionKey)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        if (string.IsNullOrEmpty(sessionKey))
+        {
+            return null;
+        }
+
+        return configuration.LogoutSessions.TryGetValue(sessionKey, out var state) ? state : null;
+    }
+
+    /// <summary>
+    /// Returns the sessions matching an inbound SAML <c>LogoutRequest</c> — the same provider and subject,
+    /// and the same session index when the request carries one (a blank <paramref name="sessionIndex"/>
+    /// matches any). Ordinal comparison; used by the SAML SLO path to resolve which sessions to revoke.
+    /// </summary>
+    /// <param name="configuration">The live configuration.</param>
+    /// <param name="provider">The provider the request arrived for.</param>
+    /// <param name="subject">The SAML NameID to match.</param>
+    /// <param name="sessionIndex">The SessionIndex to match, or blank to match every session for the subject.</param>
+    /// <returns>The matching (sessionKey, state) pairs.</returns>
+    internal static IReadOnlyList<KeyValuePair<string, LogoutSession>> FindByProviderSubject(
+        PluginConfiguration configuration, string provider, string subject, string sessionIndex)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // A blank subject must match NOTHING, never every blank-subject entry: this feeds a token-revocation
+        // path, so a LogoutRequest carrying an empty NameID must not be able to sweep unrelated sessions. The
+        // SLO caller also rejects an empty subject, but defending it here too keeps the store safe by itself.
+        if (string.IsNullOrEmpty(subject))
+        {
+            return System.Array.Empty<KeyValuePair<string, LogoutSession>>();
+        }
+
+        return configuration.LogoutSessions
+            .Where(pair =>
+                string.Equals(pair.Value.Provider, provider, StringComparison.Ordinal)
+                && string.Equals(pair.Value.Subject, subject, StringComparison.Ordinal)
+                && (string.IsNullOrEmpty(sessionIndex)
+                    || string.Equals(pair.Value.SessionIndex, sessionIndex, StringComparison.Ordinal)))
+            .ToList();
+    }
+
+    private static void Prune(PluginConfiguration configuration, DateTime nowUtc)
+    {
+        var sessions = configuration.LogoutSessions;
+
+        // Time-to-live sweep: drop anything older than MaxAge (a lower bound on CapturedUtcTicks).
+        var oldestAllowed = nowUtc.Ticks - MaxAge.Ticks;
+        var expired = sessions
+            .Where(pair => pair.Value.CapturedUtcTicks < oldestAllowed)
+            .Select(pair => pair.Key)
+            .ToList();
+        foreach (var key in expired)
+        {
+            sessions.Remove(key);
+        }
+
+        // Hard cap: if still over the limit, evict the oldest captures until within it, so the store is
+        // bounded regardless of TTL. Ordered by capture time so the eviction is deterministic.
+        if (sessions.Count > MaxEntries)
+        {
+            var overflow = sessions
+                .OrderBy(pair => pair.Value.CapturedUtcTicks)
+                .Take(sessions.Count - MaxEntries)
+                .Select(pair => pair.Key)
+                .ToList();
+            foreach (var key in overflow)
+            {
+                sessions.Remove(key);
+            }
+        }
+    }
+}

--- a/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
@@ -60,6 +60,22 @@ internal static class ConfigSecretProtection
                 saml.SamlRolloverSigningKeyPfx = store.Protect(saml.SamlRolloverSigningKeyPfx, configHasEnvelopes);
             }
         }
+
+        if (configuration.LogoutSessions != null)
+        {
+            foreach (var session in configuration.LogoutSessions.Values)
+            {
+                if (session == null)
+                {
+                    continue;
+                }
+
+                // The captured id_token (#727) is a bearer secret used as an id_token_hint at logout, so it
+                // is encrypted at rest exactly like the provider secrets — a plaintext id_token in config.xml
+                // would be a secrets-at-rest regression.
+                session.IdToken = store.Protect(session.IdToken, configHasEnvelopes);
+            }
+        }
     }
 
     // True when any protected field already carries a well-formed envelope. Inspects exactly the fields
@@ -86,6 +102,17 @@ internal static class ConfigSecretProtection
                 if (saml != null
                     && (SecretEnvelope.IsWellFormedEnvelope(saml.SamlSigningKeyPfx)
                         || SecretEnvelope.IsWellFormedEnvelope(saml.SamlRolloverSigningKeyPfx)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        if (configuration.LogoutSessions != null)
+        {
+            foreach (var session in configuration.LogoutSessions.Values)
+            {
+                if (session != null && SecretEnvelope.IsWellFormedEnvelope(session.IdToken))
                 {
                     return true;
                 }

--- a/SSO-Auth/Config/LogoutSession.cs
+++ b/SSO-Auth/Config/LogoutSession.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The per-session state a Single Logout needs, captured at login and discarded once the session ends
+/// (#727, prerequisite #154). Persisted (server-managed, never over the JSON boundary) so an RP-initiated
+/// OpenID logout can present a real <c>id_token_hint</c>, and an inbound SAML <c>LogoutRequest</c> can be
+/// matched to the session it terminates, even across a server restart.
+/// </summary>
+/// <remarks>
+/// A plain XML-serializable class (public parameterless ctor + get/set) because it is stored as the value of
+/// a <see cref="SerializableDictionary{TKey,TValue}"/> on <see cref="PluginConfiguration"/>, exactly like
+/// <see cref="OidConfig"/>/<see cref="SamlConfig"/>. <see cref="IdToken"/> is a bearer secret: it is encrypted
+/// at rest (the <c>ssoenc:</c> envelope, via ConfigSecretProtection) and withheld from every JSON response
+/// with the enclosing map, so it never reaches the admin browser or a config export.
+/// </remarks>
+public class LogoutSession
+{
+    /// <summary>
+    /// Gets or sets the protocol that minted the session — <c>"OID"</c> or <c>"SAML"</c> (the audit-protocol
+    /// spelling), selecting which logout mechanism applies.
+    /// </summary>
+    public string Protocol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the provider name (its config-dictionary key) the session was authenticated through.
+    /// </summary>
+    public string Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the stable subject (the OpenID <c>sub</c> claim or the SAML <c>NameID</c>) the inbound
+    /// SAML <c>LogoutRequest</c> path matches on.
+    /// </summary>
+    public string Subject { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identity-provider session identifier (the OpenID <c>sid</c> claim or the SAML
+    /// <c>SessionIndex</c>), when the provider issued one; otherwise blank.
+    /// </summary>
+    public string SessionIndex { get; set; }
+
+    /// <summary>
+    /// Gets or sets the id_token issuer (the <c>iss</c> claim) the logout URL is host-bound to, so an
+    /// RP-initiated logout can only be built against the discovered authority (OpenID only).
+    /// </summary>
+    public string Issuer { get; set; }
+
+    /// <summary>
+    /// Gets or sets the raw OpenID <c>id_token</c> used as the <c>id_token_hint</c> for an RP-initiated
+    /// logout (OpenID only; blank for SAML). A bearer secret: encrypted at rest and never returned over JSON.
+    /// </summary>
+    // Defense in depth: the enclosing LogoutSessions map is already [JsonIgnore], so this never reaches a
+    // JSON response today; the field-level ignore additionally guarantees that a LogoutSession serialized
+    // DIRECTLY (a future debug/admin endpoint) still cannot leak the id_token — a freshly captured token is
+    // plaintext in memory until the next persist, so the belt-and-suspenders matters. XML persistence is
+    // unaffected (XmlSerializer ignores this attribute), so the encrypted token still round-trips to disk.
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string IdToken { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Jellyfin user id whose tokens a logout revokes.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the UTC ticks at which the session was captured, used to bound the store (oldest entries
+    /// are evicted first) and to expire stale entries.
+    /// </summary>
+    public long CapturedUtcTicks { get; set; }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -10,6 +10,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfiguration
 {
     private List<Guid> _ssoOnlyRepointedUserIds;
+    private SerializableDictionary<string, LogoutSession> _logoutSessions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
@@ -69,6 +70,17 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     public bool ManageLoginPageButtons { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether Single Logout is on (#727). Off by default (fail safe): a
+    /// deployment that does not opt in captures no per-session logout state and exposes no logout surface.
+    /// When on, each successful login persists the state a logout needs (<see cref="LogoutSessions"/>) — for
+    /// OpenID the <c>id_token</c> used as an <c>id_token_hint</c>, for both protocols the subject/session
+    /// index a logout is matched on — so an RP-initiated OpenID logout or an inbound SAML <c>LogoutRequest</c>
+    /// can terminate the linked Jellyfin session. It gates only the capture and the (later) logout endpoints;
+    /// local Jellyfin logout is unaffected either way.
+    /// </summary>
+    public bool EnableSingleLogout { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether SSO-only login is on (#165): native password login is
     /// disabled per account by repointing each non-exempt user's <c>AuthenticationProviderId</c> away from
     /// Jellyfin's password provider, EXCEPT a designated break-glass admin whose password door is always
@@ -114,6 +126,25 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
         // throwaway. Every access is under ReadConfiguration/MutateConfiguration, so it cannot race.
         get => _ssoOnlyRepointedUserIds ??= new List<Guid>();
         set => _ssoOnlyRepointedUserIds = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the per-session Single Logout state captured at login (#727), keyed by an opaque session
+    /// key. Server-managed RUNTIME state, NOT an admin setting: the login path writes it (only while
+    /// <see cref="EnableSingleLogout"/> is on), the logout path reads and removes it, and it is bounded so it
+    /// cannot grow without limit. It persists in the config XML so a session survives a restart with a usable
+    /// <c>id_token_hint</c>. Withheld from JSON (<c>[JsonIgnore]</c>) and re-injected on save like the other
+    /// server-managed fields, so a config PUT can neither read the stored id_tokens nor forge session state;
+    /// each entry's <see cref="LogoutSession.IdToken"/> is additionally encrypted at rest.
+    /// </summary>
+    [XmlElement("LogoutSessions")]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SerializableDictionary<string, LogoutSession> LogoutSessions
+    {
+        // Self-healing lazy init (mirrors CanonicalLinks/SsoOnlyRepointedUserIds): a config PUT deserializes
+        // this to null (it is JSON-ignored), so a later write under the config lock must land in a stored map.
+        get => _logoutSessions ??= new SerializableDictionary<string, LogoutSession>();
+        set => _logoutSessions = value;
     }
 }
 

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -43,6 +43,13 @@ internal static class ServerManagedFields
             incoming.DisablePasswordLogin = live.DisablePasswordLogin;
             incoming.BreakGlassAdminUsername = live.BreakGlassAdminUsername;
             incoming.SsoOnlyRepointedUserIds = live.SsoOnlyRepointedUserIds;
+
+            // The Single Logout session store is server-managed runtime state (#727): it is withheld from
+            // JSON, so a config-page PUT arrives with it empty. Re-inject the live map so a save never wipes
+            // the captured sessions (which would strand every live session's id_token_hint) and a config PUT
+            // can neither read the stored id_tokens nor forge session entries — the login/logout paths are the
+            // only writers, exactly as for the SSO-only bookkeeping above.
+            incoming.LogoutSessions = live.LogoutSessions;
         }
     }
 


### PR DESCRIPTION
# What & why

Groundwork for Single Logout (#727, prerequisite #154): capture-ready, encrypted, bounded, **server-managed** storage for the per-session state a logout needs, so a later RP-initiated OpenID logout can present a real `id_token_hint`, and an inbound SAML `LogoutRequest` can be matched to the session it terminates, across a restart. This is **SLO-1** of the multi-PR decomposition on #727; it lands the persistence layer only. The login-time capture wiring (SLO-1b, which threads the id_token through the OIDC authorize state machine) and the logout endpoints (SLO-2/3) follow in their own gated PRs, **nothing writes to the store yet**.

## Design

- **`LogoutSession`**, an XML-serializable record of the state a logout consumes (protocol, provider, subject, session index, issuer, the raw `id_token`, the user id, capture time).
- **`SessionLogoutStore`**, pure, bounded operations over the new `PluginConfiguration.LogoutSessions` map: `Capture` (with a TTL sweep **and** a hard oldest-first cap, so it can never grow without limit), `Remove`, `Find`, and the `FindByProviderSubject` lookup the SAML path will use, a **blank subject matches nothing**, so it can never sweep unrelated sessions.
- **Server-managed, like the canonical-link / SSO-only bookkeeping:** the map is `[JsonIgnore]` (and the `id_token` additionally carries a field-level `[JsonIgnore]` as defense in depth), so a config PUT can neither read the stored id_tokens nor forge sessions; `ServerManagedFields.Preserve` re-injects it so a save never wipes it; and each `id_token` is **encrypted at rest** by `ConfigSecretProtection`, the same `ssoenc` envelope and orphan-prevention as the provider secrets (a lone id_token envelope with a missing key fails closed).
- **`EnableSingleLogout`** (global, default off) will gate the capture and the logout endpoints.

Refs #727.

## Type of change

- [x] Security hardening / vulnerability fix (bearer-secret at-rest + server-managed persistence)
- [ ] Bug fix
- [x] Feature (groundwork)
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a lone captured-id_token envelope with a missing key fails closed (orphan-prevention extended into `HasAnyEnvelope`); a blank-subject lookup matches nothing.
- [x] No secrets logged / exposed: the `id_token` is `[JsonIgnore]` at both the map and field level and encrypted at rest; withheld from the config export (which only snapshots the provider maps).
- [x] A security review was performed: STRIDE (on #727) + a 3-lens adversarial review (secret-at-rest, server-managed persistence, bounded-store correctness). Runtime behavior confirmed correct on every hunt; the review's findings (field-level id_token `[JsonIgnore]`, the blank-subject guard, and explicit JSON-omission + XML-round-trip pinning tests) are all incorporated.
- [x] IdP input: n/a here (no inbound message parsed yet); the capture/validation land in SLO-1b/2/3.

## Quality checklist

- [x] No duplicated logic; the store/config/secret-protection/server-managed handling mirror the established canonical-link + SSO-only patterns.
- [x] Minimal; illegal states avoided (pure bounded store, immutable-ish record).
- [x] Self-documenting; comments explain the server-managed, at-rest, and bounding rationale.
- [x] Architecture-conformance: new `Logout` module registered in the import DAG (leaf); `SessionLogoutStore` is `internal`; `_logoutSessions` documented in the mutable-keyed-state exemption alongside `_canonicalLinks`.
- [x] Docs impact: none user-facing yet (off by default, no UI/endpoint); the admin toggle + `SECURITY.md` posture land with SLO-4/5.

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 + net10.0 (0 warnings).
- [x] `dotnet test` green: 1763/1763 on both TFMs (store bounding/TTL/eviction, secret-at-rest round-trip + orphan-prevention, server-managed re-injection, JSON-omission + XML round-trip pins).
- [ ] Prettier: n/a, no `.js` / `.html` / `.css` / `.md` change.

## Notes

- **Multi-PR scope (tracked on #727):** SLO-1b (login-time capture threading the id_token through the OIDC Promote→Ready→redeem state machine), SLO-2 (OIDC RP-initiated logout), SLO-3 (SAML SLO), SLO-4 (rate-limit + audit + config + admin-UI), SLO-5 (`SECURITY.md` + full `/security-review`).