### PR TITLE
Make a forgotten rate-limit gate a red build; pin the 429 shapes

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2395,6 +2395,132 @@ public class ArchitectureConformanceTests
             .ToList();
     }
 
+    // Routes whose action MUST call RateLimitCheck (#928 U2): the anonymous login-path endpoints
+    // (challenge / callback / auth for both protocols, SP metadata, inbound SAML logout) and the
+    // admin endpoints that drive an OUTBOUND fetch (the OpenID connection tester and SAML metadata
+    // import — an authenticated admin must not be able to spin the outbound probe unthrottled), plus
+    // the account-link and unregister mutations. Adding a route here without wiring the gate fails the
+    // test; the reverse — an unclassified NEW route — fails EverySensitiveRoute_IsClassified below.
+    private static readonly string[] MustThrottleRoutes =
+    {
+        "OID/r/{provider}", "OID/redirect/{provider}", "OID/p/{provider}", "OID/start/{provider}",
+        "OID/Test/{provider}", "OID/Auth/{provider}",
+        "SAML/p/{provider}", "SAML/post/{provider}", "SAML/start/{provider}", "SAML/metadata/{provider}",
+        "SAML/Logout/{provider}", "SAML/ImportMetadata", "SAML/Auth/{provider}",
+        "Unregister/{username}", "{mode}/Link/{provider}/{jellyfinUserId}",
+        "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}",
+    };
+
+    // Routes deliberately NOT rate-limited, each with the reason it is safe: an elevation-gated admin
+    // operation with no outbound fetch, an authenticated user action, or a purely local (no-I/O) probe.
+    // Kept as an explicit allowlist so a NEW endpoint cannot be silently exempted — it must be added to
+    // one of the two lists, which is the classification decision this conformance test forces.
+    private static readonly string[] RateLimitExemptRoutes =
+    {
+        "OID/logout/{provider}", "SAML/logout/{provider}", // [Authorize] user logout, no fetch
+        "OID/Add/{provider}", "SAML/Add/{provider}", "OID/Del/{provider}", "SAML/Del/{provider}", // elevated config CRUD
+        "OID/Get", "SAML/Get", "OID/GetNames", "SAML/GetNames", "OID/States", // read-only listings
+        "SAML/Test/{provider}", // LOCAL certificate parse — no outbound fetch (unlike OID/Test)
+        "Config/Export", "Config/Import", // elevated config transfer
+        "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
+        "saml/links/{jellyfinUserId}", "oid/links/{jellyfinUserId}", // authenticated link listings
+        "{viewName}", // SSOViewsController: read-only embedded static asset (ETag/304), no I/O, no login path
+    };
+
+    [Fact]
+    public void EveryMustThrottleEndpoint_CallsTheRateLimitGate()
+    {
+        // #928 U2 — the structural half of "does every rate-limited endpoint actually rate-limit". The
+        // per-endpoint 429 response-shape tests prove the wiring behaves; this proves the wiring EXISTS on
+        // every endpoint that must have it, so the class of "a new login-path/outbound endpoint forgot the
+        // RateLimitCheck call" is a red build, not a review miss.
+        var actions = ControllerActionBlocks();
+        var missing = new List<string>();
+        foreach (var route in MustThrottleRoutes)
+        {
+            var block = actions.FirstOrDefault(a => a.Routes.Contains(route, StringComparer.Ordinal));
+            Assert.True(block.Routes is not null, $"MustThrottleRoutes lists '{route}', but no controller action declares that route — a route was renamed; update the list (#928).");
+            if (!block.Body.Contains("RateLimitCheck(SsoRateLimitClass.", StringComparison.Ordinal))
+            {
+                missing.Add(route);
+            }
+        }
+
+        Assert.True(
+            missing.Count == 0,
+            "These endpoints must call RateLimitCheck(SsoRateLimitClass.…) and do not: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void EverySensitiveRoute_IsClassified_AsThrottledOrExplicitlyExempt()
+    {
+        // The completeness guard: every controller route is in exactly one of the two lists. A NEW endpoint
+        // therefore cannot land without a deliberate decision on whether it needs rate limiting — the whole
+        // point of #928 U2's "no forgotten gate". Also fails on a stale list entry (a route no longer in
+        // the controller), so the lists cannot drift out of sync with the surface.
+        var declared = ControllerActionBlocks().SelectMany(a => a.Routes).ToList();
+        Assert.NotEmpty(declared);
+
+        var classified = MustThrottleRoutes.Concat(RateLimitExemptRoutes).ToHashSet(StringComparer.Ordinal);
+
+        var unclassified = declared.Where(r => !classified.Contains(r)).ToList();
+        Assert.True(
+            unclassified.Count == 0,
+            "These controller routes are in neither MustThrottleRoutes nor RateLimitExemptRoutes — classify each (does it need rate limiting?): " + string.Join(", ", unclassified));
+
+        var declaredSet = declared.ToHashSet(StringComparer.Ordinal);
+        var stale = classified.Where(r => !declaredSet.Contains(r)).ToList();
+        Assert.True(
+            stale.Count == 0,
+            "These routes are listed in a rate-limit classification list but no longer exist on the controller — remove them: " + string.Join(", ", stale));
+    }
+
+    // Every controller action as (its route templates, its method-body text): the body runs from an action's
+    // HTTP-attribute cluster to the next action's cluster, which is enough to see whether the (always-first)
+    // RateLimitCheck statement is present. Stacked route attributes on one method (consecutive lines) are one
+    // action. Route-template source scan, in the ControllerSourceFiles idiom (#388) so a controller split
+    // cannot hide an endpoint.
+    private static IReadOnlyList<(IReadOnlyList<string> Routes, string Body)> ControllerActionBlocks()
+    {
+        var attr = new Regex(
+            @"^\s*\[Http(?:Get|Post|Put|Delete)\(""(?<route>[^""]*)""\)\]");
+        var results = new List<(IReadOnlyList<string>, string)>();
+
+        foreach (var path in ControllerSourceFiles())
+        {
+            var lines = File.ReadAllLines(path);
+            var hits = new List<(int Line, string Route)>();
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var m = attr.Match(lines[i]);
+                if (m.Success)
+                {
+                    hits.Add((i, m.Groups["route"].Value));
+                }
+            }
+
+            // Group consecutive attribute lines (a method's stacked routes) into one action cluster.
+            for (var i = 0; i < hits.Count;)
+            {
+                var routes = new List<string> { hits[i].Route };
+                var last = i;
+                while (last + 1 < hits.Count && hits[last + 1].Line == hits[last].Line + 1)
+                {
+                    routes.Add(hits[last + 1].Route);
+                    last++;
+                }
+
+                var bodyStart = hits[last].Line;
+                var bodyEnd = last + 1 < hits.Count ? hits[last + 1].Line : lines.Length;
+                var body = string.Join("\n", lines.Skip(bodyStart).Take(bodyEnd - bodyStart));
+                results.Add((routes, body));
+                i = last + 1;
+            }
+        }
+
+        return results;
+    }
+
     [Fact]
     public void EverySourceFile_CarriesTheSpdxHeader()
     {

--- a/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Net;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// 429 response-shape pins for the login-path and outbound-fetch endpoints that were wired to the
+/// shared rate-limit gate but not individually characterised (#928 U2). Each drives its endpoint over
+/// the single-attempt budget and asserts the throttled response is byte-identical to the mapper's
+/// contract: a 429 with the fixed plain-text body and a Retry-After within the window. The structural
+/// "every such endpoint actually calls the gate" guarantee is <c>ArchitectureConformanceTests.
+/// EveryMustThrottleEndpoint_CallsTheRateLimitGate</c>; these prove the wiring produces the right wire
+/// response at each route. The already-pinned endpoints (SamlChallenge, OidCallback, Link, Unregister)
+/// keep their own tests; this fills the remainder.
+/// </summary>
+public class SSOControllerRateLimitTests
+{
+    private const string ThrottledBody = "Too many attempts. Please wait a moment and try again.";
+
+    private static SsoControllerHarness Throttling(IPAddress clientIp) => new SsoControllerHarness(
+        c =>
+        {
+            c.EnableRateLimit = true;
+            c.RateLimitMaxAttempts = 1;
+            c.RateLimitWindowSeconds = 60;
+        },
+        clientIp);
+
+    private static void AssertThrottled(SsoControllerHarness harness, ActionResult result)
+    {
+        var throttled = Assert.IsType<ContentResult>(result);
+        Assert.Equal(429, throttled.StatusCode);
+        Assert.Equal(ThrottledBody, throttled.Content);
+        Assert.Equal("text/plain", throttled.ContentType);
+
+        var retryAfter = harness.Controller.Response.Headers.RetryAfter.ToString();
+        Assert.True(
+            int.TryParse(retryAfter, out var seconds) && seconds >= 1 && seconds <= 60,
+            $"Retry-After must be whole seconds within the 60s window; was '{retryAfter}'.");
+    }
+
+    [Fact]
+    public async Task OidChallenge_OverRateLimit_Returns429()
+    {
+        // A dedicated public address per test so the process-static limiter counter is this test's alone.
+        var harness = Throttling(IPAddress.Parse("8.8.8.1"));
+
+        // The first call spends the single-attempt budget (the unknown provider then 400s, after the spend).
+        await harness.Controller.OidChallenge("does-not-exist");
+
+        AssertThrottled(harness, await harness.Controller.OidChallenge("does-not-exist"));
+    }
+
+    [Fact]
+    public async Task OidAuth_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.2"));
+
+        await harness.Controller.OidAuth("does-not-exist", new AuthResponse());
+
+        AssertThrottled(harness, await harness.Controller.OidAuth("does-not-exist", new AuthResponse()));
+    }
+
+    [Fact]
+    public async Task OidTest_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.3"));
+
+        await harness.Controller.OidTest("does-not-exist");
+
+        AssertThrottled(harness, await harness.Controller.OidTest("does-not-exist"));
+    }
+
+    [Fact]
+    public void SamlCallback_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.4"));
+
+        harness.Controller.SamlCallback("does-not-exist");
+
+        AssertThrottled(harness, harness.Controller.SamlCallback("does-not-exist"));
+    }
+
+    [Fact]
+    public void SamlMetadata_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.5"));
+
+        harness.Controller.SamlMetadata("does-not-exist");
+
+        AssertThrottled(harness, harness.Controller.SamlMetadata("does-not-exist"));
+    }
+
+    [Fact]
+    public async Task SamlLogout_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.6"));
+
+        await harness.Controller.SamlLogout("does-not-exist");
+
+        AssertThrottled(harness, await harness.Controller.SamlLogout("does-not-exist"));
+    }
+
+    [Fact]
+    public async Task SamlAuth_OverRateLimit_Returns429()
+    {
+        var harness = Throttling(IPAddress.Parse("8.8.8.7"));
+
+        await harness.Controller.SamlAuth("does-not-exist", new AuthResponse());
+
+        AssertThrottled(harness, await harness.Controller.SamlAuth("does-not-exist", new AuthResponse()));
+    }
+}


### PR DESCRIPTION
U2 of the #928 test-completeness epic. The audit found **8 of 13 `RateLimitCheck` fire points without a 429 test**, and, the structural half, **no test that a sensitive endpoint calls the gate at all**.

Two conformance tests over the controller source (`ControllerSourceFiles` idiom, so a controller split cannot hide an endpoint):

- **`EveryMustThrottleEndpoint_CallsTheRateLimitGate`**, every login-path endpoint (challenge/callback/auth both protocols, SP metadata, inbound SAML logout) and every outbound-fetch admin endpoint (`OID/Test`, `SAML/ImportMetadata`) plus the link/unregister mutations must contain a `RateLimitCheck` call. **Proven to bite:** deleting the gate from `SAML/metadata` reds the test, naming the endpoint.
- **`EverySensitiveRoute_IsClassified`**, every controller route is in exactly one of MustThrottle / explicitly-exempt, so a **new endpoint forces a rate-limit decision** and a stale entry also reds. The exempt list documents why each route is safe, incl. the LOCAL `SAML/Test` cert parse that, unlike `OID/Test`, drives no outbound fetch (a deliberate asymmetry, not a gap).

Plus **`SSOControllerRateLimitTests`**: 429 response-shape pins (fixed body, Retry-After within the window) for the 7 wired-but-unpinned endpoints.

Suite **3900/3900** on both TFMs. Refs #928 (U2 ✔).