### PR TITLE
Add admin config-page controls for the login-button settings [#722]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1437,7 +1437,7 @@ public class ArchitectureConformanceTests
         // The full save-contract roster, pinned after the #365 provider-workspace redesign reordered and
         // regrouped the form into native accordion sections. ProviderFormFieldIds_MatchOidConfigProperties
         // guards the FORWARD direction (no stray marked id) and a reverse pin for the security-critical
-        // SUBSET; this test is the exhaustive reverse pin: every one of the 34 persisting fields must still
+        // SUBSET; this test is the exhaustive reverse pin: every one of the 41 persisting fields must still
         // render as a marked input with its exact id, so a field silently dropped or unmarked during a
         // future re-layout — which would stop it persisting — fails here rather than shipping as silent data
         // loss. The provider-name KEY input (OidProviderName) is deliberately unmarked (it supplies the
@@ -1478,9 +1478,10 @@ public class ArchitectureConformanceTests
             "RequirePkce", "AllowExistingAccountLink", "ProvisionNewUsersDisabled", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
             "AcrValues", "Prompt", "MaxAge", "RequireAcr",
             "DisableHttps", "DisablePushedAuthorization", "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
+            "HideLoginButton", "LoginButtonText",
         };
 
-        Assert.Equal(39, expected.Length);
+        Assert.Equal(41, expected.Length);
         var missing = expected.Where(id => !markedIds.Contains(id)).ToList();
         Assert.True(
             missing.Count == 0,
@@ -1584,7 +1585,7 @@ public class ArchitectureConformanceTests
     public void SamlProviderForm_RendersEveryPersistingFieldId()
     {
         // The exhaustive reverse pin for the SAML save contract (#725), the twin of
-        // ProviderForm_RendersEveryPersistingFieldId: every one of the 30 persisting SAML fields must render
+        // ProviderForm_RendersEveryPersistingFieldId: every one of the 32 persisting SAML fields must render
         // as a marked input with its exact "saml-"-prefixed id, so a field silently dropped or unmarked during
         // a future re-layout — which would stop it persisting — fails here rather than shipping as silent data
         // loss. The provider-name KEY input (saml-provider-name) is deliberately unmarked (it supplies the
@@ -1624,9 +1625,10 @@ public class ArchitectureConformanceTests
             "Roles", "AdminRoles", "EnableAllFolders", "EnabledFolders", "EnableFolderRoles", "FolderRoleMapping",
             "EnableLiveTvRoles", "LiveTvRoles", "LiveTvManagementRoles", "EnableLiveTv", "EnableLiveTvManagement",
             "SchemeOverride", "PortOverride", "BaseUrlOverride",
+            "HideLoginButton", "LoginButtonText",
         };
 
-        Assert.Equal(30, expected.Length);
+        Assert.Equal(32, expected.Length);
         var missing = expected.Where(p => !markedProps.Contains(p)).ToList();
         Assert.True(
             missing.Count == 0,

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -176,6 +176,12 @@ const ssoConfigurationPage = {
           page,
           config.SamlConfigs || {},
         );
+        // The GLOBAL login-page buttons opt-in (#722) rides the same configuration load. It is a root
+        // PluginConfiguration flag, not a provider field, so it has its own save path (saveLoginButtons)
+        // and no sso-* marker class.
+        page.querySelector("#ManageLoginPageButtons").checked = Boolean(
+          config.ManageLoginPageButtons,
+        );
       },
     );
 
@@ -975,6 +981,42 @@ const ssoConfigurationPage = {
               title: "Delete failed",
               message:
                 "Could not remove the provider. The saved configuration was rejected by the server; reload the page and try again.",
+            });
+          },
+        );
+      },
+    );
+  },
+  // Save the GLOBAL login-page buttons opt-in (#722). ManageLoginPageButtons is a root
+  // PluginConfiguration flag, so this fetches the live configuration, changes ONLY this flag, and
+  // re-posts the whole document — the provider dictionaries and every other root setting ride along
+  // unchanged, exactly as the provider save/delete paths do. The server reacts to the saved
+  // configuration itself (LoginButtonManager listens for the configuration change), so no extra
+  // endpoint call is needed: on save the managed block is injected/refreshed, or — with the flag
+  // off — only the managed region is removed and the admin's own branding is preserved.
+  saveLoginButtons: (page) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        config.ManageLoginPageButtons = page.querySelector(
+          "#ManageLoginPageButtons",
+        ).checked;
+
+        ApiClient.updatePluginConfiguration(
+          ssoConfigurationPage.pluginUniqueId,
+          config,
+        ).then(
+          function (result) {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+            ssoConfigurationPage.loadConfiguration(page);
+            Dashboard.alert("Settings saved.");
+          },
+          // Report a genuine save failure rather than swallowing it: this PUT re-posts the whole
+          // configuration, so the server can reject it for a reason unrelated to this toggle (#336).
+          function () {
+            Dashboard.alert({
+              title: "Save failed",
+              message:
+                "Could not save the login-page button setting. The saved configuration was rejected by the server; reload the page and try again.",
             });
           },
         );
@@ -2236,6 +2278,12 @@ export default function initSsoConfigurationPage(view) {
 
   // Populate the redirect URI once at init (the blank editor shows its placeholder until a name is typed).
   ssoConfigurationPage.updateRedirectUri(view);
+
+  view.querySelector("#SaveLoginButtons").addEventListener("click", (e) => {
+    ssoConfigurationPage.saveLoginButtons(view);
+    e.preventDefault();
+    return false;
+  });
 
   view.querySelector("#ExportConfig").addEventListener("click", (e) => {
     ssoConfigurationPage.exportConfig(view);

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -215,6 +215,58 @@
           </form>
 
           <!--
+            Login-page buttons (#722) — GLOBAL setting. ManageLoginPageButtons lives on the root
+            PluginConfiguration, not on a provider, so it deliberately sits OUTSIDE both provider forms
+            and carries NO sso-* marker class: it is saved by its own handler (config.js
+            saveLoginButtons), which re-posts the whole configuration with only this flag changed, and
+            loaded by loadConfiguration. The per-provider button settings (HideLoginButton,
+            LoginButtonText) are ordinary persisting provider-form fields in each editor below.
+          -->
+          <form id="sso-login-buttons" class="esqConfigurationForm">
+            <div
+              class="verticalSection"
+              is="emby-collapse"
+              title="Login Page Buttons"
+            >
+              <div class="collapseContent">
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="ManageLoginPageButtons"
+                      name="ManageLoginPageButtons"
+                      type="checkbox"
+                    />
+                    <span>Manage login buttons on the login page</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    Off by default: the plugin never touches the server's login
+                    branding unless you opt in here. When on, a managed "Sign in
+                    with …" block — one button per enabled provider — is spliced
+                    into the login page's branding disclaimer and refreshed
+                    whenever this plugin's configuration is saved (and at server
+                    start). When off, only that managed block is removed; any
+                    disclaimer content you wrote yourself is preserved either
+                    way. Each provider's editor below can hide its button or
+                    give it a custom label.
+                  </div>
+                </div>
+
+                <button
+                  id="SaveLoginButtons"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span>Save</span>
+                </button>
+              </div>
+            </div>
+          </form>
+
+          <!--
             Provider workspace (#365 UI redesign). The provider LIST replaces the old select -> Load flow:
             each saved OpenID provider is a card (name + type badge + enabled/disabled pill); clicking a card
             loads it into the editor below. The hidden <select id="selectProvider"> is retained as the state
@@ -603,6 +655,50 @@
                       />
                       <span>Enabled</span>
                     </label>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="HideLoginButton"
+                        name="HideLoginButton"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Hide from managed login-page buttons</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      Excludes this provider from the managed "Sign in with …"
+                      block on the login page while keeping it usable through
+                      its direct start URL. Only takes effect while the global
+                      "Manage login buttons on the login page" option is on; it
+                      never hides anything you added to the branding yourself.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="LoginButtonText"
+                      >Login button text:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="LoginButtonText"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      Custom label for this provider's managed login-page
+                      button. Leave blank to use the provider name. Only takes
+                      effect while the global "Manage login buttons on the login
+                      page" option is on and the button is not hidden; any text
+                      is safe — it is always rendered inert, never as markup.
+                    </div>
                   </div>
                 </div>
               </div>
@@ -1968,6 +2064,50 @@
                       />
                       <span>Enabled</span>
                     </label>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-HideLoginButton"
+                        name="saml-HideLoginButton"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Hide from managed login-page buttons</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      Excludes this provider from the managed "Sign in with …"
+                      block on the login page while keeping it usable through
+                      its direct start URL. Only takes effect while the global
+                      "Manage login buttons on the login page" option is on; it
+                      never hides anything you added to the branding yourself.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="saml-LoginButtonText"
+                      >Login button text:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-LoginButtonText"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      Custom label for this provider's managed login-page
+                      button. Leave blank to use the provider name. Only takes
+                      effect while the global "Manage login buttons on the login
+                      page" option is on and the button is not hidden; any text
+                      is safe — it is always rendered inert, never as markup.
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## What & why

The #860 core (injector/builder/manager + config) was config/XML-settable only.
This surfaces the three settings on the admin page, closing the one
solo-feasible remainder of #722 (the rest, live E2E, screenshots, wiki
recipes, needs a running Jellyfin server):

- **Global "Login Page Buttons" section** with the `ManageLoginPageButtons`
  checkbox + save button. No root-config save existed on the page, so it uses
  the page's one idiom (fetch whole config → mutate the single flag → PUT),
  with `deleteProvider`'s rejection handling. The server's
  `ConfigurationChanged` subscription makes the PUT itself trigger the branding
  splice/removal, no new endpoint. Description states the fail-closed
  contract (default off; branding untouched without opt-in; disable removes
  only the managed block).
- **Per-provider** `HideLoginButton` (sso-toggle) + `LoginButtonText`
  (sso-text) in both provider forms (SAML with the mandatory `saml-` prefix).
  The marker-class save contract picks them up with zero JS; values via
  `.checked`/`.value` only (#221, no innerHTML).
- Conformance reverse-pin rosters extended per their own instruction
  (39→41 / 30→32; a stale roster comment corrected).

## Type of change

- [x] Admin UI for an existing, reviewed feature core. No server code changed.

## Security checklist

- [x] No new DOM sink (values via properties only); the admin-typed
  `LoginButtonText` reaching the login page stays HTML-encoded in
  `LoginButtonInjector` (pinned by the #860 hostile-label test, ran green).
- [x] The whole-config PUT cannot clobber server-managed state: every PUT runs
  `ServerManagedFields.Preserve` under the config lock (write-only secrets,
  canonical links, SSO-only fields all re-injected from live).
- [x] Adversarial bypass-lens review: **PASS** (only pre-existing,
  parity-inherited nits remain).

## Quality checklist

- [x] Both projects build 0/0 under `--warnaserror`; full suite green
  (3578/3578 both TFMs) incl. the extended conformance rosters.
- [x] Prettier status of the Web files unchanged vs main (the local warns are a
  CRLF checkout artifact; content is prettier-clean).

Refs #722 (the issue stays open for the live-server remainder)