### PR TITLE
Pin every SsoAudit emission: shape, level, CRLF-strip, emission points

### DIFF
--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -10,10 +10,13 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for <see cref="SsoAudit"/> — the structured security audit-log entries. Focused on the
-/// insecure-options warning (#140): it must fire at Warning level, name the provider and the enabled
-/// options, and strip line endings from the (route/admin-supplied) provider name so it cannot forge
-/// or split a log entry.
+/// Tests for <see cref="SsoAudit"/> — the structured security audit-log entries (#928 U1). Every
+/// method is pinned on three properties: the level it fires at, the "[SSO Audit]" prefix plus its
+/// key fields, and the inline line-ending strip on EVERY caller-supplied string so an identity-
+/// provider- or admin-supplied value can never forge or split an entry. The sensitive-data posture
+/// is structural — the signatures accept no secret, token, NameID or SessionIndex — and the fixed-
+/// code discipline (reason codes are enum names/constants, never request-derived text) is asserted
+/// where a code parameter exists.
 /// </summary>
 public class SsoAuditTests
 {
@@ -43,5 +46,193 @@ public class SsoAuditTests
         var message = Assert.Single(logger.Entries).Message;
         Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
         Assert.Contains("corpInjected", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoginSucceeded_LogsInformation_NamingUserProtocolProviderAndAdminFlag()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.LoginSucceeded(logger, "OpenID", "corp", "alice", isAdmin: true);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("alice", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corp", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("admin=True", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoginSucceeded_StripsLineEndings_FromUsernameAndProvider()
+    {
+        var logger = new CapturingLogger();
+
+        // Both the username (IdP-derived) and the provider (route/admin input) are foreign values.
+        SsoAudit.LoginSucceeded(logger, "SAML", "corp\nX", "ali\r\nce", isAdmin: false);
+
+        var message = Assert.Single(logger.Entries).Message;
+        Assert.DoesNotContain("\n", message, StringComparison.Ordinal);
+        Assert.Contains("alice", message, StringComparison.Ordinal);
+        Assert.Contains("corpX", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProvisionedPendingApproval_LogsWarning_SayingNoSessionWasIssued()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.ProvisionedPendingApproval(logger, "OpenID", "corp", "newbie\r\nX");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("newbieX", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("no session issued", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AccountAdopted_LogsWarning_NamingTheAdoptedAccountAndStrippingLineEndings()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.AccountAdopted(logger, "SAML", "corp\rX", "vic\ntim");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("victim", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpX", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("AllowExistingAccountLink", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ProviderConfiguredAndRemoved_LogInformation_AndStripTheProviderName(bool configured)
+    {
+        var logger = new CapturingLogger();
+
+        if (configured)
+        {
+            SsoAudit.ProviderConfigured(logger, "OpenID", "corp\r\nX");
+        }
+        else
+        {
+            SsoAudit.ProviderRemoved(logger, "OpenID", "corp\r\nX");
+        }
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(configured ? "configured" : "removed", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpX", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PkceNotAdvertised_LogsWarning_PointingAtRequirePkce_AndStripsTheProviderName()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.PkceNotAdvertised(logger, "corp\nX");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpX", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("RequirePkce", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ConfigImported_LogsWarning_WithTheMergedProviderCounts()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.ConfigImported(logger, oidProviders: 2, samlProviders: 1);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("2 OpenID", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("1 SAML", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("re-entered", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogoutRequested_LogsInformation_WithProviderAndCountOnly()
+    {
+        var logger = new CapturingLogger();
+
+        SsoAudit.LogoutRequested(logger, "corp\r\nX", usersRevoked: 3);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Information, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpX", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("3 user(s)", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LogoutRejected_LogsWarning_WithTheFixedReasonCode_AndNoSessionTerminated()
+    {
+        var logger = new CapturingLogger();
+
+        // The reason is a FIXED code (an enum member name), never request-derived text — the caller
+        // contract SSOControllerSamlLogoutTests pins from the validator side.
+        SsoAudit.LogoutRejected(logger, "corp\nX", "Replay");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpX", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("Replay", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("No session was terminated", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryEntry_CarriesTheFilterablePrefix_AndInformationLevelEmissionsRespectIsEnabled()
+    {
+        // The IsEnabled guard exists so the inline sanitizer is not evaluated when the level is off
+        // (CA1873); a disabled level must emit NOTHING rather than an unsanitized fallback.
+        var off = new LevelFilteredLogger(minimum: LogLevel.Error);
+
+        SsoAudit.LoginSucceeded(off, "OpenID", "corp", "alice", isAdmin: false);
+        SsoAudit.ProviderConfigured(off, "OpenID", "corp");
+        SsoAudit.LogoutRequested(off, "corp", 1);
+        SsoAudit.ProvisionedPendingApproval(off, "OpenID", "corp", "u");
+        SsoAudit.AccountAdopted(off, "OpenID", "corp", "u");
+        SsoAudit.PkceNotAdvertised(off, "corp");
+        SsoAudit.LogoutRejected(off, "corp", "Replay");
+
+        Assert.Empty(off.Entries);
+    }
+
+    private sealed class LevelFilteredLogger : ILogger
+    {
+        private readonly LogLevel _minimum;
+
+        internal LevelFilteredLogger(LogLevel minimum) => _minimum = minimum;
+
+        internal System.Collections.Generic.List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+        public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull => null!;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _minimum;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                Entries.Add((logLevel, formatter(state, exception)));
+            }
+        }
     }
 }

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -43,7 +43,7 @@ public class LoginCompletionServiceTests
     private static readonly Guid Existing = Guid.Parse("11111111-1111-1111-1111-111111111111");
 
 
-    private static (LoginCompletionService Service, PluginConfiguration Config, IUserManager Users, ISessionManager Sessions) Build(Action<PluginConfiguration> seed)
+    private static (LoginCompletionService Service, PluginConfiguration Config, IUserManager Users, ISessionManager Sessions) Build(Action<PluginConfiguration> seed, CapturingLogger? auditLog = null)
     {
         var cfg = new PluginConfiguration();
         seed(cfg);
@@ -55,7 +55,7 @@ public class LoginCompletionServiceTests
         var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
         var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
         var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
-        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, new CapturingLogger()), cfg, users, sessions);
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, auditLog ?? new CapturingLogger()), cfg, users, sessions);
     }
 
     private static AuthResponse Response() =>
@@ -102,6 +102,49 @@ public class LoginCompletionServiceTests
         Assert.NotNull(captured);
         Assert.Equal(Created, captured!.UserId);
         Assert.Equal("203.0.113.9", captured.RemoteEndPoint);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_SuccessfulMint_EmitsExactlyOneLoginSucceededAuditLine()
+    {
+        // The emission point (#928 U1): a session actually minted must leave exactly one
+        // "[SSO Audit] Login succeeded" line naming the user and provider — and never the subject
+        // key, which is an identity-provider identifier.
+        var config = new OidConfig { Enabled = true };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, sessions) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        var created = TestUsers.Named("alice", Created);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Created).Returns(created);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var audit = Assert.Single(auditLog.Entries, e => e.Message.Contains("[SSO Audit] Login succeeded", StringComparison.Ordinal));
+        Assert.Contains("alice", audit.Message, StringComparison.Ordinal);
+        Assert.Contains("kc", audit.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", audit.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CompleteAsync_RefusedLogin_EmitsNoLoginSucceededAuditLine()
+    {
+        // The inverse pin: a refusal must not write a success line — the audit trail's integrity
+        // depends on the line meaning "a session was issued", nothing weaker.
+        var config = new OidConfig { Enabled = true, ProvisionNewUsersDisabled = true };
+        var auditLog = new CapturingLogger();
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = config, auditLog);
+        var created = TestUsers.Named("alice", Created);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Created).Returns(created);
+
+        await service.CompleteAsync(
+            OidcIdentity("kc", "sub-1", "alice"), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.DoesNotContain(auditLog.Entries, e => e.Message.Contains("Login succeeded", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -188,7 +188,7 @@ public class CanonicalLinkServiceTests
     [Fact]
     public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
     {
-        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var (service, cfg, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
         users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
         users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
 
@@ -197,6 +197,13 @@ public class CanonicalLinkServiceTests
         Assert.Equal(Existing, resolved);
         await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+
+        // The adoption of a pre-existing account is a security-relevant event and must leave exactly
+        // one audit line naming the adopted account (#928 U1) — and never the subject key, which is
+        // an identity-provider identifier.
+        var audit = Assert.Single(log.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal) && e.Message.Contains("existing account", StringComparison.Ordinal));
+        Assert.Contains("alice", audit.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", audit.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
U1 of the #928 test-completeness epic, the audit found **9 of 14 `SsoAudit` methods without any test**.

- **Direct tests** for `LoginSucceeded`, `ProvisionedPendingApproval`, `AccountAdopted`, `ProviderConfigured/Removed`, `PkceNotAdvertised`, `ConfigImported`, `LogoutRequested`, `LogoutRejected`: each pins its level, the filterable `[SSO Audit]` prefix with the key fields, and the inline line-ending strip on **every** caller-supplied string (IdP-derived usernames included). A level-filtered logger pins the `IsEnabled` guard behaviorally: a disabled level emits nothing rather than an unsanitized fallback.
- **Emission points:** a successful mint emits exactly **one** Login-succeeded line naming user+provider and never the subject key; the refusal path emits none (the line must mean "a session was issued", nothing weaker); the adoption path emits exactly one adoption line, likewise without the subject key. The completion-service fixture gains an optional audit-logger parameter, no existing call site changes.
- Sensitive-data posture is structural (no secret/token/NameID/SessionIndex in any signature) and now negatively pinned at both emission points.

Suite **3882/3882** on both TFMs. Refs #928 (U1 ✔).