### PR TITLE
Skip blank configured role entries in all allow-list matching

### DIFF
--- a/SSO-Auth.Tests/Authz/PermissionRolePolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/PermissionRolePolicyTests.cs
@@ -300,4 +300,37 @@ public class PermissionRolePolicyTests
     {
         Assert.Equal(PermissionRolePolicy.PermissionNameStatus.Empty, PermissionRolePolicy.Classify(permission));
     }
+
+    /// <summary>
+    /// A blank configured mapping role must never be satisfiable (#935): the save-path validator checks
+    /// only the permission NAME, so a hand-edited or imported config XML can carry a blank Roles entry,
+    /// and a blank identity-provider role is producible via a terminal array element <c>""</c> or (since
+    /// #934) an object-map property named <c>""</c>. Without the blank-skip the mapping would GRANT the
+    /// permission on that phantom match instead of falling through to the explicit revoke.
+    /// </summary>
+    /// <param name="blankEntry">The blank configured mapping-role variant.</param>
+    /// <param name="blankRole">The blank identity-provider role variant.</param>
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "")]
+    [InlineData("\t", "")]
+    [InlineData("   ", "   ")]
+    public void Map_BlankConfiguredRole_NeverMatchedByBlankRole_StillRevokes(string blankEntry, string blankRole)
+    {
+        var config = Config(enable: true, Map("EnableContentDownloading", blankEntry));
+
+        var grants = PermissionRolePolicy.Map(new[] { blankRole }, config);
+
+        // The mapping stays managed (explicit revoke) — the blank entry just can never grant it.
+        Assert.Equal(false, GrantFor(grants, PermissionKind.EnableContentDownloading));
+    }
+
+    [Fact]
+    public void Map_BlankEntryBesideRealRole_RealMatchingIsUnaffected()
+    {
+        var config = Config(enable: true, Map("EnableContentDownloading", string.Empty, "downloaders"));
+
+        Assert.Equal(true, GrantFor(PermissionRolePolicy.Map(new[] { "downloaders" }, config), PermissionKind.EnableContentDownloading));
+        Assert.Equal(false, GrantFor(PermissionRolePolicy.Map(new[] { string.Empty }, config), PermissionKind.EnableContentDownloading));
+    }
 }

--- a/SSO-Auth.Tests/Authz/RolePrivilegeMapperTests.cs
+++ b/SSO-Auth.Tests/Authz/RolePrivilegeMapperTests.cs
@@ -440,4 +440,63 @@ public class RolePrivilegeMapperTests
         Assert.False(result.EnableLiveTvManagement);
         Assert.Empty(result.Folders);
     }
+
+    /// <summary>
+    /// A blank configured allow-list entry must never be satisfiable (#935). The admin form filters
+    /// blank lines, but a hand-edited or imported configuration XML can carry one, and a blank
+    /// identity-provider role is producible via a terminal array element <c>""</c> or (since #934) an
+    /// object-map property named <c>""</c>. Blank-skip aligns the mapper with
+    /// <see cref="ParentalRatingPolicy"/> (which already skipped blank configured roles) and
+    /// <see cref="PermissionRolePolicy"/> (which gained the same skip in the same change).
+    /// </summary>
+    /// <param name="blankEntry">The blank configured entry variant.</param>
+    /// <param name="blankRole">The blank identity-provider role variant.</param>
+    [Theory]
+    [InlineData("", "")]
+    [InlineData("   ", "   ")]
+    [InlineData("", "   ")]
+    [InlineData("\t", "")]
+    public void Evaluate_BlankConfiguredEntry_NeverMatchedByBlankRole(string blankEntry, string blankRole)
+    {
+        var config = Oid(c =>
+        {
+            c.Roles = new[] { blankEntry };
+            c.AdminRoles = new[] { blankEntry };
+            c.EnableFolderRoles = true;
+            c.FolderRoleMapping = new List<FolderRoleMap>
+            {
+                new FolderRoleMap { Role = blankEntry, Folders = new List<string> { "movies" } },
+            };
+            c.EnableLiveTvRoles = true;
+            c.LiveTvRoles = new[] { blankEntry };
+            c.LiveTvManagementRoles = new[] { blankEntry };
+        });
+
+        var grants = RolePrivilegeMapper.Evaluate(new[] { blankRole }, config);
+
+        Assert.False(grants.Valid);
+        Assert.False(grants.Admin);
+        Assert.False(grants.EnableLiveTv);
+        Assert.False(grants.EnableLiveTvManagement);
+        Assert.Empty(grants.Folders);
+    }
+
+    [Fact]
+    public void Evaluate_BlankEntryBesideRealEntries_RealMatchingIsUnaffected()
+    {
+        // The blank entry is skipped, not the whole list: legitimate entries beside it keep matching,
+        // and a whitespace-carrying configured entry still requires the exact ordinal role (no new
+        // trimming is introduced for non-blank entries).
+        var config = Oid(c =>
+        {
+            c.Roles = new[] { string.Empty, "user" };
+            c.AdminRoles = new[] { "  ", " admin " };
+        });
+
+        var grants = RolePrivilegeMapper.Evaluate(new[] { "user", " admin " }, config);
+
+        Assert.True(grants.Valid);
+        Assert.True(grants.Admin);
+        Assert.False(RolePrivilegeMapper.Evaluate(new[] { "admin" }, config).Admin);
+    }
 }

--- a/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
+++ b/SSO-Auth/Api/Authz/PermissionRolePolicy.cs
@@ -195,6 +195,15 @@ internal static class PermissionRolePolicy
             }
 
             var trimmed = configured.Trim();
+
+            // A configured entry that trims to empty grants nothing (#935): a blank IdP role (a terminal
+            // array element "" or, since #934, an object-map property named "") must never satisfy a
+            // mapping — the same blank-skip RolePrivilegeMapper.IsOnList and ParentalRatingPolicy apply.
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
             foreach (var role in loginRoles)
             {
                 if (string.Equals(role, trimmed, StringComparison.Ordinal))

--- a/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
+++ b/SSO-Auth/Api/Authz/RolePrivilegeMapper.cs
@@ -51,7 +51,9 @@ internal static class RolePrivilegeMapper
                 {
                     // The configured (trusted, admin-authored) map-role is trimmed before comparison; the
                     // IdP-supplied role is compared raw, so there is no whitespace-injection vector (#367).
-                    if (string.Equals(role, folderRoleMap.Role?.Trim(), StringComparison.Ordinal) && folderRoleMap.Folders != null)
+                    // A blank configured map-role grants nothing — same blank-skip as IsOnList (#935).
+                    var mappedRole = folderRoleMap.Role?.Trim();
+                    if (!string.IsNullOrEmpty(mappedRole) && string.Equals(role, mappedRole, StringComparison.Ordinal) && folderRoleMap.Folders != null)
                     {
                         // A null Folders on a matching entry (a config/deserialization edge) grants nothing
                         // for it rather than throwing an ArgumentNullException — fail closed, like IsOnList (#675).
@@ -110,9 +112,14 @@ internal static class RolePrivilegeMapper
 
     // Whether the login's role is on a configured allow-list. Null-safe both ways (ordinal): a null list
     // or a null entry is simply not a match — never a NullReferenceException — so an admin misconfiguration
-    // or a stray null fails closed (grants nothing) instead of throwing a 500.
+    // or a stray null fails closed (grants nothing) instead of throwing a 500. A blank/whitespace
+    // configured entry is skipped too (#935): the admin form filters blank lines, but a hand-edited or
+    // imported config XML can carry one, and a blank IdP role (a terminal array element "" or, since
+    // #934, an object-map property named "") must never satisfy an allow-list — the same blank-skip
+    // ParentalRatingPolicy already applied and PermissionRolePolicy gained in the same change.
     private static bool IsOnList(IEnumerable<string>? allowed, string role) =>
-        allowed != null && allowed.Any(entry => string.Equals(role, entry, StringComparison.Ordinal));
+        allowed != null && allowed.Any(entry =>
+            !string.IsNullOrWhiteSpace(entry) && string.Equals(role, entry, StringComparison.Ordinal));
 
     /// <summary>
     /// The privileges a set of roles grants under a provider configuration.


### PR DESCRIPTION
## What & why

Closes #935, a blank configured allow-list entry was satisfiable by a blank identity-provider role. The admin form filters blank lines, but a hand-edited or imported config XML carries them through both supported paths, and a blank IdP role is producible via a terminal array element `""` or (since #934) an object-map property named `""`.

Two match sites closed:

- **`RolePrivilegeMapper.IsOnList`** (`Roles`, `AdminRoles`, `LiveTvRoles`, `LiveTvManagementRoles`) skips null/whitespace configured entries; the **folder-role mapping** skips a configured role trimming to empty.
- **`PermissionRolePolicy.MatchesAnyRole`** skips a configured mapping role trimming to empty. The issue's premise that this site already skipped blanks was **wrong**, the adversarial review caught it. The save-path validator checks only the permission NAME, so a blank `Roles` entry persists even through the validating endpoints; a blank IdP role could mint a `PermissionGrant` (bounded below admin, dedicated permissions are excluded from the generic map). A blank-only `Roles` list stays *managed*: the mapping still emits its explicit revoke; only the phantom grant is gone.

`ParentalRatingPolicy` already skipped blanks. `SamlLoginPolicy` already blocks the empty-string variant on both sides; its whitespace-only residual is #952 (markedly narrower producibility). The review swept every configured-list-vs-IdP-value comparison in `SSO-Auth/Api` (incl. `AcrPolicy`), no further site exists.

## Safety argument

Strictly deny-monotonic: both predicates now match on a strict subset of their previous inputs, and every consumer only ever sets a grant flag true on a match, no deny anywhere depended on a blank match. Non-blank matching is byte-identical (ordinal, no new trimming), pinned by the beside-real-entries tests. A blank-only `config.Roles` still counts as "RBAC configured" upstream (`Length != 0`), so the misconfigured provider fails closed to denial, not open.

## Verification

- TDD: the new negatives were written first and traced to fail against the pre-fix code (including the `"\t"` row an `IsOnList`-only fix would miss; the `PermissionRolePolicy` rows distinguish managed-revoke from absent via the tri-state helper).
- Full suite **3846/3846** on net9.0 + net10.0, stable across 3 consecutive runs.
- 3-lens adversarial gate (authz-bypass / correctness / integration): initial verdicts NEEDS_IMPROVEMENT ×2 (the `PermissionRolePolicy` gap + the then-false alignment comment) + PASS; both findings fixed; re-review **PASS ×2**. ASVS 5.0 V8.1.1 (deny by default).

Closes #935. Refs #952.
