### PR TITLE
Test the login-button hosted service and pin the SAML hostile-name route

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2522,6 +2522,45 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void EveryHarnessUsingTestClass_IsInTheNonParallelControllerCollection()
+    {
+        // The SsoControllerHarness constructor swaps the process-wide SSOPlugin.Instance and resets the
+        // OIDC/SAML static caches — two harness-based classes running in parallel therefore race each
+        // other (the exact intermittent 429→400 failure that motivated this rule, #928 U4). The
+        // "SSOController" collection (DisableParallelization) is the existing convention; this makes it
+        // self-enforcing: a NEW test class that constructs the harness without joining the collection is
+        // a red build naming the file, not a flaky suite three weeks later.
+        var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
+        var offenders = new List<string>();
+        foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            // Skip THIS file: it carries the scanned literal inside the rule itself, not a harness use.
+            if (IsBuildOutput(src) || Path.GetFileName(src) == "ArchitectureConformanceTests.cs")
+            {
+                continue;
+            }
+
+            var text = File.ReadAllText(src);
+            if (text.Contains("new SsoControllerHarness", StringComparison.Ordinal)
+                && !text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
+            {
+                offenders.Add(Path.GetFileName(src));
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every test class constructing SsoControllerHarness must carry [Collection(\"SSOController\")] (the harness swaps process-wide statics; parallel classes race). Missing in: " + string.Join(", ", offenders));
+
+        // Liveness sentinel: the scan must actually see the known harness users, or a harness rename has
+        // silently blinded it.
+        Assert.True(
+            Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories)
+                .Count(f => !IsBuildOutput(f) && File.ReadAllText(f).Contains("new SsoControllerHarness", StringComparison.Ordinal)) >= 10,
+            "The harness-usage scan matched fewer than 10 files — SsoControllerHarness was renamed; update this rule.");
+    }
+
+    [Fact]
     public void EverySourceFile_CarriesTheSpdxHeader()
     {
         // #747: every C# source file opens with the SPDX copyright + licence header, so the licence of any

--- a/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
@@ -20,6 +20,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// response at each route. The already-pinned endpoints (SamlChallenge, OidCallback, Link, Unregister)
 /// keep their own tests; this fills the remainder.
 /// </summary>
+[Collection("SSOController")]
 public class SSOControllerRateLimitTests
 {
     private const string ThrottledBody = "Too many attempts. Please wait a moment and try again.";

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
@@ -68,6 +68,19 @@ public class LoginButtonInjectorTests
     }
 
     [Fact]
+    public void BuildBlock_HtmlEncodesAHostileName_OnTheSamlStartRouteToo()
+    {
+        // The SAML sibling of the pin above (#928 U4): the encoding runs through the shared builder, but the
+        // SAML start route was only ever asserted with a clean name — this pins the hostile case per route so
+        // a route-specific regression cannot hide behind the shared-code argument.
+        var block = LoginButtonInjector.BuildBlock(One("a\"b<c", "a\"b<c", LoginButtonProtocol.Saml));
+
+        Assert.DoesNotContain("<c", block, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\"b", block, System.StringComparison.Ordinal);
+        Assert.Contains("/sso/SAML/start/a%22b%3Cc", block, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Merge_AppendsWhenNoRegionExists_PreservingAdminContent()
     {
         var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonManagerTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonManagerTests.cs
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Model.Branding;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="LoginButtonManager"/> — the hosted service that keeps the login-page branding
+/// disclaimer in sync with the configured providers (#722), previously entirely untested (#928 U4).
+/// Pinned: the startup sync writes the managed block, the write-guard skips the branding save when the
+/// merge changes nothing, a configuration-change event re-syncs, StopAsync unsubscribes (a later event
+/// writes nothing), and a branding-store failure is swallowed (a branding problem must never block
+/// startup or a config save).
+/// </summary>
+public class LoginButtonManagerTests
+{
+    private static (LoginButtonManager Manager, IServerConfigurationManager Branding, BrandingOptions Options, SsoControllerHarness Harness) Build(
+        Action<PluginConfiguration>? configure = null, string? existingDisclaimer = null)
+    {
+        // The harness constructs SSOPlugin and sets the static Instance the manager reads.
+        var harness = new SsoControllerHarness(configure);
+        var options = new BrandingOptions { LoginDisclaimer = existingDisclaimer };
+        var branding = Substitute.For<IServerConfigurationManager>();
+        branding.GetConfiguration("branding").Returns(options);
+        return (new LoginButtonManager(branding, NullLogger<LoginButtonManager>.Instance), branding, options, harness);
+    }
+
+    private static void EnableButtons(PluginConfiguration c)
+    {
+        c.ManageLoginPageButtons = true;
+        c.OidConfigs["corp"] = new OidConfig { Enabled = true };
+    }
+
+    [Fact]
+    public async Task StartAsync_WithAManagedProvider_WritesTheButtonBlockIntoTheDisclaimer()
+    {
+        var (manager, branding, options, _) = Build(EnableButtons);
+
+        await manager.StartAsync(CancellationToken.None);
+
+        Assert.NotNull(options.LoginDisclaimer);
+        Assert.Contains("corp", options.LoginDisclaimer, StringComparison.Ordinal);
+        Assert.Contains("/sso/OID/start/corp", options.LoginDisclaimer, StringComparison.Ordinal);
+        branding.Received(1).SaveConfiguration("branding", options);
+
+        await manager.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StartAsync_WhenTheMergeChangesNothing_PerformsNoBrandingSave()
+    {
+        // The write-guard: management off and no managed region present leaves the disclaimer byte-identical,
+        // so the startup sync must not pay for (or version-churn) a branding save.
+        var (manager, branding, _, _) = Build(configure: null, existingDisclaimer: "house rules");
+
+        await manager.StartAsync(CancellationToken.None);
+
+        branding.DidNotReceive().SaveConfiguration(Arg.Any<string>(), Arg.Any<object>());
+
+        await manager.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task ConfigurationChanged_ReSyncsFromTheSavedConfiguration()
+    {
+        var (manager, branding, options, _) = Build();
+        await manager.StartAsync(CancellationToken.None);
+        branding.ClearReceivedCalls();
+
+        // A save that turns button management on must splice the block in via the event hook.
+        var updated = new PluginConfiguration();
+        EnableButtons(updated);
+        SSOPlugin.Instance.UpdateConfiguration(updated);
+
+        Assert.NotNull(options.LoginDisclaimer);
+        Assert.Contains("/sso/OID/start/corp", options.LoginDisclaimer, StringComparison.Ordinal);
+        branding.Received(1).SaveConfiguration("branding", options);
+
+        await manager.StopAsync(CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task StopAsync_Unsubscribes_ALaterConfigurationChangeWritesNothing()
+    {
+        var (manager, branding, _, _) = Build();
+        await manager.StartAsync(CancellationToken.None);
+        await manager.StopAsync(CancellationToken.None);
+        branding.ClearReceivedCalls();
+
+        var updated = new PluginConfiguration();
+        EnableButtons(updated);
+        SSOPlugin.Instance.UpdateConfiguration(updated);
+
+        branding.DidNotReceive().SaveConfiguration(Arg.Any<string>(), Arg.Any<object>());
+    }
+
+    [Fact]
+    public async Task BrandingStoreFailure_IsSwallowed_StartupAndConfigSaveSurvive()
+    {
+        // Fail-safe contract: a branding-store fault must never propagate — it would otherwise block host
+        // startup (StartAsync) or a plugin config save (the event hook runs inside the save path).
+        var harness = new SsoControllerHarness(EnableButtons);
+        var branding = Substitute.For<IServerConfigurationManager>();
+        branding.GetConfiguration("branding").Returns(_ => throw new InvalidOperationException("branding store down"));
+        var manager = new LoginButtonManager(branding, NullLogger<LoginButtonManager>.Instance);
+
+        await manager.StartAsync(CancellationToken.None);
+
+        var updated = new PluginConfiguration();
+        EnableButtons(updated);
+        SSOPlugin.Instance.UpdateConfiguration(updated);
+
+        await manager.StopAsync(CancellationToken.None);
+        _ = harness;
+    }
+}

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonManagerTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonManagerTests.cs
@@ -23,6 +23,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// writes nothing), and a branding-store failure is swallowed (a branding problem must never block
 /// startup or a config save).
 /// </summary>
+[Collection("SSOController")]
 public class LoginButtonManagerTests
 {
     private static (LoginButtonManager Manager, IServerConfigurationManager Branding, BrandingOptions Options, SsoControllerHarness Harness) Build(


### PR DESCRIPTION
U4 of the #928 epic. `LoginButtonManager`, the IHostedService that splices the managed "Sign in with …" block into the branding login disclaimer (#722), had **no tests at all**; its five contractual behaviors are now pinned: startup sync writes the block, the write-guard skips the branding save when the merge changes nothing, a config change re-syncs via the event hook, `StopAsync` unsubscribes (a later change writes nothing), and a branding-store fault is swallowed on both paths (startup + the event hook inside the config-save path).

NSubstitute cannot proxy `ILogger<internal type>` (DynamicProxy lacks IVT into strong-named Logging.Abstractions) → `NullLogger<T>.Instance`; no production change.

Plus the SAML sibling of the hostile-name encoding pin (the adversarial name was only asserted on the OID start route).

Suite **3918/3918** on both TFMs. Refs #928 (U4 ✔).