### PR TITLE
Generate the plugin manifest in-house: paginated, checksum-paired, per-ABI capped

### DIFF
--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -1,0 +1,205 @@
+name: Generate the Jellyfin plugin manifest
+description: >-
+  Build and commit the Jellyfin plugin repository manifest from this
+  repository's releases.
+
+  This replaces Kevinjil/jellyfin-plugin-repo-action, which produced two
+  user-facing outages in a week and could not be configured out of either:
+
+  - It selected a release's checksum BY NAME, keeping the LAST asset ending in
+    `.md5` with no pairing against the zip. Renaming the plugin moved its md5
+    ahead of `sbom.cyclonedx.md5` alphabetically, so the manifest published the
+    SBOM's checksum and every install failed verification (#942). Here the
+    checksum is taken from the sidecar that BELONGS to the selected zip, and a
+    release whose pair cannot be resolved fails the run instead of guessing.
+  - It listed releases UNPAGINATED, so only the first 30 were ever considered.
+    With one manifest branch shared by both Jellyfin generations and the JF10.11
+    line publishing far more often, the JF12 entries were being pushed off the
+    end — after which that generation silently vanishes from the manifest and
+    every Jellyfin 12.0 user's repository goes empty (#943). Here the release
+    list is paginated, and the manifest is capped PER targetAbi rather than
+    globally, so no generation can be squeezed out by another's cadence however
+    long the release history grows.
+
+  The output is byte-compatible with what the previous action produced: the same
+  plugin and version fields, keys sorted, two-space indent, versions in
+  descending version order.
+inputs:
+  repository:
+    description: owner/repo whose releases the manifest is built from.
+    required: true
+  manifest-branch:
+    description: Branch the manifest is committed to (e.g. manifest-beta).
+    required: true
+  manifest-file:
+    description: Path of the manifest within that branch.
+    required: false
+    default: manifest.json
+  include-prereleases:
+    description: >-
+      "true" for the beta channel (prereleases are the point), "false" for
+      stable.
+    required: true
+  max-versions-per-abi:
+    description: >-
+      How many versions to keep for EACH targetAbi. Per-ABI rather than an
+      overall limit is the structural fix for #943: a generation that publishes
+      rarely keeps its entries no matter how often the other one publishes.
+    required: false
+    default: "15"
+  github-token:
+    description: Token used to read releases and commit the manifest.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Generate and commit the manifest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repository }}
+        BRANCH: ${{ inputs.manifest-branch }}
+        MANIFEST_FILE: ${{ inputs.manifest-file }}
+        INCLUDE_PRERELEASES: ${{ inputs.include-prereleases }}
+        MAX_PER_ABI: ${{ inputs.max-versions-per-abi }}
+      run: |-
+        set -euo pipefail
+        work="$(mktemp -d)"
+
+        # Plugin-level metadata (guid, name, description, …) is taken from the NEWEST release
+        # that ships JPRM's metadata JSON — filled in by the release loop below, which walks
+        # releases newest-first. These are properties of the plugin rather than of a release,
+        # so any recent one carries the same values.
+        : > "$work/plugin.json"
+
+        # --paginate is the whole point: without it only the first 30 releases are seen.
+        gh api --paginate "repos/${REPO}/releases" > "$work/releases.json"
+        total="$(jq -s 'add | length' "$work/releases.json")"
+        echo "releases fetched: $total"
+
+        # Each release's targetAbi and version come from ITS OWN build.yaml — shipped as a
+        # release asset where the leg provides one (the JF12 legs must, or their builds would
+        # be labelled with the JF10.11 metadata), otherwise read from the release's tag.
+        : > "$work/versions.jsonl"
+        while IFS=$'\t' read -r tag is_draft is_pre published_at; do
+          [ "$is_draft" = "true" ] && continue
+          if [ "$is_pre" = "true" ] && [ "$INCLUDE_PRERELEASES" != "true" ]; then continue; fi
+
+          assets="$(jq -c --arg t "$tag" -s 'add[] | select(.tag_name == $t) | .assets' "$work/releases.json")"
+
+          zip_url="$(printf '%s' "$assets" | jq -r '[.[] | select(.name | endswith(".zip"))] | last | .browser_download_url // empty')"
+          zip_name="$(printf '%s' "$assets" | jq -r '[.[] | select(.name | endswith(".zip"))] | last | .name // empty')"
+          if [ -z "$zip_url" ]; then
+            echo "::notice::release $tag ships no plugin zip; skipping it"
+            continue
+          fi
+
+          # THE #942 FIX. The checksum is the sidecar belonging to THIS zip — either
+          # <zip-without-.zip>.md5 or <zip>.md5 — never merely the last `.md5` on the
+          # release. An unresolvable pair is fatal: publishing a checksum that matches
+          # nothing breaks every install, so guessing is the one thing not to do here.
+          md5_url="$(printf '%s' "$assets" | jq -r --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
+            'first(.[] | select(.name == $a or .name == $b)) | .browser_download_url // empty')"
+          if [ -z "$md5_url" ]; then
+            echo "::error::release $tag has $zip_name but no matching ${zip_name%.zip}.md5 or ${zip_name}.md5 — refusing to publish a guessed checksum"
+            exit 1
+          fi
+          checksum="$(curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$md5_url" | head -c 32)"
+          if ! printf '%s' "$checksum" | grep -qE '^[0-9a-f]{32}$'; then
+            echo "::error::release $tag — the checksum sidecar did not start with 32 hex characters"
+            exit 1
+          fi
+
+          # Version and targetAbi describe THIS release, so they come from the metadata JPRM
+          # wrote beside its zip — plain JSON, read with jq. The runner image ships jq but NOT
+          # yq (checked against the runner-images tool list, not assumed), so nothing here
+          # parses YAML in the general case.
+          meta_url="$(printf '%s' "$assets" | jq -r --arg m "${zip_name}.meta.json" \
+            'first(.[] | select(.name == $m)) | .browser_download_url // empty')"
+          if [ -n "$meta_url" ]; then
+            curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$meta_url" > "$work/release.json"
+            version="$(jq -r '.version // empty' "$work/release.json")"
+            target_abi="$(jq -r '.targetAbi // empty' "$work/release.json")"
+            [ -s "$work/plugin.json" ] || jq '.' "$work/release.json" > "$work/plugin.json"
+          else
+            # Releases published before that metadata was shipped. Only two scalars are needed
+            # and both are simple quoted values, so a line match is exact here — this is not a
+            # YAML parser and is not asked to be one.
+            build_url="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name == "build.yaml")) | .browser_download_url // empty')"
+            if [ -n "$build_url" ]; then
+              curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$build_url" > "$work/release.yaml"
+            else
+              gh api "repos/${REPO}/contents/build.yaml?ref=${tag}" -H "Accept: application/vnd.github.raw" > "$work/release.yaml"
+            fi
+            version="$(sed -n 's/^version:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
+            target_abi="$(sed -n 's/^targetAbi:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
+          fi
+          if [ -z "$version" ] || [ -z "$target_abi" ]; then
+            echo "::error::release $tag has no readable version/targetAbi in its metadata"
+            exit 1
+          fi
+
+          changelog="$(jq -r --arg t "$tag" -s 'add[] | select(.tag_name == $t) | .body // ""' "$work/releases.json")"
+          jq -nc --arg changelog "$changelog" --arg checksum "$checksum" --arg sourceUrl "$zip_url" \
+                 --arg targetAbi "$target_abi" --arg timestamp "$published_at" --arg version "$version" \
+            '{changelog:$changelog, checksum:$checksum, sourceUrl:$sourceUrl, targetAbi:$targetAbi, timestamp:$timestamp, version:$version}' \
+            >> "$work/versions.jsonl"
+        done < <(jq -r -s 'add[] | [.tag_name, (.draft|tostring), (.prerelease|tostring), .published_at] | @tsv' "$work/releases.json")
+
+        # Sort descending by NUMERIC version components (the previous action used a numeric
+        # locale compare), then keep the newest MAX_PER_ABI of each targetAbi.
+        jq -s --argjson keep "$MAX_PER_ABI" '
+          map(. + {_v: (.version | split(".") | map(tonumber? // 0))})
+          | sort_by(._v) | reverse
+          | group_by(.targetAbi)
+          | map(.[0:$keep])
+          | add
+          | sort_by(._v) | reverse
+          | map(del(._v))
+        ' "$work/versions.jsonl" > "$work/kept.json"
+
+        kept_total="$(jq 'length' "$work/kept.json")"
+        if [ "$kept_total" -eq 0 ]; then
+          echo "::error::no releases produced a manifest entry"
+          exit 1
+        fi
+        echo "manifest entries per targetAbi:"
+        jq -r 'group_by(.targetAbi)[] | "  \(.[0].targetAbi): \(length) (newest \(.[0].version))"' "$work/kept.json"
+
+        if [ ! -s "$work/plugin.json" ]; then
+          echo "::error::no release carried the plugin metadata JSON, so the manifest's plugin fields cannot be filled in"
+          exit 1
+        fi
+
+        # `jq -S` sorts keys, matching the previous action's stable stringify, and the plugin
+        # object carries exactly the fields it emitted (imageUrl only when set).
+        jq -S --slurpfile versions "$work/kept.json" '
+          {
+            category: .category,
+            description: .description,
+            guid: .guid,
+            name: .name,
+            overview: .overview,
+            owner: .owner,
+            versions: $versions[0],
+          }
+          + (if .imageUrl then {imageUrl: .imageUrl} else {} end)
+          | [.]
+        ' "$work/plugin.json" > "$work/manifest.json"
+
+        # Commit only when something changed, so an unchanged regeneration does not add an
+        # empty commit to the manifest branch on every publish.
+        current_sha="$(gh api "repos/${REPO}/contents/${MANIFEST_FILE}?ref=${BRANCH}" --jq '.sha' 2>/dev/null || true)"
+        if [ -n "$current_sha" ]; then
+          gh api "repos/${REPO}/contents/${MANIFEST_FILE}?ref=${BRANCH}" -H "Accept: application/vnd.github.raw" > "$work/live.json" 2>/dev/null || true
+          if [ -f "$work/live.json" ] && cmp -s "$work/live.json" "$work/manifest.json"; then
+            echo "manifest unchanged; nothing to commit"
+            exit 0
+          fi
+        fi
+
+        payload="$(jq -nc --arg m "Regenerate Jellyfin plugin repository." --arg b "$BRANCH" \
+          --arg c "$(base64 -w0 < "$work/manifest.json")" --arg s "${current_sha:-}" \
+          '{message:$m, branch:$b, content:$c} + (if $s == "" then {} else {sha:$s} end)')"
+        printf '%s' "$payload" | gh api -X PUT "repos/${REPO}/contents/${MANIFEST_FILE}" --input - >/dev/null
+        echo "committed $kept_total versions to ${BRANCH}/${MANIFEST_FILE}"

--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -25,6 +25,22 @@ description: >-
   plugin and version fields, keys sorted, two-space indent, versions in
   descending version order.
 inputs:
+  plugin-metadata:
+    description: >-
+      Path to the JSON metadata JPRM wrote beside the zip THIS run built, which
+      supplies the plugin-level fields (guid, name, description, …).
+
+      It is an input rather than something discovered from the releases because
+      discovery has no deterministic answer: the releases API returns neither
+      id- nor date-descending order, and the two Jellyfin generations carry
+      DIFFERENT plugin metadata — `name` is "Community SSO for Jellyfin" on the
+      10.11 line and "SSO Authentication" on the 12.0 line. Both write the same
+      shared manifest branch, which holds exactly one plugin object, so picking
+      "whichever release the API listed first" made the catalogue name and
+      description flip-flop between publishes. Taking it from the publishing leg
+      is deterministic, and it is also what lets the stable channel regenerate at
+      all: no existing stable release ships this file.
+    required: true
   repository:
     description: owner/repo whose releases the manifest is built from.
     required: true
@@ -57,6 +73,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        PLUGIN_METADATA: ${{ inputs.plugin-metadata }}
         REPO: ${{ inputs.repository }}
         BRANCH: ${{ inputs.manifest-branch }}
         MANIFEST_FILE: ${{ inputs.manifest-file }}
@@ -66,11 +83,23 @@ runs:
         set -euo pipefail
         work="$(mktemp -d)"
 
-        # Plugin-level metadata (guid, name, description, …) is taken from the NEWEST release
-        # that ships JPRM's metadata JSON — filled in by the release loop below, which walks
-        # releases newest-first. These are properties of the plugin rather than of a release,
-        # so any recent one carries the same values.
-        : > "$work/plugin.json"
+        # Plugin-level metadata comes from THIS run's build. See the input's description for why
+        # discovering it from the release list has no deterministic answer.
+        # The filename carries the version, so the input is a glob. It must resolve to exactly
+        # one file: zero means the leg did not ship the metadata and the manifest would be
+        # built from nothing, more than one means it is ambiguous which build's identity the
+        # catalogue entry would take.
+        # shellcheck disable=SC2086
+        set -- $PLUGIN_METADATA
+        if [ "$#" -ne 1 ] || [ ! -s "$1" ]; then
+          echo "::error::plugin-metadata '$PLUGIN_METADATA' resolved to $# path(s); expected exactly one readable file"
+          exit 1
+        fi
+        jq -e '.guid and .name and .category and .owner' "$1" >/dev/null || {
+          echo "::error::$1 does not carry the plugin fields the manifest requires"
+          exit 1
+        }
+        cp "$1" "$work/plugin.json"
 
         # --paginate is the whole point: without it only the first 30 releases are seen.
         gh api --paginate "repos/${REPO}/releases" > "$work/releases.json"
@@ -85,10 +114,24 @@ runs:
           [ "$is_draft" = "true" ] && continue
           if [ "$is_pre" = "true" ] && [ "$INCLUDE_PRERELEASES" != "true" ]; then continue; fi
 
-          assets="$(jq -c --arg t "$tag" -s 'add[] | select(.tag_name == $t) | .assets' "$work/releases.json")"
+          # `first(…)`: a draft can carry the same tag_name as a published release (the draft
+          # flow the beta leg used to run does exactly that), and without the draft filter plus
+          # this cutoff the lookup emits TWO JSON documents — every jq below then produces two
+          # values and the shell comparisons downstream read garbage.
+          assets="$(jq -c --arg t "$tag" -s 'first(add[] | select((.draft | not) and .tag_name == $t) | .assets)' "$work/releases.json")"
 
-          zip_url="$(printf '%s' "$assets" | jq -r '[.[] | select(.name | endswith(".zip"))] | last | .browser_download_url // empty')"
-          zip_name="$(printf '%s' "$assets" | jq -r '[.[] | select(.name | endswith(".zip"))] | last | .name // empty')"
+          # Exactly one zip, or nothing. Picking positionally out of several would publish one
+          # build with the correctly-paired checksum of THAT build — so every downstream
+          # integrity check passes and users install an artifact nobody chose. That is the same
+          # "select by position, never assert cardinality" shape as #942, one level up, so it
+          # gets the same fail-closed treatment the checksum pairing already has.
+          zip_count="$(printf '%s' "$assets" | jq '[.[] | select(.name | endswith(".zip"))] | length')"
+          if [ "$zip_count" -gt 1 ]; then
+            echo "::error::release $tag carries $zip_count plugin zips; refusing to guess which one the manifest should offer"
+            exit 1
+          fi
+          zip_url="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name | endswith(".zip"))) | .browser_download_url // empty')"
+          zip_name="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name | endswith(".zip"))) | .name // empty')"
           if [ -z "$zip_url" ]; then
             echo "::notice::release $tag ships no plugin zip; skipping it"
             continue
@@ -120,7 +163,6 @@ runs:
             curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$meta_url" > "$work/release.json"
             version="$(jq -r '.version // empty' "$work/release.json")"
             target_abi="$(jq -r '.targetAbi // empty' "$work/release.json")"
-            [ -s "$work/plugin.json" ] || jq '.' "$work/release.json" > "$work/plugin.json"
           else
             # Releases published before that metadata was shipped. Only two scalars are needed
             # and both are simple quoted values, so a line match is exact here — this is not a
@@ -165,11 +207,6 @@ runs:
         fi
         echo "manifest entries per targetAbi:"
         jq -r 'group_by(.targetAbi)[] | "  \(.[0].targetAbi): \(length) (newest \(.[0].version))"' "$work/kept.json"
-
-        if [ ! -s "$work/plugin.json" ]; then
-          echo "::error::no release carried the plugin metadata JSON, so the manifest's plugin fields cannot be filled in"
-          exit 1
-        fi
 
         # `jq -S` sorts keys, matching the previous action's stable stringify, and the plugin
         # object carries exactly the fields it emitted (imageUrl only when set).

--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -31,15 +31,20 @@ inputs:
       supplies the plugin-level fields (guid, name, description, …).
 
       It is an input rather than something discovered from the releases because
-      discovery has no deterministic answer: the releases API returns neither
-      id- nor date-descending order, and the two Jellyfin generations carry
-      DIFFERENT plugin metadata — `name` is "Community SSO for Jellyfin" on the
-      10.11 line and "SSO Authentication" on the 12.0 line. Both write the same
-      shared manifest branch, which holds exactly one plugin object, so picking
-      "whichever release the API listed first" made the catalogue name and
-      description flip-flop between publishes. Taking it from the publishing leg
-      is deterministic, and it is also what lets the stable channel regenerate at
-      all: no existing stable release ships this file.
+      discovery has no deterministic answer: the releases API guarantees no
+      ordering useful here, so "whichever release the API listed first" can hand
+      the catalogue a years-old identity mid-rename. Taking it from the
+      publishing leg is deterministic per run — and because the manifest branch
+      is SHARED between the two Jellyfin generations and holds exactly ONE
+      plugin object, the plugin-level prose in build.yaml and build-jf12.yaml
+      must be kept word-identical (enforced by a comment at both sites), or the
+      catalogue entry alternates between the legs' texts on each publish. It is
+      also what lets the stable channel regenerate at all: no existing stable
+      release ships this file.
+
+      Beyond identity, the version and targetAbi in this file pin the one
+      guarantee the action gives: the run fails unless the build THIS run
+      published survives into the committed manifest.
     required: true
   repository:
     description: owner/repo whose releases the manifest is built from.
@@ -101,8 +106,22 @@ runs:
         }
         cp "$1" "$work/plugin.json"
 
+        # The build THIS run published, identified three ways: by the zip the metadata sits
+        # beside (which release in the history is ours), and by version+targetAbi (which
+        # manifest entry must exist at the end). Both are used below to keep the fail-closed
+        # checks pointed at the release being published rather than at the whole history.
+        this_zip="$(basename "$1" .meta.json)"
+        this_version="$(jq -r '.version // empty' "$work/plugin.json")"
+        this_abi="$(jq -r '.targetAbi // empty' "$work/plugin.json")"
+        if [ -z "$this_version" ] || [ -z "$this_abi" ]; then
+          echo "::error::$1 carries no version/targetAbi, so this run's own build cannot be confirmed to reach the manifest"
+          exit 1
+        fi
+        echo "publishing $this_version (targetAbi $this_abi) from $this_zip"
+
         # --paginate is the whole point: without it only the first 30 releases are seen.
-        gh api --paginate "repos/${REPO}/releases" > "$work/releases.json"
+        # --per_page 100 keeps that from costing one API call per 30 releases forever.
+        gh api --paginate --method GET -f per_page=100 "repos/${REPO}/releases" > "$work/releases.json"
         total="$(jq -s 'add | length' "$work/releases.json")"
         echo "releases fetched: $total"
 
@@ -120,6 +139,16 @@ runs:
           # values and the shell comparisons downstream read garbage.
           assets="$(jq -c --arg t "$tag" -s 'first(add[] | select((.draft | not) and .tag_name == $t) | .assets)' "$work/releases.json")"
 
+          # Is this the release THIS run published? Releases here are immutable, so a defect in
+          # an OLD one can never be repaired by attaching the missing asset. Aborting the whole
+          # generation over it would freeze both manifest branches permanently — a worse
+          # outage than dropping that one historical entry. So every integrity check below is
+          # fatal for our own release and a loud skip for anyone else's.
+          ours=no
+          if printf '%s' "$assets" | jq -e --arg z "$this_zip" 'any(.[]; .name == $z)' >/dev/null; then
+            ours=yes
+          fi
+
           # Exactly one zip, or nothing. Picking positionally out of several would publish one
           # build with the correctly-paired checksum of THAT build — so every downstream
           # integrity check passes and users install an artifact nobody chose. That is the same
@@ -127,6 +156,10 @@ runs:
           # gets the same fail-closed treatment the checksum pairing already has.
           zip_count="$(printf '%s' "$assets" | jq '[.[] | select(.name | endswith(".zip"))] | length')"
           if [ "$zip_count" -gt 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag carries $zip_count plugin zips; dropping it from the manifest rather than guessing which one to offer"
+              continue
+            fi
             echo "::error::release $tag carries $zip_count plugin zips; refusing to guess which one the manifest should offer"
             exit 1
           fi
@@ -141,15 +174,38 @@ runs:
           # <zip-without-.zip>.md5 or <zip>.md5 — never merely the last `.md5` on the
           # release. An unresolvable pair is fatal: publishing a checksum that matches
           # nothing breaks every install, so guessing is the one thing not to do here.
-          md5_url="$(printf '%s' "$assets" | jq -r --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
-            'first(.[] | select(.name == $a or .name == $b)) | .browser_download_url // empty')"
-          if [ -z "$md5_url" ]; then
-            echo "::error::release $tag has $zip_name but no matching ${zip_name%.zip}.md5 or ${zip_name}.md5 — refusing to publish a guessed checksum"
+          md5_count="$(printf '%s' "$assets" | jq --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
+            '[.[] | select(.name == $a or .name == $b)] | length')"
+          if [ "$md5_count" -ne 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag has $zip_name and $md5_count candidate checksum sidecars; dropping it from the manifest rather than publishing a guessed checksum"
+              continue
+            fi
+            echo "::error::release $tag has $zip_name and $md5_count candidate checksum sidecars (${zip_name%.zip}.md5 / ${zip_name}.md5); refusing to publish a guessed checksum"
             exit 1
           fi
-          checksum="$(curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$md5_url" | head -c 32)"
-          if ! printf '%s' "$checksum" | grep -qE '^[0-9a-f]{32}$'; then
-            echo "::error::release $tag — the checksum sidecar did not start with 32 hex characters"
+          md5_url="$(printf '%s' "$assets" | jq -r --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
+            'first(.[] | select(.name == $a or .name == $b)) | .browser_download_url')"
+          # The sidecar is `md5sum` output: `<32 hex><space><space-or-*><filename>`. Validate the
+          # WHOLE line, filename included — not just the leading 32 characters. A sidecar written
+          # with `>>` that ended up holding two lines would otherwise pass on its first line,
+          # which may describe an entirely different file, and the manifest would again publish a
+          # checksum belonging to something other than the zip beside it (#942's shape).
+          if ! sidecar="$(curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$md5_url")"; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag — could not fetch the checksum sidecar; dropping it from the manifest this run"
+              continue
+            fi
+            echo "::error::release $tag — could not fetch the checksum sidecar"
+            exit 1
+          fi
+          checksum="$(printf '%s\n' "$sidecar" | sed -n "1s/^\([0-9a-f]\{32\}\)[[:space:]][[:space:]*]$(printf '%s' "$zip_name" | sed 's/[].[^$*\/]/\\&/g')\$/\1/p")"
+          if [ -z "$checksum" ] || [ "$(printf '%s\n' "$sidecar" | grep -c .)" -ne 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag — the checksum sidecar is not a single md5sum line naming $zip_name; dropping it from the manifest"
+              continue
+            fi
+            echo "::error::release $tag — the checksum sidecar is not a single md5sum line naming $zip_name"
             exit 1
           fi
 
@@ -159,29 +215,39 @@ runs:
           # parses YAML in the general case.
           meta_url="$(printf '%s' "$assets" | jq -r --arg m "${zip_name}.meta.json" \
             'first(.[] | select(.name == $m)) | .browser_download_url // empty')"
+          version=""
+          target_abi=""
           if [ -n "$meta_url" ]; then
-            curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$meta_url" > "$work/release.json"
-            version="$(jq -r '.version // empty' "$work/release.json")"
-            target_abi="$(jq -r '.targetAbi // empty' "$work/release.json")"
+            if curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$meta_url" > "$work/release.json"; then
+              version="$(jq -r '.version // empty' "$work/release.json")"
+              target_abi="$(jq -r '.targetAbi // empty' "$work/release.json")"
+            fi
           else
             # Releases published before that metadata was shipped. Only two scalars are needed
             # and both are simple quoted values, so a line match is exact here — this is not a
             # YAML parser and is not asked to be one.
             build_url="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name == "build.yaml")) | .browser_download_url // empty')"
+            : > "$work/release.yaml"
             if [ -n "$build_url" ]; then
-              curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$build_url" > "$work/release.yaml"
+              curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$build_url" > "$work/release.yaml" || true
             else
-              gh api "repos/${REPO}/contents/build.yaml?ref=${tag}" -H "Accept: application/vnd.github.raw" > "$work/release.yaml"
+              gh api "repos/${REPO}/contents/build.yaml?ref=${tag}" -H "Accept: application/vnd.github.raw" > "$work/release.yaml" 2>/dev/null || true
             fi
             version="$(sed -n 's/^version:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
             target_abi="$(sed -n 's/^targetAbi:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
           fi
           if [ -z "$version" ] || [ -z "$target_abi" ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag has no readable version/targetAbi; dropping it from the manifest"
+              continue
+            fi
             echo "::error::release $tag has no readable version/targetAbi in its metadata"
             exit 1
           fi
 
-          changelog="$(jq -r --arg t "$tag" -s 'add[] | select(.tag_name == $t) | .body // ""' "$work/releases.json")"
+          # Same draft filter and cutoff as the asset lookup above, for the same reason: two
+          # releases sharing a tag_name would otherwise concatenate both bodies into one entry.
+          changelog="$(jq -r --arg t "$tag" -s 'first(add[] | select((.draft | not) and .tag_name == $t) | .body // "")' "$work/releases.json")"
           jq -nc --arg changelog "$changelog" --arg checksum "$checksum" --arg sourceUrl "$zip_url" \
                  --arg targetAbi "$target_abi" --arg timestamp "$published_at" --arg version "$version" \
             '{changelog:$changelog, checksum:$checksum, sourceUrl:$sourceUrl, targetAbi:$targetAbi, timestamp:$timestamp, version:$version}' \
@@ -195,7 +261,7 @@ runs:
           | sort_by(._v) | reverse
           | group_by(.targetAbi)
           | map(.[0:$keep])
-          | add
+          | (add // [])
           | sort_by(._v) | reverse
           | map(del(._v))
         ' "$work/versions.jsonl" > "$work/kept.json"
@@ -203,6 +269,16 @@ runs:
         kept_total="$(jq 'length' "$work/kept.json")"
         if [ "$kept_total" -eq 0 ]; then
           echo "::error::no releases produced a manifest entry"
+          exit 1
+        fi
+        # The one guarantee this action exists to give: the build THIS run published is in the
+        # manifest about to be committed. Without it, a transient asset-listing gap makes the
+        # loop above skip our own release with a notice, the run stays green, and an immutable
+        # stable release exists that no Jellyfin server is ever offered — silently, until the
+        # next publish months later.
+        if ! jq -e --arg v "$this_version" --arg a "$this_abi" \
+            'any(.[]; .version == $v and .targetAbi == $a)' "$work/kept.json" >/dev/null; then
+          echo "::error::the build this run published ($this_version, targetAbi $this_abi) did not survive into the manifest — refusing to publish without it"
           exit 1
         fi
         echo "manifest entries per targetAbi:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,13 @@ jobs:
           name: build-artifact
           retention-days: 30
           if-no-files-found: error
-          path: ${{ steps.jprm.outputs.artifact }}
+          # The zip AND the metadata JPRM writes beside it. The manifest generator reads that
+          # metadata (version, targetAbi and the plugin-level fields) as JSON rather than
+          # parsing build.yaml, because the runner image ships jq but NOT yq — verified against
+          # the runner-images tool list rather than assumed.
+          path: |
+            ${{ steps.jprm.outputs.artifact }}
+            ${{ steps.jprm.outputs.artifact }}.meta.json
 
   # The CycloneDX SBOM runs in its OWN release-only job, DELIBERATELY WITHOUT the
   # signing scopes the build job holds. The SBOM generator installs a NuGet global

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -174,10 +174,10 @@ jobs:
         # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
         # integrity value for it.
         for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
         done
-        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Upload beta assets to a draft release

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -165,14 +165,14 @@ jobs:
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
-        # ONLY the plugin zip gets a `.md5`. The manifest generator
-        # (Kevinjil/jellyfin-plugin-repo-action) walks a release's assets and keeps the
-        # LAST one whose name ends in `.md5` — no break, and no pairing with the zip —
-        # so a second `.md5` asset sorting after the plugin's silently becomes the
-        # published checksum and every install then fails verification. The rename to
-        # `community-sso-for-jellyfin` did exactly that: it moved the plugin's md5 ahead
-        # of `sbom.cyclonedx.md5` alphabetically. The SBOM keeps a sha256, which is the
-        # meaningful integrity value for it and cannot collide.
+        # ONLY the plugin zip gets a `.md5`. Defence in depth: the generator this repo now
+        # owns pairs a release's checksum with ITS zip by name, but the third-party one it
+        # replaced kept the LAST asset ending in `.md5` with no pairing at all — which is how
+        # renaming the plugin to `community-sso-for-jellyfin` moved its md5 ahead of
+        # `sbom.cyclonedx.md5` alphabetically and made the manifest publish the SBOM's
+        # checksum, breaking every install (#942). One `.md5` per release keeps that class
+        # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
+        # integrity value for it.
         for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
@@ -227,16 +227,15 @@ jobs:
         REPO: ${{ github.repository }}
       run: gh api "repos/${REPO}/releases/${RELEASE_ID}" -X PATCH -F draft=false
     - name: Publish Beta Plugin Manifest
-      # ignorePrereleases: false so the beta build is included. Writes the SEPARATE
+      # include-prereleases so the beta build is included. Writes the SEPARATE
       # `manifest-beta` branch; the stable `manifest-release` is only ever written
       # by publish.yml, so a beta build can never reach the stable channel.
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      uses: ./.github/actions/generate-manifest
       with:
-        ignorePrereleases: false
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
-        pagesBranch: manifest-beta
-        pagesFile: manifest.json
+        manifest-branch: manifest-beta
+        include-prereleases: "true"
+        github-token: ${{ github.token }}
     - name: Verify the published manifest
       # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
       # nothing" (#942) — it turns a silent, user-facing install outage into a red build.

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -232,6 +232,7 @@ jobs:
       # by publish.yml, so a beta build can never reach the stable channel.
       uses: ./.github/actions/generate-manifest
       with:
+        plugin-metadata: _dist/*.zip.meta.json
         repository: ${{ github.repository }}
         manifest-branch: manifest-beta
         include-prereleases: "true"

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -209,6 +209,7 @@ jobs:
       # whichever generation publishes last leaves manifest-beta complete for both.
       uses: ./.github/actions/generate-manifest
       with:
+        plugin-metadata: _dist/*.zip.meta.json
         repository: ${{ github.repository }}
         manifest-branch: manifest-beta
         include-prereleases: "true"

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -207,7 +207,12 @@ jobs:
       # so every version lands in the manifest with its correct targetAbi, and a Jellyfin server installs
       # only the build matching its generation. publish-beta.yml (on main) regenerates the same branch, so
       # whichever generation publishes last leaves manifest-beta complete for both.
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      uses: ./.github/actions/generate-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-beta
+        include-prereleases: "true"
+        github-token: ${{ github.token }}
       with:
         ignorePrereleases: false
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -151,10 +151,10 @@ jobs:
         # sorting after the plugin's becomes the published checksum and every install
         # fails verification.
         for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
         done
-        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Upload JF12 beta assets to a draft release

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -213,12 +213,6 @@ jobs:
         manifest-branch: manifest-beta
         include-prereleases: "true"
         github-token: ${{ github.token }}
-      with:
-        ignorePrereleases: false
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        repository: ${{ github.repository }}
-        pagesBranch: manifest-beta
-        pagesFile: manifest.json
     - name: Verify the published manifest
       # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
       # nothing" (#942) — it turns a silent, user-facing install outage into a red build.

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -132,6 +132,7 @@ jobs:
       # only the build matching its generation.
       uses: ./.github/actions/generate-manifest
       with:
+        plugin-metadata: _dist/*.zip.meta.json
         repository: ${{ github.repository }}
         manifest-branch: manifest-release
         include-prereleases: "false"

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -136,12 +136,6 @@ jobs:
         manifest-branch: manifest-release
         include-prereleases: "false"
         github-token: ${{ github.token }}
-      with:
-        ignorePrereleases: true
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
-        repository: ${{ github.repository }}
-        pagesBranch: manifest-release
-        pagesFile: manifest.json
     - name: Verify the published manifest
       # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
       # nothing" (#942) — it turns a silent, user-facing install outage into a red build.

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -92,10 +92,10 @@ jobs:
         # sorting after the plugin's becomes the published checksum and every install
         # fails verification.
         for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
         done
-        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Publish output artifacts

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -130,7 +130,12 @@ jobs:
       # stable releases from publish.yml (4.x, targetAbi 10.11.0.0). Each release ships its own build.yaml,
       # so every version lands in the manifest with its correct targetAbi and a Jellyfin server installs
       # only the build matching its generation.
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      uses: ./.github/actions/generate-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-release
+        include-prereleases: "false"
+        github-token: ${{ github.token }}
       with:
         ignorePrereleases: true
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,17 +73,14 @@ jobs:
         name: sbom-artifact
     - name: Prepare GitHub Release assets
       run: |-
-        # ONLY the plugin zip gets a `.md5`. The manifest generator
-        # (Kevinjil/jellyfin-plugin-repo-action) walks a release's assets and keeps the
-        # LAST one whose name ends in `.md5` — no break, and no pairing with the zip —
-        # so any second `.md5` asset sorting after the plugin's silently becomes the
-        # published checksum and every install then fails verification. The rename to
-        # `community-sso-for-jellyfin` did exactly that on the beta channel: it moved
-        # the plugin's md5 ahead of `sbom.cyclonedx.md5` alphabetically. This job's
-        # workspace holds only the plugin zip and the SBOM, so the blanket `./*` produced
-        # exactly those two `.md5` files — enough for the next stable release to have
-        # shipped the SBOM's checksum the same way. The SBOM keeps a sha256, which is the
-        # meaningful integrity value for it and cannot collide.
+        # ONLY the plugin zip gets a `.md5`. Defence in depth: the generator this repo now
+        # owns pairs a release's checksum with ITS zip by name, but the third-party one it
+        # replaced kept the LAST asset ending in `.md5` with no pairing at all — which is how
+        # renaming the plugin to `community-sso-for-jellyfin` moved its md5 ahead of
+        # `sbom.cyclonedx.md5` alphabetically and made the manifest publish the SBOM's
+        # checksum, breaking every install (#942). One `.md5` per release keeps that class
+        # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
+        # integrity value for it.
         for file in ./*.zip; do
           md5sum ${file#./} >> ${file%.*}.md5
           sha256sum ${file#./} >> ${file%.*}.sha256
@@ -124,13 +121,12 @@ jobs:
       with:
         persist-credentials: false
     - name: Publish Plugin Manifest
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      uses: ./.github/actions/generate-manifest
       with:
-        ignorePrereleases: true
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
         repository: ${{ github.repository }}
-        pagesBranch: manifest-release
-        pagesFile: manifest.json
+        manifest-branch: manifest-release
+        include-prereleases: "false"
+        github-token: ${{ github.token }}
     - name: Verify the published manifest
       # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
       # nothing" (#942) — it turns a silent, user-facing install outage into a red build.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,14 +115,24 @@ jobs:
     needs:
     - upload
     steps:
-    # Needed only so the local verify-manifest action below resolves; the manifest step
-    # itself talks to the API and uses nothing from the working tree.
+    # Needed so the local actions below resolve; the manifest step itself talks to the
+    # API and uses nothing else from the working tree.
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
+    # The plugin identity (guid, name, description, …) the manifest is built around comes
+    # from the metadata JPRM wrote beside the zip THIS run built — the same artifact the
+    # upload job released. Reading it from the release list instead has no deterministic
+    # answer once a rename is in flight, which is exactly the state that broke #942.
+    - name: Download Artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: build-artifact
+        path: _meta
     - name: Publish Plugin Manifest
       uses: ./.github/actions/generate-manifest
       with:
+        plugin-metadata: _meta/*.zip.meta.json
         repository: ${{ github.repository }}
         manifest-branch: manifest-release
         include-prereleases: "false"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,10 +82,10 @@ jobs:
         # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
         # integrity value for it.
         for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
         done
-        sha256sum sbom.cyclonedx.json >> sbom.cyclonedx.sha256
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
         ls -l
     - name: Publish output artifacts
       id: publish-assets

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -12,11 +12,19 @@ version: "5.0.0"
 targetAbi: "12.0.0.0"
 framework: "net10.0"
 owner: "iderex"
-overview: "Authenticate users against an SSO provider."
+# overview/description MUST stay word-identical with build.yaml's. Both beta legs regenerate the
+# SHARED manifest-beta branch and the manifest holds ONE plugin object taken from the publishing
+# leg's metadata — if the prose diverges, the catalogue entry flips between the two texts on
+# alternating nightly publishes and every regeneration commits a churn diff.
+overview: "Sign in to Jellyfin through OpenID Connect or SAML 2.0 identity providers."
 description: |
-  This plugin allows users to sign in through an SSO provider (such as Google, Facebook, or your own provider). This enables one-click signin.
-  SSO sign-in works in the Jellyfin Web UI and in clients that support Quick Connect.
-  Review documentation at https://github.com/iderex/jellyfin-plugin-sso
+  Single sign-on for Jellyfin via OpenID Connect and SAML 2.0 — works with self-hosted and
+  managed identity providers such as Authelia, Authentik, Keycloak, Pocket ID and Kanidm,
+  with multiple providers side by side.
+  Role-based access from provider claims (login, administrator, library folders, Live TV),
+  avatar sync, self-service account linking, and an optional SSO-only mode that disables
+  password login for every account except a designated break-glass admin.
+  Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
 category: "Authentication"
 # The net10 shipping closure, empirically from `dotnet publish -f net10.0` (#135). It differs from the
 # net9 list in build.yaml: on .NET 10 the SAML crypto assemblies (System.Security.Cryptography.Xml /


### PR DESCRIPTION
## What & why

Replaces `Kevinjil/jellyfin-plugin-repo-action@v0.4.3` with an in-house composite action (`.github/actions/generate-manifest`), called by all four publish legs. The third-party action caused two user-facing outages in one week and can be configured out of neither:

- **#942**, it selected `checksum` as the LAST release asset ending in `.md5`, with no pairing to the zip. The plugin rename moved the plugin's md5 ahead of `sbom.cyclonedx.md5` alphabetically, so the manifest published the SBOM's checksum and every install failed Jellyfin's MD5 verification.
- **#943**, it listed releases unpaginated (first 30 only). With 33 releases and one manifest branch shared by both Jellyfin generations, the JF12 entries were being squeezed off the end; ~18 further daily publishes from losing the plugin for every JF12 user.

## How the replacement closes the classes

- Checksum = the sidecar **belonging to** the selected zip, validated as a **single `md5sum` line naming exactly that zip**; an unresolvable or ambiguous pair on the release being published is fatal.
- Release listing is **paginated** (`per_page=100`); the manifest is capped **per targetAbi** (default 15), so no generation can be squeezed out by another's cadence.
- The plugin identity comes from the metadata JPRM wrote beside the zip **this run built** (new required `plugin-metadata` input), no nondeterministic discovery from the release list mid-rename.
- The one guarantee the action exists to give is asserted: **the run fails unless the build this run published survives into the committed manifest.** This covers the two stable legs, which pass no `expect-version` to `verify-manifest`.
- Fail-closed is **scoped to the release being published**: a defect on an immutable historical release (two zips, lost sidecar, unreadable metadata) is a loud warning-plus-drop, not a permanent freeze of both manifest branches. Dropping can never silently cost a generation: the zero-entry guard, the own-build assertion, and `verify-manifest`'s undated ABI-shrink check remain.
- Exactly-one cardinality is asserted for the zip **and** the md5 candidates; the changelog lookup carries the same draft filter/`first()` cutoff as the asset lookup.
- The four prepare steps write sidecars with `>` (truncate) instead of `>>`, removing the append hazard that made a multi-line sidecar reachable.
- `build-jf12.yaml`'s `overview`/`description` are reconciled word-identical with `build.yaml`'s (comment pins them): both beta legs write the shared `manifest-beta`, which holds one plugin object from the publishing leg, divergent prose alternates the catalogue entry nightly and defeats the unchanged-manifest commit skip.

## Empirical verification (not reasoning)

- Generated against the **live repository** (all 33 releases): plugin object **byte-identical** to the published manifest; 26/27 shared version entries byte-identical; the 27th is `4.3.0.10`, the entry the replaced action got wrong.
- **All 29 generated checksums verified by downloading each artifact and computing its MD5, 29/29 match**, including `4.3.0.10`, where the live manifest does not.
- All **34 live md5 sidecars** dumped; each is a single `md5sum` line naming its zip, so the strict whole-line validation is safe against the real history.
- **Five negative tests** against the real release payload: own-release-missing → fail; historical two-zip release → dropped, run green; own two-zip release → fail; historical lost sidecar → only that entry dropped; empty history → the written diagnostic (previously an unreachable branch behind a jq crash).
- Every touched YAML strict-parsed with **js-yaml** (not yq, which tolerates the duplicate-key class that caused the earlier startup failure).

## Adversarial review

4-lens gate (availability / supply-chain-bypass / correctness-shell-semantics / integration), refute-by-default, each lens executing the generator against the live payload. All four returned NEEDS_IMPROVEMENT; every finding above traces to one of them and is fixed in the second commit. Reasoned declines:

- *Serial sidecar fetches grow with history (~2/release).* `per_page=100` fixes the listing; the per-release fetches remain O(history). At current cadence the 15/20-minute job timeouts are years away; deferring fetches to post-cap entries would need version/ABI before the fetch that provides them. Tracked as follow-up rather than complicating this PR.
- *Three legs run the manifest step inline in the job that sealed the immutable release, so "re-run failed jobs" cannot reach it.* Pre-existing structure; a manifest-only regeneration dispatch is the right recovery path and is tracked as follow-up.

## Sequencing (#944), the remaining deployment step

`nightly-betas.yml` dispatches the JF12 beta leg with `--ref 4.2`, and branch `4.2` has **no `.github/actions/` at all**, its `publish-jf12-beta.yml` still runs the old action, and `publish-jf12-stable.yml` does not exist there. The 4.2 gate is currently dormant (branch HEAD equals the last beta's commit), so nothing regenerates from 4.2 tonight, but the **first commit landing on 4.2 wakes it** and the old generator would overwrite `manifest-beta` (restoring both #942 and #943, with no detector on that copy). Therefore the port of `.github/actions/*` + the two JF12 workflows to `4.2` follows **immediately after this merges**, before anything else lands on 4.2.

Closes #943. Refs #942, #944.
