### PR TITLE
Stop the manifest publishing the SBOM's checksum, and verify what ships

### DIFF
--- a/.github/actions/verify-manifest/action.yml
+++ b/.github/actions/verify-manifest/action.yml
@@ -1,0 +1,162 @@
+name: Verify the published plugin manifest
+description: >-
+  Prove that a just-published plugin manifest actually installs: download exactly
+  what it points at and check the artifact's MD5 against the checksum it
+  publishes — for the version this run added, and for the newest entry of every
+  targetAbi it lists.
+
+  This exists because the manifest generator
+  (Kevinjil/jellyfin-plugin-repo-action) selects a release's checksum by NAME —
+  it keeps the LAST asset whose name ends in `.md5`, with no break and no
+  pairing against the zip. A second `.md5` asset that sorts after the plugin's
+  therefore becomes the published checksum, the manifest ships a value that
+  matches nothing, and every install fails Jellyfin's verification with a bare
+  "failed" and no hint at the cause. That is not hypothetical: renaming the
+  plugin to `community-sso-for-jellyfin` moved its md5 ahead of
+  `sbom.cyclonedx.md5` alphabetically and broke the beta channel exactly that
+  way (#942). The publish legs no longer emit a competing `.md5`; this action
+  re-derives the answer from the published artefacts and trusts nothing the
+  generator did.
+
+  SCOPE, honestly: this is a post-publish DETECTOR, not a preventer. It runs
+  after the release is sealed (immutable) and after the manifest branch is
+  written, so on a true positive the bad manifest is already being served — the
+  run turns red and a human has to act. It converts a silent, user-facing
+  outage into a loud build failure; it does not roll anything back.
+
+  The newest entry of EVERY targetAbi is checked, not only the one this run
+  added: the manifests are shared between the Jellyfin generations, so a run of
+  one publish leg can break the other's head entry — the entry a fresh install
+  of that generation is offered.
+inputs:
+  repository:
+    description: owner/repo whose manifest branch is being verified.
+    required: true
+  manifest-branch:
+    description: >-
+      Branch holding the published manifest.json (e.g. manifest-beta,
+      manifest-release).
+    required: true
+  github-token:
+    description: >-
+      Token used to read the manifest through the API. The API is used rather
+      than raw.githubusercontent because raw serves the branch through a cache
+      with max-age=300 and no way for a client to force revalidation — a read
+      there routinely returns the PREVIOUS revision, which would verify the
+      wrong document (a false green on the stable legs) or report the just-added
+      version as missing (a false red on the beta legs).
+    required: true
+  expect-version:
+    description: >-
+      Plugin version this run published (e.g. 4.3.0.10), which must be present
+      AND whose checksum is verified directly — being present is not enough,
+      since a version that is not its ABI's head would otherwise only be
+      checked for existence. Leave unset where the leg cannot derive it.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Verify the published manifest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repository }}
+        BRANCH: ${{ inputs.manifest-branch }}
+        EXPECT_VERSION: ${{ inputs.expect-version }}
+      run: |-
+        set -euo pipefail
+        work="$(mktemp -d)"
+        manifest="$work/manifest.json"
+
+        # Read through the API, which is read-your-writes against the commit the generator
+        # just made. Retried because the generator's write and this read are separate API
+        # calls; when a version is expected, the retry waits for THAT version rather than
+        # merely for a successful fetch — a fetch that succeeds with stale content is the
+        # failure mode, not a fetch that errors.
+        fetched=0
+        for _ in $(seq 1 12); do
+          if gh api "repos/${REPO}/contents/manifest.json?ref=${BRANCH}" \
+               -H "Accept: application/vnd.github.raw" > "$manifest" 2>/dev/null; then
+            if [ -z "$EXPECT_VERSION" ]; then
+              fetched=1
+              break
+            fi
+            if jq -e --arg v "$EXPECT_VERSION" \
+                 '.[0].versions | map(.version) | index($v)' "$manifest" >/dev/null 2>&1; then
+              fetched=1
+              break
+            fi
+          fi
+          sleep 10
+        done
+        if [ "$fetched" -ne 1 ]; then
+          echo "::error::could not read a manifest containing ${EXPECT_VERSION:-any version} from ${REPO}@${BRANCH}"
+          exit 1
+        fi
+
+        # verify <version> — download what the manifest points at and compare.
+        # Returns non-zero on any mismatch, unreachable artifact, or missing entry.
+        verify() {
+          entry="$(jq -c --arg v "$1" 'first(.[0].versions[] | select(.version == $v))' "$manifest")"
+          if [ -z "$entry" ] || [ "$entry" = "null" ]; then
+            echo "::error::version $1 is missing from the published manifest"
+            return 1
+          fi
+          want="$(printf '%s' "$entry" | jq -r '.checksum // ""')"
+          url="$(printf '%s' "$entry" | jq -r '.sourceUrl // ""')"
+          if [ -z "$want" ] || [ -z "$url" ]; then
+            echo "::error::version $1 has an empty checksum or sourceUrl in the published manifest"
+            return 1
+          fi
+          # Retried: this runs moments after the release was sealed, and asset propagation
+          # can 404 or 5xx transiently — a false red here would fail an otherwise correct
+          # publish that can no longer be re-made (the release is immutable).
+          if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --max-time 180 "$url" -o "$work/published.zip"; then
+            echo "::error::version $1 — the manifest's sourceUrl is not downloadable: $url"
+            return 1
+          fi
+          got="$(md5sum "$work/published.zip" | cut -d' ' -f1)"
+          if [ "$want" != "$got" ]; then
+            echo "::error::version $1 — the manifest publishes checksum $want but the artifact at $url is $got; every install of this build would fail verification"
+            return 1
+          fi
+          echo "ok   version=$1 checksum=$got"
+          return 0
+        }
+
+        # An ASSIGNMENT, not a `for … in $(...)` word list: `set -e` ignores a failed
+        # command substitution in a for-list, so a jq error there would yield zero
+        # iterations and a green run — the gate would pass on an empty, truncated or
+        # non-JSON manifest, which is exactly the catastrophic case it must catch.
+        abis="$(jq -r '.[0].versions | map(.targetAbi) | unique | .[]' "$manifest")" || {
+          echo "::error::the published manifest is not a readable plugin manifest (jq could not read .[0].versions); first bytes: $(head -c 200 "$manifest")"
+          exit 1
+        }
+        if [ -z "$abis" ]; then
+          echo "::error::the published manifest lists no versions at all"
+          exit 1
+        fi
+
+        fail=0
+        checked=0
+        if [ -n "$EXPECT_VERSION" ]; then
+          verify "$EXPECT_VERSION" || fail=1
+          checked=$((checked + 1))
+        fi
+        for abi in $abis; do
+          head_version="$(jq -r --arg a "$abi" 'first(.[0].versions[] | select(.targetAbi == $a)) | .version' "$manifest")"
+          echo "abi=$abi head=$head_version"
+          if [ "$head_version" != "$EXPECT_VERSION" ]; then
+            verify "$head_version" || fail=1
+            checked=$((checked + 1))
+          fi
+        done
+
+        # Belt and braces: a run that verified nothing must never report success.
+        if [ "$checked" -eq 0 ]; then
+          echo "::error::the verification checked no manifest entries at all"
+          exit 1
+        fi
+        echo "verified $checked manifest entr(y|ies)"
+        [ "$fail" -eq 0 ]

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -165,10 +165,19 @@ jobs:
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip ./sbom.cyclonedx.json; do
+        # ONLY the plugin zip gets a `.md5`. The manifest generator
+        # (Kevinjil/jellyfin-plugin-repo-action) walks a release's assets and keeps the
+        # LAST one whose name ends in `.md5` — no break, and no pairing with the zip —
+        # so a second `.md5` asset sorting after the plugin's silently becomes the
+        # published checksum and every install then fails verification. The rename to
+        # `community-sso-for-jellyfin` did exactly that: it moved the plugin's md5 ahead
+        # of `sbom.cyclonedx.md5` alphabetically. The SBOM keeps a sha256, which is the
+        # meaningful integrity value for it and cannot collide.
+        for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done
+        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Upload beta assets to a draft release
@@ -228,3 +237,14 @@ jobs:
         repository: ${{ github.repository }}
         pagesBranch: manifest-beta
         pagesFile: manifest.json
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-beta
+        github-token: ${{ github.token }}
+        expect-version: ${{ steps.version.outputs.beta }}

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -146,10 +146,15 @@ jobs:
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip ./sbom.cyclonedx.json; do
+        # ONLY the plugin zip gets a `.md5` — see the same note in publish-beta.yml. The
+        # manifest generator keeps the LAST asset ending in `.md5`, so a second one
+        # sorting after the plugin's becomes the published checksum and every install
+        # fails verification.
+        for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done
+        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Upload JF12 beta assets to a draft release
@@ -209,3 +214,14 @@ jobs:
         repository: ${{ github.repository }}
         pagesBranch: manifest-beta
         pagesFile: manifest.json
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-beta
+        github-token: ${{ github.token }}
+        expect-version: ${{ steps.version.outputs.beta }}

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -87,10 +87,15 @@ jobs:
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        for file in ./*.zip ./sbom.cyclonedx.json; do
+        # ONLY the plugin zip gets a `.md5` — see the same note in publish-beta.yml. The
+        # manifest generator keeps the LAST asset ending in `.md5`, so a second one
+        # sorting after the plugin's becomes the published checksum and every install
+        # fails verification.
+        for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done
+        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Publish output artifacts
@@ -132,3 +137,13 @@ jobs:
         repository: ${{ github.repository }}
         pagesBranch: manifest-release
         pagesFile: manifest.json
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-release
+        github-token: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,10 +73,22 @@ jobs:
         name: sbom-artifact
     - name: Prepare GitHub Release assets
       run: |-
-        for file in ./*; do
+        # ONLY the plugin zip gets a `.md5`. The manifest generator
+        # (Kevinjil/jellyfin-plugin-repo-action) walks a release's assets and keeps the
+        # LAST one whose name ends in `.md5` — no break, and no pairing with the zip —
+        # so any second `.md5` asset sorting after the plugin's silently becomes the
+        # published checksum and every install then fails verification. The rename to
+        # `community-sso-for-jellyfin` did exactly that on the beta channel: it moved
+        # the plugin's md5 ahead of `sbom.cyclonedx.md5` alphabetically. This job's
+        # workspace holds only the plugin zip and the SBOM, so the blanket `./*` produced
+        # exactly those two `.md5` files — enough for the next stable release to have
+        # shipped the SBOM's checksum the same way. The SBOM keeps a sha256, which is the
+        # meaningful integrity value for it and cannot collide.
+        for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
         done
+        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
         ls -l
     - name: Publish output artifacts
       id: publish-assets
@@ -106,6 +118,11 @@ jobs:
     needs:
     - upload
     steps:
+    # Needed only so the local verify-manifest action below resolves; the manifest step
+    # itself talks to the API and uses nothing from the working tree.
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
     - name: Publish Plugin Manifest
       uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
       with:
@@ -114,3 +131,13 @@ jobs:
         repository: ${{ github.repository }}
         pagesBranch: manifest-release
         pagesFile: manifest.json
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-release
+        github-token: ${{ github.token }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,8 +77,11 @@ inventory a downstream redistributor needs for its own CRA Annex I duties
 (and satisfies OSPS-QA-02.02). The SBOM covers the **full multi-target closure**
 (both the net9.0 / Jellyfin 10.11 and net10.0 / Jellyfin 12.0 lines) — a
 conservative superset of any single release's shipped ABI, which its tag and
-zip identify. It is shipped with the same `.md5`/`.sha256` sidecars as the plugin
-zip.
+zip identify. It ships with a `.sha256` sidecar. It deliberately carries no
+`.md5`: the Jellyfin manifest generator picks a release's checksum by filename
+and keeps the last `.md5` it sees, so a second one can silently become the
+published plugin checksum and break every install (#942). SHA-256 is the
+meaningful integrity value here in any case.
 
 The SBOM is generated in an isolated job that deliberately does **not** hold the
 release signing scopes, so the SBOM tool can never reach the provenance signing


### PR DESCRIPTION
## What & why

Closes #942 (refs #943, #944, #729). **Live outage:** installing from the beta channel on Jellyfin 10.11 fails right now.

Jellyfin verifies the downloaded zip against the manifest's `checksum` and refuses to install on a mismatch. For `4.3.0.10` the manifest publishes the MD5 of **`sbom.cyclonedx.json`**, not of the plugin zip:

| | |
| --- | --- |
| manifest `checksum` | `b702f1be7645682d87ea2c99066741f8` |
| actual zip MD5 | `efe81200364f18a3630011c0c1f504dd` |
| `sbom.cyclonedx.json` MD5 | `b702f1be7645682d87ea2c99066741f8` ← what shipped |

### Root cause

The manifest generator selects a release's checksum **by name and keeps the last match** - no `break`, no pairing against the zip:

```js
if (asset.name.endsWith('.md5')) { checksum = ... }   // last one wins
```

GitHub returns assets alphabetically and every publish leg emitted **two** `.md5` assets. Renaming the plugin to `community-sso-for-jellyfin` (#913) flipped which sorts last:

| release | `.md5` assets, in order | last match |
| --- | --- | --- |
| `4.3.0-beta.9` (old name) | `sbom.cyclonedx.md5`, `sso-authentication_….md5` | **the plugin's** ✔ |
| `4.3.0-beta.10` (new name) | `community-sso-for-jellyfin_….md5`, `sbom.cyclonedx.md5` | **the SBOM's** ✘ |

**Nothing here is insecure.** The published checksum is a real checksum of a real published file, and the mismatch makes Jellyfin **refuse** the install, a fail-closed outage, not a verification bypass.

## The fix

1. **Only the plugin zip gets a `.md5`.** The SBOM keeps a `.sha256`, the meaningful integrity value for it, which cannot collide. This removes the ambiguity **by construction** rather than by sort order. `publish.yml` checksummed its whole workspace (`for file in ./*`), the wider form of the same hazard, and is narrowed too.
2. **A new `verify-manifest` composite action** runs after the manifest step in all four legs: read back what was just published and, for the version this run added **and** the head of every `targetAbi`, download exactly what the manifest points at and compare the MD5.

The **stable** channel would have broken identically at the next release, with nothing to notice.

## Type of change

- Bug fix (release pipeline)
- Documentation

## Verification

The gate was tested against the real thing, not reasoned about:

```
LIVE broken beta manifest   → ::error::version 4.3.0.10 — the manifest publishes checksum
                               b702f1be… but the artifact at …_4.3.0.10.zip is efe81200…
                               ok version=5.0.0.20   → exit 1
LIVE healthy stable manifest → abi=10.11.0.0 head=4.2.1 / ok version=4.2.1 → exit 0
```

All five YAML files parse; `prettier --check` clean on `SECURITY.md`.

## Security checklist

- **No plugin code changed**, release pipeline and documentation.
- **Fail-closed:** every malformed-manifest case now fails by name (see the review table below).
- **No supply-chain claim weakened:** all four legs still emit and ship `sbom.cyclonedx.sha256`, so #729 / CRA Annex I / OSPS-QA-02.02 are untouched. The plugin zip's `.md5`, the load-bearing one that `CLAUDE.md` and `docs/WORKING-METHOD.md` require, is preserved. `SECURITY.md` is corrected, since it claimed the SBOM ships an `.md5`.
- **No permissions widening, no `${{ }}` in any `run:` body** (both action inputs travel via `env:`), everything SHA-pinned. The new `actions/checkout` in `publish.yml`'s manifest job uses `persist-credentials: false`, so no token lands in `.git/config` in a `contents:write` job.

## Review gate

Four refute-by-default lenses (integration, correctness, bypass, availability), each of which executed the gate script against live and synthetic manifests and read the generator source at its pinned SHA. **All four independently found that my first draft of the gate was itself fail-open**, which matters more than the original bug, because a verification that cannot fail is worse than none: it is believed.

| # | Finding | Fix |
| --- | --- | --- |
| 1 | **The gate was fail-OPEN.** `for abi in $(jq …)` does not propagate a jq failure under `set -e`, and zero iterations satisfied the final check. Measured: `[]`, `[{"versions":[]}]`, `{}`, an HTML body served 200, and a **zero-byte file** all exited **0**, green. The two **stable** legs pass no `expect-version`, so that loop was their *only* assertion. The single worst event this pipeline can produce, a manifest regenerated with zero versions, silently emptying the channel, passed. | The ABI list is now captured as an **assignment** (which `set -e` does honour) with its own named error; an empty version list is an error; and a run that verified nothing is an error. All five cases now fail by name. |
| 2 | **It read `raw.githubusercontent`**, which serves the manifest branch through a 300-second cache that a client cannot force to revalidate (measured: `Cache-Control: max-age=300`, `X-Cache: HIT`, `Source-Age: 288`). The retry loop only retried *transport failure*, never staleness. → **false green** on the stable legs (verifying the previous, good manifest) and **false red** on the beta legs. | Reads through the **API**, which is read-your-writes against the commit the generator just made, and retries until the expected version actually **appears** rather than until a fetch merely succeeds. |
| 3 | **The version this run published was asserted present but never checksummed**, unless it happened to be its ABI's head. | Verified directly, in addition to every ABI head. |
| 4 | **The artifact download had no retry** while the manifest fetch had twelve, a transient 404 during asset propagation would have failed an already-sealed, unrepeatable release. | `--retry 5 --retry-all-errors --max-time 180`. |
| 5 | `SECURITY.md` claimed the SBOM ships `.md5`/`.sha256` sidecars; `publish.yml`'s new comment mis-enumerated what its `./*` glob matched (no `meta.json`/`.md5sum` in that job). | Both corrected. |
| 6 | The action was described as a "fail-closed gate". It runs **after** the release is sealed and the manifest written, so it detects rather than prevents. | Reworded, and the scope limit is stated in the action itself. |

Two further findings are **their own issues** rather than scope creep here, and both are real, imminent outages the review surfaced:

- **#943**, the generator lists only the first **30** releases (unpaginated). There are already **32**, the beta manifest holds exactly 30, and daily JF10.11 betas are pushing the JF12 entries off the end. When the last one falls off, `targetAbi 12.0.0.0` vanishes from the beta manifest and every Jellyfin 12.0 beta user's repository silently goes empty, and this gate would not catch it, since it iterates the ABIs *present*.
- **#944**, the JF12 publish legs execute from the `4.2` branch, where `.github/actions/` does not exist, so the edits to them here are **inert** until a forward merge. JF12 is currently safe only by luck (its artifact still uses the old name, which sorts after the SBOM's); adopting the rename there without this fix breaks it identically.

## Remediation of the live channel

The beta manifest is regenerated from all prereleases on every beta publish, so the next beta run republishes it correctly, and can no longer publish it wrongly.

## Why it was not caught

The release pipeline had **no post-publish assertion at all**. Everything up to "the manifest branch was written" succeeded, and the first thing that exercised the published artifact was a user's install.
