### PR TITLE
Measure coverage in CI and gate the security surface [#718]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,6 +63,40 @@ jobs:
       run: dotnet build --no-restore --warnaserror
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    # Line coverage for the RC coverage gate (#718). A second, instrumented run
+    # of the net10.0 leg (the MTP CodeCoverage extension emits Cobertura); the
+    # plain run above stays the canonical pass/fail signal for test correctness,
+    # so a test failure under instrumentation (exit code 2 - timing heisenbugs
+    # under the ~13x instrumentation overhead) is ignored HERE only; the
+    # zero-tests exit (8) and any collector failure still fail this step.
+    - name: Coverage (net10.0)
+      run: dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --no-build --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --ignore-exit-code 2
+    - name: Enforce the security-surface coverage bar
+      # Fail-closed threshold on the security-decision surface only (#718): the
+      # whole-codebase number is reported and tracked in docs/METRICS.md, but the
+      # gate keys on the modules that decide auth/authz/linking/abuse outcomes, so
+      # a trivially-thin non-critical path cannot trip it and a security-path
+      # regression cannot slip through it.
+      #
+      # set -o pipefail is LOAD-BEARING: without it the step's status is tee's
+      # exit 0 and every rejection the script makes (below-bar, unreadable or
+      # empty report) would be silently discarded - the gate would be decorative.
+      # GitHub's default shell for a bare `run:` is `bash -e` WITHOUT pipefail
+      # (the same trap the vulnerable-dependency step above guards against).
+      run: |
+        set -o pipefail
+        python3 scripts/check-coverage.py TestResults/coverage.cobertura.xml | tee -a "$GITHUB_STEP_SUMMARY"
+    - name: Upload coverage report
+      # always(): the report must survive a gate failure - it is exactly the
+      # artifact needed to diagnose one. if-no-files-found stays error, so a
+      # missing report still reds the job through this step.
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
+      with:
+        name: coverage-report
+        retention-days: 30
+        if-no-files-found: error
+        path: TestResults/coverage.cobertura.xml
 
   # Verify the plugin's used Jellyfin API surface actually exists on the OLDEST server it claims to
   # support (build.yaml targetAbi), not only in the newer SDK the shipping build compiles against. A

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,11 @@ dotnet test --no-build --verbosity normal    # the xUnit project SSO-Auth.Tests 
 npx prettier --check "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
 ```
 
+`dotnet test` requires the **.NET 10 SDK**: the repo's `global.json` selects the
+SDK's Microsoft.Testing.Platform mode of `dotnet test` (#718), which older SDKs
+do not support (the build itself multi-targets net9.0 + net10.0 either way, so
+you need both runtimes' SDKs installed — exactly what CI installs).
+
 CI restores in a separate step, so its build/test use `--no-restore`/`--no-build`; on a fresh local clone run `dotnet restore` once first (or drop `--no-restore` on the first build) or the build fails before any package is fetched.
 
 **Developing the admin UI.** The settings page and the account-linking page are **embedded resources**, not files served from disk: `configPage.html`, `config.js`, and the `linking.*` assets are compiled into `SSO-Auth.dll` (see the `<EmbeddedResource>` entries in `SSO-Auth.csproj`). So the edit loop is **rebuild → redeploy the DLL → restart Jellyfin**: `dotnet publish -c Release`, copy the output into your Jellyfin `config/plugins/sso/`, and restart the server; there is no live reload. Jellyfin's logs (the plugin logs through them) live under the server's `config/log/` directory. One gotcha while iterating: the `/SSOViews` assets are served with an ETag derived from the assembly `FileVersion`, so a browser will `304`-serve the **previous** build of `linking.js`/`linking.css` until the version changes — disable the browser cache (DevTools → Network → "Disable cache") during a UI edit session, or you will be testing stale assets.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Found a vulnerability? Please report it **privately** via GitHub's ["Report a vu
 
 ## Contributing
 
-Issues and pull requests are welcome. The plugin targets **.NET 9** and **Jellyfin 10.11**. Build with `dotnet build` / `dotnet publish` and run the tests with `dotnet test`. CI builds and tests every change, and the login path goes through an adversarial review. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
+Issues and pull requests are welcome. The plugin targets **.NET 9 / Jellyfin 10.11** and **.NET 10 / Jellyfin 12**. Build with `dotnet build` / `dotnet publish` and run the tests with `dotnet test` (the test runner needs the .NET 10 SDK). CI builds and tests every change, and the login path goes through an adversarial review. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow.
 
 ## Credits
 

--- a/SSO-Auth.Tests/SSO-Auth.Tests.csproj
+++ b/SSO-Auth.Tests/SSO-Auth.Tests.csproj
@@ -9,7 +9,6 @@
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <!-- Same security-analyzer posture as the main project: all Security-category
          rules enabled, CA findings fail every build. -->
     <AnalysisModeSecurity>All</AnalysisModeSecurity>
@@ -21,13 +20,17 @@
          are driven from ordinary xUnit v3 [Fact]s via Prop.ForAll(...).QuickCheckThrowOnFailure(),
          avoiding the FsCheck.Xunit ↔ xunit-version coupling. -->
     <PackageReference Include="FsCheck" Version="3.3.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <!-- Statement/branch coverage for the RC coverage gate (#718): the MTP-native
+         Microsoft CodeCoverage extension emits Cobertura via the `coverage` option of
+         `dotnet test`. Its 18.9 line requires Microsoft.Testing.Platform 2.x, so the
+         runner is the MTP-v2 xunit meta package (xunit.v3.mtp-v2, same xunit with the
+         MTP 2.x bridge) and `dotnet test` runs in the .NET 10 SDK's MTP mode
+         (global.json `test.runner`). The VSTest-era packages (Microsoft.NET.Test.Sdk,
+         xunit.runner.visualstudio) are gone with that mode, per the xunit/MTP
+         migration guidance. -->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageReference Include="NSubstitute" Version="6.0.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SSO-Auth.Tests/packages.lock.json
+++ b/SSO-Auth.Tests/packages.lock.json
@@ -11,14 +11,15 @@
           "FSharp.Core": "5.0.2"
         }
       },
-      "Microsoft.NET.Test.Sdk": {
+      "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Direct",
-        "requested": "[18.7.0, )",
-        "resolved": "18.7.0",
-        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.7.0",
-          "Microsoft.TestPlatform.TestHost": "18.7.0"
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0"
         }
       },
       "NSubstitute": {
@@ -30,19 +31,15 @@
           "Castle.Core": "5.1.1"
         }
       },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "xunit.v3": {
+      "xunit.v3.mtp-v2": {
         "type": "Direct",
         "requested": "[3.2.2, )",
         "resolved": "3.2.2",
-        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
         "dependencies": {
-          "xunit.v3.mtp-v1": "[3.2.2]"
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
         }
       },
       "BitFaster.Caching": {
@@ -193,10 +190,10 @@
         "resolved": "10.0.2",
         "contentHash": "LG9Yll3B5aNpxv0+D47g6LiOiKBIlodhcHdQwcYzo8VeexFLGqx5ymetmA2aBRyo9cCcWsQWrFsdbsr8LvmWDw=="
       },
-      "Microsoft.CodeCoverage": {
+      "Microsoft.DiaSymReader": {
         "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
@@ -289,6 +286,11 @@
         "resolved": "10.0.9",
         "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
       },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw=="
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "10.0.9",
@@ -354,46 +356,32 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "1.9.1"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "1.9.1"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+        "resolved": "2.3.0",
+        "contentHash": "gsmLQaUN3Ddh0S4B0x0Q7IfBue7FNytJ8Bjec1JPad+9vqwIQvkgUS6fgmAJX/o3POu2xVbVbcaGhMV/2Ov9pg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "1.9.1"
-        }
-      },
-      "Microsoft.TestPlatform.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
-        "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Win32.Registry": {
@@ -447,15 +435,15 @@
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
-      "xunit.v3.core.mtp-v1": {
+      "xunit.v3.core.mtp-v2": {
         "type": "Transitive",
         "resolved": "3.2.2",
-        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
         "dependencies": {
-          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
-          "Microsoft.Testing.Platform": "1.9.1",
-          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
           "xunit.v3.extensibility.core": "[3.2.2]",
           "xunit.v3.runner.inproc.console": "[3.2.2]"
         }
@@ -466,16 +454,6 @@
         "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
         "dependencies": {
           "xunit.v3.common": "[3.2.2]"
-        }
-      },
-      "xunit.v3.mtp-v1": {
-        "type": "Transitive",
-        "resolved": "3.2.2",
-        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
-        "dependencies": {
-          "xunit.analyzers": "1.27.0",
-          "xunit.v3.assert": "[3.2.2]",
-          "xunit.v3.core.mtp-v1": "[3.2.2]"
         }
       },
       "xunit.v3.runner.common": {
@@ -517,14 +495,18 @@
           "FSharp.Core": "5.0.2"
         }
       },
-      "Microsoft.NET.Test.Sdk": {
+      "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Direct",
-        "requested": "[18.7.0, )",
-        "resolved": "18.7.0",
-        "contentHash": "49xH9j4UzCh2hMohJp53g3wUTvyycECw7CtVht4gfCz5ykudB1uBcF6D0TtgJPjCtP76UPW53bQElKdCeX+dUg==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "Odp8djWEUFTJoRV02y0zJaAwAHF31CtNaDgnKKM+8dBHbbaH7Ee0oo9gweLpbzjI7UrtMUzH6xLJSrICZw+Nwg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.7.0",
-          "Microsoft.TestPlatform.TestHost": "18.7.0"
+          "Microsoft.DiaSymReader": "2.2.9",
+          "Microsoft.Extensions.DependencyModel": "10.0.8",
+          "Microsoft.Testing.Platform": "2.3.0",
+          "System.IO.Pipelines": "10.0.8",
+          "System.Text.Encodings.Web": "10.0.8",
+          "System.Text.Json": "10.0.8"
         }
       },
       "NSubstitute": {
@@ -536,19 +518,15 @@
           "Castle.Core": "5.1.1"
         }
       },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
-      },
-      "xunit.v3": {
+      "xunit.v3.mtp-v2": {
         "type": "Direct",
         "requested": "[3.2.2, )",
         "resolved": "3.2.2",
-        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "contentHash": "S0LJpeMIMrmbVLXDCvPVX47OLk28qBYfGU+5SNCbarOEdw8oKLfiVqaACwuYRvLiOqDEB/+VJ8gTSB1ZwheoOQ==",
         "dependencies": {
-          "xunit.v3.mtp-v1": "[3.2.2]"
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v2": "[3.2.2]"
         }
       },
       "BitFaster.Caching": {
@@ -704,10 +682,10 @@
         "resolved": "10.0.10",
         "contentHash": "Qdx/MB+kxJoPIWZ0PpKpGSj8C02oaGXgue59HixUX/vinLsBIDYTX3RNW8mj9fBCeCmCp5+28KojlvI1N9hQPw=="
       },
-      "Microsoft.CodeCoverage": {
+      "Microsoft.DiaSymReader": {
         "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "+wFfx9s7D9wegM0RziXMj2kvYDT4qcqXXtyjiQwSZOGQ2wwcOAJQcD6eQXk02jt0MvRNawtp8TJxTrV+wD8X1g=="
+        "resolved": "2.2.9",
+        "contentHash": "WLbDc/W9XkHpGVtd1L6Vml8W6+PaaYZZTJASHjHF7W2WX/hld6bfNK102Ui+I3a6zIdx4+oKRJtMgHz44JmBfw=="
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
@@ -790,6 +768,15 @@
         "resolved": "9.0.11",
         "contentHash": "+ZxxZzcVU+IEzq12GItUzf/V3mEc5nSLiXijwvDc4zyhbjvSZZ043giSZqGnhakrjwRWjkerIHPrRwm9okEIpw=="
       },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "vLyZVpxmduO2jx+76ggqnsA3m81kwMY3NkWciNTj5E+Nvqb0VihqCvQP89QsGONWp0AJwMZG+u9GzaCjDdFGNw==",
+        "dependencies": {
+          "System.Text.Encodings.Web": "10.0.8",
+          "System.Text.Json": "10.0.8"
+        }
+      },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
         "resolved": "9.0.11",
@@ -855,46 +842,32 @@
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "resolved": "2.0.2",
+        "contentHash": "H580BvHyuADoWzlH9zRk5fqVyGucm6mhph+k40CQc9O4ie+Buxa4Pk9Q92BEClqIICqi25J7fuMII9qFYYgKtw==",
         "dependencies": {
           "Microsoft.ApplicationInsights": "2.23.0",
-          "Microsoft.Testing.Platform": "1.9.1"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "resolved": "2.0.2",
+        "contentHash": "MrHYdPZ1CiyYp5bfjzNSghfVwl/I9osMazcZMAbwZY0BhR32i70YLf4zSXECvU2qt2PvDdrjYpGRgBscFbjDpw==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "1.9.1"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Testing.Platform": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+        "resolved": "2.3.0",
+        "contentHash": "gsmLQaUN3Ddh0S4B0x0Q7IfBue7FNytJ8Bjec1JPad+9vqwIQvkgUS6fgmAJX/o3POu2xVbVbcaGhMV/2Ov9pg=="
       },
       "Microsoft.Testing.Platform.MSBuild": {
         "type": "Transitive",
-        "resolved": "1.9.1",
-        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "resolved": "2.0.2",
+        "contentHash": "2zKkQKaUoaKgb/3AekboWOdLMh4upCo1nLWQnjGzp8r9YjiNOZRrzTsJQ3A4U03AcbH0evlIvFDKYSUqmTVuug==",
         "dependencies": {
-          "Microsoft.Testing.Platform": "1.9.1"
-        }
-      },
-      "Microsoft.TestPlatform.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "6rmgU4q3/WOpOPcncI0YW0Q/QpcQtwR2TTEXDR5+4TfSimPBAk6Z/BgKLeGgp1SOun0ROVUCCafXhRLwsHaPpA=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "18.7.0",
-        "contentHash": "kYwfmebCs8992zaxEDkvG7S+YEouTeKfYVKUFEkwh1W2dIoOaevBt80XSKVXCUFEhusjOIm1sFfHBnoJgygrRA==",
-        "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.7.0",
-          "Newtonsoft.Json": "13.0.3"
+          "Microsoft.Testing.Platform": "2.0.2"
         }
       },
       "Microsoft.Win32.Registry": {
@@ -935,6 +908,11 @@
         "resolved": "10.0.10",
         "contentHash": "Lt7KTFei7vmp/+JtTCLB3D3MNDFIfyFl9zETGtKFuoeaThNeHCyE7sJTZ10wfwHbd2z0rW72fjIpNXPkxEObaA=="
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "STVNTIVd+UrYvSo31D2tOOTs19IThdjGDN14FS3/NZb4PWsVakAg/VT4sq+JYWGP/GtazzvXwebWL6LPBAwnFQ=="
+      },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
         "resolved": "10.0.10",
@@ -950,6 +928,20 @@
         "contentHash": "Mz6Y+s+uMQKj1H2BUF0OhlmaOQkLgSG34/IrUaBDirYBQ6bgwcFvO/XtXWcoDlBLFoFB0uKqDNhybHOd+fQK1A==",
         "dependencies": {
           "System.Security.Cryptography.Pkcs": "10.0.10"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "HvFIJXM/CMTRu6PBQmjukQZ/O32Vx5fOEYZs0kq0OD5s9vJQ19KHLWCVmnfh3gNC7pbYomm06tzOTgJBflr/nQ=="
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.8",
+        "contentHash": "/fysUDkD7oFGaRPoA7IaFs0wRoO3GlwlCNq2P+xWZqxLy1R4cktRSKfMjJDy9ymS4grL7IDVdt8de8L9a0z55Q==",
+        "dependencies": {
+          "System.IO.Pipelines": "10.0.8",
+          "System.Text.Encodings.Web": "10.0.8"
         }
       },
       "xunit.analyzers": {
@@ -970,15 +962,15 @@
           "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
-      "xunit.v3.core.mtp-v1": {
+      "xunit.v3.core.mtp-v2": {
         "type": "Transitive",
         "resolved": "3.2.2",
-        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "contentHash": "zW82tdCm+T1uUD1JKE+SmhgMq8nCAvcFPRLIVEiRgaxBSjcyJEKopLU3bHGOa416q+N3Dz7m1zLoPR5VJ5OQ+Q==",
         "dependencies": {
-          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
-          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
-          "Microsoft.Testing.Platform": "1.9.1",
-          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "Microsoft.Testing.Extensions.Telemetry": "2.0.2",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.0.2",
+          "Microsoft.Testing.Platform": "2.0.2",
+          "Microsoft.Testing.Platform.MSBuild": "2.0.2",
           "xunit.v3.extensibility.core": "[3.2.2]",
           "xunit.v3.runner.inproc.console": "[3.2.2]"
         }
@@ -989,16 +981,6 @@
         "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
         "dependencies": {
           "xunit.v3.common": "[3.2.2]"
-        }
-      },
-      "xunit.v3.mtp-v1": {
-        "type": "Transitive",
-        "resolved": "3.2.2",
-        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
-        "dependencies": {
-          "xunit.analyzers": "1.27.0",
-          "xunit.v3.assert": "[3.2.2]",
-          "xunit.v3.core.mtp-v1": "[3.2.2]"
         }
       },
       "xunit.v3.runner.common": {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Coverage gate for the RC coverage goal (#718).
+
+Parses the Cobertura report `dotnet test --coverage` emits and enforces the
+security-surface LINE-coverage bar: the modules that take security decisions
+(SAML validation, OIDC state/issuer/PKCE, account linking, authz, rate limit,
+avatar SSRF, network trust, logout, secrets, session mint, audit) must stay at
+or above the pinned threshold, or the job fails. The whole-codebase number is
+reported (the >=80% line RC baseline is tracked in docs/METRICS.md) but
+deliberately not enforced, so the gate cannot be tripped by a trivially-thin
+non-critical path; only the security surface hard-gates.
+
+Counting is per executable line (lines-covered / lines-valid), never a
+per-class average, so a large uncovered class cannot hide behind many small
+covered ones. Only each class's class-level <lines> block is counted - the
+per-method <line> entries duplicate the same lines and would double-count.
+Fail-closed: a missing report, an unparsable report, or zero matched
+security-surface lines is an error, not a pass.
+
+Usage: check-coverage.py <coverage.cobertura.xml>
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import PurePosixPath, PureWindowsPath
+
+# The security-decision surface: every Api module whose classes decide an
+# authentication, authorization, linking, session, network-trust, or
+# abuse-control outcome. `Shared` carries the rate-limit gate and the
+# served-flow responses; `Flows` is the per-protocol login orchestration; `Net`
+# holds the SSRF/public-address verdicts; `Logout` the session-termination
+# store; `Provider` the provider-identity validation. The deliberately ungated
+# remainder is `Http` (the controller boundary, gated by its endpoint tests and
+# the conformance rules), `Routing`/`LoginButtons` (page furniture), and the
+# non-guard Config persistence types. Config's security-guard types are matched
+# by file name below.
+SECURITY_MODULES = {
+    "Audit",
+    "Authz",
+    "Avatar",
+    "Crypto",
+    "Flows",
+    "Identity",
+    "Linking",
+    "Logout",
+    "Net",
+    "Oidc",
+    "Provider",
+    "RateLimit",
+    "Saml",
+    "Secrets",
+    "Session",
+    "Shared",
+}
+SECURITY_CONFIG_FILES = {
+    "SsoOnlyLoginGuard.cs",
+    "ServerManagedFields.cs",
+    "WriteOnlySecretConverter.cs",
+    "ConfigImport.cs",
+    "ProviderConfigValidator.cs",
+    "ProviderConfigStore.cs",
+}
+
+# The pinned bar. Set just below the first honest measurement (93.4% on
+# 2026-07-21, line-level over 5124 security-surface lines) so real regressions
+# fail while instrumentation jitter does not; ratchet it up as the number
+# climbs, never down without a documented decision.
+SECURITY_LINE_BAR = 92.0
+
+
+def module_of(filename: str) -> str | None:
+    """Returns the Api module name of a source path, or None.
+
+    A file directly under Api/ (no module folder) yields None; that layout is
+    structurally impossible - the FlatApi_HoldsNoSourceFiles conformance test
+    keeps the flat Api root empty - so nothing can hide there from this gate.
+    """
+    parts = PureWindowsPath(filename.replace("/", "\\")).parts
+    if "Api" in parts:
+        idx = parts.index("Api")
+        if idx + 1 < len(parts) - 1:
+            return parts[idx + 1]
+    if "Config" in parts and parts[-1] in SECURITY_CONFIG_FILES:
+        return "Config-guard"
+    return None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check-coverage.py <coverage.cobertura.xml>", file=sys.stderr)
+        return 2
+    try:
+        root = ET.parse(sys.argv[1]).getroot()
+    except (OSError, ET.ParseError) as err:
+        print(f"::error::Could not read the coverage report: {err}", file=sys.stderr)
+        return 1
+
+    total_valid = total_covered = 0
+    sec_valid = sec_covered = 0
+    for cls in root.iter("class"):
+        filename = cls.get("filename", "")
+        module = module_of(filename)
+        is_security = module in SECURITY_MODULES or module == "Config-guard"
+        # The class-level <lines> child only: cls.iter("line") would also walk
+        # the per-method <line> copies and double-count every line.
+        lines_block = cls.find("lines")
+        if lines_block is None:
+            continue
+        for line in lines_block.iter("line"):
+            hits = int(line.get("hits", "0"))
+            total_valid += 1
+            total_covered += 1 if hits > 0 else 0
+            if is_security:
+                sec_valid += 1
+                sec_covered += 1 if hits > 0 else 0
+
+    if total_valid == 0 or sec_valid == 0:
+        print("::error::The coverage report contains no matched lines - refusing to pass an empty measurement.", file=sys.stderr)
+        return 1
+
+    overall = 100.0 * total_covered / total_valid
+    security = 100.0 * sec_covered / sec_valid
+    print(f"Overall line coverage:          {overall:.1f}% ({total_covered}/{total_valid} lines)")
+    print(f"Security-surface line coverage: {security:.1f}% ({sec_covered}/{sec_valid} lines)")
+    print(f"Security-surface bar (pinned):  {SECURITY_LINE_BAR:.1f}%")
+
+    if security < SECURITY_LINE_BAR:
+        print(
+            f"::error::Security-surface line coverage {security:.1f}% fell below the pinned "
+            f"{SECURITY_LINE_BAR:.1f}% bar (#718). Cover the security-decision paths you touched, "
+            "or raise coverage elsewhere on the surface - the bar does not move down.",
+            file=sys.stderr,
+        )
+        return 1
+    print("Coverage gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What & why

RC gate (b) requires a defined, met coverage goal; the project measured no
coverage at all. This wires coverage into CI and pins the goal, with the
enforced threshold on the **security-decision surface only**.

- **Test runner:** migrate to the .NET 10 SDK's **MTP mode** of `dotnet test`
  (`global.json` `test.runner`) with `xunit.v3.mtp-v2` (same xunit,
  Microsoft.Testing.Platform 2.x bridge) and the MTP-native
  `Microsoft.Testing.Extensions.CodeCoverage` (Cobertura). VSTest-era packages
  (`Microsoft.NET.Test.Sdk`, `xunit.runner.visualstudio`) and
  `TestingPlatformDotnetTestSupport` are gone per the migration guidance. Plain
  suite unchanged: **1789 tests net10.0 / 3578 both TFMs, green**; the exact CI
  arg strings were exercised locally in MTP mode. Docs note the .NET 10 SDK
  requirement. The VSTest-driven weekly Stryker run needs a post-merge repair - 
  tracked in #899.
- **CI:** an instrumented net10.0 run publishes `coverage.cobertura.xml`
  (artifact, `if: always()`) and prints the numbers to the step summary; it
  ignores MTP exit 2 only (test flake under ~13x instrumentation timing skew - 
  the preceding plain run is the canonical correctness gate; exit 8 stays
  sharp).
- **`scripts/check-coverage.py`** enforces fail-closed: the security-decision
  modules (Saml, Oidc, Linking, Authz, Avatar, RateLimit, Identity, Secrets,
  Crypto, Session, Audit, Flows, Shared, **Net, Logout, Provider** + the Config
  guard/persistence types) must hold **>= 92.0% line coverage** or the job
  fails. Line-level counting from each class's class-level lines block (no
  per-method double count); a missing, unparsable, or empty-match report is an
  error, not a pass. The enforce step sets **pipefail explicitly**, GitHub's
  bare `run:` shell has none, which would have discarded the script's exit
  through the tee pipe (caught by the adversarial review).

**First honest measurement** (2026-07-21, 6011 executable lines): security
surface **93.4%**, overall **92.1%** line, the >= 80% Silver/RC baseline is
met (tracked in the local METRICS.md dashboard). The bar sits just below the
measurement and only ratchets up. Known uncovered remainder: the hosted
background services, which only run in a live server (E2E scope, #717/#720).

## Type of change

- [x] CI gate + test-infrastructure migration. No production code changed
  (`SSO-Auth/packages.lock.json` untouched).

## Security checklist

- [x] Gate is fail-closed end to end: script rejects missing/unparsable/empty
  reports and below-bar coverage; pipefail carries its exit through the tee;
  the artifact step reds on a missing report.
- [x] Known residual (standard in-repo self-gating model): a PR can edit the
  script or move files out of gated modules, the same trust boundary as every
  other in-repo check script; such a diff is loud.
- [x] No template injection in new run blocks; artifact action SHA-pinned;
  job permissions unchanged (`contents: read`, no id-token).
- [x] Supply chain: test-project lockfile only; first-party Microsoft/xunit
  packages, version-pinned, `--locked-mode` enforced.

## Review gate

Adversarial integration-lens + bypass-lens first pass: **FAIL/FAIL** (decorative
gate via missing pipefail, exactly the class this gate exists to catch, now
fixed; plus scope/counting/doc findings, all addressed). Re-review requested;
this PR's CI run is the gate script's first real execution and its empirical
proof.

Closes #718