### PR TITLE
Enable nullable reference types project-wide [#799]

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
@@ -74,7 +74,7 @@ public class SSOControllerAddTests
     {
         var harness = new SsoControllerHarness();
 
-        Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("keycloak", null));
+        Assert.Throws<ArgumentException>(() => harness.Controller.OidAdd("keycloak", null!));
 
         // Fail-closed: a null [FromBody] is rejected at the door, so no null entry is stored (#350).
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs.ContainsKey("keycloak")));
@@ -85,7 +85,7 @@ public class SSOControllerAddTests
     {
         var harness = new SsoControllerHarness();
 
-        Assert.Throws<ArgumentException>(() => harness.Controller.SamlAdd("adfs", null));
+        Assert.Throws<ArgumentException>(() => harness.Controller.SamlAdd("adfs", null!));
 
         Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs.ContainsKey("adfs")));
     }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
@@ -143,7 +141,7 @@ internal static class SsoAudit
     /// <param name="actor">The elevated administrator who enabled the mode.</param>
     /// <param name="breakGlassAdmin">The designated break-glass admin whose password door survives.</param>
     /// <param name="repointedCount">How many accounts were repointed off the password provider.</param>
-    internal static void SsoOnlyLoginEnabled(ILogger logger, string actor, string breakGlassAdmin, int repointedCount)
+    internal static void SsoOnlyLoginEnabled(ILogger logger, string actor, string? breakGlassAdmin, int repointedCount)
     {
         if (!logger.IsEnabled(LogLevel.Warning))
         {
@@ -199,7 +197,7 @@ internal static class SsoAudit
     /// <param name="logger">The logger.</param>
     /// <param name="actor">The elevated administrator who changed the designation.</param>
     /// <param name="breakGlassAdmin">The newly designated break-glass admin.</param>
-    internal static void BreakGlassAdminDesignated(ILogger logger, string actor, string breakGlassAdmin)
+    internal static void BreakGlassAdminDesignated(ILogger logger, string actor, string? breakGlassAdmin)
     {
         if (!logger.IsEnabled(LogLevel.Warning))
         {

--- a/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
+++ b/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/Authz/PermissionGrant.cs
+++ b/SSO-Auth/Api/Authz/PermissionGrant.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Jellyfin.Database.Implementations.Enums;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
 /// <summary>

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Avatar/AvatarContentType.cs
+++ b/SSO-Auth/Api/Avatar/AvatarContentType.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.IO;
 using System.Net;

--- a/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;

--- a/SSO-Auth/Api/Crypto/SigningKeyStrength.cs
+++ b/SSO-Auth/Api/Crypto/SigningKeyStrength.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Crypto;
 
 /// <summary>

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -516,7 +514,7 @@ internal sealed class OidcLoginService
     /// <param name="response">The client information carrying the state token in <c>Data</c>.</param>
     /// <param name="bindingCookie">The browser-binding cookie value the redeem presented (#326).</param>
     /// <returns>The link-creation result, or a fail-closed rejection.</returns>
-    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, string bindingCookie)
+    internal ActionResult Link(string provider, Guid jellyfinUserId, AuthResponse response, string? bindingCookie)
     {
         if (string.IsNullOrEmpty(response?.Data))
         {

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Flows/WebResponse.cs
+++ b/SSO-Auth/Api/Flows/WebResponse.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Globalization;
 using System.Text.Json;
 

--- a/SSO-Auth/Api/Http/RequestHelpers.cs
+++ b/SSO-Auth/Api/Http/RequestHelpers.cs
@@ -38,12 +38,10 @@ internal static class RequestHelpers
 
         var auth = await authContext.GetAuthorizationInfo(requestContext).ConfigureAwait(false);
 
-        var authenticatedUser = auth?.User;
-
         // Fail closed on an unresolved caller: a null authorization result or unauthenticated request
         // is an explicit deny, not a NullReferenceException that would surface as a 500. Every real
         // caller sits behind [Authorize], so this only guards the ambiguous/misconfigured case.
-        if (authenticatedUser is null)
+        if (auth?.User is not { } authenticatedUser)
         {
             return false;
         }

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -228,7 +228,7 @@ public class SSOController : ControllerBase
         var canonicalBase = CanonicalBaseUrl.Resolve(
             config?.BaseUrlOverride, Request.Scheme, Request.Host.Host, Request.Host.Port, Request.PathBase, config?.SchemeOverride, config?.PortOverride);
 
-        string endSessionUrl = null;
+        string? endSessionUrl = null;
         if (match.Value is { } captured)
         {
             try
@@ -272,7 +272,7 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <param name="baseUrlOverride">The override value posted to the Add endpoint.</param>
     /// <exception cref="ArgumentException">The override is non-blank and not a valid absolute http(s) URL.</exception>
-    internal static void RejectInvalidBaseUrlOverride(string baseUrlOverride)
+    internal static void RejectInvalidBaseUrlOverride(string? baseUrlOverride)
     {
         if (CanonicalBaseUrl.IsInvalidOverride(baseUrlOverride))
         {
@@ -292,7 +292,7 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <param name="certificateStr">The Base64-encoded (DER) X.509 certificate posted to the Add endpoint.</param>
     /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
-    internal static void RejectInvalidSamlCertificate(string certificateStr)
+    internal static void RejectInvalidSamlCertificate(string? certificateStr)
     {
         if (SamlCertificate.IsInvalid(certificateStr))
         {
@@ -313,7 +313,7 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <param name="certificateStr">The Base64-encoded (DER) X.509 certificate posted to the Add endpoint.</param>
     /// <exception cref="ArgumentException">The certificate is non-blank and not loadable.</exception>
-    internal static void RejectInvalidSamlSecondaryCertificate(string certificateStr)
+    internal static void RejectInvalidSamlSecondaryCertificate(string? certificateStr)
     {
         if (SamlCertificate.IsInvalid(certificateStr))
         {
@@ -332,7 +332,7 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <param name="signingKeyPfx">The Base64-encoded PKCS#12 (PFX) signing key posted to the Add endpoint.</param>
     /// <exception cref="ArgumentException">The key is non-blank and not a loadable PFX with an RSA or ECDSA private key.</exception>
-    internal static void RejectInvalidSamlSigningKey(string signingKeyPfx)
+    internal static void RejectInvalidSamlSigningKey(string? signingKeyPfx)
     {
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
@@ -599,7 +599,7 @@ public class SSOController : ControllerBase
     /// <returns>A webpage that will complete the client-side flow.</returns>
     [HttpPost("SAML/p/{provider}")]
     [HttpPost("SAML/post/{provider}")]
-    public ActionResult SamlCallback(string provider, [FromQuery] string relayState = null, [FromForm(Name = "SAMLResponse")] string formSamlResponse = null)
+    public ActionResult SamlCallback(string provider, [FromQuery] string? relayState = null, [FromForm(Name = "SAMLResponse")] string? formSamlResponse = null)
     {
         if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
@@ -1300,6 +1300,6 @@ public class SSOController : ControllerBase
     // IP classifier, endpoint-class keying, the #195 observability signal); this wrapper only supplies the
     // three request-scoped inputs it needs — the endpoint class, the connection's remote address, and the
     // response the retry-delay header is set on — so the controller keeps no rate-limit state of its own.
-    private ActionResult RateLimitCheck(string endpointClass) =>
+    private ActionResult? RateLimitCheck(string endpointClass) =>
         SsoRateLimitGate.Check(endpointClass, HttpContext.Connection.RemoteIpAddress, _logger, Response);
 }

--- a/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
 
 /// <summary>

--- a/SSO-Auth/Api/Http/SamlMetadataImporter.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImporter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.IO;
 using System.Net.Http;

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Identity;
 
 /// <summary>

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Identity;
 
 /// <summary>

--- a/SSO-Auth/Api/Linking/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/Linking/AccountLinkResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;

--- a/SSO-Auth/Api/Linking/AdoptionEligibilityResolver.cs
+++ b/SSO-Auth/Api/Linking/AdoptionEligibilityResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
 
 /// <summary>

--- a/SSO-Auth/Api/Linking/CanonicalLinkRevoker.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkRevoker.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
+++ b/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
 
 /// <summary>

--- a/SSO-Auth/Api/LoginButtons/LoginButton.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButton.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 
 /// <summary>

--- a/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Logout/LogoutContext.cs
+++ b/SSO-Auth/Api/Logout/LogoutContext.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Logout;
 
 /// <summary>

--- a/SSO-Auth/Api/Logout/SessionLogoutStore.cs
+++ b/SSO-Auth/Api/Logout/SessionLogoutStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/SSO-Auth/Api/Oidc/AcrPolicy.cs
+++ b/SSO-Auth/Api/Oidc/AcrPolicy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -7,8 +7,6 @@ using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
@@ -1,8 +1,6 @@
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Duende.IdentityModel.OidcClient;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth/Api/Oidc/OidcFrontChannelParameters.cs
+++ b/SSO-Auth/Api/Oidc/OidcFrontChannelParameters.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Globalization;
 using Duende.IdentityModel.Client;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -12,8 +12,6 @@ using Jellyfin.Plugin.SSO_Auth.Api.Crypto;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 

--- a/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -4,8 +4,6 @@ using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using Newtonsoft.Json;

--- a/SSO-Auth/Api/Provider/ProviderMode.cs
+++ b/SSO-Auth/Api/Provider/ProviderMode.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Provider;
 
 /// <summary>

--- a/SSO-Auth/Api/Provider/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/Provider/ProviderNameValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Buffers;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;

--- a/SSO-Auth/Api/Provider/ProviderTestResult.cs
+++ b/SSO-Auth/Api/Provider/ProviderTestResult.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/SSO-Auth/Api/RateLimit/IntervalGate.cs
+++ b/SSO-Auth/Api/RateLimit/IntervalGate.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading;
 

--- a/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
+++ b/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>

--- a/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;

--- a/SSO-Auth/Api/Routing/ChallengePath.cs
+++ b/SSO-Auth/Api/Routing/ChallengePath.cs
@@ -1,7 +1,5 @@
 using System;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 /// <summary>

--- a/SSO-Auth/Api/Routing/RouteSuffix.cs
+++ b/SSO-Auth/Api/Routing/RouteSuffix.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 /// <summary>

--- a/SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>

--- a/SSO-Auth/Api/Saml/SamlAssertionTime.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionTime.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Xml;
 

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -2,8 +2,6 @@ using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>

--- a/SSO-Auth/Api/Saml/SamlCertificate.cs
+++ b/SSO-Auth/Api/Saml/SamlCertificate.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Saml/SamlMetadataImport.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataImport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth/Api/Saml/SamlMetadataParser.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataParser.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
+++ b/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;

--- a/SSO-Auth/Api/Saml/SamlRequestCache.cs
+++ b/SSO-Auth/Api/Saml/SamlRequestCache.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;

--- a/SSO-Auth/Api/Saml/SamlResponse.cs
+++ b/SSO-Auth/Api/Saml/SamlResponse.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/SSO-Auth/Api/Saml/SamlSigningKey.cs
+++ b/SSO-Auth/Api/Saml/SamlSigningKey.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
@@ -57,7 +55,7 @@ internal static class SamlSigningKey
     /// </summary>
     /// <param name="pfxBase64">The Base64 PKCS#12 blob.</param>
     /// <returns><see langword="true"/> if the value is set but not a loadable signing key.</returns>
-    internal static bool IsInvalid(string pfxBase64)
+    internal static bool IsInvalid(string? pfxBase64)
     {
         if (string.IsNullOrWhiteSpace(pfxBase64))
         {

--- a/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.IO;
 using System.Text;
 using System.Xml;

--- a/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;

--- a/SSO-Auth/Api/Secrets/SecretEnvelope.cs
+++ b/SSO-Auth/Api/Secrets/SecretEnvelope.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Secrets/SecretStore.cs
+++ b/SSO-Auth/Api/Secrets/SecretStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Session/AuthResponse.cs
+++ b/SSO-Auth/Api/Session/AuthResponse.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 
 /// <summary>

--- a/SSO-Auth/Api/Session/LoginOutcome.cs
+++ b/SSO-Auth/Api/Session/LoginOutcome.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using MediaBrowser.Controller.Authentication;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;

--- a/SSO-Auth/Api/Session/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/Session/LoginStatusMapper.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Globalization;
 using System.Net.Mime;

--- a/SSO-Auth/Api/Session/PublicReason.cs
+++ b/SSO-Auth/Api/Session/PublicReason.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 
 /// <summary>

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Data;

--- a/SSO-Auth/Api/Session/SessionParameters.cs
+++ b/SSO-Auth/Api/Session/SessionParameters.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 
 /// <summary>

--- a/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
+++ b/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 

--- a/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -75,7 +73,7 @@ internal sealed class SsoOnlyLoginService
     /// </summary>
     /// <param name="username">The candidate break-glass admin username.</param>
     /// <returns>The resolved login state.</returns>
-    internal BreakGlassAdminState DescribeBreakGlass(string username)
+    internal BreakGlassAdminState DescribeBreakGlass(string? username)
     {
         if (string.IsNullOrWhiteSpace(username))
         {

--- a/SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Shared/AuthPageCsp.cs
+++ b/SSO-Auth/Api/Shared/AuthPageCsp.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Net.Mime;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -49,7 +47,7 @@ internal static class SsoRateLimitGate
     /// <param name="logger">The caller's logger, for the bounded throttle-engaged observability signal (#195).</param>
     /// <param name="response">The response whose Retry-After header a throttled outcome sets (#474).</param>
     /// <returns>Null when the request may proceed, or the throttled 429 outcome otherwise.</returns>
-    internal static ActionResult? Check(string endpointClass, IPAddress remoteIp, ILogger logger, HttpResponse response)
+    internal static ActionResult? Check(string endpointClass, IPAddress? remoteIp, ILogger logger, HttpResponse response)
     {
         var (enabled, maxAttempts, windowSeconds) = SSOPlugin.Instance.ReadConfiguration(
             c => (c.EnableRateLimit, c.RateLimitMaxAttempts, c.RateLimitWindowSeconds));

--- a/SSO-Auth/Config/ConfigExport.cs
+++ b/SSO-Auth/Config/ConfigExport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/ConfigExportDocument.cs
+++ b/SSO-Auth/Config/ConfigExportDocument.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/LogoutSession.cs
+++ b/SSO-Auth/Config/LogoutSession.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/Config/SerializableDictionary.cs
+++ b/SSO-Auth/Config/SerializableDictionary.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Collections.Generic;
 using System.Xml.Serialization;
 

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
@@ -87,7 +85,7 @@ internal static class ServerManagedFields
     /// </summary>
     /// <param name="incoming">The provider config about to be persisted; a null entry is skipped.</param>
     /// <param name="live">The current live provider config to read server-managed values from; null skips.</param>
-    internal static void Preserve(OidConfig incoming, OidConfig live)
+    internal static void Preserve(OidConfig incoming, OidConfig? live)
     {
         // A null provider entry (a malformed Add before #350, or a legacy store) carries no
         // server-managed fields; skip it rather than NRE the whole config-page save.
@@ -126,7 +124,7 @@ internal static class ServerManagedFields
     /// </summary>
     /// <param name="incoming">The provider config about to be persisted; a null entry is skipped.</param>
     /// <param name="live">The current live provider config to read server-managed values from; null skips.</param>
-    internal static void Preserve(SamlConfig incoming, SamlConfig live)
+    internal static void Preserve(SamlConfig incoming, SamlConfig? live)
     {
         if (incoming is null || live is null)
         {

--- a/SSO-Auth/Config/SsoOnlyLoginGuard.cs
+++ b/SSO-Auth/Config/SsoOnlyLoginGuard.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
@@ -74,7 +72,7 @@ internal static class SsoOnlyLoginGuard
     /// <param name="breakGlassUsername">The designated break-glass admin username (may be blank).</param>
     /// <param name="breakGlass">The resolved login state of that account.</param>
     /// <returns>The guard verdict.</returns>
-    internal static SsoOnlyGuardVerdict Evaluate(string breakGlassUsername, BreakGlassAdminState breakGlass)
+    internal static SsoOnlyGuardVerdict Evaluate(string? breakGlassUsername, BreakGlassAdminState breakGlass)
     {
         if (string.IsNullOrWhiteSpace(breakGlassUsername))
         {

--- a/SSO-Auth/Config/WriteOnlySecretConverter.cs
+++ b/SSO-Auth/Config/WriteOnlySecretConverter.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -7,6 +7,7 @@
          publish pipeline builds each target into its own package with its own targetAbi. -->
     <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
     <RootNamespace>Jellyfin.Plugin.SSO_Auth</RootNamespace>
+    <Nullable>enable</Nullable>
     <AssemblyVersion>4.3.0</AssemblyVersion>
     <FileVersion>4.3.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -60,7 +60,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <summary>
     /// Gets the instance of the SSO plugin.
     /// </summary>
-    public static SSOPlugin Instance { get; private set; }
+    public static SSOPlugin Instance { get; private set; } = null!;
 
     /// <summary>
     /// Gets the name of the SSO plugin.


### PR DESCRIPTION
## What & why

Completes the #799 nullable rollout by flipping the plugin to a single
project-wide contract: `<Nullable>enable</Nullable>` on `SSO-Auth.csproj` and
removal of all 117 per-file `#nullable enable` pragmas. Nullability is now one
project property instead of a file-by-file opt-in, and the 7 files that no
module pass had covered (`SSOController`, `RequestHelpers`, `SSOPlugin`, plus
four already-clean root/Http files) are checked too.

Every newly-surfaced warning is resolved **fail-closed with no behaviour
change**, C# nullable annotations and `!` emit no IL, and the sole real code
edit (RequestHelpers) is semantically identical:

- `SSOPlugin.Instance` → `{ get; private set; } = null!` (standard plugin
  singleton set in the instance ctor; the live `SSOViewsController` null-guard
  is retained).
- `RequestHelpers.AssertCanUpdateUser` folds `auth?.User` into
  `if (auth?.User is not { } authenticatedUser) return false;`, identical
  deny-on-unresolved-caller.
- `SsoRateLimitGate.Check(IPAddress? remoteIp)`: honest annotation of the
  already-nullable `RemoteIpAddress`; `NormalizeClientKey` already maps a
  null/unattributable IP to the exempt-but-globally-bounded bucket
  (anti-mass-lockout). No new guard.
- Break-glass chain (`SsoOnlyLoginGuard.Evaluate`,
  `SsoOnlyLoginService.DescribeBreakGlass`, `SsoAudit`) → `string?`; each
  `IsNullOrWhiteSpace`-guards, so null/blank = "no break-glass admin",
  fail-closed reject unchanged.
- `OidcLoginService.Link` bindingCookie, `SamlCallback` params, the
  `RejectInvalidSaml*` optional-field validators, `endSessionUrl`, and
  `ServerManagedFields.Preserve` `live` widened to nullable; each already
  null-guards to its documented fail-safe.

## Type of change

- [x] Refactor / hardening (no functional change)

## Security checklist

- [x] No authorization, session, CSRF, or crypto path changed behaviour, a
  refute-by-default bypass-lens + correctness-lens review confirmed no
  fail-closed check was flipped to fail-open (the Config-pass null-Roles class
  of bug has no analogue here; no default value replaced a null reject).
- [x] Rate-limit null-IP path is the pre-existing, documented availability
  decision (annotation-only).
- [x] Fail-closed defaults preserved everywhere null is now permitted.

## Quality checklist

- [x] Both projects build **0 warnings / 0 errors** under `--warnaserror` on
  net9.0 and net10.0.
- [x] Full suite green, **1788 passed, 0 failed**.
- [x] `<Nullable>enable</Nullable>` project-wide; **0** stray `#nullable`
  pragmas remain.

## Review gate

Adversarial bypass-lens + correctness-lens: **PASS / PASS**.

Closes #799