### PR TITLE
Add SPDX license + copyright headers to all source files [#747]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,6 +196,15 @@ The **DCO gate** verifies every non-merge commit in a pull request carries a mat
 
 We format all C# code according to the .NET formatter. Build with `dotnet build --no-restore --warnaserror` (the same command CI runs, so warnings fail the build) and fix anything it reports, and keep `dotnet test` green.
 
+Every C# source file opens with the two-line SPDX header (a conformance test fails the build without it):
+
+```csharp
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+```
+
+The project is licensed **GPL-3.0-only** (`GPL-3.0-only` is the [SPDX identifier](https://spdx.org/licenses/); see [LICENSE.txt](LICENSE.txt)).
+
 The architecture, comment/documentation, and object-oriented rules a change is held to live in one canonical place — the [Coding Standards](https://github.com/iderex/jellyfin-plugin-sso/wiki/Coding-Standards) wiki page. This guide does not restate them; read that page before a non-trivial change. They are enforced by the conformance fitness functions in `SSO-Auth.Tests/ArchitectureConformanceTests.cs` and the adversarial review gate.
 
 ### HTML/CSS/JS/Markdown

--- a/SSO-Auth.Fuzz/Program.cs
+++ b/SSO-Auth.Fuzz/Program.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -2376,6 +2379,43 @@ public class ArchitectureConformanceTests
             .Where(path => !IsBuildOutput(path))
             .Where(path => declarations.Any(d => d.IsMatch(File.ReadAllText(path))))
             .ToList();
+    }
+
+    [Fact]
+    public void EverySourceFile_CarriesTheSpdxHeader()
+    {
+        // #747: every C# source file opens with the SPDX copyright + licence header, so the licence of any
+        // one file is machine-readable at its top (REUSE / SPDX) and a new file cannot land without it.
+        // GPL-3.0-only is the project's SPDX identifier — it matches the declared "GPL v3.0" exactly, with no
+        // implicit "or later" broadening; the copyright line credits the authors collectively. This test is
+        // the drift guard that keeps the headers complete: a file added without the two opening lines fails
+        // CI here (the header must be the first two lines so it precedes the usings and the file-scoped
+        // namespace, which SPDX/REUSE tooling expects).
+        const string CopyrightLine = "// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors";
+        const string LicenceLine = "// SPDX-License-Identifier: GPL-3.0-only";
+        var offenders = new List<string>();
+        foreach (var root in new[] { "SSO-Auth", "SSO-Auth.Tests", "SSO-Auth.Fuzz" })
+        {
+            foreach (var src in Directory.EnumerateFiles(Path.Combine(RepoRoot(), root), "*.cs", SearchOption.AllDirectories))
+            {
+                if (IsBuildOutput(src))
+                {
+                    continue;
+                }
+
+                var firstLines = File.ReadLines(src).Take(2).ToList();
+                if (firstLines.Count < 2
+                    || firstLines[0].Trim() != CopyrightLine
+                    || firstLines[1].Trim() != LicenceLine)
+                {
+                    offenders.Add(Path.GetFileName(src));
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every C# source file must open with the SPDX copyright + GPL-3.0-only header (#747). Missing or incorrect in: " + string.Join(", ", offenders));
     }
 
     // obj/bin hold generated and compiled output; the source scans read hand-written source only.

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;

--- a/SSO-Auth.Tests/Authz/ParentalRatingPolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/ParentalRatingPolicyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Authz/PermissionRolePolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/PermissionRolePolicyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Authz/RolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/Authz/RolePrivilegeMapperTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Avatar/AvatarContentTypeTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarContentTypeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Xunit;

--- a/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Net;

--- a/SSO-Auth.Tests/Avatar/AvatarUrlValidatorTests.cs
+++ b/SSO-Auth.Tests/Avatar/AvatarUrlValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
 using Xunit;

--- a/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Xml.Serialization;
 using Jellyfin.Plugin.SSO_Auth.Api.Logout;

--- a/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Config/ProviderConfigStoreTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography.X509Certificates;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
+++ b/SSO-Auth.Tests/Config/SerializableDictionarySerializationTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Xml;

--- a/SSO-Auth.Tests/Config/WriteOnlySecretConverterTests.cs
+++ b/SSO-Auth.Tests/Config/WriteOnlySecretConverterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Text;

--- a/SSO-Auth.Tests/Crypto/SigningKeyStrengthTests.cs
+++ b/SSO-Auth.Tests/Crypto/SigningKeyStrengthTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Crypto;
 using Xunit;
 

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Flows/WebResponseTests.cs
+++ b/SSO-Auth.Tests/Flows/WebResponseTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;

--- a/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
+++ b/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using System.Net;

--- a/SSO-Auth.Tests/Http/RequestHelpersTests.cs
+++ b/SSO-Auth.Tests/Http/RequestHelpersTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Data;

--- a/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAddTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Http/SSOControllerAdminTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAdminTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Http/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerChallengeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Http/SSOControllerConfigTransferTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerConfigTransferTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth;

--- a/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLinkTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/SSO-Auth.Tests/Http/SSOControllerLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLogoutTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;

--- a/SSO-Auth.Tests/Http/SSOControllerOidAuthTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidAuthTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Http/SSOControllerOidChallengeTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidChallengeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/SSO-Auth.Tests/Http/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlAuthTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Http/SSOControllerSamlMetadataTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlMetadataTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;

--- a/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Http/SSOControllerScopeStringTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerScopeStringTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;

--- a/SSO-Auth.Tests/Http/SSOControllerSsoOnlyTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSsoOnlyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/SSO-Auth.Tests/Http/SSOControllerUnregisterTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerUnregisterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Reflection;

--- a/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
+++ b/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.IO;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using MediaBrowser.Common.Configuration;

--- a/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SamlImportMetadataEndpointTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
+++ b/SSO-Auth.Tests/Http/SamlMetadataImporterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net.Http;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Identity/VerifiedIdentityTests.cs
+++ b/SSO-Auth.Tests/Identity/VerifiedIdentityTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Linking/AccountLinkResolverTests.cs
+++ b/SSO-Auth.Tests/Linking/AccountLinkResolverTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;

--- a/SSO-Auth.Tests/Linking/AdoptionEligibilityResolverTests.cs
+++ b/SSO-Auth.Tests/Linking/AdoptionEligibilityResolverTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Xunit;

--- a/SSO-Auth.Tests/Linking/CanonicalLinkRevokerTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkRevokerTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Linking/CanonicalLinksSelfHealingTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinksSelfHealingTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonBuilderTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;

--- a/SSO-Auth.Tests/Logout/LogoutContextTests.cs
+++ b/SSO-Auth.Tests/Logout/LogoutContextTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Logout;
 using Xunit;
 

--- a/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
+++ b/SSO-Auth.Tests/Logout/SessionLogoutStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api.Logout;

--- a/SSO-Auth.Tests/Net/CanonicalBaseUrlTests.cs
+++ b/SSO-Auth.Tests/Net/CanonicalBaseUrlTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;

--- a/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
+++ b/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;

--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Net.Http;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using NSubstitute;

--- a/SSO-Auth.Tests/Oidc/AcrPolicyTests.cs
+++ b/SSO-Auth.Tests/Oidc/AcrPolicyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 

--- a/SSO-Auth.Tests/Oidc/AuthorizeStateBindingTests.cs
+++ b/SSO-Auth.Tests/Oidc/AuthorizeStateBindingTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/SSO-Auth.Tests/Oidc/OidcCallbackPathTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcCallbackPathTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/SSO-Auth.Tests/Oidc/OidcFrontChannelParametersTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcFrontChannelParametersTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenAcrTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenAcrTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenSidTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenSidTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Oidc/OidcInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcInsecureTogglesTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 

--- a/SSO-Auth.Tests/Oidc/OidcRedirectUriBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRedirectUriBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 

--- a/SSO-Auth.Tests/Oidc/OidcResponseIssuerTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcResponseIssuerTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Microsoft.IdentityModel.Tokens;

--- a/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Net.Http;

--- a/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Oidc/PkceDiscoveryTests.cs
+++ b/SSO-Auth.Tests/Oidc/PkceDiscoveryTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;

--- a/SSO-Auth.Tests/PropertyTests.cs
+++ b/SSO-Auth.Tests/PropertyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/Provider/ProviderModeTests.cs
+++ b/SSO-Auth.Tests/Provider/ProviderModeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Xunit;

--- a/SSO-Auth.Tests/Provider/ProviderNameValidatorTests.cs
+++ b/SSO-Auth.Tests/Provider/ProviderNameValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;

--- a/SSO-Auth.Tests/RateLimit/IntervalGateTests.cs
+++ b/SSO-Auth.Tests/RateLimit/IntervalGateTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/RateLimit/KeyedLockStoreTests.cs
+++ b/SSO-Auth.Tests/RateLimit/KeyedLockStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/RateLimit/PerClientBudgetLimiterTests.cs
+++ b/SSO-Auth.Tests/RateLimit/PerClientBudgetLimiterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/RateLimit/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/RateLimit/ProviderScopedKeyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/RateLimit/SsoRateLimiterTests.cs
+++ b/SSO-Auth.Tests/RateLimit/SsoRateLimiterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using System.Threading;

--- a/SSO-Auth.Tests/Routing/ChallengePathTests.cs
+++ b/SSO-Auth.Tests/Routing/ChallengePathTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;

--- a/SSO-Auth.Tests/Routing/RouteSuffixTests.cs
+++ b/SSO-Auth.Tests/Routing/RouteSuffixTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;

--- a/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
+++ b/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.IO;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth;

--- a/SSO-Auth.Tests/Saml/SamlAcsUrlBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAcsUrlBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;
 

--- a/SSO-Auth.Tests/Saml/SamlAssertionTimeTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAssertionTimeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth;

--- a/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/Saml/SamlAttackShapeTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAttackShapeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Xml;

--- a/SSO-Auth.Tests/Saml/SamlAuthnRequestTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAuthnRequestTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAuthorizeStateBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/Saml/SamlCertificateTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlCertificateTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlCrlfInteropTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlCrlfInteropTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;

--- a/SSO-Auth.Tests/Saml/SamlInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlInsecureTogglesTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Saml/SamlLoginPolicyTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLoginPolicyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;

--- a/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlMetadataParserTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Xunit;

--- a/SSO-Auth.Tests/Saml/SamlRedirectSignerTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRedirectSignerTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlReplayCacheTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlReplayCacheTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/Saml/SamlRequestCacheTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRequestCacheTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Globalization;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Saml/SamlResponseParsingTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlResponseParsingTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Security.Cryptography.Xml;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/Saml/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlResponseTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using System.Xml;
 using Jellyfin.Plugin.SSO_Auth;

--- a/SSO-Auth.Tests/Saml/SamlSecondaryCertificateTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlSecondaryCertificateTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Xml;
 using Jellyfin.Plugin.SSO_Auth;

--- a/SSO-Auth.Tests/Saml/SamlSignatureAlgorithmsTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlSignatureAlgorithmsTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth.Tests/Saml/SamlSigningKeyFactory.cs
+++ b/SSO-Auth.Tests/Saml/SamlSigningKeyFactory.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlSigningKeyTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlSigningKeyTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlSpMetadataBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlSpMetadataBuilderTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth.Tests/Saml/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/Saml/SamlTestFactory.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Globalization;
 using System.Security;

--- a/SSO-Auth.Tests/Saml/ValidateSamlTests.cs
+++ b/SSO-Auth.Tests/Saml/ValidateSamlTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Secrets/SecretEnvelopeTests.cs
+++ b/SSO-Auth.Tests/Secrets/SecretEnvelopeTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Secrets/SecretStoreTests.cs
+++ b/SSO-Auth.Tests/Secrets/SecretStoreTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth.Tests/Session/SessionMinterTests.cs
+++ b/SSO-Auth.Tests/Session/SessionMinterTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Session/SsoOnlyAuditTests.cs
+++ b/SSO-Auth.Tests/Session/SsoOnlyAuditTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;

--- a/SSO-Auth.Tests/Session/SsoOnlyConfigImportTests.cs
+++ b/SSO-Auth.Tests/Session/SsoOnlyConfigImportTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;

--- a/SSO-Auth.Tests/Session/SsoOnlyLoginGuardTests.cs
+++ b/SSO-Auth.Tests/Session/SsoOnlyLoginGuardTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;

--- a/SSO-Auth.Tests/Session/SsoOnlyLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Session/SsoOnlyLoginServiceTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/SSO-Auth.Tests/Session/SsoOnlyServerManagedFieldsTests.cs
+++ b/SSO-Auth.Tests/Session/SsoOnlyServerManagedFieldsTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth.Tests/Shared/AuthPageCspTests.cs
+++ b/SSO-Auth.Tests/Shared/AuthPageCspTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Xunit;

--- a/SSO-Auth.Tests/Shared/BrowserErrorPageTests.cs
+++ b/SSO-Auth.Tests/Shared/BrowserErrorPageTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth.Api.Shared;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth.Tests/Shared/FlowResponsesTests.cs
+++ b/SSO-Auth.Tests/Shared/FlowResponsesTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;

--- a/SSO-Auth.Tests/Shared/SsoRateLimitGateTests.cs
+++ b/SSO-Auth.Tests/Shared/SsoRateLimitGateTests.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Globalization;
 using System.Net;

--- a/SSO-Auth.Tests/_Support/CapturingLogger.cs
+++ b/SSO-Auth.Tests/_Support/CapturingLogger.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/SSO-Auth.Tests/_Support/EndpointCatalog.cs
+++ b/SSO-Auth.Tests/_Support/EndpointCatalog.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth.Tests/_Support/FakeCryptoProvider.cs
+++ b/SSO-Auth.Tests/_Support/FakeCryptoProvider.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using MediaBrowser.Model.Cryptography;
 

--- a/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
+++ b/SSO-Auth.Tests/_Support/SsoAuthorizationServerFixture.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/SSO-Auth.Tests/_Support/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/_Support/SsoControllerHarness.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Net;

--- a/SSO-Auth.Tests/_Support/StubHttpMessageHandler.cs
+++ b/SSO-Auth.Tests/_Support/StubHttpMessageHandler.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net.Http;
 using System.Threading;

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;

--- a/SSO-Auth.Tests/_Support/TestUsers.cs
+++ b/SSO-Auth.Tests/_Support/TestUsers.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Database.Implementations.Entities;
 

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 

--- a/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
+++ b/SSO-Auth/Api/Authz/ParentalRatingPolicy.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/Authz/PermissionGrant.cs
+++ b/SSO-Auth/Api/Authz/PermissionGrant.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Database.Implementations.Enums;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Avatar/AvatarContentType.cs
+++ b/SSO-Auth/Api/Avatar/AvatarContentType.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth/Api/Avatar/AvatarService.cs
+++ b/SSO-Auth/Api/Avatar/AvatarService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Net;

--- a/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
+++ b/SSO-Auth/Api/Avatar/AvatarUrlValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;

--- a/SSO-Auth/Api/Crypto/SigningKeyStrength.cs
+++ b/SSO-Auth/Api/Crypto/SigningKeyStrength.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Crypto;
 
 /// <summary>

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Flows/WebResponse.cs
+++ b/SSO-Auth/Api/Flows/WebResponse.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Globalization;
 using System.Text.Json;
 

--- a/SSO-Auth/Api/Http/ProviderConnectionTester.cs
+++ b/SSO-Auth/Api/Http/ProviderConnectionTester.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Net.Http;

--- a/SSO-Auth/Api/Http/RequestHelpers.cs
+++ b/SSO-Auth/Api/Http/RequestHelpers.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 // The following code is a derivative work of the code from the Jellyfin project,
 // which is licensed GPLv2. This code therefore is also licensed under the terms
 // of the GNU Public License, verison 2.

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/SSO-Auth/Api/Http/SSOViewsController.cs
+++ b/SSO-Auth/Api/Http/SSOViewsController.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using MediaBrowser.Model;

--- a/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImportRequest.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Http;
 
 /// <summary>

--- a/SSO-Auth/Api/Http/SamlMetadataImporter.cs
+++ b/SSO-Auth/Api/Http/SamlMetadataImporter.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Net.Http;

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Linking/AccountLinkResolver.cs
+++ b/SSO-Auth/Api/Linking/AccountLinkResolver.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;

--- a/SSO-Auth/Api/Linking/AdoptionEligibilityResolver.cs
+++ b/SSO-Auth/Api/Linking/AdoptionEligibilityResolver.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
 
 /// <summary>

--- a/SSO-Auth/Api/Linking/CanonicalLinkRevoker.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkRevoker.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
+++ b/SSO-Auth/Api/Linking/SsoManagedProviderId.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
 
 /// <summary>

--- a/SSO-Auth/Api/LoginButtons/LoginButton.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButton.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 
 /// <summary>

--- a/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonManager.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Logout/LogoutContext.cs
+++ b/SSO-Auth/Api/Logout/LogoutContext.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Logout;
 
 /// <summary>

--- a/SSO-Auth/Api/Logout/SessionLogoutStore.cs
+++ b/SSO-Auth/Api/Logout/SessionLogoutStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
+++ b/SSO-Auth/Api/Net/CanonicalBaseUrl.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/SSO-Auth/Api/Oidc/AcrPolicy.cs
+++ b/SSO-Auth/Api/Oidc/AcrPolicy.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeStateBinding.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Http;

--- a/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryFacts.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
+++ b/SSO-Auth/Api/Oidc/OidcCallbackPath.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Routing;
 

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryOptions.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Duende.IdentityModel.OidcClient;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;

--- a/SSO-Auth/Api/Oidc/OidcFrontChannelParameters.cs
+++ b/SSO-Auth/Api/Oidc/OidcFrontChannelParameters.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using System.Globalization;
 using Duende.IdentityModel.Client;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 

--- a/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Newtonsoft.Json;

--- a/SSO-Auth/Api/Provider/ProviderMode.cs
+++ b/SSO-Auth/Api/Provider/ProviderMode.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Provider;

--- a/SSO-Auth/Api/Provider/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/Provider/ProviderNameValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Buffers;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;

--- a/SSO-Auth/Api/Provider/ProviderTestResult.cs
+++ b/SSO-Auth/Api/Provider/ProviderTestResult.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 

--- a/SSO-Auth/Api/RateLimit/IntervalGate.cs
+++ b/SSO-Auth/Api/RateLimit/IntervalGate.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading;
 

--- a/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
+++ b/SSO-Auth/Api/RateLimit/KeyedLockStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/PerClientBudgetLimiter.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
+++ b/SSO-Auth/Api/RateLimit/ProviderScopedKey.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>

--- a/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
+++ b/SSO-Auth/Api/RateLimit/SsoRateLimiter.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using System.Globalization;

--- a/SSO-Auth/Api/Routing/ChallengePath.cs
+++ b/SSO-Auth/Api/Routing/ChallengePath.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;

--- a/SSO-Auth/Api/Routing/RouteSuffix.cs
+++ b/SSO-Auth/Api/Routing/RouteSuffix.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Routing;
 
 /// <summary>

--- a/SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
 /// <summary>

--- a/SSO-Auth/Api/Saml/SamlAssertionTime.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionTime.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Xml;
 

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthnRequest.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Api/Saml/SamlCertificate.cs
+++ b/SSO-Auth/Api/Saml/SamlCertificate.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;

--- a/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
+++ b/SSO-Auth/Api/Saml/SamlInsecureToggles.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Config;
 

--- a/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Saml/SamlMetadataImport.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataImport.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;

--- a/SSO-Auth/Api/Saml/SamlMetadataParser.cs
+++ b/SSO-Auth/Api/Saml/SamlMetadataParser.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlRecipientValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
+++ b/SSO-Auth/Api/Saml/SamlRedirectSigner.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Security.Cryptography;
 using System.Text;

--- a/SSO-Auth/Api/Saml/SamlReplayCache.cs
+++ b/SSO-Auth/Api/Saml/SamlReplayCache.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;

--- a/SSO-Auth/Api/Saml/SamlRequestCache.cs
+++ b/SSO-Auth/Api/Saml/SamlRequestCache.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Concurrent;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;

--- a/SSO-Auth/Api/Saml/SamlResponse.cs
+++ b/SSO-Auth/Api/Saml/SamlResponse.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 /*
  Was Jitbit's simple SAML 2.0 component for ASP.NET
  https://github.com/jitbit/AspNetSaml/

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
+++ b/SSO-Auth/Api/Saml/SamlSignatureAlgorithms.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 

--- a/SSO-Auth/Api/Saml/SamlSigningKey.cs
+++ b/SSO-Auth/Api/Saml/SamlSigningKey.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.IO;
 using System.Text;
 using System.Xml;

--- a/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
+++ b/SSO-Auth/Api/Secrets/ConfigSecretProtection.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Secrets;

--- a/SSO-Auth/Api/Secrets/SecretEnvelope.cs
+++ b/SSO-Auth/Api/Secrets/SecretEnvelope.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Secrets/SecretStore.cs
+++ b/SSO-Auth/Api/Secrets/SecretStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.IO;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Session/AuthResponse.cs
+++ b/SSO-Auth/Api/Session/AuthResponse.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 
 /// <summary>

--- a/SSO-Auth/Api/Session/LoginOutcome.cs
+++ b/SSO-Auth/Api/Session/LoginOutcome.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using MediaBrowser.Controller.Authentication;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;

--- a/SSO-Auth/Api/Session/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/Session/LoginStatusMapper.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Globalization;
 using System.Net.Mime;

--- a/SSO-Auth/Api/Session/PublicReason.cs
+++ b/SSO-Auth/Api/Session/PublicReason.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Session;
 
 /// <summary>

--- a/SSO-Auth/Api/Session/SessionMinter.cs
+++ b/SSO-Auth/Api/Session/SessionMinter.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading.Tasks;
 using Jellyfin.Data;

--- a/SSO-Auth/Api/Session/SessionParameters.cs
+++ b/SSO-Auth/Api/Session/SessionParameters.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;

--- a/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
+++ b/SSO-Auth/Api/Session/SsoAuthenticationProviders.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 

--- a/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyLoginService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs
+++ b/SSO-Auth/Api/Session/SsoOnlyReconciliationService.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/SSO-Auth/Api/Shared/AuthPageCsp.cs
+++ b/SSO-Auth/Api/Shared/AuthPageCsp.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
+++ b/SSO-Auth/Api/Shared/ChallengeNewPathResolver.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net.Mime;
 using System.Security.Cryptography;

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 
 /// <summary>

--- a/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitGate.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Net;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/AssemblyInfo.cs
+++ b/SSO-Auth/AssemblyInfo.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("SSO-Auth.Tests")]

--- a/SSO-Auth/Config/ConfigExport.cs
+++ b/SSO-Auth/Config/ConfigExport.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/ConfigExportDocument.cs
+++ b/SSO-Auth/Config/ConfigExportDocument.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>

--- a/SSO-Auth/Config/ConfigImport.cs
+++ b/SSO-Auth/Config/ConfigImport.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/LogoutSession.cs
+++ b/SSO-Auth/Config/LogoutSession.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;

--- a/SSO-Auth/Config/ProviderConfigStore.cs
+++ b/SSO-Auth/Config/ProviderConfigStore.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;

--- a/SSO-Auth/Config/SerializableDictionary.cs
+++ b/SSO-Auth/Config/SerializableDictionary.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Collections.Generic;
 using System.Xml.Serialization;
 

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;

--- a/SSO-Auth/Config/SsoOnlyLoginGuard.cs
+++ b/SSO-Auth/Config/SsoOnlyLoginGuard.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;

--- a/SSO-Auth/Config/WriteOnlySecretConverter.cs
+++ b/SSO-Auth/Config/WriteOnlySecretConverter.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
 using System.Threading;
 using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;


### PR DESCRIPTION
## What & why

There was no per-file license marker, the license lived only in `LICENSE.txt`
and the README. Add a two-line REUSE/SPDX header to **every** C# source file so
the license of any one file is machine-readable at its top (SPDX / REUSE
tooling), and lock it in with a conformance test so a new file cannot land
without it.

- **Header** (all 251 `.cs` under `SSO-Auth`, `SSO-Auth.Tests`, `SSO-Auth.Fuzz`):

  ```csharp
  // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
  // SPDX-License-Identifier: GPL-3.0-only
  ```

  `GPL-3.0-only` matches the declared "GPL v3.0" (README / badge / `LICENSE.txt`)
  exactly, with no implicit "or later" broadening. The copyright line credits
  contributors collectively.
- **`EverySourceFile_CarriesTheSpdxHeader`** conformance test in
  `ArchitectureConformanceTests.cs`: enumerates the project sources (build output
  excluded) and fails the build unless each opens with the two header lines, the
  drift guard that keeps coverage complete. SA1633 (StyleCop file header) is
  `none`, so the SPDX comment does not conflict.
- **`CONTRIBUTING.md`** documents the required header and the `GPL-3.0-only`
  identifier.

## Type of change

- [x] Licensing metadata + a new conformance fitness function. No product-code
  behaviour change (comment-only additions).

## Quality checklist

- [x] Both projects build **0/0** under `--warnaserror` on net10.0 (no StyleCop
  header rule tripped).
- [x] Full suite green, **1789** tests, the new conformance test included.
- [x] Headers prepended idempotently, CRLF preserved, no BOM disturbed.

## Note

The `GPL-3.0-only` vs `-or-later` choice was a decision (it sets
relicensing latitude for all contributions); `-only` was chosen to match the
existing "GPL v3.0" statement without broadening it.

Closes #747