### PR TITLE
Enable nullable reference types on the Linking module

### DIFF
--- a/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
+++ b/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
 
 /// <summary>


### PR DESCRIPTION
## What & why
Advances #799. `#nullable enable` on `SsoManagedProviderId`, completing the Linking module (5/5). Already null-clean, enabling pragma only, no code change.

## Testing
Builds clean under `--warnaserror`; all 1788 tests pass.

## Review gate
Pragma-only, zero behaviour change → standard CI gate.

Refs #799