### PR TITLE
Enable nullable reference types on the LoginButtons module

### DIFF
--- a/SSO-Auth/Api/LoginButtons/LoginButton.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButton.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 
 /// <summary>

--- a/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;


### PR DESCRIPTION
## What & why
Advances #799. `#nullable enable` on `LoginButton` and `LoginButtonBuilder`, completing the LoginButtons module (4/4 enabled). Both files were already null-clean, this is the enabling pragma only, no annotations, no code change.

## Testing
Builds clean under `--warnaserror` on net9.0 and net10.0; all 1788 tests pass.

## Review gate
Pragma-only, zero warnings, no behaviour change → standard CI gate.