### PR TITLE
Publish both betas from main; retire the stable channel until first stable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,9 +21,8 @@ name: CodeQL
 
 on:
   push:
-    # main is the released line; the release/dev branches are where feature work
-    # accumulates before promotion. 4.2 is the current one; the 4.* / 5.* globs
-    # future-proof the next release lines so a new branch is covered without
+    # main is the one code line (beta-only, #954; the 4.2 branch is retired). The
+    # 4.* / 5.* globs future-proof any later release branch so it is covered without
     # editing this file (a `*` matches any branch name that has no `/`, so plain
     # numeric release branches like 4.2 / 4.3 / 5.0 all match). A release line
     # that ever uses a non-numeric name must still be added here explicitly.

--- a/.github/workflows/nightly-betas.yml
+++ b/.github/workflows/nightly-betas.yml
@@ -2,9 +2,10 @@ name: Nightly betas
 
 # Publish betas on a daily cadence instead of on every push (#632). GitHub `schedule` events only run
 # a workflow from the DEFAULT branch, so this single scheduler lives on main and dispatches both beta
-# legs: publish-beta.yml (JF10.11, on main) and publish-jf12-beta.yml (JF12, on the 4.2 branch,
-# dispatched with --ref 4.2). Each dispatched workflow has its own gate job that skips the build unless
-# its branch has advanced since that lineage's last beta, so an unchanged day mints nothing.
+# legs: publish-beta.yml (JF10.11) and publish-jf12-beta.yml (JF12) — both from main since #954
+# consolidated the JF12/5.0 line onto the one multi-target codebase (the 4.2 branch is retired).
+# Each dispatched workflow has its own gate job that skips the build unless main has advanced since
+# that lineage's last beta, so an unchanged day mints nothing.
 on:
   schedule:
     - cron: "0 4 * * *" # 04:00 UTC, once daily
@@ -33,8 +34,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: gh workflow run publish-beta.yml --repo "$REPO" --ref main
-      - name: Trigger the JF12 beta (4.2)
+      - name: Trigger the JF12 beta (main)
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref 4.2
+        run: gh workflow run publish-jf12-beta.yml --repo "$REPO" --ref main

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -56,8 +56,15 @@ jobs:
       # and build. Skipping a real change is worse than an occasional duplicate beta.
       run: |
         set -uo pipefail
-        last_tag=$(gh api "repos/${REPO}/git/matching-refs/tags/5.0.0-JF12-beta." \
-          --jq 'map(.ref | sub("refs/tags/"; "")) | sort_by(split(".") | last | tonumber) | last // ""' 2>/dev/null || echo "")
+        # --paginate is load-bearing: the refs endpoint returns 30 per page in LEXICOGRAPHIC order,
+        # so once >30 JF12 beta tags exist the numerically-newest falls off page 1, the gate picks a
+        # stale tag, and an unchanged day mints a duplicate beta — every day, self-amplifying (each
+        # new tag sorts later and keeps the newest off-page). Same idiom as publish-beta.yml's gate:
+        # emit one tag per line across ALL pages, then sort numerically in the shell (a per-page jq
+        # max would be wrong — gh applies --jq per page, and the numeric max can sit on any page).
+        last_tag=$(gh api --paginate "repos/${REPO}/git/matching-refs/tags/5.0.0-JF12-beta." \
+          --jq '.[].ref | sub("refs/tags/"; "") | select(test("^5[.]0[.]0-JF12-beta[.][0-9]+$"))' 2>/dev/null \
+          | sort -t. -k4 -n | tail -1 || echo "")
         last_sha=""
         if [ -n "$last_tag" ]; then
           last_sha=$(gh api "repos/${REPO}/git/refs/tags/${last_tag}" --jq '.object.sha' 2>/dev/null || echo "")

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -1,21 +1,20 @@
 name: Publish JF12 Beta
 
 # The Jellyfin 12.0 (.NET 10) BETA channel — the 5.0 line (#135). Jellyfin 12.0 moves the server to
-# .NET 10 and a 10.11-ABI plugin will not load there, so upgraders need a 12-targeted build. The
-# multi-target codebase (net9.0;net10.0) lives on the `4.2` branch, so JF12 betas publish from 4.2:
-# every push to 4.2 builds the net10 target and publishes an installable prerelease into the SHARED
+# .NET 10 and a 10.11-ABI plugin will not load there, so upgraders need a 12-targeted build. Since
+# #954 the one multi-target codebase (net9.0;net10.0) lives on `main` and BOTH betas publish from it:
+# this leg builds the net10 target and publishes an installable prerelease into the SHARED
 # `manifest-beta` branch. Jellyfin filters plugin versions client-side by targetAbi, so one beta
 # manifest carries BOTH generations (4.x at targetAbi 10.11, 5.0 at 12.0) and each server installs only
-# its compatible build — no separate JF12 manifest is needed. (The JF10.11 beta is published from `main`
-# by publish-beta.yml; both regenerate the same manifest-beta from all prerelease releases.) When 4.2.0
-# releases (4.2 -> main), this leg moves to main with the multi-target codebase.
+# its compatible build — no separate JF12 manifest is needed. (The JF10.11 beta is published by
+# publish-beta.yml; both regenerate the same manifest-beta from all prerelease releases.)
 #
 # The JF12 build METADATA (version 5.0, targetAbi 12.0.0.0, framework net10.0, and the net10 shipping
 # closure) lives in build-jf12.yaml, which this job copies over build.yaml before JPRM builds — the
 # committed build.yaml stays the JF10.11 metadata.
-# No push trigger: a beta is no longer minted on every merge to 4.2 (that spammed one release per PR).
+# No push trigger: a beta is no longer minted on every merge (that spammed one release per PR).
 # nightly-betas.yml (the scheduler on the default branch) dispatches this workflow once a day; the gate
-# job below then skips the build unless 4.2 has advanced since the last JF12 beta. Still manually
+# job below then skips the build unless main has advanced since the last JF12 beta. Still manually
 # runnable via workflow_dispatch.
 on:
   workflow_dispatch:
@@ -33,20 +32,21 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Publish only when 4.2 has advanced since the last JF12 beta, so a scheduled daily run on an
-  # unchanged branch does not mint a duplicate release. Compares the current 4.2 HEAD (github.sha) to
+  # Publish only when main has advanced since the last JF12 beta, so a scheduled daily run on an
+  # unchanged branch does not mint a duplicate release. Compares the current main HEAD (github.sha) to
   # the commit the newest 5.0.0-JF12-beta.<n> tag points at. If the base version is ever bumped (the
   # JF12 line is 5.0 for now) no tag matches, last_sha is empty, and the build proceeds — the safe
-  # default is to publish, never to silently skip a real change.
+  # default is to publish, never to silently skip a real change. (The first run after #954 moved this
+  # leg from the retired 4.2 branch always builds: the last tag points at a 4.2 commit, not main HEAD.)
   gate:
-    name: Gate on new 4.2 commits
+    name: Gate on new main commits
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
-    - name: Compare 4.2 HEAD to the last JF12 beta
+    - name: Compare main HEAD to the last JF12 beta
       id: check
       env:
         GH_TOKEN: ${{ github.token }}
@@ -62,7 +62,7 @@ jobs:
         if [ -n "$last_tag" ]; then
           last_sha=$(gh api "repos/${REPO}/git/refs/tags/${last_tag}" --jq '.object.sha' 2>/dev/null || echo "")
         fi
-        echo "current 4.2 HEAD: ${CUR}"
+        echo "current main HEAD: ${CUR}"
         echo "last JF12 beta:   ${last_tag:-<none>} -> ${last_sha:-<none>}"
         if [ -n "$last_sha" ] && [ "$last_sha" = "$CUR" ]; then
           echo "No new commits since the last JF12 beta; skipping the build."
@@ -173,13 +173,12 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
           tag_name: ${{ steps.version.outputs.base }}-JF12-beta.${{ github.run_number }}
-          # Anchor the tag to the 4.2 commit this build ran on. Without this, the create-release API
-          # defaults target_commitish to the repository DEFAULT branch (main) — which is not where JF12
-          # publishing happens — so every JF12 beta tag was created on main's stale HEAD (stuck at #606)
-          # instead of the 4.2 commit that triggered the run. That made generate_release_notes compute
-          # its "What's Changed" from main's history (always the last main-merge, #606) rather than the
-          # 4.2 changes actually shipped. Pinning it to github.sha (the pushed 4.2 commit) tags the
-          # correct commit and lets the auto-notes diff the real 4.2 range against the previous JF12 beta.
+          # Anchor the tag to the exact commit this build ran on (#627 class). Without this the
+          # create-release API defaults target_commitish to the default branch's CURRENT head, which
+          # can have advanced past the dispatched commit by publish time — the tag would then name a
+          # commit this build did not ship and generate_release_notes would diff the wrong range.
+          # (Historically this leg ran from the retired 4.2 branch, where the default was outright
+          # wrong; pinning github.sha is correct on main too, so it stays.)
           target_commitish: ${{ github.sha }}
           files: |
             _dist/*

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -2,7 +2,7 @@ name: unicode-guard
 
 on:
   # Every branch and every PR: the guard is a cheap read-only scan and must cover
-  # the shipping release branches (e.g. 4.2, which ships JF12 betas), not just main.
+  # any future release branch too, not just main (one code line since #954).
   push:
     branches: ["**"]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -107,19 +107,18 @@ Jellyfin upstream is building [native OIDC](https://github.com/jellyfin/jellyfin
 
 **Add this plugin's repository, then install from the in-app catalog (recommended for testing):**
 
-1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add the repository URL for the channel you want. **One URL serves both Jellyfin generations** — your server installs the matching build automatically. Add **one** of these:
+1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add this repository URL. **One URL serves both Jellyfin generations** — your server installs the matching build automatically:
 
-   | Channel    | Repository URL                                                                                |
-   | ---------- | --------------------------------------------------------------------------------------------- |
-   | **stable** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json` |
-   | **beta**   | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`    |
-   - **stable** ships tagged releases only. **beta** publishes on a daily schedule (04:00 UTC) whenever `main` has advanced since the last beta, so betas move fast and may break — use them for testing, not production.
-   - Each manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. Jellyfin 12.0 support is currently **beta only** and **not yet validated against a live 12.0 server** (none exists at GA quality to test against): the JF12/5.0 line is CI-built and unit-tested but sits outside the 4.x release-candidate gate, and it clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available (the stable 12.0 build lands at a 12.0 stable release).
+   | Channel  | Repository URL                                                                             |
+   | -------- | ------------------------------------------------------------------------------------------ |
+   | **beta** | `https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json` |
+   - This project is **beta software — the beta channel is the only release channel** for now. Betas publish on a daily schedule (04:00 UTC) whenever `main` has advanced since the last beta. A stable channel opens when the project reaches its first stable release; the former stable manifest has been emptied so it cannot offer outdated builds (if you still have it configured, switch to the beta URL above to keep receiving updates).
+   - The manifest lists builds for **both Jellyfin 10.11** (.NET 9) and **Jellyfin 12.0** (.NET 10). Jellyfin filters by the plugin's target ABI, so your server is only ever offered the build that runs on it — you don't pick the generation, it does. The JF12/5.0 line is **not yet validated against a live 12.0 server** (none exists at GA quality to test against): it is CI-built and unit-tested and clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available.
 
 2. Go to **Dashboard → Plugins → Catalog**, find **Community SSO for Jellyfin**, and install it.
 3. **Restart Jellyfin** to load the plugin.
 
-The plugin GUID is unchanged from the original `9p4` plugin, so a new version installs over an existing one in place and keeps your existing configuration. To switch channels, replace the repository URL and let the catalog offer the other channel's build.
+The plugin GUID is unchanged from the original `9p4` plugin, so a new version installs over an existing one in place and keeps your existing configuration.
 
 **Build from source (alternative):**
 
@@ -131,7 +130,7 @@ Copy the **full publish output** (`SSO-Auth.dll` and every dependency DLL beside
 
 **Client support:** SSO sign-in runs in the Jellyfin **Web UI** and in clients that support **Quick Connect** (the mobile and TV apps drive the login through Quick Connect). A native client that does not support Quick Connect cannot complete the browser redirect flow — use the Web UI or a Quick Connect client there.
 
-**Coming from the old plugin repository?** This project is the maintained continuation of the archived `9p4/jellyfin-plugin-sso`. If your Jellyfin still points at the old `9p4` manifest — or at any other now-dead SSO manifest URL, such as a former `jellyfin-plugin-sso-V2` one — it will not receive updates from here. Packaged releases have resumed: replace the stale plugin-repository URL with the 10.11 stable manifest (`https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-release/manifest.json`) under **Dashboard → Plugins → Repositories**, then install **Community SSO for Jellyfin** from the catalog. The plugin GUID is unchanged, so it updates in place and keeps your existing configuration.
+**Coming from the old plugin repository?** This project is the maintained continuation of the archived `9p4/jellyfin-plugin-sso`. If your Jellyfin still points at the old `9p4` manifest — or at any other now-dead SSO manifest URL, such as a former `jellyfin-plugin-sso-V2` one — it will not receive updates from here. Packaged releases have resumed: replace the stale plugin-repository URL with the beta manifest (`https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json`) under **Dashboard → Plugins → Repositories**, then install **Community SSO for Jellyfin** from the catalog. The plugin GUID is unchanged, so it updates in place and keeps your existing configuration.
 
 ## Configuration
 

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -26,6 +26,8 @@ description: |
   avatar sync, self-service account linking, and an optional SSO-only mode that disables
   password login for every account except a designated break-glass admin.
   Sign-in works in the Jellyfin Web UI and, via Quick Connect, in native clients.
+  A security-first continuation of the archived 9p4/jellyfin-plugin-sso.
+  Documentation and provider setup guides: https://github.com/iderex/jellyfin-plugin-sso
 category: "Authentication"
 # The net10 shipping closure, empirically from `dotnet publish -f net10.0` (#135). It differs from the
 # net9 list in build.yaml: on .NET 10 the SAML crypto assemblies (System.Security.Cryptography.Xml /

--- a/build-jf12.yaml
+++ b/build-jf12.yaml
@@ -1,7 +1,8 @@
 name: "Community SSO for Jellyfin"
 # Same plugin GUID as the JF10.11 build (build.yaml) — one plugin, so a JF12 server updates it in
-# place. The targetAbi below gates it to the 12.0 line, so a 10.11 server never offers this build and
-# vice versa (the two generations live in separate manifest branches, manifest-jf12-* vs manifest-*).
+# place. The targetAbi below gates it to the 12.0 line: both generations share one manifest branch
+# per channel and Jellyfin filters client-side, so a 10.11 server never offers this build and vice
+# versa.
 guid: "505ce9d1-d916-42fa-86ca-673ef241d7df"
 imageUrl: "https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/logo.png"
 # The JF12 (5.0) line's target version. The beta workflow overrides this to 5.0.0.<run> at build time;


### PR DESCRIPTION
## What & why

Decision (#954): the software is beta, one code line, beta-only releases.

- **JF12 betas build from `main`.** `main` has been the multi-target codebase (net9.0;net10.0, per-TFM Jellyfin refs 10.11.11 / 12.0.0-rc2, per-TFM OidcClient 6.0.1/7.1.0) since #135/#743, only the nightly dispatch still pointed at the retired `4.2` branch, which froze JF12 users on 4.2.1-era code for 365 commits of `main`. Now `nightly-betas.yml` dispatches `--ref main`.
- **Closure verified empirically:** `dotnet publish -f net10.0` on `main` produces exactly the dependency set `build-jf12.yaml`'s artifacts list ships (the Jellyfin/server assemblies excluded, the crypto-XML set correctly absent on net10 where it is framework-provided).
- **Gate semantics:** the first run from `main` always builds (the last JF12 tag points at a 4.2 commit, never `main` HEAD, the inequality fires); afterwards the gate compares `main` HEAD as before. The `target_commitish` pin stays, correct on `main` too, since the default-branch head can advance past the dispatched commit by publish time.
- **README installs beta-only:** stable row removed, beta-software status stated, migration note points at the beta manifest. After merge, `manifest-release` is emptied so the stable URL cannot offer `4.2.1-stable`, which ships the vulnerable `System.Security.Cryptography.Xml` 10.0.9 DLL (#890's fix never reached a stable release). The stable publish legs stay dormant (tag-gated) for the eventual first stable.
- `build-jf12.yaml`: stale `manifest-jf12-*` note corrected (one manifest branch per channel, ABI-filtered client-side).

## Rollout (after merge)

1. Dispatch the JF12 beta from `main` and verify the published `manifest-beta` end to end (new entry's checksum vs the real artifact, both ABIs present).
2. Empty `manifest-release`.
3. Delete branch `4.2` (release tags remain).

Refs #954, #944, #890.
