### PR TITLE
Port the in-house manifest generator to the 4.2 publish legs

### DIFF
--- a/.github/actions/cyclonedx-sbom/action.yml
+++ b/.github/actions/cyclonedx-sbom/action.yml
@@ -1,0 +1,51 @@
+name: Generate CycloneDX SBOM
+description: >-
+  Emit a CycloneDX JSON SBOM for the SSO-Auth plugin from the locked restore
+  graph the caller has already materialised, so a release can carry the
+  dependency inventory CRA Annex I / OSPS-QA-02.02 expect. The single generator
+  for every publish leg (DRY): each leg calls this action, none re-implements it.
+  The SBOM covers the plugin's FULL multi-target dependency closure (both the
+  net9.0 / Jellyfin 10.11 and net10.0 / Jellyfin 12.0 lines) as pinned in the
+  committed packages.lock.json — a conservative superset for any single leg's
+  shipped ABI, never an under-report. Which target framework a given release
+  ships is identified by its tag and zip.
+inputs:
+  output-dir:
+    description: >-
+      Existing directory the SBOM JSON is written into (e.g. the publish leg's
+      `_dist` staging dir, or a fresh `sbom` dir in the reusable build).
+    required: true
+outputs:
+  sbom-path:
+    description: Path to the generated CycloneDX JSON SBOM.
+    value: ${{ steps.generate.outputs.sbom-path }}
+runs:
+  using: composite
+  steps:
+    - name: Generate CycloneDX SBOM
+      id: generate
+      shell: bash
+      # CycloneDX is a NuGet global tool, so it is pinned by VERSION — the correct
+      # pin mechanism for a NuGet package, and stricter than adopting a single-
+      # release third-party wrapper action into the SHA-pin trust set. It reads the
+      # caller's already-restored graph (`--disable-package-restore`): the real
+      # restore ran under RestoreLockedMode against the committed packages.lock.json,
+      # so the SBOM documents exactly the locked closure and no drifted or poisoned
+      # package can be pulled in merely to describe the bill of materials. The
+      # output path is passed through an env var, not interpolated into the script,
+      # so a caller value can never be evaluated as shell.
+      env:
+        OUTPUT_DIR: ${{ inputs.output-dir }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$OUTPUT_DIR"
+        dotnet tool install --global CycloneDX --version 6.2.0
+        export PATH="$HOME/.dotnet/tools:$PATH"
+        dotnet-CycloneDX SSO-Auth/SSO-Auth.csproj \
+          --output-format Json \
+          --output "$OUTPUT_DIR" \
+          --filename sbom.cyclonedx.json \
+          --set-nuget-purl \
+          --exclude-test-projects \
+          --disable-package-restore
+        echo "sbom-path=$OUTPUT_DIR/sbom.cyclonedx.json" >> "$GITHUB_OUTPUT"

--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -1,0 +1,318 @@
+name: Generate the Jellyfin plugin manifest
+description: >-
+  Build and commit the Jellyfin plugin repository manifest from this
+  repository's releases.
+
+  This replaces Kevinjil/jellyfin-plugin-repo-action, which produced two
+  user-facing outages in a week and could not be configured out of either:
+
+  - It selected a release's checksum BY NAME, keeping the LAST asset ending in
+    `.md5` with no pairing against the zip. Renaming the plugin moved its md5
+    ahead of `sbom.cyclonedx.md5` alphabetically, so the manifest published the
+    SBOM's checksum and every install failed verification (#942). Here the
+    checksum is taken from the sidecar that BELONGS to the selected zip, and a
+    release whose pair cannot be resolved fails the run instead of guessing.
+  - It listed releases UNPAGINATED, so only the first 30 were ever considered.
+    With one manifest branch shared by both Jellyfin generations and the JF10.11
+    line publishing far more often, the JF12 entries were being pushed off the
+    end — after which that generation silently vanishes from the manifest and
+    every Jellyfin 12.0 user's repository goes empty (#943). Here the release
+    list is paginated, and the manifest is capped PER targetAbi rather than
+    globally, so no generation can be squeezed out by another's cadence however
+    long the release history grows.
+
+  The output is byte-compatible with what the previous action produced: the same
+  plugin and version fields, keys sorted, two-space indent, versions in
+  descending version order.
+inputs:
+  plugin-metadata:
+    description: >-
+      Path to the JSON metadata JPRM wrote beside the zip THIS run built, which
+      supplies the plugin-level fields (guid, name, description, …).
+
+      It is an input rather than something discovered from the releases because
+      discovery has no deterministic answer: the releases API guarantees no
+      ordering useful here, so "whichever release the API listed first" can hand
+      the catalogue a years-old identity mid-rename. Taking it from the
+      publishing leg is deterministic per run — and because the manifest branch
+      is SHARED between the two Jellyfin generations and holds exactly ONE
+      plugin object, the plugin-level prose in build.yaml and build-jf12.yaml
+      must be kept word-identical (enforced by a comment at both sites), or the
+      catalogue entry alternates between the legs' texts on each publish. It is
+      also what lets the stable channel regenerate at all: no existing stable
+      release ships this file.
+
+      Beyond identity, the version and targetAbi in this file pin the one
+      guarantee the action gives: the run fails unless the build THIS run
+      published survives into the committed manifest.
+    required: true
+  repository:
+    description: owner/repo whose releases the manifest is built from.
+    required: true
+  manifest-branch:
+    description: Branch the manifest is committed to (e.g. manifest-beta).
+    required: true
+  manifest-file:
+    description: Path of the manifest within that branch.
+    required: false
+    default: manifest.json
+  include-prereleases:
+    description: >-
+      "true" for the beta channel (prereleases are the point), "false" for
+      stable.
+    required: true
+  max-versions-per-abi:
+    description: >-
+      How many versions to keep for EACH targetAbi. Per-ABI rather than an
+      overall limit is the structural fix for #943: a generation that publishes
+      rarely keeps its entries no matter how often the other one publishes.
+    required: false
+    default: "15"
+  github-token:
+    description: Token used to read releases and commit the manifest.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Generate and commit the manifest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PLUGIN_METADATA: ${{ inputs.plugin-metadata }}
+        REPO: ${{ inputs.repository }}
+        BRANCH: ${{ inputs.manifest-branch }}
+        MANIFEST_FILE: ${{ inputs.manifest-file }}
+        INCLUDE_PRERELEASES: ${{ inputs.include-prereleases }}
+        MAX_PER_ABI: ${{ inputs.max-versions-per-abi }}
+      run: |-
+        set -euo pipefail
+        work="$(mktemp -d)"
+
+        # Plugin-level metadata comes from THIS run's build. See the input's description for why
+        # discovering it from the release list has no deterministic answer.
+        # The filename carries the version, so the input is a glob. It must resolve to exactly
+        # one file: zero means the leg did not ship the metadata and the manifest would be
+        # built from nothing, more than one means it is ambiguous which build's identity the
+        # catalogue entry would take.
+        # shellcheck disable=SC2086
+        set -- $PLUGIN_METADATA
+        if [ "$#" -ne 1 ] || [ ! -s "$1" ]; then
+          echo "::error::plugin-metadata '$PLUGIN_METADATA' resolved to $# path(s); expected exactly one readable file"
+          exit 1
+        fi
+        jq -e '.guid and .name and .category and .owner' "$1" >/dev/null || {
+          echo "::error::$1 does not carry the plugin fields the manifest requires"
+          exit 1
+        }
+        cp "$1" "$work/plugin.json"
+
+        # The build THIS run published, identified three ways: by the zip the metadata sits
+        # beside (which release in the history is ours), and by version+targetAbi (which
+        # manifest entry must exist at the end). Both are used below to keep the fail-closed
+        # checks pointed at the release being published rather than at the whole history.
+        this_zip="$(basename "$1" .meta.json)"
+        this_version="$(jq -r '.version // empty' "$work/plugin.json")"
+        this_abi="$(jq -r '.targetAbi // empty' "$work/plugin.json")"
+        if [ -z "$this_version" ] || [ -z "$this_abi" ]; then
+          echo "::error::$1 carries no version/targetAbi, so this run's own build cannot be confirmed to reach the manifest"
+          exit 1
+        fi
+        echo "publishing $this_version (targetAbi $this_abi) from $this_zip"
+
+        # --paginate is the whole point: without it only the first 30 releases are seen.
+        # --per_page 100 keeps that from costing one API call per 30 releases forever.
+        gh api --paginate --method GET -f per_page=100 "repos/${REPO}/releases" > "$work/releases.json"
+        total="$(jq -s 'add | length' "$work/releases.json")"
+        echo "releases fetched: $total"
+
+        # Each release's targetAbi and version come from ITS OWN build.yaml — shipped as a
+        # release asset where the leg provides one (the JF12 legs must, or their builds would
+        # be labelled with the JF10.11 metadata), otherwise read from the release's tag.
+        : > "$work/versions.jsonl"
+        while IFS=$'\t' read -r tag is_draft is_pre published_at; do
+          [ "$is_draft" = "true" ] && continue
+          if [ "$is_pre" = "true" ] && [ "$INCLUDE_PRERELEASES" != "true" ]; then continue; fi
+
+          # `first(…)`: a draft can carry the same tag_name as a published release (the draft
+          # flow the beta leg used to run does exactly that), and without the draft filter plus
+          # this cutoff the lookup emits TWO JSON documents — every jq below then produces two
+          # values and the shell comparisons downstream read garbage.
+          assets="$(jq -c --arg t "$tag" -s 'first(add[] | select((.draft | not) and .tag_name == $t) | .assets)' "$work/releases.json")"
+
+          # Is this the release THIS run published? Releases here are immutable, so a defect in
+          # an OLD one can never be repaired by attaching the missing asset. Aborting the whole
+          # generation over it would freeze both manifest branches permanently — a worse
+          # outage than dropping that one historical entry. So every integrity check below is
+          # fatal for our own release and a loud skip for anyone else's.
+          ours=no
+          if printf '%s' "$assets" | jq -e --arg z "$this_zip" 'any(.[]; .name == $z)' >/dev/null; then
+            ours=yes
+          fi
+
+          # Exactly one zip, or nothing. Picking positionally out of several would publish one
+          # build with the correctly-paired checksum of THAT build — so every downstream
+          # integrity check passes and users install an artifact nobody chose. That is the same
+          # "select by position, never assert cardinality" shape as #942, one level up, so it
+          # gets the same fail-closed treatment the checksum pairing already has.
+          zip_count="$(printf '%s' "$assets" | jq '[.[] | select(.name | endswith(".zip"))] | length')"
+          if [ "$zip_count" -gt 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag carries $zip_count plugin zips; dropping it from the manifest rather than guessing which one to offer"
+              continue
+            fi
+            echo "::error::release $tag carries $zip_count plugin zips; refusing to guess which one the manifest should offer"
+            exit 1
+          fi
+          zip_url="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name | endswith(".zip"))) | .browser_download_url // empty')"
+          zip_name="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name | endswith(".zip"))) | .name // empty')"
+          if [ -z "$zip_url" ]; then
+            echo "::notice::release $tag ships no plugin zip; skipping it"
+            continue
+          fi
+
+          # THE #942 FIX. The checksum is the sidecar belonging to THIS zip — either
+          # <zip-without-.zip>.md5 or <zip>.md5 — never merely the last `.md5` on the
+          # release. An unresolvable pair is fatal: publishing a checksum that matches
+          # nothing breaks every install, so guessing is the one thing not to do here.
+          md5_count="$(printf '%s' "$assets" | jq --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
+            '[.[] | select(.name == $a or .name == $b)] | length')"
+          if [ "$md5_count" -ne 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag has $zip_name and $md5_count candidate checksum sidecars; dropping it from the manifest rather than publishing a guessed checksum"
+              continue
+            fi
+            echo "::error::release $tag has $zip_name and $md5_count candidate checksum sidecars (${zip_name%.zip}.md5 / ${zip_name}.md5); refusing to publish a guessed checksum"
+            exit 1
+          fi
+          md5_url="$(printf '%s' "$assets" | jq -r --arg a "${zip_name%.zip}.md5" --arg b "${zip_name}.md5" \
+            'first(.[] | select(.name == $a or .name == $b)) | .browser_download_url')"
+          # The sidecar is `md5sum` output: `<32 hex><space><space-or-*><filename>`. Validate the
+          # WHOLE line, filename included — not just the leading 32 characters. A sidecar written
+          # with `>>` that ended up holding two lines would otherwise pass on its first line,
+          # which may describe an entirely different file, and the manifest would again publish a
+          # checksum belonging to something other than the zip beside it (#942's shape).
+          if ! sidecar="$(curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$md5_url")"; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag — could not fetch the checksum sidecar; dropping it from the manifest this run"
+              continue
+            fi
+            echo "::error::release $tag — could not fetch the checksum sidecar"
+            exit 1
+          fi
+          checksum="$(printf '%s\n' "$sidecar" | sed -n "1s/^\([0-9a-f]\{32\}\)[[:space:]][[:space:]*]$(printf '%s' "$zip_name" | sed 's/[].[^$*\/]/\\&/g')\$/\1/p")"
+          if [ -z "$checksum" ] || [ "$(printf '%s\n' "$sidecar" | grep -c .)" -ne 1 ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag — the checksum sidecar is not a single md5sum line naming $zip_name; dropping it from the manifest"
+              continue
+            fi
+            echo "::error::release $tag — the checksum sidecar is not a single md5sum line naming $zip_name"
+            exit 1
+          fi
+
+          # Version and targetAbi describe THIS release, so they come from the metadata JPRM
+          # wrote beside its zip — plain JSON, read with jq. The runner image ships jq but NOT
+          # yq (checked against the runner-images tool list, not assumed), so nothing here
+          # parses YAML in the general case.
+          meta_url="$(printf '%s' "$assets" | jq -r --arg m "${zip_name}.meta.json" \
+            'first(.[] | select(.name == $m)) | .browser_download_url // empty')"
+          version=""
+          target_abi=""
+          if [ -n "$meta_url" ]; then
+            if curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$meta_url" > "$work/release.json"; then
+              version="$(jq -r '.version // empty' "$work/release.json")"
+              target_abi="$(jq -r '.targetAbi // empty' "$work/release.json")"
+            fi
+          else
+            # Releases published before that metadata was shipped. Only two scalars are needed
+            # and both are simple quoted values, so a line match is exact here — this is not a
+            # YAML parser and is not asked to be one.
+            build_url="$(printf '%s' "$assets" | jq -r 'first(.[] | select(.name == "build.yaml")) | .browser_download_url // empty')"
+            : > "$work/release.yaml"
+            if [ -n "$build_url" ]; then
+              curl -fsSL --retry 5 --retry-all-errors --max-time 60 "$build_url" > "$work/release.yaml" || true
+            else
+              gh api "repos/${REPO}/contents/build.yaml?ref=${tag}" -H "Accept: application/vnd.github.raw" > "$work/release.yaml" 2>/dev/null || true
+            fi
+            version="$(sed -n 's/^version:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
+            target_abi="$(sed -n 's/^targetAbi:[[:space:]]*"\([^"]*\)".*/\1/p' "$work/release.yaml" | head -1)"
+          fi
+          if [ -z "$version" ] || [ -z "$target_abi" ]; then
+            if [ "$ours" = "no" ]; then
+              echo "::warning::release $tag has no readable version/targetAbi; dropping it from the manifest"
+              continue
+            fi
+            echo "::error::release $tag has no readable version/targetAbi in its metadata"
+            exit 1
+          fi
+
+          # Same draft filter and cutoff as the asset lookup above, for the same reason: two
+          # releases sharing a tag_name would otherwise concatenate both bodies into one entry.
+          changelog="$(jq -r --arg t "$tag" -s 'first(add[] | select((.draft | not) and .tag_name == $t) | .body // "")' "$work/releases.json")"
+          jq -nc --arg changelog "$changelog" --arg checksum "$checksum" --arg sourceUrl "$zip_url" \
+                 --arg targetAbi "$target_abi" --arg timestamp "$published_at" --arg version "$version" \
+            '{changelog:$changelog, checksum:$checksum, sourceUrl:$sourceUrl, targetAbi:$targetAbi, timestamp:$timestamp, version:$version}' \
+            >> "$work/versions.jsonl"
+        done < <(jq -r -s 'add[] | [.tag_name, (.draft|tostring), (.prerelease|tostring), .published_at] | @tsv' "$work/releases.json")
+
+        # Sort descending by NUMERIC version components (the previous action used a numeric
+        # locale compare), then keep the newest MAX_PER_ABI of each targetAbi.
+        jq -s --argjson keep "$MAX_PER_ABI" '
+          map(. + {_v: (.version | split(".") | map(tonumber? // 0))})
+          | sort_by(._v) | reverse
+          | group_by(.targetAbi)
+          | map(.[0:$keep])
+          | (add // [])
+          | sort_by(._v) | reverse
+          | map(del(._v))
+        ' "$work/versions.jsonl" > "$work/kept.json"
+
+        kept_total="$(jq 'length' "$work/kept.json")"
+        if [ "$kept_total" -eq 0 ]; then
+          echo "::error::no releases produced a manifest entry"
+          exit 1
+        fi
+        # The one guarantee this action exists to give: the build THIS run published is in the
+        # manifest about to be committed. Without it, a transient asset-listing gap makes the
+        # loop above skip our own release with a notice, the run stays green, and an immutable
+        # stable release exists that no Jellyfin server is ever offered — silently, until the
+        # next publish months later.
+        if ! jq -e --arg v "$this_version" --arg a "$this_abi" \
+            'any(.[]; .version == $v and .targetAbi == $a)' "$work/kept.json" >/dev/null; then
+          echo "::error::the build this run published ($this_version, targetAbi $this_abi) did not survive into the manifest — refusing to publish without it"
+          exit 1
+        fi
+        echo "manifest entries per targetAbi:"
+        jq -r 'group_by(.targetAbi)[] | "  \(.[0].targetAbi): \(length) (newest \(.[0].version))"' "$work/kept.json"
+
+        # `jq -S` sorts keys, matching the previous action's stable stringify, and the plugin
+        # object carries exactly the fields it emitted (imageUrl only when set).
+        jq -S --slurpfile versions "$work/kept.json" '
+          {
+            category: .category,
+            description: .description,
+            guid: .guid,
+            name: .name,
+            overview: .overview,
+            owner: .owner,
+            versions: $versions[0],
+          }
+          + (if .imageUrl then {imageUrl: .imageUrl} else {} end)
+          | [.]
+        ' "$work/plugin.json" > "$work/manifest.json"
+
+        # Commit only when something changed, so an unchanged regeneration does not add an
+        # empty commit to the manifest branch on every publish.
+        current_sha="$(gh api "repos/${REPO}/contents/${MANIFEST_FILE}?ref=${BRANCH}" --jq '.sha' 2>/dev/null || true)"
+        if [ -n "$current_sha" ]; then
+          gh api "repos/${REPO}/contents/${MANIFEST_FILE}?ref=${BRANCH}" -H "Accept: application/vnd.github.raw" > "$work/live.json" 2>/dev/null || true
+          if [ -f "$work/live.json" ] && cmp -s "$work/live.json" "$work/manifest.json"; then
+            echo "manifest unchanged; nothing to commit"
+            exit 0
+          fi
+        fi
+
+        payload="$(jq -nc --arg m "Regenerate Jellyfin plugin repository." --arg b "$BRANCH" \
+          --arg c "$(base64 -w0 < "$work/manifest.json")" --arg s "${current_sha:-}" \
+          '{message:$m, branch:$b, content:$c} + (if $s == "" then {} else {sha:$s} end)')"
+        printf '%s' "$payload" | gh api -X PUT "repos/${REPO}/contents/${MANIFEST_FILE}" --input - >/dev/null
+        echo "committed $kept_total versions to ${BRANCH}/${MANIFEST_FILE}"

--- a/.github/actions/verify-manifest/action.yml
+++ b/.github/actions/verify-manifest/action.yml
@@ -1,0 +1,233 @@
+name: Verify the published plugin manifest
+description: >-
+  Prove that a just-published plugin manifest actually installs: download exactly
+  what it points at and check the artifact's MD5 against the checksum it
+  publishes — for the version this run added, and for the newest entry of every
+  targetAbi it lists.
+
+  This exists because the manifest generator
+  (Kevinjil/jellyfin-plugin-repo-action) selects a release's checksum by NAME —
+  it keeps the LAST asset whose name ends in `.md5`, with no break and no
+  pairing against the zip. A second `.md5` asset that sorts after the plugin's
+  therefore becomes the published checksum, the manifest ships a value that
+  matches nothing, and every install fails Jellyfin's verification with a bare
+  "failed" and no hint at the cause. That is not hypothetical: renaming the
+  plugin to `community-sso-for-jellyfin` moved its md5 ahead of
+  `sbom.cyclonedx.md5` alphabetically and broke the beta channel exactly that
+  way (#942). The publish legs no longer emit a competing `.md5`; this action
+  re-derives the answer from the published artefacts and trusts nothing the
+  generator did.
+
+  SCOPE, honestly: this is a post-publish DETECTOR, not a preventer. It runs
+  after the release is sealed (immutable) and after the manifest branch is
+  written, so on a true positive the bad manifest is already being served — the
+  run turns red and a human has to act. It converts a silent, user-facing
+  outage into a loud build failure; it does not roll anything back.
+
+  The newest entry of EVERY targetAbi is checked, not only the one this run
+  added: the manifests are shared between the Jellyfin generations, so a run of
+  one publish leg can break the other's head entry — the entry a fresh install
+  of that generation is offered.
+inputs:
+  repository:
+    description: owner/repo whose manifest branch is being verified.
+    required: true
+  manifest-branch:
+    description: >-
+      Branch holding the published manifest.json (e.g. manifest-beta,
+      manifest-release).
+    required: true
+  github-token:
+    description: >-
+      Token used to read the manifest through the API. The API is used rather
+      than raw.githubusercontent because raw serves the branch through a cache
+      with max-age=300 and no way for a client to force revalidation — a read
+      there routinely returns the PREVIOUS revision, which would verify the
+      wrong document (a false green on the stable legs) or report the just-added
+      version as missing (a false red on the beta legs).
+    required: true
+  expect-version:
+    description: >-
+      Plugin version this run published (e.g. 4.3.0.10), which must be present
+      AND whose checksum is verified directly — being present is not enough,
+      since a version that is not its ABI's head would otherwise only be
+      checked for existence. Leave unset where the leg cannot derive it.
+    required: false
+    default: ""
+  require-abis:
+    description: >-
+      Space-separated targetAbi values that must each still have at least one
+      entry (e.g. "10.11.0.0 12.0.0.0") — an explicit floor for the generations
+      known to belong in this manifest today.
+
+      This is the SECONDARY eviction check. The primary one needs no
+      configuration: the action compares the ABI set against the previous
+      revision of the same manifest branch and fails if one disappeared. That
+      matters because a per-leg list dates badly — the leg that must notice an
+      eviction is whichever one just published, since a generation is pushed out
+      by the OTHER generation publishing, and any hardcoded list silently
+      expires when a new generation goes GA.
+
+      Why an eviction happens at all: the generator lists only the first 30
+      releases (unpaginated), one manifest branch is shared by both Jellyfin
+      generations, and the JF10.11 line publishes far more often than the JF12
+      one — so the JF12 entries are steadily pushed off the end. When the last
+      one goes, `targetAbi 12.0.0.0` vanishes and every Jellyfin 12.0 user's
+      repository silently goes empty (#943). Note the per-ABI checksum loop
+      cannot catch this on its own: it iterates the ABIs it FINDS, so a
+      generation that is already gone yields no iteration and a green run.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Verify the published manifest
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ inputs.repository }}
+        BRANCH: ${{ inputs.manifest-branch }}
+        EXPECT_VERSION: ${{ inputs.expect-version }}
+        REQUIRE_ABIS: ${{ inputs.require-abis }}
+      run: |-
+        set -euo pipefail
+        work="$(mktemp -d)"
+        manifest="$work/manifest.json"
+
+        # Read through the API, which is read-your-writes against the commit the generator
+        # just made. Retried because the generator's write and this read are separate API
+        # calls; when a version is expected, the retry waits for THAT version rather than
+        # merely for a successful fetch — a fetch that succeeds with stale content is the
+        # failure mode, not a fetch that errors.
+        # manifest_is_current — is the fetched document the one this run expects to see? Both
+        # the expected version and the required ABIs are part of that question: asserting
+        # either against a single, possibly-lagging read would turn a slow API into a red
+        # build on a release that is already sealed and cannot be re-made.
+        manifest_is_current() {
+          if [ -n "$EXPECT_VERSION" ] && ! jq -e --arg v "$EXPECT_VERSION" \
+               '.[0].versions | map(.version) | index($v)' "$manifest" >/dev/null 2>&1; then
+            return 1
+          fi
+          for required in $REQUIRE_ABIS; do
+            if ! jq -e --arg a "$required" \
+                 'first(.[0].versions[] | select(.targetAbi == $a))' "$manifest" >/dev/null 2>&1; then
+              return 1
+            fi
+          done
+          return 0
+        }
+
+        fetched=0
+        for _ in $(seq 1 12); do
+          if gh api "repos/${REPO}/contents/manifest.json?ref=${BRANCH}" \
+               -H "Accept: application/vnd.github.raw" > "$manifest" 2>/dev/null && manifest_is_current; then
+            fetched=1
+            break
+          fi
+          sleep 10
+        done
+        if [ "$fetched" -ne 1 ]; then
+          echo "::error::could not read a manifest containing ${EXPECT_VERSION:-any version}${REQUIRE_ABIS:+ and targetAbi(s) $REQUIRE_ABIS} from ${REPO}@${BRANCH}"
+          exit 1
+        fi
+
+        # verify <version> — download what the manifest points at and compare.
+        # Returns non-zero on any mismatch, unreachable artifact, or missing entry.
+        verify() {
+          entry="$(jq -c --arg v "$1" 'first(.[0].versions[] | select(.version == $v))' "$manifest")"
+          if [ -z "$entry" ] || [ "$entry" = "null" ]; then
+            echo "::error::version $1 is missing from the published manifest"
+            return 1
+          fi
+          want="$(printf '%s' "$entry" | jq -r '.checksum // ""')"
+          url="$(printf '%s' "$entry" | jq -r '.sourceUrl // ""')"
+          if [ -z "$want" ] || [ -z "$url" ]; then
+            echo "::error::version $1 has an empty checksum or sourceUrl in the published manifest"
+            return 1
+          fi
+          # Retried: this runs moments after the release was sealed, and asset propagation
+          # can 404 or 5xx transiently — a false red here would fail an otherwise correct
+          # publish that can no longer be re-made (the release is immutable).
+          if ! curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 --max-time 180 "$url" -o "$work/published.zip"; then
+            echo "::error::version $1 — the manifest's sourceUrl is not downloadable: $url"
+            return 1
+          fi
+          got="$(md5sum "$work/published.zip" | cut -d' ' -f1)"
+          if [ "$want" != "$got" ]; then
+            echo "::error::version $1 — the manifest publishes checksum $want but the artifact at $url is $got; every install of this build would fail verification"
+            return 1
+          fi
+          echo "ok   version=$1 checksum=$got"
+          return 0
+        }
+
+        # An ASSIGNMENT, not a `for … in $(...)` word list: `set -e` ignores a failed
+        # command substitution in a for-list, so a jq error there would yield zero
+        # iterations and a green run — the gate would pass on an empty, truncated or
+        # non-JSON manifest, which is exactly the catastrophic case it must catch.
+        abis="$(jq -r '.[0].versions | map(.targetAbi) | unique | .[]' "$manifest")" || {
+          echo "::error::the published manifest is not a readable plugin manifest (jq could not read .[0].versions); first bytes: $(head -c 200 "$manifest")"
+          exit 1
+        }
+        if [ -z "$abis" ]; then
+          echo "::error::the published manifest lists no versions at all"
+          exit 1
+        fi
+
+        fail=0
+        checked=0
+
+        # DID THE ABI SET SHRINK? This is the undated form of the eviction check, and it is
+        # the one that matters: a generation is pushed out of the manifest by the OTHER
+        # generation publishing (the generator reads only the first 30 releases, and the
+        # JF10.11 line publishes far more often than the JF12 one). So the leg that must
+        # notice is whichever one just published — no per-leg list of ABIs to keep in step
+        # with reality, and no value that silently expires when a new generation goes GA.
+        # Compared against the previous revision of this same manifest branch; on the very
+        # first publish there is none, and the check simply does not apply.
+        prev_sha="$(gh api "repos/${REPO}/commits?path=manifest.json&sha=${BRANCH}&per_page=2" --jq '.[1].sha // empty' 2>/dev/null || true)"
+        if [ -n "$prev_sha" ] \
+           && gh api "repos/${REPO}/contents/manifest.json?ref=${prev_sha}" \
+                -H "Accept: application/vnd.github.raw" > "$work/previous.json" 2>/dev/null; then
+          prev_abis="$(jq -r '.[0].versions | map(.targetAbi) | unique | .[]' "$work/previous.json" 2>/dev/null || true)"
+          for was in $prev_abis; do
+            if ! printf '%s\n' "$abis" | grep -qxF "$was"; then
+              echo "::error::targetAbi $was was in the previous manifest and is GONE from the one just published — every Jellyfin server of that generation now sees an empty repository. The generator reads only the first 30 releases, so the generation that publishes less often gets pushed off the end by the one that publishes more (#943)."
+              fail=1
+            fi
+          done
+        else
+          echo "note: no previous revision of this manifest to compare against; the shrink check does not apply"
+        fi
+
+        # An explicit floor on top, for generations known to belong in this manifest today.
+        # Quoted expansion: $abis is already newline-separated, and leaving it unquoted lets
+        # pathname expansion match a stray filename and report an absent ABI as present.
+        for required in $REQUIRE_ABIS; do
+          if printf '%s\n' "$abis" | grep -qxF "$required"; then
+            echo "ok   abi=$required is present"
+          else
+            echo "::error::targetAbi $required has NO entry in the published manifest — every Jellyfin server of that generation now sees an empty repository (#943)."
+            fail=1
+          fi
+        done
+        if [ -n "$EXPECT_VERSION" ]; then
+          verify "$EXPECT_VERSION" || fail=1
+          checked=$((checked + 1))
+        fi
+        for abi in $abis; do
+          head_version="$(jq -r --arg a "$abi" 'first(.[0].versions[] | select(.targetAbi == $a)) | .version' "$manifest")"
+          echo "abi=$abi head=$head_version"
+          if [ "$head_version" != "$EXPECT_VERSION" ]; then
+            verify "$head_version" || fail=1
+            checked=$((checked + 1))
+          fi
+        done
+
+        # Belt and braces: a run that verified nothing must never report success.
+        if [ "$checked" -eq 0 ]; then
+          echo "::error::the verification checked no manifest entries at all"
+          exit 1
+        fi
+        echo "verified $checked manifest entr(y|ies)"
+        [ "$fail" -eq 0 ]

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -136,13 +136,25 @@ jobs:
         path: .
         dotnet-target: "net10.0"
         output: _dist
+    # CycloneDX SBOM of the net10 shipping closure, into the release staging dir so
+    # the checksum loop and `files: _dist/*` ship it as a beta release asset. Reads
+    # the --locked-mode restore above; the same single generator publish.yml uses.
+    - name: Generate CycloneDX SBOM
+      uses: ./.github/actions/cyclonedx-sbom
+      with:
+        output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
         pushd _dist
+        # ONLY the plugin zip gets a `.md5` — see the same note in publish-beta.yml. The
+        # manifest generator keeps the LAST asset ending in `.md5`, so a second one
+        # sorting after the plugin's becomes the published checksum and every install
+        # fails verification.
         for file in ./*.zip; do
-          md5sum ${file#./} >> ${file%.*}.md5
-          sha256sum ${file#./} >> ${file%.*}.sha256
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
         done
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
         ls -l
         popd
     - name: Upload JF12 beta assets to a draft release
@@ -176,6 +188,8 @@ jobs:
             Jellyfin 12.0 (.NET 10) beta ${{ steps.version.outputs.base }}-JF12-beta (plugin version ${{ steps.version.outputs.beta }}).
             Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
             https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+
+            Scope note (#743): the JF12/5.0 line is **not validated against a live Jellyfin 12.0 server yet** — no 12.0 GA server exists to run the E2E checklist against. It is CI-built and unit/conformance-tested only, and it is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate; the 5.0 line clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available. Use these betas for testing, not production.
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish the draft release
@@ -193,10 +207,22 @@ jobs:
       # so every version lands in the manifest with its correct targetAbi, and a Jellyfin server installs
       # only the build matching its generation. publish-beta.yml (on main) regenerates the same branch, so
       # whichever generation publishes last leaves manifest-beta complete for both.
-      uses: Kevinjil/jellyfin-plugin-repo-action@296850372cd569cbcc040e834222a5afed861485 # v0.4.3
+      uses: ./.github/actions/generate-manifest
       with:
-        ignorePrereleases: false
-        githubToken: ${{ secrets.GITHUB_TOKEN }}
+        plugin-metadata: _dist/*.zip.meta.json
         repository: ${{ github.repository }}
-        pagesBranch: manifest-beta
-        pagesFile: manifest.json
+        manifest-branch: manifest-beta
+        include-prereleases: "true"
+        github-token: ${{ github.token }}
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-beta
+        github-token: ${{ github.token }}
+        expect-version: ${{ steps.version.outputs.beta }}
+        require-abis: "10.11.0.0 12.0.0.0"

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -1,0 +1,150 @@
+name: Publish JF12 Stable
+
+# The Jellyfin 12.0 (.NET 10) STABLE channel — the 5.0 line's GA publish leg (#607). Counterpart to
+# publish.yml (JF10.11 stable, X.Y.Z-stable) and publish-jf12-beta.yml (JF12 beta). Triggered ONLY by a
+# maintainer pushing an X.Y.Z-JF12-stable tag (e.g. 5.0.0-JF12-stable): publish.yml's
+# [0-9]+.[0-9]+.[0-9]+-stable glob deliberately does NOT match -JF12-stable, so the two stable legs never
+# cross-fire. Like the JF11 stable tag, this tag is MAINTAINER-GATED (guard-git.ps1) and pushed by hand.
+#
+# DORMANT until Jellyfin 12.0 reaches GA: no X.Y.Z-JF12-stable tag is pushed until a real 12.0 stable
+# server exists, so this workflow does not run before then — but the pipeline is ready so the 5.0 line can
+# cut a stable release the day 12.0 ships. Until GA, JF12 users are served by the beta channel (#605).
+#
+# The JF12 build METADATA (version 5.0.0, targetAbi 12.0.0.0, framework net10.0, the net10 shipping
+# closure) lives in build-jf12.yaml, copied over build.yaml before JPRM builds — the same swap as
+# publish-jf12-beta.yml; the committed build.yaml stays the JF10.11 metadata. The full release
+# (prerelease: false, one shot like publish.yml) regenerates the SHARED manifest-release
+# (ignorePrereleases: true) — the same stable pages branch publish.yml writes. Each release ships its own
+# build.yaml, so Jellyfin filters client-side by targetAbi: a 12.0 server installs the 5.0 build, a 10.11
+# server the 4.x build, from one stable manifest — no separate JF12 stable manifest is needed.
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+-JF12-stable"
+  workflow_dispatch:
+
+# Explicit deny-all at workflow level; the job below opts into write access explicitly.
+permissions: {}
+
+# Serialize manifest-release regenerations so two stable publishes never race the pages branch (the same
+# reader-vs-pusher TOCTOU #135 fixed for manifest-beta). cancel-in-progress is false: a publish holding
+# contents:write must never be killed mid-run. publish.yml (JF10.11 stable) shares this same group name,
+# so the two stable legs are serialized against each other as well — a JF10.11 and a JF12 stable publish
+# can never regenerate manifest-release concurrently.
+concurrency:
+  group: publish-manifest-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build & publish JF12 stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Creates the GitHub release and updates the manifest branch, so it opts into write access.
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+    - name: Setup .NET
+      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      with:
+        # Both SDKs: the multi-target restore/build needs net9.0, the JF12 package is net10.0.
+        # No NuGet cache: this job publishes with contents:write, so a poisoned cache could reach the
+        # artifact; the --locked-mode restore re-downloads against the committed lockfile.
+        dotnet-version: |
+          9.0.x
+          10.0.x
+    - name: Restore dependencies
+      run: dotnet restore --locked-mode
+    - name: Build Dotnet
+      run: dotnet build --no-restore --warnaserror
+    - name: Use the JF12 build metadata
+      # JPRM reads build.yaml; swap in the JF12 metadata (version 5.0.0, targetAbi 12.0.0.0, framework
+      # net10.0, net10 artifacts) for this build only. The committed build.yaml is untouched in the repo —
+      # this only rewrites the runner's checkout.
+      run: cp build-jf12.yaml build.yaml
+    - name: "JPRM: Build"
+      # No explicit version input: JPRM reads the version from build.yaml (now the JF12 metadata, 5.0.0),
+      # exactly as build.yml does for the JF10.11 stable path. The stable plugin version IS build-jf12.yaml's
+      # committed version and must equal the pushed tag's numeric prefix (5.0.0 <-> 5.0.0-JF12-stable);
+      # bump build-jf12.yaml per change class before tagging.
+      uses: oddstr13/jellyfin-plugin-repository-manager@9497a0a499416cc572ed2e07a391d9f943a37b4d # v1.1.1
+      with:
+        verbosity: debug
+        path: .
+        dotnet-target: "net10.0"
+        output: _dist
+    # CycloneDX SBOM of the net10 shipping closure, into the release staging dir so
+    # the checksum loop and `files: _dist/*` ship it as a release asset. Reads the
+    # --locked-mode restore above; the same single generator publish.yml uses.
+    - name: Generate CycloneDX SBOM
+      uses: ./.github/actions/cyclonedx-sbom
+      with:
+        output-dir: _dist
+    - name: Prepare GitHub Release assets
+      run: |-
+        pushd _dist
+        # ONLY the plugin zip gets a `.md5` — see the same note in publish-beta.yml. The
+        # manifest generator keeps the LAST asset ending in `.md5`, so a second one
+        # sorting after the plugin's becomes the published checksum and every install
+        # fails verification.
+        for file in ./*.zip; do
+          md5sum ${file#./} > ${file%.*}.md5
+          sha256sum ${file#./} > ${file%.*}.sha256
+        done
+        sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
+        ls -l
+        popd
+    - name: Publish output artifacts
+      id: publish-assets
+      # Full stable release in ONE shot (prerelease: false), matching publish.yml — no draft flow. The
+      # git TAG is the pushed X.Y.Z-JF12-stable; the release NAME is that same tag. build.yaml (the JF12
+      # metadata) ships as an asset so the SHARED manifest-release picks up THIS release's targetAbi
+      # (12.0.0.0); without it the manifest would fall back to the repo's JF10.11 build.yaml and mislabel
+      # the 5.0 build. fail_on_unmatched_files stays true so a missing build asset fails the run rather
+      # than publishing an empty release.
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+      with:
+          name: ${{ github.ref_name }}
+          prerelease: false
+          # Always auto-generate the release notes from the merged PRs/commits since the previous tag.
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          tag_name: ${{ github.ref_name }}
+          # Anchor the tag AND the auto-generated notes to the built commit (#627). Without this the
+          # create-release API defaults target_commitish to the repository DEFAULT branch, which tags the
+          # wrong commit and makes generate_release_notes diff the wrong range. github.sha is the commit
+          # the pushed X.Y.Z-JF12-stable tag points at.
+          target_commitish: ${{ github.sha }}
+          files: |
+            _dist/*
+            build.yaml
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish Plugin Manifest
+      # ignorePrereleases: true — the STABLE channel. Regenerates the SHARED manifest-release from all
+      # full (non-prerelease) releases: both this JF12 build (5.0.0, targetAbi 12.0.0.0) and the JF10.11
+      # stable releases from publish.yml (4.x, targetAbi 10.11.0.0). Each release ships its own build.yaml,
+      # so every version lands in the manifest with its correct targetAbi and a Jellyfin server installs
+      # only the build matching its generation.
+      uses: ./.github/actions/generate-manifest
+      with:
+        plugin-metadata: _dist/*.zip.meta.json
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-release
+        include-prereleases: "false"
+        github-token: ${{ github.token }}
+    - name: Verify the published manifest
+      # Post-publish DETECTOR for the class of "the manifest ships a checksum that matches
+      # nothing" (#942) — it turns a silent, user-facing install outage into a red build.
+      # It does not prevent: the release is already sealed and the manifest already written
+      # by the time it runs.
+      uses: ./.github/actions/verify-manifest
+      with:
+        repository: ${{ github.repository }}
+        manifest-branch: manifest-release
+        github-token: ${{ github.token }}
+        require-abis: "10.11.0.0 12.0.0.0"

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -1,4 +1,4 @@
-name: "SSO Authentication"
+name: "Community SSO for Jellyfin"
 # Same plugin GUID as the JF10.11 build (build.yaml) — one plugin, so a JF12 server updates it in
 # place. The targetAbi below gates it to the 12.0 line, so a 10.11 server never offers this build and
 # vice versa (the two generations live in separate manifest branches, manifest-jf12-* vs manifest-*).
@@ -12,11 +12,19 @@ version: "5.0.0"
 targetAbi: "12.0.0.0"
 framework: "net10.0"
 owner: "iderex"
-overview: "Authenticate users against an SSO provider."
+# overview/description MUST stay word-identical with build.yaml's. Both beta legs regenerate the
+# SHARED manifest-beta branch and the manifest holds ONE plugin object taken from the publishing
+# leg's metadata — if the prose diverges, the catalogue entry flips between the two texts on
+# alternating nightly publishes and every regeneration commits a churn diff.
+overview: "Sign in to Jellyfin through OpenID Connect or SAML 2.0 identity providers."
 description: |
-  This plugin allows users to sign in through an SSO provider (such as Google, Facebook, or your own provider). This enables one-click signin.
-  SSO sign-in works in the Jellyfin Web UI and in clients that support Quick Connect.
-  Review documentation at https://github.com/iderex/jellyfin-plugin-sso
+  Single sign-on for Jellyfin via OpenID Connect and SAML 2.0 — works with self-hosted and
+  managed identity providers such as Authelia, Authentik, Keycloak, Pocket ID and Kanidm,
+  with multiple providers side by side.
+  Role-based access from provider claims (login, administrator, library folders, Live TV),
+  avatar sync, self-service account linking, and an optional SSO-only mode that disables
+  password login for every account except a designated break-glass admin.
+  Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
 category: "Authentication"
 # The net10 shipping closure, empirically from `dotnet publish -f net10.0` (#135). It differs from the
 # net9 list in build.yaml: on .NET 10 the SAML crypto assemblies (System.Security.Cryptography.Xml /


### PR DESCRIPTION
## What & why

Deploys the reviewed #947 manifest tooling to the branch that actually executes the JF12 legs. `nightly-betas.yml` dispatches the JF12 beta with `--ref 4.2`, so it runs **this branch's** workflow copy, which still ran the replaced third-party action against the shared `manifest-beta`, and `publish-jf12-stable.yml` did not exist here at all (a `5.0.0-JF12-stable` tag on a 4.2 commit would silently run nothing).

Without this port, the first commit landing on 4.2 wakes the nightly gate and the old generator overwrites the repaired `manifest-beta`: the SBOM checksum (#942) and the 30-release window (#943) restored, with no detector on this copy. This PR *is* that first commit, and it carries the fix with it.

## Contents (verbatim from the merged #947 state)

- `.github/actions/generate-manifest` + `verify-manifest`, plus `cyclonedx-sbom`, which the updated workflows call
- `publish-jf12-beta.yml` / `publish-jf12-stable.yml`, identical to main's copies
- `build-jf12.yaml`: the #913 rename (this line still built under the old name) and `overview`/`description` reconciled word-identical with `build.yaml`, pinned by comment, both beta legs write the shared `manifest-beta`, which holds one plugin object taken from the publishing leg, so divergent prose alternates the catalogue entry nightly

The next JF12 beta zip becomes `community-sso-for-jellyfin_5.0.0.<n>.zip`; the generator pairs checksums by name, so the rename cannot recreate #942's alphabetical-ordering failure. The generator itself was empirically verified on #947 (live-repository generation byte-compared, 29/29 artifact checksums, five negative tests); this PR adds no logic, the port's own risk is wiring, and the post-publish `verify-manifest` step (expect-version + ABI-shrink check) now guards this leg too.

Refs #943, #944, #942.
