### PR TITLE
Enable nullable reference types on the Config module

### DIFF
--- a/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
@@ -220,8 +220,8 @@ public class ConfigExportImportTests
         // The camelCase document deserializes back (case-insensitive) with the provider intact and the secret
         // still redacted to null.
         var wire = JsonSerializer.Deserialize<ConfigExportDocument>(json, options)!;
-        Assert.Equal("client-1", wire.Configuration.OidConfigs["idp"].OidClientId);
-        Assert.True(string.IsNullOrEmpty(wire.Configuration.OidConfigs["idp"].OidSecret));
+        Assert.Equal("client-1", wire.Configuration!.OidConfigs["idp"].OidClientId);
+        Assert.True(string.IsNullOrEmpty(wire.Configuration!.OidConfigs["idp"].OidSecret));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
@@ -62,8 +62,8 @@ public class ConfigPreservationTests
     [Fact]
     public void Preserve_NullConfigMaps_DoNotThrow()
     {
-        var incoming = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
-        var live = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
+        var incoming = new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! };
+        var live = new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! };
 
         // Fail-safe: a malformed config with missing maps must not NRE the save path.
         var exception = Record.Exception(() => ServerManagedFields.Preserve(incoming, live));
@@ -80,13 +80,13 @@ public class ConfigPreservationTests
         // A malformed Add before #350 could store a null provider entry; preserving with a null on
         // either side must skip it, not NRE the whole config-page save.
         var live = new PluginConfiguration();
-        live.OidConfigs["null-in-live"] = null;
+        live.OidConfigs["null-in-live"] = null!;
         live.OidConfigs["null-in-incoming"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub"] = User } };
-        live.SamlConfigs["saml-null-in-live"] = null;
+        live.SamlConfigs["saml-null-in-live"] = null!;
 
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["null-in-live"] = new OidConfig();
-        incoming.OidConfigs["null-in-incoming"] = null;
+        incoming.OidConfigs["null-in-incoming"] = null!;
         incoming.SamlConfigs["saml-null-in-live"] = new SamlConfig();
 
         var exception = Record.Exception(() => ServerManagedFields.Preserve(incoming, live));
@@ -500,7 +500,7 @@ public class ConfigPreservationTests
     {
         var incoming = new PluginConfiguration();
         incoming.OidConfigs["idp"] = new OidConfig { BaseUrlOverride = "https://jellyfin.example.com" };
-        incoming.OidConfigs["idp-blank"] = new OidConfig { BaseUrlOverride = null };
+        incoming.OidConfigs["idp-blank"] = new OidConfig { BaseUrlOverride = string.Empty };
         incoming.SamlConfigs["saml"] = new SamlConfig { BaseUrlOverride = "https://sso.example.com/jellyfin" };
         incoming.SamlConfigs["saml-blank"] = new SamlConfig { BaseUrlOverride = "   " };
 
@@ -531,7 +531,7 @@ public class ConfigPreservationTests
     [Fact]
     public void ValidateBaseUrlOverrides_NullConfigMaps_DoNotThrow()
     {
-        var incoming = new PluginConfiguration { OidConfigs = null, SamlConfigs = null };
+        var incoming = new PluginConfiguration { OidConfigs = null!, SamlConfigs = null! };
 
         ProviderConfigValidator.Validate(incoming, new PluginConfiguration());
     }
@@ -685,8 +685,8 @@ public class ConfigPreservationTests
         Assert.True(back.EnableLiveTvManagement);
         Assert.Equal(original.LiveTvRoles, back.LiveTvRoles);
         Assert.Equal(original.LiveTvManagementRoles, back.LiveTvManagementRoles);
-        Assert.Equal("user", back.FolderRoleMapping[0].Role);
-        Assert.Equal("folder-a", back.FolderRoleMapping[0].Folders[0]);
+        Assert.Equal("user", back.FolderRoleMapping![0].Role);
+        Assert.Equal("folder-a", back.FolderRoleMapping![0].Folders![0]);
         Assert.Equal("provider", back.DefaultProvider);
         Assert.Equal("https", back.SchemeOverride);
         Assert.Equal(8443, back.PortOverride);
@@ -833,7 +833,7 @@ public class ConfigPreservationTests
     [Fact]
     public void ValidateSamlCertificates_NullMap_DoesNotThrow()
     {
-        ProviderConfigValidator.Validate(new PluginConfiguration { SamlConfigs = null }, new PluginConfiguration());
+        ProviderConfigValidator.Validate(new PluginConfiguration { SamlConfigs = null! }, new PluginConfiguration());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
+++ b/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
@@ -67,6 +67,7 @@ public class SerializableDictionarySerializationTests
     }
 
     private static string Serialize<TKey, TValue>(SerializableDictionary<TKey, TValue> value)
+        where TKey : notnull
     {
         var serializer = new XmlSerializer(typeof(SerializableDictionary<TKey, TValue>));
         using var writer = new StringWriter();
@@ -75,12 +76,14 @@ public class SerializableDictionarySerializationTests
     }
 
     private static SerializableDictionary<TKey, TValue> RoundTrip<TKey, TValue>(SerializableDictionary<TKey, TValue> value)
+        where TKey : notnull
         => Deserialize<TKey, TValue>(Serialize(value));
 
     // Deserializes through the XmlReader overload with DTD processing prohibited (the
     // XmlReaderSettings default) — the hardened pattern CA5369 requires, mirroring how the
     // production type is only ever read through an XmlReader.
     private static SerializableDictionary<TKey, TValue> Deserialize<TKey, TValue>(string xml)
+        where TKey : notnull
     {
         var serializer = new XmlSerializer(typeof(SerializableDictionary<TKey, TValue>));
         using var stringReader = new StringReader(xml);

--- a/SSO-Auth.Tests/Http/SSOControllerConfigTransferTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerConfigTransferTests.cs
@@ -57,7 +57,7 @@ public class SSOControllerConfigTransferTests
 
         // Take the redacted document the export would hand out, flip a non-secret setting, and re-import it.
         var wire = WireRoundTrip(ExportedDocument(harness));
-        wire.Configuration.OidConfigs["idp"].EnableAuthorization = true;
+        wire.Configuration!.OidConfigs["idp"].EnableAuthorization = true;
 
         var result = harness.Controller.ImportConfig(wire);
 

--- a/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
@@ -169,7 +169,7 @@ public class SSOControllerEndpointTests
         var harness = new SsoControllerHarness(c =>
         {
             c.OidConfigs["keycloak"] = new OidConfig { Enabled = true };
-            c.OidConfigs["broken"] = null;
+            c.OidConfigs["broken"] = null!;
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.OidProviderNames());
@@ -209,7 +209,7 @@ public class SSOControllerEndpointTests
         var harness = new SsoControllerHarness(c =>
         {
             c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
-            c.SamlConfigs["broken"] = null;
+            c.SamlConfigs["broken"] = null!;
         });
 
         var result = Assert.IsType<OkObjectResult>(harness.Controller.SamlProviderNames());

--- a/SSO-Auth.Tests/Http/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlMetadataTests.cs
@@ -67,7 +67,7 @@ public class SSOControllerSamlMetadataTests
         {
             Enabled = true,
             SamlClientId = "https://sp",
-            BaseUrlOverride = null,
+            BaseUrlOverride = string.Empty,
         });
 
         var result = Assert.IsType<ContentResult>(harness.Controller.SamlMetadata("adfs"));

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -668,7 +668,7 @@ public class CanonicalLinkServiceTests
         // The login-path companion to the admin null-config guards: a provider stored as a null config
         // object (reachable via #350) must REJECT the login (fail closed), never fall through to the
         // adoption gate whose create/adopt arms would mint a session for an unusable provider.
-        var (service, _, users, _) = Build(c => c.OidConfigs["broken"] = null);
+        var (service, _, users, _) = Build(c => c.OidConfigs["broken"] = null!);
         users.GetUserByName("alice").Returns((User?)null); // name is free -> the create arm would fire if it fell through
 
         await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
@@ -682,7 +682,7 @@ public class CanonicalLinkServiceTests
     {
         // A provider stored with a null config object (reachable via #350's null-body add) must be read
         // as absent, not dereferenced into a 500 — same fail-closed treatment as a missing provider.
-        var (service, _, _, _) = Build(c => c.OidConfigs["broken"] = null);
+        var (service, _, _, _) = Build(c => c.OidConfigs["broken"] = null!);
 
         var result = service.TryRemoveLink(ProviderMode.Oid, "broken", "sub-1", Existing);
 
@@ -697,7 +697,7 @@ public class CanonicalLinkServiceTests
         var (service, _, _, _) = Build(c =>
         {
             c.OidConfigs["kc"] = new OidConfig { Enabled = true, CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing } };
-            c.OidConfigs["broken"] = null;
+            c.OidConfigs["broken"] = null!;
         });
 
         var oid = service.LinksByUser(ProviderMode.Oid, Existing);

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -110,7 +110,7 @@ internal static class RolePrivilegeMapper
     // Whether the login's role is on a configured allow-list. Null-safe both ways (ordinal): a null list
     // or a null entry is simply not a match — never a NullReferenceException — so an admin misconfiguration
     // or a stray null fails closed (grants nothing) instead of throwing a 500.
-    private static bool IsOnList(IEnumerable<string> allowed, string role) =>
+    private static bool IsOnList(IEnumerable<string>? allowed, string role) =>
         allowed != null && allowed.Any(entry => string.Equals(role, entry, StringComparison.Ordinal));
 
     /// <summary>

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -575,7 +575,7 @@ internal sealed class SamlLoginService
     // (DER). Fail-closed: a missing/corrupt at-rest key throws CryptographicException, and a garbage or
     // private-key-less PKCS#12 fails to load — both return false so the caller emits no descriptor for it.
     // The private key never leaves this method; only certificate.RawData (the public DER) is exported.
-    private static bool TryRevealPublicCertificate(string storedPfx, out string? publicCertificateBase64)
+    private static bool TryRevealPublicCertificate(string? storedPfx, out string? publicCertificateBase64)
     {
         publicCertificateBase64 = null;
 

--- a/SSO-Auth/Config/ConfigExport.cs
+++ b/SSO-Auth/Config/ConfigExport.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/ConfigExportDocument.cs
+++ b/SSO-Auth/Config/ConfigExportDocument.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>
@@ -24,5 +26,5 @@ public class ConfigExportDocument
     /// configuration whose secrets and server-managed link maps are withheld at the JSON boundary; on import
     /// it is the incoming configuration to merge into the target.
     /// </summary>
-    public PluginConfiguration Configuration { get; set; }
+    public PluginConfiguration? Configuration { get; set; }
 }

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
@@ -40,7 +42,7 @@ internal static class ConfigImport
     /// admin.
     /// </param>
     /// <exception cref="ArgumentException">The document is unsupported, empty, carries an invalid provider, or asserts SSO-only with no surviving admin login path.</exception>
-    internal static void Apply(PluginConfiguration live, ConfigExportDocument document, Func<string, BreakGlassAdminState> resolveBreakGlass = null)
+    internal static void Apply(PluginConfiguration live, ConfigExportDocument document, Func<string, BreakGlassAdminState>? resolveBreakGlass = null)
     {
         ArgumentNullException.ThrowIfNull(live);
         ArgumentNullException.ThrowIfNull(document);
@@ -65,7 +67,7 @@ internal static class ConfigImport
         // enables the mode through the elevated, audited SSO-Only endpoints, not by import.
         if (imported.DisablePasswordLogin)
         {
-            var breakGlass = imported.BreakGlassAdminUsername;
+            var breakGlass = imported.BreakGlassAdminUsername ?? string.Empty;
             SsoOnlyLoginGuard.AssertCanActivate(breakGlass, resolveBreakGlass?.Invoke(breakGlass) ?? default);
         }
 

--- a/SSO-Auth/Config/LogoutSession.cs
+++ b/SSO-Auth/Config/LogoutSession.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
@@ -22,37 +24,37 @@ public class LogoutSession
     /// audit-protocol spelling written by the login path, <c>VerifiedIdentity.AuditProtocol</c>), selecting
     /// which logout mechanism applies.
     /// </summary>
-    public string Protocol { get; set; }
+    public string Protocol { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the provider name (its config-dictionary key) the session was authenticated through.
     /// </summary>
-    public string Provider { get; set; }
+    public string Provider { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the stable subject (the OpenID <c>sub</c> claim or the SAML <c>NameID</c>) the inbound
     /// SAML <c>LogoutRequest</c> path matches on.
     /// </summary>
-    public string Subject { get; set; }
+    public string Subject { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the identity-provider session identifier (the OpenID <c>sid</c> claim or the SAML
     /// <c>SessionIndex</c>), when the provider issued one; otherwise blank.
     /// </summary>
-    public string SessionIndex { get; set; }
+    public string? SessionIndex { get; set; }
 
     /// <summary>
     /// Gets or sets the id_token issuer (the <c>iss</c> claim) the logout URL is host-bound to, so an
     /// RP-initiated logout can only be built against the discovered authority (OpenID only).
     /// </summary>
-    public string Issuer { get; set; }
+    public string? Issuer { get; set; }
 
     /// <summary>
     /// Gets or sets the OpenID <c>end_session_endpoint</c> captured from discovery at login (#727, SLO-2),
     /// so an RP-initiated logout needs no runtime rediscovery. Blank when the OP advertises none (or for
     /// SAML), in which case logout falls back to local-only. Not a secret — a public provider URL.
     /// </summary>
-    public string EndSessionEndpoint { get; set; }
+    public string? EndSessionEndpoint { get; set; }
 
     /// <summary>
     /// Gets or sets the raw OpenID <c>id_token</c> used as the <c>id_token_hint</c> for an RP-initiated
@@ -64,7 +66,7 @@ public class LogoutSession
     // plaintext in memory until the next persist, so the belt-and-suspenders matters. XML persistence is
     // unaffected (XmlSerializer ignores this attribute), so the encrypted token still round-trips to disk.
     [System.Text.Json.Serialization.JsonIgnore]
-    public string IdToken { get; set; }
+    public string? IdToken { get; set; }
 
     /// <summary>
     /// Gets or sets the Jellyfin user id whose tokens a logout revokes.

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
@@ -9,8 +11,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// </summary>
 public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfiguration
 {
-    private List<Guid> _ssoOnlyRepointedUserIds;
-    private SerializableDictionary<string, LogoutSession> _logoutSessions;
+    private List<Guid>? _ssoOnlyRepointedUserIds;
+    private SerializableDictionary<string, LogoutSession>? _logoutSessions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PluginConfiguration"/> class.
@@ -103,7 +105,7 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
     /// and only ever pointed at an account that is ALREADY an administrator (it cannot grant admin — T-E1).
     /// Blank means no break-glass admin is designated, so the mode cannot be enabled.
     /// </summary>
-    public string BreakGlassAdminUsername { get; set; }
+    public string? BreakGlassAdminUsername { get; set; }
 
     /// <summary>
     /// Gets or sets the ids of the accounts SSO-only mode has repointed off the built-in password provider
@@ -170,7 +172,7 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
 // is the disposition rather than a per-property annotation.
 public abstract class ProviderConfigBase
 {
-    private SerializableDictionary<string, Guid> _canonicalLinks;
+    private SerializableDictionary<string, Guid>? _canonicalLinks;
 
     /// <summary>
     /// Gets or sets the canonical external base URL for this provider, e.g.
@@ -179,7 +181,7 @@ public abstract class ProviderConfigBase
     /// <c>Host</c> header (#139), so a spoofed or proxy-forwarded host cannot redirect the login elsewhere.
     /// It overrides the scheme and port overrides. Blank keeps the request-host behavior.
     /// </summary>
-    public string BaseUrlOverride { get; set; }
+    public string BaseUrlOverride { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets a value indicating whether the provider is enabled.
@@ -194,7 +196,7 @@ public abstract class ProviderConfigBase
     /// means no post-logout redirect. No effect while <see cref="PluginConfiguration.EnableSingleLogout"/> is
     /// off.
     /// </summary>
-    public string PostLogoutRedirectUri { get; set; }
+    public string? PostLogoutRedirectUri { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
@@ -209,7 +211,7 @@ public abstract class ProviderConfigBase
     /// name. The value is HTML-encoded into the login disclaimer, so any text is safe. No effect while
     /// <see cref="PluginConfiguration.ManageLoginPageButtons"/> is off or <see cref="HideLoginButton"/> is on.
     /// </summary>
-    public string LoginButtonText { get; set; }
+    public string? LoginButtonText { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether RBAC is enabled.
@@ -243,17 +245,17 @@ public abstract class ProviderConfigBase
     /// <summary>
     /// Gets or sets what folders should users have access to by default.
     /// </summary>
-    public string[] EnabledFolders { get; set; }
+    public string[]? EnabledFolders { get; set; }
 
     /// <summary>
     /// Gets or sets the roles that are checked to determine whether the user is an administrator.
     /// </summary>
-    public string[] AdminRoles { get; set; }
+    public string[]? AdminRoles { get; set; }
 
     /// <summary>
     /// Gets or sets what roles are checked to determine whether the user is allowed to use Jellyfin.
     /// </summary>
-    public string[] Roles { get; set; }
+    public string[]? Roles { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether RBAC is used to manage folder access.
@@ -278,19 +280,19 @@ public abstract class ProviderConfigBase
     /// <summary>
     /// Gets or sets the roles that are checked to determine whether the user is allowed to view Live TV.
     /// </summary>
-    public string[] LiveTvRoles { get; set; }
+    public string[]? LiveTvRoles { get; set; }
 
     /// <summary>
     /// Gets or sets the roles that are checked to determine whether the user is allowed to manage Live TV.
     /// </summary>
-    public string[] LiveTvManagementRoles { get; set; }
+    public string[]? LiveTvManagementRoles { get; set; }
 
     /// <summary>
     /// Gets or sets which folders map to what roles in RBAC.
     /// </summary>
     [XmlArray("FolderRoleMappings")]
     [XmlArrayItem(typeof(FolderRoleMap), ElementName = "FolderRoleMappings")]
-    public List<FolderRoleMap> FolderRoleMapping { get; set; }
+    public List<FolderRoleMap>? FolderRoleMapping { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the generic role-to-permission mapping
@@ -315,7 +317,7 @@ public abstract class ProviderConfigBase
     /// </summary>
     [XmlArray("PermissionRoleMappings")]
     [XmlArrayItem(typeof(PermissionRoleMap), ElementName = "PermissionRoleMappings")]
-    public List<PermissionRoleMap> PermissionRoleMappings { get; set; }
+    public List<PermissionRoleMap>? PermissionRoleMappings { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the role-to-parental-rating mapping
@@ -339,7 +341,7 @@ public abstract class ProviderConfigBase
     /// </summary>
     [XmlArray("ParentalRatingRoleMappings")]
     [XmlArrayItem(typeof(ParentalRatingRoleMap), ElementName = "ParentalRatingRoleMappings")]
-    public List<ParentalRatingRoleMap> ParentalRatingRoleMappings { get; set; }
+    public List<ParentalRatingRoleMap>? ParentalRatingRoleMappings { get; set; }
 
     /// <summary>
     /// Gets or sets the authentication provider id written to the user's Jellyfin account
@@ -347,12 +349,12 @@ public abstract class ProviderConfigBase
     /// user attribute; SSO logins themselves always resolve through the per-provider canonical-link maps,
     /// not this field. Blank leaves the account's existing provider id untouched.
     /// </summary>
-    public string DefaultProvider { get; set; }
+    public string? DefaultProvider { get; set; }
 
     /// <summary>
     /// Gets or sets the redirect scheme override.
     /// </summary>
-    public string SchemeOverride { get; set; }
+    public string SchemeOverride { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the redirect port override.
@@ -401,17 +403,17 @@ public class SamlConfig : ProviderConfigBase
     /// <summary>
     /// Gets or sets the SAML information endpoint.
     /// </summary>
-    public string SamlEndpoint { get; set; }
+    public string SamlEndpoint { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the SAML provider's client ID.
     /// </summary>
-    public string SamlClientId { get; set; }
+    public string SamlClientId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the SAML public key.
     /// </summary>
-    public string SamlCertificate { get; set; }
+    public string? SamlCertificate { get; set; }
 
     /// <summary>
     /// Gets or sets an OPTIONAL second identity-provider signing certificate accepted alongside
@@ -430,13 +432,13 @@ public class SamlConfig : ProviderConfigBase
     /// certificate here before the cutover and promotes it into <see cref="SamlCertificate"/> (clearing
     /// this field) once the provider has fully rotated — with no login downtime across the overlap window.
     /// </summary>
-    public string SamlSecondaryCertificate { get; set; }
+    public string? SamlSecondaryCertificate { get; set; }
 
     /// <summary>
     /// Gets or sets the audience (SP entity id) that a SAML response must be addressed to. When
     /// unset, the SamlClientId is used. Ignored when <see cref="DoNotValidateAudience"/> is set.
     /// </summary>
-    public string SamlAudience { get; set; }
+    public string? SamlAudience { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to skip validating the assertion's AudienceRestriction.
@@ -480,7 +482,7 @@ public class SamlConfig : ProviderConfigBase
     /// to the config XML.
     /// </summary>
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
-    public string SamlSigningKeyPfx { get; set; }
+    public string? SamlSigningKeyPfx { get; set; }
 
     /// <summary>
     /// Gets or sets an OPTIONAL second service-provider signing key for a zero-downtime rollover of the
@@ -497,7 +499,7 @@ public class SamlConfig : ProviderConfigBase
     /// and preserved on a save that leaves it blank.
     /// </summary>
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
-    public string SamlRolloverSigningKeyPfx { get; set; }
+    public string? SamlRolloverSigningKeyPfx { get; set; }
 }
 
 /// <summary>
@@ -509,12 +511,12 @@ public class SamlConfig : ProviderConfigBase
 [XmlRoot("PluginConfiguration")]
 public class OidConfig : ProviderConfigBase
 {
-    private SerializableDictionary<string, string> _canonicalLinkIssuers;
+    private SerializableDictionary<string, string>? _canonicalLinkIssuers;
 
     /// <summary>
     /// Gets or sets the OpenID well-known information endpoint.
     /// </summary>
-    public string OidEndpoint { get; set; }
+    public string? OidEndpoint { get; set; }
 
     /// <summary>
     /// Gets or sets, per canonical link, the discovered issuer the link was minted under (#186). Keyed
@@ -543,7 +545,7 @@ public class OidConfig : ProviderConfigBase
     /// <summary>
     /// Gets or sets OpenID client ID.
     /// </summary>
-    public string OidClientId { get; set; }
+    public string OidClientId { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets OpenID shared secret.
@@ -556,7 +558,7 @@ public class OidConfig : ProviderConfigBase
     // so leaving the field blank keeps the stored secret; a new value replaces it. A plain
     // [JsonIgnore] is wrong here — it is bidirectional and would also drop the value on save.
     [System.Text.Json.Serialization.JsonConverter(typeof(WriteOnlySecretConverter))]
-    public string OidSecret { get; set; }
+    public string? OidSecret { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether adopting a same-named pre-existing account additionally
@@ -591,14 +593,14 @@ public class OidConfig : ProviderConfigBase
     /// allow-list <see cref="RequireAcr"/> checks the returned <c>acr</c> claim against. Settable in the
     /// admin provider form as well as the config XML.
     /// </summary>
-    public string AcrValues { get; set; }
+    public string? AcrValues { get; set; }
 
     /// <summary>
     /// Gets or sets the OIDC <c>prompt</c> parameter sent on the authorization request (#757, OIDC Core
     /// §3.1.2.1) — e.g. <c>login</c> to force re-authentication, or <c>consent</c>. Empty by default: the
     /// parameter is then omitted. Settable in the admin provider form as well as the config XML.
     /// </summary>
-    public string Prompt { get; set; }
+    public string? Prompt { get; set; }
 
     /// <summary>
     /// Gets or sets the OIDC <c>max_age</c> parameter (seconds) sent on the authorization request (#757,
@@ -622,22 +624,22 @@ public class OidConfig : ProviderConfigBase
     /// <summary>
     /// Gets or sets the claim to check roles against. Separated by "."s.
     /// </summary>
-    public string RoleClaim { get; set; }
+    public string? RoleClaim { get; set; }
 
     /// <summary>
     /// Gets or Sets additional Scopes to request access to in the authorization request.
     /// </summary>
-    public string[] OidScopes { get; set; }
+    public string?[]? OidScopes { get; set; }
 
     /// <summary>
     /// Gets or sets the default username claim when creating new accounts.
     /// </summary>
-    public string DefaultUsernameClaim { get; set; }
+    public string? DefaultUsernameClaim { get; set; }
 
     /// <summary>
     /// Gets or sets the URL format of the new user avatar.
     /// </summary>
-    public string AvatarUrlFormat { get; set; }
+    public string? AvatarUrlFormat { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the zero-config fallback to the standard OIDC
@@ -701,12 +703,12 @@ public class FolderRoleMap
     /// <summary>
     /// Gets or sets the role of the mapping.
     /// </summary>
-    public string Role { get; set; }
+    public string? Role { get; set; }
 
     /// <summary>
     /// Gets or sets the folders that are allowed from the given role.
     /// </summary>
-    public List<string> Folders { get; set; }
+    public List<string>? Folders { get; set; }
 }
 
 /// <summary>
@@ -722,13 +724,13 @@ public class PermissionRoleMap
     /// enum name (e.g. <c>EnableContentDownloading</c>). An unknown name, or one of the dedicated
     /// permissions managed elsewhere (administrator, all-folders, Live TV), is rejected on save.
     /// </summary>
-    public string Permission { get; set; }
+    public string? Permission { get; set; }
 
     /// <summary>
     /// Gets or sets the roles that grant the permission. A login holding any of these roles is granted
     /// the permission; a login holding none has it explicitly revoked.
     /// </summary>
-    public string[] Roles { get; set; }
+    public string[]? Roles { get; set; }
 }
 
 /// <summary>
@@ -749,5 +751,5 @@ public class ParentalRatingRoleMap
     /// Gets or sets the roles the ceiling applies to. A login holding any of these roles is capped at
     /// <see cref="Score"/>; a login holding none is left untouched.
     /// </summary>
-    public string[] Roles { get; set; }
+    public string[]? Roles { get; set; }
 }

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -113,7 +115,7 @@ internal sealed class ProviderConfigStore
     public void Save(BasePluginConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        List<(string Protocol, string Provider, IReadOnlyList<string> Options)> insecureToAudit = null;
+        List<(string Protocol, string Provider, IReadOnlyList<string> Options)>? insecureToAudit = null;
         lock (Sync)
         {
             if (configuration is PluginConfiguration incoming && !ReferenceEquals(incoming, _live()))

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -124,7 +126,7 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="config">The OpenID provider configuration to check; a null config is tolerated.</param>
     /// <exception cref="ArgumentException">RequireAcr is set with blank AcrValues.</exception>
-    internal static void ValidateAcrRequirement(string provider, OidConfig config)
+    internal static void ValidateAcrRequirement(string provider, OidConfig? config)
     {
         if (config?.RequireAcr == true && string.IsNullOrWhiteSpace(config.AcrValues))
         {
@@ -147,7 +149,7 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="baseUrlOverride">The override value to check.</param>
     /// <exception cref="ArgumentException">The override is non-blank and not a valid absolute http(s) URL.</exception>
-    internal static void ValidateBaseUrlOverride(string protocol, string provider, string baseUrlOverride)
+    internal static void ValidateBaseUrlOverride(string protocol, string provider, string? baseUrlOverride)
     {
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
         {
@@ -168,9 +170,9 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="certificate">The Base64-encoded (DER) X.509 certificate to check.</param>
     /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
-    internal static void ValidateSamlCertificate(string provider, string certificate)
+    internal static void ValidateSamlCertificate(string provider, string? certificate)
     {
-        if (SamlCertificate.IsInvalid(certificate))
+        if (SamlCertificate.IsInvalid(certificate ?? string.Empty))
         {
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
@@ -192,9 +194,9 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="certificate">The Base64-encoded (DER) X.509 certificate to check.</param>
     /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
-    internal static void ValidateSamlSecondaryCertificate(string provider, string certificate)
+    internal static void ValidateSamlSecondaryCertificate(string provider, string? certificate)
     {
-        if (SamlCertificate.IsInvalid(certificate))
+        if (SamlCertificate.IsInvalid(certificate ?? string.Empty))
         {
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid secondary signing certificate; it must be a Base64-encoded (DER) X.509 certificate.",
@@ -222,7 +224,7 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (control-stripped) in the rejection message.</param>
     /// <param name="mappings">The permission-role mappings to check.</param>
     /// <exception cref="ArgumentException">An entry names an invalid or dedicated permission.</exception>
-    internal static void ValidatePermissionRoleMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<PermissionRoleMap> mappings)
+    internal static void ValidatePermissionRoleMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<PermissionRoleMap>? mappings)
     {
         if (mappings == null)
         {
@@ -271,7 +273,7 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="mappings">The parental-rating mappings to check.</param>
     /// <exception cref="ArgumentException">An entry has a negative score or lists no roles.</exception>
-    internal static void ValidateParentalRatingMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<ParentalRatingRoleMap> mappings)
+    internal static void ValidateParentalRatingMappings(string protocol, string provider, System.Collections.Generic.IEnumerable<ParentalRatingRoleMap>? mappings)
     {
         if (mappings == null)
         {
@@ -316,9 +318,9 @@ internal static class ProviderConfigValidator
     /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
     /// <param name="signingKeyPfx">The Base64-encoded PKCS#12 (PFX) signing key to check.</param>
     /// <exception cref="ArgumentException">The key is non-blank and not a loadable PFX with an RSA or ECDSA private key.</exception>
-    internal static void ValidateSamlSigningKey(string provider, string signingKeyPfx)
+    internal static void ValidateSamlSigningKey(string provider, string? signingKeyPfx)
     {
-        if (SamlSigningKey.IsInvalid(signingKeyPfx))
+        if (SamlSigningKey.IsInvalid(signingKeyPfx ?? string.Empty))
         {
             throw new ArgumentException(
                 $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid request signing key; it must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key.",

--- a/SSO-Auth/Config/SerializableDictionary.cs
+++ b/SSO-Auth/Config/SerializableDictionary.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
@@ -12,12 +14,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 [XmlRoot("dictionary")]
 public class SerializableDictionary<TKey, TValue>
     : Dictionary<TKey, TValue>, IXmlSerializable
+    where TKey : notnull
 {
     /// <summary>
     /// Gets the schema of the XML object.
     /// </summary>
     /// <returns>Nothing.</returns>
-    public System.Xml.Schema.XmlSchema GetSchema()
+    public System.Xml.Schema.XmlSchema? GetSchema()
     {
         return null;
     }
@@ -46,11 +49,11 @@ public class SerializableDictionary<TKey, TValue>
             reader.ReadStartElement("item");
 
             reader.ReadStartElement("key");
-            TKey key = (TKey)keySerializer.Deserialize(reader);
+            TKey key = (TKey)keySerializer.Deserialize(reader)!;
             reader.ReadEndElement();
 
             reader.ReadStartElement("value");
-            TValue value = (TValue)valueSerializer.Deserialize(reader);
+            TValue value = (TValue)valueSerializer.Deserialize(reader)!;
             reader.ReadEndElement();
 
             this.Add(key, value);

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
@@ -58,7 +60,7 @@ internal static class ServerManagedFields
     // group resolves to. Only providers present in BOTH maps are touched (a deleted provider stays
     // deleted; a newly added one keeps its own empty map), and a null map on either side (a legacy store,
     // a partial post) preserves nothing rather than NRE the save.
-    private static void Preserve<T>(SerializableDictionary<string, T> incoming, SerializableDictionary<string, T> live, Action<T, T> preserveProvider)
+    private static void Preserve<T>(SerializableDictionary<string, T>? incoming, SerializableDictionary<string, T>? live, Action<T, T> preserveProvider)
         where T : ProviderConfigBase
     {
         if (incoming is null || live is null)
@@ -149,7 +151,7 @@ internal static class ServerManagedFields
     /// <param name="incoming">The key about to be persisted; blank when the save did not rotate it.</param>
     /// <param name="live">The corresponding stored key.</param>
     /// <returns>The incoming key when non-blank, otherwise the stored key.</returns>
-    private static string PreserveSigningKeyIfBlank(string incoming, string live)
+    private static string? PreserveSigningKeyIfBlank(string? incoming, string? live)
         => string.IsNullOrWhiteSpace(incoming) ? live : incoming;
 
     /// <summary>
@@ -164,7 +166,7 @@ internal static class ServerManagedFields
     /// <param name="incoming">The provider config about to be persisted.</param>
     /// <param name="live">The current live provider config.</param>
     /// <returns>The secret to persist for the updated provider.</returns>
-    internal static string ResolveUpdatedSecret(OidConfig incoming, OidConfig live)
+    internal static string? ResolveUpdatedSecret(OidConfig incoming, OidConfig live)
     {
         if (!string.IsNullOrWhiteSpace(incoming.OidSecret))
         {

--- a/SSO-Auth/Config/SsoOnlyLoginGuard.cs
+++ b/SSO-Auth/Config/SsoOnlyLoginGuard.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
@@ -154,7 +156,7 @@ internal static class SsoOnlyLoginGuard
     /// <param name="currentProviderId">The account's CURRENT <c>AuthenticationProviderId</c>, used to leave a third-party-provider account untouched exactly as the sweep does.</param>
     /// <param name="configuredDefaultProvider">The provider config's own <c>DefaultProvider</c> (already trimmed), applied only while the mode is off.</param>
     /// <returns>The provider id to write, or the configured default when the mode is off.</returns>
-    internal static string ResolveLoginProvider(PluginConfiguration configuration, string username, string currentProviderId, string configuredDefaultProvider)
+    internal static string? ResolveLoginProvider(PluginConfiguration configuration, string username, string currentProviderId, string? configuredDefaultProvider)
     {
         if (configuration is not { DisablePasswordLogin: true })
         {

--- a/SSO-Auth/Config/WriteOnlySecretConverter.cs
+++ b/SSO-Auth/Config/WriteOnlySecretConverter.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -14,13 +16,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// new-provider setup. The field is still persisted to the config XML (this converter only affects
 /// System.Text.Json).
 /// </summary>
-internal sealed class WriteOnlySecretConverter : JsonConverter<string>
+internal sealed class WriteOnlySecretConverter : JsonConverter<string?>
 {
     /// <inheritdoc />
-    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         => reader.GetString();
 
     /// <inheritdoc />
-    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
         => writer.WriteNullValue();
 }


### PR DESCRIPTION
## What & why
Advances #799. `#nullable enable` on all 11 `SSO-Auth/Config/` files (11/11), annotating the persisted configuration model from how consumers actually use each member.

## Security-relevant nullability decisions
- **RBAC role arrays stay `string[]?`**, load-bearing and **fail-closed**. `OidcAuthorizeStateBuilder` throws on a null `Roles` list (RBAC-off + only a `sub` claim → login rejected, #89). An `= Array.Empty<string>()` default (a tempting non-null fix) would have flipped that deliberate rejection into a **silent login allow**, a fail-open regression the test `OidcAuthorizeStateBuilderTests` asserts against; caught and avoided. `AdminRoles`/`LiveTvRoles`/… null = "nobody in that group", handled null-safely by `IsOnList`.
- **Write-only secrets → `string?`** (`OidSecret`, `SamlSigningKeyPfx`, rollover), forced by `ConfigSecretProtection`'s `string?` assignment; the readers fail-close on null.
- **Always-present identity fields** (`SamlEndpoint`/`ClientId`, `OidEndpoint`/`ClientId`) kept non-null via `= string.Empty` (unguarded `.Trim()`).
- `SerializableDictionary` gained `where TKey : notnull`; `WriteOnlySecretConverter` is `JsonConverter<string?>`.

Two Api-side param propagations follow (both bodies already null-safe + fail-closed): `SamlLoginService.TryRevealPublicCertificate(string? storedPfx)` and `RolePrivilegeMapper.IsOnList(IEnumerable<string>? allowed)`.

## Testing
- Builds clean under `--warnaserror` on net9.0 and net10.0 **including the test project** (verified with a full `--no-incremental` build, the gotcha `dotnet test` alone masks).
- **All 1788 tests pass**, including the null-`Roles` fail-closed assertion.

## Review gate
Config-persistence + RBAC + secret-handling surface → /security-review required; focus: the role-list fail-closed behaviour and the write-only-secret nullability. Findings on the PR.