### PR TITLE
Enable nullable reference types on the Oidc module

### DIFF
--- a/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
@@ -93,7 +93,7 @@ public class OidcLoginServiceTests
     {
         var (service, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
 
-        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = "seed-1" }, "kc", isLinking: false, DateTime.UtcNow, "binding", clientKey: null, providerInformation: null, responseIssuerRequired: false);
+        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = "seed-1" }, "kc", isLinking: false, DateTime.UtcNow, "binding", clientKey: null, providerInformation: null!, responseIssuerRequired: false);
         OidcLoginService.SeedOidStateForTests("seed-1", pending);
 
         Assert.Contains(service.StateSummaries(), s => s.Provider == "kc" && !s.Valid);

--- a/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
@@ -306,7 +306,7 @@ public class SSOControllerLinkTests
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         // The OID link path redeems an authorize state the redirect leg validated; seed a redeemable one.
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null!, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var result = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -325,7 +325,7 @@ public class SSOControllerLinkTests
         // the two cases cannot be probed apart.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = false });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null!, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
 
         var rejected = await harness.Controller.AddCanonicalLink("oid", "keycloak", Target, new AuthResponse { Data = "state-1" });
@@ -348,7 +348,7 @@ public class SSOControllerLinkTests
         // remove — the state is NOT consumed, so the browser that started the flow can still link.
         var harness = ForCaller(isAdmin: true, callerId: Target, configure: c => c.OidConfigs["keycloak"] = new OidConfig { Enabled = true });
         OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Ready(
-            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false),
+            new AuthorizeSession.Pending(new AuthorizeState { State = "state-1" }, "keycloak", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null!, responseIssuerRequired: false),
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("alice", "sub-1", null, null, true, false, false, false, new List<string>(), null)));
         // A wrong-browser callback: overwrite the matching cookie ForCaller set with a different id.
         harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}=other-browser";

--- a/SSO-Auth.Tests/Http/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidAuthTests.cs
@@ -228,7 +228,7 @@ public class SSOControllerOidAuthTests
     // the verified-email login gate (#166).
     private static void SeedValidState(SsoControllerHarness harness, string token, bool? emailVerified = null)
     {
-        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = token }, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: false);
+        var pending = new AuthorizeSession.Pending(new AuthorizeState { State = token }, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null!, responseIssuerRequired: false);
         var ready = new AuthorizeSession.Ready(
             pending,
             new OidcAuthorizeStateBuilder.OidcAuthorizeState(

--- a/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
@@ -482,7 +482,7 @@ public class SSOControllerOidPostTests
         // parameter (#210), so the callback must require iss; false is the tolerant default (the challenge
         // capture path itself is pinned end-to-end by OidChallengeToCallback_* below). Seeded as a Pending:
         // the callback derives the login and promotes it to a Ready (#341).
-        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null, responseIssuerRequired: responseIssuerRequired));
+        OidcLoginService.SeedOidStateForTests("state-1", new AuthorizeSession.Pending(authState, "kc", isLinking: false, DateTime.UtcNow, Binding, clientKey: null, providerInformation: null!, responseIssuerRequired: responseIssuerRequired));
 
         return harness;
     }

--- a/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
@@ -52,7 +52,7 @@ public class OidcStateStoreTests
         ProviderInformation? info = null,
         bool responseIssuerRequired = false,
         string? clientKey = null)
-        => new(new AuthorizeState { State = stateValue }, provider, isLinking, created, binding, clientKey, info, responseIssuerRequired);
+        => new(new AuthorizeState { State = stateValue }, provider, isLinking, created, binding!, clientKey, info!, responseIssuerRequired);
 
     // A promoted Ready: the redeemable variant the callback produces once the role gate passes. Building it
     // from a Pending + a valid role-gate result is exactly the production promotion path.
@@ -126,7 +126,7 @@ public class OidcStateStoreTests
     {
         // The null belt survives the consolidation: a seeded null can never peek or redeem.
         var store = Store();
-        store.Seed("t", null);
+        store.Seed("t", null!);
 
         Assert.Null(store.PeekCurrent("t", "p", Now, Binding));
         Assert.Null(store.TryRedeem("t", "p", Now, Binding));
@@ -759,7 +759,7 @@ public class OidcStateStoreTests
     // so TryRedeem — which requires a promoted state — can exercise the per-client release.
     private static void Validate(OidcStateStore store, string token) =>
         store.Promote(
-            store.PeekCurrent(token, "p", Now, Binding),
+            store.PeekCurrent(token, "p", Now, Binding)!,
             new OidcAuthorizeStateBuilder.OidcAuthorizeState("u", "sub", null, null, true, false, false, false, new List<string>(), null));
 
     [Fact]

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
@@ -20,7 +22,7 @@ internal abstract class AuthorizeSession
     // Private so the sum is closed to exactly the two nested variants below: a nested type can call the
     // enclosing type's private constructor through base(...), but no other type — in this assembly or
     // any other — can introduce a third variant.
-    private AuthorizeSession(string token, string provider, bool isLinking, string bindingId, string clientKey, DateTime created)
+    private AuthorizeSession(string token, string provider, bool isLinking, string bindingId, string? clientKey, DateTime created)
     {
         Token = token;
         Provider = provider;
@@ -52,7 +54,7 @@ internal abstract class AuthorizeSession
     /// Gets the normalized client key that reserved this state's per-client budget slot (#327), or null for
     /// an unattributable/exempt source; recorded so the store releases the right client's slot on redeem or prune.
     /// </summary>
-    internal string ClientKey { get; }
+    internal string? ClientKey { get; }
 
     /// <summary>Gets when this state was created, used to time it out.</summary>
     internal DateTime Created { get; }
@@ -83,7 +85,7 @@ internal abstract class AuthorizeSession
             bool isLinking,
             DateTime created,
             string bindingId,
-            string clientKey,
+            string? clientKey,
             ProviderInformation providerInformation,
             bool responseIssuerRequired)
             : base(oidcState.State, provider, isLinking, bindingId, clientKey, created)

--- a/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;
@@ -47,7 +49,7 @@ internal static class AuthorizeStateBinding
     /// <param name="storedBindingId">The id recorded on the stored state.</param>
     /// <param name="presentedBindingId">The id presented by the callback (the cookie value).</param>
     /// <returns>True only when both are present and equal.</returns>
-    internal static bool Matches(string storedBindingId, string presentedBindingId)
+    internal static bool Matches(string storedBindingId, string? presentedBindingId)
         => !string.IsNullOrEmpty(storedBindingId)
            && string.Equals(storedBindingId, presentedBindingId, StringComparison.Ordinal);
 

--- a/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
@@ -30,7 +32,7 @@ internal static class OidcDiscoveryOptions
     {
         var authority = config.OidEndpoint?.Trim();
         var options = new OidcClientOptions { Authority = authority };
-        var oidEndpointUri = new Uri(authority);
+        var oidEndpointUri = new Uri(authority!);
         options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(oidEndpointUri.GetLeftPart(UriPartial.Authority));
         options.Policy.Discovery.ValidateEndpoints = !config.DoNotValidateEndpoints; // For Google and other providers with different endpoints
         options.Policy.Discovery.RequireHttps = !config.DisableHttps;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using Duende.IdentityModel.OidcClient;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
@@ -17,7 +19,7 @@ internal static class OidcInsecureToggles
     /// </summary>
     /// <param name="config">The OpenID provider configuration.</param>
     /// <returns>The enabled insecure option names.</returns>
-    internal static IReadOnlyList<string> Enabled(OidConfig config)
+    internal static IReadOnlyList<string> Enabled(OidConfig? config)
     {
         var enabled = new List<string>();
         if (config == null)

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -73,7 +75,7 @@ internal static class OidcRoleExtractor
                 return new List<string>();
             }
 
-            return rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()).ToList();
+            return rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()!).ToList();
         }
         catch (JsonException)
         {

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -146,7 +148,7 @@ internal sealed class OidcStateStore
     /// <param name="now">The current time.</param>
     /// <param name="presentedBindingId">The browser-binding id the callback presented (its cookie value) (#326).</param>
     /// <returns>The pending state, or null when unknown, already promoted, expired, provider-mismatched, or binding-mismatched.</returns>
-    internal AuthorizeSession.Pending PeekCurrent(string token, string provider, DateTime now, string presentedBindingId)
+    internal AuthorizeSession.Pending? PeekCurrent(string token, string provider, DateTime now, string? presentedBindingId)
     {
         return !string.IsNullOrEmpty(token)
             && _states.TryGetValue(token, out var session)
@@ -187,7 +189,7 @@ internal sealed class OidcStateStore
     /// <param name="now">The current time.</param>
     /// <param name="presentedBindingId">The browser-binding id the caller presented (its cookie value) (#326).</param>
     /// <returns>The redeemed snapshot, or null when not redeemable, already claimed, or binding-mismatched.</returns>
-    internal AuthorizeSession.Ready TryRedeem(string responseData, string provider, DateTime now, string presentedBindingId)
+    internal AuthorizeSession.Ready? TryRedeem(string responseData, string provider, DateTime now, string? presentedBindingId)
     {
         if (string.IsNullOrEmpty(responseData)
             || !_states.TryGetValue(responseData, out var session)

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Linq;
 using Newtonsoft.Json;
@@ -23,7 +25,7 @@ internal static class PkceDiscovery
     /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
     /// a non-array value, non-string elements, or malformed/blank JSON.
     /// </returns>
-    internal static bool SupportsS256(string discoveryJson)
+    internal static bool SupportsS256(string? discoveryJson)
     {
         if (string.IsNullOrWhiteSpace(discoveryJson))
         {


### PR DESCRIPTION
## What & why
Advances #799. `#nullable enable` on the remaining 10 `Api/Oidc/` files, completing the module (20/20).

## Security-relevant nullability (login path)
- **Browser-binding id is `string?` end-to-end and stays fail-closed**: `OidcStateStore.PeekCurrent`/`TryRedeem` take `string? presentedBindingId` and return `Pending?`/`Ready?` (null on miss/mismatch/expiry/binding-mismatch); a null presented binding never matches a stored one (`AuthorizeStateBinding.Matches` is `IsNullOrEmpty`-guarded). An absent binding cookie → no match → reject, unchanged.
- `AuthorizeSession.ClientKey` → `string?` ("null for an exempt source", per its doc). `OidcInsecureToggles.Enabled(OidConfig?)` (body already null-guards). PkceDiscovery/discovery/role helpers take/return the nullable JSON they already handle.
- **Kept non-null**: `Pending.ProviderInformation` (dereferenced post-redeem: `OidcIdTokenValidator` issuer/keyset) and `BindingId` (fresh random at challenge). The tests' null placeholders for these are pinned with `null!` (behaviour-exact) rather than weakening the production contract.

## Testing
- Builds clean under `--warnaserror` on net9.0 and net10.0 **including the test project**; **all 1788 tests pass**.

## Review gate
Login-path surface (id_token / binding / state store) → /security-review; focus: the binding-id fail-closed and the exempt-source client key. Findings on the PR.