### PR TITLE
Add SP-initiated outbound SAML Single Logout [#727]

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -155,12 +155,20 @@ off, both the RP-initiated OIDC logout route and the inbound SAML
   ignored at runtime), and validated at both points by one shared predicate. A
   missing or unreachable `end_session_endpoint` degrades to a local-only logout —
   it never breaks sign-out.
-- **Honest scope limits.** SP-initiated outbound SAML logout and a signed
-  outbound `LogoutResponse` to the IdP are **not yet implemented** (tracked on
+- **SP-initiated outbound SAML logout** ends the caller's own local session and
+  then redirects the browser to the provider's configured `SamlSloEndpoint` (a
+  validated absolute-`https` URL, never request-derived) with a `LogoutRequest`
+  carrying only the caller's own `NameID`/`SessionIndex`, **signed** with the
+  service-provider key through the shared redirect-binding signer. It is
+  fail-safe: a missing SLO endpoint, an unloadable signing key, or no captured
+  session degrades to a local-only logout — an unsigned request is never emitted
+  and the local session is always ended.
+- **Honest scope limits.** A **signed outbound `LogoutResponse`** to an inbound
+  `LogoutRequest` is **not yet implemented** (tracked on
   [#727](https://github.com/iderex/jellyfin-plugin-sso/issues/727)): a validated
-  inbound `LogoutRequest` is answered with a `200` after revocation, which most
-  identity providers accept. Logout events (`LogoutRequested`/`LogoutRejected`)
-  are audited by reason code — never raw `NameID`/`SessionIndex` — and the inbound
+  inbound request is answered with a `200` after revocation, which most identity
+  providers accept. Logout events (`LogoutRequested`/`LogoutRejected`) are
+  audited by reason code — never raw `NameID`/`SessionIndex` — and the inbound
   endpoint is rate-limited.
 
 ## EU Cyber Resilience Act (CRA) position

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1618,7 +1618,7 @@ public class ArchitectureConformanceTests
 
         var expected = new[]
         {
-            "SamlEndpoint", "SamlClientId", "SamlCertificate", "SamlSecondaryCertificate", "SamlAudience",
+            "SamlEndpoint", "SamlSloEndpoint", "SamlClientId", "SamlCertificate", "SamlSecondaryCertificate", "SamlAudience",
             "DoNotValidateAudience", "ValidateRecipient", "ValidateInResponseTo", "SignAuthnRequests",
             "SamlSigningKeyPfx", "SamlRolloverSigningKeyPfx",
             "Enabled", "EnableAuthorization", "DefaultProvider", "AllowExistingAccountLink", "ProvisionNewUsersDisabled",
@@ -1628,7 +1628,7 @@ public class ArchitectureConformanceTests
             "HideLoginButton", "LoginButtonText",
         };
 
-        Assert.Equal(32, expected.Length);
+        Assert.Equal(33, expected.Length);
         var missing = expected.Where(p => !markedProps.Contains(p)).ToList();
         Assert.True(
             missing.Count == 0,

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -170,6 +170,37 @@ public class ProviderConfigValidatorTests
         Assert.Null(ex);
     }
 
+    // --- ValidateSamlSloEndpoint (#727, SLO-3c): reject a set-but-malformed/non-https endpoint; blank/https pass ---
+
+    [Theory]
+    [InlineData("not-a-url")] // not absolute
+    [InlineData("http://idp.example.com/slo")] // absolute but plaintext http — the signed LogoutRequest must not traverse http
+    [InlineData("ftp://idp.example.com/slo")] // absolute but not http(s)
+    [InlineData("https://user:pass@idp.example.com/slo")] // userinfo can mask the real host
+    [InlineData("https://idp.example.com/slo?x=1")] // a query is rejected by the shared absolute-URL predicate
+    public void ValidateSamlSloEndpoint_MalformedOrNonHttps_ThrowsNamingProvider(string sloEndpoint)
+    {
+        var ex = Assert.Throws<ArgumentException>(
+            () => ProviderConfigValidator.ValidateSamlSloEndpoint("idp", sloEndpoint));
+
+        Assert.Equal("sloEndpoint", ex.ParamName);
+        Assert.Contains("idp", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("invalid SAML SLO Endpoint", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")] // blank disables SP-initiated Single Logout
+    [InlineData("https://idp.example.com/slo")]
+    [InlineData("https://idp.example.com/adfs/ls")] // a path is allowed
+    public void ValidateSamlSloEndpoint_BlankOrValidHttpsUrl_DoesNotThrow(string? sloEndpoint)
+    {
+        var ex = Record.Exception(() => ProviderConfigValidator.ValidateSamlSloEndpoint("idp", sloEndpoint!));
+
+        Assert.Null(ex);
+    }
+
     // --- ValidatePostLogoutRedirectUri (#727, SLO-4): reject a set value the runtime would silently drop ---
 
     private const string PostLogoutBase = "https://jellyfin.example.com";

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -46,11 +46,12 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     };
 
     // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) — the canonical
-    // link management surface, plus the RP-initiated OpenID logout (#727), where a user logs THEMSELVES out
-    // (every action is scoped to the caller's own user id), so it is deliberately non-elevated.
+    // link management surface, plus the RP-initiated OpenID logout and the SP-initiated SAML logout (#727),
+    // where a user logs THEMSELVES out (every action is scoped to the caller's own user id), so they are
+    // deliberately non-elevated.
     private static readonly string[] ExpectedAuthenticatedActions =
     {
-        "AddCanonicalLink", "DeleteCanonicalLink", "GetSamlLinksByUser", "GetOidLinksByUser", "OidLogout",
+        "AddCanonicalLink", "DeleteCanonicalLink", "GetSamlLinksByUser", "GetOidLinksByUser", "OidLogout", "SamlSpLogout",
     };
 
     private readonly SsoAuthorizationServerFixture _fixture;

--- a/SSO-Auth.Tests/Http/SSOControllerSamlSpLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlSpLogoutTests.cs
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the SP-initiated outbound SAML logout endpoint (#727, SLO-3c) via
+/// <see cref="SsoControllerHarness"/>. They pin the fail-safe contract: the local Jellyfin logout always runs,
+/// a fully-configured captured SAML session redirects to the SLO endpoint with a signed LogoutRequest naming
+/// the caller's OWN NameID, and any missing precondition (feature off, no endpoint, unloadable key, no captured
+/// session) degrades to a local (host-independent) redirect — never a 500 or an external redirect. Every action
+/// is caller-scoped: a caller can only end their own session and can never build a request naming another user.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSamlSpLogoutTests
+{
+    private static readonly Guid Caller = Guid.Parse("55555555-5555-5555-5555-555555555555");
+    private static readonly Guid OtherUser = Guid.Parse("66666666-6666-6666-6666-666666666666");
+    private const string SloEndpoint = "https://idp.example.com/slo";
+    private const string CallerNameId = "caller-subject";
+
+    private static SsoControllerHarness ForCaller(string token, Action<PluginConfiguration> configure)
+    {
+        var harness = new SsoControllerHarness(configure);
+        var user = TestUsers.Named("caller", Caller);
+        harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>())
+            .Returns(Task.FromResult(new AuthorizationInfo { User = user, Token = token }));
+        return harness;
+    }
+
+    // A SAML provider fully configured for SP-initiated SLO: SLO endpoint + a loadable signing key.
+    private static SamlConfig FullyConfiguredProvider() => new SamlConfig
+    {
+        Enabled = true,
+        SamlClientId = "jellyfin-sp",
+        SamlSloEndpoint = SloEndpoint,
+        SignAuthnRequests = true,
+        // A plaintext PFX round-trips through Reveal unchanged, so the signing key loads at runtime.
+        SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64(),
+    };
+
+    private static LogoutSession CapturedSaml(Guid userId, string subject, string? sessionIndex) => new LogoutSession
+    {
+        Protocol = "SAML",
+        Provider = "idp",
+        Subject = subject,
+        SessionIndex = sessionIndex,
+        UserId = userId,
+    };
+
+    [Fact]
+    public async Task SamlSpLogout_FullyConfigured_EndsLocalSession_AndRedirectsToSloWithSignedRequest()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            config.LogoutSessions["saml-session-1"] = CapturedSaml(Caller, CallerNameId, "session-index-xyz");
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith(SloEndpoint + "?SAMLRequest=", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("&SigAlg=", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("&Signature=", redirect.Url, StringComparison.Ordinal);
+
+        // Caller-scoped: the LogoutRequest names the CALLER's own NameID and captured SessionIndex.
+        var doc = DecodeSamlRequest(redirect.Url);
+        var nsmgr = Namespaces(doc);
+        Assert.Equal(CallerNameId, doc.SelectSingleNode("/samlp:LogoutRequest/saml:NameID", nsmgr)!.InnerText);
+        Assert.Equal("session-index-xyz", doc.SelectSingleNode("/samlp:LogoutRequest/samlp:SessionIndex", nsmgr)!.InnerText);
+        Assert.Equal("jellyfin-sp", doc.SelectSingleNode("/samlp:LogoutRequest/saml:Issuer", nsmgr)!.InnerText);
+
+        // The caller's local session was ended and the consumed entry removed.
+        await harness.SessionManager.Received(1).Logout("caller-token");
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("saml-session-1")));
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_FeatureOff_StillLogsOutLocally_AndRedirectsLocally()
+    {
+        // EnableSingleLogout off: even with an endpoint/key configured, the SLO redirect is gated off.
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = false;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            config.LogoutSessions["saml-session-1"] = CapturedSaml(Caller, CallerNameId, "s-1");
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_NoSloEndpoint_StillLogsOutLocally_AndRedirectsLocally()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            var provider = FullyConfiguredProvider();
+            provider.SamlSloEndpoint = string.Empty; // no SLO endpoint configured
+            config.SamlConfigs["idp"] = provider;
+            config.LogoutSessions["saml-session-1"] = CapturedSaml(Caller, CallerNameId, "s-1");
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+        // The captured session was still consumed (the local logout terminated it).
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("saml-session-1")));
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_UnloadableSigningKey_StillLogsOutLocally_AndRedirectsLocally()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            var provider = FullyConfiguredProvider();
+            provider.SamlSigningKeyPfx = "not-a-real-pfx"; // set but unloadable -> fail-safe to local-only, never unsigned
+            config.SamlConfigs["idp"] = provider;
+            config.LogoutSessions["saml-session-1"] = CapturedSaml(Caller, CallerNameId, "s-1");
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_NoCapturedSession_StillLogsOutLocally_AndRedirectsLocally()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            // No captured session for the caller.
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_OnlyOtherUserHasASession_DoesNotBuildARequestForThem_AndRedirectsLocally()
+    {
+        // Caller-scoping: a session belonging to ANOTHER user must never be selected, so the caller (who has no
+        // session of their own) degrades to a local-only logout rather than logging the other user out.
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            config.LogoutSessions["other-session"] = CapturedSaml(OtherUser, "other-subject", "other-index");
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+        // The other user's session is untouched — the caller can only end their own.
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("other-session")));
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_IgnoresOpenIdCaptureForTheSameProvider()
+    {
+        // A capture for the same provider but a DIFFERENT protocol (OpenID) must not be selected by the SAML
+        // logout path — the Protocol filter keeps the two flows apart.
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            config.LogoutSessions["oid-session"] = new LogoutSession
+            {
+                Protocol = "OpenID",
+                Provider = "idp",
+                Subject = "caller-subject",
+                IdToken = "raw.id.token",
+                UserId = Caller,
+            };
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+        // The OpenID capture is left in place — the SAML SP-logout path did not consume it.
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("oid-session")));
+    }
+
+    [Fact]
+    public async Task SamlSpLogout_NoSessionIndexCaptured_StillRedirectsToSlo_WithoutASessionIndex()
+    {
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.SamlConfigs["idp"] = FullyConfiguredProvider();
+            config.LogoutSessions["saml-session-1"] = CapturedSaml(Caller, CallerNameId, sessionIndex: null);
+        });
+
+        var result = await harness.Controller.SamlSpLogout("idp");
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith(SloEndpoint + "?SAMLRequest=", redirect.Url, StringComparison.Ordinal);
+
+        var doc = DecodeSamlRequest(redirect.Url);
+        var nsmgr = Namespaces(doc);
+        Assert.Equal(CallerNameId, doc.SelectSingleNode("/samlp:LogoutRequest/saml:NameID", nsmgr)!.InnerText);
+        Assert.Null(doc.SelectSingleNode("/samlp:LogoutRequest/samlp:SessionIndex", nsmgr));
+    }
+
+    // Extracts and inflates the SAMLRequest query parameter of the redirect URL back into its XML document.
+    private static XmlDocument DecodeSamlRequest(string url)
+    {
+        var query = url[(url.IndexOf('?') + 1)..];
+        string? encoded = null;
+        foreach (var pair in query.Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == "SAMLRequest")
+            {
+                encoded = Uri.UnescapeDataString(pair[(eq + 1)..]);
+                break;
+            }
+        }
+
+        Assert.NotNull(encoded);
+        var compressed = Convert.FromBase64String(encoded!);
+        using var input = new MemoryStream(compressed);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(deflate, new UTF8Encoding(false));
+        var doc = new XmlDocument { XmlResolver = null };
+        doc.LoadXml(reader.ReadToEnd());
+        return doc;
+    }
+
+    private static XmlNamespaceManager Namespaces(XmlDocument doc)
+    {
+        var nsmgr = new XmlNamespaceManager(doc.NameTable);
+        nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nsmgr.AddNamespace("samlp", "urn:oasis:names:tc:SAML:2.0:protocol");
+        return nsmgr;
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlLogoutRequestBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutRequestBuilderTests.cs
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlLogoutRequestBuilder"/> (#727, SLO-3c): the OUTBOUND SP-initiated
+/// <c>LogoutRequest</c> builder. It mirrors <see cref="SamlAuthnRequest"/> — the same DEFLATE/Base64 encoding
+/// and the same shared <see cref="SamlRedirectSigner"/> — so these assertions pin (a) the document is a
+/// well-formed LogoutRequest carrying the Issuer, NameID, and optional SessionIndex, and (b) the emitted
+/// redirect carries a detached signature that verifies against the signer's public key over the exact octets.
+/// </summary>
+public class SamlLogoutRequestBuilderTests
+{
+    private const string SloEndpoint = "https://idp.example.com/slo";
+    private const string Issuer = "jellyfin-sp";
+    private const string NameId = "user-nameid-123";
+    private const string EcdsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
+
+    [Fact]
+    public void GetRequest_EmitsAWellFormedLogoutRequest_WithIssuerNameIdAndSessionIndex()
+    {
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, "session-index-abc");
+
+        var doc = InflateRequest(builder.GetRequest());
+        var nsmgr = Namespaces(doc);
+
+        Assert.Equal("LogoutRequest", doc.DocumentElement!.LocalName);
+        Assert.Equal("urn:oasis:names:tc:SAML:2.0:protocol", doc.DocumentElement.NamespaceURI);
+        Assert.False(string.IsNullOrEmpty(doc.DocumentElement.GetAttribute("ID")));
+        Assert.Equal("2.0", doc.DocumentElement.GetAttribute("Version"));
+        Assert.Equal(Issuer, doc.SelectSingleNode("/samlp:LogoutRequest/saml:Issuer", nsmgr)!.InnerText);
+        Assert.Equal(NameId, doc.SelectSingleNode("/samlp:LogoutRequest/saml:NameID", nsmgr)!.InnerText);
+        Assert.Equal("session-index-abc", doc.SelectSingleNode("/samlp:LogoutRequest/samlp:SessionIndex", nsmgr)!.InnerText);
+    }
+
+    [Fact]
+    public void GetRequest_ExposedIdMatchesTheDocumentId()
+    {
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, null);
+
+        var doc = InflateRequest(builder.GetRequest());
+
+        Assert.Equal(builder.Id, doc.DocumentElement!.GetAttribute("ID"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetRequest_OmitsSessionIndex_WhenNoneCaptured(string? sessionIndex)
+    {
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, sessionIndex);
+
+        var doc = InflateRequest(builder.GetRequest());
+        var nsmgr = Namespaces(doc);
+
+        // A provider that issued no SessionIndex still yields a well-formed request that names the subject.
+        Assert.Null(doc.SelectSingleNode("/samlp:LogoutRequest/samlp:SessionIndex", nsmgr));
+        Assert.Equal(NameId, doc.SelectSingleNode("/samlp:LogoutRequest/saml:NameID", nsmgr)!.InnerText);
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_EmitsSamlRequestSigAlgAndSignature_ThatVerify()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, "session-index-abc");
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, rsa);
+
+        Assert.StartsWith(SloEndpoint + "?SAMLRequest=", url, StringComparison.Ordinal);
+        Assert.Contains("&SigAlg=", url, StringComparison.Ordinal);
+        Assert.Contains("&Signature=", url, StringComparison.Ordinal);
+        Assert.True(RsaSignatureVerifies(url, rsa));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_ForeignKey_DoesNotVerify()
+    {
+        using var signer = RSA.Create(2048);
+        using var attacker = RSA.Create(2048);
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, null);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, signer);
+
+        // The signature check is real, not vacuous: the signer verifies, a different key does not.
+        Assert.True(RsaSignatureVerifies(url, signer));
+        Assert.False(RsaSignatureVerifies(url, attacker));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_EcdsaKey_SelectsEcdsaSigAlg_AndVerifies()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, null);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, ecdsa);
+
+        // The SigAlg is derived from the key type by the shared signer (#493), never SHA-1.
+        Assert.Contains("&SigAlg=" + Uri.EscapeDataString(EcdsaSha256), url, StringComparison.Ordinal);
+        Assert.True(EcdsaSignatureVerifies(url, ecdsa));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_NullEndpoint_Throws()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = new SamlLogoutRequestBuilder(Issuer, NameId, null);
+
+        Assert.Throws<ArgumentNullException>(() => { builder.GetSignedRedirectUrl(null!, null, rsa); });
+    }
+
+    // Inflates the DEFLATE+Base64 SAMLRequest back into its XML document, exactly as an identity provider does.
+    private static XmlDocument InflateRequest(string encoded)
+    {
+        var compressed = Convert.FromBase64String(encoded);
+        using var input = new MemoryStream(compressed);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(deflate, new UTF8Encoding(false));
+        var xml = reader.ReadToEnd();
+
+        var doc = new XmlDocument { XmlResolver = null };
+        doc.LoadXml(xml);
+        return doc;
+    }
+
+    private static XmlNamespaceManager Namespaces(XmlDocument doc)
+    {
+        var nsmgr = new XmlNamespaceManager(doc.NameTable);
+        nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nsmgr.AddNamespace("samlp", "urn:oasis:names:tc:SAML:2.0:protocol");
+        return nsmgr;
+    }
+
+    private static bool RsaSignatureVerifies(string url, RSA publicKey)
+        => publicKey.VerifyData(Encoding.UTF8.GetBytes(SignedQuery(url)), Signature(url), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+    private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey)
+        => publicKey.VerifyData(Encoding.UTF8.GetBytes(SignedQuery(url)), Signature(url), HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+
+    // Reconstructs the signed octet string (SAMLRequest, then SigAlg — no RelayState here) from the URL.
+    private static string SignedQuery(string url)
+    {
+        var samlRequest = QueryValue(url, "SAMLRequest");
+        var sigAlg = QueryValue(url, "SigAlg");
+        return "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+    }
+
+    private static byte[] Signature(string url) => Convert.FromBase64String(QueryValue(url, "Signature"));
+
+    private static string QueryValue(string url, string name)
+    {
+        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Mime;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
@@ -262,6 +263,123 @@ public class SSOController : ControllerBase
         return endSessionUrl is null ? LocalRedirect("~/") : Redirect(endSessionUrl);
     }
 
+    /// <summary>
+    /// SP-initiated outbound SAML Single Logout (#727, SLO-3c). Ends the CALLER's local Jellyfin session, then
+    /// — when Single Logout is enabled, the provider has a configured SLO endpoint, a signing key loads, and the
+    /// caller has a captured SAML session with a NameID — redirects the browser to the identity provider's
+    /// Single-Logout endpoint with a SIGNED <c>LogoutRequest</c>, so the IdP session is terminated too.
+    /// Fail-safe: a missing SLO endpoint, a missing/unloadable signing key, or no captured session degrades to a
+    /// local-only logout (a host-independent redirect back to this server) — none of those must ever break the
+    /// local logout or 500. Authenticated, rate-limited, and every action is scoped strictly to the caller's own
+    /// user id — a user can only log THEMSELVES out, and the LogoutRequest can only ever carry the caller's own
+    /// NameID.
+    /// </summary>
+    /// <param name="provider">The SAML provider to end the session at.</param>
+    /// <returns>A redirect to the IdP SLO URL, or to this server for a local-only logout.</returns>
+    [Authorize]
+    [HttpGet("SAML/logout/{provider}")]
+    public async Task<ActionResult> SamlSpLogout(string provider)
+    {
+        // Deliberately NOT rate-limited, matching the authenticated OID/logout route: the Logout rate-limit
+        // class guards the ANONYMOUS inbound SAML LogoutRequest endpoint (SLO-3b). Throttling this
+        // [Authorize] self-logout would risk leaving the caller's own local session live under throttle —
+        // a security action must always be able to end the caller's session, and the route already requires
+        // a valid session to reach.
+        var auth = await _authContext.GetAuthorizationInfo(HttpContext.Request).ConfigureAwait(false);
+
+        // Read the Single Logout feature flag, the provider config, AND the caller's most recent captured SAML
+        // session for this provider in one lock acquisition. Scoped to the caller's own user id (FindByUser is
+        // user-id-scoped and empty for Guid.Empty), and filtered to a SAML capture — a SAML session carries no
+        // id_token, so the Protocol tag distinguishes it from an OpenID capture for the same provider. The
+        // captured Subject is the caller's own NameID; nothing here can read another user's session.
+        var (singleLogoutEnabled, config, match) = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            (configuration.EnableSingleLogout,
+             configuration.SamlConfigs.TryGetValue(provider, out var samlConfig) ? samlConfig : null,
+             SessionLogoutStore.FindByUser(configuration, auth.UserId)
+                 .FirstOrDefault(pair =>
+                     string.Equals(pair.Value.Provider, provider, StringComparison.Ordinal)
+                     && string.Equals(pair.Value.Protocol, SamlProtocol, StringComparison.Ordinal))));
+
+        // End the caller's local Jellyfin session (their current token only) in EVERY path, then drop the
+        // consumed entry so the captured session state is not retained past the logout.
+        if (!string.IsNullOrEmpty(auth.Token))
+        {
+            await _sessionManager.Logout(auth.Token).ConfigureAwait(false);
+        }
+
+        if (match.Value is not null)
+        {
+            SSOPlugin.Instance.MutateConfiguration(configuration => SessionLogoutStore.Remove(configuration, match.Key));
+        }
+
+        // Build the signed LogoutRequest redirect only when everything the SP-initiated path needs is present:
+        // the feature is on, the caller has a captured SAML session naming a NameID, the provider is configured
+        // with an SLO endpoint, and a signing key loads. ANY missing piece — or any fault building/signing —
+        // fails SAFE to a local-only logout, never a 500 (the local logout already completed above).
+        string? sloRedirectUrl = null;
+        if (singleLogoutEnabled && config is not null && match.Value is { } captured && !string.IsNullOrEmpty(captured.Subject))
+        {
+            try
+            {
+                sloRedirectUrl = BuildSamlSloRedirectUrl(config, captured);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or CryptographicException or FormatException)
+            {
+                // Fail-safe: the local logout already stands. A missing/unloadable signing key
+                // (InvalidOperationException/CryptographicException), a corrupt at-rest secret envelope
+                // (FormatException), or a signer rejection (ArgumentException) degrades to a local-only logout
+                // rather than surfacing a 500. Key material is never part of the message, so nothing sensitive
+                // is logged.
+                if (_logger.IsEnabled(LogLevel.Error))
+                {
+                    _logger.LogError("SAML SP-initiated logout for provider {Provider} could not build the signed LogoutRequest: {Reason}; the local logout stands and the browser returns to this server.", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+                }
+            }
+        }
+
+        // Redirect to the IdP SLO URL (the SLO endpoint is validated as an absolute https URL at save), or —
+        // local-only — back to this server via a LOCAL redirect. As with the OpenID logout, the local fallback
+        // uses a host-independent "~/" redirect rather than a request-Host-derived absolute target, so a spoofed
+        // Host can never turn the fallback into an open redirect.
+        return sloRedirectUrl is null ? LocalRedirect("~/") : Redirect(sloRedirectUrl);
+    }
+
+    // Builds the signed SP-initiated LogoutRequest redirect URL for a captured SAML session (#727, SLO-3c), or
+    // null when SP-initiated SLO is not configured (no SLO endpoint). Fail-closed on the signing key: a missing
+    // or unloadable key returns null (the caller degrades to local-only) rather than sending an UNSIGNED
+    // LogoutRequest — the SLO redirect binding requires a signature, so an unsigned downgrade is never emitted.
+    // Reuses the outbound-signing infrastructure verbatim: the encrypted-at-rest signing key is revealed at the
+    // point of use (mirroring the challenge), loaded through SamlSigningKey, and handed to the shared
+    // SamlRedirectSigner via SamlLogoutRequestBuilder. The subject NameID and SessionIndex come only from the
+    // caller's OWN captured session, so the request can never name another user.
+    private static string? BuildSamlSloRedirectUrl(SamlConfig config, LogoutSession captured)
+    {
+        var sloEndpoint = config.SamlSloEndpoint?.Trim();
+        if (string.IsNullOrEmpty(sloEndpoint))
+        {
+            return null;
+        }
+
+        // Reveal the encrypted-at-rest signing key only now, at the moment it signs. A missing/unloadable key
+        // returns null (local-only), never an unsigned request.
+        if (!SamlSigningKey.TryLoad(SSOPlugin.Instance.Secrets.Reveal(config.SamlSigningKeyPfx), out var signingCertificate))
+        {
+            return null;
+        }
+
+        using (signingCertificate)
+        using (var signingKey = SamlSigningKey.GetSigningKey(signingCertificate))
+        {
+            if (signingKey is null)
+            {
+                return null;
+            }
+
+            var request = new SamlLogoutRequestBuilder(config.SamlClientId.Trim(), captured.Subject, captured.SessionIndex);
+            return request.GetSignedRedirectUrl(sloEndpoint, relayState: null, signingKey);
+        }
+    }
+
     // Rejects a malformed canonical base-URL override (#139) at the OID/SAML Add endpoints. These persist
     // through MutateConfiguration, which passes the live configuration object, so they bypass the
     // config-page save-time validation in ProviderConfigStore.Save (which only runs for a fresh
@@ -340,6 +458,29 @@ public class SSOController : ControllerBase
         if (SamlSigningKey.IsInvalid(signingKeyPfx))
         {
             throw new ArgumentException("The SAML request signing key must be a Base64-encoded, unencrypted PKCS#12 (PFX) blob containing an RSA or ECDSA private key, or left blank.", nameof(signingKeyPfx));
+        }
+    }
+
+    // Rejects a malformed SAML SLO endpoint (#727, SLO-3c) at the SAML/Add endpoint, the door that mirrors
+    // the config-page save-time SLO-endpoint check in ProviderConfigValidator for the Add path that
+    // bypasses it. It must be an absolute https URL — the redirect carries a signed LogoutRequest naming the
+    // subject, so it must not traverse plaintext http. Reuses the same CanonicalBaseUrl.TryNormalize
+    // absolute-URL predicate the Base URL override guard uses, narrowed to https. Blank is valid (no
+    // SP-initiated Single Logout). The message stays generic (never echoes the caller's endpoint back).
+
+    /// <summary>
+    /// Rejects a malformed SAML SLO endpoint at the SAML/Add endpoint (#727, SLO-3c), the Add-path
+    /// counterpart to the config-page save-time SLO-endpoint check. A blank endpoint is valid.
+    /// </summary>
+    /// <param name="sloEndpoint">The SAML SLO endpoint posted to the Add endpoint.</param>
+    /// <exception cref="ArgumentException">The endpoint is non-blank and not a valid absolute https URL.</exception>
+    internal static void RejectInvalidSamlSloEndpoint(string? sloEndpoint)
+    {
+        if (!string.IsNullOrWhiteSpace(sloEndpoint)
+            && (!CanonicalBaseUrl.TryNormalize(sloEndpoint, out var normalized)
+                || !normalized.StartsWith("https://", StringComparison.Ordinal)))
+        {
+            throw new ArgumentException("The SAML SLO Endpoint must be an absolute https URL such as https://idp.example.com/slo, or left blank.", nameof(sloEndpoint));
         }
     }
 
@@ -799,6 +940,7 @@ public class SSOController : ControllerBase
     {
         RejectNullProviderBody(newConfig);
         RejectInvalidBaseUrlOverride(newConfig.BaseUrlOverride);
+        RejectInvalidSamlSloEndpoint(newConfig.SamlSloEndpoint);
         RejectInvalidSamlCertificate(newConfig.SamlCertificate);
         RejectInvalidSamlSecondaryCertificate(newConfig.SamlSecondaryCertificate);
         RejectInvalidSamlSigningKey(newConfig.SamlSigningKeyPfx);

--- a/SSO-Auth/Api/Saml/SamlLogoutRequestBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutRequestBuilder.cs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// Builds an OUTBOUND SP-initiated SAML 2.0 <c>LogoutRequest</c> for the HTTP-Redirect binding (#727, SLO-3c)
+/// — the mirror image of <see cref="SamlAuthnRequest"/> for the logout flow. It emits the same DEFLATE +
+/// Base64 encoding as the AuthnRequest builder (<see cref="GetRequest"/>) and hands the encoded message to the
+/// SHARED <see cref="SamlRedirectSigner"/> for the mandated detached SigAlg+Signature, so the outbound-signing
+/// infrastructure is reused verbatim rather than re-implemented.
+/// </summary>
+/// <remarks>
+/// This is the OUTBOUND builder and is deliberately distinct from <see cref="SamlLogoutRequest"/>, which is the
+/// INBOUND (IdP-initiated) validator: conflating them would let a change to the session-destructive inbound
+/// parser regress the outbound builder, or vice versa. The document carries the SP <c>Issuer</c> (the same
+/// entity id the AuthnRequest sends), the subject <c>NameID</c> the caller logged in as, and the captured
+/// <c>SessionIndex</c> when one is present, in the element order SAML core §3.7.1 fixes (Issuer, then the
+/// identifier, then any SessionIndex).
+/// </remarks>
+internal sealed class SamlLogoutRequestBuilder
+{
+    private readonly string _id;
+    private readonly string _issueInstant;
+
+    private readonly string _issuer;
+    private readonly string _nameId;
+    private readonly string? _sessionIndex;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlLogoutRequestBuilder"/> class.
+    /// </summary>
+    /// <param name="issuer">The SP entity id (the same value the AuthnRequest sends as its Issuer).</param>
+    /// <param name="nameId">The subject NameID the caller authenticated as (their own, caller-scoped).</param>
+    /// <param name="sessionIndex">The captured identity-provider SessionIndex, or null/blank when none.</param>
+    public SamlLogoutRequestBuilder(string issuer, string nameId, string? sessionIndex)
+    {
+        _id = "_" + Guid.NewGuid().ToString();
+        _issueInstant = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        _issuer = issuer;
+        _nameId = nameId;
+        _sessionIndex = sessionIndex;
+    }
+
+    /// <summary>
+    /// Gets the request's unique <c>ID</c> (the value sent as the LogoutRequest ID).
+    /// </summary>
+    public string Id => _id;
+
+    /// <summary>
+    /// Builds the <c>LogoutRequest</c> as a Base64-encoded, DEFLATE-compressed string. The DEFLATE/encoding
+    /// approach is copied verbatim from <see cref="SamlAuthnRequest.GetRequest"/> so both outbound
+    /// redirect-binding messages encode identically.
+    /// </summary>
+    /// <returns>The request as a Base64-encoded, DEFLATE-compressed string.</returns>
+    public string GetRequest()
+    {
+        using var sw = new StringWriter(CultureInfo.InvariantCulture);
+        var xws = new XmlWriterSettings();
+        xws.OmitXmlDeclaration = true;
+
+        using (var xw = XmlWriter.Create(sw, xws))
+        {
+            xw.WriteStartElement("samlp", "LogoutRequest", "urn:oasis:names:tc:SAML:2.0:protocol");
+            xw.WriteAttributeString("ID", _id);
+            xw.WriteAttributeString("Version", "2.0");
+            xw.WriteAttributeString("IssueInstant", _issueInstant);
+
+            xw.WriteStartElement("saml", "Issuer", "urn:oasis:names:tc:SAML:2.0:assertion");
+            xw.WriteString(_issuer);
+            xw.WriteEndElement();
+
+            xw.WriteStartElement("saml", "NameID", "urn:oasis:names:tc:SAML:2.0:assertion");
+            xw.WriteString(_nameId);
+            xw.WriteEndElement();
+
+            // SessionIndex is optional (SAML core §3.7.1): emit it only when the login captured one, so a
+            // provider that issues no SessionIndex still gets a well-formed request that logs the subject out.
+            if (!string.IsNullOrEmpty(_sessionIndex))
+            {
+                xw.WriteStartElement("samlp", "SessionIndex", "urn:oasis:names:tc:SAML:2.0:protocol");
+                xw.WriteString(_sessionIndex);
+                xw.WriteEndElement();
+            }
+
+            xw.WriteEndElement();
+        }
+
+        // The exact DEFLATE + Base64 approach SamlAuthnRequest.GetRequest uses for the HTTP-Redirect binding.
+        var memoryStream = new MemoryStream();
+        var writer = new StreamWriter(new DeflateStream(memoryStream, CompressionMode.Compress, true), new UTF8Encoding(false));
+        writer.Write(sw.ToString());
+        writer.Close();
+        return Convert.ToBase64String(memoryStream.GetBuffer(), 0, (int)memoryStream.Length, Base64FormattingOptions.None);
+    }
+
+    /// <summary>
+    /// Gets the redirect URL to the identity provider's Single-Logout endpoint with the LogoutRequest SIGNED
+    /// for the HTTP-Redirect binding — delegating to the SHARED <see cref="SamlRedirectSigner"/> exactly as
+    /// <see cref="SamlAuthnRequest.GetSignedRedirectUrl"/> does, so the SigAlg/Signature policy (key-type
+    /// derived, allowlist-checked, no SHA-1) is reused rather than re-implemented.
+    /// </summary>
+    /// <param name="sloEndpoint">The identity provider's Single-Logout (SLO) endpoint URL.</param>
+    /// <param name="relayState">The relay state, omitted when null or empty.</param>
+    /// <param name="signingKey">The service-provider private key — RSA or ECDSA.</param>
+    /// <returns>The signed redirect URL.</returns>
+    public string GetSignedRedirectUrl(string sloEndpoint, string? relayState, AsymmetricAlgorithm signingKey)
+    {
+        ArgumentNullException.ThrowIfNull(sloEndpoint);
+
+        return SamlRedirectSigner.BuildSignedRedirectUrl(sloEndpoint, "SAMLRequest", GetRequest(), relayState, signingKey);
+    }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -407,6 +407,17 @@ public class SamlConfig : ProviderConfigBase
     public string SamlEndpoint { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the identity provider's SAML Single-Logout (SLO) endpoint — a DISTINCT URL from
+    /// <see cref="SamlEndpoint"/> (the SSO endpoint), where the browser is redirected with a signed
+    /// SP-initiated <c>LogoutRequest</c> (#727, SLO-3c). Blank (the default) means no SP-initiated Single
+    /// Logout: the logout route degrades to a fail-safe local-only logout. It must be an absolute https URL
+    /// when set (validated at save by <see cref="ProviderConfigValidator.ValidateSamlSloEndpoint"/>), so the
+    /// signed LogoutRequest — which names the subject NameID — never traverses plaintext http. No effect while
+    /// <see cref="PluginConfiguration.EnableSingleLogout"/> is off.
+    /// </summary>
+    public string SamlSloEndpoint { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the SAML provider's client ID.
     /// </summary>
     public string SamlClientId { get; set; } = string.Empty;

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -75,6 +75,7 @@ internal static class ProviderConfigValidator
             {
                 ValidateProviderName("SAML", kvp.Key, isNew: live?.SamlConfigs?.ContainsKey(kvp.Key) != true);
                 ValidateBaseUrlOverride("SAML", kvp.Key, kvp.Value?.BaseUrlOverride);
+                ValidateSamlSloEndpoint(kvp.Key, kvp.Value?.SamlSloEndpoint);
                 ValidateSamlCertificate(kvp.Key, kvp.Value?.SamlCertificate);
                 ValidateSamlSecondaryCertificate(kvp.Key, kvp.Value?.SamlSecondaryCertificate);
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlSigningKeyPfx);
@@ -205,6 +206,40 @@ internal static class ProviderConfigValidator
             throw new ArgumentException(
                 $"{protocol} provider '{provider?.ReplaceLineEndings(string.Empty)}' has a Post Logout Redirect URI that is not at or under the configured Base URL; it must be an absolute http(s) URL at or under this server's base URL, or it is ignored at logout. Leave it blank for no post-logout redirect.",
                 nameof(postLogoutRedirectUri));
+        }
+    }
+
+    // A malformed SAML SLO endpoint (#727, SLO-3c) would be persisted and then silently disable SP-initiated
+    // Single Logout (the logout route falls back to local-only), so the admin gets no feedback that the
+    // endpoint they configured never fires. Reject it at save. It reuses the SAME absolute-URL predicate the
+    // Base URL override validates through (CanonicalBaseUrl.TryNormalize — absolute http(s), no
+    // query/fragment/userinfo) and then narrows to https: the redirect carries a signed LogoutRequest naming
+    // the subject NameID, so it must not traverse plaintext http. Blank is valid (no SP-initiated SLO). The
+    // provider name is line-ending-stripped inline in case it reaches a log through the thrown exception.
+
+    /// <summary>
+    /// Rejects a SAML Single-Logout (SLO) endpoint (#727, SLO-3c) that is set but is not a valid absolute
+    /// https URL, which would otherwise persist and then silently disable SP-initiated Single Logout (the
+    /// logout route falls back to local-only). Reuses <see cref="CanonicalBaseUrl.TryNormalize"/> — the same
+    /// absolute-URL predicate the Base URL override validates through — and narrows to https so the signed
+    /// LogoutRequest never traverses plaintext http. A blank endpoint is valid (no SP-initiated SLO).
+    /// </summary>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="sloEndpoint">The SAML SLO endpoint to check.</param>
+    /// <exception cref="ArgumentException">The endpoint is non-blank and not a valid absolute https URL.</exception>
+    internal static void ValidateSamlSloEndpoint(string provider, string? sloEndpoint)
+    {
+        if (string.IsNullOrWhiteSpace(sloEndpoint))
+        {
+            return;
+        }
+
+        if (!CanonicalBaseUrl.TryNormalize(sloEndpoint, out var normalized)
+            || !normalized.StartsWith("https://", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"SAML provider '{provider?.ReplaceLineEndings(string.Empty)}' has an invalid SAML SLO Endpoint; it must be an absolute https URL such as https://idp.example.com/slo, or left blank to disable SP-initiated Single Logout.",
+                nameof(sloEndpoint));
         }
     }
 

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -1999,6 +1999,36 @@
                   <div class="inputContainer">
                     <label
                       class="inputLabel inputLabelUnfocused"
+                      for="saml-SamlSloEndpoint"
+                      >SAML SLO Endpoint:</label
+                    >
+                    <input
+                      is="emby-input"
+                      id="saml-SamlSloEndpoint"
+                      type="text"
+                      class="sso-text"
+                      aria-describedby="saml-SamlSloEndpoint-error"
+                    />
+                    <div
+                      class="sso-inline-error"
+                      id="saml-SamlSloEndpoint-error"
+                      role="alert"
+                      hidden
+                    ></div>
+                    <div class="fieldDescription">
+                      The identity provider's Single-Logout (SLO) URL — a
+                      distinct endpoint from the SSO endpoint above, where the
+                      browser is redirected with a signed SP-initiated
+                      LogoutRequest. Must be an absolute https URL. Leave blank
+                      to disable SP-initiated Single Logout (logout stays
+                      local-only). Only used when the global "Enable Single
+                      Logout" option is on.
+                    </div>
+                  </div>
+
+                  <div class="inputContainer">
+                    <label
+                      class="inputLabel inputLabelUnfocused"
                       for="saml-SamlClientId"
                       >SAML Client ID (SP entity id):
                       <span class="sso-required" aria-hidden="true"


### PR DESCRIPTION
## What & why

**SLO-3c (part 1)** of #727: an authenticated route that propagates a Jellyfin
logout to the SAML IdP. Before, a Jellyfin sign-out ended only the local
session; the IdP session stayed live.

- **`SamlLogoutRequestBuilder`**, builds a `samlp:LogoutRequest` (Issuer,
  NameID, optional SessionIndex per SAML core §3.7.1), DEFLATE+Base64 exactly
  like `SamlAuthnRequest`, and signs it **only** through the shared
  `SamlRedirectSigner.BuildSignedRedirectUrl` (HTTP-Redirect binding, detached
  SigAlg+Signature from the key type, algorithm-allowlist checked). No signing
  re-implemented; separate from the inbound `SamlLogoutRequest` validator;
  NameID/SessionIndex written via `XmlWriter`, never concatenated.
- **`SSOController.SamlSpLogout`** (`[Authorize] GET SAML/logout/{provider}`,
  mirroring `OidLogout`): ends the caller's own local session in **every** path,
  resolves the caller's own captured SAML session (`FindByUser(auth.UserId)`
  filtered to the provider + SAML protocol, caller-scoped, no IDOR), removes
  the consumed entry, redirects to `SamlSloEndpoint` with the signed request.
  **Fail-safe local-only logout** when the feature is off / no SLO endpoint /
  unloadable key / no captured session, an unsigned request is never emitted
  and no branch 500s. **Not rate-limited** (unlike the anonymous inbound
  endpoint): a self-logout must always end the caller's session.
- **`SamlConfig.SamlSloEndpoint`**, validated as an absolute `https` URL at
  **both** the config-page save and the `SAML/Add` endpoint (reusing
  `CanonicalBaseUrl`'s predicate); admin-UI field on the SAML form. SECURITY.md
  updated (SP-initiated outbound now implemented; only the signed outbound
  `LogoutResponse` remains scoped out).

## Security checklist

- [x] Outbound request signed only via the shared allowlist-checked signer; a
  missing/unloadable key falls back to local-only, never an unsigned request;
  the key is revealed from `Secret<T>` at point of use, never logged.
- [x] Strictly caller-scoped (`auth.UserId`); cannot name or end another user's
  session (negative test).
- [x] Local session ended in every functional branch (availability of the
  security action); no 500.
- [x] Redirect target only the validated `https` `SamlSloEndpoint` or a local
  fallback, no open-redirect/SSRF; the value is admin-configured, never
  request-derived.
- [x] Adversarial bypass-lens: **PASS**.

## Quality checklist

- [x] Builder + route + validator tests incl. every fail-safe fallback +
  caller-scoping; suite green **1876/1876** both TFMs; both projects 0/0
  `--warnaserror`; commit DCO-signed. Conformance rosters kept consistent
  (SAML form 32→33; the SP-logout route added to the bare-`[Authorize]` roster;
  the RateLimitCheck sentinel stays 13, this route is intentionally not
  rate-limited).

Refs #727 (only the signed outbound `LogoutResponse` + the full `/security-review`
sweep remain)