### PR TITLE
Treat whitespace-only SAML roles as blank in the login allow-list

### DIFF
--- a/SSO-Auth.Tests/Saml/SamlLoginPolicyTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLoginPolicyTests.cs
@@ -54,4 +54,41 @@ public class SamlLoginPolicyTests
         Assert.False(SamlLoginPolicy.IsLoginAllowed(new string?[] { null }, new string?[] { null }));
         Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "" }, new[] { "" }));
     }
+
+    /// <summary>
+    /// The whitespace variant of the blank class (#952, follow-up to #935): a whitespace-only
+    /// configured entry (hand-edited or imported config XML) must not be satisfiable by a
+    /// whitespace-only assertion role — XML text nodes preserve whitespace and the assertion
+    /// roles are compared raw, so the pair is producible. Aligns SAML login validity with the
+    /// OIDC allow-list, which skips whitespace-only entries since #935.
+    /// </summary>
+    /// <param name="configured">The blank configured entry variant.</param>
+    /// <param name="asserted">The blank assertion-role variant.</param>
+    [Theory]
+    [InlineData("   ", "   ")]
+    [InlineData("\t", "\t")]
+    [InlineData(" ", " ")]
+    public void WhitespaceOnlyRolesNeverAuthorize(string configured, string asserted)
+    {
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { asserted }, new[] { configured }));
+    }
+
+    [Fact]
+    public void WhitespaceOnlyAllowList_StillCountsAsConfigured_AndDeniesRealRoles()
+    {
+        // A list holding only a blank entry is a misconfiguration, and it fails CLOSED: it does not
+        // fall into the RBAC-off early return (Length > 0), so a real asserted role is denied.
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "jellyfin" }, new[] { "   " }));
+    }
+
+    [Fact]
+    public void WhitespaceEntryBesideRealEntry_RealMatchingIsUnaffected()
+    {
+        // The blank entry is skipped per-entry, not per-list, and no trimming is introduced for
+        // non-blank values: an entry carrying inner/outer whitespace still requires the exact
+        // ordinal role.
+        Assert.True(SamlLoginPolicy.IsLoginAllowed(new[] { "jellyfin" }, new[] { "   ", "jellyfin" }));
+        Assert.True(SamlLoginPolicy.IsLoginAllowed(new[] { " jellyfin " }, new[] { " jellyfin " }));
+        Assert.False(SamlLoginPolicy.IsLoginAllowed(new[] { "jellyfin" }, new[] { " jellyfin " }));
+    }
 }

--- a/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
+++ b/SSO-Auth/Api/Saml/SamlLoginPolicy.cs
@@ -33,14 +33,17 @@ internal static class SamlLoginPolicy
         {
             foreach (var role in assertionRoles)
             {
-                // Skip empty/null role values so a missing role can never satisfy the allow-list
-                // (a null/empty on both sides must not authorize).
-                if (string.IsNullOrEmpty(role))
+                // Skip blank (null/empty/whitespace-only) role values so a missing role can never
+                // satisfy the allow-list. Whitespace counts as blank (#952): XML text nodes preserve
+                // whitespace and assertion roles are compared raw, so a whitespace-only configured
+                // entry (hand-edited/imported config) paired with a whitespace-only asserted value
+                // must not authorize — the same blank definition the OIDC allow-list applies (#935).
+                if (string.IsNullOrWhiteSpace(role))
                 {
                     continue;
                 }
 
-                if (allowedRoles.Any(allowed => !string.IsNullOrEmpty(allowed) && string.Equals(allowed, role, StringComparison.Ordinal)))
+                if (allowedRoles.Any(allowed => !string.IsNullOrWhiteSpace(allowed) && string.Equals(allowed, role, StringComparison.Ordinal)))
                 {
                     return true;
                 }


### PR DESCRIPTION
## What & why

Closes #952 (follow-up to #935): `SamlLoginPolicy.IsLoginAllowed` skipped only null/empty role values, so a **whitespace-only** configured allow-list entry (hand-edited or imported config XML) was satisfiable by a whitespace-only SAML assertion value, XML text nodes preserve whitespace and assertion roles are compared raw. The blank-skip widens to `IsNullOrWhiteSpace` on **both** sides, so SAML and OIDC login validity now apply the same blank definition (#935).

## Safety argument

- **Strictly deny-monotonic:** `IsNullOrEmpty ⇒ IsNullOrWhiteSpace`, so the accepting set only shrinks; the only flipped inputs are whitespace-only↔whitespace-only pairs (allowed → denied).
- **Fails closed on the misconfigured list:** a whitespace-only-entry-only list still has `Length > 0`, so RBAC stays on and a real asserted role is denied (lockout, not fall-open), pinned by test.
- **No new trimming:** an entry carrying whitespace around a real value still requires the exact ordinal role, pinned by test.
- **Enforcement point:** the callback is the single structural gate; the session-minting endpoint accepts only the one-time outcome-store token that witnesses a passed gate (#528).

## Verification

TDD (3 whitespace rows red pre-fix, 6 failures across both TFMs), suite **3854/3854** on net9.0+net10.0, authz-bypass lens **PASS** (deny-monotonicity, call-site trace, revert detection). ASVS 5.0 V8.1.1.
