### PR TITLE
Generate and attach a CycloneDX SBOM to every release [#729]

### DIFF
--- a/.github/actions/cyclonedx-sbom/action.yml
+++ b/.github/actions/cyclonedx-sbom/action.yml
@@ -1,0 +1,51 @@
+name: Generate CycloneDX SBOM
+description: >-
+  Emit a CycloneDX JSON SBOM for the SSO-Auth plugin from the locked restore
+  graph the caller has already materialised, so a release can carry the
+  dependency inventory CRA Annex I / OSPS-QA-02.02 expect. The single generator
+  for every publish leg (DRY): each leg calls this action, none re-implements it.
+  The SBOM covers the plugin's FULL multi-target dependency closure (both the
+  net9.0 / Jellyfin 10.11 and net10.0 / Jellyfin 12.0 lines) as pinned in the
+  committed packages.lock.json — a conservative superset for any single leg's
+  shipped ABI, never an under-report. Which target framework a given release
+  ships is identified by its tag and zip.
+inputs:
+  output-dir:
+    description: >-
+      Existing directory the SBOM JSON is written into (e.g. the publish leg's
+      `_dist` staging dir, or a fresh `sbom` dir in the reusable build).
+    required: true
+outputs:
+  sbom-path:
+    description: Path to the generated CycloneDX JSON SBOM.
+    value: ${{ steps.generate.outputs.sbom-path }}
+runs:
+  using: composite
+  steps:
+    - name: Generate CycloneDX SBOM
+      id: generate
+      shell: bash
+      # CycloneDX is a NuGet global tool, so it is pinned by VERSION — the correct
+      # pin mechanism for a NuGet package, and stricter than adopting a single-
+      # release third-party wrapper action into the SHA-pin trust set. It reads the
+      # caller's already-restored graph (`--disable-package-restore`): the real
+      # restore ran under RestoreLockedMode against the committed packages.lock.json,
+      # so the SBOM documents exactly the locked closure and no drifted or poisoned
+      # package can be pulled in merely to describe the bill of materials. The
+      # output path is passed through an env var, not interpolated into the script,
+      # so a caller value can never be evaluated as shell.
+      env:
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$OUTPUT_DIR"
+        dotnet tool install --global CycloneDX --version 6.2.0
+        export PATH="$HOME/.dotnet/tools:$PATH"
+        dotnet-CycloneDX SSO-Auth/SSO-Auth.csproj \
+          --output-format Json \
+          --output "$OUTPUT_DIR" \
+          --filename sbom.cyclonedx.json \
+          --set-nuget-purl \
+          --exclude-test-projects \
+          --disable-package-restore
+        echo "sbom-path=$OUTPUT_DIR/sbom.cyclonedx.json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,3 +85,54 @@ jobs:
           retention-days: 30
           if-no-files-found: error
           path: ${{ steps.jprm.outputs.artifact }}
+
+  # The CycloneDX SBOM runs in its OWN release-only job, DELIBERATELY WITHOUT the
+  # signing scopes the build job holds. The SBOM generator installs a NuGet global
+  # tool at run time; keeping it out of the job that carries id-token/attestations
+  # write means a compromised tool can never reach the Sigstore signing identity or
+  # mint a provenance attestation (SLSA L3 build-isolation). The SBOM is shipped as
+  # a checksummed release asset (like the beta/JF12 legs), not attested — the
+  # isolation is worth more than attesting the side-document.
+  sbom:
+    name: Generate SBOM
+    if: ${{ inputs.attest }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Both SDKs: the SBOM documents the FULL multi-target closure, so the
+      # whole-solution restore must evaluate both the net9.0 and net10.0 targets
+      # (matching the JF12 legs' dual-SDK setup) regardless of which single target a
+      # given publish leg ships.
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      # Materialise the locked restore graph the SBOM reads. --locked-mode rejects a
+      # drifted or tampered graph (RestoreLockedMode is also forced in CI), so the
+      # SBOM documents exactly the committed packages.lock.json closure.
+      - name: Restore dependencies
+        run: dotnet restore --locked-mode
+
+      - name: Generate CycloneDX SBOM
+        id: sbom
+        uses: ./.github/actions/cyclonedx-sbom
+        with:
+          output-dir: sbom
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
+        with:
+          name: sbom-artifact
+          retention-days: 30
+          if-no-files-found: error
+          path: ${{ steps.sbom.outputs.sbom-path }}

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -155,10 +155,17 @@ jobs:
         path: .
         dotnet-target: "net9.0"
         output: _dist
+    # CycloneDX SBOM of the net9 shipping closure, into the release staging dir so
+    # the checksum loop and `files: _dist/*` ship it as a beta release asset. Reads
+    # the --locked-mode restore above; the same single generator publish.yml uses.
+    - name: Generate CycloneDX SBOM
+      uses: ./.github/actions/cyclonedx-sbom
+      with:
+        output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip; do
+        for file in ./*.zip ./sbom.cyclonedx.json; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -136,10 +136,17 @@ jobs:
         path: .
         dotnet-target: "net10.0"
         output: _dist
+    # CycloneDX SBOM of the net10 shipping closure, into the release staging dir so
+    # the checksum loop and `files: _dist/*` ship it as a beta release asset. Reads
+    # the --locked-mode restore above; the same single generator publish.yml uses.
+    - name: Generate CycloneDX SBOM
+      uses: ./.github/actions/cyclonedx-sbom
+      with:
+        output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip; do
+        for file in ./*.zip ./sbom.cyclonedx.json; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -77,10 +77,17 @@ jobs:
         path: .
         dotnet-target: "net10.0"
         output: _dist
+    # CycloneDX SBOM of the net10 shipping closure, into the release staging dir so
+    # the checksum loop and `files: _dist/*` ship it as a release asset. Reads the
+    # --locked-mode restore above; the same single generator publish.yml uses.
+    - name: Generate CycloneDX SBOM
+      uses: ./.github/actions/cyclonedx-sbom
+      with:
+        output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip; do
+        for file in ./*.zip ./sbom.cyclonedx.json; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,13 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: build-artifact
+    # The CycloneDX SBOM the reusable workflow's isolated `sbom` job produced,
+    # downloaded beside the plugin zip so the checksum loop and `files: ./*` ship it
+    # as a release asset.
+    - name: Download SBOM
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: sbom-artifact
     - name: Prepare GitHub Release assets
       run: |-
         for file in ./*; do

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,27 @@ gh attestation verify <plugin>.zip --repo iderex/jellyfin-plugin-sso
 The provenance attestation complements the checksum sidecars — it does not
 replace the manifest MD5.
 
+### Software Bill of Materials (SBOM)
+
+Every release also ships a **CycloneDX SBOM** (`sbom.cyclonedx.json`) enumerating
+the plugin's direct and transitive dependency closure, generated from the
+committed `packages.lock.json` restored in locked mode. It is the dependency
+inventory a downstream redistributor needs for its own CRA Annex I duties
+(and satisfies OSPS-QA-02.02). The SBOM covers the **full multi-target closure**
+(both the net9.0 / Jellyfin 10.11 and net10.0 / Jellyfin 12.0 lines) — a
+conservative superset of any single release's shipped ABI, which its tag and
+zip identify. It is shipped with the same `.md5`/`.sha256` sidecars as the plugin
+zip.
+
+The SBOM is generated in an isolated job that deliberately does **not** hold the
+release signing scopes, so the SBOM tool can never reach the provenance signing
+identity; it is therefore checksummed rather than attested.
+
+Honest framing: the SBOM documents the shipped dependency set — it is a
+transparency artifact, not a compliance certificate or a statement that those
+dependencies are free of vulnerabilities (that is what the dependency-review and
+vulnerable-dependency scans below cover).
+
 ### Reproducible compile
 
 The build is **deterministic**: `Directory.Build.props` sets `Deterministic` and


### PR DESCRIPTION
## What & why

Releases shipped checksums and (JF10.11) a SLSA build-provenance attestation but
no SBOM. Provenance proves _who built_ the artifact; an SBOM says _what is in it_
 - the dependency inventory **CRA Annex I Part II** and **OSPS-QA-02.02** expect,
and that a downstream commercial redistributor needs for its own CRA duties from
2027-12-11.

One CycloneDX generator, reused by every publish leg (DRY):

- **`.github/actions/cyclonedx-sbom`** (composite action): generates
  `sbom.cyclonedx.json` for `SSO-Auth.csproj` from the **already-locked** restore
  graph (`--disable-package-restore`; the real restore runs under
  `RestoreLockedMode` against the committed `packages.lock.json`), so no
  drifted/poisoned package can be pulled in merely to describe the BOM. The tool
  is a NuGet global tool pinned by version; the caller's output dir is passed via
  env, never interpolated into the shell.
- **Full multi-target closure** (net9.0/JF10.11 + net10.0/JF12): a conservative
  superset of any single leg's shipped ABI, never an under-report, the release
  tag and zip identify which TFM ships. (Per-TFM filtering with the locked graph
  is not achievable with this tool; verified empirically.)
- **build.yml (JF10.11 stable):** the SBOM is generated in its **own release-only
  `sbom` job holding `contents: read` only**, deliberately NOT the signing scopes
  (`id-token`/`attestations: write`) the build job carries. Isolating the run-time
  NuGet tool from the Sigstore signing identity means a compromised tool can never
  mint a provenance attestation (SLSA L3 build-isolation); the plugin-zip
  attestation path is untouched. `publish.yml` downloads the sbom-artifact beside
  the zip; the checksum loop and `files: ./*` ship it and its sidecars.
- **The three inline legs** (JF12 stable, JF10.11 beta, JF12 beta): generate into
  `_dist` after JPRM and checksum alongside the zip; `files: _dist/*` attaches it.
  These legs hold no signing scopes.
- **SECURITY.md:** documents the SBOM beside provenance verification, full
  multi-target closure, checksummed on every release (not attested; the isolation
  is worth more than attesting the side-document), with the honest framing that it
  is a transparency artifact, not a compliance certificate.

## Type of change

- [x] New capability (release supply-chain artifact); CI-path behaviour unchanged.

## Security checklist

- [x] The run-time NuGet SBOM tool never executes in a job holding the OIDC /
  attestation signing scopes (dedicated `contents: read` job).
- [x] No template injection: the only caller value in a `run:` block is routed
  through `env` (`OUTPUT_DIR`); every other `${{ }}` is passed to an action input.
- [x] Fail-closed: `set -euo pipefail` in the action, `if-no-files-found: error`,
  `fail_on_unmatched_files: true`, a failed SBOM fails the release, never ships
  silently without one.
- [x] `--disable-package-restore` keeps the locked graph authoritative; the
  shipped binary is untouched.
- [x] All actions SHA-pinned; the new action is local; `persist-credentials: false`.

## Quality checklist

- [x] All six workflow/action YAML files parse; `SECURITY.md` passes prettier.
- [x] CycloneDX invocation + full dependency-closure output (incl. CVE-fixed
  `System.Security.Cryptography.Xml 10.0.10`) verified locally against the lockfile.

## Review gate

Adversarial integration-lens + supply-chain bypass-lens: both findings from the
first pass (multi-TFM accuracy framing; tool-in-signing-job isolation) addressed;
re-review confirmation folded in.

Closes #729