### PR TITLE
Surface the Single-Logout settings in the admin config page [#727]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1437,7 +1437,7 @@ public class ArchitectureConformanceTests
         // The full save-contract roster, pinned after the #365 provider-workspace redesign reordered and
         // regrouped the form into native accordion sections. ProviderFormFieldIds_MatchOidConfigProperties
         // guards the FORWARD direction (no stray marked id) and a reverse pin for the security-critical
-        // SUBSET; this test is the exhaustive reverse pin: every one of the 41 persisting fields must still
+        // SUBSET; this test is the exhaustive reverse pin: every one of the 42 persisting fields must still
         // render as a marked input with its exact id, so a field silently dropped or unmarked during a
         // future re-layout — which would stop it persisting — fails here rather than shipping as silent data
         // loss. The provider-name KEY input (OidProviderName) is deliberately unmarked (it supplies the
@@ -1478,10 +1478,10 @@ public class ArchitectureConformanceTests
             "RequirePkce", "AllowExistingAccountLink", "ProvisionNewUsersDisabled", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
             "AcrValues", "Prompt", "MaxAge", "RequireAcr",
             "DisableHttps", "DisablePushedAuthorization", "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
-            "HideLoginButton", "LoginButtonText",
+            "HideLoginButton", "LoginButtonText", "PostLogoutRedirectUri",
         };
 
-        Assert.Equal(41, expected.Length);
+        Assert.Equal(42, expected.Length);
         var missing = expected.Where(id => !markedIds.Contains(id)).ToList();
         Assert.True(
             missing.Count == 0,

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -170,6 +170,82 @@ public class ProviderConfigValidatorTests
         Assert.Null(ex);
     }
 
+    // --- ValidatePostLogoutRedirectUri (#727, SLO-4): reject a set value the runtime would silently drop ---
+
+    private const string PostLogoutBase = "https://jellyfin.example.com";
+
+    // PostLogoutRedirectUri is an OpenID-only concept (only OidcLogout consumes it; the SAML LogoutRequest
+    // path just revokes and returns), so ProviderConfigValidator.Validate runs this only over the OpenID
+    // providers — hence every case here uses the "OpenID" protocol label.
+    [Theory]
+    [InlineData("https://evil.example.net/steal")] // off-base: a different authority
+    [InlineData("https://jellyfin.example.com.evil.net/")] // sibling-prefix host: still off-base
+    [InlineData("not-a-url")] // malformed: not an absolute URL
+    [InlineData("ftp://jellyfin.example.com/x")] // absolute but not http(s)
+    [InlineData("https://user:pass@jellyfin.example.com/")] // userinfo can mask the real host
+    public void ValidatePostLogoutRedirectUri_SetButNotAtOrUnderBase_ThrowsNamingProtocolAndProvider(string postLogoutRedirectUri)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", PostLogoutBase, postLogoutRedirectUri));
+
+        Assert.Equal("postLogoutRedirectUri", ex.ParamName);
+        Assert.Contains("OpenID", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("not at or under the configured Base URL", ex.Message, StringComparison.Ordinal);
+        // Message discipline (RejectInvalid*): the rejected candidate value is NOT echoed back, so a hostile
+        // value cannot ride the exception into any log the controller surfaces.
+        Assert.DoesNotContain(postLogoutRedirectUri, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("https://jellyfin.example.com/web/")] // under the base path
+    [InlineData("https://jellyfin.example.com")] // the base itself
+    [InlineData("https://jellyfin.example.com/sso/goodbye")] // a deeper path under the base
+    public void ValidatePostLogoutRedirectUri_AtOrUnderBase_DoesNotThrow(string postLogoutRedirectUri)
+    {
+        var ex = Record.Exception(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", PostLogoutBase, postLogoutRedirectUri));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")] // blank means no post-logout redirect — always valid
+    public void ValidatePostLogoutRedirectUri_Blank_DoesNotThrow(string? postLogoutRedirectUri)
+    {
+        var ex = Record.Exception(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", PostLogoutBase, postLogoutRedirectUri));
+
+        Assert.Null(ex);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidatePostLogoutRedirectUri_NoDeterminateBase_DoesNotThrowEvenForAnOffBaseValue(string? baseUrlOverride)
+    {
+        // Without a Base URL Override the canonical base is derived from the request Host at logout time and is
+        // unknowable at save; the runtime allow-list stays the only check, so the save does not reject a value
+        // it cannot evaluate against the same base the runtime will use. An external URL passes here by design.
+        var ex = Record.Exception(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", baseUrlOverride, "https://evil.example.net/steal"));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void ValidatePostLogoutRedirectUri_ControlCharacterInProvider_IsStrippedFromTheEchoedMessage()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "co\nrp", PostLogoutBase, "https://evil.example.net/"));
+
+        Assert.DoesNotContain('\n', ex.Message);
+        Assert.DoesNotContain('\r', ex.Message);
+    }
+
     // --- ValidateSamlCertificate (#206): reject a set-but-unloadable X.509; blank/valid pass ---
 
     [Theory]

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -85,4 +85,39 @@ public class OidcLogoutTests
         var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, null, "c", null, Base);
         Assert.Equal(EndSession + "?client_id=c", url);
     }
+
+    // The allow-list predicate is now internal and reused by the config-page save validator (#727, SLO-4), so
+    // pin its contract directly — it is the single source of truth both the runtime builder above and
+    // ProviderConfigValidator.ValidatePostLogoutRedirectUri call.
+
+    [Theory]
+    [InlineData("https://jellyfin.example.com")] // the base itself
+    [InlineData("https://jellyfin.example.com/web/")] // under the base path
+    public void IsAllowedPostLogoutRedirect_AtOrUnderBase_IsAllowed_AndReturnsTheCandidate(string candidate)
+    {
+        Assert.True(OidcLogout.IsAllowedPostLogoutRedirect(candidate, Base, out var allowed));
+        Assert.Equal(candidate, allowed);
+    }
+
+    [Theory]
+    [InlineData("https://evil.example.net/steal")] // different authority
+    [InlineData("https://jellyfin.example.com.evil.net/")] // sibling-prefix host
+    [InlineData("not-a-url")] // not absolute
+    [InlineData("ftp://jellyfin.example.com/x")] // not http(s)
+    [InlineData("https://user:pass@jellyfin.example.com/")] // userinfo
+    [InlineData("")] // blank candidate
+    public void IsAllowedPostLogoutRedirect_OffBaseOrMalformedOrBlank_IsRejected_WithEmptyOut(string candidate)
+    {
+        Assert.False(OidcLogout.IsAllowedPostLogoutRedirect(candidate, Base, out var allowed));
+        Assert.Equal(string.Empty, allowed);
+    }
+
+    [Fact]
+    public void IsAllowedPostLogoutRedirect_BlankBase_IsRejected()
+    {
+        // A blank canonical base cannot allow-list anything (the save validator relies on this to skip the
+        // check when no Base URL Override pins a determinate base).
+        Assert.False(OidcLogout.IsAllowedPostLogoutRedirect(Base, null, out var allowed));
+        Assert.Equal(string.Empty, allowed);
+    }
 }

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -104,9 +104,20 @@ internal static class OidcLogout
             && string.Equals(a.Host, b.Host, StringComparison.OrdinalIgnoreCase)
             && a.Port == b.Port;
 
-    // The return URL is allowed only when it normalizes to a valid base and sits at or under the server's
-    // canonical base (same origin + path prefix), so logout can only return to this Jellyfin.
-    private static bool IsAllowedPostLogoutRedirect(string? candidate, string? canonicalBaseUrl, out string allowed)
+    /// <summary>
+    /// Whether a <c>post_logout_redirect_uri</c> candidate is allowed: it normalizes to a valid http(s) URL
+    /// with no userinfo and sits at or under this server's <paramref name="canonicalBaseUrl"/> (same origin +
+    /// path prefix), so a logout can only return the browser to this Jellyfin. The SINGLE source of truth for
+    /// the return-URL rule — the runtime builder above and the save-time
+    /// <c>ProviderConfigValidator.ValidatePostLogoutRedirectUri</c> both call it, so the config-page save
+    /// rejects exactly the values the runtime would silently drop (no second, divergent URL rule). A blank
+    /// candidate or blank base yields <see langword="false"/>.
+    /// </summary>
+    /// <param name="candidate">The desired post-logout return URL (may be null/blank).</param>
+    /// <param name="canonicalBaseUrl">This server's canonical base, the allow-list root.</param>
+    /// <param name="allowed">The accepted return URL when the result is <see langword="true"/>, else empty.</param>
+    /// <returns><see langword="true"/> if the candidate is a return URL at or under the canonical base.</returns>
+    internal static bool IsAllowedPostLogoutRedirect(string? candidate, string? canonicalBaseUrl, out string allowed)
     {
         allowed = string.Empty;
         if (string.IsNullOrWhiteSpace(candidate)

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 
@@ -17,6 +18,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// by composing the per-provider checks below; those per-provider methods are also exercised directly,
 /// one predicate at a time, by the unit tests (hence internal, not private). The single source of truth
 /// is the underlying <see cref="CanonicalBaseUrl.IsInvalidOverride"/>,
+/// <see cref="OidcLogout.IsAllowedPostLogoutRedirect"/> (the SAME allow-list the logout runtime enforces),
 /// <see cref="SamlCertificate.IsInvalid"/>, <see cref="SamlSigningKey.IsInvalid"/>, and
 /// <see cref="ProviderNameValidator.IsInvalid"/> predicates — the SAME ones the Add endpoints' own
 /// guards (<c>SSOController.RejectInvalid*</c>) delegate to. The two admin write paths keep separate
@@ -57,6 +59,7 @@ internal static class ProviderConfigValidator
             {
                 ValidateProviderName("OpenID", kvp.Key, isNew: live?.OidConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride);
+                ValidatePostLogoutRedirectUri("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride, kvp.Value?.PostLogoutRedirectUri);
                 ValidatePermissionRoleMappings("OpenID", kvp.Key, kvp.Value?.PermissionRoleMappings);
                 ValidateParentalRatingMappings("OpenID", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
                 ValidateAcrRequirement(kvp.Key, kvp.Value);
@@ -157,6 +160,51 @@ internal static class ProviderConfigValidator
             throw new ArgumentException(
                 $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid Base URL override; it must be an absolute http(s) URL such as https://jellyfin.example.com.",
                 nameof(baseUrlOverride));
+        }
+    }
+
+    // A post_logout_redirect_uri that is set but not at/under this server's canonical base is silently
+    // dropped at logout (OidcLogout omits it and the logout completes with no redirect back), so the admin
+    // gets no feedback that their configured return URL never fires (#727, SLO-4). Reject it at save so the
+    // mis-set is caught instead of failing as a silent runtime no-op. The base is only DETERMINATE at save
+    // time when it is pinned via the per-provider Base URL Override — without an override the runtime derives
+    // it from the request Host, which does not exist at save time — so the check applies exactly when the
+    // canonical base is knowable from the config alone, and it reuses the SAME allow-list predicate the
+    // runtime enforces (OidcLogout.IsAllowedPostLogoutRedirect) rather than restating the URL rule. The
+    // provider name is line-ending-stripped inline in case it reaches a log through the thrown exception, and
+    // the candidate value is deliberately NOT echoed (RejectInvalid* message discipline). OpenID-only: only
+    // the OpenID logout path consumes post_logout_redirect_uri, so Validate runs this only over OidConfigs
+    // (the property lives on the shared base but no SAML runtime path honours it).
+
+    /// <summary>
+    /// Rejects a non-blank <c>post_logout_redirect_uri</c> (#727, SLO-4) that the runtime would silently drop
+    /// — i.e. one that is not an absolute http(s) URL at or under this server's canonical base — so the admin
+    /// gets feedback instead of a return URL that never fires. OpenID-only (only the OpenID logout path uses
+    /// it). The base is taken from the provider's Base URL Override; when no override pins it (the base is
+    /// request-derived and unknown at save time) the check is skipped, leaving the runtime allow-list as the
+    /// sole check. A blank value is valid (no post-logout redirect). Reuses
+    /// <see cref="OidcLogout.IsAllowedPostLogoutRedirect"/>, the one allow-list predicate.
+    /// </summary>
+    /// <param name="protocol">The protocol label (always "OpenID") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="baseUrlOverride">The provider's canonical base-URL override; only a valid override makes the base determinate at save time.</param>
+    /// <param name="postLogoutRedirectUri">The configured post-logout return URL to check.</param>
+    /// <exception cref="ArgumentException">The value is non-blank, the base is determinate, and the value is not at/under it.</exception>
+    internal static void ValidatePostLogoutRedirectUri(string protocol, string provider, string? baseUrlOverride, string? postLogoutRedirectUri)
+    {
+        // Blank means no post-logout redirect — always valid. Without a determinate canonical base the
+        // runtime's own allow-list stays the only check (the base is the request Host, unknown here).
+        if (string.IsNullOrWhiteSpace(postLogoutRedirectUri)
+            || !CanonicalBaseUrl.TryNormalize(baseUrlOverride, out var canonicalBase))
+        {
+            return;
+        }
+
+        if (!OidcLogout.IsAllowedPostLogoutRedirect(postLogoutRedirectUri, canonicalBase, out _))
+        {
+            throw new ArgumentException(
+                $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has a Post Logout Redirect URI that is not at or under the configured Base URL; it must be an absolute http(s) URL at or under this server's base URL, or it is ignored at logout. Leave it blank for no post-logout redirect.",
+                nameof(postLogoutRedirectUri));
         }
     }
 

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -182,6 +182,12 @@ const ssoConfigurationPage = {
         page.querySelector("#ManageLoginPageButtons").checked = Boolean(
           config.ManageLoginPageButtons,
         );
+        // The GLOBAL Single Logout opt-in (#727) rides the same configuration load. Like
+        // ManageLoginPageButtons it is a root PluginConfiguration flag, not a provider field, so it has its
+        // own save path (saveSingleLogout) and no sso-* marker class.
+        page.querySelector("#EnableSingleLogout").checked = Boolean(
+          config.EnableSingleLogout,
+        );
       },
     );
 
@@ -1017,6 +1023,39 @@ const ssoConfigurationPage = {
               title: "Save failed",
               message:
                 "Could not save the login-page button setting. The saved configuration was rejected by the server; reload the page and try again.",
+            });
+          },
+        );
+      },
+    );
+  },
+  // Save the GLOBAL Single Logout opt-in (#727). EnableSingleLogout is a root PluginConfiguration flag, so
+  // — exactly like saveLoginButtons — this fetches the live configuration, changes ONLY this flag, and
+  // re-posts the whole document, so the provider dictionaries and every other root setting ride along
+  // unchanged. The per-provider post-logout redirect URL is saved with its provider, not here.
+  saveSingleLogout: (page) => {
+    ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
+      (config) => {
+        config.EnableSingleLogout = page.querySelector(
+          "#EnableSingleLogout",
+        ).checked;
+
+        ApiClient.updatePluginConfiguration(
+          ssoConfigurationPage.pluginUniqueId,
+          config,
+        ).then(
+          function (result) {
+            Dashboard.processPluginConfigurationUpdateResult(result);
+            ssoConfigurationPage.loadConfiguration(page);
+            Dashboard.alert("Settings saved.");
+          },
+          // Report a genuine save failure rather than swallowing it: this PUT re-posts the whole
+          // configuration, so the server can reject it for a reason unrelated to this toggle (#336).
+          function () {
+            Dashboard.alert({
+              title: "Save failed",
+              message:
+                "Could not save the Single Logout setting. The saved configuration was rejected by the server; reload the page and try again.",
             });
           },
         );
@@ -2281,6 +2320,12 @@ export default function initSsoConfigurationPage(view) {
 
   view.querySelector("#SaveLoginButtons").addEventListener("click", (e) => {
     ssoConfigurationPage.saveLoginButtons(view);
+    e.preventDefault();
+    return false;
+  });
+
+  view.querySelector("#SaveSingleLogout").addEventListener("click", (e) => {
+    ssoConfigurationPage.saveSingleLogout(view);
     e.preventDefault();
     return false;
   });

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -267,6 +267,60 @@
           </form>
 
           <!--
+            Single Logout (#727) — GLOBAL setting. EnableSingleLogout lives on the root PluginConfiguration,
+            not on a provider, so — like ManageLoginPageButtons above — it sits OUTSIDE both provider forms and
+            carries NO sso-* marker class: it is saved by its own handler (config.js saveSingleLogout), which
+            re-posts the whole configuration with only this flag changed, and loaded by loadConfiguration. The
+            per-provider return URL (PostLogoutRedirectUri) is an ordinary persisting provider-form field in
+            each editor below.
+          -->
+          <form id="sso-single-logout" class="esqConfigurationForm">
+            <div
+              class="verticalSection"
+              is="emby-collapse"
+              title="Single Logout"
+            >
+              <div class="collapseContent">
+                <div
+                  class="checkboxContainer checkboxContainer-withDescription"
+                >
+                  <label>
+                    <input
+                      is="emby-checkbox"
+                      id="EnableSingleLogout"
+                      name="EnableSingleLogout"
+                      type="checkbox"
+                    />
+                    <span>Enable Single Logout</span>
+                  </label>
+                  <div class="fieldDescription checkboxFieldDescription">
+                    Off by default. When on, each successful login stores the
+                    per-session state a logout needs, and two logout surfaces
+                    become active: the RP-initiated OpenID logout route (which
+                    ends the linked Jellyfin session and can redirect the
+                    browser on to the identity provider's end-session endpoint)
+                    and the inbound SAML LogoutRequest endpoint (which ends the
+                    Jellyfin session matched by the request). While off, no
+                    per-session logout state is captured and both surfaces
+                    reject; local Jellyfin logout is unaffected either way. Set
+                    each OpenID provider's optional post-logout redirect URL in
+                    its editor below.
+                  </div>
+                </div>
+
+                <button
+                  id="SaveSingleLogout"
+                  is="emby-button"
+                  type="button"
+                  class="raised button-submit block emby-button"
+                >
+                  <span>Save</span>
+                </button>
+              </div>
+            </div>
+          </form>
+
+          <!--
             Provider workspace (#365 UI redesign). The provider LIST replaces the old select -> Load flow:
             each saved OpenID provider is a card (name + type badge + enabled/disabled pill); clicking a card
             loads it into the editor below. The hidden <select id="selectProvider"> is retained as the state
@@ -698,6 +752,30 @@
                       effect while the global "Manage login buttons on the login
                       page" option is on and the button is not hidden; any text
                       is safe — it is always rendered inert, never as markup.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
+                      for="PostLogoutRedirectUri"
+                      >Post-logout redirect URL:
+                      <span class="sso-optional">(optional)</span></label
+                    >
+                    <input
+                      is="emby-input"
+                      id="PostLogoutRedirectUri"
+                      type="text"
+                      class="sso-text"
+                    />
+                    <div class="fieldDescription">
+                      The URL the identity provider returns the browser to after
+                      an RP-initiated OpenID logout, sent as
+                      post_logout_redirect_uri. Honoured only if it is an
+                      absolute http(s) URL at or under this server's base URL;
+                      an off-base or malformed value is rejected on save. Leave
+                      blank for no post-logout redirect. Only takes effect while
+                      the global "Enable Single Logout" option is on.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## What & why

**SLO-4** of #727: `EnableSingleLogout` and the OIDC post-logout redirect were
config/XML-settable only. Surface them on the admin page and validate the
redirect at save time, following the #905 admin-UI patterns.

- **Global "Single Logout" section**, `EnableSingleLogout` checkbox + save
  button (the page's fetch-config → mutate-one-flag → PUT idiom; same
  `ServerManagedFields.Preserve` whole-config contract as the login-buttons
  section). Honest description: off by default; enables the RP-initiated OIDC
  logout route + the inbound SAML LogoutRequest endpoint; off → both reject.
- **Per-provider `PostLogoutRedirectUri`** (`sso-text`) in the **OpenID form
  only**, it is an OIDC concept (only `OidcLogout` consumes it; no SAML path
  honours it), so it is not surfaced on the SAML form. Value via `.value`; no
  string-built DOM.
- **Save-time validator** (`ProviderConfigValidator`, OpenID loop only): a
  non-blank redirect that is off-base / malformed / non-http(s) is rejected at
  save instead of being silently ignored at runtime. It **reuses the exact
  runtime allow-list predicate** `OidcLogout.IsAllowedPostLogoutRedirect`
  (promoted `private`→`internal`, body unchanged) against the same canonical
  base the runtime derives, one allow-list, no second URL rule. When no
  override pins a determinate base, the save check is skipped (never
  less-safe). Fail-closed; the exception never echoes the candidate URL.

## Security checklist

- [x] Single-source allow-list (runtime predicate reused, unchanged, SLO-2
  open-redirect defense intact); save-validation matches the runtime base.
- [x] No candidate-URL info leak in the rejection message.
- [x] XSS-safe UI (`.checked`/`.value`, no innerHTML); whole-config PUT rides
  `ServerManagedFields.Preserve`.
- [x] `Config → Api.Oidc` import consistent with the existing
  `CanonicalBaseUrl`/`SamlCertificate` delegations; no DAG rule broken.
- [x] Adversarial bypass-lens: PASS after the fix (the inert copy-pasted SAML
  field is now OpenID-only).

## Quality checklist

- [x] 25 tests (validator accept/reject matrix + the predicate pinned
  directly); suite green **3700/3700** both TFMs; both projects 0/0
  `--warnaserror`; commit DCO-signed. Conformance roster 41→42 (OpenID).

Refs #727 (SLO-3c SP-outbound + SLO-5 SECURITY.md/full review remain)