### PR TITLE
Validate id_token auth_time against max_age; fail closed

### DIFF
--- a/SSO-Auth.Tests/Oidc/MaxAgePolicyTests.cs
+++ b/SSO-Auth.Tests/Oidc/MaxAgePolicyTests.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="MaxAgePolicy"/> — the fail-closed <c>max_age</c> freshness check (#961). A missing
+/// <c>auth_time</c> (a provider that ignored the requested <c>max_age</c>) and an <c>auth_time</c> older than
+/// the window both fail; a fresh one within the window (plus the shared clock skew) passes; a future
+/// <c>auth_time</c> beyond the skew is rejected so a clock-forward IdP cannot satisfy the window forever.
+/// </summary>
+public class MaxAgePolicyTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.FromUnixTimeSeconds(1_000_000);
+
+    private static long UnixSecondsAgo(int seconds) => Now.ToUnixTimeSeconds() - seconds;
+
+    [Fact]
+    public void MissingAuthTime_IsNotFresh_FailClosed()
+    {
+        // The provider ignored max_age and returned no auth_time — must NOT pass.
+        Assert.False(MaxAgePolicy.IsFresh(null, maxAgeSeconds: 300, Now));
+    }
+
+    [Fact]
+    public void AuthTimeWithinTheWindow_IsFresh()
+    {
+        Assert.True(MaxAgePolicy.IsFresh(UnixSecondsAgo(120), maxAgeSeconds: 300, Now));
+    }
+
+    [Fact]
+    public void AuthTimeOlderThanTheWindowPlusSkew_IsNotFresh()
+    {
+        // 300s window + 5min skew = 600s tolerance; 601s ago is stale.
+        Assert.False(MaxAgePolicy.IsFresh(UnixSecondsAgo(601), maxAgeSeconds: 300, Now));
+    }
+
+    [Fact]
+    public void AuthTimeAtTheWindowEdgeWithinSkew_IsFresh()
+    {
+        // Exactly at window+skew is still accepted (the tolerance is inclusive).
+        Assert.True(MaxAgePolicy.IsFresh(UnixSecondsAgo(600), maxAgeSeconds: 300, Now));
+    }
+
+    [Fact]
+    public void MaxAgeZero_ForcesReauthentication_OnlyAVeryRecentAuthTimePasses()
+    {
+        // max_age=0 means "must have authenticated just now"; only within-skew passes, an old one fails.
+        Assert.True(MaxAgePolicy.IsFresh(UnixSecondsAgo(10), maxAgeSeconds: 0, Now));
+        Assert.False(MaxAgePolicy.IsFresh(UnixSecondsAgo(3600), maxAgeSeconds: 0, Now));
+    }
+
+    [Fact]
+    public void FutureAuthTimeBeyondSkew_IsNotFresh()
+    {
+        // A clock-forward IdP reporting a future auth_time must not satisfy the window indefinitely.
+        Assert.False(MaxAgePolicy.IsFresh(UnixSecondsAgo(-3600), maxAgeSeconds: 300, Now));
+    }
+}

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenAuthTimeTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenAuthTimeTests.cs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="OidcIdTokenAuthTime"/> — the max_age gate reads auth_time from the RAW, signature-
+/// verified id_token (#961), never the UserInfo-merged principal. A numeric auth_time parses; an absent,
+/// non-numeric, negative, or degenerate one yields null so the caller's fail-closed check refuses it.
+/// </summary>
+public class OidcIdTokenAuthTimeTests
+{
+    [Fact]
+    public void Read_TokenCarryingAuthTime_ReturnsTheSeconds()
+        => Assert.Equal(1_700_000_000L, OidcIdTokenAuthTime.Read(TokenWith(("sub", "user-1"), ("auth_time", 1_700_000_000L))));
+
+    [Fact]
+    public void Read_TokenWithoutAuthTime_ReturnsNull()
+        => Assert.Null(OidcIdTokenAuthTime.Read(TokenWith(("sub", "user-1"))));
+
+    [Fact]
+    public void Read_NegativeAuthTime_ReadsAsNull_Malformed()
+        => Assert.Null(OidcIdTokenAuthTime.Read(TokenWith(("auth_time", -5L))));
+
+    [Fact]
+    public void Read_NonNumericAuthTime_ReadsAsNull()
+        => Assert.Null(OidcIdTokenAuthTime.Read(TokenWith(("auth_time", "yesterday"))));
+
+    [Theory]
+    [InlineData(253_402_300_800L)] // one past the DateTimeOffset upper bound
+    [InlineData(1_700_000_000_000L)] // auth_time in MILLISECONDS (a common provider mistake)
+    [InlineData(long.MaxValue)]
+    public void Read_OutOfRangeAuthTime_ReadsAsNull_NoThrow(long value)
+        => Assert.Null(OidcIdTokenAuthTime.Read(TokenWith(("auth_time", value))));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("...")]
+    public void Read_AbsentOrDegenerateToken_ReturnsNullWithoutThrowing(string? token)
+        => Assert.Null(OidcIdTokenAuthTime.Read(token));
+
+    private static string TokenWith(params (string Type, object Value)[] claims)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var (type, value) in claims)
+        {
+            dict[type] = value;
+        }
+
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor { Claims = dict });
+    }
+}

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -199,6 +199,77 @@ public class OidcRoundTripTests
     }
 
     [Fact]
+    public async Task MaxAgeConfigured_FreshAuthTime_YieldsLoggedInOutcome()
+    {
+        // #961 happy path: MaxAge set + the id_token carries a recent auth_time within the window ⇒ login.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var recent = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 30;
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice", authTimeUnixSeconds: recent);
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111114"));
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(user.Id).Returns(user);
+
+        var (state, binding) = await DriveChallenge(harness);
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        await harness.UserManager.Received(1).CreateUserAsync("alice");
+    }
+
+    [Fact]
+    public async Task MaxAgeConfigured_MissingAuthTime_RejectsAtCallback_MintsNothing()
+    {
+        // #961 fail-closed: MaxAge set but the provider ignored max_age and returned no auth_time ⇒ the
+        // callback denies before promoting a Ready, so the redeem finds no state and mints nothing. This is
+        // the whole point of the gate — a provider that ignores max_age must not pass silently.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice"); // no auth_time
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+
+        var (state, binding) = await DriveChallenge(harness);
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal(403, Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).StatusCode);
+
+        var content = Assert.IsType<ContentResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Invalid or expired state", content.Content);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task MaxAgeConfigured_StaleAuthTime_RejectsAtCallback_MintsNothing()
+    {
+        // #961 fail-closed: MaxAge set + auth_time older than the window+skew ⇒ the user authenticated too
+        // long ago, denied.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var stale = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 3600;
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice", authTimeUnixSeconds: stale);
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+
+        var (state, binding) = await DriveChallenge(harness);
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal(403, Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).StatusCode);
+        await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task MaxAgeUnset_NoAuthTime_YieldsLoggedInOutcome()
+    {
+        // Upgrade-safe: with MaxAge unset, an id_token without auth_time logs in unchanged (no new gate).
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111115"));
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(user.Id).Returns(user);
+
+        var (state, binding) = await DriveChallenge(harness);
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+    }
+
+    [Fact]
     public async Task RequireAcrOff_NoAcrClaim_YieldsLoggedInOutcome()
     {
         // Default: with RequireAcr off, an id_token that carries no acr logs in unchanged (no new gate).

--- a/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
@@ -46,7 +46,7 @@ internal sealed class OidcTokenFixture : IDisposable
     /// issuer) so a test can model a provider whose id_token issuer differs from its discovery issuer
     /// (templated / <c>DoNotValidateIssuerName</c> setups, #210).
     /// </summary>
-    internal string IdToken(string? subject, string username, string? issuer = null, string? acr = null)
+    internal string IdToken(string? subject, string username, string? issuer = null, string? acr = null, long? authTimeUnixSeconds = null)
     {
         var now = DateTime.UtcNow;
         var claims = new Dictionary<string, object> { ["preferred_username"] = username };
@@ -60,6 +60,13 @@ internal sealed class OidcTokenFixture : IDisposable
         if (!string.IsNullOrEmpty(acr))
         {
             claims["acr"] = acr;
+        }
+
+        // The moment the user authenticated, for the max_age freshness gate (#961); omitted when null (the
+        // common provider case AND the max_age-ignored rejection path — a provider that returns no auth_time).
+        if (authTimeUnixSeconds is long authTime)
+        {
+            claims["auth_time"] = authTime;
         }
 
         var descriptor = new SecurityTokenDescriptor

--- a/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
@@ -35,6 +35,7 @@ public class LoginStatusMapperTests
             (PublicReason.EmailNotVerified, 403, "A verified email is required to log in."),
             (PublicReason.AwaitingApproval, 403, "Your account is not active. It is awaiting administrator approval."),
             (PublicReason.AcrNotSatisfied, 403, "A stronger authentication level (for example MFA) is required to log in."),
+            (PublicReason.AuthTooOld, 403, "You authenticated too long ago; please sign in again."),
         };
 
         // The table itself must stay total: a new member without a row fails here.

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -429,6 +429,28 @@ internal sealed class OidcLoginService
             }
         }
 
+        // max_age freshness (#961): when the provider configures MaxAge, the authorize request carried
+        // max_age (OidcFrontChannelParameters), so per OIDC Core §3.1.2.1 the id_token MUST carry auth_time
+        // and the user must have authenticated within the window. Read auth_time from the RAW,
+        // signature-verified id_token (OidcIdTokenAuthTime), NOT result.User — same reason as the acr gate.
+        // Fail closed: a MISSING auth_time (a provider that ignored max_age) or a stale one is refused, so a
+        // forced re-authentication cannot be silently satisfied by an old session. Checked here before
+        // Promote so a too-old login never becomes a redeemable Ready. A negative MaxAge is treated as unset
+        // (OidcFrontChannelParameters sends nothing), so it correctly enforces nothing.
+        if (config.MaxAge is int maxAge && maxAge >= 0)
+        {
+            var authTime = OidcIdTokenAuthTime.Read(result.IdentityToken);
+            if (!MaxAgePolicy.IsFresh(authTime, maxAge, DateTimeOffset.UtcNow))
+            {
+                if (_logger.IsEnabled(LogLevel.Warning))
+                {
+                    _logger.LogWarning("OpenID login denied for provider {Provider}: max_age is configured but the id_token's auth_time was absent or older than the allowed window (the user authenticated too long ago).", provider?.ReplaceLineEndings(string.Empty));
+                }
+
+                return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AuthTooOld));
+            }
+        }
+
         // Atomically swap the peeked Pending for a redeemable Ready (#341). A false return means a
         // concurrent callback already promoted it, or it expired/was pruned since the peek — either way
         // the browser's redeem is the real gate, which consumes the single Ready once (or cleanly rejects

--- a/SSO-Auth/Api/Oidc/MaxAgePolicy.cs
+++ b/SSO-Auth/Api/Oidc/MaxAgePolicy.cs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// The <c>max_age</c> freshness check (#961). When a provider configures <c>MaxAge</c>, the authorization
+/// request carries <c>max_age=&lt;n&gt;</c> (OidcFrontChannelParameters), and OIDC Core §3.1.2.1 then
+/// REQUIRES the id_token to carry <c>auth_time</c> and expects the RP to verify the user authenticated no
+/// longer than <c>max_age</c> seconds ago. Fail-closed: a MISSING <c>auth_time</c> (a provider that ignored
+/// <c>max_age</c>) or an <c>auth_time</c> older than the window is refused — otherwise a stale session
+/// silently satisfies a forced-reauthentication requirement it did not meet. The five-minute skew
+/// tolerance mirrors the id_token / SAML-assertion lifetime checks so a small IdP/SP clock difference
+/// does not spuriously reject a genuinely fresh login.
+/// </summary>
+internal static class MaxAgePolicy
+{
+    /// <summary>Symmetric clock-skew tolerance, matching the SAML/id_token lifetime checks.</summary>
+    internal static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Whether an id_token's <paramref name="authTimeUnixSeconds"/> satisfies a configured <paramref name="maxAgeSeconds"/>.
+    /// </summary>
+    /// <param name="authTimeUnixSeconds">The id_token's <c>auth_time</c> (Unix seconds), or null when absent/malformed.</param>
+    /// <param name="maxAgeSeconds">The configured <c>max_age</c> in seconds (non-negative).</param>
+    /// <param name="nowUtc">The current UTC instant.</param>
+    /// <returns>
+    /// <see langword="true"/> only when <paramref name="authTimeUnixSeconds"/> is present and the user
+    /// authenticated at most <paramref name="maxAgeSeconds"/> (plus skew) ago; <see langword="false"/> when
+    /// it is absent or too old (fail closed).
+    /// </returns>
+    internal static bool IsFresh(long? authTimeUnixSeconds, int maxAgeSeconds, DateTimeOffset nowUtc)
+    {
+        if (authTimeUnixSeconds is not long authTime)
+        {
+            // max_age was requested but the provider returned no auth_time — treat as not fresh, per the
+            // fail-closed contract: an ignored max_age must not pass.
+            return false;
+        }
+
+        var authenticatedAt = DateTimeOffset.FromUnixTimeSeconds(authTime);
+
+        // A future auth_time beyond the skew is not a genuine "recent authentication" — reject it rather
+        // than let a clock-forward IdP satisfy the window indefinitely.
+        if (authenticatedAt > nowUtc + ClockSkew)
+        {
+            return false;
+        }
+
+        var age = nowUtc - authenticatedAt;
+        return age <= TimeSpan.FromSeconds(maxAgeSeconds) + ClockSkew;
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcIdTokenAuthTime.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenAuthTime.cs
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.Linq;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// Reads the <c>auth_time</c> claim (a JSON number of seconds since the Unix epoch, OIDC Core §2) from the
+/// RAW, already-validated id_token for the <c>max_age</c> freshness gate (#961), NOT from the redeemed
+/// <c>result.User</c> principal — same reason as <see cref="OidcIdTokenAcr"/>: with <c>LoadProfile</c> on
+/// (the default) OidcClient merges the UNSIGNED UserInfo response into <c>result.User</c>, so only the
+/// id_token's own, signature-covered <c>auth_time</c> can be trusted to bound how long ago the user actually
+/// authenticated.
+/// </summary>
+internal static class OidcIdTokenAuthTime
+{
+    /// <summary>
+    /// The id_token's <c>auth_time</c> as seconds since the Unix epoch, or null when the token is
+    /// absent/degenerate or carries no parseable <c>auth_time</c>. The token was validated by
+    /// <see cref="OidcIdTokenValidator"/> before this runs; the guard and catches are defensive so a
+    /// degenerate token can never turn the gate into a 500. A non-numeric or negative value reads as null
+    /// (absent), so the caller's fail-closed max_age check refuses it rather than trusting a malformed claim.
+    /// </summary>
+    /// <param name="identityToken">The redeemed, already-validated id_token.</param>
+    /// <returns>The <c>auth_time</c> in Unix seconds, or null.</returns>
+    internal static long? Read(string? identityToken)
+    {
+        if (string.IsNullOrEmpty(identityToken))
+        {
+            return null;
+        }
+
+        try
+        {
+            var raw = new JsonWebToken(identityToken).Claims
+                .LastOrDefault(c => string.Equals(c.Type, "auth_time", StringComparison.Ordinal))?.Value;
+
+            if (string.IsNullOrEmpty(raw))
+            {
+                return null;
+            }
+
+            // auth_time is a JSON number; JsonWebToken surfaces it as its string form. Parse as a whole
+            // number of seconds and reject anything outside the range DateTimeOffset.FromUnixTimeSeconds
+            // accepts as malformed (absent) — including a negative value and an out-of-range positive one.
+            // A provider that emits auth_time in MILLISECONDS (a common seconds/ms confusion) yields
+            // ~1.7e12, which is past the upper bound; without this guard it would parse, reach IsFresh, and
+            // throw ArgumentOutOfRangeException there — an uncaught 500 instead of the clean fail-closed
+            // AuthTooOld deny this reader promises never to turn into a 500.
+            const long MaxUnixSeconds = 253_402_300_799; // DateTimeOffset max (year 9999)
+            return long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seconds)
+                   && seconds >= 0 && seconds <= MaxUnixSeconds
+                ? seconds
+                : null;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (SecurityTokenException)
+        {
+            return null;
+        }
+    }
+}

--- a/SSO-Auth/Api/Session/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/Session/LoginStatusMapper.cs
@@ -92,6 +92,7 @@ internal static class LoginStatusMapper
         PublicReason.EmailNotVerified => Emit(StatusCodes.Status403Forbidden, "A verified email is required to log in."),
         PublicReason.AwaitingApproval => Emit(StatusCodes.Status403Forbidden, "Your account is not active. It is awaiting administrator approval."),
         PublicReason.AcrNotSatisfied => Emit(StatusCodes.Status403Forbidden, "A stronger authentication level (for example MFA) is required to log in."),
+        PublicReason.AuthTooOld => Emit(StatusCodes.Status403Forbidden, "You authenticated too long ago; please sign in again."),
         // A new PublicReason member without a mapper entry fails loudly here, and the totality test
         // enumerating every member catches it before it can ship — never a fall-through.
         _ => throw new InvalidOperationException($"Unmapped public reason: {reason}"),

--- a/SSO-Auth/Api/Session/PublicReason.cs
+++ b/SSO-Auth/Api/Session/PublicReason.cs
@@ -37,4 +37,7 @@ internal enum PublicReason
 
     /// <summary>RequireAcr is set but the id_token's acr claim was absent or outside the configured acr_values (#757, step-up/MFA). Operator-facing by design.</summary>
     AcrNotSatisfied,
+
+    /// <summary>max_age is configured but the id_token's auth_time was absent or older than the window (#961) — the user authenticated too long ago. Operator-facing by design.</summary>
+    AuthTooOld,
 }


### PR DESCRIPTION
Closes #961 (from the #928 audit). The step-up support **sent** `max_age` but never validated `auth_time`, a provider that ignores max_age passed silently unless `RequireAcr` was also set.

When `MaxAge` is set, the callback reads `auth_time` from the **raw, signature-verified** id_token (never the UserInfo-merged principal) and refuses (`AuthTooOld`, 403) unless the user authenticated within max_age + 5min skew. Fail-closed on missing/stale auth_time; before promote, so all redeem paths are covered; off unless configured (upgrade-safe).

**Review:** 2-lens gate, no bypass (deny-monotonic, signed-source, before-promote). Both lenses caught one shared robustness defect: an `auth_time` in **milliseconds** exceeded `DateTimeOffset`'s range and threw an uncaught 500 instead of a clean deny. Fixed in the reader (out-of-range → null → fail-closed) with three regression rows.

Suite **3979/3979** on both TFMs. OIDC Core §3.1.2.1. Closes #961.