### PR TITLE
Point the repo docs at the consolidated wiki; fix module-table and beta-trigger drift

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish Release
 
 # A three-part stable tag push (e.g. 4.1.1-stable) is the ONLY publish trigger,
-# per the Release-Policy wiki page
-# (https://github.com/iderex/jellyfin-plugin-sso/wiki/Release-Policy) — the beta
+# per the Releasing wiki page
+# (https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing) — the beta
 # soak / promotion gate a stable tag clears. The
 # channel/generation is the tag SUFFIX — this is
 # the JF10.11 line, so `X.Y.Z-stable`; the JF12 line publishes from `X.Y.Z-JF12-stable`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 - [VSCode](https://code.visualstudio.com/docs/languages/dotnet)
 - [N/Vim](https://github.com/OmniSharp/Omnisharp-vim)
 
-**Getting oriented.** Before diving into `SSOController.cs` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) wiki page and the in-tree [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals) — together they walk an OpenID and a SAML sign-in from challenge to session and map the code layout, so you can place a change onto the flow instead of reverse-engineering it. The Architecture Internals page also separates that current shape from the [#318](https://github.com/iderex/jellyfin-plugin-sso/issues/318) target architecture the codebase is migrating toward.
+**Getting oriented.** Before diving into the `SSOController` and the SAML/OpenID helpers, read the [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) and [Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture) wiki pages — together they walk an OpenID and a SAML sign-in from challenge to session and map the module layout, so you can place a change onto the flow instead of reverse-engineering it.
 
 **Building and testing.** CI runs these on every pull request and they must pass:
 
@@ -175,15 +175,17 @@ Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); e
 
 We format all C# code according to the .NET formatter. Build with `dotnet build --no-restore --warnaserror` (the same command CI runs, so warnings fail the build) and fix anything it reports, and keep `dotnet test` green.
 
+The architecture, comment/documentation, and object-oriented rules a change is held to live in one canonical place — the [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. This guide does not restate them; read that page before a non-trivial change. They are enforced by the conformance fitness functions in `SSO-Auth.Tests/ArchitectureConformanceTests.cs` and the adversarial review gate.
+
 ### HTML/CSS/JS/Markdown
 
 We use [Prettier](https://prettier.io) to format these files. Run `npx prettier --write "**/*.{js,html,md,css,scss}"` before committing, and `npx prettier --check "**/*.{js,html,md,css,scss}"` to confirm — CI enforces the check (only `*.min.js` is exempt).
 
-Not every file under `SSO-Auth/Views` is project code. Check the provenance header before editing: `emby-restyle.css` and the minified `jellyfin-apiClient.esm.min.js` are **vendored** from jellyfin-web — update them by re-copying from upstream, not by editing in place — whereas `ApiClient.js` is **project-maintained** code (loosely based on the linked upstream) that carries our own security logic and is edited here directly.
+Not every file under `SSO-Auth/Web` is project code. Check the provenance header before editing: `emby-restyle.css` and the minified `jellyfin-apiClient.esm.min.js` are **vendored** from jellyfin-web — update them by re-copying from upstream, not by editing in place — whereas `ApiClient.js` is **project-maintained** code (loosely based on the linked upstream) that carries our own security logic and is edited here directly.
 
 ### Keeping the docs in step
 
-When a code change makes any **README section or wiki page** wrong or incomplete — a changed behaviour, a moved file the [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals) page names, a new or renamed config option, an altered login flow — the documentation follow-up must not be lost. Either **update the docs in the same pull request**, or **open a `documentation`-labelled issue on the current-release milestone** so it ships before the next release. The PR checklist has a box for this. (The wiki has no pull-request flow — wiki edits are pushed directly to its repository — but the _tracking_ still lives as an issue in the main repository.)
+When a code change makes any **README section or wiki page** wrong or incomplete — a changed behaviour, a moved type the [Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture) page names, a new or renamed config option, an altered login flow — the documentation follow-up must not be lost. Either **update the docs in the same pull request**, or **open a `documentation`-labelled issue on the current-release milestone** so it ships before the next release. The PR checklist has a box for this. (The wiki has no pull-request flow — wiki edits are pushed directly to its repository — but the _tracking_ still lives as an issue in the main repository.)
 
 <!-- omit in toc -->
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -30,7 +30,7 @@ wiki page).
 - **Scope and releases** I decide, guided by the public
   [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap) and its
   maturity ladder; releases follow the
-  [Release Policy](https://github.com/iderex/jellyfin-plugin-sso/wiki/Release-Policy)
+  [Releasing](https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing)
   (channel/soak promotion).
 - **Security decisions outrank feature decisions.** Anything touching the login
   path passes the adversarial review gate before merge.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Jellyfin upstream is building [native OIDC](https://github.com/jellyfin/jellyfin
    | ---------- | --------------------------------------------------------------------------------------------- |
    | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json` |
    | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`    |
-   - **stable** ships tagged releases only. **beta** publishes on every merge, so betas move fast and may break — use them for testing, not production.
+   - **stable** ships tagged releases only. **beta** publishes on a daily schedule (04:00 UTC) whenever `main` has advanced since the last beta, so betas move fast and may break — use them for testing, not production.
    - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** (the stable 12.0 build lands at a 12.0 stable release).
 
 2. Go to **Dashboard → Plugins → Catalog**, find **SSO Authentication**, and install it.

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Broader documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-p
 
 - [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Per-identity-provider setup: [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup)
-- In-tree contributor map of the login flow and code layout: [Architecture Internals](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture-Internals)
+- Contributor map of the login flow and module layout: [Architecture](https://github.com/iderex/jellyfin-plugin-sso/wiki/Architecture)
 - Project policies: [Governance](GOVERNANCE.md) · [Privacy & data handling](docs/PRIVACY.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
-- Honest maturity self-assessment (Silver/Gold + OSPS, incl. what a solo project structurally cannot meet): [Maturity Map](https://github.com/iderex/jellyfin-plugin-sso/wiki/Maturity-Map)
+- Honest maturity self-assessment (Silver/Gold + OSPS, incl. what a solo project structurally cannot meet): [Security & Maturity Self-Assessment](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-and-Maturity-Self-Assessment)
 
 ## Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,7 +46,7 @@ consistently — they are not a contractual SLA.
   months' notice before the final security update of a line.
 
 Release integrity, channels and the soak/promotion model are described in the
-[Release Policy](https://github.com/iderex/jellyfin-plugin-sso/wiki/Release-Policy)
+[Releasing](https://github.com/iderex/jellyfin-plugin-sso/wiki/Releasing)
 wiki page.
 
 ## Verifying a release download
@@ -94,7 +94,7 @@ integrity is covered by the SLSA attestation and the checksum sidecars above.
 - **Dependabot** opens dependency-update pull requests; a dependency-review check blocks a pull request that introduces or upgrades to a known-vulnerable dependency; and the build fails on any known-vulnerable dependency, transitive ones included.
 - Pull requests to `main` run CodeQL, a Trojan-Source/Unicode check, and a build with warnings treated as errors; a GitHub Actions workflow audit (zizmor) and repository-specific security-invariant checks (Opengrep) run on every pull request. A scheduled OpenSSF Scorecard scan audits the repository's supply-chain posture and publishes its results to code scanning. Changes to the login path additionally go through an adversarial security review before they merge.
 
-For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). For how they map onto the OpenSSF Best Practices passing-level criteria, see [OpenSSF Best Practices](https://github.com/iderex/jellyfin-plugin-sso/wiki/OpenSSF-Best-Practices); for an honest Silver/Gold + OSPS-Baseline map — including the criteria a solo, AI-assisted project structurally cannot meet — see the [Maturity Map](https://github.com/iderex/jellyfin-plugin-sso/wiki/Maturity-Map). For the authentication surface mapped to OWASP ASVS 5.0 and the OAuth 2.0 Security BCP (RFC 9700) — Met / Partial / N-A with source citations and honestly-recorded residuals — see the [Security Conformance self-assessment](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Conformance).
+For how these controls together cover what an automated PR reviewer would catch — and the one accepted residual — see [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate). For how they map onto the OpenSSF Best Practices passing level through an honest Silver/Gold + OSPS-Baseline assessment — including the criteria a solo, AI-assisted project structurally cannot meet — see the [Security & Maturity Self-Assessment](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-and-Maturity-Self-Assessment). For the authentication surface mapped to OWASP ASVS 5.0 and the OAuth 2.0 Security BCP (RFC 9700) — Met / Partial / N-A with source citations and honestly-recorded residuals — see the [Security Conformance self-assessment](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Conformance).
 
 ## EU Cyber Resilience Act (CRA) position
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -34,25 +34,27 @@ case declaring its allowed edges; an import to any other Api module fails the
 test. Importing non-`Api` namespaces (e.g. `Config`) is permitted; there is no
 longer a flat `Api` core to import (see _The kernel is dissolved_ below).
 
-| Module      | Purpose                                                                             | May depend on                                                                                       |
-| ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `Net`       | Networking / SSRF / URL primitives                                                  | — (leaf)                                                                                            |
-| `Secrets`   | Secrets at rest (envelope, store, config wrapping)                                  | — (leaf)                                                                                            |
-| `Audit`     | Append-only SSO audit logging                                                       | — (leaf)                                                                                            |
-| `Authz`     | Role → permission mapping                                                           | — (leaf)                                                                                            |
-| `Routing`   | Route-shape contract (suffix reader, path classifier)                               | — (leaf)                                                                                            |
-| `Crypto`    | Shared asymmetric signing-key strength policy (min RSA bits / approved EC curves)   | — (leaf)                                                                                            |
-| `Avatar`    | Avatar fetch + SSRF-gated validation                                                | `Net`, `RateLimit`                                                                                  |
-| `RateLimit` | Login throttling (buckets, gates, keys)                                             | `Net`                                                                                               |
-| `Provider`  | Provider config / naming / test-result                                              | `Net`, `RateLimit`                                                                                  |
-| `Linking`   | Account link resolution / adoption / revocation                                     | `Audit`, `Provider`, `RateLimit`                                                                    |
-| `Identity`  | The protocol-validated identity keystone                                            | `Authz`, `Provider`                                                                                 |
-| `Session`   | Session mint + login outcomes + SSO-only                                            | `Authz`, `Avatar`, `Linking`                                                                        |
-| `Saml`      | SAML core, validators, caches, metadata                                             | `Authz`, `Identity`, `RateLimit`, `Session`                                                         |
-| `Oidc`      | OIDC flow, discovery, id_token, state                                               | `Authz`, `Avatar`, `Identity`, `Net`, `Provider`, `RateLimit`, `Routing`                            |
-| `Flows`     | Per-protocol login orchestration services                                           | `Audit`, `Identity`, `Linking`, `Net`, `Oidc`, `Provider`, `RateLimit`, `Saml`, `Session`, `Shared` |
-| `Shared`    | Shared served-page / flow-response helpers                                          | `Avatar`, `Linking`, `RateLimit`, `Routing`, `Session`                                              |
-| `Http`      | The web boundary: `SSOController`, request helpers, the admin test-connection probe | the composition top — fronts every flow (wide by design); nothing imports it back                   |
+| Module         | Purpose                                                                             | May depend on                                                                                       |
+| -------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Net`          | Networking / SSRF / URL primitives                                                  | — (leaf)                                                                                            |
+| `Secrets`      | Secrets at rest (envelope, store, config wrapping)                                  | — (leaf)                                                                                            |
+| `Audit`        | Append-only SSO audit logging                                                       | — (leaf)                                                                                            |
+| `Authz`        | Role → permission mapping                                                           | — (leaf)                                                                                            |
+| `Routing`      | Route-shape contract (suffix reader, path classifier)                               | — (leaf)                                                                                            |
+| `Crypto`       | Shared asymmetric signing-key strength policy (min RSA bits / approved EC curves)   | — (leaf)                                                                                            |
+| `LoginButtons` | Login-page button rendering + branding-sync hosted service (#722)                   | — (leaf)                                                                                            |
+| `Logout`       | Single Logout session-state store (#727)                                            | — (leaf)                                                                                            |
+| `Avatar`       | Avatar fetch + SSRF-gated validation                                                | `Net`, `RateLimit`                                                                                  |
+| `RateLimit`    | Login throttling (buckets, gates, keys)                                             | `Net`                                                                                               |
+| `Provider`     | Provider config / naming / test-result                                              | `Net`, `RateLimit`                                                                                  |
+| `Linking`      | Account link resolution / adoption / revocation                                     | `Audit`, `Provider`, `RateLimit`                                                                    |
+| `Identity`     | The protocol-validated identity keystone                                            | `Authz`, `Provider`                                                                                 |
+| `Session`      | Session mint + login outcomes + SSO-only                                            | `Authz`, `Avatar`, `Linking`                                                                        |
+| `Saml`         | SAML core, validators, caches, metadata                                             | `Authz`, `Identity`, `RateLimit`, `Session`                                                         |
+| `Oidc`         | OIDC flow, discovery, id_token, state                                               | `Authz`, `Avatar`, `Identity`, `Net`, `Provider`, `RateLimit`, `Routing`                            |
+| `Flows`        | Per-protocol login orchestration services                                           | `Audit`, `Identity`, `Linking`, `Net`, `Oidc`, `Provider`, `RateLimit`, `Saml`, `Session`, `Shared` |
+| `Shared`       | Shared served-page / flow-response helpers                                          | `Avatar`, `Linking`, `RateLimit`, `Routing`, `Session`                                              |
+| `Http`         | The web boundary: `SSOController`, request helpers, the admin test-connection probe | the composition top — fronts every flow (wide by design); nothing imports it back                   |
 
 `Saml` and `Oidc` are **sibling protocol modules**: neither imports the other.
 Dependencies point _into_ the low-level leaves (`Net`, `Secrets`, `Audit`,


### PR DESCRIPTION
## What & why
The in-repo side of the wiki/standards consolidation (#871, #872). The wiki has been restructured so each fact has one canonical home; this repoints the repository's docs at it and repairs the drift the consolidation surfaced. The wiki pages referenced here are already live.

**Standards consolidation (#871):**
- The canonical coding/comment/OO standard now lives on the [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. `CONTRIBUTING.md` (### C#) and `CLAUDE.md` (directive 4) now **point there** instead of restating the rules.
- Repaired the reference cascade the wiki restructure created: every in-repo link to a merged/renamed page is repointed, Architecture-Internals → Architecture, Release-Policy → Releasing, OpenSSF-Best-Practices + Maturity-Map → Security & Maturity Self-Assessment (CONTRIBUTING, README, SECURITY, GOVERNANCE, and a comment in publish.yml). No link left dangling.

**Drift the consolidation surfaced (fixed):**
- `docs/ARCHITECTURE.md` DAG table listed **17 modules; the tree and the conformance test have 19**, added `LoginButtons` (#722) and `Logout` (#727) as leaves.
- `CLAUDE.md` repo map still described a monolithic `SSOController`, `Saml.cs`, and `SSO-Auth/Views/`, updated to the module layout (#790/#807) and `SSO-Auth/Web/` (#869); dropped the stale "#318 migration in progress" framing.
- `CONTRIBUTING.md` still named `SSO-Auth/Views` for the served assets → `SSO-Auth/Web`.
- **README beta-trigger was wrong**: it said "publishes on every merge"; the real mechanism is the daily 04:00 UTC scheduler (`nightly-betas.yml`, #632; `publish-beta.yml` has no push trigger). Corrected to match the wiki.

## Type of change
Documentation. No code, no CI behaviour (publish.yml change is a comment-only reference).

## Review gate
Docs-only. `publish.yml` is touched but only in a comment (verified: the diff is the wiki-page name in two comment lines); no workflow behaviour changes. Standard CI gate (prettier).