### PR TITLE
E2E: exercise SAML metadata import/SP-metadata, assert secrets-at-rest + audit

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -159,6 +159,39 @@ jobs:
           docker compose -f "$COMPOSE" up \
             --abort-on-container-exit --exit-code-from harness
 
+      - name: Assert secrets-at-rest and the audit trail (#928 U8)
+        # Two assertions the in-container harness cannot make itself (no docker access, no bind mount of
+        # Jellyfin's config): the persisted provider secret is an ssoenc:v1 envelope on disk, not
+        # plaintext, and the security audit trail actually reached the log. Runs only on a green harness,
+        # so a real login/config failure surfaces as the harness failure, not here.
+        if: success()
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: |
+          set -euo pipefail
+          config="test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml"
+          echo "===== secrets at rest ====="
+          if [ ! -s "$config" ]; then
+            echo "::error::the plugin persisted no configuration at $config"; exit 1
+          fi
+          if grep -q "ssoenc:v1:" "$config"; then
+            echo "OK: the persisted provider secret is an ssoenc:v1 envelope, not plaintext"
+          else
+            echo "::error::no ssoenc:v1 envelope in the persisted config — a provider secret may be stored in plaintext"; exit 1
+          fi
+
+          echo "===== audit trail ====="
+          logs="$(docker compose -f "$COMPOSE" logs jellyfin --no-color 2>/dev/null || true)"
+          for expected in \
+            "[SSO Audit] Provider configured:" \
+            "[SSO Audit] Login succeeded:"; do
+            if printf '%s' "$logs" | grep -qF "$expected"; then
+              echo "OK: audit line present -> $expected"
+            else
+              echo "::error::expected audit line missing from the Jellyfin log: $expected"; exit 1
+            fi
+          done
+
       - name: Dump container logs on failure
         if: failure()
         env:

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -70,6 +70,10 @@ services:
       # canonical stack.
       ADMIN_ROLES_JSON: '["jellyfin-admin"]'
       EXTENDED_PHASES: "true"
+      # The canonical base URL the plugin publishes in its SP metadata (#928 U8): the SAML/metadata
+      # endpoint fails closed without it (the ACS URL must never come from a spoofable request Host).
+      # This IS the Jellyfin service URL on the harness network, so the advertised ACS is reachable.
+      SAML_BASE_URL_OVERRIDE: http://jellyfin:8096
     volumes:
       - ./harness:/harness:ro
     command: ["sh", "/harness/harness.sh"]

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1362,6 +1362,44 @@ else
 fi
 
 # --------------------------------------------------------------------------------------------------
+# Extended SAML admin surfaces (#928 U8), gated by EXTENDED_PHASES: the plugin's own metadata importer
+# and its SP-metadata endpoint, neither of which any harness exercised (the config above extracts the
+# cert with grep/sed rather than through the importer).
+# --------------------------------------------------------------------------------------------------
+if [ "$EXTENDED_PHASES" = "true" ]; then
+  log "== Extended: SAML/ImportMetadata parses the live IdP descriptor =="
+  # The plugin fetches and parses the SAME descriptor the harness read; the parsed cert and endpoint must
+  # match what the harness extracted by hand. This exercises SamlMetadataImporter against a real IdP,
+  # through the SSRF-hardened outbound client (the harness subnet is public-looking, so the guard stays
+  # engaged and still permits the fetch).
+  IMP="$(curl -sS -o /tmp/import.out -w '%{http_code}' -X POST "$JELLYFIN/sso/SAML/ImportMetadata" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+    -d "{\"Url\":\"$SAML_DESCRIPTOR_URL\"}")"
+  if [ "$IMP" = "200" ]; then
+    IMP_CERT="$(jq -r '.primaryCertificate // empty' /tmp/import.out | tr -d ' \t')"
+    IMP_EP="$(jq -r '.endpoint // empty' /tmp/import.out)"
+    if [ "$IMP_CERT" = "$IDP_CERT" ] && [ -n "$IMP_EP" ]; then
+      pass "SAML/ImportMetadata parsed the descriptor: cert matches the hand-extracted one, endpoint=$IMP_EP"
+    else
+      fail "SAML/ImportMetadata returned a cert/endpoint that does not match the descriptor (cert-match=$([ "$IMP_CERT" = "$IDP_CERT" ] && echo yes || echo no), endpoint='$IMP_EP')"
+    fi
+  else
+    fail "SAML/ImportMetadata returned HTTP $IMP: $(head -c 300 /tmp/import.out 2>/dev/null)"
+  fi
+
+  log "== Extended: SAML/metadata SP descriptor is served and well-formed =="
+  # The published SP metadata a real IdP would consume: an EntityDescriptor carrying the ACS URL the
+  # plugin advertises (built from the canonical base, #928 U5 territory), served anonymously.
+  SPMETA="$(curl -fsS "$JELLYFIN/sso/SAML/metadata/$PROVIDER")" || SPMETA=""
+  if printf '%s' "$SPMETA" | grep -q "EntityDescriptor" && printf '%s' "$SPMETA" | grep -q "AssertionConsumerService"; then
+    pass "SAML/metadata serves an SP EntityDescriptor with an AssertionConsumerService"
+  else
+    fail "SAML/metadata did not serve a well-formed SP descriptor (first 200 chars: $(printf '%s' "$SPMETA" | head -c 200))"
+  fi
+fi
+
+# --------------------------------------------------------------------------------------------------
 # Phase 8 — full SAML round-trip for carol (milestone 4)
 # --------------------------------------------------------------------------------------------------
 log "== SAML round-trip: carol (expect success) =="

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -1377,8 +1377,10 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
     -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
     -d "{\"Url\":\"$SAML_DESCRIPTOR_URL\"}")"
   if [ "$IMP" = "200" ]; then
-    IMP_CERT="$(jq -r '.primaryCertificate // empty' /tmp/import.out | tr -d ' \t')"
-    IMP_EP="$(jq -r '.endpoint // empty' /tmp/import.out)"
+    # Jellyfin's MVC serializes PascalCase (the harness reads .AccessToken, .Policy.IsAdministrator the
+    # same way), so the import record's fields are PrimaryCertificate / Endpoint, not camelCase.
+    IMP_CERT="$(jq -r '.PrimaryCertificate // empty' /tmp/import.out | tr -d ' \t')"
+    IMP_EP="$(jq -r '.Endpoint // empty' /tmp/import.out)"
     if [ "$IMP_CERT" = "$IDP_CERT" ] && [ -n "$IMP_EP" ]; then
       pass "SAML/ImportMetadata parsed the descriptor: cert matches the hand-extracted one, endpoint=$IMP_EP"
     else


### PR DESCRIPTION
U8 of the #928 epic, the E2E extras the audit named, none previously exercised by any harness.

**Harness** (`EXTENDED_PHASES`, canonical Keycloak stack):
- **`SAML/ImportMetadata`**, the plugin fetches + parses the **live** IdP descriptor through its own importer (over the SSRF-hardened client, the harness subnet is public-looking, so the guard stays engaged and still permits the fetch); the parsed cert/endpoint must match the harness's hand extraction. The importer was never touched end to end before.
- **`SAML/metadata`**, the published SP `EntityDescriptor` is served with an `AssertionConsumerService`; the keycloak stack now sets `SAML_BASE_URL_OVERRIDE` (the endpoint fails closed without a canonical base).

**Workflow** (every provider, post-green harness, the in-container harness has no docker access):
- **secrets at rest**, the persisted config carries an `ssoenc:v1` envelope, not a plaintext secret.
- **audit trail**, the Jellyfin log carries the `[SSO Audit]` Provider-configured + Login-succeeded lines (exact strings observed in the U5 run). Reports presence only, never config content or a secret; fails on any missing line.

**Verification:** local runs are blocked by host resource pressure (SIGKILL at startup, as in U5), so the **mandatory CI Keycloak (OIDC + SAML) run is the verification**, the watch-and-merge gates on it, so a wrong assertion reds CI and does not merge. Refs #928 (U8 ✔).