### PR TITLE
Emit a signed SAML LogoutResponse on inbound Single Logout

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -144,9 +144,9 @@ off, both the RP-initiated OIDC logout route and the inbound SAML
   Jellyfin's token revocation is **user-scoped** (there is no per-token revoke),
   so a `SessionIndex`-scoped request still revokes the whole matched user's
   tokens — documented, and safe (it errs toward ending more of the named user's
-  sessions, never someone else's). A `200` is returned only when at least one
+  sessions, never someone else's). Success is reported only when at least one
   session was actually revoked; a request that matched sessions but revoked none
-  fails closed.
+  fails closed with the uniform 400.
 - **RP-initiated OIDC logout** ends the caller's own local session, then
   redirects to the IdP's discovered `end_session_endpoint` — **host-bound to the
   discovered issuer** (open-redirect/SSRF defense) — with the caller's own
@@ -163,13 +163,19 @@ off, both the RP-initiated OIDC logout route and the inbound SAML
   fail-safe: a missing SLO endpoint, an unloadable signing key, or no captured
   session degrades to a local-only logout — an unsigned request is never emitted
   and the local session is always ended.
-- **Honest scope limits.** A **signed outbound `LogoutResponse`** to an inbound
-  `LogoutRequest` is **not yet implemented** (tracked on
-  [#727](https://github.com/iderex/jellyfin-plugin-sso/issues/727)): a validated
-  inbound request is answered with a `200` after revocation, which most identity
-  providers accept. Logout events (`LogoutRequested`/`LogoutRejected`) are
-  audited by reason code — never raw `NameID`/`SessionIndex` — and the inbound
-  endpoint is rate-limited.
+- **The inbound endpoint answers with a signed `LogoutResponse`.** After a
+  validated request revokes a session, the SP closes the IdP's Single-Logout loop
+  by redirecting the browser to the provider's configured `SamlSloEndpoint` with
+  a **signed** `LogoutResponse` (`Status=Success`, `InResponseTo` bound to the
+  request ID, `Destination` pinned to that endpoint), signed with the
+  service-provider key through the same shared redirect-binding signer. It is
+  emitted **only on the success path** — every rejection keeps the uniform 400,
+  so no rejection cause can leak through a status-bearing response — and is
+  **fail-safe**: with no SLO endpoint or no loadable signing key the endpoint
+  answers a bare `200` (an unsigned response is never emitted). Any inbound
+  `RelayState` is echoed only within the 80-byte SAML binding cap. Logout events
+  (`LogoutRequested`/`LogoutRejected`) are audited by reason code — never raw
+  `NameID`/`SessionIndex` — and the inbound endpoint is rate-limited.
 
 ## EU Cyber Resilience Act (CRA) position
 

--- a/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
 using System.Threading.Tasks;
+using System.Xml;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
@@ -25,6 +29,9 @@ public class SSOControllerSamlLogoutTests
     private static readonly Guid UserB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
 
     private const string UniformRejectionBody = "SAML logout request could not be processed";
+    private const string SloEndpoint = "https://idp.example.com/slo";
+    private const string SpEntityId = "jellyfin-sp";
+    private const string SuccessStatus = "urn:oasis:names:tc:SAML:2.0:status:Success";
 
     private static LogoutSession Session(string subject, Guid userId, string? sessionIndex) => new LogoutSession
     {
@@ -244,10 +251,207 @@ public class SSOControllerSamlLogoutTests
         Assert.Equal(400, unsignedResult.StatusCode);
     }
 
+    [Fact]
+    public async Task SamlLogout_FullyConfigured_RevokesAndRedirectsToSlo_WithSignedSuccessResponse()
+    {
+        // SLO-3c: with an SLO endpoint AND a signing key configured, a validated request that revokes a session
+        // answers the IdP with a SIGNED LogoutResponse redirect (Success, InResponseTo bound to the request).
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice", requestId: "_req-abc");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                SamlCertificate = fixture.CertificateBase64, // the IdP cert that validates the inbound request
+                SamlClientId = SpEntityId,
+                SamlSloEndpoint = SloEndpoint,
+                SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64(), // OUR SP key that signs the response
+            };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.StartsWith(SloEndpoint + "?SAMLResponse=", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("&SigAlg=", redirect.Url, StringComparison.Ordinal);
+        Assert.Contains("&Signature=", redirect.Url, StringComparison.Ordinal);
+
+        // The response binds to the request (InResponseTo) and reports Success, from our SP Issuer.
+        var doc = DecodeSamlResponse(redirect.Url);
+        var nsmgr = Namespaces(doc);
+        Assert.Equal("_req-abc", doc.DocumentElement!.GetAttribute("InResponseTo"));
+        Assert.Equal(SpEntityId, doc.SelectSingleNode("/samlp:LogoutResponse/saml:Issuer", nsmgr)!.InnerText);
+        Assert.Equal(SuccessStatus, ((XmlElement)doc.SelectSingleNode("/samlp:LogoutResponse/samlp:Status/samlp:StatusCode", nsmgr)!).GetAttribute("Value"));
+
+        // The revocation still happened and the entry was consumed — the signed response is additive.
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_SloEndpointButNoLoadableSigningKey_Returns200Fallback_NeverUnsigned()
+    {
+        // Fail-safe: an SLO endpoint is set but the signing key does not load. The revocation stands, and the
+        // endpoint answers a bare 200 rather than emitting an UNSIGNED response or a 500.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                SamlCertificate = fixture.CertificateBase64,
+                SamlClientId = SpEntityId,
+                SamlSloEndpoint = SloEndpoint,
+                SamlSigningKeyPfx = "not-a-real-pfx", // set but unloadable
+            };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task SamlLogout_EchoesInboundRelayState_OnTheSignedResponse()
+    {
+        // The inbound RelayState is echoed on the signed response so the IdP can correlate its SLO loop.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                SamlCertificate = fixture.CertificateBase64,
+                SamlClientId = SpEntityId,
+                SamlSloEndpoint = SloEndpoint,
+                SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64(),
+            };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        const string RelayState = "idp-correlation-99";
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest(), RelayState);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains("&RelayState=" + Uri.EscapeDataString(RelayState), redirect.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SamlLogout_OverlongRelayState_IsDropped_NotReflected()
+    {
+        // A RelayState beyond the 80-byte SAML binding cap is non-conformant and dropped rather than reflected.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                SamlCertificate = fixture.CertificateBase64,
+                SamlClientId = SpEntityId,
+                SamlSloEndpoint = SloEndpoint,
+                SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64(),
+            };
+            c.LogoutSessions["a"] = Session("alice", UserA, null);
+        });
+
+        var overlong = new string('x', 81);
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest(), overlong);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.DoesNotContain("&RelayState=", redirect.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SamlLogout_RelayStateAtExactly80Bytes_IsEchoed()
+    {
+        // Lower-boundary of the 80-byte cap: exactly 80 bytes is within the limit and MUST be echoed (pins the
+        // <= 80 boundary so a <=-to-< mutant is caught).
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = SignedResponseHarness(fixture);
+
+        var relayState = new string('x', 80); // 80 ASCII bytes
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest(), relayState);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.Contains("&RelayState=" + Uri.EscapeDataString(relayState), redirect.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SamlLogout_MultibyteRelayStateOver80Bytes_IsDropped()
+    {
+        // The cap is measured in UTF-8 BYTES, not UTF-16 chars: 41 euro signs are 41 chars but 123 bytes, so
+        // they exceed the 80-byte binding limit and are dropped rather than reflected over-cap.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = SignedResponseHarness(fixture);
+
+        var multibyte = new string('€', 41); // 41 UTF-16 chars, 123 UTF-8 bytes
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest(), multibyte);
+
+        var redirect = Assert.IsType<RedirectResult>(result);
+        Assert.DoesNotContain("&RelayState=", redirect.Url, StringComparison.Ordinal);
+    }
+
+    // A harness fully configured for the signed inbound LogoutResponse: the fixture's IdP cert validates the
+    // inbound request, and an SLO endpoint + a loadable SP signing key let the success path sign the response.
+    private static SsoControllerHarness SignedResponseHarness(SamlLogoutFixture fixture) => new SsoControllerHarness(c =>
+    {
+        c.EnableSingleLogout = true;
+        c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            SamlClientId = SpEntityId,
+            SamlSloEndpoint = SloEndpoint,
+            SamlSigningKeyPfx = SamlSigningKeyFactory.CreatePfxBase64(),
+        };
+        c.LogoutSessions["a"] = Session("alice", UserA, null);
+    });
+
     private static void AssertUniformRejection(ActionResult result)
     {
         var content = Assert.IsType<ContentResult>(result);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal(UniformRejectionBody, content.Content);
+    }
+
+    // Extracts and inflates the SAMLResponse query parameter of the redirect URL back into its XML document.
+    private static XmlDocument DecodeSamlResponse(string url)
+    {
+        var query = url[(url.IndexOf('?') + 1)..];
+        string? encoded = null;
+        foreach (var pair in query.Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == "SAMLResponse")
+            {
+                encoded = Uri.UnescapeDataString(pair[(eq + 1)..]);
+                break;
+            }
+        }
+
+        Assert.NotNull(encoded);
+        var compressed = Convert.FromBase64String(encoded!);
+        using var input = new MemoryStream(compressed);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(deflate, new UTF8Encoding(false));
+        var doc = new XmlDocument { XmlResolver = null };
+        doc.LoadXml(reader.ReadToEnd());
+        return doc;
+    }
+
+    private static XmlNamespaceManager Namespaces(XmlDocument doc)
+    {
+        var nsmgr = new XmlNamespaceManager(doc.NameTable);
+        nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nsmgr.AddNamespace("samlp", "urn:oasis:names:tc:SAML:2.0:protocol");
+        return nsmgr;
     }
 }

--- a/SSO-Auth.Tests/Saml/SamlLogoutResponseBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutResponseBuilderTests.cs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SamlLogoutResponseBuilder"/> (#727, SLO-3c): the OUTBOUND signed <c>LogoutResponse</c>
+/// the SP returns to close the IdP's Single-Logout loop. It mirrors <see cref="SamlLogoutRequestBuilder"/> —
+/// the same DEFLATE/Base64 encoding and the shared <see cref="SamlRedirectSigner"/> — so these assertions pin
+/// (a) the document is a well-formed LogoutResponse carrying the Issuer, InResponseTo, Destination, and a
+/// Success status, and (b) the emitted redirect (under the SAMLResponse parameter, echoing RelayState) carries
+/// a detached signature that verifies against the signer's public key over the exact octets.
+/// </summary>
+public class SamlLogoutResponseBuilderTests
+{
+    private const string SloEndpoint = "https://idp.example.com/slo";
+    private const string Issuer = "jellyfin-sp";
+    private const string InResponseTo = "_request-id-123";
+    private const string SuccessStatus = "urn:oasis:names:tc:SAML:2.0:status:Success";
+    private const string EcdsaSha256 = "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256";
+
+    [Fact]
+    public void GetResponse_EmitsAWellFormedLogoutResponse_WithIssuerInResponseToDestinationAndSuccess()
+    {
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var doc = Inflate(builder.GetResponse());
+        var nsmgr = Namespaces(doc);
+
+        Assert.Equal("LogoutResponse", doc.DocumentElement!.LocalName);
+        Assert.Equal("urn:oasis:names:tc:SAML:2.0:protocol", doc.DocumentElement.NamespaceURI);
+        Assert.False(string.IsNullOrEmpty(doc.DocumentElement.GetAttribute("ID")));
+        Assert.Equal("2.0", doc.DocumentElement.GetAttribute("Version"));
+        Assert.Equal(InResponseTo, doc.DocumentElement.GetAttribute("InResponseTo"));
+        Assert.Equal(SloEndpoint, doc.DocumentElement.GetAttribute("Destination"));
+        Assert.Equal(Issuer, doc.SelectSingleNode("/samlp:LogoutResponse/saml:Issuer", nsmgr)!.InnerText);
+        Assert.Equal(SuccessStatus, ((XmlElement)doc.SelectSingleNode("/samlp:LogoutResponse/samlp:Status/samlp:StatusCode", nsmgr)!).GetAttribute("Value"));
+    }
+
+    [Fact]
+    public void GetResponse_ExposedIdMatchesTheDocumentId()
+    {
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var doc = Inflate(builder.GetResponse());
+
+        Assert.Equal(builder.Id, doc.DocumentElement!.GetAttribute("ID"));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_EmitsSamlResponseSigAlgAndSignature_ThatVerify()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, rsa);
+
+        // A response rides the SAMLResponse parameter, not SAMLRequest.
+        Assert.StartsWith(SloEndpoint + "?SAMLResponse=", url, StringComparison.Ordinal);
+        Assert.Contains("&SigAlg=", url, StringComparison.Ordinal);
+        Assert.Contains("&Signature=", url, StringComparison.Ordinal);
+        Assert.DoesNotContain("&RelayState=", url, StringComparison.Ordinal);
+        Assert.True(RsaSignatureVerifies(url, rsa, relayState: null));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_EchoesRelayState_AndSignsOverIt()
+    {
+        using var rsa = RSA.Create(2048);
+        const string RelayState = "opaque-idp-state-42";
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, RelayState, rsa);
+
+        Assert.Contains("&RelayState=" + Uri.EscapeDataString(RelayState), url, StringComparison.Ordinal);
+        // The RelayState is part of the signed octet string (order: SAMLResponse, RelayState, SigAlg).
+        Assert.True(RsaSignatureVerifies(url, rsa, RelayState));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_ForeignKey_DoesNotVerify()
+    {
+        using var signer = RSA.Create(2048);
+        using var attacker = RSA.Create(2048);
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, signer);
+
+        // The signature check is real, not vacuous: the signer verifies, a different key does not.
+        Assert.True(RsaSignatureVerifies(url, signer, relayState: null));
+        Assert.False(RsaSignatureVerifies(url, attacker, relayState: null));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_EcdsaKey_SelectsEcdsaSigAlg_AndVerifies()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        var url = builder.GetSignedRedirectUrl(SloEndpoint, relayState: null, ecdsa);
+
+        // The SigAlg is derived from the key type by the shared signer (#493), never SHA-1.
+        Assert.Contains("&SigAlg=" + Uri.EscapeDataString(EcdsaSha256), url, StringComparison.Ordinal);
+        Assert.True(EcdsaSignatureVerifies(url, ecdsa, relayState: null));
+    }
+
+    [Fact]
+    public void GetSignedRedirectUrl_NullEndpoint_Throws()
+    {
+        using var rsa = RSA.Create(2048);
+        var builder = new SamlLogoutResponseBuilder(Issuer, InResponseTo, SloEndpoint);
+
+        Assert.Throws<ArgumentNullException>(() => { builder.GetSignedRedirectUrl(null!, null, rsa); });
+    }
+
+    // Inflates the DEFLATE+Base64 SAMLResponse back into its XML document, exactly as an identity provider does.
+    private static XmlDocument Inflate(string encoded)
+    {
+        var compressed = Convert.FromBase64String(encoded);
+        using var input = new MemoryStream(compressed);
+        using var deflate = new DeflateStream(input, CompressionMode.Decompress);
+        using var reader = new StreamReader(deflate, new UTF8Encoding(false));
+        var xml = reader.ReadToEnd();
+
+        var doc = new XmlDocument { XmlResolver = null };
+        doc.LoadXml(xml);
+        return doc;
+    }
+
+    private static XmlNamespaceManager Namespaces(XmlDocument doc)
+    {
+        var nsmgr = new XmlNamespaceManager(doc.NameTable);
+        nsmgr.AddNamespace("saml", "urn:oasis:names:tc:SAML:2.0:assertion");
+        nsmgr.AddNamespace("samlp", "urn:oasis:names:tc:SAML:2.0:protocol");
+        return nsmgr;
+    }
+
+    private static bool RsaSignatureVerifies(string url, RSA publicKey, string? relayState)
+        => publicKey.VerifyData(Encoding.UTF8.GetBytes(SignedQuery(url, relayState)), Signature(url), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+    private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey, string? relayState)
+        => publicKey.VerifyData(Encoding.UTF8.GetBytes(SignedQuery(url, relayState)), Signature(url), HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+
+    // Reconstructs the signed octet string (SAMLResponse, then RelayState when present, then SigAlg) from the URL.
+    private static string SignedQuery(string url, string? relayState)
+    {
+        var samlResponse = QueryValue(url, "SAMLResponse");
+        var sigAlg = QueryValue(url, "SigAlg");
+        var query = "SAMLResponse=" + Uri.EscapeDataString(samlResponse);
+        if (!string.IsNullOrEmpty(relayState))
+        {
+            query += "&RelayState=" + Uri.EscapeDataString(relayState);
+        }
+
+        return query + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
+    }
+
+    private static byte[] Signature(string url) => Convert.FromBase64String(QueryValue(url, "Signature"));
+
+    private static string QueryValue(string url, string name)
+    {
+        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
@@ -32,11 +32,13 @@ public class SamlLogoutValidatorTests : IDisposable
         var fixture = SamlLogoutTestFactory.Create(nameId: "alice", sessionIndexes: new[] { "idx-1" });
         var validator = new SamlLogoutValidator();
 
-        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out var nameId, out var sessionIndexes, out var reason);
+        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out var nameId, out var sessionIndexes, out var requestId, out var reason);
 
         Assert.True(ok);
         Assert.Equal("alice", nameId);
         Assert.Equal(new[] { "idx-1" }, sessionIndexes);
+        // The validated request ID is exposed so the endpoint can echo it as the LogoutResponse InResponseTo.
+        Assert.False(string.IsNullOrEmpty(requestId));
         Assert.Equal(string.Empty, reason);
     }
 
@@ -49,9 +51,9 @@ public class SamlLogoutValidatorTests : IDisposable
         var config = ProviderTrusting(fixture.CertificateBase64);
         var encoded = fixture.EncodeRequest();
 
-        Assert.True(validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out _));
+        Assert.True(validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out _, out _));
 
-        var replayed = validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out var reason);
+        var replayed = validator.TryValidate(config, "adfs", encoded, DateTime.UtcNow, out _, out _, out _, out var reason);
 
         Assert.False(replayed);
         Assert.Equal(SamlLogoutValidator.RejectReason.Replay, reason);
@@ -63,7 +65,7 @@ public class SamlLogoutValidatorTests : IDisposable
         var fixture = SamlLogoutTestFactory.Create(sign: false);
         var validator = new SamlLogoutValidator();
 
-        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out _, out _, out var reason);
+        var ok = validator.TryValidate(ProviderTrusting(fixture.CertificateBase64), "adfs", fixture.EncodeRequest(), DateTime.UtcNow, out _, out _, out _, out var reason);
 
         Assert.False(ok);
         Assert.Equal(SamlLogoutValidator.RejectReason.Invalid, reason);
@@ -74,7 +76,7 @@ public class SamlLogoutValidatorTests : IDisposable
     {
         var validator = new SamlLogoutValidator();
 
-        var ok = validator.TryValidate(ProviderTrusting(SamlFixture.ForeignCertificateBase64()), "adfs", "not-base64-!!!", DateTime.UtcNow, out _, out _, out var reason);
+        var ok = validator.TryValidate(ProviderTrusting(SamlFixture.ForeignCertificateBase64()), "adfs", "not-base64-!!!", DateTime.UtcNow, out _, out _, out _, out var reason);
 
         Assert.False(ok);
         Assert.Equal(SamlLogoutValidator.RejectReason.Malformed, reason);
@@ -90,7 +92,7 @@ public class SamlLogoutValidatorTests : IDisposable
         var noName = SamlLogoutTestFactory.Create(includeNameId: false, requestId: SharedId);
         var validator = new SamlLogoutValidator();
 
-        var firstOk = validator.TryValidate(ProviderTrusting(noName.CertificateBase64), "adfs", noName.EncodeRequest(), DateTime.UtcNow, out _, out _, out var reason);
+        var firstOk = validator.TryValidate(ProviderTrusting(noName.CertificateBase64), "adfs", noName.EncodeRequest(), DateTime.UtcNow, out _, out _, out _, out var reason);
 
         Assert.False(firstOk);
         Assert.Equal(SamlLogoutValidator.RejectReason.Invalid, reason);
@@ -98,7 +100,7 @@ public class SamlLogoutValidatorTests : IDisposable
         // Re-present the SAME request ID, now with a NameID: it must succeed — the slot was never consumed, so
         // this is not rejected as a Replay (which would prove the NameID guard ran before TryConsume).
         var corrected = SamlLogoutTestFactory.Create(nameId: "alice", requestId: SharedId);
-        var secondOk = validator.TryValidate(ProviderTrusting(corrected.CertificateBase64), "adfs", corrected.EncodeRequest(), DateTime.UtcNow, out var nameId, out _, out var secondReason);
+        var secondOk = validator.TryValidate(ProviderTrusting(corrected.CertificateBase64), "adfs", corrected.EncodeRequest(), DateTime.UtcNow, out var nameId, out _, out _, out var secondReason);
 
         Assert.True(secondOk);
         Assert.NotEqual(SamlLogoutValidator.RejectReason.Replay, secondReason);

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -813,9 +813,10 @@ public class SSOController : ControllerBase
     /// </summary>
     /// <param name="provider">The SAML provider the LogoutRequest arrived for.</param>
     /// <param name="samlRequest">The <c>SAMLRequest</c> form field (model-bound, so a non-form POST binds null and is rejected).</param>
-    /// <returns>200 when a validated request revoked at least one session; a uniform 400 otherwise.</returns>
+    /// <param name="relayState">The optional <c>RelayState</c> form field, echoed on the signed <c>LogoutResponse</c> (#727, SLO-3c) when within the 80-byte SAML binding cap.</param>
+    /// <returns>A signed <c>LogoutResponse</c> redirect (302) when a validated request revoked at least one session and the provider is configured to sign it, a bare 200 when it cannot be signed, or a uniform 400 otherwise.</returns>
     [HttpPost("SAML/Logout/{provider}")]
-    public async Task<ActionResult> SamlLogout(string provider, [FromForm(Name = "SAMLRequest")] string? samlRequest = null)
+    public async Task<ActionResult> SamlLogout(string provider, [FromForm(Name = "SAMLRequest")] string? samlRequest = null, [FromForm(Name = "RelayState")] string? relayState = null)
     {
         if (RateLimitCheck(SsoRateLimitClass.Logout) is { } throttled)
         {
@@ -839,7 +840,7 @@ public class SSOController : ControllerBase
         // FIXED constant (never request-derived) written only to the audit trail; the caller sees the uniform
         // 400 with no branch-distinguishing detail.
         var validator = new SamlLogoutValidator();
-        if (!validator.TryValidate(config, provider, samlRequest, DateTime.UtcNow, out var nameId, out var sessionIndexes, out var reasonCode))
+        if (!validator.TryValidate(config, provider, samlRequest, DateTime.UtcNow, out var nameId, out var sessionIndexes, out var requestId, out var reasonCode))
         {
             SsoAudit.LogoutRejected(_logger, provider, reasonCode);
             return UniformLogoutRejection();
@@ -915,7 +916,77 @@ public class SSOController : ControllerBase
         }
 
         SsoAudit.LogoutRequested(_logger, provider, succeeded.Count);
-        return Ok();
+
+        // SLO-3c: answer the IdP with a SIGNED LogoutResponse so its Single-Logout loop completes, redirecting
+        // the browser to the IdP SLO endpoint. Emitted ONLY here — on the success path, after a validated
+        // request actually revoked a session — so no rejection can ever produce a signed status-bearing
+        // response (every failure above keeps the uniform 400, no cause oracle). Fail-SAFE: when no SLO
+        // endpoint or signing key is configured, or the build/sign faults, fall back to the bare 200 — the
+        // revocation already stands, and a missing response is degraded interop, never a 500 or an unsigned
+        // downgrade. The redirect target is the save-validated absolute-https SamlSloEndpoint (never
+        // request-derived), so it cannot be an open redirect.
+        string? responseRedirectUrl = null;
+        try
+        {
+            responseRedirectUrl = BuildSamlLogoutResponseRedirectUrl(config, requestId, relayState);
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or ArgumentException or CryptographicException or FormatException)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError("SAML inbound logout for provider {Provider} could not build the signed LogoutResponse: {Reason}; the revocation stands and the endpoint answers 200.", provider?.ReplaceLineEndings(string.Empty), ex.Message);
+            }
+        }
+
+        return responseRedirectUrl is null ? Ok() : Redirect(responseRedirectUrl);
+    }
+
+    // Builds the signed outbound SAML LogoutResponse redirect URL answering a validated inbound LogoutRequest
+    // (#727, SLO-3c), or null when the response cannot be signed (no SLO endpoint, or no loadable signing key).
+    // Fail-closed on the signing key exactly like BuildSamlSloRedirectUrl: a missing/unloadable key returns
+    // null (the endpoint degrades to a bare 200) rather than emitting an UNSIGNED response — the redirect
+    // binding mandates a signature, so an unsigned downgrade is never sent. Reuses the outbound-signing stack
+    // verbatim (revealed-at-use key via SamlSigningKey, the shared SamlRedirectSigner via
+    // SamlLogoutResponseBuilder). InResponseTo/Destination are bound to the validated request and the trusted
+    // configured endpoint; the inbound RelayState is echoed only when within the 80-byte SAML binding cap.
+    private static string? BuildSamlLogoutResponseRedirectUrl(SamlConfig config, string requestId, string? relayState)
+    {
+        var sloEndpoint = config.SamlSloEndpoint?.Trim();
+        if (string.IsNullOrEmpty(sloEndpoint))
+        {
+            return null;
+        }
+
+        // Without an SP entity id there is no valid Issuer for the response. Fail-safe to null (the endpoint
+        // degrades to a bare 200) rather than emit a malformed empty-Issuer response — and this also removes
+        // any NullReferenceException risk from Trim() on a null-deserialized SamlClientId.
+        var issuer = config.SamlClientId?.Trim();
+        if (string.IsNullOrEmpty(issuer))
+        {
+            return null;
+        }
+
+        if (!SamlSigningKey.TryLoad(SSOPlugin.Instance.Secrets.Reveal(config.SamlSigningKeyPfx), out var signingCertificate))
+        {
+            return null;
+        }
+
+        using (signingCertificate)
+        using (var signingKey = SamlSigningKey.GetSigningKey(signingCertificate))
+        {
+            if (signingKey is null)
+            {
+                return null;
+            }
+
+            // Echo the inbound RelayState only when it is within the SAML HTTP binding's 80-BYTE cap
+            // (saml-bindings-2.0 §3.4.3) — measured in UTF-8 bytes, not UTF-16 chars, so a multi-byte value
+            // cannot slip over the wire limit; anything longer is non-conformant and dropped, not reflected.
+            var echoedRelayState = !string.IsNullOrEmpty(relayState) && System.Text.Encoding.UTF8.GetByteCount(relayState) <= 80 ? relayState : null;
+
+            var response = new SamlLogoutResponseBuilder(issuer, requestId, sloEndpoint);
+            return response.GetSignedRedirectUrl(sloEndpoint, echoedRelayState, signingKey);
+        }
     }
 
     // The single uniform rejection for the inbound SAML logout endpoint: one fixed 400 body for every

--- a/SSO-Auth/Api/Saml/SamlLogoutResponseBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutResponseBuilder.cs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Xml;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+
+/// <summary>
+/// Builds an OUTBOUND SAML 2.0 <c>LogoutResponse</c> for the HTTP-Redirect binding (#727, SLO-3c) — the SP's
+/// signed answer to a validated inbound IdP-initiated <see cref="SamlLogoutRequest"/>. It emits the same
+/// DEFLATE + Base64 encoding as <see cref="SamlLogoutRequestBuilder"/> and hands the encoded message to the
+/// SHARED <see cref="SamlRedirectSigner"/> under the <c>SAMLResponse</c> parameter, so the outbound-signing
+/// policy (key-type-derived SigAlg, allowlist-checked, no SHA-1) is reused rather than re-implemented.
+/// </summary>
+/// <remarks>
+/// The response is emitted ONLY after the inbound request passed full signature validation and at least one
+/// session was actually revoked, and it always reports <c>Success</c> — the SP never emits a status-bearing
+/// error response, so no rejection cause can leak through this channel (the endpoint keeps its uniform 400 for
+/// every failure). The document carries the SP <c>Issuer</c> (the same entity id the LogoutRequest sends), the
+/// <c>InResponseTo</c> that binds it to the IdP's request, and the <c>Destination</c> pinned to the IdP SLO
+/// endpoint the signed message is sent to (so a captured response cannot be replayed to a different endpoint).
+/// </remarks>
+internal sealed class SamlLogoutResponseBuilder
+{
+    private const string SuccessStatusCode = "urn:oasis:names:tc:SAML:2.0:status:Success";
+
+    private readonly string _id;
+    private readonly string _issueInstant;
+
+    private readonly string _issuer;
+    private readonly string _inResponseTo;
+    private readonly string _destination;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SamlLogoutResponseBuilder"/> class.
+    /// </summary>
+    /// <param name="issuer">The SP entity id (the same value the LogoutRequest sends as its Issuer).</param>
+    /// <param name="inResponseTo">The validated inbound <c>LogoutRequest</c> ID this response answers.</param>
+    /// <param name="destination">The IdP Single-Logout endpoint the response is sent to (its <c>Destination</c>).</param>
+    public SamlLogoutResponseBuilder(string issuer, string inResponseTo, string destination)
+    {
+        _id = "_" + Guid.NewGuid().ToString();
+        _issueInstant = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        _issuer = issuer;
+        _inResponseTo = inResponseTo;
+        _destination = destination;
+    }
+
+    /// <summary>
+    /// Gets the response's unique <c>ID</c> (the value sent as the LogoutResponse ID).
+    /// </summary>
+    public string Id => _id;
+
+    /// <summary>
+    /// Builds the <c>LogoutResponse</c> as a Base64-encoded, DEFLATE-compressed string. The DEFLATE/encoding
+    /// approach is copied verbatim from <see cref="SamlLogoutRequestBuilder.GetRequest"/> so both outbound
+    /// redirect-binding messages encode identically.
+    /// </summary>
+    /// <returns>The response as a Base64-encoded, DEFLATE-compressed string.</returns>
+    public string GetResponse()
+    {
+        using var sw = new StringWriter(CultureInfo.InvariantCulture);
+        var xws = new XmlWriterSettings();
+        xws.OmitXmlDeclaration = true;
+
+        using (var xw = XmlWriter.Create(sw, xws))
+        {
+            xw.WriteStartElement("samlp", "LogoutResponse", "urn:oasis:names:tc:SAML:2.0:protocol");
+            xw.WriteAttributeString("ID", _id);
+            xw.WriteAttributeString("Version", "2.0");
+            xw.WriteAttributeString("IssueInstant", _issueInstant);
+            xw.WriteAttributeString("InResponseTo", _inResponseTo);
+            xw.WriteAttributeString("Destination", _destination);
+
+            xw.WriteStartElement("saml", "Issuer", "urn:oasis:names:tc:SAML:2.0:assertion");
+            xw.WriteString(_issuer);
+            xw.WriteEndElement();
+
+            // Status is REQUIRED (SAML core §3.7.2) and always Success: the SP answers only a request it
+            // already validated and acted on, and never encodes a rejection reason here (the endpoint keeps a
+            // uniform 400 for every failure, so this channel carries no cause oracle).
+            xw.WriteStartElement("samlp", "Status", "urn:oasis:names:tc:SAML:2.0:protocol");
+            xw.WriteStartElement("samlp", "StatusCode", "urn:oasis:names:tc:SAML:2.0:protocol");
+            xw.WriteAttributeString("Value", SuccessStatusCode);
+            xw.WriteEndElement();
+            xw.WriteEndElement();
+
+            xw.WriteEndElement();
+        }
+
+        // The exact DEFLATE + Base64 approach SamlLogoutRequestBuilder.GetRequest uses for the HTTP-Redirect
+        // binding.
+        var memoryStream = new MemoryStream();
+        var writer = new StreamWriter(new DeflateStream(memoryStream, CompressionMode.Compress, true), new UTF8Encoding(false));
+        writer.Write(sw.ToString());
+        writer.Close();
+        return Convert.ToBase64String(memoryStream.GetBuffer(), 0, (int)memoryStream.Length, Base64FormattingOptions.None);
+    }
+
+    /// <summary>
+    /// Gets the redirect URL to the identity provider's Single-Logout endpoint with the LogoutResponse SIGNED
+    /// for the HTTP-Redirect binding — delegating to the SHARED <see cref="SamlRedirectSigner"/> exactly as
+    /// <see cref="SamlLogoutRequestBuilder.GetSignedRedirectUrl"/> does, so the SigAlg/Signature policy
+    /// (key-type derived, allowlist-checked, no SHA-1) is reused rather than re-implemented. The message rides
+    /// the <c>SAMLResponse</c> parameter (a response, not a request).
+    /// </summary>
+    /// <param name="sloEndpoint">The identity provider's Single-Logout (SLO) endpoint URL (the response <c>Destination</c>).</param>
+    /// <param name="relayState">The relay state echoed from the inbound request, omitted when null or empty.</param>
+    /// <param name="signingKey">The service-provider private key — RSA or ECDSA.</param>
+    /// <returns>The signed redirect URL.</returns>
+    public string GetSignedRedirectUrl(string sloEndpoint, string? relayState, AsymmetricAlgorithm signingKey)
+    {
+        ArgumentNullException.ThrowIfNull(sloEndpoint);
+
+        return SamlRedirectSigner.BuildSignedRedirectUrl(sloEndpoint, "SAMLResponse", GetResponse(), relayState, signingKey);
+    }
+}

--- a/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
@@ -45,6 +45,7 @@ internal sealed class SamlLogoutValidator
     /// <param name="nowUtc">The current UTC time (supplied for determinism).</param>
     /// <param name="nameId">On success, the subject NameID the request names.</param>
     /// <param name="sessionIndexes">On success, the SessionIndex values the request carries (possibly empty).</param>
+    /// <param name="requestId">On success, the request's <c>ID</c> — the value the SP echoes as the <c>InResponseTo</c> of the signed <c>LogoutResponse</c> (#727, SLO-3c). Empty on failure.</param>
     /// <param name="reasonCode">On failure, a fixed audit reason code; empty on success.</param>
     /// <returns><see langword="true"/> when the request is fully valid; otherwise <see langword="false"/>.</returns>
     internal bool TryValidate(
@@ -54,11 +55,13 @@ internal sealed class SamlLogoutValidator
         DateTime nowUtc,
         out string nameId,
         out IReadOnlyList<string> sessionIndexes,
+        out string requestId,
         out string reasonCode)
     {
         ArgumentNullException.ThrowIfNull(config);
         nameId = string.Empty;
         sessionIndexes = Array.Empty<string>();
+        requestId = string.Empty;
 
         if (!SamlLogoutRequest.TryParse(config.SamlCertificate ?? string.Empty, config.SamlSecondaryCertificate, rawRequest, out var logoutRequest))
         {
@@ -102,7 +105,8 @@ internal sealed class SamlLogoutValidator
         // still finds and acts on them. Replay protection here is a hygiene/DoS bound, not a session-minting
         // gate, so single-use-regardless is the safe default.
         var retention = SamlReplayCache.ComputeRetention(nowUtc, logoutRequest.GetNotOnOrAfter());
-        var replayKey = ProviderScopedKey.For(provider, logoutRequest.GetRequestId());
+        var resolvedRequestId = logoutRequest.GetRequestId();
+        var replayKey = ProviderScopedKey.For(provider, resolvedRequestId);
         if (!LogoutReplays.TryConsume(replayKey, retention, nowUtc, out _))
         {
             reasonCode = RejectReason.Replay;
@@ -111,6 +115,9 @@ internal sealed class SamlLogoutValidator
 
         nameId = resolvedNameId;
         sessionIndexes = logoutRequest.GetSessionIndexes();
+        // TryConsume succeeded above, and ProviderScopedKey.For fails closed on a null/blank id, so a true
+        // return here guarantees a usable request ID to echo as the LogoutResponse InResponseTo.
+        requestId = resolvedRequestId ?? string.Empty;
         reasonCode = string.Empty;
         return true;
     }


### PR DESCRIPTION
Closes the last code gap on #727 (SLO-3c part 2). The inbound IdP-initiated `SAML/Logout/{provider}` endpoint answered a validated request with a bare `200` after revoking, so the IdP never received the `LogoutResponse` its Single-Logout loop expects. It now returns a **signed** SAML 2.0 `LogoutResponse` (HTTP-Redirect binding) on success.

## What & why
- **New `SamlLogoutResponseBuilder`** mirrors `SamlLogoutRequestBuilder`: `<samlp:LogoutResponse>` with `Status=Success`, `InResponseTo` bound to the request ID, `Issuer` = the SP entity id, `Destination` pinned to the SLO endpoint; DEFLATE+Base64; signed through the shared `SamlRedirectSigner` under the `SAMLResponse` parameter (key-type-derived SigAlg, allowlist-checked, no SHA-1).
- **`SamlLogoutValidator` exposes `out requestId`** (the same one-time-consumed ID) so the endpoint can set `InResponseTo`, no new replay window.
- **Endpoint success branch** emits the signed response **only** after a validated request actually revoked a session; every rejection keeps the uniform `400` (no cause oracle). **Fail-safe**: no SLO endpoint / no loadable signing key / blank SP entity id / any build-or-sign fault degrades to the bare `200`, an unsigned response is never emitted, and there is no `500`. The redirect target/`Destination` is the save-validated absolute-`https` `SamlSloEndpoint`, never request-derived (no open redirect). Inbound `RelayState` is echoed only within the SAML binding 80-byte cap (measured in UTF-8 bytes).
- **`SECURITY.md`** updated: the signed-response posture replaces the former bare-200 scope-limit note.

## Review gate
- Adversarial `/security-review`: **bypass-lens PASS**; **correctness-lens** raised three findings (UTF-16-char vs 80-byte RelayState cap; unpinned lower boundary / surviving mutant; `SamlClientId` NRE + empty-Issuer), **all fixed** with tests, re-verified **PASS**.
- Tests: builder unit tests (well-formed doc, `InResponseTo`/`Status`, RSA+ECDSA signature verifies non-vacuously, foreign key fails, RelayState signed-over) and endpoint tests (302-signed-on-success, 200 fail-safe on unloadable key, RelayState echo + exact-80-byte boundary + multibyte-over-cap dropped). Full suite green at **1889**.

Remaining on #727 after this: only SLO-5 (the final full-stack `/security-review` sweep).