### PR TITLE
OIDC RP-initiated logout (SLO-2) [#727]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -214,7 +214,7 @@ public class ArchitectureConformanceTests
     [InlineData("Session", "Authz", "Avatar", "Linking")] // session mint + login outcomes — applies grants (Authz), sets avatars (Avatar), reconciles links (Linking)
     [InlineData("Shared", "Avatar", "Linking", "RateLimit", "Routing", "Session")] // shared served-page / flow-response + rate-limit-gate helpers — depend downward on the session/linking/avatar/throttle/route tiers, never on a protocol or the boundary
     [InlineData("Flows", "Audit", "Identity", "Linking", "Logout", "Net", "Oidc", "Provider", "RateLimit", "Saml", "Session", "Shared")] // per-protocol login orchestration — drives both protocol modules (Oidc/Saml) and the downstream mint/link/session tiers; persists the captured logout state at the mint (Logout, #727); nothing above the boundary imports it
-    [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide; nothing imports it back (#790/#807)
+    [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Logout", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide (incl. the RP-initiated logout store, #727); nothing imports it back (#790/#807)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);

--- a/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
@@ -932,6 +932,7 @@ public class ConfigPreservationTests
             Subject = "sub-1",
             SessionIndex = "sid-1",
             Issuer = "https://idp.example",
+            EndSessionEndpoint = "https://idp.example/logout",
             IdToken = "ssoenc:v1:PERSISTED-ENVELOPE",
             UserId = User,
             CapturedUtcTicks = 638000000000000000,
@@ -957,6 +958,7 @@ public class ConfigPreservationTests
         Assert.Equal("sub-1", entry.Subject);
         Assert.Equal("sid-1", entry.SessionIndex);
         Assert.Equal("https://idp.example", entry.Issuer);
+        Assert.Equal("https://idp.example/logout", entry.EndSessionEndpoint);
         Assert.Equal("ssoenc:v1:PERSISTED-ENVELOPE", entry.IdToken);
         Assert.Equal(User, entry.UserId);
         Assert.Equal(638000000000000000, entry.CapturedUtcTicks);

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -168,7 +168,7 @@ public class LoginCompletionServiceTests
 
         await service.CompleteAsync(
             OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9",
-            new LogoutContext("sid-1", "raw.id.token"));
+            new LogoutContext("sid-1", "raw.id.token", "https://idp.example/logout"));
 
         Assert.True(cfg.LogoutSessions.ContainsKey("session-key-1"));
         var entry = cfg.LogoutSessions["session-key-1"];
@@ -176,6 +176,7 @@ public class LoginCompletionServiceTests
         Assert.Equal("sub-1", entry.Subject);
         Assert.Equal("sid-1", entry.SessionIndex);
         Assert.Equal("kc", entry.Provider);
+        Assert.Equal("https://idp.example/logout", entry.EndSessionEndpoint);
         Assert.Equal(Created, entry.UserId);
     }
 

--- a/SSO-Auth.Tests/Kernel/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerAuthorizationTests.cs
@@ -43,10 +43,11 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     };
 
     // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) — the canonical
-    // link management surface.
+    // link management surface, plus the RP-initiated OpenID logout (#727), where a user logs THEMSELVES out
+    // (every action is scoped to the caller's own user id), so it is deliberately non-elevated.
     private static readonly string[] ExpectedAuthenticatedActions =
     {
-        "AddCanonicalLink", "DeleteCanonicalLink", "GetSamlLinksByUser", "GetOidLinksByUser",
+        "AddCanonicalLink", "DeleteCanonicalLink", "GetSamlLinksByUser", "GetOidLinksByUser", "OidLogout",
     };
 
     private readonly SsoAuthorizationServerFixture _fixture;

--- a/SSO-Auth.Tests/Kernel/SSOControllerLogoutTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerLogoutTests.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the RP-initiated OpenID logout endpoint (#727, SLO-2) via
+/// <see cref="SsoControllerHarness"/>. They pin the fail-safe contract: the local Jellyfin logout always
+/// runs, a captured session redirects to the issuer-host-bound end_session URL, and the absence of a
+/// captured session degrades to a local (host-independent) redirect — never a 500 or an external redirect.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerLogoutTests
+{
+    private static readonly Guid Caller = Guid.Parse("77777777-7777-7777-7777-777777777777");
+
+    private static SsoControllerHarness ForCaller(string token, Action<PluginConfiguration> configure)
+    {
+        var harness = new SsoControllerHarness(configure);
+        var user = new User("caller", "SSO-Auth", "Default") { Id = Caller };
+        harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>())
+            .Returns(System.Threading.Tasks.Task.FromResult(new AuthorizationInfo { User = user, Token = token }));
+        return harness;
+    }
+
+    [Fact]
+    public async Task OidLogout_WithACapturedSession_EndsTheLocalSessionAndRedirectsToTheIssuer()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.OidConfigs["kc"] = new OidConfig { Enabled = true, OidClientId = "client-kc" };
+            config.LogoutSessions["session-1"] = new LogoutSession
+            {
+                Protocol = "OpenID",
+                Provider = "kc",
+                Subject = "sub-1",
+                Issuer = "https://idp.example",
+                EndSessionEndpoint = "https://idp.example/logout",
+                IdToken = "raw.id.token", // plaintext round-trips through Reveal unchanged
+                UserId = Caller,
+            };
+        });
+
+        var result = await harness.Controller.OidLogout("kc");
+
+        // Redirected to the issuer-host-bound end_session URL with the hint + client id.
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith("https://idp.example/logout?", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("id_token_hint=raw.id.token", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("client_id=client-kc", redirect.Url, StringComparison.Ordinal);
+
+        // The caller's local session was ended, and the consumed entry removed so the id_token is not retained.
+        await harness.SessionManager.Received(1).Logout("caller-token");
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("session-1")));
+    }
+
+    [Fact]
+    public async Task OidLogout_NoCapturedSession_StillLogsOutLocally_AndRedirectsLocally()
+    {
+        // Feature off / nothing captured: the endpoint must still end the local session and degrade to a
+        // LOCAL redirect (never a 500, never an external host).
+        var harness = ForCaller("caller-token", config => config.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var result = await harness.Controller.OidLogout("kc");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+    }
+}

--- a/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
+++ b/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
@@ -96,6 +96,38 @@ public class SessionLogoutStoreTests
     }
 
     [Fact]
+    public void FindByUser_ReturnsOnlyThatUsersSessions_NewestFirst()
+    {
+        var alice = System.Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var bob = System.Guid.Parse("22222222-2222-2222-2222-222222222222");
+        var config = new PluginConfiguration();
+
+        var older = State("keycloak", "alice");
+        older.UserId = alice;
+        older.CapturedUtcTicks = Now.Ticks;
+        config.LogoutSessions["a-old"] = older;
+
+        var newer = State("authelia", "alice");
+        newer.UserId = alice;
+        newer.CapturedUtcTicks = Now.Ticks + 1000;
+        config.LogoutSessions["a-new"] = newer;
+
+        var other = State("keycloak", "bob");
+        other.UserId = bob;
+        config.LogoutSessions["b"] = other;
+
+        var found = SessionLogoutStore.FindByUser(config, alice);
+
+        Assert.Equal(2, found.Count);
+        Assert.Equal("a-new", found[0].Key); // newest first
+        Assert.Equal("a-old", found[1].Key);
+        Assert.All(found, p => Assert.Equal(alice, p.Value.UserId));
+
+        // A blank user matches nothing (never sweeps unrelated sessions).
+        Assert.Empty(SessionLogoutStore.FindByUser(config, System.Guid.Empty));
+    }
+
+    [Fact]
     public void FindByProviderSubject_MatchesProviderAndSubject_AndSessionIndexWhenGiven()
     {
         var config = new PluginConfiguration();

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -1,0 +1,85 @@
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcLogout"/> — the RP-initiated end_session URL builder (#727, SLO-2). The security
+/// pins: the endpoint must be host-bound to the discovered issuer, and the post_logout_redirect_uri must be
+/// allow-listed against this server's canonical base, so a logout can never navigate the browser to an
+/// attacker host. A missing endpoint yields null (local-only logout).
+/// </summary>
+public class OidcLogoutTests
+{
+    private const string Issuer = "https://idp.example.com";
+    private const string EndSession = "https://idp.example.com/protocol/openid-connect/logout";
+    private const string Base = "https://jellyfin.example.com";
+
+    [Fact]
+    public void Build_HappyPath_IncludesHintClientIdAndAllowedReturn_Escaped()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, "raw.id.token", "jellyfin-client", Base + "/web/", Base);
+
+        Assert.StartsWith(EndSession + "?", url, System.StringComparison.Ordinal);
+        Assert.Contains("id_token_hint=raw.id.token", url, System.StringComparison.Ordinal);
+        Assert.Contains("client_id=jellyfin-client", url, System.StringComparison.Ordinal);
+        // The return URL is present and percent-encoded (the "://" becomes %3A%2F%2F).
+        Assert.Contains("post_logout_redirect_uri=https%3A%2F%2Fjellyfin.example.com", url, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_NoEndSessionEndpoint_ReturnsNull_ForLocalOnlyLogout()
+    {
+        Assert.Null(OidcLogout.BuildEndSessionUrl(null, Issuer, "t", "c", Base, Base));
+        Assert.Null(OidcLogout.BuildEndSessionUrl("   ", Issuer, "t", "c", Base, Base));
+        Assert.Null(OidcLogout.BuildEndSessionUrl("not-a-url", Issuer, "t", "c", Base, Base));
+    }
+
+    [Fact]
+    public void Build_EndSessionOnADifferentHostThanTheIssuer_ReturnsNull()
+    {
+        // Host-binding: a discovery document pointing end_session at an attacker host must not redirect there.
+        Assert.Null(OidcLogout.BuildEndSessionUrl("https://evil.example.net/logout", Issuer, "t", "c", Base, Base));
+        // A different port is also a different authority.
+        Assert.Null(OidcLogout.BuildEndSessionUrl("https://idp.example.com:8443/logout", Issuer, "t", "c", Base, Base));
+    }
+
+    [Fact]
+    public void Build_PostLogoutRedirectOnAnAttackerHost_IsOmitted_NotIncluded()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, "t", "c", "https://evil.example.net/steal", Base);
+
+        Assert.NotNull(url);
+        Assert.DoesNotContain("post_logout_redirect_uri", url, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("evil.example.net", url, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_PostLogoutRedirectUnderTheCanonicalBase_IsAllowed()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, "t", "c", Base + "/sso/goodbye", Base);
+        Assert.Contains("post_logout_redirect_uri=", url, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_PostLogoutRedirectOnASiblingPrefixHost_IsRejected()
+    {
+        // A host that merely starts with the base host string is a different authority — must not pass.
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, "t", "c", "https://jellyfin.example.com.evil.net/", Base);
+        Assert.DoesNotContain("post_logout_redirect_uri", url, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_EndpointWithExistingQuery_AppendsWithAmpersand()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession + "?ui_locales=en", Issuer, "t", "c", null, Base);
+        Assert.StartsWith(EndSession + "?ui_locales=en&", url, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Build_NoHintNoReturn_ReturnsTheEndpointWithOnlyClientId()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, null, "c", null, Base);
+        Assert.Equal(EndSession + "?client_id=c", url);
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -178,6 +178,7 @@ internal sealed class LoginCompletionService
                 SessionIndex = context.SessionIndex,
                 Issuer = identity.Issuer,
                 IdToken = context.IdToken,
+                EndSessionEndpoint = context.EndSessionEndpoint,
                 UserId = userId,
             };
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -341,7 +341,14 @@ internal sealed class OidcLoginService : ILoginService
         // carries the unsigned UserInfo merge, so — as with acr (OidcIdTokenAcr) and iss (OidcResponseIssuer)
         // — only the id_token's own sid is trustworthy for a value that later keys a logout.
         var sid = OidcIdTokenSid.Read(result.IdentityToken);
-        derived = derived with { IdToken = result.IdentityToken, SessionIndex = sid };
+        derived = derived with
+        {
+            IdToken = result.IdentityToken,
+            SessionIndex = sid,
+            // The end_session_endpoint from the SAME discovery that fed this login (#727, SLO-2), stored so a
+            // later RP-initiated logout needs no rediscovery; null when the OP advertises none.
+            EndSessionEndpoint = pending.ProviderInformation?.EndSessionEndpoint,
+        };
 
         // Fail closed (#155): a valid OpenID login must resolve a stable subject to key the account
         // link on. sub is an OIDC Core MUST and (post-#134) the id_token validator has verified the

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -199,6 +199,10 @@ public class SSOController : ControllerBase
 
         // The caller's most recent captured OpenID session for this provider (an id_token distinguishes an
         // OpenID capture from a SAML one). Scoped to the caller's own user id, read under the config lock.
+        // Best-effort with multiple concurrent sessions: "most recent" may differ from the exact session the
+        // local Logout below ends, but both belong to the caller and the id_token_hint is a valid token for
+        // the same subject at the same issuer, so RP-initiated logout is still correct — a within-user,
+        // best-effort SLO, never a cross-user effect (FindByUser is user-id-scoped and empty for Guid.Empty).
         var match = SSOPlugin.Instance.ReadConfiguration(configuration =>
             SessionLogoutStore.FindByUser(configuration, auth.UserId)
                 .FirstOrDefault(pair =>
@@ -228,14 +232,24 @@ public class SSOController : ControllerBase
         string endSessionUrl = null;
         if (match.Value is { } captured)
         {
-            // Reveal the encrypted id_token only now, at the moment it is sent as the id_token_hint.
-            endSessionUrl = OidcLogout.BuildEndSessionUrl(
-                captured.EndSessionEndpoint,
-                captured.Issuer,
-                SSOPlugin.Instance.Secrets.Reveal(captured.IdToken),
-                config?.OidClientId,
-                config?.PostLogoutRedirectUri,
-                canonicalBase);
+            try
+            {
+                // Reveal the encrypted id_token only now, at the moment it is sent as the id_token_hint.
+                endSessionUrl = OidcLogout.BuildEndSessionUrl(
+                    captured.EndSessionEndpoint,
+                    captured.Issuer,
+                    SSOPlugin.Instance.Secrets.Reveal(captured.IdToken),
+                    config?.OidClientId,
+                    config?.PostLogoutRedirectUri,
+                    canonicalBase);
+            }
+            catch (Exception ex)
+            {
+                // Fail-safe: the local logout already completed above. A reveal fault (a missing/corrupt
+                // at-rest key, as TryReveal guards on the login path) or a build fault must degrade to a
+                // local-only logout, never surface a 500 — honouring the endpoint's stated contract.
+                _logger.LogError(ex, "Building the OpenID end-session redirect failed; the local logout stands and the browser returns to this server.");
+            }
         }
 
         // Redirect to the IdP end-session URL (an absolute URL host-bound to the discovered issuer by

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -12,6 +12,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Logout;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
@@ -178,6 +179,71 @@ public class SSOController : ControllerBase
         // redirects to the identity provider (setting the binding cookie on the response).
         // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
         return BrowserErrorPage.Wrap(await _oidc.ChallengeAsync(provider, isLinking, Request, Response).ConfigureAwait(false), Request, Response);
+    }
+
+    /// <summary>
+    /// RP-initiated OpenID logout (#727, SLO-2). Ends the CALLER's local Jellyfin session, then — when the
+    /// caller has a captured OpenID session for this provider (Single Logout enabled) — redirects the browser
+    /// to the identity provider's <c>end_session_endpoint</c> with the stored <c>id_token_hint</c>, so the IdP
+    /// session is terminated too. Fail-safe: a missing/unsafe endpoint or a disabled feature degrades to a
+    /// local-only logout (the browser returns to this server). Authenticated, and every action is scoped
+    /// strictly to the caller's own user id — a user can only log THEMSELVES out.
+    /// </summary>
+    /// <param name="provider">The OpenID provider to end the session at.</param>
+    /// <returns>A redirect to the IdP end-session URL, or to this server for a local-only logout.</returns>
+    [Authorize]
+    [HttpGet("OID/logout/{provider}")]
+    public async Task<ActionResult> OidLogout(string provider)
+    {
+        var auth = await _authContext.GetAuthorizationInfo(HttpContext.Request).ConfigureAwait(false);
+
+        // The caller's most recent captured OpenID session for this provider (an id_token distinguishes an
+        // OpenID capture from a SAML one). Scoped to the caller's own user id, read under the config lock.
+        var match = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            SessionLogoutStore.FindByUser(configuration, auth.UserId)
+                .FirstOrDefault(pair =>
+                    string.Equals(pair.Value.Provider, provider, StringComparison.Ordinal)
+                    && !string.IsNullOrEmpty(pair.Value.IdToken)));
+
+        // End the caller's local Jellyfin session (their current token only), then drop the consumed entry so
+        // the id_token is not retained past the logout.
+        if (!string.IsNullOrEmpty(auth.Token))
+        {
+            await _sessionManager.Logout(auth.Token).ConfigureAwait(false);
+        }
+
+        if (match.Value is not null)
+        {
+            SSOPlugin.Instance.MutateConfiguration(configuration => SessionLogoutStore.Remove(configuration, match.Key));
+        }
+
+        var config = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            configuration.OidConfigs.TryGetValue(provider, out var oidConfig) ? oidConfig : null);
+
+        // This server's canonical base — the allow-list root for the post-logout return URL, and the
+        // local-only fallback target. Derived exactly as the login builds its own external URLs.
+        var canonicalBase = CanonicalBaseUrl.Resolve(
+            config?.BaseUrlOverride, Request.Scheme, Request.Host.Host, Request.Host.Port, Request.PathBase, config?.SchemeOverride, config?.PortOverride);
+
+        string endSessionUrl = null;
+        if (match.Value is { } captured)
+        {
+            // Reveal the encrypted id_token only now, at the moment it is sent as the id_token_hint.
+            endSessionUrl = OidcLogout.BuildEndSessionUrl(
+                captured.EndSessionEndpoint,
+                captured.Issuer,
+                SSOPlugin.Instance.Secrets.Reveal(captured.IdToken),
+                config?.OidClientId,
+                config?.PostLogoutRedirectUri,
+                canonicalBase);
+        }
+
+        // Redirect to the IdP end-session URL (an absolute URL host-bound to the discovered issuer by
+        // OidcLogout), or — local-only — back to this server via a LOCAL redirect. The local fallback must NOT
+        // reuse the canonical base as an absolute target: with no Base URL Override that base is derived from
+        // the request Host header, so a spoofed Host would turn the fallback into an open redirect. A local
+        // ("~/") redirect is host-independent and ASP.NET Core rejects any non-local value outright.
+        return endSessionUrl is null ? LocalRedirect("~/") : Redirect(endSessionUrl);
     }
 
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist

--- a/SSO-Auth/Api/Logout/LogoutContext.cs
+++ b/SSO-Auth/Api/Logout/LogoutContext.cs
@@ -10,7 +10,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Logout;
 /// </summary>
 /// <param name="SessionIndex">The OpenID <c>sid</c> claim or the SAML <c>SessionIndex</c>, or null when absent.</param>
 /// <param name="IdToken">The raw OpenID <c>id_token</c> (a bearer secret), or null for SAML.</param>
-internal readonly record struct LogoutContext(string? SessionIndex, string? IdToken)
+/// <param name="EndSessionEndpoint">The OpenID <c>end_session_endpoint</c> from discovery, stored so an RP-initiated logout needs no runtime rediscovery (#727, SLO-2); null for SAML or when the OP advertises none.</param>
+internal readonly record struct LogoutContext(string? SessionIndex, string? IdToken, string? EndSessionEndpoint = null)
 {
     /// <summary>
     /// Redacts the bearer <see cref="IdToken"/> from the record's synthesized string form, so a stray

--- a/SSO-Auth/Api/Logout/SessionLogoutStore.cs
+++ b/SSO-Auth/Api/Logout/SessionLogoutStore.cs
@@ -106,6 +106,28 @@ internal static class SessionLogoutStore
             .ToList();
     }
 
+    /// <summary>
+    /// Returns the sessions captured for a given Jellyfin user, newest first (#727, SLO-2). The OIDC
+    /// RP-initiated logout uses this to pick the caller's most recent session for a provider, whose id_token
+    /// is the id_token_hint. A blank/empty user id matches nothing, so it can never sweep unrelated sessions.
+    /// </summary>
+    /// <param name="configuration">The live configuration.</param>
+    /// <param name="userId">The Jellyfin user id to match.</param>
+    /// <returns>The user's captured sessions, ordered newest first.</returns>
+    internal static IReadOnlyList<KeyValuePair<string, LogoutSession>> FindByUser(PluginConfiguration configuration, Guid userId)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        if (userId == Guid.Empty)
+        {
+            return System.Array.Empty<KeyValuePair<string, LogoutSession>>();
+        }
+
+        return configuration.LogoutSessions
+            .Where(pair => pair.Value.UserId == userId)
+            .OrderByDescending(pair => pair.Value.CapturedUtcTicks)
+            .ToList();
+    }
+
     private static void Prune(PluginConfiguration configuration, DateTime nowUtc)
     {
         var sessions = configuration.LogoutSessions;

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -136,7 +136,7 @@ internal abstract class AuthorizeSession
             // Carry the OpenID logout material (#727, SLO-1b) alongside the keystone rather than inside it:
             // the id_token and sid are needed only by the (opt-in) logout capture at the mint, so keeping them
             // off VerifiedIdentity leaves the keystone's minimal contract intact.
-            LogoutContext = new LogoutContext(derived.SessionIndex, derived.IdToken);
+            LogoutContext = new LogoutContext(derived.SessionIndex, derived.IdToken, derived.EndSessionEndpoint);
         }
 
         /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -267,6 +267,12 @@ internal static class OidcAuthorizeStateBuilder
         internal string? SessionIndex { get; init; }
 
         /// <summary>
+        /// Gets the OpenID <c>end_session_endpoint</c> from discovery (#727, SLO-2), captured so an
+        /// RP-initiated logout needs no runtime rediscovery; null when the OP advertises none.
+        /// </summary>
+        internal string? EndSessionEndpoint { get; init; }
+
+        /// <summary>
         /// Redacts the bearer <see cref="IdToken"/> from the record's synthesized string form (#727), so a
         /// stray <c>$"{state}"</c> or a logged state can never spill the id_token.
         /// </summary>

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -1,0 +1,149 @@
+#nullable enable
+
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// Composes the OpenID Connect RP-initiated logout (<c>end_session</c>) URL the browser is redirected to
+/// after the local Jellyfin session is ended (#727, SLO-2). Pure string logic so its two security controls
+/// are unit-testable, because this URL navigates an authenticated user's browser to an external host.
+/// </summary>
+/// <remarks>
+/// Two fail-closed defenses, both here:
+/// <list type="bullet">
+/// <item><description>
+/// <b>Issuer host-binding.</b> The <c>end_session_endpoint</c> comes from the provider's own discovery
+/// document, but a tampered/misconfigured discovery could point it at an attacker host. The endpoint is
+/// therefore accepted only when its authority (scheme + host + port) equals the discovered issuer's — so a
+/// logout can never navigate the browser anywhere but the identity provider itself (an open-redirect / SSRF
+/// defense mirroring the login path's issuer checks). A mismatch yields <c>null</c> (local-only logout).
+/// </description></item>
+/// <item><description>
+/// <b><c>post_logout_redirect_uri</c> allow-listing.</b> The return URL is included only when it normalizes
+/// (via <see cref="CanonicalBaseUrl"/>) and sits at or under this server's canonical base — so logout can
+/// only return the browser to this Jellyfin, never to an attacker site. An absent, malformed, or off-base
+/// value is simply omitted; the logout still happens, without a redirect back.
+/// </description></item>
+/// </list>
+/// A blank <c>end_session_endpoint</c> (the OP advertises none, or discovery was unreachable) yields
+/// <c>null</c>, and the caller falls back to a local-only logout — a missing OP endpoint must never break it.
+/// </remarks>
+internal static class OidcLogout
+{
+    /// <summary>
+    /// Builds the RP-initiated <c>end_session</c> URL, or <c>null</c> when RP-initiated logout is not possible
+    /// or not safe (no endpoint, or the endpoint is not host-bound to the issuer) — the caller then performs a
+    /// local-only logout.
+    /// </summary>
+    /// <param name="endSessionEndpoint">The OP's advertised <c>end_session_endpoint</c> (may be null/empty).</param>
+    /// <param name="issuer">The discovered issuer (its authority host-binds the endpoint).</param>
+    /// <param name="idTokenHint">The revealed captured <c>id_token</c> for the <c>id_token_hint</c> (may be null).</param>
+    /// <param name="clientId">The provider's client id.</param>
+    /// <param name="postLogoutRedirectUri">The desired post-logout return URL (allow-listed below; may be null).</param>
+    /// <param name="canonicalBaseUrl">This server's canonical base, the allow-list root for the return URL.</param>
+    /// <returns>The absolute end-session URL, or <c>null</c> for a local-only logout.</returns>
+    internal static string? BuildEndSessionUrl(
+        string? endSessionEndpoint,
+        string? issuer,
+        string? idTokenHint,
+        string? clientId,
+        string? postLogoutRedirectUri,
+        string? canonicalBaseUrl)
+    {
+        if (string.IsNullOrWhiteSpace(endSessionEndpoint)
+            || !Uri.TryCreate(endSessionEndpoint, UriKind.Absolute, out var endSession)
+            || (!string.Equals(endSession.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                && !string.Equals(endSession.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal)))
+        {
+            return null;
+        }
+
+        // Issuer host-binding: only redirect to the discovered issuer's own authority.
+        if (string.IsNullOrWhiteSpace(issuer)
+            || !Uri.TryCreate(issuer, UriKind.Absolute, out var issuerUri)
+            || !IsSameAuthority(endSession, issuerUri))
+        {
+            return null;
+        }
+
+        var query = new System.Text.StringBuilder();
+
+        if (!string.IsNullOrEmpty(idTokenHint))
+        {
+            Append(query, "id_token_hint", idTokenHint);
+        }
+
+        if (!string.IsNullOrEmpty(clientId))
+        {
+            Append(query, "client_id", clientId);
+        }
+
+        // Allow-list the return URL against this server's canonical base; omit it otherwise.
+        if (IsAllowedPostLogoutRedirect(postLogoutRedirectUri, canonicalBaseUrl, out var allowed))
+        {
+            Append(query, "post_logout_redirect_uri", allowed);
+        }
+
+        // The endpoint may already carry a query (RFC 6749 §3.1); use '?' or '&' accordingly. When there is
+        // nothing to add, return it unchanged.
+        if (query.Length == 0)
+        {
+            return endSessionEndpoint;
+        }
+
+        var separator = string.IsNullOrEmpty(endSession.Query) ? "?" : "&";
+        return endSessionEndpoint + separator + query;
+    }
+
+    // Two URIs share an authority when scheme, host (ordinal-ignore-case per DNS), and effective port match.
+    private static bool IsSameAuthority(Uri a, Uri b)
+        => string.Equals(a.Scheme, b.Scheme, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(a.Host, b.Host, StringComparison.OrdinalIgnoreCase)
+            && a.Port == b.Port;
+
+    // The return URL is allowed only when it normalizes to a valid base and sits at or under the server's
+    // canonical base (same origin + path prefix), so logout can only return to this Jellyfin.
+    private static bool IsAllowedPostLogoutRedirect(string? candidate, string? canonicalBaseUrl, out string allowed)
+    {
+        allowed = string.Empty;
+        if (string.IsNullOrWhiteSpace(candidate)
+            || string.IsNullOrWhiteSpace(canonicalBaseUrl)
+            || !Uri.TryCreate(candidate, UriKind.Absolute, out var candidateUri)
+            || (!string.Equals(candidateUri.Scheme, Uri.UriSchemeHttp, StringComparison.Ordinal)
+                && !string.Equals(candidateUri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+            || !string.IsNullOrEmpty(candidateUri.UserInfo)
+            || !Uri.TryCreate(canonicalBaseUrl, UriKind.Absolute, out var baseUri))
+        {
+            return false;
+        }
+
+        // Same authority as the canonical base, and its path is under the base path — a prefix check on the
+        // canonicalized origin+path, so a sibling host or a path-traversal cannot slip through.
+        if (!IsSameAuthority(candidateUri, baseUri))
+        {
+            return false;
+        }
+
+        var basePath = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        var candidatePath = candidateUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        allowed = candidate;
+        return true;
+    }
+
+    private static void Append(System.Text.StringBuilder query, string name, string value)
+    {
+        if (query.Length > 0)
+        {
+            query.Append('&');
+        }
+
+        query.Append(name).Append('=').Append(Uri.EscapeDataString(value));
+    }
+}

--- a/SSO-Auth/Config/LogoutSession.cs
+++ b/SSO-Auth/Config/LogoutSession.cs
@@ -48,6 +48,13 @@ public class LogoutSession
     public string Issuer { get; set; }
 
     /// <summary>
+    /// Gets or sets the OpenID <c>end_session_endpoint</c> captured from discovery at login (#727, SLO-2),
+    /// so an RP-initiated logout needs no runtime rediscovery. Blank when the OP advertises none (or for
+    /// SAML), in which case logout falls back to local-only. Not a secret — a public provider URL.
+    /// </summary>
+    public string EndSessionEndpoint { get; set; }
+
+    /// <summary>
     /// Gets or sets the raw OpenID <c>id_token</c> used as the <c>id_token_hint</c> for an RP-initiated
     /// logout (OpenID only; blank for SAML). A bearer secret: encrypted at rest and never returned over JSON.
     /// </summary>

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -187,6 +187,16 @@ public abstract class ProviderConfigBase
     public bool Enabled { get; set; }
 
     /// <summary>
+    /// Gets or sets the URL the identity provider should return the browser to after an RP-initiated logout
+    /// (#727, SLO-2), sent as <c>post_logout_redirect_uri</c>. It is honoured only when it sits at or under
+    /// this server's canonical base URL (an open-redirect defense enforced by <c>OidcLogout</c>); an off-base
+    /// or malformed value is silently ignored (the logout still completes, without a redirect back). Blank
+    /// means no post-logout redirect. No effect while <see cref="PluginConfiguration.EnableSingleLogout"/> is
+    /// off.
+    /// </summary>
+    public string PostLogoutRedirectUri { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
     /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
     /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a


### PR DESCRIPTION
# What & why

SLO-2 of #727: the **OIDC RP-initiated logout**, the first consumer of the captured session state. A new authenticated `/sso/OID/logout/{provider}` route ends the caller's local Jellyfin session, then (when the caller has a captured OpenID session for the provider) redirects the browser to the identity provider's `end_session_endpoint` with the stored `id_token_hint`, terminating the IdP session too. My chosen approach: the full route + IdP redirect (standard RP-initiated semantics).

## Design & security controls

- **`OidcLogout` (pure builder, exhaustively unit-tested):** two fail-closed defenses, the `end_session_endpoint` is accepted only when **host-bound to the discovered issuer authority** (a tampered discovery can't redirect the browser elsewhere), and the `post_logout_redirect_uri` is included only when **allow-listed at or under this server's canonical base** (same-authority + path-prefix + `UserInfo`-reject). A blank endpoint → `null` → local-only logout.
- **The endpoint:** every action is **scoped to the caller**, the lookup is by the caller's own user id (new `SessionLogoutStore.FindByUser`, newest-first, blank-user matches nothing) and the local logout ends the caller's own token. The `id_token` is **revealed only at send time** and the consumed entry is **removed** so it is not retained. The `end_session_endpoint` is captured from the login's discovery (extending the SLO-1b capture) so logout needs **no runtime rediscovery**.
- **No open redirect:** the local-only fallback is a host-independent `LocalRedirect("~/")` (ASP.NET rejects any non-local value), deliberately **not** an absolute canonical-base redirect, which a spoofed `Host` could hijack. The IdP redirect is the issuer-host-bound URL.
- **Fail-safe:** the local logout runs first; a reveal/build fault degrades to the local redirect (never a 500). A missing endpoint / disabled feature → local-only.

Refs #727.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed / fail-safe: local logout always runs; build faults degrade to a local redirect; a blank/unsafe endpoint → local-only.
- [x] No secrets logged: the `id_token` is revealed only at send, travels only to the issuer-host-bound endpoint (per OIDC spec), is `[JsonIgnore]` + encrypted at rest, and redacted from `ToString`; no log carries it.
- [x] A security review was performed: 3-lens adversarial review (authz/scoping, open-redirect/SSRF, availability/correctness). Authz = PASS (no cross-user reach, every action is caller-scoped, IDOR-refuted), open-redirect = PASS (host-binding + LocalRedirect + admin-only allow-list candidate). The availability lens's findings, the reveal/build fail-safe, the multi-session documentation, and the controller-level fail-safe tests, are all incorporated.
- [x] IdP input: the `end_session`/`issuer` are captured server-side from discovery/the signed id_token, ride the `[JsonIgnore]` server-managed store, and cannot be set via a config PUT.

## Quality checklist

- [x] No duplicated logic; `OidcLogout` reuses `CanonicalBaseUrl`; the endpoint reuses the SLO-1 store + the injected secret store.
- [x] Minimal; the keystone (`VerifiedIdentity`) stays untouched, the logout material rides the OpenID flow types.
- [x] Self-documenting; comments explain the host-binding, allow-listing, LocalRedirect, and best-effort multi-session rationale.
- [x] Architecture-conformance: `Http` imports the `Logout` leaf (DAG updated); `OidLogout` is correctly in the plain-`[Authorize]` (non-elevated, self-service) roster.
- [x] Docs impact: the admin-page toggle for `PostLogoutRedirectUri`/`EnableSingleLogout` and the `SECURITY.md` posture land with SLO-4/5.

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 + net10.0 (0 warnings).
- [x] `dotnet test` green: 1786/1786 on both TFMs (builder host-binding/allow-list/escaping, `FindByUser`, capture round-trip, and the controller-level fail-safe: captured→issuer-redirect+local-logout+entry-removed, none→local-redirect+local-logout).
- [ ] Prettier: n/a, no `.js` / `.html` / `.css` / `.md` change.

## Notes

- **Next (tracked on #727):** SLO-3 (SAML SLO + the SAML capture), SLO-4 (Logout rate-limit + audit + admin-UI for the new config), SLO-5 (`SECURITY.md` + full `/security-review`).
- **Best-effort, documented:** with multiple concurrent sessions for one provider, the id_token_hint's session may differ from the exact session ended, both the caller's own; the hint stays valid for the same subject at the same issuer.