### PR TITLE
Rename the plugin to "Community SSO for Jellyfin" [#913]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ digit and differ by release cadence). The channel and Jellyfin generation are a
 suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 `-JF12-*`), never part of the installed numeric version.
 
+## Unreleased
+
+### Changed
+
+- **Renamed to "Community SSO for Jellyfin".** The plugin's display name (the
+  catalog entry, the dashboard plugin name, and the documentation) is now
+  **Community SSO for Jellyfin**. The plugin GUID, the assembly, and the
+  configuration are unchanged, so the rename lands as an in-place update that
+  keeps every existing setting.
+
 ## 4.3.0
 
 A feature release. This line advances the plugin's maturity to **Beta** on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!-- omit in toc -->
 
-# Contributing to Jellyfin SSO Plugin
+# Contributing to Community SSO for Jellyfin
 
 First off, thanks for taking the time to contribute! ❤️
 
@@ -107,7 +107,7 @@ Once it's filed:
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Jellyfin SSO Plugin, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
+This section guides you through submitting an enhancement suggestion for Community SSO for Jellyfin, **including completely new features and minor improvements to existing functionality**. Following these guidelines will help maintainers and the community to understand your suggestion and find related suggestions.
 
 <!-- omit in toc -->
 
@@ -128,7 +128,7 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/iderex
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 - **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 - You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux. <!-- this should only be included if the project has a GUI -->
-- **Explain why this enhancement would be useful** to most Jellyfin SSO Plugin users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
+- **Explain why this enhancement would be useful** to most Community SSO for Jellyfin users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 <!-- You might want to create an issue template for enhancement suggestions that can be used as a guide and that defines the structure of the information to be included. If you do so, reference it here in the description. -->
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 >
 > **Status: Beta** — the third rung of the maturity ladder (**In-Development → Alpha → Beta → Release Candidate → Full Release**; see the [Roadmap](https://github.com/iderex/jellyfin-plugin-sso/wiki/Roadmap)). Installable by adding this plugin's own repository to Jellyfin (see [Installing](#installing)).
 
-<h1 align="center">Jellyfin SSO Plugin</h1>
+<h1 align="center">Community SSO for Jellyfin</h1>
 
 <p align="center">
-<img alt="Jellyfin SSO Plugin" src="https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
+<img alt="Community SSO for Jellyfin" src="https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
 <br/>
 <br/>
 <a href="https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt">
@@ -110,7 +110,7 @@ Jellyfin upstream is building [native OIDC](https://github.com/jellyfin/jellyfin
    - **stable** ships tagged releases only. **beta** publishes on a daily schedule (04:00 UTC) whenever `main` has advanced since the last beta, so betas move fast and may break — use them for testing, not production.
    - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** and **not yet validated against a live 12.0 server** (none exists at GA quality to test against): the JF12/5.0 line is CI-built and unit-tested but sits outside the 4.x release-candidate gate, and it clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available (the stable 12.0 build lands at a 12.0 stable release).
 
-2. Go to **Dashboard → Plugins → Catalog**, find **SSO Authentication**, and install it.
+2. Go to **Dashboard → Plugins → Catalog**, find **Community SSO for Jellyfin**, and install it.
 3. **Restart Jellyfin** to load the plugin.
 
 The plugin GUID is unchanged from the original `9p4` plugin, so a new version installs over an existing one in place and keeps your existing configuration. To switch channels, replace the repository URL and let the catalog offer the other channel's build.
@@ -125,7 +125,7 @@ Copy the **full publish output** (`SSO-Auth.dll` and every dependency DLL beside
 
 **Client support:** SSO sign-in runs in the Jellyfin **Web UI** and in clients that support **Quick Connect** (the mobile and TV apps drive the login through Quick Connect). A native client that does not support Quick Connect cannot complete the browser redirect flow — use the Web UI or a Quick Connect client there.
 
-**Coming from the old plugin repository?** This project is the maintained continuation of the archived `9p4/jellyfin-plugin-sso`. If your Jellyfin still points at the old `9p4` manifest — or at any other now-dead SSO manifest URL, such as a former `jellyfin-plugin-sso-V2` one — it will not receive updates from here. Packaged releases have resumed: replace the stale plugin-repository URL with the 10.11 stable manifest (`https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json`) under **Dashboard → Plugins → Repositories**, then install **SSO Authentication** from the catalog. The plugin GUID is unchanged, so it updates in place and keeps your existing configuration.
+**Coming from the old plugin repository?** This project is the maintained continuation of the archived `9p4/jellyfin-plugin-sso`. If your Jellyfin still points at the old `9p4` manifest — or at any other now-dead SSO manifest URL, such as a former `jellyfin-plugin-sso-V2` one — it will not receive updates from here. Packaged releases have resumed: replace the stale plugin-repository URL with the 10.11 stable manifest (`https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json`) under **Dashboard → Plugins → Repositories**, then install **Community SSO for Jellyfin** from the catalog. The plugin GUID is unchanged, so it updates in place and keeps your existing configuration.
 
 ## Configuration
 

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -23,6 +23,13 @@ namespace Jellyfin.Plugin.SSO_Auth;
 /// </summary>
 public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
+    // The STABLE config-page registration prefix, deliberately DECOUPLED from the display Name below
+    // (the rebrand to "Community SSO for Jellyfin"): these strings are page identifiers baked into the
+    // served config-page URLs and the .js/.css the pages load by name, so they are part of the plugin's
+    // page identity — like the root namespace, they must NOT track a display-name change (a rename here
+    // would break every existing config page's load path). The display Name is free to change; this is not.
+    private const string PageId = "SSO-Auth";
+
     private readonly Lazy<SecretStore> _secrets;
 
     /// <summary>
@@ -68,7 +75,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     /// <summary>
     /// Gets the name of the SSO plugin.
     /// </summary>
-    public override string Name => "SSO-Auth";
+    public override string Name => "Community SSO for Jellyfin";
 
     /// <summary>
     /// Gets the GUID of the SSO plugin.
@@ -164,11 +171,11 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
     public IEnumerable<PluginPageInfo> GetPages() =>
         new[]
         {
-            Page(Name, "Web.configPage.html"),
-            Page(Name + ".js", "Web.config.js"),
-            Page(Name + ".css", "Web.style.css"),
-            Page(Name + "-linking", "Web.linking.html"),
-            Page(Name + "-linking.js", "Web.linking.js"),
+            Page(PageId, "Web.configPage.html"),
+            Page(PageId + ".js", "Web.config.js"),
+            Page(PageId + ".css", "Web.style.css"),
+            Page(PageId + "-linking", "Web.linking.html"),
+            Page(PageId + "-linking.js", "Web.linking.js"),
         };
 
     /// <summary>

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -1,4 +1,4 @@
-name: "SSO Authentication"
+name: "Community SSO for Jellyfin"
 # Same plugin GUID as the JF10.11 build (build.yaml) — one plugin, so a JF12 server updates it in
 # place. The targetAbi below gates it to the 12.0 line, so a 10.11 server never offers this build and
 # vice versa (the two generations live in separate manifest branches, manifest-jf12-* vs manifest-*).

--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-name: "SSO Authentication"
+name: "Community SSO for Jellyfin"
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
 version: "4.3.0"


### PR DESCRIPTION
## What & why

Rebrand the plugin's **display name** to **Community SSO for Jellyfin**, the
catalog entry, the dashboard plugin name, the manifest, and the docs.

- **`SSOPlugin.Name`** → "Community SSO for Jellyfin". `GetPages()` previously
  used the display `Name` as the config-**page** registration prefix, so a
  display rename would have changed every served config-page URL (and the
  `.js`/`.css` those pages load by name) and broken existing installs. This
  **decouples** them: a stable `PageId = "SSO-Auth"` constant now supplies the
  page identifiers; the display `Name` is free to change. The page identity - 
  like the root namespace, stays fixed.
- **`build.yaml` / `build-jf12.yaml`** manifest name → "Community SSO for Jellyfin".
- **README + CONTRIBUTING** display strings.
- **CHANGELOG** `Unreleased` entry.

**Unchanged (deliberately):** the plugin GUID `505ce9d1-…`, the assembly, the
`Jellyfin.Plugin.SSO_Auth` root namespace, and the config-page identifiers, so
the rename is an **in-place update that keeps every existing setting**.

## Type of change

- [x] Rebrand (display-name + docs). No behaviour change; plugin identity
  (GUID / namespace / page ids) preserved.

## Quality checklist

- [x] Both projects build **0/0** under `--warnaserror`; full suite green
  (**1876**), incl. the page-manifest pin which still asserts the stable
  `SSO-Auth` page ids.
- [x] CHANGELOG + prettier clean; commit DCO-signed.

## Follow-up (not in this diff)

The `img/banner.png` / `img/logo.png` still carry the old wordmark (a graphic,
not text), a new banner/logo asset is a separate design task.

Refs #913