### PR TITLE
Correct a false claim about one-shot init containers

### DIFF
--- a/test/e2e/zitadel/docker-compose.yml
+++ b/test/e2e/zitadel/docker-compose.yml
@@ -33,9 +33,8 @@ services:
     image: ghcr.io/zitadel/zitadel:v2.71.16
     # The token volume is created root-owned and this image otherwise runs unprivileged, so writing the
     # token fails with "permission denied" and takes the whole setup migration down with it. Running the
-    # container as root is the one-line fix; a separate chmod init container is NOT an option, because the
-    # run uses --abort-on-container-exit, under which a one-shot service finishing successfully tears the
-    # entire stack down mid-migration. The image ships no shell, so the chmod cannot be folded into command.
+    # container as root is the one-line fix, and the image ships no shell, so a chmod cannot be folded into
+    # its command either.
     user: "0:0"
     # The master key encrypts Zitadel's own secrets at rest; it must be exactly 32 bytes. Test-only.
     command: >


### PR DESCRIPTION
## What & why

Refs #924, #923. A comment-only correction to `test/e2e/zitadel/docker-compose.yml`.

The file asserts that a separate chmod init container is not an option *"because the run uses `--abort-on-container-exit`, under which a one-shot service finishing successfully tears the entire stack down mid-migration"*.

**That is wrong, and it was my inference from a correlation rather than a test.** In the failed run that produced it, Postgres was SIGKILLed shortly after an init container exited, and I wrote the causal claim straight into the file.

Tested properly with a purpose-built three-service stack, a long-runner, a one-shot, and a main service, under `--abort-on-container-exit --exit-code-from main`:

```
Container abort-test-oneshot-1 Exited
main-1        | main start
longrunner-1  | long 2 … long 6          <- stack still running for 12s after the one-shot exited
Container abort-test-longrunner-1 Stopped
main-1        | main end
main-1 exited with code 0
```

The one-shot exits, the stack keeps running, and the abort happens only when `main` exits. With `--exit-code-from`, compose aborts on the **named service alone**.

The `user: "0:0"` fix itself stands, the token volume is root-owned, the image runs unprivileged, and it ships no shell to fold a chmod into its command. Only the justification was false.

**Why it matters enough to fix on its own:** it is load-bearing guidance in the file the next provider harness will be copied from. It would have steered #923 (Kanidm) away from an init-container design that is in fact perfectly usable, which is exactly what it did to me while I was designing that harness, and how the error surfaced.

## Type of change

- Documentation / comment correction (no behaviour change)

## Verification

No code changed, the diff is five comment lines. `yq` parses the compose unchanged. The Zitadel harness's behaviour is untouched; it was last verified green (6 assertions) in the six-provider CI matrix on #939.

## Security checklist

Not applicable, comment-only. The security-relevant property the comment sits on (`user: "0:0"`, and why it is acceptable for an ephemeral test rig) is unchanged and still stated.

## Review gate

No adversarial review run: this is a comment-only change with no behavioural surface, and the claim being corrected was itself verified by direct experiment above rather than by reasoning.