### PR TITLE
Pin the internal-doc gate severities so it cannot be silently disabled

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -306,6 +306,29 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void InternalDocumentationGate_StaysEnforced()
+    {
+        // #864/#873 — guard for the guard. The internal-surface XML-doc completeness gate rests on two
+        // switches that a single quiet edit could disable: SA1600 must stay at warning-or-error in
+        // .editorconfig (CI's warnaserror turns it into a build failure), and stylecop.json must keep
+        // documentInternalElements=true (without it SA1600 checks only the public surface). Neither is
+        // exercised by any other test, so pin both here — a revert to none, suggestion, silent, or
+        // documentInternalElements=false fails this test rather than silently reopening the internal API to
+        // undocumented members.
+        var editorConfig = File.ReadAllText(Path.Combine(RepoRoot(), ".editorconfig"));
+        var severity = editorConfig
+            .Split('\n')
+            .Select(line => line.Trim())
+            .FirstOrDefault(line => line.StartsWith("dotnet_diagnostic.SA1600.severity", StringComparison.Ordinal));
+        Assert.True(
+            severity is not null && (severity.EndsWith("= warning", StringComparison.Ordinal) || severity.EndsWith("= error", StringComparison.Ordinal)),
+            $"SA1600 must stay enforced (warning or error) so the #864 internal-doc gate cannot be silently switched off — found: '{severity ?? "(missing)"}'.");
+
+        var styleCop = File.ReadAllText(Path.Combine(RepoRoot(), "stylecop.json"));
+        Assert.Contains("\"documentInternalElements\": true", styleCop, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MutableKeyedState_LivesOnlyInsideStoreLikeTypes()
     {
         // Locked in by the OidcStateStore consolidation (#318): a raw dictionary holding runtime state


### PR DESCRIPTION
## What & why
From the drift-guard sweep (#873), the guard for the guard. The #864 internal XML-doc completeness gate (landed in #881) rests on two switches a single quiet edit could flip off:
- `SA1600.severity` in `.editorconfig` (a revert to `none`/`suggestion`/`silent` disables the build failure), and
- `documentInternalElements` in `stylecop.json` (false makes SA1600 check only the public surface).

Neither was exercised by any test, so a revert would silently reopen the internal API to undocumented members **with a green build**. `InternalDocumentationGate_StaysEnforced` pins both: SA1600 must stay warning-or-error, and documentInternalElements must stay true.

## Type of change
Test-only (new conformance fitness function). No production code.

## Testing
- Passes against the current committed state; non-vacuous (reads the real `.editorconfig` and `stylecop.json`).
- Full suite green on net10.0 (1788); builds clean under `--warnaserror`.

## Review gate
Test-only, no security surface → standard CI gate. Completes the machine-enforced part of #873 (namespace-mirror #880, resource-resolution #869, severity-pin here); the CI wiki-lint is coupled to the wiki restructure (#872) and follows with it.