### PR TITLE
Adopt a DCO sign-off with a self-contained check [#746]

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,80 @@
+# Developer Certificate of Origin (DCO) sign-off gate (#746). A contributor
+# legal-authorization mechanism — OpenSSF Silver / OSPS-LE-01.01 — implemented as a
+# self-contained first-party check, no external DCO App or third-party action (the
+# same internal-only posture as the PR-hygiene gate). It verifies every non-merge
+# commit in the PR carries a `Signed-off-by:` trailer matching its author, i.e. the
+# author asserted the DCO in ./DCO. Fail-closed: any unsigned commit reds the check.
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Read-only: the check only reads git history.
+permissions:
+  contents: read
+
+# Cancel a superseded run on the same PR; re-verification is cheap and idempotent.
+concurrency:
+  group: dco-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so the base..head commit range is walkable; no push, so
+          # drop the persisted token.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify DCO sign-off on every commit
+        # The base/head SHAs are passed via env, never interpolated into the script,
+        # so an attacker-crafted ref can never be evaluated as shell.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          fail=0
+          # Guard the walk explicitly so a `git rev-list` failure reds the job
+          # instead of silently passing it. A command-substitution failure inside a
+          # `for ... in $(...)` word list does not trip `set -e`, which would pass
+          # the gate with nothing verified (fail-open); an `if !` guard is
+          # unambiguously fail-closed in every shell.
+          if ! commits=$(git rev-list --no-merges "$BASE_SHA".."$HEAD_SHA"); then
+            echo "::error::Could not walk the commit range ${BASE_SHA}..${HEAD_SHA}."
+            exit 1
+          fi
+          for sha in $commits; do
+            author_name=$(git show -s --format='%an' "$sha")
+            author_email=$(git show -s --format='%ae' "$sha")
+            # Trusted first-party automation authors bot commits that cannot
+            # self-sign; exempt them, as the DCO App does. An explicit allowlist of
+            # GitHub's own bot identities — not a `*[bot]@...` glob — so a human
+            # cannot self-exempt by crafting a `[bot]`-shaped author email.
+            case "$author_email" in
+              *"+dependabot[bot]@users.noreply.github.com" \
+              | "dependabot[bot]@users.noreply.github.com" \
+              | *"+github-actions[bot]@users.noreply.github.com" \
+              | "github-actions[bot]@users.noreply.github.com")
+                echo "skip  $sha (bot: $author_email)"; continue ;;
+            esac
+            expected="Signed-off-by: ${author_name} <${author_email}>"
+            if git show -s --format='%B' "$sha" | grep -qxF "$expected"; then
+              echo "ok    $sha"
+            else
+              echo "FAIL  $sha is missing: ${expected}"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more commits lack a DCO Signed-off-by matching the author. Sign your work with 'git commit -s' (or add it retroactively with 'git rebase --signoff <base>'). See CONTRIBUTING.md and ./DCO."
+            exit 1
+          fi
+          echo "All commits carry a matching DCO sign-off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Improving The Documentation](#improving-the-documentation)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
+  - [Sign Your Work (DCO)](#sign-your-work-dco)
 - [Join The Project Team](#join-the-project-team)
 
 > Project governance — who holds access, how decisions are made, and the continuity model — is documented in [GOVERNANCE.md](GOVERNANCE.md).
@@ -170,6 +171,26 @@ We are always open to better docs! The main place documentation could be improve
 ### Commit Messages
 
 Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); explain the _why_ in the body. **Every commit subject ends with its issue reference(s) in brackets** — `Add SAML replay cache [#123]`, multiple issues as `[#123][#456]` — so the link survives `git blame`/`bisect`/`log`, which show only the subject. GitHub's auto-close keywords (`Closes #N`) additionally go in the body when the commit resolves the issue. The PR-hygiene gate enforces the bracketed subject reference per commit (bots and merge commits exempt).
+
+### Sign Your Work (DCO)
+
+This project uses the [Developer Certificate of Origin](DCO) (DCO 1.1) — a lightweight, standard way to certify that you wrote or otherwise have the right to submit the code you contribute, under the project's GPL-3.0 license. It is not a copyright-assignment CLA; you keep your copyright.
+
+**Every commit must be signed off.** Add the sign-off automatically with `-s`:
+
+```sh
+git commit -s -m "Add SAML replay cache [#123]"
+```
+
+This appends a trailer matching your commit author identity:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+By adding it you certify the [DCO](DCO). Forgot to sign off? Add it retroactively across your branch with `git rebase --signoff <base>` and force-push.
+
+The **DCO gate** verifies every non-merge commit in a pull request carries a matching sign-off and fails the check otherwise (trusted first-party bot commits, e.g. Dependabot, are exempt). This is fail-closed: an unsigned commit blocks the pull request until it is signed off.
 
 ### C#
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,34 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## What & why

There was no DCO, CLA, or documented mechanism by which a contributor asserts
the right to submit their work. Add a **Developer Certificate of Origin**
sign-off as that legal-authorization mechanism, **OpenSSF Silver** /
**OSPS-LE-01.01 (L2)**. DCO is preferred over a CLA: lighter, no copyright
assignment, standard for a GPL project.

- **`DCO`**, the verbatim developercertificate.org 1.1 text.
- **`.github/workflows/dco.yml`**, a self-contained first-party gate (no external
  DCO App or third-party action, matching the internal-only merge-gate posture).
  It walks every non-merge commit in the PR range and **fails closed** unless each
  carries a `Signed-off-by:` trailer exactly matching its author. Trusted
  first-party bots (Dependabot, github-actions) are exempt via an explicit
  allowlist of GitHub's own `…[bot]@users.noreply.github.com` identities, not a
  `*[bot]@…` glob, so a human cannot self-exempt with a crafted author email. The
  base/head SHAs are env-routed, never interpolated into the shell.
- **`CONTRIBUTING.md`**, a "Sign Your Work (DCO)" section (`git commit -s`, the
  retroactive `git rebase --signoff` fix, the fail-closed gate) + a TOC entry.

My own commits carry the sign-off (this PR's commit is signed off).

## Type of change

- [x] New CI gate + contributor-governance docs. No product code touched.

## Security checklist

- [x] **Fail-closed**, verified empirically: an unsigned or wrong-author commit
  reds the check; a signed commit passes; a `git rev-list` walk failure is caught
  by an explicit `if !` guard and reds the job (not a silent pass).
- [x] **Bot exemption is an explicit allowlist** of GitHub bot noreply identities
 , a `foo[bot]@example.com` or `evil[bot]@users.noreply.github.com` author is
  still checked, not exempted.
- [x] **No template/shell injection**: SHAs via env; the commit-controlled author
  name/email are only used in a quoted `grep -qxF` (fixed-string, whole-line) and
  `echo`, never re-evaluated; git strips newlines from author idents.
- [x] `permissions: contents: read`; checkout SHA-pinned; `persist-credentials:
  false`; `fetch-depth: 0`.

## Quality checklist

- [x] `dco.yml` YAML parses; `CONTRIBUTING.md` passes prettier.
- [x] Match logic, bot allowlist, and fail-closed walk verified locally, plus an
  end-to-end run of the full check body over this PR's signed commit (green).

## Follow-up (out of this diff)

The check reds on an unsigned commit, but **blocking the merge** requires adding
"DCO sign-off" to the "Protect main" required-status-checks ruleset (a GitHub
repo-settings step, gated on my sign-off), otherwise it is advisory like PR-hygiene.

## Review gate

Adversarial bypass-lens: the one real finding (fail-open on a walk error) is
fixed with the explicit guard; the bot-exemption spoof was tightened to an
allowlist; injection/permissions posture confirmed clean.

Closes #746
