### PR TITLE
Deduplicate the SAML metadata action doc; document two nested members

### DIFF
--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -592,12 +592,9 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
-    /// Serves this service provider's SAML 2.0 metadata for <paramref name="provider"/> (#162), so an
-    /// administrator can register the SP at the identity provider by URL instead of hand-configuring the
-    /// entity id, assertion-consumer URL and signing certificate. Anonymous by design — SP metadata is
-    /// public (a real identity provider fetches it unauthenticated) — and deliberately request-free: the
-    /// published entity id and ACS URL are built only from the provider's configured canonical Base URL,
-    /// never the request Host.
+    /// Serves this service provider's SAML 2.0 metadata for <paramref name="provider"/> (#162). The
+    /// request-free, canonical-Base-URL-only construction and its fail-closed rationale live on the single
+    /// authoritative implementation, <see cref="SamlLoginService.Metadata"/>.
     /// </summary>
     /// <param name="provider">The SAML provider whose metadata to serve.</param>
     /// <returns>The SP metadata document, or a fail-closed rejection when the provider is unknown/disabled or its canonical Base URL is unconfigured.</returns>

--- a/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
+++ b/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
@@ -124,6 +124,7 @@ internal sealed class KeyedLockStore
             _holder = holder;
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0)

--- a/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
@@ -153,6 +153,7 @@ internal static class SamlSpMetadataBuilder
     // default StringWriter reports UTF-16, which would mislabel the served UTF-8 document).
     private sealed class Utf8StringWriter : StringWriter
     {
+        /// <inheritdoc/>
         public override Encoding Encoding => Encoding.UTF8;
     }
 }


### PR DESCRIPTION
## What & why
From the repo-wide cleanup audit (Tier 1, Unit 1). Closes #865.

- The delegating `SamlMetadata` controller action (`SSOController`) carried a full second copy of the request-free / canonical-Base-URL-only / fail-closed rationale that already lives on the single authoritative implementation `SamlLoginService.Metadata`. Two copies of one security contract drift independently, the action now states its purpose in one line and points at the implementation with a `cref`.
- Closed two SA1600-invisible doc gaps (both nested in private classes, so CS1591 never flagged them): `<inheritdoc/>` on `Utf8StringWriter.Encoding` and on `Releaser.Dispose`.

## Type of change
Documentation / code-quality. No behaviour change.

## Security & quality
- No behaviour, control-flow, or security surface touched, pure documentation.
- The single authoritative security-why doc on `SamlLoginService.Metadata` is unchanged; the removed copy was redundant, not load-bearing in its own right.
- Builds clean under `--warnaserror` (0 warnings) on both target frameworks; the new `cref` resolves.

## Review gate
Doc-only, no security surface → standard CI gate. Part of the audit-driven cleanup series (#865–#870, #864); establishes the 'delegating members get a one-liner + pointer, not a duplicated doc' rule that #871 anchors and #873 guards.