### PR TITLE
Read OpenID roles from an object-map claim when a provider opts in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ## Unreleased
 
+### Added
+
+- **OpenID role claims carried as an object map.** A new per-provider option,
+  **Role claim is an object map**, reads the roles from the property _names_ of
+  a JSON object instead of from a list of strings. Zitadel needs it: it emits
+  `{"jellyfin-access": {"<orgId>": "<domain>"}}` under
+  `urn:zitadel:iam:org:project:roles`, which no previous configuration could
+  read, so its role gate could never be enabled. Only the names are read —
+  never the values, never nested objects — and every other claim shape still
+  fails closed to no roles. The option is **off by default**, so no existing
+  provider changes behaviour.
+
 ### Changed
 
 - **Renamed to "Community SSO for Jellyfin".** The plugin's display name (the

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1437,11 +1437,16 @@ public class ArchitectureConformanceTests
         // The full save-contract roster, pinned after the #365 provider-workspace redesign reordered and
         // regrouped the form into native accordion sections. ProviderFormFieldIds_MatchOidConfigProperties
         // guards the FORWARD direction (no stray marked id) and a reverse pin for the security-critical
-        // SUBSET; this test is the exhaustive reverse pin: every one of the 42 persisting fields must still
-        // render as a marked input with its exact id, so a field silently dropped or unmarked during a
-        // future re-layout — which would stop it persisting — fails here rather than shipping as silent data
-        // loss. The provider-name KEY input (OidProviderName) is deliberately unmarked (it supplies the
-        // OidConfigs dictionary key, not an OidConfig property) and is asserted present separately.
+        // SUBSET; this test is the exhaustive reverse pin: every persisting field must still render as a
+        // marked input with its exact id, so a field silently dropped or unmarked during a future re-layout —
+        // which would stop it persisting — fails here rather than shipping as silent data loss. The
+        // provider-name KEY input (OidProviderName) is deliberately unmarked (it supplies the OidConfigs
+        // dictionary key, not an OidConfig property) and is asserted present separately.
+        //
+        // The roster is compared as a SET IN BOTH DIRECTIONS (#934). A subset assertion silently tolerated a
+        // newly added field that nobody listed here — which is exactly how DisableAvatarFromPictureClaim
+        // (#723) and RoleClaimIsObjectMap escaped it — so a new form field now fails this test until it is
+        // rostered, instead of shipping outside the guard.
         var markerClasses = new[] { "sso-text", "sso-line-list", "sso-toggle", "sso-folder-list", "sso-role-map" };
         var form = OidcProviderFormMarkup(
             File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Web", "configPage.html")));
@@ -1471,7 +1476,8 @@ public class ArchitectureConformanceTests
         var expected = new[]
         {
             "OidEndpoint", "OidClientId", "OidSecret", "OidScopes", "Enabled",
-            "EnableAuthorization", "DefaultUsernameClaim", "DefaultProvider", "AvatarUrlFormat", "RoleClaim",
+            "EnableAuthorization", "DefaultUsernameClaim", "DefaultProvider", "AvatarUrlFormat", "DisableAvatarFromPictureClaim",
+            "RoleClaim", "RoleClaimIsObjectMap",
             "Roles", "AdminRoles", "EnableAllFolders", "EnabledFolders", "EnableFolderRoles", "FolderRoleMapping",
             "EnableLiveTvRoles", "LiveTvRoles", "LiveTvManagementRoles", "EnableLiveTv", "EnableLiveTvManagement",
             "DoNotLoadProfile", "SchemeOverride", "PortOverride", "BaseUrlOverride",
@@ -1481,11 +1487,17 @@ public class ArchitectureConformanceTests
             "HideLoginButton", "LoginButtonText", "PostLogoutRedirectUri",
         };
 
-        Assert.Equal(42, expected.Length);
+        Assert.Equal(44, expected.Length);
         var missing = expected.Where(id => !markedIds.Contains(id)).ToList();
         Assert.True(
             missing.Count == 0,
             "These persisting provider-form fields are missing their marked input in configPage.html (a re-layout dropped or unmarked them, so they would stop persisting): " + string.Join(", ", missing));
+
+        // The other direction: a marked input nobody rostered is a field that shipped outside this guard.
+        var unrostered = markedIds.Where(id => !expected.Contains(id, StringComparer.Ordinal)).OrderBy(id => id, StringComparer.Ordinal).ToList();
+        Assert.True(
+            unrostered.Count == 0,
+            "These provider-form fields render a marked input but are not in this test's roster, so they are outside the persistence guard — add them to `expected` and bump its count: " + string.Join(", ", unrostered));
 
         // The provider-name KEY input must still be present (unmarked by design).
         Assert.Contains("id=\"OidProviderName\"", form, StringComparison.Ordinal);

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -685,4 +685,85 @@ public class OidcAuthorizeStateBuilderTests
         Assert.True(result.EnableLiveTv);            // from config default
         Assert.True(result.EnableLiveTvManagement);  // granted by the role
     }
+
+    [Fact]
+    public void ObjectMapRoleClaim_MatchesTheAllowList_WhenTheProviderOptsIn()
+    {
+        // #934, Zitadel's shape end to end: the role claim's property NAMES are the roles.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-access" };
+            c.RoleClaim = "urn:zitadel:iam:org:project:roles";
+            c.RoleClaimIsObjectMap = true;
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "alice"),
+                ("urn:zitadel:iam:org:project:roles", "{\"jellyfin-access\":{\"orgid\":\"example.com\"}}")),
+            config);
+
+        Assert.Equal("alice", result.Username);
+        Assert.True(result.Valid);
+    }
+
+    [Fact]
+    public void ObjectMapRoleClaim_UnmatchedRole_IsRefused()
+    {
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-access" };
+            c.RoleClaim = "urn:zitadel:iam:org:project:roles";
+            c.RoleClaimIsObjectMap = true;
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "bob"),
+                ("urn:zitadel:iam:org:project:roles", "{\"some-other-role\":{\"orgid\":\"example.com\"}}")),
+            config);
+
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void ObjectMapRoleClaim_WithoutOptIn_IsRefused()
+    {
+        // The default is unchanged: without the opt-in the same object claim grants nothing, so no existing
+        // provider silently starts accepting a shape it did not before.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-access" };
+            c.RoleClaim = "urn:zitadel:iam:org:project:roles";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "alice"),
+                ("urn:zitadel:iam:org:project:roles", "{\"jellyfin-access\":{\"orgid\":\"example.com\"}}")),
+            config);
+
+        Assert.False(result.Valid);
+    }
+
+    [Fact]
+    public void ObjectMapRoleClaim_DoesNotReadTheValues()
+    {
+        // Only the property names are roles. Zitadel puts the granting org's id→domain map in the VALUE;
+        // reading it would turn an org domain the user never had granted into a matching role.
+        var config = Config(c =>
+        {
+            c.Roles = new[] { "jellyfin-access" };
+            c.RoleClaim = "urn:zitadel:iam:org:project:roles";
+            c.RoleClaimIsObjectMap = true;
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "mallory"),
+                ("urn:zitadel:iam:org:project:roles", "{\"nothing\":{\"orgid\":\"jellyfin-access\"}}")),
+            config);
+
+        Assert.False(result.Valid);
+    }
 }

--- a/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
@@ -19,13 +19,13 @@ public class OidcRoleExtractorTests
     public void SingleSegment_ReturnsRawClaimValueAsOneRole()
     {
         // A one-segment path is not JSON: the claim value itself is the single role.
-        Assert.Equal(new List<string> { "jellyfin-admin" }, OidcRoleExtractor.ExtractRoles(new[] { "Role" }, "jellyfin-admin"));
+        Assert.Equal(new List<string> { "jellyfin-admin" }, OidcRoleExtractor.ExtractRoles(new[] { "Role" }, "jellyfin-admin", false));
     }
 
     [Fact]
     public void TwoSegments_ReadsTerminalArray()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\",\"admins\"]}");
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\",\"admins\"]}", false);
         Assert.Equal(new List<string> { "users", "admins" }, roles);
     }
 
@@ -33,7 +33,7 @@ public class OidcRoleExtractorTests
     public void NestedSegments_WalkTheJsonPath()
     {
         var value = "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]}}}";
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value);
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
         Assert.Equal(new List<string> { "media" }, roles);
     }
 
@@ -42,28 +42,28 @@ public class OidcRoleExtractorTests
     {
         // The intermediate "jellyfin" key is absent inside resource_access, so the walk stops short.
         var value = "{\"resource_access\":{\"other\":{\"roles\":[\"x\"]}}}";
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value);
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void IntermediateNodeNotAnObject_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}");
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}", false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void TerminalNotAnArray_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}");
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}", false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void MissingTerminalKey_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}");
+        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}", false);
         Assert.Empty(roles);
     }
 
@@ -71,7 +71,7 @@ public class OidcRoleExtractorTests
     public void JsonNull_ReturnsEmpty()
     {
         // A literal JSON null deserializes to a null dictionary → no roles (not a throw).
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "null"));
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "null", false));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class OidcRoleExtractorTests
     {
         // #216: a multi-segment path over a malformed (non-JSON) claim value fails CLOSED to no roles
         // instead of throwing an unhandled 500 on the public callback.
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json"));
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json", false));
     }
 
     [Fact]
@@ -89,7 +89,116 @@ public class OidcRoleExtractorTests
         // elements are taken as roles.
         var roles = OidcRoleExtractor.ExtractRoles(
             new[] { "realm_access", "roles" },
-            "{\"roles\":[\"users\",1,{\"nested\":true},\"admins\"]}");
+            "{\"roles\":[\"users\",1,{\"nested\":true},\"admins\"]}",
+            false);
         Assert.Equal(new List<string> { "users", "admins" }, roles);
+    }
+
+    [Fact]
+    public void ObjectMap_SingleSegment_ReadsThePropertyNamesAsRoles()
+    {
+        // #934: Zitadel's shape. The claim value IS the terminal object, and its property NAMES are the
+        // roles; the values are the granting org's id→domain bookkeeping and are deliberately not read.
+        var roles = OidcRoleExtractor.ExtractRoles(
+            new[] { "urn:zitadel:iam:org:project:roles" },
+            "{\"jellyfin-access\":{\"orgid\":\"example.com\"},\"jellyfin-admin\":{\"orgid\":\"example.com\"}}",
+            true);
+        Assert.Equal(new List<string> { "jellyfin-access", "jellyfin-admin" }, roles);
+    }
+
+    [Fact]
+    public void ObjectMap_NestedPath_ReadsTheTerminalObjectsPropertyNames()
+    {
+        var value = "{\"resource_access\":{\"jellyfin\":{\"roles\":{\"media\":{\"x\":1}}}}}";
+        var roles = OidcRoleExtractor.ExtractRoles(
+            new[] { "claim", "resource_access", "jellyfin", "roles" },
+            value,
+            true);
+        Assert.Equal(new List<string> { "media" }, roles);
+    }
+
+    [Fact]
+    public void ObjectMap_EmptyObject_ReturnsNoRoles()
+    {
+        // An empty map must mean NO roles, never "any role" — the allow-list check would otherwise be
+        // satisfiable by a provider that granted the user nothing.
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "{}", true));
+    }
+
+    [Fact]
+    public void ObjectMap_ArrayTerminal_ReturnsEmpty()
+    {
+        // The flag names the shape; a mismatched terminal is no roles, not a fallback guess.
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\"]}", true));
+    }
+
+    [Fact]
+    public void ObjectMap_ScalarClaimValue_ReturnsEmpty()
+    {
+        // A single-segment object-map path no longer takes the raw value as a role: a provider that
+        // regressed to emitting a plain string must grant nothing, not a role literally named "users".
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "users", true));
+    }
+
+    [Fact]
+    public void ObjectMap_JsonArrayClaimValue_ReturnsEmpty()
+    {
+        // Deserializing a JSON array into the object shape throws inside the try — it must fail closed to
+        // no roles, never an unhandled 500 on the public callback (#216).
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "[\"users\"]", true));
+    }
+
+    [Fact]
+    public void ObjectMap_MalformedClaimValue_ReturnsEmpty()
+    {
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "not-json", true));
+    }
+
+    [Theory]
+    [InlineData("{\"a\":{},\"a\":{}}")]      // duplicate JSON keys
+    [InlineData("{\"\":{}}")]                // empty property name
+    [InlineData("{\"a\":null}")]
+    [InlineData("{\"a\":1}")]
+    [InlineData("{\"a\":[1,2]}")]
+    [InlineData("\"scalar\"")]
+    [InlineData("123")]
+    [InlineData("true")]
+    [InlineData("")]
+    [InlineData("[\"users\"]")]
+    public void ObjectMap_HostileClaimValues_NeverThrow(string claimValue)
+    {
+        // #216/#934: the claim value is attacker-influenced and reaches this parser on the ANONYMOUS public
+        // callback, so no shape may escape as an unhandled exception (a 500). The method catches JsonException
+        // only, so this pins that nothing else — a duplicate-key dictionary populate, an empty key, a scalar
+        // or array root — throws something outside it.
+        Assert.NotNull(OidcRoleExtractor.ExtractRoles(new[] { "roles" }, claimValue, true));
+    }
+
+    [Fact]
+    public void ObjectMap_PathologicallyDeepClaimValue_FailsClosedWithoutThrowing()
+    {
+        // A depth-bomb claim value must fail closed, not stack-overflow or escape as a 500. Newtonsoft's
+        // depth limit surfaces as a JsonException, which the parser already swallows.
+        var deep = new System.Text.StringBuilder();
+        for (int i = 0; i < 5000; i++)
+        {
+            deep.Append("{\"a\":");
+        }
+
+        deep.Append('1');
+        for (int i = 0; i < 5000; i++)
+        {
+            deep.Append('}');
+        }
+
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "roles" }, deep.ToString(), true));
+    }
+
+    [Fact]
+    public void ArrayMode_ObjectTerminal_StillReturnsEmpty()
+    {
+        // The pre-#934 behaviour is unchanged for every provider that does not opt in: an object terminal
+        // read in array mode yields no roles rather than silently adopting the new shape.
+        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":{\"users\":{}}}", false));
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -217,7 +217,7 @@ internal static class OidcAuthorizeStateBuilder
 
             if (roleClaimSegments.Length > 0 && string.Equals(claim.Type, roleClaimSegments[0], StringComparison.Ordinal))
             {
-                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value));
+                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value, config.RoleClaimIsObjectMap));
             }
         }
 

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -11,9 +11,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// <summary>
 /// Reads the role values out of an OpenID claim according to the configured role-claim path.
 /// The path is the pre-split <c>RoleClaim</c> (see the controller): its first segment names the
-/// claim, and any further segments walk into the claim's JSON object to the array that holds the
-/// roles. This is pure parsing — it makes no authorization decision; the caller maps the returned
-/// role strings to privileges.
+/// claim, and any further segments walk into the claim's JSON object to the node that holds the roles —
+/// an array of role strings, or, for a provider that opts into <c>RoleClaimIsObjectMap</c> (#934), an
+/// object whose property names are the roles. A one-segment path takes the claim value as the role
+/// verbatim, except in object-map mode, where that value IS the object. This is pure parsing — it makes
+/// no authorization decision; the caller maps the returned role strings to privileges.
 /// </summary>
 internal static class OidcRoleExtractor
 {
@@ -25,25 +27,32 @@ internal static class OidcRoleExtractor
     /// name). Must be non-empty; the caller only invokes this for the claim whose type equals segment[0].
     /// </param>
     /// <param name="claimValue">The matched claim's value (a raw role, or a JSON object for a nested path).</param>
+    /// <param name="terminalIsObjectMap">
+    /// The provider's <c>RoleClaimIsObjectMap</c>: the terminal node is a JSON object whose property NAMES
+    /// are the roles (Zitadel, #934) instead of an array of role strings. Deliberately has no default so
+    /// every call site has to state which shape it reads.
+    /// </param>
     /// <returns>
-    /// The extracted roles: the raw claim value as a single role for a one-segment path; otherwise the
-    /// string elements of the array reached by walking the JSON path (non-string elements are ignored).
-    /// Returns an empty list when the path does not resolve to a JSON array (missing segment, non-object
-    /// node, or non-array terminal) and when the claim value is malformed JSON — a multi-segment parse
-    /// fails closed to no roles rather than throwing (#216).
+    /// The extracted roles: for an array terminal, the string elements of the array reached by walking the
+    /// JSON path (non-string elements are ignored); for an object-map terminal, that object's property
+    /// names; and, only when the path is one segment and the terminal is not an object map, the raw claim
+    /// value as a single role. Returns an empty list when the path does not resolve to the expected shape
+    /// (missing segment, non-object node, wrong terminal type) and when the claim value is malformed
+    /// JSON — a parse failure fails closed to no roles rather than throwing (#216).
     /// </returns>
-    internal static List<string> ExtractRoles(string[] roleClaimSegments, string claimValue)
+    internal static List<string> ExtractRoles(string[] roleClaimSegments, string claimValue, bool terminalIsObjectMap)
     {
-        // A single-segment path is not JSON: the claim value itself is the role.
-        if (roleClaimSegments.Length == 1)
+        // A single-segment path is not JSON: the claim value itself is the role. An object-map claim is the
+        // exception — there the claim value IS the terminal object, so it falls through to the parse below.
+        if (roleClaimSegments.Length == 1 && !terminalIsObjectMap)
         {
             return new List<string> { claimValue };
         }
 
-        // A multi-segment path parses the claim value as a JSON object and walks it. The claim value is
+        // Everything else parses the claim value as a JSON object and walks it. The claim value is
         // attacker-influenced, so it must never throw an unhandled 500 on the public callback (#216): any
-        // malformed or non-resolving shape (non-object root, non-object node, non-array terminal) fails
-        // closed to an empty role set, and the terminal array is filtered to its string elements — a mixed
+        // malformed or non-resolving shape (non-object root, non-object node, wrong terminal type) fails
+        // closed to an empty role set, and an array terminal is filtered to its string elements — a mixed
         // array keeps its strings, an array with no strings yields none.
         try
         {
@@ -51,6 +60,13 @@ internal static class OidcRoleExtractor
             if (json is null)
             {
                 return new List<string>();
+            }
+
+            // A one-segment object-map path has no key to look under: the parsed claim value IS the terminal
+            // object, so its property names are the roles. An empty object yields NO roles, never "any role".
+            if (roleClaimSegments.Length == 1)
+            {
+                return json.Keys.ToList();
             }
 
             // Walk the intermediate segments; any missing key or non-object node yields no roles.
@@ -69,14 +85,25 @@ internal static class OidcRoleExtractor
                 }
             }
 
-            // The terminal segment must resolve to a JSON array; take only its string elements so a
-            // terminal array of objects or numbers cannot throw.
-            if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken) || rolesToken is not JArray rolesArray)
+            if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken))
             {
                 return new List<string>();
             }
 
-            return rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()!).ToList();
+            // The terminal must resolve to the configured shape — anything else is no roles, not a guess.
+            if (terminalIsObjectMap)
+            {
+                // Property NAMES only: the values are provider bookkeeping (Zitadel puts the granting org
+                // there), and reading them, or recursing, would turn unrelated data into granted roles.
+                return rolesToken is JObject rolesObject
+                    ? rolesObject.Properties().Select(property => property.Name).ToList()
+                    : new List<string>();
+            }
+
+            // Take only the array's string elements so a terminal array of objects or numbers cannot throw.
+            return rolesToken is JArray rolesArray
+                ? rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()!).ToList()
+                : new List<string>();
         }
         catch (JsonException)
         {

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -639,6 +639,18 @@ public class OidConfig : ProviderConfigBase
     public string? RoleClaim { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the node <see cref="RoleClaim"/> resolves to is a JSON
+    /// <b>object whose property names are the role names</b>, rather than a JSON array of role strings
+    /// (#934). Zitadel emits exactly that shape — <c>{"jellyfin-access": {"&lt;orgId&gt;": "&lt;domain&gt;"}}</c>
+    /// under <c>urn:zitadel:iam:org:project:roles</c> — so without this its roles are unreadable and its
+    /// role gate can never be turned on. Off by default, so no existing provider changes behaviour.
+    /// Only the property NAMES are read, never the values and never nested objects; any other shape
+    /// (array, scalar, malformed JSON) still fails closed to no roles. Settable in the admin provider
+    /// form as well as the config XML.
+    /// </summary>
+    public bool RoleClaimIsObjectMap { get; set; }
+
+    /// <summary>
     /// Gets or Sets additional Scopes to request access to in the authorization request.
     /// </summary>
     public string?[]? OidScopes { get; set; }

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -142,6 +142,12 @@ const OIDC_PRESET_MANAGED_TOGGLES = [
   "DoNotValidateResponseIssuer",
   "DisableHttps",
   "DoNotLoadProfile",
+  // Not an insecure toggle — it names the SHAPE of the RoleClaim path's terminal (#934). It is here because
+  // every preset sets RoleClaim, so leaving a previous provider's shape flag ticked while the claim path is
+  // replaced by an array-shaped one (Keycloak's realm_access.roles) would extract ZERO roles and lock the
+  // whole userbase out on the next login. Clearing is correct for every shipped preset; a future
+  // object-map preset (Zitadel) can pre-check it from its own `toggles`.
+  "RoleClaimIsObjectMap",
 ];
 const SAML_PRESET_MANAGED_TOGGLES = ["DoNotValidateAudience"];
 

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -926,7 +926,8 @@
                       roles. The first element is the claim type, the subsequent
                       values are to parse the JSON of the claim value. Use a
                       <code>"\."</code> to denote a literal ".". This expects a
-                      list of strings from the OIDC server.
+                      list of strings from the OIDC server, unless "Role claim
+                      is an object map" below is on.
                       <br />
                       For Keycloak, it is <code>realm_access.roles</code> by
                       default for realm roles. For client roles, it is
@@ -934,6 +935,34 @@
                       (e.g. resource_access.jellyfin.roles)
                       <br />
                       For Authelia, it is <code>groups</code>
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="RoleClaimIsObjectMap"
+                        name="RoleClaimIsObjectMap"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Role claim is an object map</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      Read the roles from the property <em>names</em> of a JSON
+                      object instead of from a list of strings. Zitadel needs
+                      this: it emits
+                      <code
+                        >{"jellyfin-access": {"&lt;orgId&gt;":
+                        "&lt;domain&gt;"}}</code
+                      >
+                      under <code>urn:zitadel:iam:org:project:roles</code>. Only
+                      the names are read — never the values, never nested
+                      objects. Off by default; leave it off for a provider that
+                      returns a list (Keycloak, Authelia, authentik).
                     </div>
                   </div>
                 </div>
@@ -964,7 +993,10 @@
                       <br />
                       If a user has any of these roles, then the user is
                       authenticated. This validates the OpenID response against
-                      the claim set in <strong>"RoleClaim"</strong>.
+                      the claim set in <strong>"RoleClaim"</strong>. (If your
+                      provider — Zitadel does this — carries the roles as object
+                      keys, also tick "Role claim is an object map" beside the
+                      Role Claim field.)
                       <br />
                       Leave blank to disable role checking.
                     </div>


### PR DESCRIPTION
## What & why

Closes #934 (refs #924, #935).

`OidcRoleExtractor` required the `RoleClaim` path's terminal to be a **JSON array of role strings**, and treated a one-segment path as "the raw claim value IS the role". Zitadel emits neither shape - its roles are an **object map** under a single-segment claim name:

```json
"urn:zitadel:iam:org:project:roles": { "jellyfin-access": { "<orgId>": "<domain>" } }
```

so no configuration could read them and Zitadel's role gate could never be turned on at all. That is a functional gap for a mainstream self-hosted provider, and it blocks an honest role-gate assertion in the Zitadel E2E harness (#924).

A new per-provider option, **`RoleClaimIsObjectMap`**, reads the roles from the terminal object's property **names**.

- It is passed to `ExtractRoles` as a **required parameter with no default**, so every call site has to state which shape it reads.
- It defaults to **false**, so no existing provider changes behaviour.
- Only property **names** are read, never the values, never nested objects. Zitadel puts the granting organisation's id→domain map in the value; reading or recursing into it would turn provider bookkeeping into a granted role.
- Every other shape still fails closed to no roles: an array terminal in object-map mode, an object terminal in array mode, a scalar, a JSON array root, malformed JSON.

## Type of change

- New feature (per-provider option), authorization-relevant
- Test / conformance hardening
- Documentation

## Verification

`dotnet build --warnaserror` clean; **1913/1913 tests pass**.

The claim value is attacker-influenced and reaches this parser on the **anonymous** callback, and the method catches `JsonException` only, so the exception surface was **measured, not assumed**. New tests pin as fail-closed (no throw, no roles): duplicate JSON keys at the root, at the terminal, and through the intermediate `ToObject` hop; an empty property name; scalar / array / null roots; an empty value; and a 5 000-level depth bomb. Newtonsoft's depth limit surfaces as a `JsonException`, so a nesting bomb cannot escape as a 500.

The new reverse conformance guard was **mutation-verified**: adding an unrostered marked input to the provider form fails it by name.

## Security checklist

- **Fail-closed:** every shape that is not exactly the configured one yields an empty role set. An empty object grants **nothing**, never "any role".
- **No privilege escalation:** values and nested objects are never read; pinned by `ObjectMapRoleClaim_DoesNotReadTheValues`, which feeds `{"nothing": {"orgid": "jellyfin-access"}}` and asserts refusal.
- **Default unchanged, proven:** with the flag false the pre-change code path is taken verbatim (the one-segment early return is untouched; the terminal rewrite is the same predicate as a ternary), and a legacy config XML without the element deserializes to `false`. `ArrayMode_ObjectTerminal_StillReturnsEmpty` pins the flag-off side.
- **Ordinal matching downstream is unchanged**, so a case or homoglyph variant of a role name still cannot match an allow-list entry.
- **No 500 vector** on the anonymous callback (above).

## Review gate

Four refute-by-default lenses (authz, bypass, correctness, availability), each reading the full touched files plus `ScanClaims`/`Build`/`SessionMinter`/`RolePrivilegeMapper`, and each settling its hypotheses by running throwaway probes (~60 hostile inputs, depth bombs to 200 000 levels, XmlSerializer round-trips of legacy configs) rather than by reasoning.

**No privilege-escalation path, no fail-open, and no crash path was found by any lens.** All four returned NEEDS_IMPROVEMENT on findings around the change:

| # | Finding | Fix |
| --- | --- | --- |
| 1 | **Lockout vector:** `applyOidcPreset` never cleared the new toggle. Every preset sets `RoleClaim`, so opening a Zitadel provider then applying the **Keycloak** template left the shape flag ticked over an array-shaped claim path → zero roles for every login → silent full-userbase lockout on the next save. | Added to `OIDC_PRESET_MANAGED_TOGGLES`. |
| 2 | **The provider-form persistence roster was a subset assertion**, so a new field could ship entirely outside the guard, which is how both this field *and* `DisableAvatarFromPictureClaim` (#723) escaped it. If the marker class were later dropped, a stored `true` would become invisible and unclearable while object-map parsing stayed in force. | Roster now compared as a **set in both directions**; both missing fields rostered (42 → 44); mutation-verified. |
| 3 | The extractor's **class-level XML doc** still said further segments walk "to the array that holds the roles". | Corrected. |
| 4 | The **`RoleClaim` field help text** still said unconditionally "This expects a list of strings from the OIDC server", directly above the checkbox that falsifies it. | Qualified. |
| 5 | The added cross-reference pointed "below" at a control that renders **above** it, in a different accordion section. | Reworded to name the location. |
| 6 | No `## Unreleased` CHANGELOG entry for a new user-visible provider option. | Added. |

Deferred with a written home rather than scope-creeping this PR:

- A **Zitadel preset** in `OIDC_PRESETS` and a **`#zitadel` wiki Provider Setup section** belong with the harness that proves their exact endpoint/scope values, recorded on #924. (`RoleClaimIsObjectMap` is now in the preset-managed list, so that preset can pre-check it.)
- A **pre-existing** inconsistency the review surfaced, `RolePrivilegeMapper.IsOnList` does not skip a blank configured allow-list entry, while the two sibling role matchers do, is #935.

The local `docs/E2E-CHECKLIST.md` (gitignored) gained a manual check for the object-map shape, including the mis-set direction.