### PR TITLE
Add a shared TestUsers.Named factory; remove three copied user helpers

### DIFF
--- a/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
@@ -135,14 +135,13 @@ public class AvatarServiceTests
     private static string ProfilePath(string username, string extension)
         => Path.Combine(UserDataRoot, username, "profile" + extension);
 
-    private static User UserNamed(string name) => new User(name, "SSO-Auth", "Default");
 
     [Fact]
     public async Task TrySetAsync_NullUrl_DoesNothing()
     {
         var (service, providers, users, _) = Build();
 
-        await service.TrySetAsync(UserNamed("alice"), null);
+        await service.TrySetAsync(TestUsers.Named("alice"), null);
 
         await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
@@ -158,7 +157,7 @@ public class AvatarServiceTests
     {
         var (service, providers, users, log) = Build();
 
-        await service.TrySetAsync(UserNamed("alice"), url);
+        await service.TrySetAsync(TestUsers.Named("alice"), url);
 
         await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
@@ -171,7 +170,7 @@ public class AvatarServiceTests
         // The #377 regression: a transient save failure must not downgrade the user from a working
         // avatar to a cleared record plus a dangling path — the write comes first, the user last.
         var (service, providers, users, _) = Build();
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         var previous = new ImageInfo(ProfilePath("alice", ".jpg"));
         user.ProfileImage = previous;
         providers.SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>())
@@ -192,7 +191,7 @@ public class AvatarServiceTests
         // it would drop and re-insert the record for nothing. The timestamp refresh is what makes
         // clients re-fetch the changed image.
         var (service, providers, users, _) = Build();
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = DateTime.UtcNow.AddDays(-1) };
         user.ProfileImage = previous;
 
@@ -210,7 +209,7 @@ public class AvatarServiceTests
         // A changed content type moves the stored path: the old record+file are dropped only once
         // the new bytes are safely on disk (write -> clear order is the rollback-safety property).
         var (service, providers, users, _) = Build();
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         user.ProfileImage = new ImageInfo(ProfilePath("alice", ".jpg"));
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
@@ -233,7 +232,7 @@ public class AvatarServiceTests
         // to a single consistent record. (Unrelated users never block each other — KeyedLockStoreTests.)
         var locks = new KeyedLockStore(StringComparer.Ordinal);
         var (service, providers, users, _) = Build(locks);
-        var user = UserNamed("racer");
+        var user = TestUsers.Named("racer");
 
         Task store;
         using (await locks.AcquireAsync(user.Username, TestContext.Current.CancellationToken))
@@ -264,7 +263,7 @@ public class AvatarServiceTests
         // exception into the best-effort login path.
         var locks = new KeyedLockStore(StringComparer.Ordinal);
         var (service, providers, users, log) = Build(locks, TimeSpan.FromMilliseconds(50));
-        var user = UserNamed("racer");
+        var user = TestUsers.Named("racer");
         var previous = new ImageInfo(ProfilePath("racer", ".jpg"));
         user.ProfileImage = previous;
 
@@ -289,7 +288,7 @@ public class AvatarServiceTests
         // wait, it does not shrink the normal-load window.
         var locks = new KeyedLockStore(StringComparer.Ordinal);
         var (service, providers, _, log) = Build(locks, TimeSpan.FromSeconds(3));
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
 
@@ -309,7 +308,7 @@ public class AvatarServiceTests
         // lock) until we release it, so the second store provably cannot enter until then.
         var locks = new KeyedLockStore(StringComparer.Ordinal);
         var (service, providers, users, _) = Build(locks);
-        var user = UserNamed("racer");
+        var user = TestUsers.Named("racer");
         var ct = TestContext.Current.CancellationToken;
 
         var pngPath = ProfilePath("racer", ".png"); // the first store's target
@@ -360,7 +359,7 @@ public class AvatarServiceTests
     public async Task StoreAsync_NoPreviousImage_AssignsWithoutClearing()
     {
         var (service, providers, users, _) = Build();
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
 
@@ -383,7 +382,7 @@ public class AvatarServiceTests
         // fail closed: no out-of-directory write (SaveImage is never called with any path), no throw (login
         // is best-effort and must still complete), and no profile-image record.
         var (service, providers, users, log) = Build();
-        var user = UserNamed(username);
+        var user = TestUsers.Named(username);
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
 
@@ -399,7 +398,7 @@ public class AvatarServiceTests
         // Fail-closed must not be destructive either: a rejected ".." username skips the write AND leaves
         // any previously set profile-image record exactly as it was (no clear, no re-point).
         var (service, providers, users, _) = Build();
-        var user = UserNamed("..");
+        var user = TestUsers.Named("..");
         var previous = new ImageInfo(ProfilePath("alice", ".jpg"));
         user.ProfileImage = previous;
 
@@ -420,7 +419,7 @@ public class AvatarServiceTests
         // stripped, so "victim." is a distinct literal directory and the avatar stores there normally.
         // Either way there is no cross-user write and no escape.
         var (service, providers, users, log) = Build();
-        var user = UserNamed("victim.");
+        var user = TestUsers.Named("victim.");
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
 
@@ -444,7 +443,7 @@ public class AvatarServiceTests
         // Behavior preserved for legitimate usernames the host allows (dots and '@' are valid — e.g. an
         // email-style preferred_username): the store path is unchanged and the write happens as before.
         var (service, providers, _, _) = Build();
-        var user = UserNamed("first.last@example.com");
+        var user = TestUsers.Named("first.last@example.com");
 
         await service.StoreAsync(user, new MemoryStream(new byte[] { 1 }), "image/png", ".png");
 
@@ -484,7 +483,7 @@ public class AvatarServiceTests
         using var response = ImageResponse("text/html", Encoding.UTF8.GetBytes("<html></html>"));
         var (service, providers, users, log) = Build(response);
 
-        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
 
         await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
         await users.DidNotReceive().ClearProfileImageAsync(Arg.Any<User>());
@@ -498,7 +497,7 @@ public class AvatarServiceTests
         using var response = ImageResponse("image/png", new byte[1], contentLength: AvatarService.MaxAvatarBytes + 1);
         var (service, providers, _, _) = Build(response);
 
-        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
 
         await providers.DidNotReceive().SaveImage(Arg.Any<Stream>(), Arg.Any<string>(), Arg.Any<string>());
     }
@@ -511,7 +510,7 @@ public class AvatarServiceTests
         using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
         var (service, providers, _, _) = Build(response);
 
-        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
 
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
     }
@@ -541,7 +540,7 @@ public class AvatarServiceTests
         // download/store nothing. 304 must be handled BEFORE EnsureSuccessStatusCode (which throws on it).
         using var response = NotModifiedResponse();
         var (service, providers, users, handler, log) = BuildWithHandler(response);
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
         user.ProfileImage = previous;
 
@@ -566,7 +565,7 @@ public class AvatarServiceTests
         // the new bytes are fetched and re-stored over the same path — the conditional header was still sent.
         using var response = ImageResponse("image/png", new byte[] { 9 });
         var (service, providers, _, handler, _) = BuildWithHandler(response);
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
 
         await service.TrySetAsync(user, AllowedUrl);
@@ -583,7 +582,7 @@ public class AvatarServiceTests
         using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
         var (service, providers, _, handler, _) = BuildWithHandler(response);
 
-        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
 
         Assert.Null(handler.LastIfModifiedSince);
         await providers.Received(1).SaveImage(Arg.Any<Stream>(), "image/png", ProfilePath("alice", ".png"));
@@ -599,7 +598,7 @@ public class AvatarServiceTests
         // the self-heal that the always-download behaviour had before #248, back for the missing-file case only.
         using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
         var (service, providers, _, handler, _) = BuildWithHandler(response, fileExists: _ => false);
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
 
         await service.TrySetAsync(user, AllowedUrl);
@@ -619,7 +618,7 @@ public class AvatarServiceTests
         // Pins that the header is suppressed and that the 304 short-circuit stays safe when the file is missing.
         using var response = NotModifiedResponse();
         var (service, providers, users, handler, log) = BuildWithHandler(response, fileExists: _ => false);
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         var previous = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc) };
         user.ProfileImage = previous;
 
@@ -642,7 +641,7 @@ public class AvatarServiceTests
         // `>`->`>=` slip would send the sentinel as the conditional header, which this asserts against.
         using var response = ImageResponse("image/png", new byte[] { 1, 2, 3 });
         var (service, providers, _, handler, _) = BuildWithHandler(response); // file present (default _ => true)
-        var user = UserNamed("alice");
+        var user = TestUsers.Named("alice");
         user.ProfileImage = new ImageInfo(ProfilePath("alice", ".png")) { LastModified = DateTime.MinValue };
 
         await service.TrySetAsync(user, AllowedUrl);
@@ -682,8 +681,8 @@ public class AvatarServiceTests
         using var response = ImageResponse("image/png", new byte[] { 1 });
         var (service, _, _, handler, _) = BuildWithHandler(response);
 
-        await service.TrySetAsync(UserNamed("alice"), AllowedUrl);
-        await service.TrySetAsync(UserNamed("bob"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("alice"), AllowedUrl);
+        await service.TrySetAsync(TestUsers.Named("bob"), AllowedUrl);
 
         Assert.Equal(2, handler.Invocations);
     }

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -39,7 +39,6 @@ public class LoginCompletionServiceTests
     private static readonly Guid Created = Guid.Parse("33333333-3333-3333-3333-333333333333");
     private static readonly Guid Existing = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
-    private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
 
     private static (LoginCompletionService Service, PluginConfiguration Config, IUserManager Users, ISessionManager Sessions) Build(Action<PluginConfiguration> seed)
     {
@@ -85,7 +84,7 @@ public class LoginCompletionServiceTests
     {
         var config = new OidConfig { Enabled = true };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -109,7 +108,7 @@ public class LoginCompletionServiceTests
         // when the OpenID path supplies the id_token/sid.
         var config = new OidConfig { Enabled = true };
         var (service, cfg, users, sessions) = Build(c => c.OidConfigs["kc"] = config); // EnableSingleLogout defaults off
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -133,7 +132,7 @@ public class LoginCompletionServiceTests
             c.EnableSingleLogout = true;
             c.OidConfigs["kc"] = config;
         });
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -158,7 +157,7 @@ public class LoginCompletionServiceTests
             c.EnableSingleLogout = true;
             c.OidConfigs["kc"] = config;
         });
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -189,7 +188,7 @@ public class LoginCompletionServiceTests
         // and pass the per-unit tests while silently failing to reach the mint; this fails if it does.
         var config = new OidConfig { Enabled = true, EnableAuthorization = true };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         created.MaxParentalRatingScore = 100; // a looser existing value the resolved ceiling must overwrite
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
@@ -210,7 +209,7 @@ public class LoginCompletionServiceTests
         // account, mint the session, carry the supplied remote endpoint — indistinguishable from OpenID.
         var config = new SamlConfig { Enabled = true };
         var (service, _, users, sessions) = Build(c => c.SamlConfigs["okta"] = config);
-        var created = UserNamed("bob", Created);
+        var created = TestUsers.Named("bob", Created);
         users.GetUserByName("bob").Returns((User?)null);
         users.CreateUserAsync("bob").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -249,7 +248,7 @@ public class LoginCompletionServiceTests
             c.DisablePasswordLogin = true;
             c.BreakGlassAdminUsername = "root";
         });
-        var root = UserNamed("root", Existing);
+        var root = TestUsers.Named("root", Existing);
         root.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId;
         root.SetPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator, true);
         users.GetUserById(Existing).Returns(root);
@@ -284,7 +283,7 @@ public class LoginCompletionServiceTests
             c.DisablePasswordLogin = true;
             c.BreakGlassAdminUsername = "root";
         });
-        var alice = UserNamed("alice", Existing);
+        var alice = TestUsers.Named("alice", Existing);
         alice.AuthenticationProviderId = SsoAuthenticationProviders.DefaultPasswordProviderId; // still had a password door
         users.GetUserById(Existing).Returns(alice);
         users.GetUserByName("alice").Returns(alice);
@@ -307,7 +306,7 @@ public class LoginCompletionServiceTests
         // moved as a whole unit, so a refusal cannot fall through to the mint.
         var config = new OidConfig { Enabled = true, AllowExistingAccountLink = false };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         var result = await service.CompleteAsync(
             OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
@@ -326,7 +325,7 @@ public class LoginCompletionServiceTests
         // minted. This is the core fail-closed onboarding control.
         var config = new OidConfig { Enabled = true, ProvisionNewUsersDisabled = true };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        var created = UserNamed("alice", Created);
+        var created = TestUsers.Named("alice", Created);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Created).Returns(created);
@@ -355,7 +354,7 @@ public class LoginCompletionServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        var existing = UserNamed("alice", Existing);
+        var existing = TestUsers.Named("alice", Existing);
         existing.SetPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsAdministrator, true);
         users.GetUserById(Existing).Returns(existing);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -382,7 +381,7 @@ public class LoginCompletionServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         };
         var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config);
-        var pending = UserNamed("alice", Existing);
+        var pending = TestUsers.Named("alice", Existing);
         pending.SetPermission(Jellyfin.Database.Implementations.Enums.PermissionKind.IsDisabled, true);
         users.GetUserById(Existing).Returns(pending);
 

--- a/SSO-Auth.Tests/Kernel/SSOControllerLogoutTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerLogoutTests.cs
@@ -25,7 +25,7 @@ public class SSOControllerLogoutTests
     private static SsoControllerHarness ForCaller(string token, Action<PluginConfiguration> configure)
     {
         var harness = new SsoControllerHarness(configure);
-        var user = new User("caller", "SSO-Auth", "Default") { Id = Caller };
+        var user = TestUsers.Named("caller", Caller);
         harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>())
             .Returns(System.Threading.Tasks.Task.FromResult(new AuthorizationInfo { User = user, Token = token }));
         return harness;

--- a/SSO-Auth.Tests/Kernel/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerOidAuthTests.cs
@@ -236,7 +236,7 @@ public class SSOControllerOidAuthTests
                 EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>(), AvatarUrl: null));
         OidcLoginService.SeedOidStateForTests(token, ready);
 
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(UserId).Returns(user);
     }

--- a/SSO-Auth.Tests/Kernel/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerOidPostTests.cs
@@ -73,7 +73,7 @@ public class SSOControllerOidPostTests
         // LoginCompletionService -> CanonicalLinkService runs against the fixture's actual token here.
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1");
-        var user = new User("alice", "SSO-Auth", "Default") { Id = Guid.Parse("55555555-5555-5555-5555-555555555555") };
+        var user = TestUsers.Named("alice", Guid.Parse("55555555-5555-5555-5555-555555555555"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 

--- a/SSO-Auth.Tests/Kernel/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerSamlAuthTests.cs
@@ -55,7 +55,7 @@ public class SSOControllerSamlAuthTests
             AllowExistingAccountLink = false,
             ValidateInResponseTo = validateInResponseTo,
         });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(UserId).Returns(user);
         return harness;

--- a/SSO-Auth.Tests/Kernel/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerSamlTokenTests.cs
@@ -48,7 +48,7 @@ public class SSOControllerSamlTokenTests
             EnableAuthorization = false,
             AllowExistingAccountLink = false,
         });
-        var provisioned = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var provisioned = TestUsers.Named("alice", UserId);
         harness.UserManager.CreateUserAsync("alice").Returns(provisioned);
         harness.UserManager.GetUserById(UserId).Returns(provisioned);
         user = provisioned;

--- a/SSO-Auth.Tests/Kernel/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/Kernel/SSOControllerUnregisterTests.cs
@@ -192,7 +192,7 @@ public class SSOControllerUnregisterTests
     // Registers a user with the harness's mocked IUserManager so GetUserByName resolves it.
     private static User SeedUser(SsoControllerHarness harness)
     {
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         harness.UserManager.GetUserByName("alice").Returns(user);
         return user;
     }

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -27,11 +27,10 @@ public class CanonicalLinkServiceTests
     private static readonly Guid Existing = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid Other = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
-    private static User UserNamed(string name, Guid id) => new User(name, "SSO-Auth", "Default") { Id = id };
 
     private static User AdminUserNamed(string name, Guid id)
     {
-        var user = UserNamed(name, id);
+        var user = TestUsers.Named(name, id);
         user.SetPermission(PermissionKind.IsAdministrator, true);
         return user;
     }
@@ -60,7 +59,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
 
@@ -72,7 +71,7 @@ public class CanonicalLinkServiceTests
     public async Task ResolveOrCreateAsync_NoLinkNoAccount_CreatesAndLinksOnTheSubjectKey()
     {
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
@@ -92,7 +91,7 @@ public class CanonicalLinkServiceTests
         // once at the provisioning event, and it is then reported as awaiting approval so the completion path
         // refuses the login.
         var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
@@ -114,7 +113,7 @@ public class CanonicalLinkServiceTests
         // ENABLED and link-less (a later login could adopt it and mint a session). It is deleted, the login
         // fails closed (the failure propagates), and no canonical link is written.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
@@ -137,7 +136,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        var pending = UserNamed("alice", Existing);
+        var pending = TestUsers.Named("alice", Existing);
         pending.SetPermission(PermissionKind.IsDisabled, true);
         users.GetUserById(Existing).Returns(pending);
 
@@ -155,7 +154,7 @@ public class CanonicalLinkServiceTests
         // Default (policy off): the new account is NOT disabled and is NOT persisted by the linking layer —
         // the session minter persists it, exactly as before #737. No behavior change for existing deployments.
         var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
@@ -172,10 +171,10 @@ public class CanonicalLinkServiceTests
     public void IsAccountAwaitingApproval_DisabledUser_True_EnabledUser_False_MissingUser_False()
     {
         var (service, _, users, _) = Build();
-        var disabled = UserNamed("alice", Existing);
+        var disabled = TestUsers.Named("alice", Existing);
         disabled.SetPermission(PermissionKind.IsDisabled, true);
         users.GetUserById(Existing).Returns(disabled);
-        users.GetUserById(Other).Returns(UserNamed("bob", Other)); // enabled
+        users.GetUserById(Other).Returns(TestUsers.Named("bob", Other)); // enabled
         users.GetUserById(Arg.Is<Guid>(g => g != Existing && g != Other)).Returns((User?)null); // missing
 
         Assert.True(service.IsAccountAwaitingApproval(Existing));
@@ -187,8 +186,8 @@ public class CanonicalLinkServiceTests
     public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
     {
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
@@ -204,7 +203,7 @@ public class CanonicalLinkServiceTests
         // with adoption off, must be refused — not silently take the account over. No controller test
         // reached this path before the extraction; this pins it directly.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false));
@@ -241,8 +240,8 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true);
 
@@ -264,8 +263,8 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "alice", allowExistingAccountLink: false));
@@ -295,9 +294,9 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("renamed-alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("renamed-alice", Existing));
         users.GetUserByName("alice").Returns((User?)null);
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
 
@@ -335,8 +334,8 @@ public class CanonicalLinkServiceTests
         };
         var store = new ProviderConfigStore(() => cfg, _ => { }, new CapturingLogger());
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
         var log = new CapturingLogger();
 
         var now = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
@@ -386,9 +385,9 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("newname", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("newname", Existing));
         users.GetUserByName("oldname").Returns((User?)null); // renamed: no live account bears the key
-        var created = UserNamed("oldname", Other);
+        var created = TestUsers.Named("oldname", Other);
         users.CreateUserAsync("oldname").Returns(created);
         users.GetUserById(Other).Returns(created);
 
@@ -419,9 +418,9 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["oldname"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("newname", Existing)); // the victim, renamed away
-        users.GetUserByName("oldname").Returns(UserNamed("oldname", Other)); // a different account now holds the name
-        users.GetUserById(Other).Returns(UserNamed("oldname", Other));
+        users.GetUserById(Existing).Returns(TestUsers.Named("newname", Existing)); // the victim, renamed away
+        users.GetUserByName("oldname").Returns(TestUsers.Named("oldname", Other)); // a different account now holds the name
+        users.GetUserById(Other).Returns(TestUsers.Named("oldname", Other));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "attacker-sub", "oldname", allowExistingAccountLink: true);
 
@@ -444,7 +443,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["opaque-sub-123"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "opaque-sub-123", "opaque-sub-123", allowExistingAccountLink: false);
 
@@ -479,8 +478,8 @@ public class CanonicalLinkServiceTests
         var cfg = new PluginConfiguration();
         cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         // The first store access is the candidate-resolving Read; the second is the migrate Mutate.
         // Removing the provider on the second access reproduces an admin delete racing the login.
@@ -519,7 +518,7 @@ public class CanonicalLinkServiceTests
         var cfg = new PluginConfiguration();
         cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
         var persists = 0;
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
@@ -539,8 +538,8 @@ public class CanonicalLinkServiceTests
         var cfg = new PluginConfiguration();
         cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
         var persists = 0;
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
@@ -565,8 +564,8 @@ public class CanonicalLinkServiceTests
         var cfg = new PluginConfiguration();
         cfg.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing } };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         // Access 1 is the candidate-resolving Read; access 2 is the migrate Mutate. Interposing the
         // concurrent winner's committed migration right before the second access reproduces the race
@@ -941,7 +940,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         Assert.True(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
@@ -955,7 +954,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         Assert.True(service.IsIdentityStillLinked(ProviderMode.Saml, "adfs", "alice", Existing));
     }
@@ -970,7 +969,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         service.RemoveUserEverywhere(Existing);
 
@@ -987,7 +986,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
         cfg.OidConfigs["kc"].Enabled = false;
 
         Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
@@ -1023,7 +1022,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Other },
         });
-        users.GetUserById(Other).Returns(UserNamed("bob", Other));
+        users.GetUserById(Other).Returns(TestUsers.Named("bob", Other));
 
         Assert.False(service.IsIdentityStillLinked(ProviderMode.Oid, "kc", "sub-1", Existing));
     }
@@ -1064,7 +1063,7 @@ public class CanonicalLinkServiceTests
             Enabled = false,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
@@ -1084,7 +1083,7 @@ public class CanonicalLinkServiceTests
         users.GetUserByName("alice").Returns(_ =>
         {
             cfg.OidConfigs["kc"].Enabled = false;
-            return UserNamed("alice", Existing);
+            return TestUsers.Named("alice", Existing);
         });
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
@@ -1111,9 +1110,9 @@ public class CanonicalLinkServiceTests
         users.GetUserById(Existing).Returns(_ =>
         {
             cfg.OidConfigs["kc"].Enabled = false;
-            return UserNamed("alice", Existing);
+            return TestUsers.Named("alice", Existing);
         });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true));
@@ -1190,8 +1189,8 @@ public class CanonicalLinkServiceTests
         // #218: with the verified-email gate on, a non-admin login carrying email_verified == true clears
         // it and adopts, keying the link on the stable subject as usual.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: true));
 
@@ -1207,7 +1206,7 @@ public class CanonicalLinkServiceTests
         // #218: with the gate on, an absent or false email_verified claim fails closed — no link, no
         // account, and the takeover-blocking 403 (AccountLinkForbiddenException) is thrown.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: true, EmailVerified: emailVerified)));
@@ -1258,7 +1257,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["1"] = Existing },
             CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["1"] = OldIssuer },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "1", "mallory", allowExistingAccountLink: false, issuer: NewIssuer));
@@ -1285,7 +1284,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer },
         };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
         var persists = 0;
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
@@ -1309,7 +1308,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         };
         var users = Substitute.For<IUserManager>();
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
         var persists = 0;
         var store = new ProviderConfigStore(() => cfg, _ => persists++, new CapturingLogger());
         var service = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
@@ -1331,7 +1330,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         // First login stamps the current issuer.
         await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: OldIssuer);
@@ -1354,7 +1353,7 @@ public class CanonicalLinkServiceTests
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
             CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = OldIssuer },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
             service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: null));
@@ -1366,7 +1365,7 @@ public class CanonicalLinkServiceTests
         // A newly created account's link is issuer-bound at creation (#186), so it is protected from the
         // first login onward, not only after a later trust-on-first-use pass.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        var created = UserNamed("alice", Other);
+        var created = TestUsers.Named("alice", Other);
         users.GetUserByName("alice").Returns((User?)null);
         users.CreateUserAsync("alice").Returns(created);
         users.GetUserById(Other).Returns(created);
@@ -1381,8 +1380,8 @@ public class CanonicalLinkServiceTests
     public async Task ResolveOrCreateAsync_AdoptExistingAccount_StampsTheLoginIssuer()
     {
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, issuer: NewIssuer);
 
@@ -1400,8 +1399,8 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, issuer: NewIssuer);
 
@@ -1421,7 +1420,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false, issuer: null);
 
@@ -1439,7 +1438,7 @@ public class CanonicalLinkServiceTests
             Enabled = true,
             CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
         });
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Saml, "adfs", "alice", "alice", allowExistingAccountLink: false, issuer: NewIssuer);
 
@@ -1503,8 +1502,8 @@ public class CanonicalLinkServiceTests
         // email_verified claim, so a conformant deployment already using AllowExistingAccountLink is not
         // silently locked out on upgrade.
         var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
-        users.GetUserByName("alice").Returns(UserNamed("alice", Existing));
-        users.GetUserById(Existing).Returns(UserNamed("alice", Existing));
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
         var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: true, new AdoptionGate(RequireVerifiedEmail: false, EmailVerified: null));
 

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -51,7 +51,7 @@ public class OidcRoundTripTests
         var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken));
 
         // Provision hooks the completion tail drives for a first-time login of "alice".
-        var user = new User("alice", "SSO-Auth", "Default") { Id = Guid.Parse("19999999-1111-1111-1111-111111111111") };
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111111"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
@@ -154,7 +154,7 @@ public class OidcRoundTripTests
             cfg.AcrValues = "phr mfa";
             cfg.RequireAcr = true;
         });
-        var user = new User("alice", "SSO-Auth", "Default") { Id = Guid.Parse("19999999-1111-1111-1111-111111111112") };
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111112"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
@@ -201,7 +201,7 @@ public class OidcRoundTripTests
         // Default: with RequireAcr off, an id_token that carries no acr logs in unchanged (no new gate).
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
-        var user = new User("alice", "SSO-Auth", "Default") { Id = Guid.Parse("19999999-1111-1111-1111-111111111113") };
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111113"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 

--- a/SSO-Auth.Tests/Session/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/Session/SessionMinterTests.cs
@@ -97,7 +97,7 @@ public class SessionMinterTests
         // The extraction's one behavior change: the controller resolves the client IP from HttpContext and
         // passes it in, so it must land on the AuthenticationRequest unchanged (#177) alongside the user.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         users.GetUserById(UserId).Returns(user);
         AuthenticationRequest? captured = null;
         sessions.AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => captured = r)).Returns(new AuthenticationResult());
@@ -117,7 +117,7 @@ public class SessionMinterTests
         // Live TV grants — and folder access is restricted (!EnableAllFolders), which also writes the
         // enabled-folder list as a preference.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         // Seed the OPPOSITE state so the assertions prove the grant flipped, not just that a fresh user
         // happens to match: start with all-folders granted and no admin.
         user.SetPermission(PermissionKind.EnableAllFolders, true);
@@ -142,7 +142,7 @@ public class SessionMinterTests
         // The other side of the EnableAllFolders branch: all folders granted, so the enabled-folder
         // preference write is skipped (that path is only for the restricted case above).
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         user.SetPermission(PermissionKind.EnableAllFolders, false); // seed a restriction, so the grant must flip to true
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -160,7 +160,7 @@ public class SessionMinterTests
         // to false; a correct skip leaves the seeded admin intact. This pins that EnableAuthorization
         // gates the block AND that it never touches pre-existing permissions when off.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         user.SetPermission(PermissionKind.IsAdministrator, true);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -177,7 +177,7 @@ public class SessionMinterTests
         // a granted permission is set true and a revoked one set false. Seed the OPPOSITE of each so the
         // assertions prove the mint flipped them, not that a fresh user happened to match.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         user.SetPermission(PermissionKind.EnableContentDownloading, false); // grant must flip to true
         user.SetPermission(PermissionKind.EnableContentDeletion, true); // revoke must flip to false
         users.GetUserById(UserId).Returns(user);
@@ -205,7 +205,7 @@ public class SessionMinterTests
         // (#215): with it off, a mapped permission is NOT applied. Seed the opposite of the grant and pass
         // the master switch off — a correct skip leaves the seed intact.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         user.SetPermission(PermissionKind.EnableContentDownloading, false);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -229,7 +229,7 @@ public class SessionMinterTests
         // recovery admin becomes useless once the IdP is down. Seed admin=true so the assertion proves the
         // demotion was SUPPRESSED, not that a fresh user happened to be non-admin.
         var (minter, users, sessions) = Build();
-        var user = new User("root", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("root", UserId);
         user.SetPermission(PermissionKind.IsAdministrator, true);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -249,7 +249,7 @@ public class SessionMinterTests
         // its login carries no admin claim (default-deny). The exemption is narrow — it must never leak to
         // ordinary accounts. Seed admin=true; a correct write flips it to false.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         user.SetPermission(PermissionKind.IsAdministrator, true);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
@@ -269,7 +269,7 @@ public class SessionMinterTests
         // one UpdateUserAsync, so it persists in a single write (#391) — the pre-extraction Authenticate
         // wrote the user a second time just for this field.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         users.GetUserById(UserId).Returns(user);
         sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
 
@@ -292,7 +292,7 @@ public class SessionMinterTests
         // The first gate refuses BEFORE any user side effect, so no grants are persisted and no session is
         // minted — fail closed exactly like the deleted-user guard.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         users.GetUserById(UserId).Returns(user);
 
         await Assert.ThrowsAsync<AuthenticationException>(() => minter.MintAsync(Params(), () => "203.0.113.7", () => false));
@@ -309,7 +309,7 @@ public class SessionMinterTests
         // immediately before AuthenticateDirect (so a revocation landing mid-mint still yields no session).
         // A recording predicate captures the state at each firing.
         var (minter, users, sessions) = Build();
-        var user = new User("alice", "SSO-Auth", "Default") { Id = UserId };
+        var user = TestUsers.Named("alice", UserId);
         users.GetUserById(UserId).Returns(user);
 
         var userWritten = false;

--- a/SSO-Auth.Tests/_Support/TestUsers.cs
+++ b/SSO-Auth.Tests/_Support/TestUsers.cs
@@ -1,0 +1,24 @@
+using System;
+using Jellyfin.Database.Implementations.Entities;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Factory for the Jellyfin <see cref="User"/> that SSO tests provision. Every SSO test user shares the same
+/// authentication-provider pair (<c>"SSO-Auth"</c> authentication provider id, <c>"Default"</c> password-reset
+/// provider id); keeping that pair here means renaming the provider id is one edit, not a sweep across every
+/// test file. Composition, not a base class — a test that needs extra state sets it on the returned user.
+/// </summary>
+internal static class TestUsers
+{
+    /// <summary>Creates a user against this plugin's authentication provider, id left at the entity default.</summary>
+    internal static User Named(string name) => new(name, "SSO-Auth", "Default");
+
+    /// <summary>Creates a user as <see cref="Named(string)"/> with an explicit <see cref="User.Id"/>.</summary>
+    internal static User Named(string name, Guid id)
+    {
+        var user = Named(name);
+        user.Id = id;
+        return user;
+    }
+}


### PR DESCRIPTION
## What & why
From the repo-wide cleanup audit (Tier 1, Unit 2). Closes #866.

Three test files each defined a byte-identical `UserNamed` helper, and the `"SSO-Auth"`/`"Default"` authentication-provider pair was hand-written across 35 call sites in 15 files, a provider-id rename would have been a sweep.

- Add one `_Support/TestUsers.Named` factory: two overloads (name-only; name+id for the common pinned-id case). The pair now lives in exactly one place.
- Delete the three local `UserNamed` helpers and point their callers, plus the identical id-only `new User(...) { Id = ... }` sites, at the factory.
- **Deliberately left inline** (they set a field the factory does not model, per the audit): the SSO-only `Password` seeds, the `MaxParentalRatingScore` seeds, and the `EnableUserPreferenceAccess` sites.

## Test architecture note
Composition, not a base class, the audit's decisive answer was that no test-inheritance tier is warranted anywhere in this repo; the one real shared-construction win is this flat factory. This establishes that as the standard (#871).

## Type of change
Test-only refactor. No production code touched.

## Security & quality
- No behaviour change: **all 1786 tests pass on net9.0 and net10.0**; the factory reproduces each call site's construction exactly.
- Builds clean under `--warnaserror` on both TFMs.

## Review gate
Test-only, no security surface → standard CI gate.