### PR TITLE
Enable nullable reference types on the Saml module (completes #799)

### DIFF
--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -738,9 +738,13 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        string providerUserId = samlResponse.GetNameID();
+        // GetNameID is null when the assertion carries no NameID; coalesce to empty so it flows into
+        // TryCreateLink's fail-closed empty-subject guard (which rejects a blank key as EmptyKey), never
+        // creating a canonical link keyed on an absent subject — the same fail-closed treatment the
+        // session-mint path applies (#95).
+        var providerUserId = samlResponse.GetNameID();
 
-        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Saml, provider, providerUserId, jellyfinUserId));
+        return FlowResponses.MapCanonicalLinkWrite(_canonicalLinks.TryCreateLink(ProviderMode.Saml, provider, providerUserId ?? string.Empty, jellyfinUserId));
     }
 
     // Reads a provider's config under the config lock, so an anonymous login-path lookup does not race an

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -1,5 +1,8 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
@@ -91,7 +94,7 @@ internal sealed class SamlAssertionValidator
     /// <param name="rawResponse">The untrusted, Base64-encoded SAMLResponse.</param>
     /// <param name="samlResponse">The parsed, validated response on success; otherwise null.</param>
     /// <returns>True when the response parsed and passed response-level validation; otherwise false.</returns>
-    internal bool TryValidate(SamlConfig config, string provider, string requestBaseUrl, string rawResponse, out SamlResponse samlResponse)
+    internal bool TryValidate(SamlConfig config, string provider, string requestBaseUrl, string? rawResponse, [NotNullWhen(true)] out SamlResponse? samlResponse)
     {
         // A malformed response (non-base64, malformed XML, prohibited DOCTYPE) fails TryParse and is
         // rejected the same way an invalid one is — a clean 4xx, never an unhandled 500 (#199). The
@@ -99,7 +102,7 @@ internal sealed class SamlAssertionValidator
         // accepted across an identity-provider signing-key overlap window (#491); when it is blank the
         // trial narrows to the primary alone (both the primary and any secondary are additionally required
         // to be within their validity window — see IsWithinValidityPeriod).
-        if (!SamlResponseLoader.TryParse(config.SamlCertificate, config.SamlSecondaryCertificate, rawResponse, out samlResponse))
+        if (!SamlResponseLoader.TryParse(config.SamlCertificate ?? string.Empty, config.SamlSecondaryCertificate, rawResponse, out samlResponse))
         {
             return false;
         }
@@ -168,7 +171,7 @@ internal sealed class SamlAssertionValidator
     /// <param name="identity">The verified identity on success; otherwise null.</param>
     /// <param name="rejection">The fail-closed outcome on failure; otherwise null.</param>
     /// <returns>True with <paramref name="identity"/> set on success; false with <paramref name="rejection"/> set.</returns>
-    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, IReadOnlyList<string> assertionRoles, out VerifiedIdentity identity, out LoginOutcome rejection)
+    internal bool TryProduceVerifiedIdentity(SamlConfig config, string provider, SamlResponse samlResponse, IReadOnlyList<string> assertionRoles, [NotNullWhen(true)] out VerifiedIdentity? identity, [NotNullWhen(false)] out LoginOutcome? rejection)
     {
         identity = null;
 

--- a/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/
@@ -93,7 +95,7 @@ internal sealed class SamlAuthnRequest
     /// <param name="samlEndpoint">The SAML endpoint.</param>
     /// <param name="relayState">The relay state.</param>
     /// <returns>The redirect url.</returns>
-    public string GetRedirectUrl(string samlEndpoint, string relayState = null)
+    public string GetRedirectUrl(string samlEndpoint, string? relayState = null)
     {
         ArgumentNullException.ThrowIfNull(samlEndpoint);
 
@@ -120,7 +122,7 @@ internal sealed class SamlAuthnRequest
     /// <param name="relayState">The relay state, omitted when null or empty.</param>
     /// <param name="signingKey">The service-provider private key — RSA or ECDSA (#493).</param>
     /// <returns>The signed redirect url.</returns>
-    public string GetSignedRedirectUrl(string samlEndpoint, string relayState, AsymmetricAlgorithm signingKey)
+    public string GetSignedRedirectUrl(string samlEndpoint, string? relayState, AsymmetricAlgorithm signingKey)
     {
         ArgumentNullException.ThrowIfNull(samlEndpoint);
 

--- a/SSO-Auth/Api/Saml/SamlCertificate.cs
+++ b/SSO-Auth/Api/Saml/SamlCertificate.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -22,7 +24,7 @@ internal static class SamlCertificate
     /// </summary>
     /// <param name="certificateStr">The Base64-encoded (DER) certificate string.</param>
     /// <returns><see langword="true"/> if the value is set but not a loadable certificate.</returns>
-    internal static bool IsInvalid(string certificateStr)
+    internal static bool IsInvalid(string? certificateStr)
     {
         if (string.IsNullOrWhiteSpace(certificateStr))
         {

--- a/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
@@ -18,7 +20,7 @@ internal static class SamlInsecureToggles
     /// </summary>
     /// <param name="config">The SAML provider configuration.</param>
     /// <returns>The enabled insecure option names.</returns>
-    internal static IReadOnlyList<string> Enabled(SamlConfig config)
+    internal static IReadOnlyList<string> Enabled(SamlConfig? config)
     {
         var enabled = new List<string>();
         if (config == null)

--- a/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,7 +20,7 @@ internal static class SamlLoginPolicy
     /// <param name="assertionRoles">The role values carried by the (already signature-validated) assertion.</param>
     /// <param name="allowedRoles">The provider's configured login allow-list.</param>
     /// <returns>True when no allow-list is configured (RBAC off) or the assertion carries at least one allowed role.</returns>
-    internal static bool IsLoginAllowed(IEnumerable<string> assertionRoles, string[] allowedRoles)
+    internal static bool IsLoginAllowed(IEnumerable<string?>? assertionRoles, string?[]? allowedRoles)
     {
         // No allow-list configured => role-based login is disabled, everyone authenticated is allowed.
         if (allowedRoles == null || allowedRoles.Length == 0)

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -122,7 +124,7 @@ internal sealed class SamlOutcomeStore
     /// <param name="now">The reference time driving the throttled capacity warning.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning.</param>
     /// <returns>True if a slot was reserved; false if refused (per-client sub-cap or global cap).</returns>
-    internal bool TryReserve(string clientKey, DateTime now, out bool shouldWarnCapacity)
+    internal bool TryReserve(string? clientKey, DateTime now, out bool shouldWarnCapacity)
     {
         // Per-client sub-cap (#327): reserve this client's slot BEFORE the global check so one source cannot
         // fill the whole budget and lock out every other login. A null key is exempt.
@@ -164,7 +166,7 @@ internal sealed class SamlOutcomeStore
     /// client's sub-cap slot does not leak. A null/exempt key reserved nothing, so it releases nothing.
     /// </summary>
     /// <param name="clientKey">The client key whose reserved slot is freed, or null (a no-op).</param>
-    internal void ReleaseReservation(string clientKey) => _perClient.Release(clientKey);
+    internal void ReleaseReservation(string? clientKey) => _perClient.Release(clientKey);
 
     /// <summary>
     /// Registers a fully-verified login outcome under its CSPRNG token in one atomic step — a convenience for
@@ -207,7 +209,7 @@ internal sealed class SamlOutcomeStore
     /// <param name="provider">The provider named in the consuming request's route.</param>
     /// <param name="now">The current time.</param>
     /// <returns>The redeemed outcome, or null when not redeemable.</returns>
-    internal SamlLoginOutcome TryRedeem(string token, string provider, DateTime now)
+    internal SamlLoginOutcome? TryRedeem(string? token, string provider, DateTime now)
     {
         if (string.IsNullOrEmpty(token)
             || !_outcomes.TryGetValue(token, out var outcome)
@@ -292,5 +294,5 @@ internal sealed record SamlLoginOutcome(
     string Provider,
     VerifiedIdentity Identity,
     string InResponseTo,
-    string ClientKey,
+    string? ClientKey,
     DateTime Created);

--- a/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -22,7 +24,7 @@ internal static class SamlRecipientValidator
     /// True when the Recipient is present and matches an expected URL, and the Destination (if any)
     /// also matches. False otherwise — a missing Recipient fails closed.
     /// </returns>
-    internal static bool IsBound(string recipient, string destination, IReadOnlyCollection<string> expectedAcsUrls)
+    internal static bool IsBound(string? recipient, string? destination, IReadOnlyCollection<string> expectedAcsUrls)
     {
         recipient = recipient?.Trim();
         if (string.IsNullOrEmpty(recipient) || !expectedAcsUrls.Contains(recipient, StringComparer.Ordinal))

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
@@ -124,7 +126,7 @@ internal sealed class SamlReplayCache
     /// <param name="nowUtc">The current time.</param>
     /// <param name="shouldWarnCapacity">True for at most one caller per interval when a fail-closed cap refusal occurred, so the caller can log it once; false on any other outcome (first use, replay, missing ID).</param>
     /// <returns>True if this is the first use; false on replay, a missing ID, or a fail-closed cap refusal.</returns>
-    internal bool TryConsume(string assertionId, DateTime expiryUtc, DateTime nowUtc, out bool shouldWarnCapacity)
+    internal bool TryConsume(string? assertionId, DateTime expiryUtc, DateTime nowUtc, out bool shouldWarnCapacity)
     {
         PruneExpired(nowUtc);
         shouldWarnCapacity = false;

--- a/SSO-Auth/Api/Saml/SamlRequestCache.cs
+++ b/SSO-Auth/Api/Saml/SamlRequestCache.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
@@ -89,7 +91,7 @@ internal sealed class SamlRequestCache
     /// <param name="clientKey">The normalized client key for the per-client sub-cap (#327), or null to exempt.</param>
     /// <param name="shouldWarnCapacity">True when the caller should emit the throttled capacity warning (a cap refusal, at most once per interval).</param>
     /// <returns>True if the entry was registered; false if refused (blank ID, per-client sub-cap, or global cap).</returns>
-    internal bool Register(string requestId, string bindingId, DateTime expiryUtc, DateTime nowUtc, string clientKey, out bool shouldWarnCapacity)
+    internal bool Register(string? requestId, string bindingId, DateTime expiryUtc, DateTime nowUtc, string? clientKey, out bool shouldWarnCapacity)
     {
         PruneExpired(nowUtc);
         shouldWarnCapacity = false;
@@ -133,7 +135,7 @@ internal sealed class SamlRequestCache
     /// <param name="nowUtc">The current time.</param>
     /// <param name="bindingId">The binding id recorded at registration (empty if none), when this returns true.</param>
     /// <returns>True if the ID was outstanding and is now consumed; false otherwise.</returns>
-    internal bool TryConsume(string requestId, DateTime nowUtc, out string bindingId)
+    internal bool TryConsume(string? requestId, DateTime nowUtc, out string bindingId)
     {
         PruneExpired(nowUtc);
         bindingId = string.Empty;
@@ -192,5 +194,5 @@ internal sealed class SamlRequestCache
     // exempt source). The binding id ties the eventual response to the browser that started the flow; it
     // is returned on consume so the session-mint endpoint can require the request's cookie to match.
     // Empty binding for entries registered before browser binding existed (treated as unbound).
-    private readonly record struct Entry(DateTime ExpiryUtc, string BindingId, string ClientKey);
+    private readonly record struct Entry(DateTime ExpiryUtc, string BindingId, string? ClientKey);
 }

--- a/SSO-Auth/Api/Saml/SamlResponse.cs
+++ b/SSO-Auth/Api/Saml/SamlResponse.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/
@@ -65,7 +67,7 @@ internal sealed class SamlResponse : IDisposable
     /// <param name="certificateStr">The primary certificate formatted as a Base64 string.</param>
     /// <param name="secondaryCertificateStr">The optional secondary certificate (Base64), or blank for none.</param>
     /// <param name="responseString">The SAML response formatted as a string.</param>
-    public SamlResponse(string certificateStr, string secondaryCertificateStr, string responseString)
+    public SamlResponse(string certificateStr, string? secondaryCertificateStr, string responseString)
     {
         // Decode and load the certificate(s), then parse the response — in that exact order, so the
         // exception sequence SamlResponseLoader.TryParse catches is unchanged: FormatException (bad
@@ -107,7 +109,7 @@ internal sealed class SamlResponse : IDisposable
     // are the identity provider's PUBLIC signing certificate; a configured-but-unloadable secondary throws
     // the same load exceptions as the primary and is rejected the same fail-closed way (the admin write
     // paths reject it up front via SamlCertificate.IsInvalid).
-    private static List<X509Certificate2> LoadCandidateCertificates(string certificateStr, string secondaryCertificateStr)
+    private static List<X509Certificate2> LoadCandidateCertificates(string certificateStr, string? secondaryCertificateStr)
     {
         var certificates = new List<X509Certificate2>
         {
@@ -235,18 +237,30 @@ internal sealed class SamlResponse : IDisposable
     // Runs after ValidateSignatureReference, which guarantees exactly one reference exists.
     private static bool IsSignatureAlgorithmAllowed(SignedXml signedXml)
     {
-        if (!SamlSignatureAlgorithms.IsCanonicalizationAllowed(signedXml.SignedInfo.CanonicalizationMethod))
+        // A null SignedInfo (SignedXml exposes it as nullable) means there is nothing to allow-list against,
+        // so reject rather than risk trusting an unvalidated algorithm — fail closed. In practice LoadXml has
+        // already populated it (a malformed signature throws instead), so this guard never fires on a
+        // well-formed signature; every unexpected null flows to a rejection.
+        var signedInfo = signedXml.SignedInfo;
+        if (signedInfo is null)
+        {
+            return false;
+        }
+
+        // Every algorithm URI the BCL exposes as nullable is coalesced to string.Empty, which is not in any
+        // allowlist, so a missing/null algorithm is rejected exactly like a disallowed one (fail closed).
+        if (!SamlSignatureAlgorithms.IsCanonicalizationAllowed(signedInfo.CanonicalizationMethod ?? string.Empty))
         {
             return false;
         }
 
         var digestMethods = new List<string>();
-        foreach (Reference reference in signedXml.SignedInfo.References)
+        foreach (Reference reference in signedInfo.References)
         {
             var transforms = new List<string>();
             foreach (Transform transform in reference.TransformChain)
             {
-                transforms.Add(transform.Algorithm);
+                transforms.Add(transform.Algorithm ?? string.Empty);
             }
 
             if (!SamlSignatureAlgorithms.AreTransformsAllowed(transforms))
@@ -254,10 +268,10 @@ internal sealed class SamlResponse : IDisposable
                 return false;
             }
 
-            digestMethods.Add(reference.DigestMethod);
+            digestMethods.Add(reference.DigestMethod ?? string.Empty);
         }
 
-        return SamlSignatureAlgorithms.IsAllowed(signedXml.SignedInfo.SignatureMethod, digestMethods);
+        return SamlSignatureAlgorithms.IsAllowed(signedInfo.SignatureMethod ?? string.Empty, digestMethods);
     }
 
     // The signature must verify against at least one candidate certificate that is CURRENTLY within its
@@ -310,7 +324,7 @@ internal sealed class SamlResponse : IDisposable
     /// </summary>
     /// <param name="expectedAudience">The audience (SP entity id) this response must be addressed to.</param>
     /// <returns>Whether the response is valid and bound to this audience.</returns>
-    public bool IsValid(string expectedAudience)
+    public bool IsValid(string? expectedAudience)
     {
         if (!IsValid())
         {
@@ -334,7 +348,7 @@ internal sealed class SamlResponse : IDisposable
     /// a log); it is never a substitute for <see cref="IsValid()"/>.
     /// </summary>
     /// <returns>The SignedInfo signature-method URI, or null if unsigned.</returns>
-    public string GetSignatureAlgorithm()
+    public string? GetSignatureAlgorithm()
     {
         // Same position-bound selection as IsValid, so the diagnostic reflects the signature that
         // would actually be validated rather than any signature found anywhere in the document.
@@ -351,8 +365,8 @@ internal sealed class SamlResponse : IDisposable
         try
         {
             var signedXml = new SignedXml(_xmlDoc);
-            signedXml.LoadXml((XmlElement)nodeList[0]);
-            return signedXml.SignedInfo.SignatureMethod;
+            signedXml.LoadXml((XmlElement)nodeList[0]!);
+            return signedXml.SignedInfo?.SignatureMethod;
         }
         catch (Exception ex) when (ex is CryptographicException or XmlException or ArgumentException or FormatException)
         {
@@ -394,7 +408,7 @@ internal sealed class SamlResponse : IDisposable
     /// Gets the ID attribute of the assertion, used to enforce one-time use (replay protection).
     /// </summary>
     /// <returns>The assertion ID, or null when absent.</returns>
-    public string GetAssertionId()
+    public string? GetAssertionId()
     {
         var assertion = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]", _xmlNameSpaceManager) as XmlElement;
         var id = assertion?.GetAttribute("ID");
@@ -436,22 +450,27 @@ internal sealed class SamlResponse : IDisposable
     // still matches the copied element elsewhere in the tree.
     private bool ValidateSignatureReference(SignedXml signedXml, XmlElement signatureElement)
     {
-        if (signedXml.SignedInfo.References.Count != 1) // exactly one reference, no more, no less
+        // A null SignedInfo (nullable on SignedXml) carries no reference to bind, so reject — fail closed.
+        // LoadXml populates it on a well-formed signature (and throws otherwise), so this never fires in
+        // practice; an unexpected null is a rejection, never a pass.
+        var signedInfo = signedXml.SignedInfo;
+        if (signedInfo is null || signedInfo.References.Count != 1) // exactly one reference, no more, no less
         {
             return false;
         }
 
-        var reference = (Reference)signedXml.SignedInfo.References[0];
+        var reference = (Reference)signedInfo.References[0]!;
 
         // A same-document ID reference only ("#id"); an empty (whole-document "") or external URI is
         // rejected. A "#"-only or non-NCName fragment never reaches here — SignedXml.LoadXml resolves
         // the reference eagerly and throws on it, which IsValid catches and turns into a rejection.
-        if (string.IsNullOrEmpty(reference.Uri) || reference.Uri[0] != '#')
+        var referenceUri = reference.Uri;
+        if (string.IsNullOrEmpty(referenceUri) || referenceUri[0] != '#')
         {
             return false;
         }
 
-        var idElement = signedXml.GetIdElement(_xmlDoc, reference.Uri.Substring(1));
+        var idElement = signedXml.GetIdElement(_xmlDoc, referenceUri.Substring(1));
         if (idElement == null)
         {
             return false;
@@ -511,7 +530,7 @@ internal sealed class SamlResponse : IDisposable
     /// </summary>
     /// <returns>The name ID attribute, or null when the assertion carries no NameID (the caller
     /// rejects such a login; previously this threw and surfaced as a 500).</returns>
-    public string GetNameID()
+    public string? GetNameID()
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:NameID", _xmlNameSpaceManager);
         return node?.InnerText;
@@ -524,7 +543,7 @@ internal sealed class SamlResponse : IDisposable
     /// binds it to this service provider's own ACS URL (#156).
     /// </summary>
     /// <returns>The Recipient attribute, or null when absent.</returns>
-    public string GetRecipient()
+    public string? GetRecipient()
     {
         var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var recipient = node?.GetAttribute("Recipient");
@@ -538,7 +557,7 @@ internal sealed class SamlResponse : IDisposable
     /// IdP-initiated (unsolicited) response.
     /// </summary>
     /// <returns>The InResponseTo attribute, or null when absent.</returns>
-    public string GetInResponseTo()
+    public string? GetInResponseTo()
     {
         var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var inResponseTo = node?.GetAttribute("InResponseTo");
@@ -552,7 +571,7 @@ internal sealed class SamlResponse : IDisposable
     /// always-signed <see cref="GetRecipient"/> (#156).
     /// </summary>
     /// <returns>The Destination attribute, or null when absent.</returns>
-    public string GetDestination()
+    public string? GetDestination()
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response", _xmlNameSpaceManager) as XmlElement;
         var destination = node?.GetAttribute("Destination");
@@ -594,7 +613,7 @@ internal sealed class SamlResponse : IDisposable
 
             foreach (XmlNode value in values)
             {
-                output.Add(value?.InnerText);
+                output.Add(value?.InnerText ?? string.Empty);
             }
         }
 

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Xml;
 
@@ -32,7 +35,7 @@ internal static class SamlResponseLoader
     /// <param name="responseString">The untrusted SAML response (Base64).</param>
     /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
-    internal static bool TryParse(string certificateStr, string responseString, out SamlResponse response)
+    internal static bool TryParse(string certificateStr, string? responseString, [NotNullWhen(true)] out SamlResponse? response)
         => TryParse(certificateStr, null, responseString, out response);
 
     /// <summary>
@@ -46,7 +49,7 @@ internal static class SamlResponseLoader
     /// <param name="responseString">The untrusted SAML response (Base64).</param>
     /// <param name="response">The parsed response on success; otherwise <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if the response parsed; otherwise <see langword="false"/>.</returns>
-    internal static bool TryParse(string certificateStr, string secondaryCertificateStr, string responseString, out SamlResponse response)
+    internal static bool TryParse(string certificateStr, string? secondaryCertificateStr, string? responseString, [NotNullWhen(true)] out SamlResponse? response)
     {
         // A null or empty body is the most common malformed callback (an absent SAMLResponse form field
         // yields a null string on the unauthenticated ACS endpoint); reject it here rather than let

--- a/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -64,7 +66,7 @@ internal static class SamlSignatureAlgorithms
     /// </summary>
     /// <param name="transforms">The transform-algorithm URIs of one reference, in order.</param>
     /// <returns>True only if there is at least one transform and all are allowed.</returns>
-    internal static bool AreTransformsAllowed(IEnumerable<string> transforms)
+    internal static bool AreTransformsAllowed(IEnumerable<string?> transforms)
         => AllOnList(AllowedTransforms, transforms);
 
     /// <summary>
@@ -83,7 +85,7 @@ internal static class SamlSignatureAlgorithms
     /// <param name="signatureMethod">The SignedInfo signature-method URI.</param>
     /// <param name="digestMethods">The digest-method URI of every reference.</param>
     /// <returns>True only if the signature method is allowed and there is at least one reference, all of whose digests are allowed.</returns>
-    internal static bool IsAllowed(string signatureMethod, IEnumerable<string> digestMethods)
+    internal static bool IsAllowed(string signatureMethod, IEnumerable<string?> digestMethods)
         => IsSignatureMethodAllowed(signatureMethod)
            && AllOnList(AllowedDigestMethods, digestMethods);
 
@@ -92,7 +94,7 @@ internal static class SamlSignatureAlgorithms
     // rejected, an empty chain is rejected (nothing was actually signed/canonicalized), and a null
     // element normalizes to string.Empty — never on any allowlist — so it is rejected too. Short-circuits
     // on the first off-list element. Defined once so the two call sites cannot drift apart (#395).
-    private static bool AllOnList(HashSet<string> allow, IEnumerable<string> values)
+    private static bool AllOnList(HashSet<string> allow, IEnumerable<string?> values)
     {
         if (values == null)
         {

--- a/SSO-Auth/Api/Saml/SamlSigningKey.cs
+++ b/SSO-Auth/Api/Saml/SamlSigningKey.cs
@@ -1,4 +1,7 @@
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
@@ -20,7 +23,7 @@ internal static class SamlSigningKey
     /// <param name="pfxBase64">The stored Base64 PKCS#12 blob, or blank when signing is not configured.</param>
     /// <param name="certificate">The loaded certificate with its private key, or null on failure.</param>
     /// <returns><see langword="true"/> only when a non-blank blob loaded into a usable certificate.</returns>
-    internal static bool TryLoad(string pfxBase64, out X509Certificate2 certificate)
+    internal static bool TryLoad(string? pfxBase64, [NotNullWhen(true)] out X509Certificate2? certificate)
     {
         certificate = null;
         if (string.IsNullOrWhiteSpace(pfxBase64))
@@ -82,12 +85,12 @@ internal static class SamlSigningKey
     /// </summary>
     /// <param name="certificate">The loaded signing certificate.</param>
     /// <returns>The RSA or ECDSA private key, or null when the certificate cannot sign.</returns>
-    internal static AsymmetricAlgorithm GetSigningKey(X509Certificate2 certificate)
+    internal static AsymmetricAlgorithm? GetSigningKey(X509Certificate2 certificate)
     {
         ArgumentNullException.ThrowIfNull(certificate);
 
         // Prefer RSA (the common case and the byte-identical existing path); fall back to ECDSA. Any other
         // key type returns null, which the callers treat as "unusable" and fail closed on.
-        return (AsymmetricAlgorithm)certificate.GetRSAPrivateKey() ?? certificate.GetECDsaPrivateKey();
+        return (AsymmetricAlgorithm?)certificate.GetRSAPrivateKey() ?? certificate.GetECDsaPrivateKey();
     }
 }


### PR DESCRIPTION
## What & why
Completes #799, `#nullable enable` on the remaining `Api/Saml/` files, the SAML **signature + assertion validation crypto core**. After this every SSO-Auth source file is nullable-enabled (117/117).

## Every annotation is fail-closed (the crypto core)
- **`SamlResponse`**: a null BCL `SignedInfo` → reject; each canonicalization/transform/signature/digest algorithm coalesces `?? string.Empty` → on no allowlist → reject (the `SamlSignatureAlgorithms` template); reference `Count != 1` or null `SignedInfo` → reject; the `References[0]` cast is presence-guaranteed by the preceding `Count == 1`. Null/blank audience still rejects. The id/subject/recipient getters return `string?` exactly as before; every consumer treats absent as reject.
- **`SamlAssertionValidator`/`SamlLoginService`**: null primary cert → `""` → X509 load throws → caught → reject; null NameID subject → existing empty-key guard → no link, reject.
- **Caches fail closed on null key**: `SamlReplayCache` ("no id → cannot enforce one-time use → reject"), `SamlRequestCache`, `SamlOutcomeStore`; a null client key = exempt source (bounded by the global cap), unchanged.
- `SamlSignatureAlgorithms` treats a null element as `""` → not allowed.

## Testing
- **No test files or `//` security-why comments touched**, the whole test cascade resolved by widening null-safe production signatures.
- Both projects build clean under `--warnaserror` on net9.0 and net10.0; **all 1788 tests pass**.

## Review gate
The SAML signature/assertion crypto core → /security-review required; confirm no null path weakens a signature/time/audience/recipient/replay/algorithm-allowlist check. Findings on the PR.