### PR TITLE
Close the four small unit holes from the coverage audit

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLogoutTests.cs
@@ -78,4 +78,34 @@ public class SSOControllerLogoutTests
         Assert.IsType<LocalRedirectResult>(result);
         await harness.SessionManager.Received(1).Logout("caller-token");
     }
+
+    [Fact]
+    public async Task OidLogout_EndSessionBuildThrows_LocalLogoutStands_AndDegradesToALocalRedirect()
+    {
+        // The fail-safe catch (#928 U6, previously untested): a captured session whose stored id_token
+        // cannot be revealed (an ssoenc envelope with no at-rest key — the harness's plugin data dir is a
+        // fresh temp, so no key exists) makes the end-session URL build throw. The contract: the local
+        // logout already ran and STANDS, the browser degrades to a LOCAL redirect, never a 500 and never
+        // a half-built external redirect.
+        var harness = ForCaller("caller-token", config =>
+        {
+            config.EnableSingleLogout = true;
+            config.OidConfigs["kc"] = new OidConfig { Enabled = true, OidClientId = "client-kc" };
+            config.LogoutSessions["session-1"] = new LogoutSession
+            {
+                Protocol = "OpenID",
+                Provider = "kc",
+                Subject = "sub-1",
+                Issuer = "https://idp.example",
+                EndSessionEndpoint = "https://idp.example/logout",
+                IdToken = "ssoenc:v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // envelope, no key -> Reveal throws
+                UserId = Caller,
+            };
+        });
+
+        var result = await harness.Controller.OidLogout("kc");
+
+        Assert.IsType<LocalRedirectResult>(result);
+        await harness.SessionManager.Received(1).Logout("caller-token");
+    }
 }

--- a/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerTestConnectionTests.cs
@@ -139,6 +139,52 @@ public class SSOControllerTestConnectionTests
         Assert.DoesNotContain(SamlKeySentinel, json, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SamlTest_UnparsableCertificate_ReportsFailure_WithoutLeakingTheKey()
+    {
+        // The controller-level negative (#928 U6): the tester-level parse failure was pinned, but the
+        // endpoint wrapping it was only asserted on the happy path. An unparsable stored certificate must
+        // come back as a failed-but-OK test result (the admin sees WHY), never a 500, and never the key.
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["idp"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = "not-a-base64-der-certificate",
+            SamlSigningKeyPfx = SamlKeySentinel,
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.SamlTest("idp"));
+        var result = Assert.IsType<ProviderTestResult>(ok.Value);
+
+        Assert.False(result.Ok);
+        Assert.Contains("could not be parsed", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(SamlKeySentinel, JsonSerializer.Serialize(ok.Value), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProviderGetEndpoints_MvcCamelCaseSerialization_NeverCarriesASecret()
+    {
+        // #928 U6: the OID/Get and SAML/Get snapshots were asserted as objects, but the redaction lives in
+        // WriteOnlySecretConverter attributes — so the property that matters is what the MVC serializer
+        // actually EMITS. Serialize both snapshots with the camelCase options MVC uses and pin that neither
+        // the OIDC client secret nor the SAML signing key reaches the wire.
+        const string OidSecretSentinel = "get-endpoint-oid-secret";
+        var harness = new SsoControllerHarness(c =>
+        {
+            c.OidConfigs["kc"] = new OidConfig { Enabled = true, OidSecret = OidSecretSentinel };
+            c.SamlConfigs["idp"] = new SamlConfig { Enabled = true, SamlSigningKeyPfx = SamlKeySentinel };
+        });
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+        var oidJson = JsonSerializer.Serialize(Assert.IsType<OkObjectResult>(harness.Controller.OidProviders()).Value, options);
+        var samlJson = JsonSerializer.Serialize(Assert.IsType<OkObjectResult>(harness.Controller.SamlProviders()).Value, options);
+
+        Assert.DoesNotContain(OidSecretSentinel, oidJson, StringComparison.Ordinal);
+        Assert.DoesNotContain(SamlKeySentinel, samlJson, StringComparison.Ordinal);
+        // Liveness: the snapshots really carried the providers (the redaction is not vacuous).
+        Assert.Contains("kc", oidJson, StringComparison.Ordinal);
+        Assert.Contains("idp", samlJson, StringComparison.Ordinal);
+    }
+
     // Serves the discovery document and a one-key JWKS; any other URL 404s so an unexpected call is visible.
     private static HttpResponseMessage Responder(HttpRequestMessage request)
     {

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -215,6 +215,26 @@ public class OidcRoundTripTests
     }
 
     [Fact]
+    public async Task LinkingChallenge_ThreadsIsLinkingIntoTheRegisteredState()
+    {
+        // #928 U6: the OIDC linking-mode challenge was never driven end-to-start — only hand-seeded states
+        // carried the flag. isLinking=true through the real OidChallenge must register an authorize state
+        // whose summary says linking, which is what the callback later uses to route to the link workflow
+        // instead of a login.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+        Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc", isLinking: true));
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidStates());
+        var summaries = Assert.IsAssignableFrom<System.Collections.Generic.IEnumerable<OidcStateStore.Summary>>(ok.Value);
+        var summary = Assert.Single(summaries);
+        Assert.True(summary.IsLinking);
+        Assert.Equal("kc", summary.Provider);
+    }
+
+    [Fact]
     public async Task ParAdvertisedAndEnabled_ChallengePushesTheRequest_AndRedirectsByRequestUri()
     {
         // #928 U3: PAR is ON by default in production (DisablePushedAuthorization defaults false), yet no


### PR DESCRIPTION
U6 of the #928 epic, the audit's G6 sweep:

- **OIDC linking challenge end-to-start**: `isLinking=true` through the real `OidChallenge` registers an authorize state whose summary says linking (previously only hand-seeded states carried the flag).
- **`OidLogout` fail-safe catch**: an unrevealable stored id_token (ssoenc envelope, no key) makes the end-session build throw, the local logout stands, LOCAL redirect, never a 500.
- **`OID/Get` / `SAML/Get` MVC-serialized redaction**: the camelCase-emitted JSON never carries the OIDC client secret or SAML signing key (the redaction lives in converter attributes, so the wire shape is what matters); liveness asserts keep it non-vacuous.
- **`SamlTest` controller-level negative**: unparsable certificate → failed-but-OK result naming the parse problem, no 500, no key.

Suite **3928/3928** on both TFMs. Refs #928 (U6 ✔).