### PR TITLE
Capture the SAML SessionIndex at login for Single Logout [#727]

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
@@ -11,6 +11,9 @@ using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
 using Xunit;
@@ -75,6 +78,29 @@ public class SSOControllerSamlTokenTests
     }
 
     [Fact]
+    public async Task LoginRoundTrip_SingleLogoutOn_CapturesTheAssertionSessionIndex()
+    {
+        // SLO-3a (#727) end to end: the ACS callback reads the assertion's SessionIndex into the stored
+        // outcome, the token mint hands it to the shared completion tail as the SAML logout context (no
+        // id_token — SAML has none), and with EnableSingleLogout on the tail persists it keyed by the
+        // minted session id, so a later Single Logout request can resolve the session.
+        var fixture = SamlTestFactory.Create(nameId: "alice", sessionIndex: "_slo-session-1");
+        var harness = ProvisioningHarness(fixture, out _);
+        harness.Configuration.EnableSingleLogout = true;
+        harness.SessionManager.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
+            .Returns(new AuthenticationResult { SessionInfo = new SessionInfoDto { Id = "session-key-slo" } });
+
+        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
+
+        Assert.True(harness.Configuration.LogoutSessions.ContainsKey("session-key-slo"));
+        var entry = harness.Configuration.LogoutSessions["session-key-slo"];
+        Assert.Equal("_slo-session-1", entry.SessionIndex);
+        Assert.Equal("adfs", entry.Provider);
+        Assert.Null(entry.IdToken);
+    }
+
+    [Fact]
     public async Task Token_IsSingleUse_ReplayRejectsWithoutSecondMint()
     {
         var fixture = SamlTestFactory.Create(nameId: "alice");
@@ -115,7 +141,7 @@ public class SSOControllerSamlTokenTests
         // it as out of its window, so it cannot mint even though its token is otherwise well-formed.
         var identity = TestIdentities.Saml("adfs", "alice", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
         var token = SamlOutcomeStore.NewToken();
-        SamlLoginService.SeedSamlOutcomeForTests(new SamlLoginOutcome(token, "adfs", identity, string.Empty, null, DateTime.UtcNow.AddHours(-1)));
+        SamlLoginService.SeedSamlOutcomeForTests(new SamlLoginOutcome(token, "adfs", identity, string.Empty, null, null, DateTime.UtcNow.AddHours(-1)));
 
         var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
         Assert.Equal(400, result.StatusCode);
@@ -180,7 +206,7 @@ public class SSOControllerSamlTokenTests
         SamlLoginService.SetSamlOutcomeStoreForTests(store);
         var filler = SamlOutcomeStore.NewToken();
         var fillerIdentity = TestIdentities.Saml("adfs", "filler", SamlAuthorizeStateBuilder.Build(new System.Collections.Generic.List<string>(), new SamlConfig()));
-        Assert.True(store.TryAdd(new SamlLoginOutcome(filler, "adfs", fillerIdentity, string.Empty, null, DateTime.UtcNow), out _));
+        Assert.True(store.TryAdd(new SamlLoginOutcome(filler, "adfs", fillerIdentity, string.Empty, null, null, DateTime.UtcNow), out _));
 
         // The callback is refused at the store cap — a fail-closed 500 — and the assertion's one-time replay
         // id is NOT consumed, because the reservation is checked ahead of the consume.

--- a/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlOutcomeStoreTests.cs
@@ -31,8 +31,8 @@ public class SamlOutcomeStoreTests
     private static VerifiedIdentity Identity(string provider = "adfs") =>
         TestIdentities.Saml(provider, "alice", SamlAuthorizeStateBuilder.Build(new List<string>(), new SamlConfig()));
 
-    private static SamlLoginOutcome Outcome(string token, string provider = "adfs", string inResponseTo = "", string? clientKey = null, DateTime? created = null) =>
-        new SamlLoginOutcome(token, provider, Identity(provider), inResponseTo, clientKey, created ?? Now);
+    private static SamlLoginOutcome Outcome(string token, string provider = "adfs", string inResponseTo = "", string? sessionIndex = null, string? clientKey = null, DateTime? created = null) =>
+        new SamlLoginOutcome(token, provider, Identity(provider), inResponseTo, sessionIndex, clientKey, created ?? Now);
 
     [Fact]
     public void Add_ThenRedeem_SucceedsOnce_ThenReplayReturnsNull()
@@ -46,6 +46,20 @@ public class SamlOutcomeStoreTests
 
         // Single-use: a replay of the same token finds nothing (the atomic redeem removed it).
         Assert.Null(store.TryRedeem("tok-1", "adfs", Now));
+    }
+
+    [Fact]
+    public void Redeem_YieldsTheStoredSessionIndex()
+    {
+        // The SessionIndex tunnel (#727, SLO-3a): the ACS callback stores the assertion's SessionIndex on
+        // the outcome, and the mint leg gets it back verbatim on the redeem — with null (an assertion
+        // without one) tunnelling through just as faithfully, so absence stays "simply no capture".
+        var store = new SamlOutcomeStore();
+        Assert.True(store.TryAdd(Outcome("tok-1", sessionIndex: "_slo-session-1"), out _));
+        Assert.True(store.TryAdd(Outcome("tok-2"), out _));
+
+        Assert.Equal("_slo-session-1", store.TryRedeem("tok-1", "adfs", Now)!.SessionIndex);
+        Assert.Null(store.TryRedeem("tok-2", "adfs", Now)!.SessionIndex);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Saml/SamlResponseTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlResponseTests.cs
@@ -338,6 +338,90 @@ public class SamlResponseTests
         Assert.Null(Load(fixture).GetNameID());
     }
 
+    // --- SessionIndex capture for Single Logout (#727, SLO-3a) ---
+
+    [Fact]
+    public void GetSessionIndex_ValidResponse_ReturnsSignedSessionIndex()
+    {
+        // The AuthnStatement sits inside the assertion, so the SessionIndex is signature-covered.
+        var fixture = SamlTestFactory.Create(sessionIndex: "_slo-session-42");
+        var response = Load(fixture);
+
+        Assert.True(response.IsValid());
+        Assert.Equal("_slo-session-42", response.GetSessionIndex());
+    }
+
+    [Fact]
+    public void GetSessionIndex_AuthnStatementWithoutSessionIndex_ReturnsNull()
+    {
+        // An IdP that emits an AuthnStatement without a SessionIndex simply yields no capture — null,
+        // never a throw (fail-safe: Single Logout is then unavailable for the session, nothing else).
+        var fixture = SamlTestFactory.Create(includeAuthnStatement: true);
+        Assert.Null(Load(fixture).GetSessionIndex());
+    }
+
+    [Fact]
+    public void GetSessionIndex_NoAuthnStatement_ReturnsNull()
+    {
+        var fixture = SamlTestFactory.Create();
+        Assert.Null(Load(fixture).GetSessionIndex());
+    }
+
+    [Fact]
+    public void GetSessionIndex_SecondAuthnStatement_IsNotConsulted()
+    {
+        // Session-index smuggling via a second statement: only the FIRST AuthnStatement is read, so a
+        // trailing statement carrying a different (attacker-chosen) index never becomes the captured value —
+        // neither when the first statement has its own index nor when it lacks the attribute entirely.
+        // GetSessionIndex reads the DOM, so no signature is needed here (same idiom as the multi-value
+        // Role test in this suite).
+        var firstIndexed =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"_a\" Version=\"2.0\">" +
+                    "<saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject>" +
+                    "<saml:AuthnStatement SessionIndex=\"_genuine\" />" +
+                    "<saml:AuthnStatement SessionIndex=\"_smuggled\" />" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+        using (var response = new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(firstIndexed)))
+        {
+            Assert.Equal("_genuine", response.GetSessionIndex());
+        }
+
+        var firstBare =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"_a\" Version=\"2.0\">" +
+                    "<saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject>" +
+                    "<saml:AuthnStatement />" +
+                    "<saml:AuthnStatement SessionIndex=\"_smuggled\" />" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+        using (var response = new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(firstBare)))
+        {
+            Assert.Null(response.GetSessionIndex());
+        }
+    }
+
+    [Fact]
+    public void GetSessionIndex_AuthnStatementInSecondAssertion_IsNotConsulted()
+    {
+        // Assertion[1] scoping, consistent with every other getter: an AuthnStatement smuggled into a
+        // SECOND assertion is never read (such a response is rejected by the single-assertion invariant
+        // anyway, but the getter must not widen its scope regardless).
+        var xml =
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Assertion ID=\"_a\" Version=\"2.0\">" +
+                    "<saml:Subject><saml:NameID>alice</saml:NameID></saml:Subject>" +
+                "</saml:Assertion>" +
+                "<saml:Assertion ID=\"_b\" Version=\"2.0\">" +
+                    "<saml:AuthnStatement SessionIndex=\"_smuggled\" />" +
+                "</saml:Assertion>" +
+            "</samlp:Response>";
+        using var response = new SamlResponse(SamlFixture.ForeignCertificateBase64(), SamlFixture.Encode(xml));
+
+        Assert.Null(response.GetSessionIndex());
+    }
+
     [Fact]
     public void GetCustomAttributes_ValidResponse_ReturnsRole()
     {

--- a/SSO-Auth.Tests/Saml/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/Saml/SamlTestFactory.cs
@@ -46,6 +46,8 @@ internal static class SamlTestFactory
     /// <param name="audience">When set, emits a Conditions/AudienceRestriction with this single Audience.</param>
     /// <param name="audiences">When set, emits a Conditions/AudienceRestriction with these Audiences (overrides audience).</param>
     /// <param name="scope">Which element to sign.</param>
+    /// <param name="sessionIndex">When set, emits an AuthnStatement carrying this SessionIndex attribute (#727, SLO-3a).</param>
+    /// <param name="includeAuthnStatement">When true, emits an AuthnStatement even without a sessionIndex (the absent-attribute case).</param>
     /// <param name="signWithSha1">When true, sign with RSA-SHA1/SHA1 digest (for weak-algorithm tests).</param>
     /// <param name="signingKeyBits">RSA signing-key size in bits; defaults to 2048. Set below the floor (e.g. 1024) for the minimum signing-key-strength tests (#733).</param>
     /// <returns>A fixture exposing the certificate and the signed document.</returns>
@@ -60,6 +62,8 @@ internal static class SamlTestFactory
         string? audience = null,
         string[]? audiences = null,
         SignatureScope scope = SignatureScope.Response,
+        string? sessionIndex = null,
+        bool includeAuthnStatement = false,
         bool signWithSha1 = false,
         bool signWithCommentsC14n = false,
         bool signWithInclusiveC14n = false,
@@ -157,6 +161,14 @@ internal static class SamlTestFactory
             ? "<saml:Advice><saml:Assertion ID=\"_advice\" Version=\"2.0\"><saml:Issuer>https://idp.example.com</saml:Issuer></saml:Assertion></saml:Advice>"
             : string.Empty;
 
+        // The AuthnStatement whose SessionIndex the Single Logout capture reads (#727, SLO-3a). Emitted with
+        // the attribute when sessionIndex is set, or bare (includeAuthnStatement) for the absent-attribute case.
+        var authnStatement = sessionIndex != null || includeAuthnStatement
+            ? "<saml:AuthnStatement" + (sessionIndex == null ? string.Empty : " SessionIndex=\"" + SecurityElement.Escape(sessionIndex) + "\"") + ">" +
+                  "<saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></saml:AuthnContext>" +
+              "</saml:AuthnStatement>"
+            : string.Empty;
+
         var xml =
             "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + responseId + "\" Version=\"2.0\"" + destinationAttribute + ">" +
                 "<saml:Assertion ID=\"" + assertionId + "\" Version=\"2.0\">" +
@@ -169,6 +181,7 @@ internal static class SamlTestFactory
                             subjectConfirmationData +
                         "</saml:SubjectConfirmation>" +
                     "</saml:Subject>" +
+                    authnStatement +
                     "<saml:AttributeStatement>" +
                         "<saml:Attribute Name=\"Role\"><saml:AttributeValue>" + SecurityElement.Escape(role) + "</saml:AttributeValue></saml:Attribute>" +
                     "</saml:AttributeStatement>" +

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -73,7 +73,7 @@ internal sealed class LoginCompletionService
     /// <param name="config">The provider configuration governing authorization/folder/default-provider grants.</param>
     /// <param name="adoptionGate">The extra proof a same-named adoption must clear (#218).</param>
     /// <param name="remoteEndPointResolver">Resolves the normalized client IP for the activity log (#177); the controller reads it from <c>HttpContext</c> and passes it in so this tier stays HttpContext-free. Evaluated at the original point inside the minter — after avatar/persistence, and not at all on the fail-closed path.</param>
-    /// <param name="logoutContext">The optional Single Logout material captured at the callback (the id_token/sid, #727); persisted after the mint only when <c>EnableSingleLogout</c> is on. Null (the default, and the SAML path today) skips the capture.</param>
+    /// <param name="logoutContext">The optional Single Logout material captured at the callback (the OpenID id_token/sid or the SAML SessionIndex, #727); persisted after the mint only when <c>EnableSingleLogout</c> is on. Null (the default) skips the capture.</param>
     /// <returns>The HTTP result for the completed (or refused) login.</returns>
     internal async Task<ActionResult> CompleteAsync(
         VerifiedIdentity identity,

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Logout;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
@@ -321,6 +322,7 @@ internal sealed class SamlLoginService
                 provider,
                 identity,
                 samlResponse.GetInResponseTo() ?? string.Empty,
+                samlResponse.GetSessionIndex(),
                 clientKey,
                 DateTime.UtcNow);
             if (!_outcomes.CommitReserved(outcome))
@@ -652,13 +654,16 @@ internal sealed class SamlLoginService
         //
         // From here the SAML and OpenID paths are one: the verified identity flows into the shared completion
         // tail. SAML keys the link on the NameID and carries no email_verified claim, so AdoptionGate.None; the
-        // resolver's admin-adoption refusal (#218) still applies.
+        // resolver's admin-adoption refusal (#218) still applies. The logout context carries the assertion's
+        // SessionIndex captured at the callback (#727, SLO-3a) — SAML has no id_token — so the completion tail
+        // can persist the Single Logout state (EnableSingleLogout-gated, fail-safe) exactly as for OpenID.
         return await _loginCompletion.CompleteAsync(
             outcome.Identity,
             response,
             config,
             AdoptionGate.None,
-            remoteEndPointResolver).ConfigureAwait(false);
+            remoteEndPointResolver,
+            logoutContext: new LogoutContext(outcome.SessionIndex, IdToken: null)).ConfigureAwait(false);
     }
 
     // Correlates a response to an AuthnRequest this server issued (#156, #415) and enforces the browser

--- a/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
+++ b/SSO-Auth/Api/Saml/SamlOutcomeStore.cs
@@ -282,12 +282,14 @@ internal sealed class SamlOutcomeStore
 /// redeem is an atomic remove of the whole record, so a redeemer never observes a torn outcome. It carries
 /// the protocol-agnostic <see cref="VerifiedIdentity"/> the mint path needs plus the correlation facts the
 /// mint leg still enforces there (the assertion's <c>InResponseTo</c>, matched against the browser-binding
-/// cookie that the cross-site ACS POST could not carry).
+/// cookie that the cross-site ACS POST could not carry), and the assertion's <c>SessionIndex</c> so the
+/// completion tail can capture the Single Logout state (#727, SLO-3a).
 /// </summary>
 /// <param name="Token">The CSPRNG token keying the entry — the only value that crosses to the browser.</param>
 /// <param name="Provider">The provider that verified the login; a token is redeemable only on its own provider's endpoint.</param>
 /// <param name="Identity">The verified identity and privileges the mint path is keyed on (#473).</param>
 /// <param name="InResponseTo">The assertion's <c>InResponseTo</c> (empty for an unsolicited response), correlated + browser-bound at the mint leg (#415).</param>
+/// <param name="SessionIndex">The assertion's first AuthnStatement <c>SessionIndex</c> (#727, SLO-3a), or null when absent — a later Single Logout request resolves the session by it.</param>
 /// <param name="ClientKey">The normalized client key that reserved this outcome's per-client budget slot (#327), or null for an exempt source.</param>
 /// <param name="Created">When the outcome was created, used to time it out.</param>
 internal sealed record SamlLoginOutcome(
@@ -295,5 +297,6 @@ internal sealed record SamlLoginOutcome(
     string Provider,
     VerifiedIdentity Identity,
     string InResponseTo,
+    string? SessionIndex,
     string? ClientKey,
     DateTime Created);

--- a/SSO-Auth/Api/Saml/SamlResponse.cs
+++ b/SSO-Auth/Api/Saml/SamlResponse.cs
@@ -538,6 +538,22 @@ internal sealed class SamlResponse : IDisposable
     }
 
     /// <summary>
+    /// Gets the first AuthnStatement's SessionIndex — the identity provider's handle for the SSO session
+    /// this assertion established, captured at login so a later Single Logout request can name the session
+    /// it ends (#727, SLO-3a). It lives inside the assertion, so it is signature-covered; read from
+    /// Assertion[1] only, consistent with every other getter (the validated assertion), and from the FIRST
+    /// AuthnStatement only, so a second statement cannot smuggle in a different index.
+    /// </summary>
+    /// <returns>The SessionIndex attribute, or null when the assertion carries no AuthnStatement or the
+    /// statement carries no SessionIndex (fail-safe: absent simply means no capture).</returns>
+    public string? GetSessionIndex()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:AuthnStatement", _xmlNameSpaceManager) as XmlElement;
+        var sessionIndex = node?.GetAttribute("SessionIndex");
+        return string.IsNullOrEmpty(sessionIndex) ? null : sessionIndex;
+    }
+
+    /// <summary>
     /// Gets the bearer SubjectConfirmationData's Recipient — the assertion-consumer URL the identity
     /// provider minted this assertion for. It lives inside the assertion, so it is covered by the
     /// signature regardless of whether the whole Response or only the Assertion is signed. The caller


### PR DESCRIPTION
## What & why

**SLO-3a** of the #727 Single-Logout build-out. The logout store and the
protocol-neutral capture tail (SLO-1/1b) were ready, but the SAML login path
never supplied a `LogoutContext`, no SAML session could ever be matched by a
future `LogoutRequest`. This threads the SessionIndex through:

- **`SamlResponse.GetSessionIndex()`**, reads the `SessionIndex` attribute of
  the first `AuthnStatement` of `Assertion[1]` **only**: the single assertion
  `IsValid()` enforces (exactly-one invariant) and the signature covers. Same
  DOM-getter idiom as `GetNameID` (absent = null, never a throw). A second
  AuthnStatement or a second assertion is never consulted, session-index
  smuggling defense, pinned by tests.
- **`SamlLoginOutcome`** carries the value from the ACS validation to the token
  redeem (extracted strictly post-`TryValidate`, tunneled like `InResponseTo`).
- **`SamlLoginService`** passes `LogoutContext(SessionIndex, IdToken: null)`
  into the shared completion tail, mirroring the OpenID path.
  `CaptureLogoutState`'s `EnableSingleLogout` gating + fail-safe catch are
  untouched, with the feature off (default) login behaviour is unchanged.

## Security checklist

- [x] Extraction is first-only from the validated, signature-covered assertion
  (proven against the exactly-one-assertion + reference-binding invariants);
  smuggling negatives for a second statement and a second assertion.
- [x] No login-validation branch touched; the capture stays opt-in + fail-safe.
- [x] No new logging of the value; XmlSerializer-escaped persistence.
- [x] Adversarial bypass-lens review: **PASS** (argument-order swap ruled out - 
  a swap would fail correlation fail-closed and the E2E test).

## Quality checklist

- [x] 7 new tests (extraction positives/negatives, outcome tunnel, E2E capture
  round-trip); full suite green **3592/3592** across both TFMs; both projects
  0/0 under `--warnaserror`; commit DCO-signed.

Refs #727 (SLO-3b, the inbound LogoutRequest endpoint, follows against the
threat model posted on the issue)