### PR TITLE
Scope inbound SAML logout to SAML captures only

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
@@ -399,6 +399,35 @@ public class SSOControllerSamlLogoutTests
         Assert.DoesNotContain("&RelayState=", redirect.Url, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task SamlLogout_DoesNotRevokeAnOpenIdCaptureOfTheSameProviderAndSubject()
+    {
+        // Protocol isolation (SLO-5): a signed SAML LogoutRequest for (adfs, alice) must NOT revoke an OpenID
+        // capture that happens to share the provider name and subject string. The SAML and OpenID flows stay
+        // apart — the inbound path resolves only SAML captures, exactly as the SP-initiated path does.
+        var fixture = SamlLogoutTestFactory.Create(nameId: "alice");
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.SamlConfigs["adfs"] = new SamlConfig { Enabled = true, SamlCertificate = fixture.CertificateBase64 };
+            c.LogoutSessions["oid"] = new LogoutSession
+            {
+                Protocol = "OpenID",
+                Provider = "adfs",
+                Subject = "alice",
+                IdToken = "raw.id.token",
+                UserId = UserA,
+            };
+        });
+
+        var result = await harness.Controller.SamlLogout("adfs", fixture.EncodeRequest());
+
+        // No SAML capture matched -> uniform 400, and the OpenID entry is untouched (never revoked, never removed).
+        AssertUniformRejection(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("oid")));
+    }
+
     // A harness fully configured for the signed inbound LogoutResponse: the fixture's IdP cert validates the
     // inbound request, and an SLO endpoint + a loadable SP signing key let the success path sign the response.
     private static SsoControllerHarness SignedResponseHarness(SamlLogoutFixture fixture) => new SsoControllerHarness(c =>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -846,13 +846,18 @@ public class SSOController : ControllerBase
             return UniformLogoutRejection();
         }
 
-        // Resolve the targeted sessions — strictly the SAME provider and subject (ordinal exact). This is the
-        // blast-radius bound: FindByProviderSubject filters by (provider, subject), so a logout for one
-        // subject can never touch another subject's or another provider's sessions. When the request names
-        // SessionIndex element(s), keep only entries whose captured index is among them; a request with NO
-        // SessionIndex targets every session of the subject (SAML core §3.7).
+        // Resolve the targeted sessions — strictly the SAME provider and subject (ordinal exact), AND only
+        // SAML captures. This is the blast-radius bound: FindByProviderSubject filters by (provider, subject),
+        // so a logout for one subject can never touch another subject's or another provider's sessions. The
+        // Protocol filter keeps the SAML and OpenID flows apart exactly as the SP-initiated path does (an
+        // OpenID and a SAML provider can share a config name and a subject string): a signed SAML LogoutRequest
+        // must never revoke an OpenID capture. When the request names SessionIndex element(s), keep only entries
+        // whose captured index is among them; a request with NO SessionIndex targets every session of the
+        // subject (SAML core §3.7).
         var matches = SSOPlugin.Instance.ReadConfiguration(configuration =>
-            SessionLogoutStore.FindByProviderSubject(configuration, provider, nameId, string.Empty));
+            SessionLogoutStore.FindByProviderSubject(configuration, provider, nameId, string.Empty)
+                .Where(pair => string.Equals(pair.Value.Protocol, SamlProtocol, StringComparison.Ordinal))
+                .ToList());
         if (sessionIndexes.Count > 0)
         {
             matches = matches


### PR DESCRIPTION
Closes the one finding from the final full-stack SLO-5 `/security-review` sweep on #727 (authz lens).

## Problem
The inbound IdP-initiated `SAML/Logout/{provider}` endpoint resolved sessions by `(provider, subject)` alone, without the `Protocol` tag the two SP-initiated logout routes enforce (`OidLogout` gates on a non-empty `IdToken`; `SamlSpLogout` on `Protocol == "SAML"`). Because an OpenID and a SAML provider can share a config name, and a SAML `NameID` can collide with an OpenID `sub`, a validly-signed SAML `LogoutRequest` for `(provider, subject)` could also revoke and delete an **OpenID** capture with the same name and subject.

Impact is bounded to **logout** (revocation can never grant or link), but a SAML IdP sharing a config name with an unrelated OpenID provider could terminate that OpenID user's sessions, a cross-protocol confused-deputy / targeted logout, and a break of the SAML/OpenID separation invariant.

## Fix
Filter the inbound match to `Protocol == "SAML"` at the call site, symmetric with the SP-initiated path, so a signed SAML `LogoutRequest` can never reach an OpenID capture. The filter runs before the SessionIndex narrowing and the uniform-400 gate, so an OpenID-only match now yields the uniform 400 with no revoke and the entry retained.

## Tests / review
- New negative test `SamlLogout_DoesNotRevokeAnOpenIdCaptureOfTheSameProviderAndSubject` (uniform 400, no `RevokeUserTokens`, OpenID entry retained). Full suite green at **1890**.
- SLO-5 sweep: bypass-lens PASS, audit-integrity-lens PASS, authz-lens NEEDS_IMPROVEMENT → **fixed** → re-verified **PASS**.

This closes the last item on #727 (the full SLO stack is complete and reviewed).