### PR TITLE
Record the OIDC/SAML shared-abstraction evaluation; codify the ≥2-consumer rule

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,13 +113,19 @@ none merely "good enough":
    namespace**; the flat `Api` root stays empty (a conformance test enforces it).
    A genuinely new concern gets a **new module** (folder + namespace + a DAG
    `InlineData` case), not a smear across the tree.
-3. **Object-oriented structure** — shared behaviour lives behind a **shared
-   abstraction** with protocols/variants as specializations, realised
-   **composition- and interface-first, with shallow inheritance only where it is
-   genuinely `is-a`** (not a deep inheritance tower). `ProviderConfigBase`
-   (shared by `OidConfig`/`SamlConfig`) is the model to follow; the broader
-   OIDC/SAML shared-contract work is #790. A third IdP type must slot into the
-   shared abstraction, not fork a third parallel path.
+3. **Object-oriented structure** — shared behaviour lives in a **single concrete
+   home reached by composition**, not duplicated across protocols. An **interface
+   or abstract contract earns its place only when ≥2 real consumers dispatch
+   through it polymorphically**; until then a concrete type is clearer and an
+   interface is speculative (composition- and interface-first, shallow
+   inheritance only where it is genuinely `is-a`, never a deep inheritance
+   tower). `ProviderConfigBase` (the genuine `is-a` shared by
+   `OidConfig`/`SamlConfig`) and the `ValidatedLogin` → `VerifiedIdentity`
+   keystone both protocol validators feed are the models; a third IdP type slots
+   into those shared homes, not a third parallel path. The full object-oriented
+   rule is the canonical
+   [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards);
+   the OIDC/SAML seam evaluation that settled it is #790.
 
 **This applies to the whole repository, not only `Api/`.** In particular the
 **test project mirrors the source module structure** — a module's tests live in


### PR DESCRIPTION
## What & why
Closes #790, the written evaluation of every OIDC/SAML seam, with an interface/composition/inheritance call per seam. The honest conclusion: **the shared abstractions that genuinely warrant existing already exist; every remaining seam stays separate because none has ≥2 real consumers dispatching through it polymorphically.** No new abstraction is warranted, consistent with the repo-wide audit (which deleted the one speculative abstraction, `ILoginService`, in #870).

## Per-seam evaluation (the acceptance criterion)

| Seam | Call | Rationale |
|---|---|---|
| **Flows**, `OidcLoginService` / `SamlLoginService` | **keep separate + composition** | `ILoginService` had 1 of 4 flow ops and **zero polymorphic consumers** (the controller holds the concrete types); deleted in #870. The genuinely shared tail is already a single concrete home reached by composition, `LoginCompletionService`, `RolePrivilegeMapper`, `PermissionRolePolicy`, `FlowResponses`, `LoginStatusMapper`. No interface earns its place. |
| **Config**, `OidConfig` / `SamlConfig` | **keep the shared base** | `ProviderConfigBase` (#204) is a genuine shallow `is-a` and already carries the common surface; nothing protocol-specific leaks up. The model to follow. |
| **Authorize-state builders**, `OidcAuthorizeStateBuilder` / `SamlAuthorizeStateBuilder` | **keep separate** | Different inputs (OIDC claims + issuer vs SAML roles) producing protocol-specific record structs. Their **shared shape already exists one layer down**: both feed the neutral `ValidatedLogin` → `VerifiedIdentity` keystone (the Identity module). The shared contract is the keystone, not a builder interface. |
| **Connection testing**, `ProviderConnectionTester` | **keep separate** | `TestOidcAsync(OidConfig)` and `TestSaml(SamlConfig)` take different config types and share no logic (OIDC does discovery; SAML parses a certificate). The caller always knows the protocol **statically**, there is no polymorphic dispatch to serve, so an `IProviderProbe` would be exactly the speculative abstraction `ILoginService` was. |
| **Stores / caches**, OidcStateStore / SamlOutcomeStore / SamlReplayCache / SamlRequestCache | **keep separate** | They differ in security-load-bearing ways (two-phase promotion #326, reserve/commit/release #539, never-evict-a-live-entry #32, register/consume). The shared *mechanism* is already extracted (`IntervalGate`, `PerClientBudgetLimiter`); a generic store would force four intentionally-divergent policies through one path. |

## The rule, codified
`docs/ARCHITECTURE.md` extension contract (point 3) now states: shared behaviour lives in a **single concrete home reached by composition**; an interface/abstract earns its place **only at ≥2 real polymorphic consumers**. The full OO rule (composition over inheritance, no test base classes) is the canonical [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. A third IdP type slots into the existing shared homes (`ProviderConfigBase`, the `ValidatedLogin`/`VerifiedIdentity` keystone), not a fourth parallel path.

## Type of change
Documentation (records a completed architecture evaluation; no code change). Standard CI gate.