### PR TITLE
Document the internal API surface and enforce it via SA1600

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,7 +29,7 @@ dotnet_diagnostic.SA1402.severity = none
 dotnet_diagnostic.SA1413.severity = none
 dotnet_diagnostic.SA1512.severity = none
 dotnet_diagnostic.SA1515.severity = none
-dotnet_diagnostic.SA1600.severity = none
+dotnet_diagnostic.SA1600.severity = warning
 dotnet_diagnostic.SA1633.severity = none
 dotnet_diagnostic.SA1649.severity = none
 

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -65,6 +65,16 @@ internal sealed class AvatarService
     private readonly Func<string, bool> _fileExists;
     private readonly TimeSpan _storeLockAcquireTimeout;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AvatarService"/> class for production, fetching over
+    /// the process-wide shared client built on the hardened SSRF-safe handler. Delegates to the injectable
+    /// constructor; the test seam (#385) uses that overload directly with a stubbed client.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager.</param>
+    /// <param name="providerManager">The Jellyfin provider manager (image saving).</param>
+    /// <param name="serverConfigurationManager">The server configuration manager (user data paths).</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="userAgent">The outbound User-Agent.</param>
     internal AvatarService(
         IUserManager userManager,
         IProviderManager providerManager,
@@ -369,6 +379,15 @@ internal sealed class AvatarService
     // exhaust resources with an unbounded (or Content-Length-lying) download. Internal so the streamed
     // size cap (#220) — the most security-relevant branch — is unit-testable over a StreamContent body
     // without live HTTP (#385).
+
+    /// <summary>
+    /// Copies a response body into memory, aborting the moment it exceeds <paramref name="maxBytes"/>, so a
+    /// hostile or Content-Length-lying endpoint cannot exhaust memory with an unbounded download (#220).
+    /// </summary>
+    /// <param name="response">The response whose content stream is read.</param>
+    /// <param name="maxBytes">The inclusive byte ceiling; the read aborts once the total would exceed it.</param>
+    /// <param name="cancellationToken">Cancels the streamed read (the end-to-end fetch deadline).</param>
+    /// <returns>The buffered body, positioned at its start.</returns>
     internal static async ValueTask<MemoryStream> ReadCappedAsync(HttpResponseMessage response, long maxBytes, CancellationToken cancellationToken)
     {
         var buffer = new MemoryStream();

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -37,6 +37,15 @@ internal sealed class LoginCompletionService
     private readonly ProviderConfigStore _configStore;
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LoginCompletionService"/> class, wiring the account-
+    /// linking, session-minting, SSO-only-enforcement and configuration collaborators the login tail needs.
+    /// </summary>
+    /// <param name="canonicalLinks">The account-linking workflow (resolve/adopt/create).</param>
+    /// <param name="sessionMinter">The session minter run under the in-flight revocation gate.</param>
+    /// <param name="ssoOnly">The SSO-only login enforcement service.</param>
+    /// <param name="configStore">The provider configuration store.</param>
+    /// <param name="logger">The logger.</param>
     internal LoginCompletionService(CanonicalLinkService canonicalLinks, SessionMinter sessionMinter, SsoOnlyLoginService ssoOnly, ProviderConfigStore configStore, ILogger logger)
     {
         _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -65,6 +65,16 @@ internal sealed class OidcLoginService
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OidcLoginService"/> class, wiring the shared login
+    /// completion and account-linking collaborators plus the HTTP-client and logger factories the
+    /// token-exchange leg needs.
+    /// </summary>
+    /// <param name="loginCompletion">The shared post-validation login completion pipeline.</param>
+    /// <param name="canonicalLinks">The account-linking workflow used by the OID manual-link redeem.</param>
+    /// <param name="httpClientFactory">The factory for the token-endpoint client.</param>
+    /// <param name="loggerFactory">The factory for the underlying OIDC client's logger.</param>
+    /// <param name="logger">The service logger.</param>
     internal OidcLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -91,6 +101,11 @@ internal sealed class OidcLoginService
     // Also resets the shared NewPath persist-throttle gate (#412 review follow-up, #670): SsoControllerHarness
     // calls this for every test, so a change persisted in one test can never throttle a genuine change in
     // the next one. The gate now lives on the shared ChallengeNewPathResolver, so the reset delegates there.
+
+    /// <summary>
+    /// Test-only. Clears the process-wide OpenID authorize-state store and resets the shared NewPath
+    /// persist-throttle gate so state does not leak into a sibling test in the same non-parallel collection.
+    /// </summary>
     internal static void ResetOidStateForTests()
     {
         StateStore.Clear();
@@ -101,6 +116,13 @@ internal sealed class OidcLoginService
     // (which consume an already-validated state that the browser redirect leg normally populates) without
     // standing up the full token-exchange flow. Same test-only surface as ResetOidStateForTests (internal,
     // InternalsVisibleTo, no endpoint/DI) — never reachable in production. Moved here with the statics (#160).
+
+    /// <summary>
+    /// Test-only. Seeds a single authorize-state entry so a test can exercise the callback/authenticate legs
+    /// without standing up the full token-exchange flow.
+    /// </summary>
+    /// <param name="token">The state token to key the seeded entry under.</param>
+    /// <param name="state">The authorize state to store (a Pending or a promoted Ready).</param>
     internal static void SeedOidStateForTests(string token, AuthorizeSession state) => StateStore.Seed(token, state);
 
     /// <summary>
@@ -530,6 +552,14 @@ internal sealed class OidcLoginService
     // anonymous challenge endpoint) or pads the scope string with null entries. Blank elements inside a
     // non-null array are dropped too, so a persisted null/empty/whitespace scope cannot inject a
     // doubled or trailing separator (#407). Shared by both sites.
+
+    /// <summary>
+    /// Builds the space-delimited OpenID scope string, always leading with the base "openid profile" and
+    /// dropping null/empty/whitespace entries so a persisted bad scope cannot inject a doubled or trailing
+    /// separator (#407) or throw on a provider stored without scopes (#368).
+    /// </summary>
+    /// <param name="config">The provider configuration whose <c>OidScopes</c> are appended.</param>
+    /// <returns>The normalized scope string.</returns>
     internal static string BuildScopeString(OidConfig config)
         => string.Join(" ", (config.OidScopes ?? Array.Empty<string>())
             .Where(s => !string.IsNullOrWhiteSpace(s))

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -84,6 +84,13 @@ internal sealed class SamlLoginService
 
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlLoginService"/> class, wiring the shared login
+    /// completion and account-linking collaborators and constructing the per-request assertion validator.
+    /// </summary>
+    /// <param name="loginCompletion">The shared post-validation login completion pipeline.</param>
+    /// <param name="canonicalLinks">The account-linking workflow used by the SAML manual-link redeem.</param>
+    /// <param name="logger">The logger, also passed to the constructed assertion validator.</param>
     internal SamlLoginService(
         LoginCompletionService loginCompletion,
         CanonicalLinkService canonicalLinks,
@@ -102,6 +109,11 @@ internal sealed class SamlLoginService
     // resets the shared NewPath persist-throttle gate (#412 review follow-up, #670): SsoControllerHarness
     // calls this for every test, so a change persisted in one test can never throttle a genuine change in
     // the next one. The gate now lives on the shared ChallengeNewPathResolver, so the reset delegates there.
+
+    /// <summary>
+    /// Test-only. Clears the outstanding-SAML-request cache and resets the shared NewPath persist-throttle
+    /// gate so no seeded or in-flight state leaks between tests.
+    /// </summary>
     internal static void ResetSamlRequestsForTests()
     {
         SamlRequests.Clear();
@@ -112,21 +124,47 @@ internal sealed class SamlLoginService
     // process-wide-static reset reason as ResetSamlRequestsForTests. Installing a new instance (rather than
     // Clear) also un-swaps any small-cap store a prior test installed via SetSamlOutcomeStoreForTests, so cap
     // state cannot leak across tests. Internal, InternalsVisibleTo, never wired to an endpoint/DI.
+
+    /// <summary>
+    /// Test-only. Installs a fresh in-flight login-outcome store between tests, also un-swapping any
+    /// small-cap store a prior test installed so cap state cannot leak across tests.
+    /// </summary>
     internal static void ResetSamlOutcomesForTests() => _outcomes = new SamlOutcomeStore();
 
     // Test-only: swaps in a specific outcome store so a test can drive the cap path the production ceiling
     // (100k) makes unreachable — e.g. proving a cap refusal at the ACS callback no longer burns the assertion
     // (#539). Un-swapped by the next ResetSamlOutcomesForTests. Internal, InternalsVisibleTo, no endpoint/DI.
+
+    /// <summary>
+    /// Test-only. Swaps in a specific outcome store so a test can drive the cap path the production ceiling
+    /// makes unreachable; un-swapped by the next <see cref="ResetSamlOutcomesForTests"/>.
+    /// </summary>
+    /// <param name="store">The outcome store to install.</param>
     internal static void SetSamlOutcomeStoreForTests(SamlOutcomeStore store) => _outcomes = store;
 
     // Test-only: seeds a single login outcome so a test can drive the token-redeem mint leg without first
     // running the callback that normally populates the store. Same test-only surface as the resets above.
+
+    /// <summary>
+    /// Test-only. Seeds a single login outcome so a test can drive the token-redeem mint leg without first
+    /// running the callback that normally populates the store.
+    /// </summary>
+    /// <param name="outcome">The login outcome to seed.</param>
     internal static void SeedSamlOutcomeForTests(SamlLoginOutcome outcome) => _outcomes.Seed(outcome);
 
     // Test-only seed of an outstanding SAML AuthnRequest so a test can exercise SamlAuth's browser
     // binding (#415) — normally populated by the challenge redirect leg — without deriving the random
     // request id from the emitted AuthnRequest. Same test-only surface as SeedOidStateForTests
     // (internal, InternalsVisibleTo, no endpoint/DI); never reachable in production. Moved here (#160).
+
+    /// <summary>
+    /// Test-only. Seeds an outstanding SAML AuthnRequest so a test can exercise the browser-binding leg
+    /// without deriving the random request id from an emitted AuthnRequest.
+    /// </summary>
+    /// <param name="provider">The provider the request belongs to.</param>
+    /// <param name="requestId">The AuthnRequest id to register.</param>
+    /// <param name="bindingId">The browser-binding id tied to the request.</param>
+    /// <param name="expiryUtc">The UTC expiry of the outstanding request.</param>
     internal static void SeedSamlRequestForTests(string provider, string requestId, string bindingId, DateTime expiryUtc) =>
         SamlRequests.Register(ProviderScopedKey.For(provider, requestId), bindingId, expiryUtc, DateTime.UtcNow, clientKey: null, out _);
 

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -265,6 +265,13 @@ public class SSOController : ControllerBase
     // incoming config). Without this, a malformed override set via the Add API would be persisted and then
     // silently fall back to the request Host at login. Throwing keeps it out of the store, so the
     // "rejected at every admin write path" invariant holds. Blank is valid (the feature is off).
+
+    /// <summary>
+    /// Rejects a malformed canonical base-URL override at the OID/SAML Add endpoints (#139), the door that
+    /// mirrors the config-page save-time check for the Add path that bypasses it. A blank override is valid.
+    /// </summary>
+    /// <param name="baseUrlOverride">The override value posted to the Add endpoint.</param>
+    /// <exception cref="ArgumentException">The override is non-blank and not a valid absolute http(s) URL.</exception>
     internal static void RejectInvalidBaseUrlOverride(string baseUrlOverride)
     {
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
@@ -278,6 +285,13 @@ public class SSOController : ControllerBase
     // ProviderConfigValidator.Validate. Without this, a garbage certificate set via the Add API would be
     // persisted and then throw a CryptographicException on every callback (an unhandled 500). Blank is
     // valid (a half-configured provider).
+
+    /// <summary>
+    /// Rejects a non-loadable SAML signing certificate at the SAML/Add endpoint (#206), the Add-path
+    /// counterpart to the config-page save-time certificate check. A blank certificate is valid.
+    /// </summary>
+    /// <param name="certificateStr">The Base64-encoded (DER) X.509 certificate posted to the Add endpoint.</param>
+    /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
     internal static void RejectInvalidSamlCertificate(string certificateStr)
     {
         if (SamlCertificate.IsInvalid(certificateStr))
@@ -291,6 +305,14 @@ public class SSOController : ControllerBase
     // secondary would persist and then throw a CryptographicException on every callback (an unhandled
     // 500). It is the identity provider's PUBLIC certificate, so it is validated exactly like the primary.
     // Blank is valid (no overlap window configured).
+
+    /// <summary>
+    /// Rejects a non-loadable inbound secondary verification certificate at the SAML/Add endpoint (#491) —
+    /// the identity provider's public certificate for a key-overlap window, validated like the primary. A
+    /// blank value is valid (no overlap window configured).
+    /// </summary>
+    /// <param name="certificateStr">The Base64-encoded (DER) X.509 certificate posted to the Add endpoint.</param>
+    /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
     internal static void RejectInvalidSamlSecondaryCertificate(string certificateStr)
     {
         if (SamlCertificate.IsInvalid(certificateStr))
@@ -303,6 +325,13 @@ public class SSOController : ControllerBase
     // fail-closed door as the inbound certificate guard above: a garbage or private-key-less PKCS#12 set
     // here would persist and then fail every signed challenge. Blank is valid (signing simply stays off,
     // or the stored key is preserved on save).
+
+    /// <summary>
+    /// Rejects a non-loadable service-provider request signing key at the SAML/Add endpoint (#167). A blank
+    /// key is valid (signing stays off, or the stored key is preserved on save).
+    /// </summary>
+    /// <param name="signingKeyPfx">The Base64-encoded PKCS#12 (PFX) signing key posted to the Add endpoint.</param>
+    /// <exception cref="ArgumentException">The key is non-blank and not a loadable PFX with an RSA or ECDSA private key.</exception>
     internal static void RejectInvalidSamlSigningKey(string signingKeyPfx)
     {
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
@@ -316,6 +345,13 @@ public class SSOController : ControllerBase
     // in the config map that then NREs the config-page save (ServerManagedFields.Preserve). Reject at
     // the door so the store never holds a null provider — the same fail-closed posture as the other
     // Add-endpoint gates.
+
+    /// <summary>
+    /// Rejects a null provider body at the Add endpoints (#350), so a null or literal "null" JSON payload
+    /// can never put a null entry in the config map that would later NRE the config-page save.
+    /// </summary>
+    /// <param name="config">The model-bound provider configuration body.</param>
+    /// <exception cref="ArgumentException">The body is null.</exception>
     internal static void RejectNullProviderBody(object config)
     {
         if (config is null)
@@ -332,6 +368,15 @@ public class SSOController : ControllerBase
     // EXISTING name stays allowed: its URL bytes are already registered at the IdP, and blocking the
     // update would strand the deployment behind a rename (encoding the built URLs instead is pinned
     // off by SsoUrlBuilderTests).
+
+    /// <summary>
+    /// Rejects a NEW provider name containing control characters, a backslash, or a URI-reserved character
+    /// (#336, #360), because the name is appended raw to the callback URLs registered with the identity
+    /// provider. Updating an existing name stays allowed so a deployment is not stranded behind a rename.
+    /// </summary>
+    /// <param name="provider">The provider name posted to the Add endpoint.</param>
+    /// <param name="providerExists">Whether the name already names a registered provider; only new names are validated.</param>
+    /// <exception cref="ArgumentException">The name is new and contains a forbidden character.</exception>
     internal static void RejectInvalidNewProviderName(string provider, bool providerExists)
     {
         if (!providerExists && ProviderNameValidator.IsInvalid(provider))

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -118,6 +118,17 @@ internal sealed class CanonicalLinkService
     private readonly IntervalGate _legacyLinkWarnGate;
     private readonly Func<DateTime> _clock;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CanonicalLinkService"/> class. The optional gate and
+    /// clock are test seams: production omits them, taking the process-wide legacy-link warn gate and the
+    /// wall clock so the warning throttle survives this per-request service's reconstruction.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager.</param>
+    /// <param name="cryptoProvider">The crypto provider used for legacy link hashing.</param>
+    /// <param name="configStore">The provider configuration store the link maps live in.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="legacyLinkWarnGate">The pending-legacy-link warning throttle; null takes the shared process-wide gate.</param>
+    /// <param name="clock">The clock driving the warning throttle; null uses the wall clock.</param>
     internal CanonicalLinkService(
         IUserManager userManager,
         ICryptoProvider cryptoProvider,

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -65,6 +65,18 @@ internal abstract class AuthorizeSession
     /// </summary>
     internal sealed class Pending : AuthorizeSession
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Pending"/> class, capturing everything the callback's
+        /// token exchange needs and nothing derived from an identity, so a Pending cannot mint a session.
+        /// </summary>
+        /// <param name="oidcState">The OidcClient authorize state (code_verifier, redirect URI); its <c>State</c> is the store key.</param>
+        /// <param name="provider">The provider the challenge was minted for.</param>
+        /// <param name="isLinking">Whether the challenge intends to link an account rather than authenticate.</param>
+        /// <param name="created">When the state was created, used to time it out.</param>
+        /// <param name="bindingId">The browser-binding id tying the state to the initiating browser.</param>
+        /// <param name="clientKey">The normalized client key whose per-client budget slot this state holds, or null for an exempt source.</param>
+        /// <param name="providerInformation">The challenge-time discovery metadata to reuse at the callback (#247), or null to rediscover.</param>
+        /// <param name="responseIssuerRequired">Whether the callback must require the RFC 9207 response <c>iss</c> (#210).</param>
         internal Pending(
             AuthorizeState oidcState,
             string provider,
@@ -105,6 +117,14 @@ internal abstract class AuthorizeSession
     /// </summary>
     internal sealed class Ready : AuthorizeSession
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ready"/> class from the peeked <paramref name="pending"/>
+        /// and the passed role-gate result, folding them into the one protocol-agnostic verified identity the
+        /// mint path is keyed on. Reachable only from <see cref="OidcStateStore.Promote"/>, so its existence is
+        /// evidence the role gate passed (#341, #473).
+        /// </summary>
+        /// <param name="pending">The pending state this Ready supersedes; its correlation fields are carried over.</param>
+        /// <param name="derived">The passed role-gate result snapshotted into the redeemable identity.</param>
         internal Ready(Pending pending, OidcAuthorizeStateBuilder.OidcAuthorizeState derived)
             : base(pending.Token, pending.Provider, pending.IsLinking, pending.BindingId, pending.ClientKey, pending.Created)
         {

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -18,17 +18,23 @@ internal sealed class OidcStateStore
     // cannot grow the store without bound (mirrors SamlRequestCache); at the cap a fresh challenge is
     // refused rather than evicting an in-flight state, and rate-limiting at the edge (#128) is the
     // primary defense (#246).
+
+    /// <summary>The production ceiling on outstanding authorize states; at the cap a fresh challenge is refused, never an in-flight state evicted.</summary>
     internal const int DefaultMaxEntries = 100_000;
 
     // How long an in-flight OpenID authorize state may live before it is rejected/pruned. This bounds
     // the whole interactive leg (OidChallenge -> IdP login/MFA/consent -> callback -> mint), so it
     // must accommodate a real user completing MFA, not just a fast round trip.
+
+    /// <summary>How long an in-flight authorize state may live before it is rejected and pruned; bounds the whole challenge-to-mint interactive leg (including MFA).</summary>
     internal static readonly TimeSpan DefaultLifetime = TimeSpan.FromMinutes(15);
 
     // The expired-state sweep (PruneExpired) is an O(n) scan; throttling it to at most once per this
     // interval stops an anonymous challenge flood from amplifying into CPU load (mirrors
     // SamlRequestCache). This only defers memory reclamation — the peek/redeem predicates reject an
     // expired state independently, so a not-yet-swept entry never grants a login (#246).
+
+    /// <summary>The minimum interval between expired-state sweeps, keeping the O(n) scan off the anonymous hot path.</summary>
     internal static readonly TimeSpan DefaultPruneInterval = TimeSpan.FromMinutes(1);
 
     private readonly int _maxEntries;
@@ -55,6 +61,10 @@ internal sealed class OidcStateStore
     // so a single anonymous source cannot fill the store and lock out everyone else's logins.
     private readonly PerClientBudgetLimiter _perClient;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OidcStateStore"/> class with the production cap,
+    /// lifetime and prune interval.
+    /// </summary>
     internal OidcStateStore()
         : this(DefaultMaxEntries, DefaultLifetime, DefaultPruneInterval)
     {
@@ -62,6 +72,14 @@ internal sealed class OidcStateStore
 
     // Test constructor: small caps and lifetimes make the cap and expiry paths reachable in unit
     // tests (the production values are unreachable there). IntervalGate rejects a non-positive interval.
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OidcStateStore"/> class with explicit bounds, so a
+    /// unit test can reach the cap and expiry paths that the production values make unreachable.
+    /// </summary>
+    /// <param name="maxEntries">The global ceiling on outstanding authorize states.</param>
+    /// <param name="lifetime">How long a stored state may live before it expires.</param>
+    /// <param name="pruneInterval">The minimum interval between expired-state sweeps.</param>
     internal OidcStateStore(int maxEntries, TimeSpan lifetime, TimeSpan pruneInterval)
     {
         _maxEntries = maxEntries;

--- a/SSO-Auth/Api/Provider/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/Provider/ProviderNameValidator.cs
@@ -32,6 +32,14 @@ internal static class ProviderNameValidator
     // A null or blank name yields an empty span, so the loop never runs and it stays valid — no route can
     // produce an empty provider segment, matching the blank-is-valid convention of the sibling predicates
     // (CanonicalBaseUrl, SamlCertificate).
+
+    /// <summary>
+    /// Determines whether a provider name would corrupt the login callback URL it becomes part of — true if
+    /// it contains any control character, a backslash, or a URI-reserved character. A null or blank name is
+    /// valid (no route produces an empty provider segment), matching the sibling predicates.
+    /// </summary>
+    /// <param name="name">The provider name to check.</param>
+    /// <returns>True if the name contains a forbidden character; otherwise false.</returns>
     internal static bool IsInvalid(string? name)
     {
         foreach (char c in name.AsSpan())

--- a/SSO-Auth/Api/RateLimit/IntervalGate.cs
+++ b/SSO-Auth/Api/RateLimit/IntervalGate.cs
@@ -21,6 +21,13 @@ internal sealed class IntervalGate
     // torn-read-safe). Starts at MinValue so the first call always sees a full interval and enters.
     private long _cursor = DateTime.MinValue.Ticks;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntervalGate"/> class with the throttle interval,
+    /// throwing on a non-positive interval so a field-ordering mistake cannot silently disable the throttle
+    /// and turn the gate into the flood amplifier it exists to prevent.
+    /// </summary>
+    /// <param name="interval">The minimum span between admissions; must be strictly positive.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="interval"/> is zero or negative.</exception>
     internal IntervalGate(TimeSpan interval)
     {
         // A non-positive interval would silently disable the throttle (every call enters), turning the

--- a/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
+++ b/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
@@ -23,6 +23,13 @@ internal sealed class KeyedLockStore
     // key identity: the avatar store passes Ordinal so the key is exactly the profile-path determinant.
     private readonly ConcurrentDictionary<string, Holder> _holders;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="KeyedLockStore"/> class. The comparer decides key
+    /// identity: the avatar store passes <see cref="StringComparer.Ordinal"/> so a key is exactly its
+    /// profile-path determinant.
+    /// </summary>
+    /// <param name="comparer">The comparer determining key identity.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
     internal KeyedLockStore(IEqualityComparer<string> comparer)
     {
         _holders = new ConcurrentDictionary<string, Holder>(comparer ?? throw new ArgumentNullException(nameof(comparer)));

--- a/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
@@ -23,6 +23,8 @@ internal sealed class PerClientBudgetLimiter
     // distinct attributable public sources to exhaust the budget and no single one can lock out logins,
     // while >=99% stays free for everyone else. A constant, not config — a login-path safety limit whose
     // mis-set value would itself be a lockout (too low) or a no-op (too high).
+
+    /// <summary>The reciprocal of one client's share of the global cap (1/100): it takes at least this many distinct sources to exhaust the budget, and no single one can lock out logins.</summary>
     internal const int ShareDivisor = 100;
 
     // clientKey -> live reservations; a key is present only while it holds >=1 (dropped at zero), so
@@ -31,6 +33,11 @@ internal sealed class PerClientBudgetLimiter
     private readonly ConcurrentDictionary<string, int> _counts = new(StringComparer.Ordinal);
     private readonly int _perKeyCap;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PerClientBudgetLimiter"/> class with an explicit
+    /// per-key cap. Most callers use <see cref="FromGlobalCap"/> so the 1/100 policy lives in one place.
+    /// </summary>
+    /// <param name="perKeyCap">The maximum concurrent reservations a single client key may hold.</param>
     internal PerClientBudgetLimiter(int perKeyCap) => _perKeyCap = perKeyCap;
 
     /// <summary>Gets the derived per-key cap. Test-only.</summary>

--- a/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
@@ -12,6 +12,15 @@ internal static class ProviderScopedKey
 {
     // The newline separator cannot occur in a Guid-based AuthnRequest id, and both parts come from the
     // same trusted config/flow, so it partitions the key space by provider without collision.
+
+    /// <summary>
+    /// Forms the provider-scoped cache key <c>provider + "\n" + id</c>, so a one-time-use key issued under
+    /// one provider cannot be consumed on another's callback (#156, #219). A null or empty
+    /// <paramref name="id"/> passes through unchanged so the caller handles an absent correlation id itself.
+    /// </summary>
+    /// <param name="provider">The provider the key is scoped to.</param>
+    /// <param name="id">The correlation id (e.g. AuthnRequest id); null/empty returns unchanged.</param>
+    /// <returns>The scoped key, or the original null/empty id.</returns>
     internal static string? For(string provider, string? id) =>
         string.IsNullOrEmpty(id) ? id : provider + "\n" + id;
 }

--- a/SSO-Auth/Api/Saml/SamlAssertionTime.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionTime.cs
@@ -82,6 +82,14 @@ internal static class SamlAssertionTime
         return true;
     }
 
+    /// <summary>
+    /// Parses a SAML xsd:dateTime condition bound to UTC using the faithful <see cref="XmlConvert"/> grammar,
+    /// failing closed (returning false) on any malformed value. Normalizes any offset to UTC and asserts the
+    /// resulting <see cref="DateTimeKind.Utc"/> so a bound is never compared in a mismatched kind (#677).
+    /// </summary>
+    /// <param name="raw">The raw xsd:dateTime string from the assertion; null fails closed.</param>
+    /// <param name="utc">On success, the parsed UTC instant; otherwise <c>default</c>.</param>
+    /// <returns>True if the value parsed to a UTC instant; false otherwise.</returns>
     internal static bool TryParseUtc(string? raw, out DateTime utc)
     {
         utc = default;

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -47,6 +47,11 @@ internal sealed class SamlAssertionValidator
 
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlAssertionValidator"/> class. Constructed per request
+    /// by the SAML flow service, though it owns the process-wide replay cache as a static.
+    /// </summary>
+    /// <param name="logger">The logger for validation-failure diagnostics.</param>
     internal SamlAssertionValidator(ILogger logger)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -56,6 +61,11 @@ internal sealed class SamlAssertionValidator
     // reason as the flow service's request/outcome resets — a test that consumed an assertion id must not
     // leak it into a sibling test. Internal, reachable only through InternalsVisibleTo; never wired to an
     // endpoint or DI, so it adds no runtime or security surface.
+
+    /// <summary>
+    /// Test-only. Clears the process-wide one-time replay cache between tests so a consumed assertion id
+    /// does not leak into a sibling test.
+    /// </summary>
     internal static void ResetReplaysForTests() => SamlReplays.Clear();
 
     /// <summary>
@@ -225,6 +235,15 @@ internal sealed class SamlAssertionValidator
     // unless explicitly opted out. Expected audience is the configured SamlAudience, falling back to the
     // SamlClientId (SP entity id). Both are trimmed so the comparison matches the trimmed Issuer sent in the
     // AuthnRequest, and an empty SamlAudience falls through to the client id.
+
+    /// <summary>
+    /// Validates a SAML response's signature and time bounds, and — unless the provider explicitly opts out —
+    /// its AudienceRestriction binding to this service provider. The expected audience is the configured
+    /// <c>SamlAudience</c>, falling back to the <c>SamlClientId</c>.
+    /// </summary>
+    /// <param name="samlResponse">The response to validate.</param>
+    /// <param name="config">The provider configuration supplying the expected audience and the opt-out flag.</param>
+    /// <returns>True if the response passes every applicable check; false otherwise.</returns>
     internal static bool ValidateSaml(SamlResponse samlResponse, SamlConfig config)
     {
         if (config.DoNotValidateAudience)

--- a/SSO-Auth/Api/Saml/SamlMetadataImport.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataImport.cs
@@ -35,11 +35,22 @@ internal sealed record SamlMetadataImport(
 /// </summary>
 internal sealed class SamlMetadataException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlMetadataException"/> class with an admin-facing
+    /// message.
+    /// </summary>
+    /// <param name="message">The admin-facing failure message, free of internal detail.</param>
     internal SamlMetadataException(string message)
         : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlMetadataException"/> class wrapping the underlying
+    /// parse failure.
+    /// </summary>
+    /// <param name="message">The admin-facing failure message, free of internal detail.</param>
+    /// <param name="innerException">The underlying exception that caused the failure.</param>
     internal SamlMetadataException(string message, Exception innerException)
         : base(message, innerException)
     {

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -31,16 +31,22 @@ internal sealed class SamlOutcomeStore
     // refused rather than evicting an in-flight one; the callback path is reached only after full signature
     // validation, so it is not anonymously floodable, and rate-limiting at the edge (#128) is the primary
     // defense.
+
+    /// <summary>The production ceiling on outstanding login outcomes; at the cap a fresh outcome is refused, never an in-flight one evicted.</summary>
     internal const int DefaultMaxEntries = 100_000;
 
     // How long a stored login outcome may live before it is rejected/pruned. It bounds the gap between the
     // ACS callback rendering the page and the browser posting the token back — a fast same-origin round
     // trip — so it matches the sibling in-flight lifetimes (the outstanding-request/authorize-state window).
+
+    /// <summary>How long a stored outcome may live before it is rejected and pruned; bounds the ACS-render-to-mint round trip.</summary>
     internal static readonly TimeSpan DefaultLifetime = TimeSpan.FromMinutes(15);
 
     // The expired-entry sweep is an O(n) scan; throttling it to at most once per this interval keeps it off
     // the hot path (mirrors the siblings). Throttling only defers memory reclamation — the redeem predicate
     // rejects an expired outcome independently, so a not-yet-swept entry never completes a login.
+
+    /// <summary>The minimum interval between expired-entry sweeps, keeping the O(n) scan off the hot path.</summary>
     internal static readonly TimeSpan DefaultPruneInterval = TimeSpan.FromMinutes(1);
 
     private readonly int _maxEntries;
@@ -62,6 +68,10 @@ internal sealed class SamlOutcomeStore
     // a single source cannot fill the store and lock out everyone else's logins.
     private readonly PerClientBudgetLimiter _perClient;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlOutcomeStore"/> class with the production cap,
+    /// lifetime and prune interval.
+    /// </summary>
     internal SamlOutcomeStore()
         : this(DefaultMaxEntries, DefaultLifetime, DefaultPruneInterval)
     {
@@ -69,6 +79,14 @@ internal sealed class SamlOutcomeStore
 
     // Test constructor: small caps and lifetimes make the cap and expiry paths reachable in unit tests (the
     // production values are unreachable there). IntervalGate rejects a non-positive interval.
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlOutcomeStore"/> class with explicit bounds, so a
+    /// unit test can reach the cap and expiry paths that the production values make unreachable.
+    /// </summary>
+    /// <param name="maxEntries">The global ceiling on outstanding outcomes.</param>
+    /// <param name="lifetime">How long a stored outcome may live before it expires.</param>
+    /// <param name="pruneInterval">The minimum interval between expired-entry sweeps.</param>
     internal SamlOutcomeStore(int maxEntries, TimeSpan lifetime, TimeSpan pruneInterval)
     {
         _maxEntries = maxEntries;

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -29,6 +29,8 @@ internal sealed class SamlReplayCache
     // runs only after signature validation — but a defense-in-depth memory bound. The check-then-insert is
     // not serialized, so concurrent consumes can transiently overshoot by at most the number of in-flight
     // threads; immaterial against a best-effort backstop.
+
+    /// <summary>The production ceiling on retained consumed-assertion IDs; at the cap a new login is refused fail-closed, never a still-valid entry evicted.</summary>
     internal const int DefaultMaxEntries = 100_000;
 
     // The expired-entry sweep is an O(n) scan; throttling it to at most once per this interval matches the
@@ -55,6 +57,10 @@ internal sealed class SamlReplayCache
     // crosses a helper boundary; this cache only decides WHETHER to warn.
     private readonly IntervalGate _capWarnGate;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlReplayCache"/> class with the production cap and
+    /// prune interval.
+    /// </summary>
     internal SamlReplayCache()
         : this(DefaultMaxEntries, DefaultPruneInterval)
     {
@@ -62,6 +68,13 @@ internal sealed class SamlReplayCache
 
     // Test constructor: a small cap and short interval make the cap and prune-throttle paths reachable in
     // unit tests (the production values are unreachable there). IntervalGate rejects a non-positive interval.
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlReplayCache"/> class with explicit bounds, so a unit
+    /// test can reach the cap and prune-throttle paths the production values make unreachable.
+    /// </summary>
+    /// <param name="maxEntries">The global ceiling on retained consumed-assertion IDs.</param>
+    /// <param name="pruneInterval">The minimum interval between expired-entry sweeps.</param>
     internal SamlReplayCache(int maxEntries, TimeSpan pruneInterval)
     {
         _maxEntries = maxEntries;

--- a/SSO-Auth/Api/Saml/SamlRequestCache.cs
+++ b/SSO-Auth/Api/Saml/SamlRequestCache.cs
@@ -19,6 +19,8 @@ internal sealed class SamlRequestCache
     // transiently overshoot by at most the number of in-flight threads — immaterial against a
     // best-effort DoS backstop. Given the short request lifetime, real load never approaches it;
     // rate-limiting at the edge (#128) is the primary defense.
+
+    /// <summary>The production ceiling on outstanding AuthnRequest entries; at the cap a fresh challenge is refused, never an in-flight entry evicted.</summary>
     internal const int DefaultMaxEntries = 100_000;
 
     // Expired-entry sweeping is throttled to at most once per this interval. The sweep is an O(n)
@@ -46,6 +48,10 @@ internal sealed class SamlRequestCache
     // so a single anonymous source cannot fill the cache and deny every other login's callback.
     private readonly PerClientBudgetLimiter _perClient;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlRequestCache"/> class with the production cap and
+    /// prune interval.
+    /// </summary>
     internal SamlRequestCache()
         : this(DefaultMaxEntries, DefaultPruneInterval)
     {
@@ -53,6 +59,13 @@ internal sealed class SamlRequestCache
 
     // Test constructor: a small cap makes the global-cap and per-client sub-cap paths reachable in unit
     // tests (the production values are unreachable there).
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlRequestCache"/> class with explicit bounds, so a
+    /// unit test can reach the global-cap and per-client sub-cap paths the production values make unreachable.
+    /// </summary>
+    /// <param name="maxEntries">The global ceiling on outstanding entries.</param>
+    /// <param name="pruneInterval">The minimum interval between expired-entry sweeps.</param>
     internal SamlRequestCache(int maxEntries, TimeSpan pruneInterval)
     {
         _maxEntries = maxEntries;

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -19,6 +19,8 @@ internal static class SamlResponseLoader
     // parse on the unauthenticated callback path (#249), where a multi-MB body would otherwise cost ~100 MB
     // of transient allocations before any signature is checked. The DTD prohibition stops entity expansion
     // but not raw bulk, and the rate limiter is opt-in — this is the always-on cap.
+
+    /// <summary>The always-on ceiling (256 KB) on the Base64 SAMLResponse length, bounding the decode and DOM parse on the unauthenticated callback path before any signature is checked (#249).</summary>
     internal const int MaxEncodedResponseLength = 256 * 1024;
 
     /// <summary>

--- a/SSO-Auth/Api/Session/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/Session/LoginStatusMapper.cs
@@ -42,6 +42,16 @@ internal static class LoginStatusMapper
     /// </summary>
     internal const string RateLimitedMessage = "Too many attempts. Please wait a moment and try again.";
 
+    /// <summary>
+    /// Translates a login outcome into its HTTP result, mapping success to the session body and each refusal
+    /// to its fail-closed public status/message. A <see cref="LoginOutcome.Throttled"/> cannot be rendered
+    /// here because it needs the response for its Retry-After header — it throws, forcing callers through the
+    /// response-aware overload — and an impossible case is a server fault that also throws (never a
+    /// default-accept).
+    /// </summary>
+    /// <param name="outcome">The login outcome to translate.</param>
+    /// <returns>The HTTP action result.</returns>
+    /// <exception cref="InvalidOperationException">The outcome is Throttled (needs the response) or an unmapped case.</exception>
     internal static ActionResult ToActionResult(LoginOutcome outcome) => outcome switch
     {
         LoginOutcome.Success success => new OkObjectResult(success.Session),

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -27,6 +27,14 @@ internal sealed class SessionMinter
     private readonly ISessionManager _sessionManager;
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SessionMinter"/> class, wiring the user, avatar and
+    /// session-manager collaborators the mint applies grants and authenticates through.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager the granted privileges are applied to.</param>
+    /// <param name="avatarService">The avatar fetch/store service run during the mint.</param>
+    /// <param name="sessionManager">The session manager that authenticates the client.</param>
+    /// <param name="logger">The logger.</param>
     internal SessionMinter(IUserManager userManager, AvatarService avatarService, ISessionManager sessionManager, ILogger logger)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));

--- a/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
@@ -52,6 +52,13 @@ internal sealed class SsoOnlyLoginService
     private readonly ProviderConfigStore _configStore;
     private readonly ILogger _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SsoOnlyLoginService"/> class, wiring the user manager it
+    /// sweeps accounts through and the configuration store whose lock guards every read/write of the mode flags.
+    /// </summary>
+    /// <param name="userManager">The Jellyfin user manager used to enumerate and re-route accounts.</param>
+    /// <param name="configStore">The provider configuration store owning the SSO-only mode flags and their lock.</param>
+    /// <param name="logger">The logger.</param>
     internal SsoOnlyLoginService(IUserManager userManager, ProviderConfigStore configStore, ILogger logger)
     {
         _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -67,6 +67,21 @@ internal static class ChallengeNewPathResolver
     // for a later login, never a requirement for THIS one to succeed. Internal (not private) so
     // ProviderConfigStoreTests-style callers can exercise the race-window fallback branch directly and
     // deterministically, the way the flow services' test hooks already do for other login-flow internals.
+
+    /// <summary>
+    /// Resolves the NewPath spelling for a login challenge and, for a non-linking challenge whose derived
+    /// spelling differs from the stored one, best-effort persists it through <c>MutateConfiguration</c> under
+    /// the write lock (throttled, race-safe, failure-swallowed). The returned value always reflects this
+    /// request's own path whether or not the write landed; a linking challenge only reads the stored value (#412).
+    /// </summary>
+    /// <typeparam name="T">The provider configuration type (OpenID or SAML), selected via <paramref name="selectConfigs"/>.</typeparam>
+    /// <param name="provider">The provider name, used to re-resolve the live entry inside the mutation.</param>
+    /// <param name="config">The provider configuration read outside the write lock; its stored NewPath is compared, never written directly.</param>
+    /// <param name="isLinking">Whether this is a linking challenge (read-only) rather than a login challenge.</param>
+    /// <param name="request">The current request, whose path the derived spelling comes from.</param>
+    /// <param name="logger">The logger for a swallowed best-effort persist failure; may be null.</param>
+    /// <param name="selectConfigs">Selects the provider map (OidConfigs or SamlConfigs) to re-resolve the live entry from.</param>
+    /// <returns>The NewPath spelling this login/redirect should use.</returns>
     internal static bool ResolveChallengeNewPath<T>(
         string provider,
         T config,

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -29,6 +29,8 @@ internal static class FlowResponses
     // is denied with an empty allowlist. HSTS is deliberately NOT set per page: transport security for the
     // whole origin is the operator's reverse proxy / Jellyfin global responsibility (#756), not a per-response
     // plugin header.
+
+    /// <summary>The restrictive Permissions-Policy header value shared by both served HTML pages (the auth-completion and browser-navigated error pages), denying every listed browser feature so the two cannot drift.</summary>
     internal const string ServedPagePermissionsPolicy =
         "camera=(), microphone=(), geolocation=(), payment=(), usb=(), accelerometer=(), gyroscope=(), magnetometer=(), autoplay=(), display-capture=()";
 

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -18,11 +18,24 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 /// </summary>
 internal static class SsoRateLimitClass
 {
+    /// <summary>The anonymous login-challenge stage that begins an OpenID/SAML flow.</summary>
     internal const string Challenge = "challenge";
+
+    /// <summary>The anonymous callback stage where the identity provider returns the login result.</summary>
     internal const string Callback = "callback";
+
+    /// <summary>The anonymous authentication stage that mints the Jellyfin session.</summary>
     internal const string Auth = "auth";
+
+    /// <summary>The elevation-gated Test-connection provider probe.</summary>
     internal const string Test = "test";
+
+    /// <summary>The anonymous service-provider SAML metadata read.</summary>
     internal const string Metadata = "metadata";
+
+    /// <summary>The admin SSO-revoke (unregister) surface (#516).</summary>
     internal const string Unregister = "unregister";
+
+    /// <summary>The authenticated account link/unlink write surface (#382).</summary>
     internal const string Link = "link";
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -36,6 +36,16 @@ internal static class ProviderConfigValidator
     // ValidateProviderName). Only the admin config-page save path validates the whole config; the Add
     // endpoints validate their own incoming provider at the controller, and login-path writes reuse
     // the live object and are never revalidated.
+
+    /// <summary>
+    /// Validates an entire incoming provider configuration fail-closed before the config-page save
+    /// persists it, throwing on the first invalid provider found. Composes the per-provider name,
+    /// base-URL-override, certificate, signing-key, ACR, permission-role and parental-rating checks
+    /// over every OpenID and SAML provider; a valid config returns without effect.
+    /// </summary>
+    /// <param name="incoming">The configuration about to be persisted.</param>
+    /// <param name="live">The current live configuration, used to tell a newly added provider from an existing one.</param>
+    /// <exception cref="ArgumentException">A provider fails any per-provider rule.</exception>
     internal static void Validate(PluginConfiguration incoming, PluginConfiguration live)
     {
         if (incoming.OidConfigs != null)
@@ -75,6 +85,17 @@ internal static class ProviderConfigValidator
     // rejected — an existing name, whose URL bytes the identity provider already has registered, must
     // keep saving unchanged or the deployment would be stranded behind a rename. The echoed name gets a
     // full control strip (stronger than the line-ending strip below — see the inline comment).
+
+    /// <summary>
+    /// Rejects a NEW provider whose name would corrupt the login callback URL it becomes part of: a name
+    /// that is new to the live configuration and contains control characters, a backslash, or a
+    /// URI-reserved character is refused. An already-registered name is exempt so a deployment is never
+    /// stranded behind a rename.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name to check.</param>
+    /// <param name="isNew">Whether this name is absent from the live configuration; only new names are validated.</param>
+    /// <exception cref="ArgumentException">The name is new and contains a forbidden character.</exception>
     internal static void ValidateProviderName(string protocol, string provider, bool isNew)
     {
         if (isNew && ProviderNameValidator.IsInvalid(provider))
@@ -94,6 +115,15 @@ internal static class ProviderConfigValidator
     // allow-list is empty, so no returned acr can satisfy it) — a silent lockout (#757). Reject it at save so
     // the mis-set is caught before it takes effect, rather than failing open (a no-op) or locking out. The
     // provider name is line-ending-stripped inline in case it reaches a log through the thrown exception.
+
+    /// <summary>
+    /// Rejects an OpenID provider that requires an ACR but supplies no acr_values, which would otherwise
+    /// persist and then silently lock out every login for that provider (the allow-list is empty, so no
+    /// returned acr can satisfy it). Caught at save rather than failing open or locking out (#757).
+    /// </summary>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="config">The OpenID provider configuration to check; a null config is tolerated.</param>
+    /// <exception cref="ArgumentException">RequireAcr is set with blank AcrValues.</exception>
     internal static void ValidateAcrRequirement(string provider, OidConfig config)
     {
         if (config?.RequireAcr == true && string.IsNullOrWhiteSpace(config.AcrValues))
@@ -107,6 +137,16 @@ internal static class ProviderConfigValidator
     // A malformed override would be persisted and then silently fall back to the request Host at
     // login (#139). The provider name is line-ending-stripped inline in case it reaches a log through
     // the thrown exception.
+
+    /// <summary>
+    /// Rejects a canonical base-URL override that is set but is not a valid absolute http(s) base URL,
+    /// which would otherwise persist and then silently fall back to the request Host at login (#139). A
+    /// blank override is valid (the feature is off).
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="baseUrlOverride">The override value to check.</param>
+    /// <exception cref="ArgumentException">The override is non-blank and not a valid absolute http(s) URL.</exception>
     internal static void ValidateBaseUrlOverride(string protocol, string provider, string baseUrlOverride)
     {
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
@@ -119,6 +159,15 @@ internal static class ProviderConfigValidator
 
     // A garbage certificate would be persisted and then throw a CryptographicException on every
     // callback — an unhandled 500 (#206). Same inline line-ending strip as above.
+
+    /// <summary>
+    /// Rejects a SAML provider whose signing certificate is set but is not a loadable X.509 certificate,
+    /// which would otherwise persist and then throw on every callback (an unhandled 500, #206). A blank
+    /// certificate is valid (a half-configured provider).
+    /// </summary>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="certificate">The Base64-encoded (DER) X.509 certificate to check.</param>
+    /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
     internal static void ValidateSamlCertificate(string provider, string certificate)
     {
         if (SamlCertificate.IsInvalid(certificate))
@@ -134,6 +183,15 @@ internal static class ProviderConfigValidator
     // set-but-unloadable value would be persisted and then throw a CryptographicException on every callback
     // (an unhandled 500, #206). Blank is valid (no overlap window configured). Same inline line-ending
     // strip as above.
+
+    /// <summary>
+    /// Rejects a SAML provider whose OPTIONAL secondary verification certificate (#491) is set but not
+    /// loadable — the identity provider's public certificate for a key-overlap window, validated exactly
+    /// like the primary. A blank value is valid (no overlap window configured).
+    /// </summary>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="certificate">The Base64-encoded (DER) X.509 certificate to check.</param>
+    /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
     internal static void ValidateSamlSecondaryCertificate(string provider, string certificate)
     {
         if (SamlCertificate.IsInvalid(certificate))
@@ -153,6 +211,17 @@ internal static class ProviderConfigValidator
     // (it grants nothing at runtime). Both the config-page save and the Add endpoints run this. The
     // provider name and the echoed permission are control-stripped in case they reach a log through the
     // thrown exception.
+
+    /// <summary>
+    /// Rejects a permission-role mapping (#164) whose Permission is empty, is not a known Jellyfin
+    /// PermissionKind, or names one of the dedicated permissions owned by their own fields (administrator,
+    /// all-folders, Live TV, account-disable). Such an entry would otherwise persist and silently grant
+    /// nothing at login. A null mappings collection or a null entry maps nothing and is tolerated.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (control-stripped) in the rejection message.</param>
+    /// <param name="mappings">The permission-role mappings to check.</param>
+    /// <exception cref="ArgumentException">An entry names an invalid or dedicated permission.</exception>
     internal static void ValidatePermissionRoleMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<PermissionRoleMap> mappings)
     {
         if (mappings == null)
@@ -192,6 +261,16 @@ internal static class ProviderConfigValidator
     // caught before it takes effect. A null entry maps nothing and is tolerated (it contributes nothing at
     // runtime). Both the config-page save and the Add endpoints run this. The provider name is control-
     // stripped in case it reaches a log through the thrown exception.
+
+    /// <summary>
+    /// Rejects a parental-rating mapping (#736) with a negative score or with no roles — the former is a
+    /// nonsensical ceiling, the latter would never apply. Both are caught at save so a mis-set is found
+    /// before it takes effect. A null mappings collection or a null entry maps nothing and is tolerated.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="mappings">The parental-rating mappings to check.</param>
+    /// <exception cref="ArgumentException">An entry has a negative score or lists no roles.</exception>
     internal static void ValidateParentalRatingMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<ParentalRatingRoleMap> mappings)
     {
         if (mappings == null)
@@ -227,6 +306,16 @@ internal static class ProviderConfigValidator
     // challenge. On the config-page save the key is withheld from JSON so it arrives blank (valid) and the
     // stored one is re-injected afterwards; this rejects the case where a non-blank, unloadable key is
     // posted. Same inline line-ending strip as above.
+
+    /// <summary>
+    /// Rejects a service-provider request signing key (#167/#491) that is non-blank but not a loadable
+    /// unencrypted PKCS#12 blob, which would otherwise persist and fail every signed challenge. A blank
+    /// key is valid — a config-page save withholds the key from JSON, so it arrives blank and the stored
+    /// one is re-injected afterwards.
+    /// </summary>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="signingKeyPfx">The Base64-encoded PKCS#12 (PFX) signing key to check.</param>
+    /// <exception cref="ArgumentException">The key is non-blank and not a loadable PFX with an RSA or ECDSA private key.</exception>
     internal static void ValidateSamlSigningKey(string provider, string signingKeyPfx)
     {
         if (SamlSigningKey.IsInvalid(signingKeyPfx))

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -77,6 +77,14 @@ internal static class ServerManagedFields
 
     // Links + issuer bindings + secret: an OpenID provider carries these server-managed fields
     // (#157/#189/#186).
+
+    /// <summary>
+    /// Re-injects an OpenID provider's server-managed fields (#157/#189/#186): its canonical links and their
+    /// issuer bindings — carried over only while the discovery endpoint is unchanged, dropped on a repoint so
+    /// a re-identified provider does not silently inherit another's mappings — and its write-only client secret.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted; a null entry is skipped.</param>
+    /// <param name="live">The current live provider config to read server-managed values from; null skips.</param>
     internal static void Preserve(OidConfig incoming, OidConfig live)
     {
         // A null provider entry (a malformed Add before #350, or a legacy store) carries no
@@ -107,6 +115,15 @@ internal static class ServerManagedFields
     // since #167, an optional service-provider signing key plus its optional rollover key (#491), each
     // withheld from JSON like the OpenID secret, so a save that did not rotate one arrives blank and must
     // keep the stored value.
+
+    /// <summary>
+    /// Re-injects a SAML provider's server-managed fields: its canonical link map (#157) and its write-only
+    /// service-provider signing keys — the primary (#167) and optional rollover key (#491) — each kept when
+    /// the incoming value is blank (a save that did not rotate it) so a config-page save neither wipes the
+    /// key nor silently ends a rollover overlap.
+    /// </summary>
+    /// <param name="incoming">The provider config about to be persisted; a null entry is skipped.</param>
+    /// <param name="live">The current live provider config to read server-managed values from; null skips.</param>
     internal static void Preserve(SamlConfig incoming, SamlConfig live)
     {
         if (incoming is null || live is null)

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -85,4 +85,11 @@
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- StyleCop settings live at the repo root and are shared into this project (the only one that
+         references StyleCop.Analyzers). documentInternalElements=true makes SA1600 require XML docs on
+         the internal surface too (#864); private members stay exempt. -->
+    <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
 </Project>

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "documentInternalElements": true,
+      "documentPrivateElements": false,
+      "documentPrivateFields": false,
+      "documentInterfaces": true
+    }
+  }
+}


### PR DESCRIPTION
## What & why
Implements the XML-documentation half of the #864 code-quality standard as a hard gate. Closes #864.

- Added complete, intention-revealing XML docs to the **74 internal members** that lacked them, contract-first summaries with `param`/`returns`/`typeparam`/`exception` tags, mirroring the existing house style (e.g. the fail-closed Add-endpoint guards in `SSOController`, the SAML crypto validators, the replay/interval/budget caches, `ProviderConfigValidator`, the `SsoRateLimitClass` classifications).
- Turned the gate on: `stylecop.json` sets `documentInternalElements=true`; `.editorconfig` promotes `SA1600` `none` → `warning`, which CI's warnaserror build makes a hard error. Private members stay exempt; the test and fuzz projects don't reference StyleCop, so they're exempt by construction.

## Security & quality (docs-only, mechanically proven)
- The **entire diff removes exactly one line**, the old `SA1600=none` severity. Every other changed line is an added `///` doc or a blank. **No `//` inline comment was removed anywhere** (verified: `git diff` shows zero `//`-comment deletions), so every load-bearing security-why rationale on the auth/crypto/cache surface is intact. No code, signature, or behaviour changed, XML doc comments are non-executable.
- This IS the security-review evidence for a docs-only change on the auth surface: the adversarial gate's questions (was any security-why lost? did behaviour change?) are answered conclusively by the diff. Build clean under `--warnaserror` on net9.0 and net10.0; the gate now proves completeness.

## Follow-ups (noted, not blocking)
- Three members have interpretive wording worth a glance from me (the `SsoRateLimitClass` stage boundaries, `ChallengeNewPathResolver.ResolveChallengeNewPath`, and the `LoginStatusMapper` fail-closed `exception` tag), all correct, just confirm emphasis.
- The inline-comment ban half of #864 stays review-enforced. A follow-up pins the analyzer severities so this gate cannot be silently switched back off (#873).

## Type of change
Documentation + enabling the doc-completeness gate. No production behaviour change.