### PR TITLE
Fail the publish when a Jellyfin generation drops out of the manifest

### DIFF
--- a/.github/actions/verify-manifest/action.yml
+++ b/.github/actions/verify-manifest/action.yml
@@ -54,6 +54,30 @@ inputs:
       checked for existence. Leave unset where the leg cannot derive it.
     required: false
     default: ""
+  require-abis:
+    description: >-
+      Space-separated targetAbi values that must each still have at least one
+      entry (e.g. "10.11.0.0 12.0.0.0") — an explicit floor for the generations
+      known to belong in this manifest today.
+
+      This is the SECONDARY eviction check. The primary one needs no
+      configuration: the action compares the ABI set against the previous
+      revision of the same manifest branch and fails if one disappeared. That
+      matters because a per-leg list dates badly — the leg that must notice an
+      eviction is whichever one just published, since a generation is pushed out
+      by the OTHER generation publishing, and any hardcoded list silently
+      expires when a new generation goes GA.
+
+      Why an eviction happens at all: the generator lists only the first 30
+      releases (unpaginated), one manifest branch is shared by both Jellyfin
+      generations, and the JF10.11 line publishes far more often than the JF12
+      one — so the JF12 entries are steadily pushed off the end. When the last
+      one goes, `targetAbi 12.0.0.0` vanishes and every Jellyfin 12.0 user's
+      repository silently goes empty (#943). Note the per-ABI checksum loop
+      cannot catch this on its own: it iterates the ABIs it FINDS, so a
+      generation that is already gone yields no iteration and a green run.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -64,6 +88,7 @@ runs:
         REPO: ${{ inputs.repository }}
         BRANCH: ${{ inputs.manifest-branch }}
         EXPECT_VERSION: ${{ inputs.expect-version }}
+        REQUIRE_ABIS: ${{ inputs.require-abis }}
       run: |-
         set -euo pipefail
         work="$(mktemp -d)"
@@ -74,24 +99,35 @@ runs:
         # calls; when a version is expected, the retry waits for THAT version rather than
         # merely for a successful fetch — a fetch that succeeds with stale content is the
         # failure mode, not a fetch that errors.
+        # manifest_is_current — is the fetched document the one this run expects to see? Both
+        # the expected version and the required ABIs are part of that question: asserting
+        # either against a single, possibly-lagging read would turn a slow API into a red
+        # build on a release that is already sealed and cannot be re-made.
+        manifest_is_current() {
+          if [ -n "$EXPECT_VERSION" ] && ! jq -e --arg v "$EXPECT_VERSION" \
+               '.[0].versions | map(.version) | index($v)' "$manifest" >/dev/null 2>&1; then
+            return 1
+          fi
+          for required in $REQUIRE_ABIS; do
+            if ! jq -e --arg a "$required" \
+                 'first(.[0].versions[] | select(.targetAbi == $a))' "$manifest" >/dev/null 2>&1; then
+              return 1
+            fi
+          done
+          return 0
+        }
+
         fetched=0
         for _ in $(seq 1 12); do
           if gh api "repos/${REPO}/contents/manifest.json?ref=${BRANCH}" \
-               -H "Accept: application/vnd.github.raw" > "$manifest" 2>/dev/null; then
-            if [ -z "$EXPECT_VERSION" ]; then
-              fetched=1
-              break
-            fi
-            if jq -e --arg v "$EXPECT_VERSION" \
-                 '.[0].versions | map(.version) | index($v)' "$manifest" >/dev/null 2>&1; then
-              fetched=1
-              break
-            fi
+               -H "Accept: application/vnd.github.raw" > "$manifest" 2>/dev/null && manifest_is_current; then
+            fetched=1
+            break
           fi
           sleep 10
         done
         if [ "$fetched" -ne 1 ]; then
-          echo "::error::could not read a manifest containing ${EXPECT_VERSION:-any version} from ${REPO}@${BRANCH}"
+          echo "::error::could not read a manifest containing ${EXPECT_VERSION:-any version}${REQUIRE_ABIS:+ and targetAbi(s) $REQUIRE_ABIS} from ${REPO}@${BRANCH}"
           exit 1
         fi
 
@@ -140,6 +176,41 @@ runs:
 
         fail=0
         checked=0
+
+        # DID THE ABI SET SHRINK? This is the undated form of the eviction check, and it is
+        # the one that matters: a generation is pushed out of the manifest by the OTHER
+        # generation publishing (the generator reads only the first 30 releases, and the
+        # JF10.11 line publishes far more often than the JF12 one). So the leg that must
+        # notice is whichever one just published — no per-leg list of ABIs to keep in step
+        # with reality, and no value that silently expires when a new generation goes GA.
+        # Compared against the previous revision of this same manifest branch; on the very
+        # first publish there is none, and the check simply does not apply.
+        prev_sha="$(gh api "repos/${REPO}/commits?path=manifest.json&sha=${BRANCH}&per_page=2" --jq '.[1].sha // empty' 2>/dev/null || true)"
+        if [ -n "$prev_sha" ] \
+           && gh api "repos/${REPO}/contents/manifest.json?ref=${prev_sha}" \
+                -H "Accept: application/vnd.github.raw" > "$work/previous.json" 2>/dev/null; then
+          prev_abis="$(jq -r '.[0].versions | map(.targetAbi) | unique | .[]' "$work/previous.json" 2>/dev/null || true)"
+          for was in $prev_abis; do
+            if ! printf '%s\n' "$abis" | grep -qxF "$was"; then
+              echo "::error::targetAbi $was was in the previous manifest and is GONE from the one just published — every Jellyfin server of that generation now sees an empty repository. The generator reads only the first 30 releases, so the generation that publishes less often gets pushed off the end by the one that publishes more (#943)."
+              fail=1
+            fi
+          done
+        else
+          echo "note: no previous revision of this manifest to compare against; the shrink check does not apply"
+        fi
+
+        # An explicit floor on top, for generations known to belong in this manifest today.
+        # Quoted expansion: $abis is already newline-separated, and leaving it unquoted lets
+        # pathname expansion match a stray filename and report an absent ABI as present.
+        for required in $REQUIRE_ABIS; do
+          if printf '%s\n' "$abis" | grep -qxF "$required"; then
+            echo "ok   abi=$required is present"
+          else
+            echo "::error::targetAbi $required has NO entry in the published manifest — every Jellyfin server of that generation now sees an empty repository (#943)."
+            fail=1
+          fi
+        done
         if [ -n "$EXPECT_VERSION" ]; then
           verify "$EXPECT_VERSION" || fail=1
           checked=$((checked + 1))

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -248,3 +248,4 @@ jobs:
         manifest-branch: manifest-beta
         github-token: ${{ github.token }}
         expect-version: ${{ steps.version.outputs.beta }}
+        require-abis: "10.11.0.0 12.0.0.0"

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -225,3 +225,4 @@ jobs:
         manifest-branch: manifest-beta
         github-token: ${{ github.token }}
         expect-version: ${{ steps.version.outputs.beta }}
+        require-abis: "10.11.0.0 12.0.0.0"

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -147,3 +147,4 @@ jobs:
         repository: ${{ github.repository }}
         manifest-branch: manifest-release
         github-token: ${{ github.token }}
+        require-abis: "10.11.0.0 12.0.0.0"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,3 +141,8 @@ jobs:
         repository: ${{ github.repository }}
         manifest-branch: manifest-release
         github-token: ${{ github.token }}
+        # Only 10.11 today: no JF12 STABLE release exists, so requiring 12.0.0.0 here would red
+        # every JF10.11 stable publish. This value does not need updating when JF12 goes GA —
+        # the action's undated shrink check (ABI set vs the previous manifest revision) is what
+        # catches a generation being evicted from this shared branch, from whichever leg published.
+        require-abis: "10.11.0.0"


### PR DESCRIPTION
## What & why

Refs #943 (#942, #944). The next scheduled outage, caught before it happens.

The manifest generator calls `listReleases` **without pagination**, so it only ever sees the first **30** releases. One manifest branch is shared by both Jellyfin generations, and the JF10.11 line publishes far more often than the JF12 one, so the JF12 entries are steadily pushed off the end. When the last one goes, `targetAbi 12.0.0.0` disappears from the beta manifest and every Jellyfin 12.0 user's plugin repository **silently goes empty**. No error, no stale-but-working entry.

Measured:

```
non-draft releases:            33
versions in manifest-beta:     30      (the generator's page size)
newest JF12 release position:  13 of 30
```

≈ **18 daily publishes** before Jellyfin 12 beta users lose the plugin.

The verification added in #942 could not catch it: it iterates the ABIs it **finds**, so a generation that has already vanished yields no iteration and a green run.

## The check is deliberately undated

The primary mechanism compares the ABI set of the manifest just published against the **previous revision of the same branch**, and fails if a generation disappeared.

My first draft instead gave each publish leg a hardcoded list of required ABIs. The review showed that was **wired backwards**: the leg that must notice an eviction is whichever one just published, because a generation is pushed out by _the other_ generation publishing. Under that draft `publish.yml` asked only for the ABI it had just published, which by construction can never be absent, so it could never fire, while the leg that _cannot_ cause an eviction was the only one asserting the other generation. And any such list silently expires the day a new generation goes GA. The hardcoded lists stay as an explicit floor, but nothing now depends on keeping them in step with reality.

## Type of change

- Bug fix (release pipeline hardening)

## Verification

Against the **live repository through the real API**, including the commits lookup and the shrink comparison:

| case | result |
| --- | --- |
| live `manifest-beta`, beta wiring | exit 0, both ABIs present, both heads checksum-verified |
| live `manifest-release`, stable wiring | exit 0 |
| JF12 entries stripped, **no configured ABI list at all** | exit 1 naming the generation, **and the checksum verification still ran** |
| healthy manifest, no configured list | exit 0 |
| first-ever publish, no previous revision | exit 0 with a note, not a red |

All YAML parses.

## Security checklist

- **No plugin code changed**, release pipeline only.
- **Fail-closed**, and the quoting fix below closes a demonstrated fail-open.
- **No false red introduced** on the highest-stakes run: the required ABIs are now part of the retry predicate rather than asserted against a single read.
- No permissions widening; no `${{ }}` in any `run:` body; everything SHA-pinned.

## Review gate

Three refute-by-default lenses (correctness, availability, bypass), each of which executed the gate against the live manifests and against crafted ones. All three confirmed the predicate itself is sound, `grep -qxF` is the right pairing, placement is right, an ABI present but unusable still reds, and all three found the same structural problem plus three real defects:

| # | Finding | Fix |
| --- | --- | --- |
| 1 | **The wiring was backwards** (above), and the per-leg lists expire at JF12 GA with nothing recording it. | Undated shrink check as the primary mechanism; lists demoted to a floor; a comment on `publish.yml` explaining why its value needs no GA update. |
| 2 | The check **exited the step immediately**, so for the whole remediation window, many daily publishes, since making this loud does not stop it, the artifact each run had just sealed was **never checksum-verified**. | Records the failure and lets the verification finish. Confirmed in the test above. |
| 3 | The required ABIs were asserted against a **single, possibly-lagging read**. For the legs with no expected version that is a false red on an already-sealed release, and the JF12 stable leg is a one-shot, hand-tagged GA publish gated on my sign-off where the tag is permanently burned. | Folded into the retry predicate: wait for the manifest to actually contain them, fail only after. |
| 4 | `printf '%s\n' $abis` was **unquoted**, so pathname expansion could report an absent ABI as present, reproduced. A fail-open in the one check whose whole purpose is fail-closed. | Quoted. |
| 5 | The error text blamed the _older_ generation; it is the newer one, pushed off because it publishes _less often_. That is the text I read when the alarm fires. | Corrected. |

## What this does not do

It makes the eviction **loud**; it does not stop it. Preventing it means either pruning old beta prereleases, which deletes immutable releases and permanently burns their tags, and is gated by `guard-git.ps1`, or replacing the generator with a paginating one, which would also remove #942's root cause rather than guarding around it. That choice is recorded on #943 with a recommendation and is yours to make.

The JF12 legs execute from the `4.2` branch, where `.github/actions/` does not exist, so the wiring added to them here is **inert until a forward merge** (#944). Detection still works, because the leg that causes the eviction is `publish-beta.yml`.
