### PR TITLE
Validate inbound SAML LogoutRequest and revoke matching sessions [#727]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1151,7 +1151,7 @@ public class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 12;
+        const int expectedTypedCallSites = 13;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the inbound IdP-initiated SAML LogoutRequest endpoint (#727, SLO-3b) via
+/// <see cref="SsoControllerHarness"/>, using <see cref="SamlLogoutTestFactory"/> to produce a real, signed
+/// request so the actual signature-validation path runs. They pin the SLO-3b threat-model mitigations: the
+/// feature gate, the uniform-400 rejection, the blast-radius bound, SessionIndex scoping, and the fail-safe
+/// revoke loop.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlLogoutTests
+{
+    private static readonly Guid UserA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UserB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private const string UniformRejectionBody = "SAML logout request could not be processed";
+
+    private static LogoutSession Session(string subject, Guid userId, string? sessionIndex) => new LogoutSession
+    {
+        Protocol = "SAML",
+        Provider = "adfs",
+        Subject = subject,
+        SessionIndex = sessionIndex,
+        UserId = userId,
+    };
+
+    [Fact]
+    public async Task SamlLogout_FeatureOff_ReturnsUniform400_WithoutTouchingSessions()
+    {
+        // The whole surface is opt-in: with EnableSingleLogout off, even a perfectly valid signed request is
+        // rejected — and no session is revoked.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = false;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        AssertUniformRejection(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_UnknownProvider_ReturnsUniform400()
+    {
+        var fixture = SamlLogoutTestFactory.Create();
+        var harness = new SsoControllerHarness(c => c.EnableSingleLogout = true);
+
+        var result = await harness.Controller.SamlLogout("nope", fixture.EncodeRequest());
+
+        AssertUniformRejection(result);
+    }
+
+    [Fact]
+    public async Task SamlLogout_ValidRequestForSubjectA_RevokesA_AndLeavesSubjectBIntact()
+    {
+        // Blast-radius bound (T-D1): a valid logout for (adfs, alice) revokes only user A and consumes only
+        // A's store entry; user B's session and entry are untouched.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, "sA");
+            c.LogoutSessions["b"] = Session("bob", UserB, "sB");
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(UserB, Arg.Any<string>());
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("b")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_SessionIndexScoped_RevokesOnlyTheMatchingEntry()
+    {
+        // A request naming SessionIndex "idx-1" consumes only the idx-1 entry; the subject's idx-2 session
+        // survives in the store (revoke is user-scoped, but entry consumption is index-scoped).
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice", sessionIndexes: new[] { "idx-1" });
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a1"] = Session("alice", UserA, "idx-1");
+            c.LogoutSessions["a2"] = Session("alice", UserA, "idx-2");
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a1")));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a2")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_NoSessionIndex_RevokesAllOfTheSubjectsSessions()
+    {
+        // A request with no SessionIndex targets every session of the subject (SAML core §3.7).
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a1"] = Session("alice", UserA, "idx-1");
+            c.LogoutSessions["a2"] = Session("alice", UserA, "idx-2");
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a1")));
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a2")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_OneUserRevokeThrows_StillRevokesTheOther_AndKeepsTheFaultedEntry()
+    {
+        // Availability fail-safe: one matched user's revoke fault must NOT abort the loop for the rest, and the
+        // faulted user's store entry is LEFT in place (retry possible) while the succeeded user's is consumed.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, "sA");
+            c.LogoutSessions["b"] = Session("alice", UserB, "sB");
+        });
+        // User A's revoke faults; user B's succeeds (the substitute's default completed Task).
+        harness.SessionManager.RevokeUserTokens(UserA, Arg.Any<string>()).Returns(Task.FromException(new InvalidOperationException("boom")));
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        // A's fault did not abort the loop — B was still revoked, so at least one user logged out → 200.
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserB, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("b")));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_TheOnlyMatchedUserRevokeThrows_ReturnsUniform400_AndKeepsTheEntry()
+    {
+        // Fail-closed on the destructive action: sessions matched but the sole revoke faulted, so NOTHING was
+        // revoked and the user stays authenticated — the endpoint must NOT report success (no 200), and the
+        // entry is left in the store for a retry.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+        harness.SessionManager.RevokeUserTokens(UserA, Arg.Any<string>()).Returns(Task.FromException(new InvalidOperationException("boom")));
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        AssertUniformRejection(result);
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_ValidRequestForUnknownSubject_ReturnsUniform400()
+    {
+        // "Unknown subject" (no captured session) is the uniform 400 — indistinguishable from a bad signature.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "ghost");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        AssertUniformRejection(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SamlLogout_ReplayedRequest_ReturnsUniform400()
+    {
+        // The second presentation of the same request ID is a replay — rejected, and it does not revoke again.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice", requestId: "_replay-id");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+        var encoded = fixture.EncodeRequest();
+
+        Assert.IsType<OkResult>(await harness.Controller.SamlLogout("adfs", encoded));
+
+        // Re-seed the (now-consumed) entry so the only reason a second run fails is the replay cache, not a
+        // missing session.
+        SSOPlugin.Instance.MutateConfiguration(c => c.LogoutSessions["a"] = Session("alice", UserA, null));
+        var replay = await harness.Controller.SamlLogout("adfs", encoded);
+
+        AssertUniformRejection(replay);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+    }
+
+    [Fact]
+    public async Task SamlLogout_TwoDifferentRejectionCauses_ReturnByteIdenticalResponses()
+    {
+        // Information-disclosure mitigation: an unsigned request and a wrong-certificate request must be
+        // indistinguishable on the wire (same status, same body).
+        var unsigned = SamlLogoutTestFactory.Create(nameId: "alice", sign: false);
+        var wrongCert = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            // Trust a certificate that signs NEITHER request, so both fail signature validation.
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = SamlFixture.ForeignCertificateBase64() };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var unsignedResult = Assert.IsType<ContentResult>(await harness.Controller.SamlLogout("adfs", unsigned.EncodeRequest()));
+        var wrongCertResult = Assert.IsType<ContentResult>(await harness.Controller.SamlLogout("adfs", wrongCert.EncodeRequest()));
+
+        Assert.Equal(unsignedResult.StatusCode, wrongCertResult.StatusCode);
+        Assert.Equal(unsignedResult.Content, wrongCertResult.Content);
+        Assert.Equal(UniformRejectionBody, unsignedResult.Content);
+        Assert.Equal(400, unsignedResult.StatusCode);
+    }
+
+    private static void AssertUniformRejection(ActionResult result)
+    {
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal(UniformRejectionBody, content.Content);
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlLogoutRequestTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutRequestTests.cs
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the inbound SAML <c>LogoutRequest</c> parse-and-signature validator (<see cref="SamlLogoutRequest"/>,
+/// #727 SLO-3b) against real signed documents from <see cref="SamlLogoutTestFactory"/>. Each fail-closed
+/// branch from the SLO-3b threat model has a negative test: unsigned, wrong-key, weak algorithm, signature
+/// wrapping, a prohibited DTD, malformed input, and an expired NotOnOrAfter must all fail validation.
+/// </summary>
+public class SamlLogoutRequestTests
+{
+    private static SamlLogoutRequest Parse(string certificate, string encodedRequest)
+    {
+        Assert.True(SamlLogoutRequest.TryParse(certificate, null, encodedRequest, out var request));
+        return request;
+    }
+
+    [Fact]
+    public void ValidSignedRequest_IsValid_AndExposesTheSubjectSessionIndexesAndId()
+    {
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice", sessionIndexes: new[] { "idx-1", "idx-2" });
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.True(request.IsValid());
+        Assert.Equal("alice", request.GetNameId());
+        Assert.Equal(new[] { "idx-1", "idx-2" }, request.GetSessionIndexes());
+        Assert.Equal(fixture.RequestId, request.GetRequestId());
+    }
+
+    [Fact]
+    public void UnsignedRequest_IsRejected()
+    {
+        // T-S1 (spoofing): an unsigned LogoutRequest must never validate — THE core defense.
+        var fixture = SamlLogoutTestFactory.Create(sign: false);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void RequestSignedByAnotherCertificate_IsRejected()
+    {
+        // T-S1: signed by a real key, but the provider trusts a DIFFERENT certificate — the crypto check
+        // must reject it (a forged/attacker-signed request).
+        var fixture = SamlLogoutTestFactory.Create();
+
+        using var request = Parse(SamlFixture.ForeignCertificateBase64(), fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void RequestSignedWithSha1_IsRejected()
+    {
+        // T-T2 (algorithm downgrade): RSA-SHA1 / SHA-1 digest is off the allowlist even when it verifies.
+        var fixture = SamlLogoutTestFactory.Create(signWithSha1: true);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void WeakSigningKey_IsRejected()
+    {
+        // A 1024-bit RSA key is below the shared signing-key strength floor (SamlCertificate) — its signature
+        // is not accepted even though it verifies.
+        var fixture = SamlLogoutTestFactory.Create(signingKeyBits: 1024);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void SignatureWrappingOverASmuggledSibling_IsRejected()
+    {
+        // T-T1 (signature wrapping): a cryptographically valid signature whose single reference covers a
+        // smuggled sibling — not the LogoutRequest root — must be rejected by the reference-covers-root bind.
+        var fixture = SamlLogoutTestFactory.Create(wrapSignature: true);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void DtdBearingRequest_FailsToParse()
+    {
+        // T-T3 (XXE / entity bomb): a DOCTYPE is rejected at parse (DtdProcessing.Prohibit), fail-closed.
+        var dtd = "<!DOCTYPE foo [<!ENTITY x \"y\">]>" +
+            "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_r\" Version=\"2.0\">" +
+                "<saml:Issuer>https://idp.example.com</saml:Issuer><saml:NameID>alice</saml:NameID>" +
+            "</samlp:LogoutRequest>";
+
+        Assert.False(SamlLogoutRequest.TryParse(SamlFixture.ForeignCertificateBase64(), null, SamlLogoutTestFactory.Encode(dtd), out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-base64-!!!")]
+    public void MalformedBody_FailsToParse(string? body)
+    {
+        Assert.False(SamlLogoutRequest.TryParse(SamlFixture.ForeignCertificateBase64(), null, body, out _));
+    }
+
+    [Fact]
+    public void OversizedBody_FailsToParse()
+    {
+        var oversized = new string('A', SamlLogoutRequest.MaxEncodedRequestLength + 1);
+
+        Assert.False(SamlLogoutRequest.TryParse(SamlFixture.ForeignCertificateBase64(), null, oversized, out _));
+    }
+
+    [Fact]
+    public void ExpiredNotOnOrAfter_IsRejected()
+    {
+        // T-D2 (replay/time): a NotOnOrAfter in the past (beyond the clock skew) is honoured when present —
+        // a stale request is rejected even though its signature is valid.
+        var fixture = SamlLogoutTestFactory.Create(notOnOrAfter: DateTime.UtcNow.AddHours(-1));
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.False(request.IsValid());
+    }
+
+    [Fact]
+    public void FutureNotOnOrAfter_IsAccepted()
+    {
+        var fixture = SamlLogoutTestFactory.Create(notOnOrAfter: DateTime.UtcNow.AddMinutes(5));
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.True(request.IsValid());
+    }
+
+    [Fact]
+    public void ValidSignatureWithoutNameId_IsValidButExposesNoSubject()
+    {
+        // A signature-valid request with no NameID passes the pure signature check here; the subject-resolution
+        // rejection lives in SamlLogoutValidator/the endpoint, not in this parse type.
+        var fixture = SamlLogoutTestFactory.Create(includeNameId: false);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.True(request.IsValid());
+        Assert.True(string.IsNullOrEmpty(request.GetNameId()));
+    }
+
+    [Fact]
+    public void NoSessionIndex_YieldsAnEmptyList()
+    {
+        var fixture = SamlLogoutTestFactory.Create(sessionIndexes: null);
+
+        using var request = Parse(fixture.CertificateBase64, fixture.EncodeRequest());
+
+        Assert.Empty(request.GetSessionIndexes());
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlLogoutTestFactory.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutTestFactory.cs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Builds real, cryptographically-signed SAML 2.0 <c>LogoutRequest</c> documents (and deliberately broken
+/// variants) against a throw-away self-signed certificate, so the SLO-3b tests exercise the actual
+/// signature-validation path in <c>SamlLogoutRequest</c> rather than mocks — the LogoutRequest analogue of
+/// <see cref="SamlTestFactory"/>.
+/// </summary>
+internal static class SamlLogoutTestFactory
+{
+    private const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
+
+    /// <summary>
+    /// Produces a self-signed certificate plus a signed LogoutRequest for the given subject/session indexes.
+    /// </summary>
+    /// <param name="nameId">The value placed in saml:NameID.</param>
+    /// <param name="includeNameId">When false, the saml:NameID element is omitted entirely.</param>
+    /// <param name="sessionIndexes">Zero or more samlp:SessionIndex values; null emits none.</param>
+    /// <param name="notOnOrAfter">When set, emits the request's NotOnOrAfter attribute.</param>
+    /// <param name="issuer">The saml:Issuer value.</param>
+    /// <param name="requestId">The request ID attribute (defaults to a fresh one); reuse a fixed value for the replay test.</param>
+    /// <param name="sign">When false, the request is left unsigned.</param>
+    /// <param name="signWithSha1">When true, sign with RSA-SHA1/SHA1 digest (the weak-algorithm case).</param>
+    /// <param name="wrapSignature">When true, sign a smuggled sibling element and move the (valid) signature to the root — the XML-signature-wrapping case.</param>
+    /// <param name="signingKeyBits">RSA signing-key size in bits; defaults to 2048.</param>
+    /// <returns>A fixture exposing the certificate and the signed document.</returns>
+    internal static SamlLogoutFixture Create(
+        string nameId = "alice",
+        bool includeNameId = true,
+        string[]? sessionIndexes = null,
+        DateTime? notOnOrAfter = null,
+        string issuer = "https://idp.example.com",
+        string? requestId = null,
+        bool sign = true,
+        bool signWithSha1 = false,
+        bool wrapSignature = false,
+        int signingKeyBits = 2048)
+    {
+        var rootId = requestId ?? ("_" + Guid.NewGuid().ToString("N"));
+        var issueInstant = DateTime.UtcNow.ToString(TimeFormat, CultureInfo.InvariantCulture);
+        var notOnOrAfterAttr = notOnOrAfter == null
+            ? string.Empty
+            : " NotOnOrAfter=\"" + notOnOrAfter.Value.ToUniversalTime().ToString(TimeFormat, CultureInfo.InvariantCulture) + "\"";
+
+        // The smuggled, separately-signed sibling used by the wrapping case: it carries its own ID so a
+        // signature can reference it instead of the document root.
+        const string EvilId = "_evil";
+        var evil = wrapSignature
+            ? "<samlp:Extensions ID=\"" + EvilId + "\"><saml:NameID>attacker</saml:NameID></samlp:Extensions>"
+            : string.Empty;
+
+        var sessionIndexElements = new StringBuilder();
+        if (sessionIndexes != null)
+        {
+            foreach (var index in sessionIndexes)
+            {
+                sessionIndexElements.Append("<samlp:SessionIndex>" + SecurityElement.Escape(index) + "</samlp:SessionIndex>");
+            }
+        }
+
+        var xml =
+            "<samlp:LogoutRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + rootId + "\" Version=\"2.0\" IssueInstant=\"" + issueInstant + "\"" + notOnOrAfterAttr + ">" +
+                "<saml:Issuer>" + SecurityElement.Escape(issuer) + "</saml:Issuer>" +
+                evil +
+                (includeNameId ? "<saml:NameID>" + SecurityElement.Escape(nameId) + "</saml:NameID>" : string.Empty) +
+                sessionIndexElements +
+            "</samlp:LogoutRequest>";
+
+        using var rsa = RSA.Create(signingKeyBits);
+        var request = new CertificateRequest("CN=Test SAML IdP", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var certificate = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(10));
+
+        var document = new XmlDocument { PreserveWhitespace = true };
+        document.LoadXml(xml);
+
+        if (sign)
+        {
+            // Wrapping: sign the smuggled sibling (a cryptographically VALID signature), then move it to the
+            // root so it sits at the position-bound location but its reference covers the sibling, not the
+            // root — exactly the shape the reference-covers-root defense must reject.
+            var referenceId = wrapSignature ? EvilId : rootId;
+            SignElement(document, referenceId, rsa, certificate, signWithSha1, moveSignatureToRoot: wrapSignature);
+        }
+
+        return new SamlLogoutFixture(certificate, document, rootId);
+    }
+
+    /// <summary>Encodes an arbitrary XML string as a Base64 SAMLRequest (used for the DTD/malformed cases).</summary>
+    /// <param name="xml">The raw XML.</param>
+    /// <returns>The Base64 SAMLRequest.</returns>
+    internal static string Encode(string xml) => Convert.ToBase64String(Encoding.UTF8.GetBytes(xml));
+
+    private static void SignElement(XmlDocument document, string referenceId, RSA signingKey, X509Certificate2 certificate, bool useSha1, bool moveSignatureToRoot)
+    {
+        var signedXml = new SignedXml(document) { SigningKey = signingKey };
+
+        var reference = new Reference("#" + referenceId) { DigestMethod = useSha1 ? SignedXml.XmlDsigSHA1Url : SignedXml.XmlDsigSHA256Url };
+        reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+        reference.AddTransform(new XmlDsigExcC14NTransform());
+        signedXml.AddReference(reference);
+
+        signedXml.SignedInfo!.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
+        signedXml.SignedInfo.SignatureMethod = useSha1 ? SignedXml.XmlDsigRSASHA1Url : SignedXml.XmlDsigRSASHA256Url;
+
+        var keyInfo = new KeyInfo();
+        keyInfo.AddClause(new KeyInfoX509Data(certificate));
+        signedXml.KeyInfo = keyInfo;
+
+        signedXml.ComputeSignature();
+
+        var signatureElement = signedXml.GetXml();
+        // Normally the enveloped signature is appended inside the element it covers. For the wrapping case the
+        // signature is instead appended to the document root, so it sits at the validator's position-bound
+        // location while its reference points at the smuggled sibling.
+        var target = moveSignatureToRoot
+            ? document.DocumentElement!
+            : (XmlElement)signedXml.GetIdElement(document, referenceId)!;
+        target.AppendChild(document.ImportNode(signatureElement, true));
+    }
+}
+
+/// <summary>A signed SAML LogoutRequest together with the certificate that signed it.</summary>
+internal sealed class SamlLogoutFixture
+{
+    private readonly X509Certificate2 _certificate;
+
+    internal SamlLogoutFixture(X509Certificate2 certificate, XmlDocument document, string requestId)
+    {
+        _certificate = certificate;
+        Document = document;
+        RequestId = requestId;
+    }
+
+    /// <summary>Gets the signed document (mutable, so tests can inject attacks).</summary>
+    internal XmlDocument Document { get; }
+
+    /// <summary>Gets the ID attribute of the root LogoutRequest element.</summary>
+    internal string RequestId { get; }
+
+    /// <summary>Gets the signing certificate exported as a Base64 DER string (the public part only).</summary>
+    internal string CertificateBase64 => Convert.ToBase64String(_certificate.Export(X509ContentType.Cert));
+
+    /// <summary>Encodes the current document as the Base64 SAMLRequest string the endpoint expects.</summary>
+    internal string EncodeRequest() => SamlLogoutTestFactory.Encode(Document.OuterXml);
+}

--- a/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the SLO-3b orchestrator <see cref="SamlLogoutValidator"/>: it composes the
+/// <see cref="SamlLogoutRequest"/> signature/time validation with the one-time-use (replay) consume and
+/// returns a FIXED reason code per fail-closed branch. The reason codes are what the audit trail records;
+/// the endpoint collapses them all to one uniform 400.
+/// </summary>
+public class SamlLogoutValidatorTests : IDisposable
+{
+    public SamlLogoutValidatorTests() => SamlLogoutValidator.ResetReplaysForTests();
+
+    public void Dispose() => SamlLogoutValidator.ResetReplaysForTests();
+
+    private static SamlConfig ProviderTrusting(string certificate) => new SamlConfig
+    {
+        Enabled = true,
+        SamlCertificate = certificate,
+    };
+
+    [Fact]
+    public void ValidRequest_Succeeds_AndExposesSubjectAndSessionIndexes()
+    {
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice", sessionIndexes: new[] { "idx-1" });
+        var validator = new SamlLogoutValidator();
+
+        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out var nameId, out var sessionIndexes, out var reason);
+
+        Assert.True(ok);
+        Assert.Equal("alice", nameId);
+        Assert.Equal(new[] { "idx-1" }, sessionIndexes);
+        Assert.Equal(string.Empty, reason);
+    }
+
+    [Fact]
+    public void ReplayedRequestId_IsRejected()
+    {
+        // T-D2 (replay): the same request ID cannot be consumed twice — the second presentation fails closed.
+        var fixture = SamlLogoutTestFactory.Create(requestId: "_fixed-id");
+        var validator = new SamlLogoutValidator();
+        var config = ProviderTrusting(fixture.CertificateBase64);
+        var encoded = fixture.EncodeRequest();
+
+        Assert.True(validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out _));
+
+        var replayed = validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out var reason);
+
+        Assert.False(replayed);
+        Assert.Equal(SamlLogoutValidator.RejectReason.Replay, reason);
+    }
+
+    [Fact]
+    public void UnsignedRequest_IsRejected_WithInvalidReason()
+    {
+        var fixture = SamlLogoutTestFactory.Create(sign: false);
+        var validator = new SamlLogoutValidator();
+
+        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out _, out _, out var reason);
+
+        Assert.False(ok);
+        Assert.Equal(SamlLogoutValidator.RejectReason.Invalid, reason);
+    }
+
+    [Fact]
+    public void MalformedBody_IsRejected_WithMalformedReason()
+    {
+        var validator = new SamlLogoutValidator();
+
+        var ok = validator.TryValidate(ProviderTrusting(SamlFixture.ForeignCertificateBase64()), "adfs", "not-base64-!!!", DateTime.UtcNow, out _, out _, out var reason);
+
+        Assert.False(ok);
+        Assert.Equal(SamlLogoutValidator.RejectReason.Malformed, reason);
+    }
+
+    [Fact]
+    public void ValidSignatureButNoNameId_IsRejected_WithoutConsumingReplay()
+    {
+        // A signature-valid request that resolves no subject is rejected as Invalid — and because the reject
+        // happens BEFORE the replay consume, the request ID is NOT burned. Prove it: a corrected request that
+        // carries the SAME ID (with a NameID this time) is then accepted, not turned away as a replay.
+        const string SharedId = "_no-nameid-id";
+        var noName = SamlLogoutTestFactory.Create(includeNameId: false, requestId: SharedId);
+        var validator = new SamlLogoutValidator();
+
+        var firstOk = validator.TryValidate(ProviderTrusting(noName.CertificateBase64), "adfs", noName.EncodeRequest(), DateTime.UtcNow, out _, out _, out var reason);
+
+        Assert.False(firstOk);
+        Assert.Equal(SamlLogoutValidator.RejectReason.Invalid, reason);
+
+        // Re-present the SAME request ID, now with a NameID: it must succeed — the slot was never consumed, so
+        // this is not rejected as a Replay (which would prove the NameID guard ran before TryConsume).
+        var corrected = SamlLogoutTestFactory.Create(nameId: "alice", requestId: SharedId);
+        var secondOk = validator.TryValidate(ProviderTrusting(corrected.CertificateBase64), "adfs", corrected.EncodeRequest(), DateTime.UtcNow, out var nameId, out _, out var secondReason);
+
+        Assert.True(secondOk);
+        Assert.NotEqual(SamlLogoutValidator.RejectReason.Replay, secondReason);
+        Assert.Equal("alice", nameId);
+    }
+}

--- a/SSO-Auth.Tests/_Support/SsoControllerHarness.cs
+++ b/SSO-Auth.Tests/_Support/SsoControllerHarness.cs
@@ -67,6 +67,9 @@ internal sealed class SsoControllerHarness
         // statics too; clear them so a prior test's stored outcome or consumed assertion id cannot leak in.
         SamlLoginService.ResetSamlOutcomesForTests();
         SamlAssertionValidator.ResetReplaysForTests();
+        // The inbound SAML LogoutRequest one-time-use cache (#727, SLO-3b) is a process-wide static too;
+        // clear it so a prior test's consumed request id cannot leak into this one.
+        SamlLogoutValidator.ResetReplaysForTests();
 
         Configuration = new PluginConfiguration();
         configure?.Invoke(Configuration);

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -213,6 +213,51 @@ internal static class SsoAudit
             breakGlassAdmin?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records a validated inbound SAML <c>LogoutRequest</c> that terminated sessions (#727, SLO-3b). Only
+    /// non-sensitive fields are logged: the provider name and the count of Jellyfin users whose tokens were
+    /// revoked — never the raw NameID or SessionIndex, which are subject identifiers (T-I1). The provider is
+    /// route input, so its line endings are stripped inline before logging (log-forging defense).
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="provider">The SAML provider the request arrived for.</param>
+    /// <param name="usersRevoked">How many distinct Jellyfin users had their tokens revoked.</param>
+    internal static void LogoutRequested(ILogger logger, string provider, int usersRevoked)
+    {
+        if (!logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        logger.LogInformation(
+            "[SSO Audit] SAML logout requested: a validated LogoutRequest for provider '{Provider}' revoked tokens for {UsersRevoked} user(s).",
+            provider?.ReplaceLineEndings(string.Empty),
+            usersRevoked);
+    }
+
+    /// <summary>
+    /// Records an inbound SAML <c>LogoutRequest</c> being rejected fail-closed (#727, SLO-3b). The reason is a
+    /// FIXED code (unsigned/malformed/replay/no-matching-session, a constant, never request-derived text), so
+    /// a blocked forged logout leaves a trail (T-R1) without disclosing subject identifiers or which branch
+    /// rejected it to the caller (the caller sees only a uniform 400). The provider is route input, stripped
+    /// of line endings inline before logging.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="provider">The SAML provider the request arrived for.</param>
+    /// <param name="reasonCode">The fixed rejection reason code (not request-derived).</param>
+    internal static void LogoutRejected(ILogger logger, string provider, string reasonCode)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] SAML logout request REJECTED for provider '{Provider}' ({ReasonCode}). No session was terminated.",
+            provider?.ReplaceLineEndings(string.Empty),
+            reasonCode);
+    }
+
     /// <summary>Records a provider being saved with one or more default-on security checks disabled (#140, #672).</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -660,6 +660,134 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Inbound IdP-initiated SAML Single Logout (#727, SLO-3b): accepts a signed <c>LogoutRequest</c> and
+    /// revokes the linked Jellyfin sessions. This is the UNAUTHENTICATED, session-destructive surface — its
+    /// only trust anchor is the request's XML signature against the provider's configured certificate(s), so
+    /// it mirrors the login-side hardening (enveloped-signature + wrapping defense, weak-algorithm rejection,
+    /// DTD-prohibited parse, replay one-time-use). POST-binding only (the <c>SAMLRequest</c> form field,
+    /// Base64). Single Logout is opt-in and off by default: while it is off the whole surface rejects WITHOUT
+    /// parsing. Every rejection — feature off, unknown provider, bad signature, replay, unknown subject — is
+    /// the SAME uniform 400 with a fixed body, so the causes cannot be told apart (no oracle); only a
+    /// validly-signed request that resolves at least one session returns 200.
+    /// </summary>
+    /// <param name="provider">The SAML provider the LogoutRequest arrived for.</param>
+    /// <param name="samlRequest">The <c>SAMLRequest</c> form field (model-bound, so a non-form POST binds null and is rejected).</param>
+    /// <returns>200 when a validated request revoked at least one session; a uniform 400 otherwise.</returns>
+    [HttpPost("SAML/Logout/{provider}")]
+    public async Task<ActionResult> SamlLogout(string provider, [FromForm(Name = "SAMLRequest")] string? samlRequest = null)
+    {
+        if (RateLimitCheck(SsoRateLimitClass.Logout) is { } throttled)
+        {
+            return throttled;
+        }
+
+        // Read the feature flag AND the provider config in one lock acquisition. Single Logout is opt-in/off
+        // by default: a disabled feature, an unknown provider, and a disabled provider all collapse to the ONE
+        // uniform 400 below, and NONE of them parses the untrusted body — so the inbound signed-XML sink is
+        // unreachable while the feature is off, and neither the feature state nor the provider set can be
+        // probed apart.
+        var (singleLogoutEnabled, config) = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            (configuration.EnableSingleLogout, configuration.SamlConfigs.TryGetValue(provider, out var samlConfig) ? samlConfig : null));
+
+        if (!singleLogoutEnabled || config is not { Enabled: true })
+        {
+            return UniformLogoutRejection();
+        }
+
+        // Parse + signature/time-bound validate + one-time-use consume. On any failure the reason code is a
+        // FIXED constant (never request-derived) written only to the audit trail; the caller sees the uniform
+        // 400 with no branch-distinguishing detail.
+        var validator = new SamlLogoutValidator();
+        if (!validator.TryValidate(config, provider, samlRequest, DateTime.UtcNow, out var nameId, out var sessionIndexes, out var reasonCode))
+        {
+            SsoAudit.LogoutRejected(_logger, provider, reasonCode);
+            return UniformLogoutRejection();
+        }
+
+        // Resolve the targeted sessions — strictly the SAME provider and subject (ordinal exact). This is the
+        // blast-radius bound: FindByProviderSubject filters by (provider, subject), so a logout for one
+        // subject can never touch another subject's or another provider's sessions. When the request names
+        // SessionIndex element(s), keep only entries whose captured index is among them; a request with NO
+        // SessionIndex targets every session of the subject (SAML core §3.7).
+        var matches = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            SessionLogoutStore.FindByProviderSubject(configuration, provider, nameId, string.Empty));
+        if (sessionIndexes.Count > 0)
+        {
+            matches = matches
+                .Where(pair => sessionIndexes.Contains(pair.Value.SessionIndex ?? string.Empty, StringComparer.Ordinal))
+                .ToList();
+        }
+
+        // A validated request resolving NO session is the "unknown-subject" case: render the SAME uniform 400
+        // as a validation failure. An anonymous attacker can never produce a valid signature to reach here, so
+        // this discloses nothing; only the trusted IdP (which already knows its own subjects) can distinguish
+        // it from a 200, which is acceptable.
+        if (matches.Count == 0)
+        {
+            SsoAudit.LogoutRejected(_logger, provider, "no_matching_session");
+            return UniformLogoutRejection();
+        }
+
+        // Revoke the tokens of each DISTINCT matched user. RevokeUserTokens is USER-scoped — Jellyfin exposes
+        // no per-token revoke — so a SessionIndex-scoped request still revokes the whole matched user's tokens;
+        // that is honest and safe (a logout can only ever end sessions, never grant or link). A revoke fault
+        // for one user must NOT abort the loop (availability fail-safe): the remaining users are still logged
+        // out, and a faulted user's store entry is LEFT in place (not consumed) so nothing is silently dropped.
+        var succeeded = new HashSet<Guid>();
+        foreach (var userId in matches.Select(pair => pair.Value.UserId).Distinct())
+        {
+            try
+            {
+                await _sessionManager.RevokeUserTokens(userId, null).ConfigureAwait(false);
+                succeeded.Add(userId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Revoking tokens during SAML logout failed for one user; the remaining matched users are still logged out.");
+            }
+        }
+
+        // Remove only the entries whose user was actually revoked, so a transient revoke fault leaves that
+        // user's entry for a later retry/prune rather than dropping it.
+        var consumedKeys = matches.Where(pair => succeeded.Contains(pair.Value.UserId)).Select(pair => pair.Key).ToList();
+        if (consumedKeys.Count > 0)
+        {
+            SSOPlugin.Instance.MutateConfiguration(configuration =>
+            {
+                foreach (var key in consumedKeys)
+                {
+                    SessionLogoutStore.Remove(configuration, key);
+                }
+            });
+        }
+
+        // Fail-closed on the destructive action itself: a 200 must mean at least one user was ACTUALLY logged
+        // out. Sessions matched but EVERY revoke faulted (succeeded.Count == 0) means no token was invalidated
+        // and the user stays authenticated — so we must NOT tell the IdP the logout succeeded. Audit the fault
+        // and return the uniform 400; the matched entries were left in the store above (nothing was consumed),
+        // so a retry can still act. This is the fail-CLOSED half of the per-user fail-SAFE loop: one user's
+        // fault does not abort the others (availability), but zero successful revokes is never reported as done.
+        if (succeeded.Count == 0)
+        {
+            SsoAudit.LogoutRejected(_logger, provider, "revoke_failed");
+            return UniformLogoutRejection();
+        }
+
+        SsoAudit.LogoutRequested(_logger, provider, succeeded.Count);
+        return Ok();
+    }
+
+    // The single uniform rejection for the inbound SAML logout endpoint: one fixed 400 body for every
+    // rejection cause (feature off, unknown/disabled provider, bad signature, replay, unknown subject), so no
+    // branch-distinguishing detail leaks to the caller. Plain text, mirroring LoginStatusMapper's Emit shape.
+    private static ContentResult UniformLogoutRejection() => new ContentResult
+    {
+        Content = "SAML logout request could not be processed",
+        ContentType = MediaTypeNames.Text.Plain,
+        StatusCode = StatusCodes.Status400BadRequest,
+    };
+
+    /// <summary>
     /// Adds a SAML configuration. If the provider already exists, overwrite it.
     /// </summary>
     /// <param name="provider">The provider name to add.</param>

--- a/SSO-Auth/Api/Saml/SamlLogoutRequest.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutRequest.cs
@@ -1,0 +1,416 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// Parses and validates an inbound IdP-initiated SAML 2.0 <c>LogoutRequest</c> (#727, SLO-3b) — the
+/// unauthenticated, session-destructive surface. It deliberately MIRRORS the signed-XML hardening of
+/// <see cref="SamlResponse"/> (DTD-prohibited size-bounded parse, exactly-one enveloped signature whose
+/// single reference covers the signed root, the RSA/ECDSA-SHA-256-or-stronger algorithm allowlist, the
+/// candidate-certificate trial across the validity window) but against a different document: the signed
+/// element is the <c>samlp:LogoutRequest</c> root itself (there is no assertion, no bearer confirmation,
+/// no audience). It is a FOCUSED validator that reuses the shared primitives
+/// (<see cref="SamlSignatureAlgorithms"/>, <see cref="SamlCertificate"/>, <see cref="SamlAssertionTime"/>)
+/// rather than re-implementing the algorithm lists or certificate strength policy — a separate type from
+/// <see cref="SamlResponse"/> so hardening the logout path cannot regress the heavily-tested login path.
+/// </summary>
+/// <remarks>
+/// Fail-closed throughout: an unsigned, wrong-key, wrapped, weak-algorithm, malformed or DTD-bearing
+/// request fails <see cref="IsValid"/> (or never parses). One-time-use (replay) and the feature gate live
+/// in the orchestrating <see cref="SamlLogoutValidator"/> and the controller endpoint; this type is the
+/// pure parse-plus-signature step and exposes only the validated NameID, the SessionIndex list, and the
+/// request ID once <see cref="IsValid"/> has returned true.
+/// </remarks>
+internal sealed class SamlLogoutRequest : IDisposable
+{
+    // The only position an enveloped LogoutRequest signature may occupy: a direct child of the
+    // LogoutRequest root. A relative //ds:Signature would also match a signature relocated into a wrapper,
+    // so the XPath is anchored to the root — the LogoutRequest analogue of SamlResponse.SignatureXPath.
+    private const string SignatureXPath = "/samlp:LogoutRequest/ds:Signature";
+
+    /// <summary>The always-on ceiling (256 KB) on the Base64 SAMLRequest length, bounding the decode and DOM parse on the unauthenticated logout path before any signature is checked (mirrors <see cref="SamlResponseLoader.MaxEncodedResponseLength"/>).</summary>
+    internal const int MaxEncodedRequestLength = 256 * 1024;
+
+    private readonly List<X509Certificate2> _certificates;
+    private readonly XmlDocument _xmlDoc;
+    private readonly XmlNamespaceManager _xmlNameSpaceManager;
+
+    private SamlLogoutRequest(List<X509Certificate2> certificates, XmlDocument xmlDoc)
+    {
+        _certificates = certificates;
+        _xmlDoc = xmlDoc;
+        _xmlNameSpaceManager = GetNamespaceManager();
+    }
+
+    /// <summary>
+    /// Tries to parse an untrusted, Base64-encoded <c>LogoutRequest</c> against the provider's primary
+    /// signing certificate OR an optional secondary certificate (the verification-key overlap window, #491),
+    /// returning <see langword="false"/> (rather than throwing) on the malformed-input the parse raises —
+    /// a non-base64 body, malformed XML, a prohibited DOCTYPE, or an unloadable configured certificate. The
+    /// caller rejects a false the same fail-closed way it rejects a failed signature (a uniform 400).
+    /// </summary>
+    /// <param name="certificateStr">The identity provider's primary signing certificate as a Base64 string.</param>
+    /// <param name="secondaryCertificateStr">The optional secondary certificate (Base64), or blank for none.</param>
+    /// <param name="requestString">The untrusted <c>SAMLRequest</c> (Base64).</param>
+    /// <param name="logoutRequest">The parsed request on success; otherwise <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the request parsed; otherwise <see langword="false"/>.</returns>
+    internal static bool TryParse(string certificateStr, string? secondaryCertificateStr, string? requestString, [NotNullWhen(true)] out SamlLogoutRequest? logoutRequest)
+    {
+        logoutRequest = null;
+
+        // A null/empty body is the most common malformed request (an absent SAMLRequest form field binds to
+        // null); reject it here rather than let Convert.FromBase64String(null) throw and escape as a 500.
+        if (string.IsNullOrEmpty(requestString))
+        {
+            return false;
+        }
+
+        // Reject an oversized body before decoding/parsing it — fail closed, no crypto or allocation spent on
+        // untrusted bulk (mirrors SamlResponseLoader.MaxEncodedResponseLength on the unauthenticated path).
+        if (requestString.Length > MaxEncodedRequestLength)
+        {
+            return false;
+        }
+
+        List<X509Certificate2>? certificates = null;
+        try
+        {
+            certificates = LoadCandidateCertificates(certificateStr, secondaryCertificateStr);
+            var xmlDoc = ParseRequestXml(requestString);
+            logoutRequest = new SamlLogoutRequest(certificates, xmlDoc);
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or XmlException or CryptographicException or ArgumentException)
+        {
+            // A malformed request body (FormatException/XmlException, incl. a prohibited DOCTYPE) or a
+            // null/garbage configured certificate (CryptographicException/ArgumentException) fails closed to a
+            // clean rejection here rather than an unhandled 500 — the same mapping SamlResponseLoader uses.
+            if (certificates != null)
+            {
+                foreach (var certificate in certificates)
+                {
+                    certificate.Dispose();
+                }
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Disposes the loaded identity-provider signing certificate(s): each <see cref="X509Certificate2"/>
+    /// wraps an unmanaged key handle, and one instance is constructed per inbound logout request. Disposal
+    /// must happen only AFTER the request is fully consumed (signature validation and every getter read),
+    /// because the candidate-certificate trial uses these certificates.
+    /// </summary>
+    public void Dispose()
+    {
+        foreach (var certificate in _certificates)
+        {
+            certificate.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Checks whether the request is valid: a single enveloped signature, at the position-bound root
+    /// location, whose one reference covers the LogoutRequest document root, whose algorithms are on the
+    /// allowlist, that verifies against a candidate certificate — AND, when the request carries a
+    /// <c>NotOnOrAfter</c>, that it has not expired (honoured when present, per SAML core §3.7). Fail-closed
+    /// on any missing/malformed piece.
+    /// </summary>
+    /// <returns>Whether the LogoutRequest is signature- and time-valid.</returns>
+    internal bool IsValid()
+    {
+        // Exactly one enveloped signature, at the position-bound root location only. Zero signatures (an
+        // unsigned request) or a signature relocated anywhere else is rejected before any cryptographic work.
+        var signatureNodes = _xmlDoc.SelectNodes(SignatureXPath, _xmlNameSpaceManager);
+        if (signatureNodes == null || signatureNodes.Count != 1)
+        {
+            return false;
+        }
+
+        try
+        {
+            var signatureElement = (XmlElement)signatureNodes[0]!;
+            var signedXml = new SignedXml(_xmlDoc);
+            signedXml.LoadXml(signatureElement);
+
+            if (!ValidateSignatureReference(signedXml, signatureElement)
+                || !IsSignatureAlgorithmAllowed(signedXml)
+                || !VerifiesAgainstCandidateCertificate(signedXml))
+            {
+                return false;
+            }
+
+            return IsWithinTimeBounds();
+        }
+        catch (Exception ex) when (ex is CryptographicException or ArgumentException or FormatException or XmlException)
+        {
+            // A malformed signature on this untrusted-input path is rejected as invalid rather than surfacing
+            // as an unhandled 500 (fail closed) — the same exception set SamlResponse.IsValid catches.
+            return false;
+        }
+    }
+
+    /// <summary>Gets the request's <c>ID</c> attribute, used for one-time-use (replay) enforcement.</summary>
+    /// <returns>The ID, or null when absent.</returns>
+    internal string? GetRequestId()
+    {
+        var id = (_xmlDoc.SelectSingleNode("/samlp:LogoutRequest", _xmlNameSpaceManager) as XmlElement)?.GetAttribute("ID");
+        return string.IsNullOrEmpty(id) ? null : id;
+    }
+
+    /// <summary>Gets the request's <c>saml:Issuer</c> value, or null when absent.</summary>
+    /// <returns>The Issuer, or null when absent.</returns>
+    internal string? GetIssuer()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:LogoutRequest/saml:Issuer", _xmlNameSpaceManager);
+        var issuer = node?.InnerText;
+        return string.IsNullOrEmpty(issuer) ? null : issuer;
+    }
+
+    /// <summary>
+    /// Gets the subject <c>saml:NameID</c> the request names — the value matched (exact ordinal) against the
+    /// captured login-time NameID to resolve which sessions to revoke. Direct child of the LogoutRequest root.
+    /// </summary>
+    /// <returns>The NameID, or null when absent.</returns>
+    internal string? GetNameId()
+    {
+        var node = _xmlDoc.SelectSingleNode("/samlp:LogoutRequest/saml:NameID", _xmlNameSpaceManager);
+        return node?.InnerText;
+    }
+
+    /// <summary>
+    /// Gets the zero-or-more <c>samlp:SessionIndex</c> values the request carries. An empty list means the
+    /// request names no specific session, so it targets every session of the subject (SAML core §3.7).
+    /// </summary>
+    /// <returns>The SessionIndex values in document order (possibly empty, never null).</returns>
+    internal IReadOnlyList<string> GetSessionIndexes()
+    {
+        var output = new List<string>();
+        var nodes = _xmlDoc.SelectNodes("/samlp:LogoutRequest/samlp:SessionIndex", _xmlNameSpaceManager);
+        if (nodes == null)
+        {
+            return output;
+        }
+
+        foreach (XmlNode node in nodes)
+        {
+            var value = node?.InnerText;
+            if (!string.IsNullOrEmpty(value))
+            {
+                output.Add(value);
+            }
+        }
+
+        return output;
+    }
+
+    /// <summary>Gets the request's <c>NotOnOrAfter</c> as UTC, or null when the request declares none.</summary>
+    /// <returns>The parsed UTC upper bound, or null when absent or unparseable.</returns>
+    internal DateTime? GetNotOnOrAfter()
+    {
+        var raw = (_xmlDoc.SelectSingleNode("/samlp:LogoutRequest", _xmlNameSpaceManager) as XmlElement)?.GetAttribute("NotOnOrAfter");
+        return !string.IsNullOrEmpty(raw) && SamlAssertionTime.TryParseUtc(raw, out var parsed) ? parsed : null;
+    }
+
+    // Loads the candidate identity-provider signing certificates: the primary always, the optional secondary
+    // only when configured (#491). Identical policy to SamlResponse.LoadCandidateCertificates — both are the
+    // IdP's PUBLIC signing certificate, and an unloadable value throws the same load exceptions TryParse maps.
+    private static List<X509Certificate2> LoadCandidateCertificates(string certificateStr, string? secondaryCertificateStr)
+    {
+        var certificates = new List<X509Certificate2>
+        {
+            X509CertificateLoader.LoadCertificate(Convert.FromBase64String(certificateStr)),
+        };
+
+        if (!string.IsNullOrWhiteSpace(secondaryCertificateStr))
+        {
+            certificates.Add(X509CertificateLoader.LoadCertificate(Convert.FromBase64String(secondaryCertificateStr)));
+        }
+
+        return certificates;
+    }
+
+    // Parses the untrusted, Base64-encoded LogoutRequest into a hardened XmlDocument. The DTD-prohibit /
+    // PreserveWhitespace / null-resolver / size-cap hardening is IDENTICAL to SamlResponse.ParseResponseXml —
+    // PreserveWhitespace is load-bearing for signature canonicalization, DtdProcessing.Prohibit blocks the
+    // billion-laughs/XXE class, and MaxCharactersInDocument bounds the DOM on the pre-signature path.
+    private static XmlDocument ParseRequestXml(string base64Request)
+    {
+        var xml = Encoding.UTF8.GetString(Convert.FromBase64String(base64Request));
+
+        var xmlDoc = new XmlDocument
+        {
+            PreserveWhitespace = true,
+            XmlResolver = null,
+        };
+
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = 256 * 1024,
+        };
+        using (var stringReader = new StringReader(xml))
+        using (var reader = XmlReader.Create(stringReader, settings))
+        {
+            xmlDoc.Load(reader);
+        }
+
+        return xmlDoc;
+    }
+
+    // A single same-document reference is required, and it must cover the LogoutRequest document root — the
+    // element whose NameID/SessionIndex/ID are actually read. .NET's CheckSignature validates the digest but
+    // not WHAT is signed, so without this a signature over a smuggled sibling would pass (signature-wrapping).
+    // The signature must additionally be enveloped inside the root it covers. Mirrors
+    // SamlResponse.ValidateSignatureReference, narrowed to the single permitted covered element (the root).
+    private bool ValidateSignatureReference(SignedXml signedXml, XmlElement signatureElement)
+    {
+        var signedInfo = signedXml.SignedInfo;
+        if (signedInfo is null || signedInfo.References.Count != 1)
+        {
+            return false;
+        }
+
+        var reference = (Reference)signedInfo.References[0]!;
+
+        // A same-document ID reference only ("#id"); an empty (whole-document "") or external URI is rejected.
+        var referenceUri = reference.Uri;
+        if (string.IsNullOrEmpty(referenceUri) || referenceUri[0] != '#')
+        {
+            return false;
+        }
+
+        var idElement = signedXml.GetIdElement(_xmlDoc, referenceUri.Substring(1));
+        if (idElement == null || idElement != _xmlDoc.DocumentElement)
+        {
+            return false;
+        }
+
+        return IsEnvelopedWithin(signatureElement, idElement);
+    }
+
+    // Whether the signature element is a descendant of the element its reference covers (an enveloped
+    // signature sits inside the element it signs). Identical to SamlResponse.IsEnvelopedWithin.
+    private static bool IsEnvelopedWithin(XmlElement signatureElement, XmlElement signedElement)
+    {
+        for (var parent = signatureElement.ParentNode; parent != null; parent = parent.ParentNode)
+        {
+            if (parent == signedElement)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Rejects weak/legacy signature and digest algorithms (RSA-SHA1, SHA-1 digest) and any
+    // canonicalization/transform outside the comment-free-C14N + enveloped-signature allowlist, by delegating
+    // to the SHARED SamlSignatureAlgorithms allowlist — the SAME lists the login path enforces, never a copy.
+    private static bool IsSignatureAlgorithmAllowed(SignedXml signedXml)
+    {
+        var signedInfo = signedXml.SignedInfo;
+        if (signedInfo is null)
+        {
+            return false;
+        }
+
+        if (!SamlSignatureAlgorithms.IsCanonicalizationAllowed(signedInfo.CanonicalizationMethod ?? string.Empty))
+        {
+            return false;
+        }
+
+        var digestMethods = new List<string>();
+        foreach (Reference reference in signedInfo.References)
+        {
+            var transforms = new List<string>();
+            foreach (Transform transform in reference.TransformChain)
+            {
+                transforms.Add(transform.Algorithm ?? string.Empty);
+            }
+
+            if (!SamlSignatureAlgorithms.AreTransformsAllowed(transforms))
+            {
+                return false;
+            }
+
+            digestMethods.Add(reference.DigestMethod ?? string.Empty);
+        }
+
+        return SamlSignatureAlgorithms.IsAllowed(signedInfo.SignatureMethod ?? string.Empty, digestMethods);
+    }
+
+    // The signature must verify against at least one candidate certificate that is CURRENTLY within its
+    // validity window and meets the shared signing-key strength floor. Only the cryptographic key trial spans
+    // the primary and optional secondary; the reference/algorithm binding above runs cert-independently.
+    // Delegates the strength floor to the SHARED SamlCertificate.HasAcceptableSigningKey — never a copy.
+    private bool VerifiesAgainstCandidateCertificate(SignedXml signedXml)
+    {
+        var utcNow = DateTime.UtcNow;
+        foreach (var certificate in _certificates)
+        {
+            if (SamlCertificate.HasAcceptableSigningKey(certificate)
+                && IsWithinValidityPeriod(certificate, utcNow)
+                && signedXml.CheckSignature(certificate, true))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Whether the certificate is within its own [NotBefore, NotAfter] window at verification time, with the
+    // shared clock-skew tolerance on both edges. Identical to SamlResponse.IsWithinValidityPeriod.
+    private static bool IsWithinValidityPeriod(X509Certificate2 certificate, DateTime utcNow)
+    {
+        return utcNow >= certificate.NotBefore.ToUniversalTime() - SamlAssertionTime.ClockSkew
+            && utcNow <= certificate.NotAfter.ToUniversalTime() + SamlAssertionTime.ClockSkew;
+    }
+
+    // Time-bounding for a LogoutRequest: NotOnOrAfter is OPTIONAL (unlike an assertion, which must carry an
+    // upper bound). When absent, the request is time-unbounded and accepted (replay one-time-use is the DoS
+    // backstop). When present, it is honoured with the shared clock skew — a stale request is rejected.
+    private bool IsWithinTimeBounds()
+    {
+        var raw = (_xmlDoc.SelectSingleNode("/samlp:LogoutRequest", _xmlNameSpaceManager) as XmlElement)?.GetAttribute("NotOnOrAfter");
+        if (string.IsNullOrEmpty(raw))
+        {
+            return true;
+        }
+
+        if (!SamlAssertionTime.TryParseUtc(raw, out var notOnOrAfter))
+        {
+            // Present but unparseable -> fail closed, exactly as SamlAssertionTime treats a bad upper bound.
+            return false;
+        }
+
+        // NotOnOrAfter is an exclusive upper bound; apply the skew to "now" so a small IdP/SP clock difference
+        // does not spuriously reject an otherwise-valid request.
+        return DateTime.UtcNow - SamlAssertionTime.ClockSkew < notOnOrAfter;
+    }
+
+    private XmlNamespaceManager GetNamespaceManager()
+    {
+        var manager = new XmlNamespaceManager(_xmlDoc.NameTable);
+        manager.AddNamespace("ds", SignedXml.XmlDsigNamespaceUrl);
+        manager.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        manager.AddNamespace("samlp", "urn:oasis:names:tc:SAML:2.0:protocol");
+
+        return manager;
+    }
+}

--- a/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// Orchestrates the inbound IdP-initiated SAML <c>LogoutRequest</c> validation (#727, SLO-3b): parse plus
+/// signature/time validation (<see cref="SamlLogoutRequest"/>) followed by the one-time-use (replay)
+/// consume of the request <c>ID</c>. It is the SAML-logout analogue of
+/// <see cref="SamlAssertionValidator"/> — it owns the process-wide replay cache as a <c>static readonly</c>
+/// field, so the controller endpoint that calls it holds no mutable static state, and reuses the SHARED
+/// <see cref="SamlReplayCache"/> primitive rather than a copy.
+/// </summary>
+/// <remarks>
+/// On success the caller receives the validated NameID and SessionIndex list; on failure it receives a
+/// FIXED reason code (never request-derived text) for the audit trail. The reason is server-side only — the
+/// endpoint renders every failure as one uniform 400, so the caller cannot tell the causes apart.
+/// </remarks>
+internal sealed class SamlLogoutValidator
+{
+    // One-time-use tracking for consumed LogoutRequest IDs (replay protection), process-wide exactly like the
+    // login-path SamlAssertionValidator.SamlReplays — a captured LogoutRequest must not revoke twice.
+    private static readonly SamlReplayCache LogoutReplays = new SamlReplayCache();
+
+    /// <summary>
+    /// Test-only. Clears the process-wide one-time replay cache between tests so a consumed request ID does
+    /// not leak into a sibling test (mirrors <see cref="SamlAssertionValidator.ResetReplaysForTests"/>).
+    /// </summary>
+    internal static void ResetReplaysForTests() => LogoutReplays.Clear();
+
+    /// <summary>
+    /// Parses and fully validates an inbound <c>LogoutRequest</c> for a provider: signature (against the
+    /// provider's configured primary/secondary certificate), the optional <c>NotOnOrAfter</c> time bound,
+    /// and one-time use of the request ID. Fail-closed: any failure returns <see langword="false"/> with a
+    /// fixed <paramref name="reasonCode"/> and no resolved subject.
+    /// </summary>
+    /// <param name="config">The SAML provider configuration (signing certificate(s)).</param>
+    /// <param name="provider">The provider the request arrived for (scopes the replay key so two IdPs cannot block each other).</param>
+    /// <param name="rawRequest">The untrusted, Base64-encoded <c>SAMLRequest</c>.</param>
+    /// <param name="nowUtc">The current UTC time (supplied for determinism).</param>
+    /// <param name="nameId">On success, the subject NameID the request names.</param>
+    /// <param name="sessionIndexes">On success, the SessionIndex values the request carries (possibly empty).</param>
+    /// <param name="reasonCode">On failure, a fixed audit reason code; empty on success.</param>
+    /// <returns><see langword="true"/> when the request is fully valid; otherwise <see langword="false"/>.</returns>
+    internal bool TryValidate(
+        SamlConfig config,
+        string provider,
+        string? rawRequest,
+        DateTime nowUtc,
+        out string nameId,
+        out IReadOnlyList<string> sessionIndexes,
+        out string reasonCode)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        nameId = string.Empty;
+        sessionIndexes = Array.Empty<string>();
+
+        if (!SamlLogoutRequest.TryParse(config.SamlCertificate ?? string.Empty, config.SamlSecondaryCertificate, rawRequest, out var logoutRequest))
+        {
+            reasonCode = RejectReason.Malformed;
+            return false;
+        }
+
+        // The parsed request owns an unmanaged certificate handle; dispose it on every path.
+        using var owned = logoutRequest;
+
+        // Signature + time-bound validation. An unsigned, wrong-key, wrapped, weak-algorithm or expired
+        // request fails here, before any subject is exposed or any replay slot is consumed.
+        if (!logoutRequest.IsValid())
+        {
+            reasonCode = RejectReason.Invalid;
+            return false;
+        }
+
+        // A validated request with no usable NameID resolves no subject — reject rather than fall through to a
+        // blank-subject lookup (SessionLogoutStore.FindByProviderSubject also refuses a blank subject, but the
+        // guard here keeps the contract explicit and fail-closed).
+        var resolvedNameId = logoutRequest.GetNameId();
+        if (string.IsNullOrEmpty(resolvedNameId))
+        {
+            reasonCode = RejectReason.Invalid;
+            return false;
+        }
+
+        // One-time use: consume the request ID so a captured LogoutRequest cannot be replayed to revoke again.
+        // Retained for the request's own NotOnOrAfter window (or the one-hour floor when it carries none), the
+        // same retention policy the login replay path uses. A missing ID fails closed inside TryConsume.
+        //
+        // DELIBERATE ORDERING — consume at validation time, BEFORE the endpoint's revoke, not only on a
+        // successful revoke (#727). A signed LogoutRequest is single-use by design regardless of downstream
+        // outcome, mirroring the login-side SamlAssertionValidator consume. Two reasons this is the more
+        // correct SLO semantic than a consume-on-success: (1) TryConsume is the ATOMIC claim that serialises
+        // concurrent copies of the same request — without it two in-flight copies could both resolve and
+        // revoke and race on removing store entries; (2) revocation is idempotent and a real IdP mints a FRESH
+        // request ID per retry, so burning the ID on a transient revoke fault blocks no genuine retry — the
+        // endpoint additionally leaves the matched entries in the store on a revoke fault, so a fresh-ID retry
+        // still finds and acts on them. Replay protection here is a hygiene/DoS bound, not a session-minting
+        // gate, so single-use-regardless is the safe default.
+        var retention = SamlReplayCache.ComputeRetention(nowUtc, logoutRequest.GetNotOnOrAfter());
+        var replayKey = ProviderScopedKey.For(provider, logoutRequest.GetRequestId());
+        if (!LogoutReplays.TryConsume(replayKey, retention, nowUtc, out _))
+        {
+            reasonCode = RejectReason.Replay;
+            return false;
+        }
+
+        nameId = resolvedNameId;
+        sessionIndexes = logoutRequest.GetSessionIndexes();
+        reasonCode = string.Empty;
+        return true;
+    }
+
+    /// <summary>The fixed audit reason codes for a rejected logout request; never request-derived text.</summary>
+    internal static class RejectReason
+    {
+        /// <summary>The body did not parse (non-base64, malformed XML, prohibited DOCTYPE, or an unloadable configured certificate).</summary>
+        internal const string Malformed = "malformed";
+
+        /// <summary>The signature or time-bound validation failed (unsigned, wrong key, wrapped, weak algorithm, expired).</summary>
+        internal const string Invalid = "signature_or_time_invalid";
+
+        /// <summary>The request ID was already consumed (a replay) or absent.</summary>
+        internal const string Replay = "replay";
+    }
+}

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -8,8 +8,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Shared;
 /// folds the class into the limiter key as <c>class + ":" + clientKey</c>, so each value here names one
 /// independent budget: the anonymous login stages (<see cref="Challenge"/>/<see cref="Callback"/>/<see cref="Auth"/>),
 /// the elevation-gated Test-connection probe (<see cref="Test"/>), the anonymous SP-metadata read
-/// (<see cref="Metadata"/>), the admin SSO-revoke (<see cref="Unregister"/>, #516), and the authenticated
-/// link/unlink write surface (<see cref="Link"/>, #382). These are named constants rather than bare string
+/// (<see cref="Metadata"/>), the admin SSO-revoke (<see cref="Unregister"/>, #516), the authenticated
+/// link/unlink write surface (<see cref="Link"/>, #382), and the Single Logout surface
+/// (<see cref="Logout"/>, #727). These are named constants rather than bare string
 /// literals at the call sites precisely because the value is LOAD-BEARING on the limiter grouping: a typo in a
 /// literal ("challange") compiles cleanly and silently mints a separate, empty bucket, weakening the rate limit
 /// undetectably. Referencing a member instead makes a typo a compile error, and the
@@ -39,4 +40,7 @@ internal static class SsoRateLimitClass
 
     /// <summary>The authenticated account link/unlink write surface (#382).</summary>
     internal const string Link = "link";
+
+    /// <summary>The anonymous inbound SAML <c>LogoutRequest</c> Single Logout surface (#727, SLO-3b). (The authenticated OIDC RP-initiated logout route is caller-scoped and not rate-limited today.)</summary>
+    internal const string Logout = "logout";
 }


### PR DESCRIPTION
## What & why

**SLO-3b** of #727: the IdP-initiated SAML Single-Logout endpoint
(`POST SAML/Logout/{provider}`). An **unauthenticated, session-destructive**
surface, validated fail-closed exactly like the login path, STRIDE
threat-modelled (the mitigations posted on #727 are the test list).

- **`SamlLogoutRequest`**, parses + validates against the provider's cert(s),
  mirroring `SamlResponse` on the `samlp:LogoutRequest` root: hardened parse
  (DtdProcessing.Prohibit, resolver-null, 256 KB bound), exactly-one enveloped
  signature at the position-bound root, single-reference-covers-root +
  enveloped-within wrapping defense, the shared algorithm allowlist (no
  SHA-1/MD5) over signature/digest/transforms/c14n, candidate-cert trial with
  validity-window + strength-floor, optional `NotOnOrAfter`. NameID/SessionIndex/ID
  are read only from the signed region. **No crypto copied**, reuses
  `SamlSignatureAlgorithms`/`SamlCertificate`/`SamlReplayCache`/`SamlAssertionTime`/
  `ProviderScopedKey`; `SamlResponse` untouched.
- **`SamlLogoutValidator`**, parse → signature/time → one-time-use replay
  consume (provider-scoped), fixed reason code per branch.
- **Endpoint**, POST-only, `EnableSingleLogout`-gated (off → reject without
  parsing), rate-limited via the new `SsoRateLimitClass.Logout`. Resolves
  sessions by `(provider, NameID)`, filters to the request's SessionIndex set
  (a null-index session is never matched by an indexed request; no SessionIndex
  → subject-wide, per SAML core §3.7), revokes each distinct user in a fail-safe
  loop. **A 200 is returned only when ≥1 user was actually revoked**, matched
  but all-faulted fails closed (uniform 400, entries retained for retry). Store
  entries removed only for successfully-revoked users. Every rejection is a
  byte-identical uniform 400 (no cause oracle).

## Security checklist

- [x] Signature/wrapping/downgrade/replay/DTD each defended in the domain with
  a negative test; unsigned/forged never revokes.
- [x] Blast-radius bounded to `(provider, subject)`; ordinal-exact subject
  match; no cross-subject/provider/all-user sweep.
- [x] **Logout integrity:** 200 ⇒ ≥1 token actually revoked (the review's one
  real finding, a 200 on zero revokes, is fixed and pinned).
- [x] Fail-safe revoke loop; replay is a single-use hygiene bound (consume-
  before-revoke, rationale documented; a real IdP retries with a fresh ID).
- [x] Audited by reason code; NameID/SessionIndex never logged raw.
- [x] Adversarial **bypass-lens: PASS**; **correctness-lens** findings fixed +
  re-reviewed.

## Quality checklist

- [x] 30 tests (a negative per fail-closed branch + blast-radius + revoke-fault
  fail-safe + uniform-body); suite green **1826/1826** both TFMs; both projects
  0/0 `--warnaserror`; commit DCO-signed. Conformance `RateLimitCheck` sentinel
  bumped 12→13 (real new call site).

Refs #727 (SLO-4 = logout audit polish + config validator + admin UI;
SLO-3c = SP-initiated outbound + signed LogoutResponse; SLO-5 = SECURITY.md +
full /security-review - the remaining checklist items on the issue)