### PR TITLE
Add an automated E2E SSO login harness (Jellyfin + Keycloak in CI) [#720]

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -1,0 +1,80 @@
+# End-to-end SSO login harness (#720/#727). Boots a real Jellyfin 10.11 + Keycloak stack with the
+# PACKAGED plugin zip installed, and drives full OIDC login round-trips headlessly, asserting a
+# Jellyfin session token is minted and usable, that the role gate refuses a role-less user, and that
+# a replayed one-time state is refused. It supplements — never replaces — the manual Release-QA
+# checklist. The maintainer's local Docker is currently broken by a version bug, so this runs on the
+# GitHub runners' working Docker; it also runs locally once Docker is restored (see test/e2e/README.md).
+name: E2E Login Harness
+
+on:
+  # Push-triggered on the harness branch so the compose flow can be iterated against real Docker in
+  # CI. workflow_dispatch allows an on-demand run from any branch.
+  push:
+    branches: ["feature/e2e-login-harness-720"]
+  workflow_dispatch:
+
+# Deny-all at the workflow level; the single job reads the repo to build the plugin and needs nothing else.
+permissions: {}
+
+# Cancel a superseded run on the same ref — this is a test harness, not a publish, so cancelling an
+# obsolete run is safe.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: OIDC round-trip (Jellyfin + Keycloak)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Build packaged plugin (JPRM)
+        uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
+        id: jprm
+        with:
+          dotnet-target: "net9.0"
+
+      - name: Install the packaged plugin into the Jellyfin config
+        # Unpack the exact packaged zip the release ships (meta.json + the plugin and its
+        # non-host-provided dependency DLLs) into the bind-mounted Jellyfin plugins directory, so the
+        # harness exercises the SAME artifact users install — including the packaged crypto DLL load
+        # path on Linux (#181) that `dotnet test` cannot see. World-writable so the Jellyfin container
+        # can persist the plugin's own provider configuration under /config regardless of its uid.
+        env:
+          ARTIFACT: ${{ steps.jprm.outputs.artifact }}
+        run: |
+          set -euo pipefail
+          plugin_dir="test/e2e/jellyfin/config/plugins/SSO-Auth"
+          mkdir -p "$plugin_dir"
+          unzip -o "$ARTIFACT" -d "$plugin_dir"
+          echo "Installed plugin files:"
+          ls -la "$plugin_dir"
+          chmod -R 0777 test/e2e/jellyfin
+
+      - name: Run the E2E login harness
+        run: |
+          set -euo pipefail
+          docker compose -f test/e2e/docker-compose.yml up \
+            --abort-on-container-exit --exit-code-from harness
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "===== docker compose logs ====="
+          docker compose -f test/e2e/docker-compose.yml logs --no-color || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f test/e2e/docker-compose.yml down -v || true

--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -7,10 +7,17 @@
 name: E2E Login Harness
 
 on:
-  # Push-triggered on the harness branch so the compose flow can be iterated against real Docker in
-  # CI. workflow_dispatch allows an on-demand run from any branch.
-  push:
-    branches: ["feature/e2e-login-harness-720"]
+  # Nightly, so a real-stack OIDC+SAML login pass is per-day evidence (#720 gate-(a) support), offset
+  # from the Scorecard (27 4) and Stryker (41 5) crons so the scheduled runs do not contend for a runner.
+  schedule:
+    - cron: "17 3 * * *"
+  # Re-validate whenever the harness itself changes (a PR touching the compose/realm/driver or this
+  # workflow), so the E2E stays green as it evolves — without paying the ~10-min Docker run on every push.
+  pull_request:
+    paths:
+      - "test/e2e/**"
+      - ".github/workflows/e2e-login.yml"
+  # On-demand from any branch.
   workflow_dispatch:
 
 # Deny-all at the workflow level; the single job reads the repo to build the plugin and needs nothing else.

--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -1,7 +1,7 @@
 # End-to-end SSO login harness (#720/#727). Boots a real Jellyfin 10.11 + Keycloak stack with the
-# PACKAGED plugin zip installed, and drives full OIDC login round-trips headlessly, asserting a
-# Jellyfin session token is minted and usable, that the role gate refuses a role-less user, and that
-# a replayed one-time state is refused. It supplements — never replaces — the manual Release-QA
+# PACKAGED plugin zip installed, and drives full OIDC and SAML login round-trips headlessly, asserting a
+# Jellyfin session token is minted and usable, that the role gate refuses a role-less user, and that a
+# replayed one-time state/token is refused. It supplements — never replaces — the manual Release-QA
 # checklist. The maintainer's local Docker is currently broken by a version bug, so this runs on the
 # GitHub runners' working Docker; it also runs locally once Docker is restored (see test/e2e/README.md).
 name: E2E Login Harness
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   e2e:
-    name: OIDC round-trip (Jellyfin + Keycloak)
+    name: OIDC + SAML round-trip (Jellyfin + Keycloak)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/test/e2e/.gitattributes
+++ b/test/e2e/.gitattributes
@@ -1,0 +1,2 @@
+# The harness runs in a Linux container; keep LF endings regardless of host checkout settings.
+*.sh text eol=lf

--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,3 @@
+# The Jellyfin server state and the unpacked plugin are generated at run time (the workflow, or the
+# local build step in test/e2e/README.md) — never committed.
+jellyfin/config/

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,60 @@
+# End-to-end SSO login harness
+
+An automated, reproducible end-to-end login test (#720/#727) that boots a **real Jellyfin 10.11
+server with the packaged plugin installed** and a **real Keycloak identity provider**, then drives
+full login round-trips headlessly and asserts the outcomes. It supplements — it does **not** replace
+— the manual `Release-QA-Checklist`.
+
+It runs in CI via [`.github/workflows/e2e-login.yml`](../../.github/workflows/e2e-login.yml) and can
+be run locally with one command once you have built the plugin.
+
+## What it verifies
+
+- The **packaged JPRM zip** loads on Linux (the `#181` packaged-crypto-DLL load path that
+  `dotnet test` cannot see), proven by the plugin's anonymous `GET /sso/OID/GetNames` listing the
+  configured, enabled provider.
+- A **full OIDC round-trip** for `alice` (challenge → Keycloak login → callback → `OID/Auth`) mints a
+  Jellyfin session token that works against `GET /Users/Me`.
+- **Role gating**: `bob`, who lacks the `jellyfin-access` role, is refused at the callback.
+- A **fail-closed negative**: a replayed one-time state token is refused.
+
+SAML round-trips are added in a later milestone.
+
+## Architecture (avoiding the issuer-hostname trap)
+
+Everything runs in one `docker compose` stack on a shared network, **including the harness**. Every
+service is addressed by its service-DNS name, so the OIDC issuer and redirect URLs are byte-identical
+whether Jellyfin resolves them server-to-server (discovery, token exchange) or the harness resolves
+them in its browser role:
+
+- issuer: `http://keycloak:8080/realms/e2e`
+- Jellyfin: `http://jellyfin:8096`
+- plugin redirect: `http://jellyfin:8096/sso/OID/redirect/keycloak`
+
+The Keycloak realm (`test/e2e/keycloak/e2e-realm.json`) defines the `jellyfin-oidc` client, the
+`jellyfin-access` realm role, and the users `alice` (in the role) and `bob` (not). A protocol mapper
+emits the realm roles into the id_token as `realm_access.roles`, which the plugin's `RoleClaim` reads.
+
+## Run it locally
+
+Local Docker must be working. The harness installs the **packaged** plugin, so build the zip first.
+
+```sh
+# 1. Build the packaged plugin zip (requires the .NET 9 SDK and JPRM: `pip install jprm`).
+jprm --verbosity=debug plugin build . --output ./artifacts --dotnet-framework net9.0
+
+# 2. Unpack it into the Jellyfin plugins directory the compose stack mounts.
+mkdir -p test/e2e/jellyfin/config/plugins/SSO-Auth
+unzip -o ./artifacts/sso-authentication_*.zip -d test/e2e/jellyfin/config/plugins/SSO-Auth
+chmod -R 0777 test/e2e/jellyfin
+
+# 3. Boot the stack and run the harness (its exit code is the run's exit code).
+docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+
+# 4. Tear down.
+docker compose -f test/e2e/docker-compose.yml down -v
+```
+
+A green run prints `ALL E2E CHECKS PASSED`. In CI, container logs are dumped automatically on
+failure.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,10 +15,13 @@ be run locally with one command once you have built the plugin.
   configured, enabled provider.
 - A **full OIDC round-trip** for `alice` (challenge → Keycloak login → callback → `OID/Auth`) mints a
   Jellyfin session token that works against `GET /Users/Me`.
-- **Role gating**: `bob`, who lacks the `jellyfin-access` role, is refused at the callback.
-- A **fail-closed negative**: a replayed one-time state token is refused.
-
-SAML round-trips are added in a later milestone.
+- A **full SAML round-trip** for `carol` (challenge → Keycloak login → ACS POST → `SAML/Auth`) mints a
+  Jellyfin session token that works against `GET /Users/Me` — exercising the packaged SAML crypto DLLs
+  (#181) and the signed-assertion validation path.
+- **Role gating**: `bob` (OIDC) and `dave` (SAML), who lack the `jellyfin-access` role, are refused at
+  the callback.
+- **Fail-closed negatives**: a replayed one-time OIDC state, and a replayed one-time SAML login-outcome
+  token, are both refused.
 
 ## Architecture (avoiding the issuer-hostname trap)
 
@@ -31,9 +34,13 @@ them in its browser role:
 - Jellyfin: `http://jellyfin:8096`
 - plugin redirect: `http://jellyfin:8096/sso/OID/redirect/keycloak`
 
-The Keycloak realm (`test/e2e/keycloak/e2e-realm.json`) defines the `jellyfin-oidc` client, the
-`jellyfin-access` realm role, and the users `alice` (in the role) and `bob` (not). A protocol mapper
-emits the realm roles into the id_token as `realm_access.roles`, which the plugin's `RoleClaim` reads.
+The Keycloak realm (`test/e2e/keycloak/e2e-realm.json`) defines the `jellyfin-oidc` and `jellyfin-saml`
+clients, the `jellyfin-access` realm role, and four users: `alice`/`carol` (in the role) and
+`bob`/`dave` (not). OIDC uses `alice`/`bob`; SAML uses the distinct `carol`/`dave` so the two protocols
+never contend over the same Jellyfin account. A protocol mapper emits the realm roles into the id_token
+as `realm_access.roles` (read by the plugin's OIDC `RoleClaim`) and into the SAML assertion as a `Role`
+attribute (read by the SAML role gate). The SAML IdP signing certificate is fetched at run time from
+Keycloak's SAML descriptor and configured through the plugin's `SAML/Add` admin API.
 
 ## Run it locally
 

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -1,0 +1,70 @@
+# End-to-end SSO login harness (#720/#727). Boots a real Jellyfin 10.11 server with the
+# packaged plugin installed, a real Keycloak identity provider (OIDC, and later SAML), and a
+# small harness container that drives full login round-trips against them.
+#
+# Every service shares one Docker network and is addressed by its service-DNS name, so the
+# OIDC issuer/redirect URLs are byte-identical whether Jellyfin resolves them server-to-server
+# (discovery, token exchange) or the harness resolves them in its browser role. That is what
+# avoids the classic issuer-hostname mismatch: issuer is always http://keycloak:8080/realms/e2e,
+# Jellyfin is always http://jellyfin:8096, and the plugin redirect is always
+# http://jellyfin:8096/sso/OID/redirect/keycloak.
+#
+# Local run (see test/e2e/README.md for the plugin-build prerequisite):
+#   docker compose -f test/e2e/docker-compose.yml up --build \
+#     --abort-on-container-exit --exit-code-from harness
+name: sso-e2e
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.0
+    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HTTP_ENABLED: "true"
+      # Dev mode already derives the issuer from the request host (keycloak:8080 for both the
+      # server-to-server and browser legs); strict hostname off keeps that behaviour explicit.
+      KC_HOSTNAME_STRICT: "false"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./keycloak/e2e-realm.json:/opt/keycloak/data/import/e2e-realm.json:ro
+    networks:
+      - ssonet
+
+  jellyfin:
+    image: jellyfin/jellyfin:10.11.0
+    environment:
+      # A container-local cache/data root keeps the writable state off the bind-mounted /config
+      # so only the plugin drop and the plugin's own configuration live under ./jellyfin/config.
+      JELLYFIN_CACHE_DIR: /cache
+    volumes:
+      # The packaged plugin zip is unpacked into ./jellyfin/config/plugins/<Name>_<ver>/ before
+      # the stack comes up (the workflow does this; locally, see the README). /config must be
+      # writable — the plugin persists its provider configuration under /config/plugins/configurations/.
+      - ./jellyfin/config:/config
+    networks:
+      - ssonet
+
+  harness:
+    image: alpine:3.20
+    depends_on:
+      - jellyfin
+      - keycloak
+    environment:
+      JELLYFIN_URL: http://jellyfin:8096
+      KEYCLOAK_URL: http://keycloak:8080
+      REALM: e2e
+      PROVIDER: keycloak
+      OIDC_CLIENT_ID: jellyfin-oidc
+      OIDC_CLIENT_SECRET: jellyfin-oidc-secret
+      JF_ADMIN_USER: e2eadmin
+      JF_ADMIN_PASS: e2e-admin-pw
+    volumes:
+      - ./harness:/harness:ro
+    command: ["sh", "/harness/harness.sh"]
+    networks:
+      - ssonet
+
+networks:
+  ssonet:
+    driver: bridge

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -73,3 +73,14 @@ services:
 networks:
   ssonet:
     driver: bridge
+    ipam:
+      config:
+        # The plugin hardens its outbound OIDC backchannel (discovery/token/JWKS) with an SSRF guard
+        # that refuses to connect to any RFC1918 / loopback / CGNAT address (IpAddressClassifier) — a
+        # production defense we must NOT weaken. Every default Docker subnet (10/8, 172.16/12,
+        # 192.168/16) is blocked by it, so a containerised IdP on a default network is unreachable and
+        # discovery fails closed. Put this test network on an IP range the guard treats as public so the
+        # containerised Keycloak is reachable exactly as a real public IdP would be, with the
+        # hostname-based issuer (http://keycloak:8080/realms/e2e) preserved. 11.0.0.0/24 is not routed
+        # anywhere the stack needs; only the three containers use it.
+        - subnet: 11.0.0.0/24

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -32,7 +32,12 @@ services:
       - ssonet
 
   jellyfin:
-    image: jellyfin/jellyfin:10.11.0
+    # Match the Jellyfin version the plugin is COMPILED against (SSO-Auth.csproj JellyfinVersion,
+    # currently 10.11.11): the packaged plugin references MediaBrowser.Controller 10.11.11.0, and .NET
+    # will not bind an assembly reference DOWN to an older patch, so an older 10.11.0 server refuses to
+    # load the plugin. targetAbi (10.11.0.0) governs the API surface the abi-floor job checks, not the
+    # embedded reference version the runtime binds against.
+    image: jellyfin/jellyfin:10.11.11
     environment:
       # A container-local cache/data root keeps the writable state off the bind-mounted /config
       # so only the plugin drop and the plugin's own configuration live under ./jellyfin/config.

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -328,7 +328,11 @@ saml_authorize() {
 
 # saml_acs_post <jar> <form_action> <user> <pass> : posts credentials to Keycloak, parses the returned
 # SAML POST-binding auto-submit form, and posts SAMLResponse to the plugin's ACS. Prints the ACS response
-# body on stdout; diagnostics to stderr. Returns non-zero if any leg fails to produce what the next needs.
+# body on stdout, with a trailing  __ACSHTTP__<code>  marker line carrying the ACS HTTP status (so a caller
+# can tell an actual plugin-side deny — a reached-ACS non-2xx — apart from a token-less body a broken leg
+# would also produce); diagnostics go to stderr. Returns NON-ZERO if it cannot get through the Keycloak
+# login, cannot parse the SAMLResponse form, or cannot connect to the ACS — i.e. a genuine transport break
+# is a hard failure the caller must red on, never something to swallow as a "refusal".
 saml_acs_post() {
   jar="$1"; form_action="$2"; user="$3"; pass="$4"
   post_page="$(curl -sSL -c "$jar" -b "$jar" \
@@ -344,10 +348,13 @@ saml_acs_post() {
     return 1
   fi
   printf 'saml_acs_post: posting SAMLResponse to %s\n' "$acs_url" >&2
+  # -w appends the ACS HTTP status so the caller can assert an actual plugin refusal; NO -f, so a
+  # non-2xx deny still returns the body+marker (a role-gate refusal is an expected outcome here, not a
+  # transport error). A real connection failure to the ACS still exits non-zero and reds the caller.
   if [ -n "$relay" ]; then
-    curl -sS -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp" --data-urlencode "RelayState=$relay"
+    curl -sS -w '\n__ACSHTTP__%{http_code}' -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp" --data-urlencode "RelayState=$relay"
   else
-    curl -sS -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp"
+    curl -sS -w '\n__ACSHTTP__%{http_code}' -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp"
   fi
 }
 
@@ -432,18 +439,29 @@ fi
 log "== SAML round-trip: dave (expect role-gate refusal) =="
 JAR_SD="$(mktemp)"
 SHDR_D="$(mktemp)"
-if SFORM_D="$(saml_authorize "$JAR_SD" "$SHDR_D")"; then
-  # dave authenticates at Keycloak, but the assertion carries no jellyfin-access role, so the ACS
-  # callback denies (no login-outcome token is minted). A token here would be a role-gate failure.
-  ACS_PAGE_D="$(saml_acs_post "$JAR_SD" "$SFORM_D" "dave" "dave" || true)"
-  DTOKEN="$(printf '%s' "$ACS_PAGE_D" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
-  if [ -n "$DTOKEN" ]; then
-    fail "dave: the ACS callback minted a token — the SAML role gate did NOT refuse a role-less user"
-  else
-    pass "dave: SAML callback refused the role-less user (role gate holds)"
-  fi
+# dave must run the SAME real round-trip carol does — reach the Keycloak SAML login form, authenticate,
+# and drive a genuine SAMLResponse POST to the plugin's ACS — and ONLY THEN be refused by the plugin. A
+# broken transport leg (no login form, failed Keycloak login, unparseable SAMLResponse, or an
+# unreachable ACS) must RED the run, not masquerade as a role-gate refusal: a token-less body from a
+# broken leg is indistinguishable from a deny unless we first prove the round-trip actually happened.
+SFORM_D="$(saml_authorize "$JAR_SD" "$SHDR_D")" || die "dave: could not reach the Keycloak SAML login form"
+# saml_acs_post returns non-zero only when it cannot get dave through Keycloak or reach the ACS at all;
+# a reached-ACS (any HTTP status, including the expected deny) returns 0 with the body + status marker.
+ACS_PAGE_D="$(saml_acs_post "$JAR_SD" "$SFORM_D" "dave" "dave")" || die "dave: could not authenticate at Keycloak or reach the SAML ACS (broken negative test)"
+ACS_STATUS_D="$(printf '%s' "$ACS_PAGE_D" | sed -n 's/.*__ACSHTTP__\([0-9][0-9]*\)$/\1/p')"
+DTOKEN="$(printf '%s' "$ACS_PAGE_D" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
+log "dave: reached the SAML ACS; it returned HTTP ${ACS_STATUS_D:-<none>}"
+# The refusal must be an ACTUAL plugin-side deny after a real ACS round-trip: a non-2xx status AND no
+# login-outcome token minted. A minted token is a role-gate failure; a 2xx (or an unreadable status) is
+# a broken test, not a proven refusal.
+if [ -n "$DTOKEN" ]; then
+  fail "dave: the ACS callback minted a login-outcome token — the SAML role gate did NOT refuse a role-less user"
+elif [ -z "$ACS_STATUS_D" ]; then
+  fail "dave: could not read the ACS HTTP status — cannot prove a plugin-side refusal (broken negative test)"
+elif [ "$ACS_STATUS_D" -ge 200 ] && [ "$ACS_STATUS_D" -lt 300 ]; then
+  fail "dave: the ACS returned $ACS_STATUS_D with no token — expected a non-2xx plugin refusal, not an ambiguous empty body"
 else
-  fail "dave: could not reach the Keycloak SAML login form"
+  pass "dave: SAML ACS refused the role-less user at the plugin (HTTP $ACS_STATUS_D, no token minted — role gate holds)"
 fi
 
 # --------------------------------------------------------------------------------------------------

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1,0 +1,265 @@
+#!/bin/sh
+# End-to-end SSO login harness (#720/#727). Runs inside a container on the compose network so it
+# reaches Jellyfin and Keycloak by their service-DNS names — the same names Jellyfin uses
+# server-to-server — so every issuer/redirect URL is identical from both sides.
+#
+# It (1) waits for both servers, (2) completes the Jellyfin first-run wizard and grabs an admin
+# token, (3) configures the OpenID provider through the plugin's admin API, (4) asserts the plugin
+# loaded and the provider is enabled, then drives full browser-role login round-trips:
+#   - alice (in the jellyfin-access role)  -> a Jellyfin session token, usable against /Users/Me
+#   - bob   (no role)                      -> refused at the callback (role gate)
+#   - a replayed one-time state            -> refused (fail-closed)
+#
+# Fail-closed: any assertion miss increments FAILURES; the script exits non-zero at the end, which
+# (with --exit-code-from harness) reds the whole compose run and the CI job.
+set -eu
+
+JELLYFIN="${JELLYFIN_URL:-http://jellyfin:8096}"
+KEYCLOAK="${KEYCLOAK_URL:-http://keycloak:8080}"
+REALM="${REALM:-e2e}"
+PROVIDER="${PROVIDER:-keycloak}"
+CLIENT_ID="${OIDC_CLIENT_ID:-jellyfin-oidc}"
+CLIENT_SECRET="${OIDC_CLIENT_SECRET:-jellyfin-oidc-secret}"
+ADMIN_USER="${JF_ADMIN_USER:-e2eadmin}"
+ADMIN_PASS="${JF_ADMIN_PASS:-e2e-admin-pw}"
+
+# A stable device identity for the harness's Jellyfin API calls (the MediaBrowser auth scheme).
+CLIENT="e2e-harness"
+DEVICE="harness"
+DEVICE_ID="e2e-harness-device"
+VERSION="1.0.0"
+EMBY_AUTH="MediaBrowser Client=\"$CLIENT\", Device=\"$DEVICE\", DeviceId=\"$DEVICE_ID\", Version=\"$VERSION\""
+
+FAILURES=0
+log()  { printf '%s\n' "$*"; }
+pass() { printf 'PASS: %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*"; FAILURES=$((FAILURES + 1)); }
+die()  { printf 'FATAL: %s\n' "$*"; exit 1; }
+
+log "== Installing curl + jq =="
+apk add --no-cache curl jq >/dev/null 2>&1 || die "could not install curl/jq"
+
+wait_for() {
+  # wait_for <label> <url>
+  label="$1"; url="$2"; i=0
+  log "Waiting for $label ($url) ..."
+  while [ "$i" -lt 90 ]; do
+    if curl -fsS -o /dev/null "$url" 2>/dev/null; then
+      log "$label is up"
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 5
+  done
+  die "$label did not become ready in time"
+}
+
+# --------------------------------------------------------------------------------------------------
+# Phase 0 — readiness
+# --------------------------------------------------------------------------------------------------
+wait_for "Keycloak realm discovery" "$KEYCLOAK/realms/$REALM/.well-known/openid-configuration"
+wait_for "Jellyfin" "$JELLYFIN/System/Info/Public"
+
+# --------------------------------------------------------------------------------------------------
+# Phase 1 — Jellyfin first-run wizard + admin token
+# --------------------------------------------------------------------------------------------------
+log "== Completing Jellyfin startup wizard =="
+jf() {
+  # jf METHOD PATH [json-body]
+  method="$1"; path="$2"; body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -fsS -X "$method" "$JELLYFIN$path" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: $EMBY_AUTH" \
+      -d "$body"
+  else
+    curl -fsS -X "$method" "$JELLYFIN$path" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: $EMBY_AUTH"
+  fi
+}
+
+# If the wizard is already complete (a re-run against a persisted /config), skip it.
+WIZARD_DONE="$(curl -fsS "$JELLYFIN/System/Info/Public" | jq -r '.StartupWizardCompleted // false')"
+if [ "$WIZARD_DONE" != "true" ]; then
+  jf GET  "/Startup/Configuration" >/dev/null || die "wizard: get configuration failed"
+  jf POST "/Startup/Configuration" '{"UICulture":"en-US","MetadataCountryCode":"US","PreferredMetadataLanguage":"en"}' >/dev/null || die "wizard: set configuration failed"
+  jf GET  "/Startup/User" >/dev/null || die "wizard: get user failed"
+  jf POST "/Startup/User" "{\"Name\":\"$ADMIN_USER\",\"Password\":\"$ADMIN_PASS\"}" >/dev/null || die "wizard: create admin failed"
+  jf POST "/Startup/RemoteAccess" '{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}' >/dev/null || die "wizard: remote access failed"
+  jf POST "/Startup/Complete" '' >/dev/null || die "wizard: complete failed"
+  log "Wizard complete; admin '$ADMIN_USER' created"
+else
+  log "Wizard already complete; reusing existing server"
+fi
+
+log "== Authenticating as admin =="
+AUTH_JSON="$(curl -fsS -X POST "$JELLYFIN/Users/AuthenticateByName" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: $EMBY_AUTH" \
+  -d "{\"Username\":\"$ADMIN_USER\",\"Pw\":\"$ADMIN_PASS\"}")" || die "admin authenticate failed"
+ADMIN_TOKEN="$(printf '%s' "$AUTH_JSON" | jq -r '.AccessToken')"
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || die "no admin access token minted"
+log "Admin token acquired"
+
+# --------------------------------------------------------------------------------------------------
+# Phase 2 — configure the OpenID provider through the plugin admin API
+# --------------------------------------------------------------------------------------------------
+log "== Configuring OpenID provider '$PROVIDER' =="
+# DisableHttps: the containerised Keycloak issuer is plaintext http (a test-IdP quirk); this is the
+#   existing per-provider escape hatch, not a production default change.
+# DoNotLoadProfile: the id_token is the whole identity (username + realm_access.roles), so no userinfo
+#   fetch is needed — mirrors the in-repo OidcRoundTripTests.
+# DisablePushedAuthorization: keep the challenge a plain redirect the harness can follow with curl.
+# Roles + RoleClaim: the login allow-list. alice carries realm_access.roles=["jellyfin-access"]; bob
+#   does not, so bob is refused at the callback.
+OID_CONFIG="$(cat <<JSON
+{
+  "OidEndpoint": "$KEYCLOAK/realms/$REALM",
+  "OidClientId": "$CLIENT_ID",
+  "OidSecret": "$CLIENT_SECRET",
+  "Enabled": true,
+  "OidScopes": ["email"],
+  "DoNotLoadProfile": true,
+  "DisablePushedAuthorization": true,
+  "DisableHttps": true,
+  "EnableAuthorization": true,
+  "Roles": ["jellyfin-access"],
+  "RoleClaim": "realm_access.roles"
+}
+JSON
+)"
+curl -fsS -X POST "$JELLYFIN/sso/OID/Add/$PROVIDER" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+  -d "$OID_CONFIG" >/dev/null || die "OID/Add failed"
+log "Provider configured"
+
+# --------------------------------------------------------------------------------------------------
+# Phase 3 — assert the plugin loaded and the provider is enabled (milestone 1)
+# --------------------------------------------------------------------------------------------------
+log "== Asserting plugin loaded (GET /sso/OID/GetNames) =="
+NAMES="$(curl -fsS "$JELLYFIN/sso/OID/GetNames")" || die "GetNames request failed"
+log "GetNames => $NAMES"
+if printf '%s' "$NAMES" | jq -e --arg p "$PROVIDER" 'index($p)' >/dev/null 2>&1; then
+  pass "plugin loaded and provider '$PROVIDER' is listed by GetNames"
+else
+  fail "provider '$PROVIDER' not listed by GetNames (plugin may not have loaded)"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# OIDC browser-role helpers
+# --------------------------------------------------------------------------------------------------
+# oidc_authorize <cookiejar> : drives start -> keycloak login page, prints the login form action URL.
+oidc_authorize() {
+  jar="$1"
+  auth_url="$(curl -fsS -c "$jar" -b "$jar" -o /dev/null -w '%{redirect_url}' "$JELLYFIN/sso/OID/start/$PROVIDER")"
+  [ -n "$auth_url" ] || { log "no authorize redirect from /start"; return 1; }
+  login_page="$(curl -fsSL -c "$jar" -b "$jar" "$auth_url")" || { log "keycloak login page fetch failed"; return 1; }
+  form_action="$(printf '%s' "$login_page" | grep -oE 'action="[^"]*"' | head -1 | sed -e 's/^action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+  [ -n "$form_action" ] || { log "could not parse keycloak login form action"; return 1; }
+  printf '%s' "$form_action"
+}
+
+# --------------------------------------------------------------------------------------------------
+# Phase 4 — full OIDC round-trip for alice (milestone 2)
+# --------------------------------------------------------------------------------------------------
+log "== OIDC round-trip: alice (expect success) =="
+JAR="$(mktemp)"
+FORM_ACTION="$(oidc_authorize "$JAR")" || die "alice: could not reach keycloak login form"
+
+# Post alice's credentials; Keycloak 302s back to the plugin callback with code + state.
+CB_URL="$(curl -fsS -c "$JAR" -b "$JAR" -o /dev/null -w '%{redirect_url}' \
+  --data-urlencode "username=alice" \
+  --data-urlencode "password=alice" \
+  --data-urlencode "credentialId=" \
+  "$FORM_ACTION")" || die "alice: credential POST failed"
+log "alice callback URL => ${CB_URL%%\?*}?<query>"
+case "$CB_URL" in
+  "$JELLYFIN"/sso/OID/redirect/*) : ;;
+  *) die "alice: unexpected callback URL: $CB_URL" ;;
+esac
+
+# Follow the callback WITH the binding cookie so the plugin promotes the state to redeemable, and
+# capture the intermediate auth page. The page embeds  var data = "<state>";  which is exactly what
+# a real browser posts to OID/Auth.
+AUTH_PAGE="$(curl -fsS -c "$JAR" -b "$JAR" "$CB_URL")" || die "alice: callback did not return the auth page"
+STATE="$(printf '%s' "$AUTH_PAGE" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
+[ -n "$STATE" ] || die "alice: could not extract state token from the auth page"
+
+# Post to OID/Auth with the binding cookie -> the minted Jellyfin session (AuthenticationResult).
+AUTH_RESULT="$(curl -fsS -c "$JAR" -b "$JAR" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
+  -H "Content-Type: application/json" \
+  -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STATE\"}")" || die "alice: OID/Auth failed"
+JF_TOKEN="$(printf '%s' "$AUTH_RESULT" | jq -r '.AccessToken')"
+JF_USER="$(printf '%s' "$AUTH_RESULT" | jq -r '.User.Name')"
+if [ -n "$JF_TOKEN" ] && [ "$JF_TOKEN" != "null" ]; then
+  pass "alice: Jellyfin session token minted (user='$JF_USER')"
+else
+  fail "alice: OID/Auth did not mint a session token"
+fi
+
+# The minted token must be usable against a real Jellyfin API.
+if [ -n "${JF_TOKEN:-}" ] && [ "$JF_TOKEN" != "null" ]; then
+  ME="$(curl -fsS "$JELLYFIN/Users/Me" -H "Authorization: MediaBrowser Token=\"$JF_TOKEN\"")" || ME=""
+  ME_NAME="$(printf '%s' "$ME" | jq -r '.Name // empty' 2>/dev/null || true)"
+  if [ "$ME_NAME" = "alice" ]; then
+    pass "alice: session token works against GET /Users/Me (Name='alice')"
+  else
+    fail "alice: GET /Users/Me did not return the alice user (got '$ME_NAME')"
+  fi
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Phase 5 — role-gate negative: bob is refused (milestone 3)
+# --------------------------------------------------------------------------------------------------
+log "== OIDC round-trip: bob (expect role-gate refusal) =="
+JAR_BOB="$(mktemp)"
+if FORM_ACTION_BOB="$(oidc_authorize "$JAR_BOB")"; then
+  CB_URL_BOB="$(curl -fsS -c "$JAR_BOB" -b "$JAR_BOB" -o /dev/null -w '%{redirect_url}' \
+    --data-urlencode "username=bob" \
+    --data-urlencode "password=bob" \
+    --data-urlencode "credentialId=" \
+    "$FORM_ACTION_BOB" || true)"
+  if [ -z "$CB_URL_BOB" ]; then
+    fail "bob: Keycloak did not redirect back (authentication itself failed unexpectedly)"
+  else
+    # The callback must NOT return the success auth page: the role gate denies bob, so the plugin
+    # returns a non-2xx error page. curl -f makes a 4xx a non-zero exit.
+    if curl -fsS -o /dev/null -c "$JAR_BOB" -b "$JAR_BOB" "$CB_URL_BOB" 2>/dev/null; then
+      fail "bob: callback returned success — the role gate did NOT refuse a role-less user"
+    else
+      pass "bob: callback refused the role-less user (role gate holds)"
+    fi
+  fi
+else
+  fail "bob: could not reach the Keycloak login form"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Phase 6 — fail-closed negative: a replayed one-time state is refused
+# --------------------------------------------------------------------------------------------------
+log "== Fail-closed negative: replayed state (expect refusal) =="
+if [ -n "${STATE:-}" ]; then
+  # alice's STATE was already redeemed once in Phase 4; replaying it must be rejected.
+  if curl -fsS -o /dev/null -c "$JAR" -b "$JAR" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
+      -H "Content-Type: application/json" \
+      -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STATE\"}" 2>/dev/null; then
+    fail "replayed state was accepted — one-time-use is NOT enforced"
+  else
+    pass "replayed state refused (one-time-use holds)"
+  fi
+else
+  fail "replay check skipped: no state captured from the alice round-trip"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------------------------------
+log ""
+if [ "$FAILURES" -eq 0 ]; then
+  log "ALL E2E CHECKS PASSED"
+  exit 0
+fi
+log "E2E CHECKS FAILED: $FAILURES assertion(s) did not hold"
+exit 1

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -297,6 +297,172 @@ else
   fail "replay check skipped: no state captured from the alice round-trip"
 fi
 
+# ==================================================================================================
+# SAML
+# ==================================================================================================
+# The SAML browser-binding cookie (#415) — like the OpenID one, always Secure, so presented explicitly
+# over plaintext http. It is checked at the same-origin SAML/Auth mint leg (the cross-site ACS POST does
+# not carry it).
+SAML_BINDING_COOKIE_NAME="__Host-sso_saml_state_binding"
+
+# saml_authorize <jar> <start_hdr> : /start -> keycloak login form action URL (stdout). Diagnostics to
+# stderr. Writes the /start response headers (carrying the SAML binding Set-Cookie) to start_hdr.
+saml_authorize() {
+  jar="$1"; start_hdr="$2"
+  start_out="$(curl -sS -D "$start_hdr" -o /dev/null -c "$jar" -b "$jar" -w '%{http_code} %{redirect_url}' "$JELLYFIN/sso/SAML/start/$PROVIDER")"
+  code="${start_out%% *}"; auth_url="${start_out#* }"
+  printf 'saml_authorize: /start -> HTTP %s location=%s\n' "$code" "${auth_url%%\?*}?<SAMLRequest>" >&2
+  if [ -z "$auth_url" ]; then
+    printf 'saml_authorize: /start returned no redirect; body was:\n' >&2
+    curl -sS -c "$jar" -b "$jar" "$JELLYFIN/sso/SAML/start/$PROVIDER" >&2 || true
+    return 1
+  fi
+  login_page="$(curl -sSL -c "$jar" -b "$jar" "$auth_url")" || { printf 'saml_authorize: login page curl failed\n' >&2; return 1; }
+  form_action="$(printf '%s' "$login_page" | grep -oE 'action="[^"]*"' | head -1 | sed -e 's/^action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+  if [ -z "$form_action" ]; then
+    printf 'saml_authorize: could not parse a form action; first 800 chars:\n%s\n' "$(printf '%s' "$login_page" | head -c 800)" >&2
+    return 1
+  fi
+  printf '%s' "$form_action"
+}
+
+# saml_acs_post <jar> <form_action> <user> <pass> : posts credentials to Keycloak, parses the returned
+# SAML POST-binding auto-submit form, and posts SAMLResponse to the plugin's ACS. Prints the ACS response
+# body on stdout; diagnostics to stderr. Returns non-zero if any leg fails to produce what the next needs.
+saml_acs_post() {
+  jar="$1"; form_action="$2"; user="$3"; pass="$4"
+  post_page="$(curl -sSL -c "$jar" -b "$jar" \
+    --data-urlencode "username=$user" \
+    --data-urlencode "password=$pass" \
+    --data-urlencode "credentialId=" \
+    "$form_action")" || { printf 'saml_acs_post: credential POST failed\n' >&2; return 1; }
+  acs_url="$(printf '%s' "$post_page" | grep -oE 'form[^>]*action="[^"]*"' | head -1 | sed -E 's/.*action="//; s/".*//; s/&amp;/\&/g')"
+  saml_resp="$(printf '%s' "$post_page" | grep -oE 'name="SAMLResponse"[^>]*value="[^"]*"' | head -1 | sed -E 's/.*value="//; s/".*//')"
+  relay="$(printf '%s' "$post_page" | grep -oE 'name="RelayState"[^>]*value="[^"]*"' | head -1 | sed -E 's/.*value="//; s/".*//')"
+  if [ -z "$acs_url" ] || [ -z "$saml_resp" ]; then
+    printf 'saml_acs_post: could not parse SAMLResponse form (acs=%s, resp_len=%s); first 800 chars:\n%s\n' "$acs_url" "${#saml_resp}" "$(printf '%s' "$post_page" | head -c 800)" >&2
+    return 1
+  fi
+  printf 'saml_acs_post: posting SAMLResponse to %s\n' "$acs_url" >&2
+  if [ -n "$relay" ]; then
+    curl -sS -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp" --data-urlencode "RelayState=$relay"
+  else
+    curl -sS -X POST "$acs_url" --data-urlencode "SAMLResponse=$saml_resp"
+  fi
+}
+
+# --------------------------------------------------------------------------------------------------
+# Phase 7 — configure the SAML provider (IdP signing cert fetched from Keycloak's SAML descriptor)
+# --------------------------------------------------------------------------------------------------
+log "== Configuring SAML provider '$PROVIDER' =="
+DESCRIPTOR="$(curl -fsS "$KEYCLOAK/realms/$REALM/protocol/saml/descriptor")" || die "SAML: descriptor fetch failed"
+IDP_CERT="$(printf '%s' "$DESCRIPTOR" | tr -d '\n\r' | grep -oiE '<[a-z0-9]*:?X509Certificate>[^<]*' | head -1 | sed -E 's/.*X509Certificate>//' | tr -d ' \t')"
+[ -n "$IDP_CERT" ] || die "SAML: could not extract the IdP signing certificate from the descriptor"
+log "SAML IdP signing certificate captured (${#IDP_CERT} base64 chars)"
+
+SAML_CONFIG="$(cat <<JSON
+{
+  "SamlEndpoint": "$KEYCLOAK/realms/$REALM/protocol/saml",
+  "SamlClientId": "jellyfin-saml",
+  "SamlCertificate": "$IDP_CERT",
+  "Enabled": true,
+  "EnableAuthorization": true,
+  "Roles": ["jellyfin-access"]
+}
+JSON
+)"
+SADD_STATUS="$(curl -sS -o /tmp/samladd.out -w '%{http_code}' -X POST "$JELLYFIN/sso/SAML/Add/$PROVIDER" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+  -d "$SAML_CONFIG")" || true
+if [ "$SADD_STATUS" != "200" ] && [ "$SADD_STATUS" != "204" ]; then
+  log "SAML/Add returned HTTP $SADD_STATUS: $(cat /tmp/samladd.out 2>/dev/null)"
+  die "SAML/Add failed"
+fi
+SNAMES="$(curl -fsS "$JELLYFIN/sso/SAML/GetNames")" || die "SAML GetNames failed"
+log "SAML GetNames => $SNAMES"
+if printf '%s' "$SNAMES" | jq -e --arg p "$PROVIDER" 'index($p)' >/dev/null 2>&1; then
+  pass "SAML provider '$PROVIDER' is listed by SAML/GetNames"
+else
+  fail "SAML provider '$PROVIDER' not listed by SAML/GetNames"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Phase 8 — full SAML round-trip for carol (milestone 4)
+# --------------------------------------------------------------------------------------------------
+log "== SAML round-trip: carol (expect success) =="
+JAR_S="$(mktemp)"
+SHDR="$(mktemp)"
+SFORM="$(saml_authorize "$JAR_S" "$SHDR")" || die "carol: could not reach the Keycloak SAML login form"
+SBIND="$(grep -i '^set-cookie:' "$SHDR" 2>/dev/null | grep -o "$SAML_BINDING_COOKIE_NAME=[^;]*" | head -1 | cut -d= -f2-)"
+[ -n "$SBIND" ] || die "carol: /start set no SAML browser-binding cookie"
+
+ACS_PAGE="$(saml_acs_post "$JAR_S" "$SFORM" "carol" "carol")" || die "carol: SAML login/ACS leg failed"
+STOKEN="$(printf '%s' "$ACS_PAGE" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
+if [ -z "$STOKEN" ]; then
+  log "carol: ACS response carried no login token; first 600 chars: $(printf '%s' "$ACS_PAGE" | head -c 600)"
+  die "carol: the ACS callback did not mint a login-outcome token (signature/audience/role gate?)"
+fi
+
+# Redeem the token at the same-origin SAML/Auth mint leg, presenting the SAML binding cookie explicitly.
+SAUTH="$(curl -fsS -H "Cookie: $SAML_BINDING_COOKIE_NAME=$SBIND" -X POST "$JELLYFIN/sso/SAML/Auth/$PROVIDER" \
+  -H "Content-Type: application/json" \
+  -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STOKEN\"}")" || die "carol: SAML/Auth failed"
+S_JF_TOKEN="$(printf '%s' "$SAUTH" | jq -r '.AccessToken')"
+S_JF_USER="$(printf '%s' "$SAUTH" | jq -r '.User.Name')"
+if [ -n "$S_JF_TOKEN" ] && [ "$S_JF_TOKEN" != "null" ]; then
+  pass "carol: Jellyfin session token minted via SAML (user='$S_JF_USER')"
+else
+  fail "carol: SAML/Auth did not mint a session token"
+fi
+
+if [ -n "${S_JF_TOKEN:-}" ] && [ "$S_JF_TOKEN" != "null" ]; then
+  SME="$(curl -fsS "$JELLYFIN/Users/Me" -H "Authorization: MediaBrowser Token=\"$S_JF_TOKEN\"")" || SME=""
+  SME_NAME="$(printf '%s' "$SME" | jq -r '.Name // empty' 2>/dev/null || true)"
+  if [ "$SME_NAME" = "carol" ]; then
+    pass "carol: SAML session token works against GET /Users/Me (Name='carol')"
+  else
+    fail "carol: GET /Users/Me did not return the carol user (got '$SME_NAME')"
+  fi
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Phase 9 — SAML role-gate negative: dave is refused
+# --------------------------------------------------------------------------------------------------
+log "== SAML round-trip: dave (expect role-gate refusal) =="
+JAR_SD="$(mktemp)"
+SHDR_D="$(mktemp)"
+if SFORM_D="$(saml_authorize "$JAR_SD" "$SHDR_D")"; then
+  # dave authenticates at Keycloak, but the assertion carries no jellyfin-access role, so the ACS
+  # callback denies (no login-outcome token is minted). A token here would be a role-gate failure.
+  ACS_PAGE_D="$(saml_acs_post "$JAR_SD" "$SFORM_D" "dave" "dave" || true)"
+  DTOKEN="$(printf '%s' "$ACS_PAGE_D" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
+  if [ -n "$DTOKEN" ]; then
+    fail "dave: the ACS callback minted a token — the SAML role gate did NOT refuse a role-less user"
+  else
+    pass "dave: SAML callback refused the role-less user (role gate holds)"
+  fi
+else
+  fail "dave: could not reach the Keycloak SAML login form"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Phase 10 — SAML fail-closed negative: a replayed one-time login-outcome token is refused
+# --------------------------------------------------------------------------------------------------
+log "== SAML fail-closed negative: replayed token (expect refusal) =="
+if [ -n "${STOKEN:-}" ]; then
+  # carol's STOKEN was already redeemed once in Phase 8; replaying it must be rejected.
+  if curl -fsS -o /dev/null -H "Cookie: $SAML_BINDING_COOKIE_NAME=$SBIND" -X POST "$JELLYFIN/sso/SAML/Auth/$PROVIDER" \
+      -H "Content-Type: application/json" \
+      -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STOKEN\"}" 2>/dev/null; then
+    fail "SAML: replayed login-outcome token was accepted — one-time-use is NOT enforced"
+  else
+    pass "SAML: replayed login-outcome token refused (one-time-use holds)"
+  fi
+else
+  fail "SAML replay check skipped: no token captured from the carol round-trip"
+fi
+
 # --------------------------------------------------------------------------------------------------
 # Summary
 # --------------------------------------------------------------------------------------------------

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -154,14 +154,31 @@ fi
 # --------------------------------------------------------------------------------------------------
 # OIDC browser-role helpers
 # --------------------------------------------------------------------------------------------------
-# oidc_authorize <cookiejar> : drives start -> keycloak login page, prints the login form action URL.
+# oidc_authorize <cookiejar> : drives start -> keycloak login page, prints the login form action URL
+# on stdout. ALL diagnostics go to stderr so they are not captured by the caller's $(...) and are
+# visible in the container log.
 oidc_authorize() {
   jar="$1"
-  auth_url="$(curl -fsS -c "$jar" -b "$jar" -o /dev/null -w '%{redirect_url}' "$JELLYFIN/sso/OID/start/$PROVIDER")"
-  [ -n "$auth_url" ] || { log "no authorize redirect from /start"; return 1; }
-  login_page="$(curl -fsSL -c "$jar" -b "$jar" "$auth_url")" || { log "keycloak login page fetch failed"; return 1; }
+  # /start must 302 to the IdP authorize endpoint.
+  start_out="$(curl -sS -o /dev/null -c "$jar" -b "$jar" -w '%{http_code} %{redirect_url}' "$JELLYFIN/sso/OID/start/$PROVIDER")"
+  start_code="${start_out%% *}"
+  auth_url="${start_out#* }"
+  printf 'oidc_authorize: /start -> HTTP %s location=%s\n' "$start_code" "$auth_url" >&2
+  if [ -z "$auth_url" ]; then
+    printf 'oidc_authorize: /start returned no redirect; body was:\n' >&2
+    curl -sS -c "$jar" -b "$jar" "$JELLYFIN/sso/OID/start/$PROVIDER" >&2 || true
+    return 1
+  fi
+  # Fetch the Keycloak login page (following any Keycloak-internal redirect), keeping the HTTP code.
+  login_page="$(curl -sSL -c "$jar" -b "$jar" -w '\n__HTTP__%{http_code}' "$auth_url")" || { printf 'oidc_authorize: login page curl failed\n' >&2; return 1; }
+  page_code="$(printf '%s' "$login_page" | sed -n 's/.*__HTTP__\([0-9]*\)$/\1/p')"
+  printf 'oidc_authorize: keycloak authorize page -> HTTP %s\n' "$page_code" >&2
   form_action="$(printf '%s' "$login_page" | grep -oE 'action="[^"]*"' | head -1 | sed -e 's/^action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
-  [ -n "$form_action" ] || { log "could not parse keycloak login form action"; return 1; }
+  if [ -z "$form_action" ]; then
+    printf 'oidc_authorize: could not parse a form action from the authorize page; first 1200 chars:\n%s\n' "$(printf '%s' "$login_page" | head -c 1200)" >&2
+    return 1
+  fi
+  printf 'oidc_authorize: form action=%s\n' "$form_action" >&2
   printf '%s' "$form_action"
 }
 

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -129,10 +129,14 @@ OID_CONFIG="$(cat <<JSON
 }
 JSON
 )"
-curl -fsS -X POST "$JELLYFIN/sso/OID/Add/$PROVIDER" \
+ADD_STATUS="$(curl -sS -o /tmp/add.out -w '%{http_code}' -X POST "$JELLYFIN/sso/OID/Add/$PROVIDER" \
   -H "Content-Type: application/json" \
   -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-  -d "$OID_CONFIG" >/dev/null || die "OID/Add failed"
+  -d "$OID_CONFIG")" || true
+if [ "$ADD_STATUS" != "200" ] && [ "$ADD_STATUS" != "204" ]; then
+  log "OID/Add returned HTTP $ADD_STATUS: $(cat /tmp/add.out 2>/dev/null)"
+  die "OID/Add failed (is the plugin loaded? a 404 means it is not)"
+fi
 log "Provider configured"
 
 # --------------------------------------------------------------------------------------------------

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -30,6 +30,14 @@ DEVICE_ID="e2e-harness-device"
 VERSION="1.0.0"
 EMBY_AUTH="MediaBrowser Client=\"$CLIENT\", Device=\"$DEVICE\", DeviceId=\"$DEVICE_ID\", Version=\"$VERSION\""
 
+# The plugin's browser-binding cookie (#326). It is always marked Secure (every real OpenID deployment is
+# HTTPS at the browser edge), so over the harness's plaintext http, curl stores it but will NOT send it
+# back. We therefore capture its value from the /start response and present it EXPLICITLY as a Cookie
+# header on the callback and OID/Auth legs — curl does not enforce Secure on a manually-set header, and the
+# server reads the cookie by name regardless of the __Host- prefix. This exercises the real binding check
+# without weakening the production Secure/__Host- policy.
+BINDING_COOKIE_NAME="__Host-sso_oid_state_binding"
+
 FAILURES=0
 log()  { printf '%s\n' "$*"; }
 pass() { printf 'PASS: %s\n' "$*"; }
@@ -154,13 +162,20 @@ fi
 # --------------------------------------------------------------------------------------------------
 # OIDC browser-role helpers
 # --------------------------------------------------------------------------------------------------
-# oidc_authorize <cookiejar> : drives start -> keycloak login page, prints the login form action URL
-# on stdout. ALL diagnostics go to stderr so they are not captured by the caller's $(...) and are
+# extract_binding <headers_file> : prints the browser-binding cookie value from a /start response's
+# Set-Cookie headers.
+extract_binding() {
+  grep -i '^set-cookie:' "$1" 2>/dev/null | grep -o "$BINDING_COOKIE_NAME=[^;]*" | head -1 | cut -d= -f2-
+}
+
+# oidc_authorize <cookiejar> <start_headers_file> : drives start -> keycloak login page, prints the login
+# form action URL on stdout and writes the /start response headers (carrying the binding Set-Cookie) to the
+# headers file. ALL diagnostics go to stderr so they are not captured by the caller's $(...) and are
 # visible in the container log.
 oidc_authorize() {
-  jar="$1"
+  jar="$1"; start_hdr="$2"
   # /start must 302 to the IdP authorize endpoint.
-  start_out="$(curl -sS -o /dev/null -c "$jar" -b "$jar" -w '%{http_code} %{redirect_url}' "$JELLYFIN/sso/OID/start/$PROVIDER")"
+  start_out="$(curl -sS -D "$start_hdr" -o /dev/null -c "$jar" -b "$jar" -w '%{http_code} %{redirect_url}' "$JELLYFIN/sso/OID/start/$PROVIDER")"
   start_code="${start_out%% *}"
   auth_url="${start_out#* }"
   printf 'oidc_authorize: /start -> HTTP %s location=%s\n' "$start_code" "$auth_url" >&2
@@ -187,7 +202,10 @@ oidc_authorize() {
 # --------------------------------------------------------------------------------------------------
 log "== OIDC round-trip: alice (expect success) =="
 JAR="$(mktemp)"
-FORM_ACTION="$(oidc_authorize "$JAR")" || die "alice: could not reach keycloak login form"
+START_HDR="$(mktemp)"
+FORM_ACTION="$(oidc_authorize "$JAR" "$START_HDR")" || die "alice: could not reach keycloak login form"
+BINDING="$(extract_binding "$START_HDR")"
+[ -n "$BINDING" ] || die "alice: /start set no browser-binding cookie"
 
 # Post alice's credentials; Keycloak 302s back to the plugin callback with code + state.
 CB_URL="$(curl -fsS -c "$JAR" -b "$JAR" -o /dev/null -w '%{redirect_url}' \
@@ -201,15 +219,16 @@ case "$CB_URL" in
   *) die "alice: unexpected callback URL: $CB_URL" ;;
 esac
 
-# Follow the callback WITH the binding cookie so the plugin promotes the state to redeemable, and
-# capture the intermediate auth page. The page embeds  var data = "<state>";  which is exactly what
-# a real browser posts to OID/Auth.
-AUTH_PAGE="$(curl -fsS -c "$JAR" -b "$JAR" "$CB_URL")" || die "alice: callback did not return the auth page"
+# Follow the callback WITH the binding cookie (presented explicitly — see BINDING_COOKIE_NAME above) so
+# the plugin's browser-binding check passes and it promotes the state to redeemable, and capture the
+# intermediate auth page. The page embeds  var data = "<state>";  which is exactly what a real browser
+# posts to OID/Auth.
+AUTH_PAGE="$(curl -fsS -H "Cookie: $BINDING_COOKIE_NAME=$BINDING" "$CB_URL")" || die "alice: callback did not return the auth page"
 STATE="$(printf '%s' "$AUTH_PAGE" | grep -oE 'var data = "[^"]*"' | head -1 | sed -e 's/^var data = "//' -e 's/"$//')"
 [ -n "$STATE" ] || die "alice: could not extract state token from the auth page"
 
 # Post to OID/Auth with the binding cookie -> the minted Jellyfin session (AuthenticationResult).
-AUTH_RESULT="$(curl -fsS -c "$JAR" -b "$JAR" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
+AUTH_RESULT="$(curl -fsS -H "Cookie: $BINDING_COOKIE_NAME=$BINDING" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
   -H "Content-Type: application/json" \
   -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STATE\"}")" || die "alice: OID/Auth failed"
 JF_TOKEN="$(printf '%s' "$AUTH_RESULT" | jq -r '.AccessToken')"
@@ -236,7 +255,9 @@ fi
 # --------------------------------------------------------------------------------------------------
 log "== OIDC round-trip: bob (expect role-gate refusal) =="
 JAR_BOB="$(mktemp)"
-if FORM_ACTION_BOB="$(oidc_authorize "$JAR_BOB")"; then
+START_HDR_BOB="$(mktemp)"
+if FORM_ACTION_BOB="$(oidc_authorize "$JAR_BOB" "$START_HDR_BOB")"; then
+  BINDING_BOB="$(extract_binding "$START_HDR_BOB")"
   CB_URL_BOB="$(curl -fsS -c "$JAR_BOB" -b "$JAR_BOB" -o /dev/null -w '%{redirect_url}' \
     --data-urlencode "username=bob" \
     --data-urlencode "password=bob" \
@@ -245,9 +266,11 @@ if FORM_ACTION_BOB="$(oidc_authorize "$JAR_BOB")"; then
   if [ -z "$CB_URL_BOB" ]; then
     fail "bob: Keycloak did not redirect back (authentication itself failed unexpectedly)"
   else
-    # The callback must NOT return the success auth page: the role gate denies bob, so the plugin
-    # returns a non-2xx error page. curl -f makes a 4xx a non-zero exit.
-    if curl -fsS -o /dev/null -c "$JAR_BOB" -b "$JAR_BOB" "$CB_URL_BOB" 2>/dev/null; then
+    # The callback must NOT return the success auth page: bob authenticates at Keycloak, but the role
+    # gate denies him, so the plugin returns a non-2xx error page (curl -f makes a 4xx a non-zero exit).
+    # The binding cookie is presented, so this isolates the ROLE gate — a refusal here is the role gate,
+    # not a binding miss.
+    if curl -fsS -o /dev/null -H "Cookie: $BINDING_COOKIE_NAME=$BINDING_BOB" "$CB_URL_BOB" 2>/dev/null; then
       fail "bob: callback returned success — the role gate did NOT refuse a role-less user"
     else
       pass "bob: callback refused the role-less user (role gate holds)"
@@ -263,7 +286,7 @@ fi
 log "== Fail-closed negative: replayed state (expect refusal) =="
 if [ -n "${STATE:-}" ]; then
   # alice's STATE was already redeemed once in Phase 4; replaying it must be rejected.
-  if curl -fsS -o /dev/null -c "$JAR" -b "$JAR" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
+  if curl -fsS -o /dev/null -H "Cookie: $BINDING_COOKIE_NAME=$BINDING" -X POST "$JELLYFIN/sso/OID/Auth/$PROVIDER" \
       -H "Content-Type: application/json" \
       -d "{\"deviceId\":\"$DEVICE_ID\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"$DEVICE\",\"data\":\"$STATE\"}" 2>/dev/null; then
     fail "replayed state was accepted — one-time-use is NOT enforced"

--- a/test/e2e/keycloak/e2e-realm.json
+++ b/test/e2e/keycloak/e2e-realm.json
@@ -1,0 +1,93 @@
+{
+  "realm": "e2e",
+  "enabled": true,
+  "sslRequired": "none",
+  "loginWithEmailAllowed": false,
+  "registrationAllowed": false,
+  "roles": {
+    "realm": [
+      {
+        "name": "jellyfin-access",
+        "description": "Realm role that gates access to the Jellyfin SSO plugin (the plugin Roles allow-list)."
+      }
+    ]
+  },
+  "groups": [],
+  "clients": [
+    {
+      "clientId": "jellyfin-oidc",
+      "name": "Jellyfin SSO (OIDC)",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "jellyfin-oidc-secret",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://jellyfin:8096/sso/OID/redirect/*",
+        "http://jellyfin:8096/sso/OID/r/*"
+      ],
+      "webOrigins": [
+        "http://jellyfin:8096"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": ""
+      },
+      "protocolMappers": [
+        {
+          "name": "realm-roles-in-id-token",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "usermodel.realmRoleMapping.rolePrefix": "",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "alice@example.com",
+      "firstName": "Alice",
+      "lastName": "Example",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "alice",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "jellyfin-access"
+      ]
+    },
+    {
+      "username": "bob",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "bob@example.com",
+      "firstName": "Bob",
+      "lastName": "Example",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "bob",
+          "temporary": false
+        }
+      ],
+      "realmRoles": []
+    }
+  ]
+}

--- a/test/e2e/keycloak/e2e-realm.json
+++ b/test/e2e/keycloak/e2e-realm.json
@@ -52,6 +52,40 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "jellyfin-saml",
+      "name": "Jellyfin SSO (SAML)",
+      "enabled": true,
+      "protocol": "saml",
+      "frontchannelLogout": true,
+      "redirectUris": [
+        "http://jellyfin:8096/sso/SAML/post/*",
+        "http://jellyfin:8096/sso/SAML/p/*"
+      ],
+      "attributes": {
+        "saml.server.signature": "true",
+        "saml.assertion.signature": "true",
+        "saml.client.signature": "false",
+        "saml.force.post.binding": "true",
+        "saml.authnstatement": "true",
+        "saml_name_id_format": "username",
+        "saml_signature_canonicalization_method": "http://www.w3.org/2001/10/xml-exc-c14n#",
+        "saml.signature.algorithm": "RSA_SHA256"
+      },
+      "protocolMappers": [
+        {
+          "name": "role-list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
     }
   ],
   "users": [
@@ -84,6 +118,40 @@
         {
           "type": "password",
           "value": "bob",
+          "temporary": false
+        }
+      ],
+      "realmRoles": []
+    },
+    {
+      "username": "carol",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "carol@example.com",
+      "firstName": "Carol",
+      "lastName": "Example",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "carol",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "jellyfin-access"
+      ]
+    },
+    {
+      "username": "dave",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "dave@example.com",
+      "firstName": "Dave",
+      "lastName": "Example",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "dave",
           "temporary": false
         }
       ],


### PR DESCRIPTION
## What & why

An automated end-to-end SSO-login harness (#720/#727 gate-(a) support). A
`docker compose` stack, a new workflow `.github/workflows/e2e-login.yml` +
`test/e2e/`, boots **Jellyfin 10.11 + Keycloak** (OIDC **and** SAML), installs
the **packaged JPRM plugin zip**, and drives full login round-trips headlessly.
It supplements, never replaces, the manual Release-QA checklist. Runs on GitHub's
Docker (nightly + on harness changes + on-demand).

**Green run (all 10 assertions):**
- ✅ plugin loads; provider listed by `GetNames`
- ✅ OIDC: `alice` → real Jellyfin session token → works against `/Users/Me`
- ✅ SAML: `carol` → same
- ✅ role gate: `bob` (OIDC) + `dave` (SAML) refused **at the plugin after a real IdP round-trip** (proven 401, no token minted)
- ✅ fail-closed: replayed OIDC state + replayed SAML one-time token refused

## Exercises what `dotnet test` can't
Packaged-plugin **crypto-DLL load on Linux** (#181), real discovery/token/ACS
over the wire, and the role gate + replay defenses end to end.

## Notes / real findings surfaced during bring-up (all confined to `test/e2e/`, no production code touched)
- A Jellyfin server **older than the compiled-against patch** (`10.11.0` vs the
  `10.11.11`-referenced build) refuses to load the plugin, the harness pins the
  server image to match (a genuine ABI data point).
- The plugin's **SSRF guard** refuses every RFC1918/loopback address, so the
  compose network uses `11.0.0.0/24` (which the existing guard treats as public
 , no production default weakened).
- The `__Host-` secure binding cookies are captured and presented explicitly by
  the harness over the test's plaintext http (client-side only).

## Type of change

- [x] Test infrastructure (CI). **No production plugin code changed.**

## Security checklist

- [x] Workflow: `permissions: {}` + job `contents: read`; all actions SHA-pinned;
  `persist-credentials: false`; no `${{ }}` in any `run:` (artifact path via env);
  `pull_request` (not `_target`), no secrets, a fork PR gets a read-only token.
- [x] Adversarial bypass-lens: **PASS** (test-only, no real secrets, no production
  default weakened; the SAML negative hardened to prove a real plugin-side deny).
- [x] Fixtures (alice/bob/carol/dave, realm secret) are self-evident test-only.

## Quality checklist

- [x] Full OIDC + SAML round-trips + role-gate + replay negatives green in CI;
  one documented local command (`test/e2e/README.md`); commits DCO-signed.

Closes #720