### PR TITLE
Collapse the two identical SAML signing-key resolvers into one helper

### DIFF
--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -113,41 +113,25 @@ internal static class ServerManagedFields
         }
 
         incoming.CanonicalLinks = live.CanonicalLinks;
-        incoming.SamlSigningKeyPfx = ResolveUpdatedSigningKey(incoming, live);
-
-        // The rollover signing key (#491) is withheld from JSON exactly like the primary, so a config-page
-        // save arrives with it blank and must keep the stored value; a non-blank incoming value is an
-        // intentional rotation of the overlap key and wins. Same no-identity-guard reasoning as the primary.
-        incoming.SamlRolloverSigningKeyPfx = ResolveUpdatedRolloverSigningKey(incoming, live);
+        incoming.SamlSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlSigningKeyPfx, live.SamlSigningKeyPfx);
+        incoming.SamlRolloverSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlRolloverSigningKeyPfx, live.SamlRolloverSigningKeyPfx);
     }
 
     /// <summary>
-    /// Decides which service-provider signing key an updated SAML provider should keep (#167). A non-blank
-    /// incoming key is an explicit rotation and wins; a blank one keeps the stored key, so a config-page
-    /// save (which never carries the withheld key) does not wipe it. Unlike the OpenID client secret this
-    /// has no provider-identity guard: the key is never transmitted anywhere — it is used only to sign a
-    /// public AuthnRequest locally — so repointing the endpoint cannot exfiltrate it, and carrying it over
-    /// keeps a working signed-login provider from breaking on an unrelated edit.
+    /// Decides which service-provider signing key an updated SAML provider should keep — the one rule shared
+    /// by the primary key (#167) and the OPTIONAL rollover key (#491). A non-blank incoming key is an explicit
+    /// rotation and wins; a blank one keeps the stored key, so a config-page save (which never carries the
+    /// withheld keys) neither wipes the key nor silently ends a rollover overlap window. Unlike the OpenID
+    /// client secret these carry NO provider-identity guard: a signing key is never transmitted anywhere — it
+    /// signs a public AuthnRequest locally, and only its public certificate is ever published into metadata —
+    /// so repointing the endpoint cannot exfiltrate it, and carrying it over keeps a working signed-login
+    /// provider from breaking on an unrelated edit.
     /// </summary>
-    /// <param name="incoming">The provider config about to be persisted.</param>
-    /// <param name="live">The current live provider config.</param>
-    /// <returns>The signing key to persist for the updated provider.</returns>
-    internal static string ResolveUpdatedSigningKey(SamlConfig incoming, SamlConfig live)
-        => string.IsNullOrWhiteSpace(incoming.SamlSigningKeyPfx) ? live.SamlSigningKeyPfx : incoming.SamlSigningKeyPfx;
-
-    /// <summary>
-    /// Decides which OPTIONAL rollover signing key an updated SAML provider should keep (#491), the exact
-    /// same blank-keeps-stored / non-blank-rotates rule as <see cref="ResolveUpdatedSigningKey"/>: the
-    /// rollover key is withheld from JSON, so a config-page save arrives blank and must keep the stored
-    /// value rather than silently ending the overlap window, while an explicit non-blank value stages a new
-    /// overlap certificate. Like the primary it is never transmitted (publish-only, used to export its
-    /// public certificate into metadata), so it carries no provider-identity guard.
-    /// </summary>
-    /// <param name="incoming">The provider config about to be persisted.</param>
-    /// <param name="live">The current live provider config.</param>
-    /// <returns>The rollover signing key to persist for the updated provider.</returns>
-    internal static string ResolveUpdatedRolloverSigningKey(SamlConfig incoming, SamlConfig live)
-        => string.IsNullOrWhiteSpace(incoming.SamlRolloverSigningKeyPfx) ? live.SamlRolloverSigningKeyPfx : incoming.SamlRolloverSigningKeyPfx;
+    /// <param name="incoming">The key about to be persisted; blank when the save did not rotate it.</param>
+    /// <param name="live">The corresponding stored key.</param>
+    /// <returns>The incoming key when non-blank, otherwise the stored key.</returns>
+    private static string PreserveSigningKeyIfBlank(string incoming, string live)
+        => string.IsNullOrWhiteSpace(incoming) ? live : incoming;
 
     /// <summary>
     /// Decides which OpenID client secret an updated provider should keep (#189), the single rule

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -19,9 +19,10 @@ internal static class ServerManagedFields
     /// <paramref name="incoming"/> are touched (a deleted provider stays deleted; a newly added one
     /// keeps its own empty map). Two kinds of field are preserved: the per-provider canonical links
     /// (always server-owned, #157), and the write-only secrets (the OpenID client secret #189, the SAML
-    /// signing key #167) — the latter only when the incoming value is blank, since a secret is withheld
-    /// from JSON responses so a save that did not set a new one arrives empty and must keep the stored
-    /// value (a non-blank incoming value is an intentional rotation and is left as-is).
+    /// signing key #167 and its optional rollover key #491) — the latter only when the incoming value is
+    /// blank, since a secret is withheld from JSON responses so a save that did not set a new one arrives
+    /// empty and must keep the stored value (a non-blank incoming value is an intentional rotation and is
+    /// left as-is).
     /// </summary>
     /// <param name="incoming">The configuration about to be persisted.</param>
     /// <param name="live">The current live configuration to read server-managed values from.</param>
@@ -102,9 +103,10 @@ internal static class ServerManagedFields
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
 
-    // Links + the write-only signing key: a SAML provider carries the server-managed link map (#157) and,
-    // since #167, an optional service-provider signing key that is withheld from JSON like the OpenID
-    // secret, so a save that did not rotate it arrives blank and must keep the stored value.
+    // Links + the write-only signing keys: a SAML provider carries the server-managed link map (#157) and,
+    // since #167, an optional service-provider signing key plus its optional rollover key (#491), each
+    // withheld from JSON like the OpenID secret, so a save that did not rotate one arrives blank and must
+    // keep the stored value.
     internal static void Preserve(SamlConfig incoming, SamlConfig live)
     {
         if (incoming is null || live is null)


### PR DESCRIPTION
## What & why
From the repo-wide cleanup audit (Tier 2, Unit 4). Closes #868.

`ResolveUpdatedSigningKey` (#167) and `ResolveUpdatedRolloverSigningKey` (#491) were byte-identical modulo the field name, the same `IsNullOrWhiteSpace(incoming) ? live : incoming` ternary, each with its own ~13-line doc. Neither had a caller outside `Preserve(SamlConfig)` and neither was unit-tested (only `ResolveUpdatedSecret`, which genuinely differs via its OpenID identity guard, is).

Replaced both with one `private PreserveSigningKeyIfBlank(incoming, live)` taking the two field values, called per key.

## Security
- **No behaviour change**: the blank-keeps-stored / non-blank-rotates decision is identical for both keys.
- The consolidated doc keeps the load-bearing rationale verbatim: unlike the OpenID client secret the signing keys carry **no provider-identity guard** because they are never transmitted (a key signs a public AuthnRequest locally; only its public certificate is published into metadata), so repointing the endpoint cannot exfiltrate them. #167 + #491 refs retained.
- Touches config-persistence + crypto surface → **/security-review run as the mandatory gate** (findings documented on the PR).

## Type of change
Refactor (de-duplication) on a security surface. Net ≈ −15 LOC.

## Testing
Builds clean under `--warnaserror` on both TFMs; all 1786 tests pass on net9.0 and net10.0.