### PR TITLE
Scope the JF12/5.0 line out of the 4.x RC [#743]

### DIFF
--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -183,6 +183,8 @@ jobs:
             Jellyfin 12.0 (.NET 10) beta ${{ steps.version.outputs.base }}-JF12-beta (plugin version ${{ steps.version.outputs.beta }}).
             Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
             https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+
+            Scope note (#743): the JF12/5.0 line is **not validated against a live Jellyfin 12.0 server yet** — no 12.0 GA server exists to run the E2E checklist against. It is CI-built and unit/conformance-tested only, and it is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate; the 5.0 line clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available. Use these betas for testing, not production.
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish the draft release

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Jellyfin upstream is building [native OIDC](https://github.com/jellyfin/jellyfin
    | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json` |
    | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`    |
    - **stable** ships tagged releases only. **beta** publishes on a daily schedule (04:00 UTC) whenever `main` has advanced since the last beta, so betas move fast and may break — use them for testing, not production.
-   - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** (the stable 12.0 build lands at a 12.0 stable release).
+   - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** and **not yet validated against a live 12.0 server** (none exists at GA quality to test against): the JF12/5.0 line is CI-built and unit-tested but sits outside the 4.x release-candidate gate, and it clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available (the stable 12.0 build lands at a 12.0 stable release).
 
 2. Go to **Dashboard → Plugins → Catalog**, find **SSO Authentication**, and install it.
 3. **Restart Jellyfin** to load the plugin.


### PR DESCRIPTION
## What & why

The repo carries a full parallel 5.0/JF12 line, but nothing stated whether it is
in scope for the imminent 4.x release candidate or how it ever clears a live
gate when no Jellyfin 12.0 GA server exists. Left ambiguous, the JF12 line
either silently blocks the 4.x RC or gets promoted without any live validation - 
a mass-lockout shape on the first 12.0 upgrade wave.

Documentation-only scoping (#743's three acceptance criteria):

1. **P8 tracker statement**, posted on the promotion epic (#716): the 4.x
   (JF10.11) line reaches RC now; the 5.0 (JF12) line gates separately.
2. **Documented JF12 live-validation trigger**, the local E2E checklist gains a
   dedicated JF12 section: trigger (first Jellyfin 12.0 RC/GA build), the
   JF12-specific hazards (host-provided crypto assemblies that must not ship on
   .NET 10, legacy-auth-enforcement login #136, OidcClient 7.x runtime
   construction), and the rule that 5.0 reaches its own RC only after a
   recorded pass.
3. **Channel notes**, `publish-jf12-beta.yml` release notes now label every
   JF12 beta as not-yet-validated-against-a-live-server and outside the 4.x RC
   gate; the README channel section states the same where users pick a
   repository URL.

## Type of change

- [x] Documentation/scoping only. The workflow change is prose inside the
  release-notes literal block, no step, permission, trigger, or expression
  changed (no `${{ }}` in the added text).

## Quality checklist

- [x] YAML parses; README passes prettier; commit DCO-signed.

Closes #743