### PR TITLE
Exercise the SSRF connect guard at the real socket layer

### DIFF
--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -1,7 +1,12 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using NSubstitute;
 using Xunit;
@@ -51,5 +56,78 @@ public class SsoHttpTests
         Assert.False(handler.UseProxy);
         Assert.True(handler.AllowAutoRedirect);
         Assert.Equal(5, handler.MaxAutomaticRedirections);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1")] // IPv4 loopback literal
+    [InlineData("http://[::1]")] // IPv6 loopback literal
+    [InlineData("http://10.0.0.1")] // RFC1918 private literal
+    [InlineData("http://169.254.169.254")] // link-local cloud metadata endpoint
+    [InlineData("http://localhost")] // a NAME that resolves to loopback
+    public async Task HardenedHandler_RefusesAConnectionToABlockedAddress_AtTheSocketLayer(string baseUrl)
+    {
+        // #928 U7 — the real socket-level integration test the configuration pin above explicitly could not
+        // provide. This drives the ACTUAL hardened handler (its ConnectCallback resolves the host and refuses
+        // any blocked address before connecting), so a regression that lets the guard connect to a
+        // loopback / RFC1918 / link-local address is a red build — not merely a changed handler property.
+        // A live listener on the loopback port proves the point: the guard must refuse BEFORE any socket
+        // reaches it.
+        using var listener = new BlockedListener();
+        using var handler = SsoHttp.CreateHardenedHandler();
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+        var target = $"{baseUrl}:{listener.Port}/";
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync(target, TestContext.Current.CancellationToken));
+
+        // The guard's own diagnostics — proves the refusal came from ConnectToAllowedAddressAsync, not an
+        // unrelated transport error.
+        Assert.Contains("blocked address", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // And nothing reached the socket: the listener never accepted a connection.
+        Assert.False(listener.Accepted, "the SSRF guard let a socket reach the blocked loopback listener");
+    }
+
+    // A loopback TCP listener that would accept any connection reaching it — so a passing test proves the
+    // guard refused BEFORE the socket layer, not that the port simply happened to be closed.
+    private sealed class BlockedListener : IDisposable
+    {
+        private readonly Socket _socket;
+        private readonly CancellationTokenSource _cts = new();
+
+        internal BlockedListener()
+        {
+            _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            _socket.Listen(16);
+            Port = ((IPEndPoint)_socket.LocalEndPoint!).Port;
+            _ = AcceptLoopAsync(_cts.Token);
+        }
+
+        internal int Port { get; }
+
+        internal bool Accepted { get; private set; }
+
+        private async Task AcceptLoopAsync(CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    using var conn = await _socket.AcceptAsync(token).ConfigureAwait(false);
+                    Accepted = true;
+                }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException or SocketException)
+            {
+                // Listener torn down — expected on dispose.
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _socket.Dispose();
+            _cts.Dispose();
+        }
     }
 }


### PR DESCRIPTION
U7 of the #928 epic. `SsoHttpTests` pinned only the handler **configuration** and stated outright that the connect guard *"cannot be exercised at unit level (it fires only on a real socket connect)"*, so the one runtime behavior the guard exists for was untested (audit G6).

This drives the **actual** hardened handler end to end against a **live loopback listener**: a request to a blocked address (IPv4/IPv6 loopback literal, an RFC1918 private literal, `169.254.169.254` cloud-metadata, and a **name** that resolves to loopback) must throw with the guard's own `blocked address` diagnostic **and the listener must never accept a connection**, proving `ConnectToAllowedAddressAsync` refuses *before* the socket layer, not that the port was simply closed.

**Proven to bite:** neutralising the `IsBlockedAddress` check reds all five theory rows on both TFMs. Offline and deterministic (loopback + literals, no external DNS). Suite **3938/3938**. Refs #928 (U7 ✔).