### PR TITLE
Add OIDC back-channel logout (logout_token validation + endpoint)

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -72,7 +72,7 @@ public class ArchitectureConformanceTests
     // login-path cache is added here once, and both fitness functions guard it.
     private static readonly Type[] LoginPathCapWarnCaches =
     {
-        typeof(SamlReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore), typeof(SamlOutcomeStore),
+        typeof(ReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore), typeof(SamlOutcomeStore),
     };
 
     // Every production type, compiler-generated ones excluded — the base sequence for structural rules
@@ -368,7 +368,7 @@ public class ArchitectureConformanceTests
     {
         // Locked in by #452: the login-path caches converged on one bounding pattern — an
         // IntervalGate-throttled expired-entry sweep plus a hard global cap — so none can regress to the
-        // unthrottled full-dictionary sweep (or the unbounded set) SamlReplayCache carried before #452.
+        // unthrottled full-dictionary sweep (or the unbounded set) ReplayCache carried before #452.
         // Each named cache must declare the PRUNE gate specifically (an IntervalGate field named
         // "_pruneGate"), not merely some IntervalGate: the siblings also carry a "_capWarnGate", so keying
         // on the field type alone would miss a sibling that dropped its prune gate but kept cap-warn.
@@ -983,15 +983,17 @@ public class ArchitectureConformanceTests
         // holds those SAML caches nor drives the SAML challenge/validation protocol itself. Call-level
         // property, so it is a source scan like the other controller rules above.
         //
-        // The two cache tokens are nameof-derived, so a rename of either type fails to COMPILE this rule
+        // The request-cache token is nameof-derived, so a rename of that type fails to COMPILE this rule
         // rather than passing vacuously; the two protocol tokens are the outgoing-request builder
         // (SamlAuthnRequest, which the challenge constructs and signs) and the response validator
         // (ValidateSaml). The shared per-client rate limiter is deliberately NOT a marker — it fronts BOTH
         // protocols, so it lives in the shared SsoRateLimitGate (#160), pinned off the controller by
-        // Controller_HoldsNoMutableStaticState, exactly as in the OpenID rule.
-        var replayToken = nameof(SamlReplayCache);
+        // Controller_HoldsNoMutableStaticState, exactly as in the OpenID rule. The replay cache was a SAML
+        // marker until #962 moved it to the shared RateLimit module (protocol-neutral ReplayCache, used by
+        // both the SAML replay path and the OIDC back-channel-logout jti check), so it is no longer a
+        // SAML-ownership marker.
         var requestToken = nameof(SamlRequestCache);
-        var markers = new[] { replayToken, requestToken, "SamlAuthnRequest", "ValidateSaml" };
+        var markers = new[] { requestToken, "SamlAuthnRequest", "ValidateSaml" };
 
         var controllerHits = ControllerSourceFiles()
             .SelectMany(path => File.ReadAllLines(path)
@@ -1151,7 +1153,7 @@ public class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 13;
+        const int expectedTypedCallSites = 14;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);
@@ -2404,7 +2406,7 @@ public class ArchitectureConformanceTests
     private static readonly string[] MustThrottleRoutes =
     {
         "OID/r/{provider}", "OID/redirect/{provider}", "OID/p/{provider}", "OID/start/{provider}",
-        "OID/Test/{provider}", "OID/Auth/{provider}",
+        "OID/Test/{provider}", "OID/Auth/{provider}", "OID/backchannel-logout/{provider}",
         "SAML/p/{provider}", "SAML/post/{provider}", "SAML/start/{provider}", "SAML/metadata/{provider}",
         "SAML/Logout/{provider}", "SAML/ImportMetadata", "SAML/Auth/{provider}",
         "Unregister/{username}", "{mode}/Link/{provider}/{jellyfinUserId}",

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the anonymous OpenID back-channel logout endpoint (#962), driving a real signed
+/// logout_token against discovery + JWKS served in-process by <see cref="OidcTokenFixture"/>. They pin the
+/// fail-closed contract: the feature and per-provider opt-in gate reject WITHOUT reading the token; a valid
+/// token revokes only the matched user's OpenID sessions for that provider (never cross-provider, never a
+/// SAML capture); and every rejection is the uniform 400 with no subject oracle.
+/// </summary>
+[Collection("SSOController")]
+public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
+{
+    private const string Authority = "https://idp-bcl.example.test";
+    private static readonly Guid UserA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid UserB = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    private readonly OidcTokenFixture _fixture = new(Authority, "jf");
+
+    public SSOControllerOidBackChannelLogoutTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public async Task ValidLogoutToken_RevokesTheMatchedUser_AndReturns200()
+    {
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task FeatureDisabled_RejectsWithoutReadingTheToken()
+    {
+        // EnableSingleLogout off: the endpoint must NOT reach the validator (no discovery fetch), just reject.
+        var harness = Harness(c => c.OidConfigs["kc"] = Provider(backChannel: true), withResponder: false);
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1"));
+
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task PerProviderOptInOff_Rejects()
+    {
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: false);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        }, withResponder: false);
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1"));
+
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task UnknownProvider_Rejects_NoOracle()
+    {
+        var harness = Harness(c => c.EnableSingleLogout = true, withResponder: false);
+
+        AssertUniform400(await harness.Controller.OidBackChannelLogout("nope", _fixture.LogoutToken("sub-1")));
+    }
+
+    [Fact]
+    public async Task ForgedToken_Rejects_MintsNoRevoke()
+    {
+        using var attacker = new OidcTokenFixture(Authority, "jf");
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        });
+
+        // Signed by a DIFFERENT key than the served JWKS.
+        var result = await harness.Controller.OidBackChannelLogout("kc", attacker.LogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task NeverRevokesASamlCaptureWithTheSameSubject()
+    {
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            // A SAML capture for the SAME provider name + subject must be untouched by an OpenID logout.
+            c.LogoutSessions["saml"] = new LogoutSession { Protocol = "SAML", Provider = "kc", Subject = "sub-1", SessionIndex = "sess-9", UserId = UserB };
+        });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        // No OpenID capture matched -> uniform 400, and the SAML user is never revoked.
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(UserB, Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("saml")));
+    }
+
+    [Fact]
+    public async Task SubOnlyToken_RevokesEveryOpenIdSessionOfThatSubjectForThisProvider()
+    {
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a1"] = Session("sub-1", "sess-1", UserA);
+            c.LogoutSessions["a2"] = Session("sub-1", "sess-2", UserA);
+            c.LogoutSessions["other"] = Session("sub-2", "sess-3", UserB);
+        });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1"));
+
+        Assert.IsType<OkResult>(result);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(UserB, Arg.Any<string>());
+    }
+
+    private static void AssertUniform400(ActionResult result)
+    {
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Logout token could not be processed", content.Content);
+    }
+
+    private OidConfig Provider(bool backChannel) => new OidConfig
+    {
+        Enabled = true,
+        OidEndpoint = Authority,
+        OidClientId = "jf",
+        EnableBackChannelLogout = backChannel,
+    };
+
+    private static LogoutSession Session(string subject, string sessionIndex, Guid userId) => new LogoutSession
+    {
+        Protocol = "OpenID",
+        Provider = "kc",
+        Subject = subject,
+        SessionIndex = sessionIndex,
+        UserId = userId,
+        IdToken = "raw.id.token",
+    };
+
+    private SsoControllerHarness Harness(Action<PluginConfiguration> configure, bool withResponder = true)
+        => new SsoControllerHarness(configure, httpResponder: withResponder ? Responder : null);
+
+    // Serves this fixture's discovery document and JWKS; any other URL 404s so an unexpected call is visible.
+    private HttpResponseMessage Responder(HttpRequestMessage request)
+    {
+        var url = request.RequestUri!.AbsoluteUri;
+        if (url == _fixture.DiscoveryUrl)
+        {
+            return Json(_fixture.Discovery());
+        }
+
+        if (url == _fixture.JwksUrl)
+        {
+            return Json(_fixture.Jwks());
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.NotFound);
+    }
+
+    private static HttpResponseMessage Json(string body) => new HttpResponseMessage(HttpStatusCode.OK)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+}

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -28,6 +28,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     private const string KeyId = "test-signing-key";
     private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
 
+    private static readonly TimeSpan Skew = TimeSpan.FromMinutes(5);
+
     private readonly RSA _rsa = RSA.Create(2048);
     private readonly OidcLogoutTokenValidator _validator = new();
     private readonly DateTime _now = DateTime.UtcNow;
@@ -45,7 +47,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1", sid: "sess-9"));
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.True(result.IsValid);
         Assert.Equal("user-1", result.Subject);
@@ -56,7 +58,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task SubOnly_Succeeds_SidNull()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sub: "user-1")), Params(), _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sub: "user-1")), Params(), Skew, _now);
 
         Assert.True(result.IsValid);
         Assert.Equal("user-1", result.Subject);
@@ -66,7 +68,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task SidOnly_Succeeds_SubNull()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sid: "sess-9")), Params(), _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sid: "sess-9")), Params(), Skew, _now);
 
         Assert.True(result.IsValid);
         Assert.Null(result.Subject);
@@ -79,7 +81,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     public async Task AbsentToken_IsMalformed(string? token)
     {
         // Nothing was sent — a distinct fail-closed code from a bad token that reached the JWT handler.
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Malformed, result.ReasonCode);
@@ -93,7 +95,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         // A non-empty non-JWT reaches the handler and fails signature/parse validation — still fail-closed,
         // reported as Invalid (the handler catches it, it never throws a 500).
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -105,7 +107,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         using var attacker = RSA.Create(2048);
         var forged = new JsonWebTokenHandler().CreateToken(Descriptor(Claims(sub: "user-1"), signingKey: attacker));
 
-        var result = await _validator.ValidateAsync(forged, Params(), _now);
+        var result = await _validator.ValidateAsync(forged, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -116,7 +118,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), issuer: "https://evil.example.test");
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -127,7 +129,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), audience: "another-client");
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -139,7 +141,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // 10 minutes past exp is beyond the default 5-minute clock skew.
         var token = CreateToken(claims: Claims(sub: "user-1"), lifetime: TimeSpan.FromMinutes(-10));
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -150,7 +152,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: new Dictionary<string, object> { ["sub"] = "user-1", ["jti"] = Guid.NewGuid().ToString() });
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
@@ -164,7 +166,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         claims["events"] = new Dictionary<string, object> { ["http://schemas.openid.net/event/some-other"] = new Dictionary<string, object>() };
         var token = CreateToken(claims: claims);
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
@@ -178,7 +180,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         claims["nonce"] = "abc123";
         var token = CreateToken(claims: claims);
 
-        var result = await _validator.ValidateAsync(token, Params(), _now);
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.ProhibitedNonce, result.ReasonCode);
@@ -187,7 +189,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task NeitherSubNorSid_IsRejected()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims()), Params(), _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims()), Params(), Skew, _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NoSubjectOrSid, result.ReasonCode);
@@ -198,8 +200,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1", jti: "fixed-jti"));
 
-        var first = await _validator.ValidateAsync(token, Params(), _now);
-        var second = await _validator.ValidateAsync(token, Params(), _now);
+        var first = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var second = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.True(first.IsValid);
         Assert.False(second.IsValid);
@@ -212,8 +214,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // A token with no jti still gets one-time-use via its signature — a byte-identical resend collides.
         var token = CreateToken(claims: Claims(sub: "user-1"));
 
-        Assert.True((await _validator.ValidateAsync(token, Params(), _now)).IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, (await _validator.ValidateAsync(token, Params(), _now)).ReasonCode);
+        Assert.True((await _validator.ValidateAsync(token, Params(), Skew, _now)).IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, (await _validator.ValidateAsync(token, Params(), Skew, _now)).ReasonCode);
     }
 
     [Fact]
@@ -222,11 +224,65 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // Fixed codes only — a rejection is never a subject oracle (T-I1).
         var token = CreateToken(claims: Claims(sub: "secret-subject", sid: "secret-session"));
         // Force a replay rejection carrying no subject text.
-        await _validator.ValidateAsync(token, Params(), _now);
-        var replay = await _validator.ValidateAsync(token, Params(), _now);
+        await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var replay = await _validator.ValidateAsync(token, Params(), Skew, _now);
 
         Assert.DoesNotContain("secret-subject", replay.ReasonCode, StringComparison.Ordinal);
         Assert.DoesNotContain("secret-session", replay.ReasonCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task NoExpClaim_StillSucceeds()
+    {
+        // #962 review fix: OIDC Back-Channel Logout §2.4 does NOT require exp; a spec-compliant exp-less
+        // IdP must NOT be silently no-op'd. Replay is bounded by jti one-time-use, not exp.
+        var token = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = DateTime.UtcNow - TimeSpan.FromMinutes(1),
+            Claims = Claims(sub: "user-1"),
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        });
+
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("user-1", result.Subject);
+    }
+
+    [Fact]
+    public async Task AzpMismatch_IsInvalid()
+    {
+        // Parity with the id_token validator (OIDC Core 3.1.3.7 rule 5): an azp naming a different party is
+        // refused even though this client is the audience.
+        var claims = Claims(sub: "user-1");
+        claims["azp"] = "another-client";
+        var result = await _validator.ValidateAsync(CreateToken(claims: claims), Params(), Skew, _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task MultipleAudiencesWithoutAzp_IsInvalid()
+    {
+        // Rules 3-4: a multi-audience token MUST carry azp; one minted for a co-listed different party is refused.
+        var claims = Claims(sub: "user-1");
+        claims["aud"] = new[] { ClientId, "another-client" }; // multi-audience, no azp
+        var token = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            IssuedAt = DateTime.UtcNow - TimeSpan.FromMinutes(1),
+            Expires = DateTime.UtcNow + TimeSpan.FromMinutes(5),
+            Claims = claims,
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        });
+
+        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
     }
 
     private static Dictionary<string, object> Claims(string? sub = null, string? sid = null, string? jti = null)
@@ -265,7 +321,9 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
                 KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
             },
         };
-        return OidcSignatureKeys.BuildValidationParameters(options, new List<IDisposable>());
+        // The back-channel path builds with requireExpiration:false (OIDC Back-Channel Logout §2.4 does not
+        // mandate exp), so the tests validate under the same posture the endpoint uses.
+        return OidcSignatureKeys.BuildValidationParameters(options, new List<IDisposable>(), requireExpiration: false);
     }
 
     private string CreateToken(IDictionary<string, object> claims, string issuer = Issuer, string audience = ClientId, TimeSpan? lifetime = null)

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Exercises <see cref="OidcLogoutTokenValidator"/> against a static JWKS (#962). Every OIDC Back-Channel
+/// Logout 1.0 §2.6 rule is fail-closed and has a negative test — signature/issuer/audience/lifetime (the
+/// SAME <see cref="OidcSignatureKeys"/> basis the id_token uses), the mandatory back-channel-logout event
+/// member, the forbidden nonce (an id_token replayed as a logout_token), the at-least-one-of-sub/sid rule,
+/// and jti one-time-use. Each rejection carries a fixed reason code and never a subject identifier.
+/// </summary>
+public sealed class OidcLogoutTokenValidatorTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcLogoutTokenValidator _validator = new();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    public OidcLogoutTokenValidatorTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public async Task ValidLogoutToken_WithSubAndSid_Succeeds()
+    {
+        var token = CreateToken(claims: Claims(sub: "user-1", sid: "sess-9"));
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("user-1", result.Subject);
+        Assert.Equal("sess-9", result.SessionIndex);
+        Assert.Empty(result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task SubOnly_Succeeds_SidNull()
+    {
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sub: "user-1")), Params(), _now);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("user-1", result.Subject);
+        Assert.Null(result.SessionIndex);
+    }
+
+    [Fact]
+    public async Task SidOnly_Succeeds_SubNull()
+    {
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sid: "sess-9")), Params(), _now);
+
+        Assert.True(result.IsValid);
+        Assert.Null(result.Subject);
+        Assert.Equal("sess-9", result.SessionIndex);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task AbsentToken_IsMalformed(string? token)
+    {
+        // Nothing was sent — a distinct fail-closed code from a bad token that reached the JWT handler.
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Malformed, result.ReasonCode);
+    }
+
+    [Theory]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("a.b.c")]
+    public async Task GarbageNonJwt_IsInvalid_FailClosed(string token)
+    {
+        // A non-empty non-JWT reaches the handler and fails signature/parse validation — still fail-closed,
+        // reported as Invalid (the handler catches it, it never throws a 500).
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task WrongSigningKey_IsInvalid()
+    {
+        using var attacker = RSA.Create(2048);
+        var forged = new JsonWebTokenHandler().CreateToken(Descriptor(Claims(sub: "user-1"), signingKey: attacker));
+
+        var result = await _validator.ValidateAsync(forged, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task WrongIssuer_IsInvalid()
+    {
+        var token = CreateToken(claims: Claims(sub: "user-1"), issuer: "https://evil.example.test");
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task WrongAudience_IsInvalid()
+    {
+        var token = CreateToken(claims: Claims(sub: "user-1"), audience: "another-client");
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task ExpiredToken_IsInvalid()
+    {
+        // 10 minutes past exp is beyond the default 5-minute clock skew.
+        var token = CreateToken(claims: Claims(sub: "user-1"), lifetime: TimeSpan.FromMinutes(-10));
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task NoEventsClaim_IsNotALogoutToken()
+    {
+        var token = CreateToken(claims: new Dictionary<string, object> { ["sub"] = "user-1", ["jti"] = Guid.NewGuid().ToString() });
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task EventsWithoutTheBackChannelMember_IsNotALogoutToken()
+    {
+        // A valid, signed token whose events claim names a DIFFERENT event — not a back-channel logout.
+        var claims = Claims(sub: "user-1");
+        claims["events"] = new Dictionary<string, object> { ["http://schemas.openid.net/event/some-other"] = new Dictionary<string, object>() };
+        var token = CreateToken(claims: claims);
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task TokenCarryingNonce_IsRejected_IdTokenReplayedAsLogout()
+    {
+        // §2.4: a logout_token MUST NOT carry a nonce — this is what refuses an id_token replayed here.
+        var claims = Claims(sub: "user-1");
+        claims["nonce"] = "abc123";
+        var token = CreateToken(claims: claims);
+
+        var result = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.ProhibitedNonce, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task NeitherSubNorSid_IsRejected()
+    {
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims()), Params(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.NoSubjectOrSid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task ReplayedJti_IsRejected_OneTimeUse()
+    {
+        var token = CreateToken(claims: Claims(sub: "user-1", jti: "fixed-jti"));
+
+        var first = await _validator.ValidateAsync(token, Params(), _now);
+        var second = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.True(first.IsValid);
+        Assert.False(second.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, second.ReasonCode);
+    }
+
+    [Fact]
+    public async Task NoJti_ByteIdenticalResend_IsCaughtAsReplay()
+    {
+        // A token with no jti still gets one-time-use via its signature — a byte-identical resend collides.
+        var token = CreateToken(claims: Claims(sub: "user-1"));
+
+        Assert.True((await _validator.ValidateAsync(token, Params(), _now)).IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, (await _validator.ValidateAsync(token, Params(), _now)).ReasonCode);
+    }
+
+    [Fact]
+    public async Task NoSubjectIdentifierEverAppearsInAReasonCode()
+    {
+        // Fixed codes only — a rejection is never a subject oracle (T-I1).
+        var token = CreateToken(claims: Claims(sub: "secret-subject", sid: "secret-session"));
+        // Force a replay rejection carrying no subject text.
+        await _validator.ValidateAsync(token, Params(), _now);
+        var replay = await _validator.ValidateAsync(token, Params(), _now);
+
+        Assert.DoesNotContain("secret-subject", replay.ReasonCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-session", replay.ReasonCode, StringComparison.Ordinal);
+    }
+
+    private static Dictionary<string, object> Claims(string? sub = null, string? sid = null, string? jti = null)
+    {
+        var claims = new Dictionary<string, object>
+        {
+            ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
+        };
+        if (sub != null)
+        {
+            claims["sub"] = sub;
+        }
+
+        if (sid != null)
+        {
+            claims["sid"] = sid;
+        }
+
+        claims["jti"] = jti ?? Guid.NewGuid().ToString();
+        return claims;
+    }
+
+    private TokenValidationParameters Params()
+    {
+        var p = _rsa.ExportParameters(false);
+        var jwks = $$"""
+            {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """;
+        var options = new OidcClientOptions
+        {
+            ClientId = ClientId,
+            ProviderInformation = new ProviderInformation
+            {
+                IssuerName = Issuer,
+                KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
+            },
+        };
+        return OidcSignatureKeys.BuildValidationParameters(options, new List<IDisposable>());
+    }
+
+    private string CreateToken(IDictionary<string, object> claims, string issuer = Issuer, string audience = ClientId, TimeSpan? lifetime = null)
+        => new JsonWebTokenHandler().CreateToken(Descriptor(claims, issuer, audience, lifetime));
+
+    private SecurityTokenDescriptor Descriptor(IDictionary<string, object> claims, string issuer = Issuer, string audience = ClientId, TimeSpan? lifetime = null, RSA? signingKey = null)
+    {
+        var now = DateTime.UtcNow;
+        return new SecurityTokenDescriptor
+        {
+            Issuer = issuer,
+            Audience = audience,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + (lifetime ?? TimeSpan.FromMinutes(5)),
+            Claims = claims,
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(signingKey ?? _rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        };
+    }
+}

--- a/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
@@ -82,6 +82,47 @@ internal sealed class OidcTokenFixture : IDisposable
         return new JsonWebTokenHandler().CreateToken(descriptor);
     }
 
+    /// <summary>
+    /// A signed back-channel <c>logout_token</c> (#962) carrying the mandatory events member plus the given
+    /// sub/sid/jti, for the OidBackChannelLogout endpoint test. A null sub or sid is omitted.
+    /// </summary>
+    /// <param name="subject">The <c>sub</c> claim, or null to omit it.</param>
+    /// <param name="sessionIndex">The <c>sid</c> claim, or null to omit it.</param>
+    /// <param name="jti">The <c>jti</c> claim (a fresh GUID when null).</param>
+    /// <returns>The signed logout_token.</returns>
+    internal string LogoutToken(string? subject, string? sessionIndex = null, string? jti = null)
+    {
+        var claims = new Dictionary<string, object>
+        {
+            ["events"] = new Dictionary<string, object>
+            {
+                ["http://schemas.openid.net/event/backchannel-logout"] = new Dictionary<string, object>(),
+            },
+            ["jti"] = jti ?? System.Guid.NewGuid().ToString(),
+        };
+        if (subject != null)
+        {
+            claims["sub"] = subject;
+        }
+
+        if (sessionIndex != null)
+        {
+            claims["sid"] = sessionIndex;
+        }
+
+        var now = DateTime.UtcNow;
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = claims,
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        });
+    }
+
     /// <summary>The token-endpoint response body carrying the signed id_token.</summary>
     internal string TokenEndpointJson(string idToken) =>
         "{\"access_token\":\"test-access-token\",\"token_type\":\"Bearer\",\"expires_in\":3600,\"id_token\":\"" + idToken + "\"}";

--- a/SSO-Auth.Tests/RateLimit/ProviderScopedKeyTests.cs
+++ b/SSO-Auth.Tests/RateLimit/ProviderScopedKeyTests.cs
@@ -50,7 +50,7 @@ public class ProviderScopedKeyTests
         var replayKey = ProviderScopedKey.For("kc", string.Empty);
         var requestKey = ProviderScopedKey.For("kc", null);
 
-        Assert.False(new SamlReplayCache().TryConsume(replayKey, now.AddMinutes(10), now, out _));
+        Assert.False(new ReplayCache().TryConsume(replayKey, now.AddMinutes(10), now, out _));
 
         var requests = new SamlRequestCache();
         requests.Register(requestKey!, "binding", now.AddMinutes(15), now, clientKey: null, out _);

--- a/SSO-Auth.Tests/RateLimit/ReplayCacheTests.cs
+++ b/SSO-Auth.Tests/RateLimit/ReplayCacheTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// Tests for <see cref="SamlReplayCache"/> — one-time-use of SAML assertion IDs, the retention
+/// Tests for <see cref="ReplayCache"/> — one-time-use of SAML assertion IDs, the retention
 /// window that keeps a consumed id long enough that it cannot be replayed while still acceptable, and
 /// the throttled cap-refusal capacity-warning signal (#470).
 /// </summary>
@@ -24,7 +24,7 @@ public class SamlReplayCacheTests
     [Fact]
     public void TryConsume_FirstUse_Succeeds_SecondUse_IsReplay()
     {
-        var cache = new SamlReplayCache();
+        var cache = new ReplayCache();
         var expiry = Now.AddMinutes(10);
 
         Assert.True(cache.TryConsume("_assertion-1", expiry, Now, out _));
@@ -34,7 +34,7 @@ public class SamlReplayCacheTests
     [Fact]
     public void TryConsume_DistinctIds_EachSucceedOnce()
     {
-        var cache = new SamlReplayCache();
+        var cache = new ReplayCache();
         var expiry = Now.AddMinutes(10);
 
         Assert.True(cache.TryConsume("_a", expiry, Now, out _));
@@ -46,7 +46,7 @@ public class SamlReplayCacheTests
     [InlineData("")]
     public void TryConsume_MissingId_FailsClosed(string? id)
     {
-        var cache = new SamlReplayCache();
+        var cache = new ReplayCache();
         Assert.False(cache.TryConsume(id!, Now.AddMinutes(10), Now, out _));
     }
 
@@ -55,7 +55,7 @@ public class SamlReplayCacheTests
     {
         // Once retention has elapsed the entry is evicted; a fresh assertion reusing the id (a new
         // login, not a replay of the same still-valid assertion) is accepted again.
-        var cache = new SamlReplayCache();
+        var cache = new ReplayCache();
         Assert.True(cache.TryConsume("_a", Now.AddMinutes(10), Now, out _));
 
         var later = Now.AddMinutes(20);
@@ -65,7 +65,7 @@ public class SamlReplayCacheTests
     // --- Hard cap + throttled prune (#452) ---
 
     // A cache whose cap is small and reachable (production 100k is not).
-    private static SamlReplayCache SmallCache(int cap = 3) => new SamlReplayCache(cap, PruneInterval);
+    private static ReplayCache SmallCache(int cap = 3) => new ReplayCache(cap, PruneInterval);
 
     [Fact]
     public void TryConsume_ReplayStillRejected_UnderCapPressure()
@@ -121,7 +121,7 @@ public class SamlReplayCacheTests
         // The sweep must be throttled, not run on every consume. Add an entry that expires, then a consume
         // WITHIN the prune interval must leave the expired entry in place (an unthrottled sweep would drop
         // it) — proving the IntervalGate throttle is in effect.
-        var cache = new SamlReplayCache(); // production cap: the cap path never fires here
+        var cache = new ReplayCache(); // production cap: the cap path never fires here
         Assert.True(cache.TryConsume("_a", Now.AddSeconds(30), Now, out _)); // enters the gate
 
         var within = Now.AddSeconds(40); // past _a's expiry, within the 1-minute interval
@@ -136,7 +136,7 @@ public class SamlReplayCacheTests
     [Fact]
     public void TryConsume_ExpiredEntry_ReclaimedByThrottledPrune()
     {
-        var cache = new SamlReplayCache();
+        var cache = new ReplayCache();
         Assert.True(cache.TryConsume("_a", Now.AddMinutes(1), Now, out _));
 
         // A later consume past the prune interval sweeps the expired _a.
@@ -217,20 +217,20 @@ public class SamlReplayCacheTests
     [Fact]
     public void ComputeRetention_NoExpiry_UsesOneHourFloor()
     {
-        Assert.Equal(Now.AddHours(1), SamlReplayCache.ComputeRetention(Now, null));
+        Assert.Equal(Now.AddHours(1), ReplayCache.ComputeRetention(Now, null, SamlAssertionTime.ClockSkew));
     }
 
     [Fact]
     public void ComputeRetention_ShortExpiry_UsesFloor()
     {
         // A 5-minute assertion expiry (+skew) is below the one-hour floor, so the floor wins.
-        Assert.Equal(Now.AddHours(1), SamlReplayCache.ComputeRetention(Now, Now.AddMinutes(5)));
+        Assert.Equal(Now.AddHours(1), ReplayCache.ComputeRetention(Now, Now.AddMinutes(5), SamlAssertionTime.ClockSkew));
     }
 
     [Fact]
     public void ComputeRetention_LongExpiry_UsesExpiryPlusSkew()
     {
         var expiry = Now.AddHours(3);
-        Assert.Equal(expiry + SamlAssertionTime.ClockSkew, SamlReplayCache.ComputeRetention(Now, expiry));
+        Assert.Equal(expiry + SamlAssertionTime.ClockSkew, ReplayCache.ComputeRetention(Now, expiry, SamlAssertionTime.ClockSkew));
     }
 }

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -686,8 +686,11 @@ internal sealed class OidcLoginService
         var ephemeralKeys = new List<IDisposable>();
         try
         {
-            var parameters = OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys);
-            return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, parameters, DateTime.UtcNow).ConfigureAwait(false);
+            // requireExpiration:false — OIDC Back-Channel Logout 1.0 §2.4 does not mandate exp on a
+            // logout_token; replay is bounded by the jti one-time-use, not by exp. Requiring it would
+            // silently reject (and thus no-op the logout for) a spec-compliant exp-less IdP (#962).
+            var parameters = OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys, requireExpiration: false);
+            return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, parameters, options.ClockSkew, DateTime.UtcNow).ConfigureAwait(false);
         }
         finally
         {

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -638,6 +638,66 @@ internal sealed class OidcLoginService
     // decided from whether ProviderInformation is set at construction, so the assignment must happen before
     // `new OidcClient(options)`, not after. A null OidEndpoint still fails at the same point it did before
     // (the Uri constructor, after the options object).
+
+    /// <summary>
+    /// Validates an inbound back-channel <c>logout_token</c> for a provider (#962): reads the provider's
+    /// discovery document for its JWKS + issuer, builds the SAME hardened validation parameters the id_token
+    /// uses, and runs <see cref="OidcLogoutTokenValidator"/>. No client secret is revealed — verifying a
+    /// signature needs no credential, so the back-channel path never touches the secret at rest. Every
+    /// failure (a malformed endpoint, an unreadable discovery document, or any §2.6 rule) is fail-closed and
+    /// carries a fixed reason code for the caller to audit; the caller performs the revocation.
+    /// </summary>
+    /// <param name="config">The provider configuration.</param>
+    /// <param name="provider">The provider name (route input, used only for the SSRF-guarded discovery read).</param>
+    /// <param name="logoutToken">The raw <c>logout_token</c> from the anonymous POST body.</param>
+    /// <returns>The validation outcome — on success, the (sub, sid) the caller keys its revocation lookup on.</returns>
+    internal async Task<OidcLogoutTokenValidator.Result> ValidateBackChannelLogoutAsync(OidConfig config, string provider, string? logoutToken)
+    {
+        OidcClientOptions options;
+        try
+        {
+            // Validation-only options: Authority + discovery policy + client id, under the ONE shared
+            // discovery posture (RequireHttps / ValidateIssuerName / ValidateEndpoints). A malformed/absent
+            // endpoint throws here — caught as a fail-closed reject rather than a 500.
+            options = OidcDiscoveryOptions.Build(config);
+        }
+        catch (Exception ex) when (ex is UriFormatException or ArgumentException)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning("OpenID back-channel logout refused for provider {Provider}: the configured endpoint is not a usable URL.", provider?.ReplaceLineEndings(string.Empty));
+            }
+
+            return new OidcLogoutTokenValidator.Result(false, null, null, "discovery_unavailable");
+        }
+
+        options.ClientId = config.OidClientId?.Trim();
+        options.LoggerFactory = _loggerFactory;
+        options.HttpClientFactory = _ => SsoHttp.CreateClient(_httpClientFactory);
+
+        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger).ConfigureAwait(false);
+        if (!discovery.Available)
+        {
+            return new OidcLogoutTokenValidator.Result(false, null, null, "discovery_unavailable");
+        }
+
+        options.ProviderInformation = discovery.ProviderInformation;
+
+        var ephemeralKeys = new List<IDisposable>();
+        try
+        {
+            var parameters = OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys);
+            return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, parameters, DateTime.UtcNow).ConfigureAwait(false);
+        }
+        finally
+        {
+            foreach (var key in ephemeralKeys)
+            {
+                key.Dispose();
+            }
+        }
+    }
+
     private OidcClientOptions BuildOidcOptions(OidConfig config, string redirectUri, string scope)
     {
         // Authority and the discovery policy (RequireHttps / ValidateIssuerName / ValidateEndpoints + the

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -264,6 +264,127 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Inbound OpenID Connect back-channel logout (#962, OIDC Back-Channel Logout 1.0). The identity provider
+    /// POSTs a signed <c>logout_token</c> here to propagate an IdP-side session termination into Jellyfin.
+    /// The endpoint is ANONYMOUS — the token's signature is the only authenticator — so it is fail-closed at
+    /// every step: a disabled feature, an unknown/disabled provider, and a provider without the per-provider
+    /// opt-in all collapse to the SAME uniform response WITHOUT parsing the token, and the validated (sub, sid)
+    /// revokes only the matched user's OpenID sessions for THIS provider (never cross-provider, never a SAML
+    /// capture, never another user). Rate-limited on the Logout class. Every rejection audits a fixed reason
+    /// code and discloses no subject identifier.
+    /// </summary>
+    /// <param name="provider">The OpenID provider the logout_token arrived for.</param>
+    /// <param name="logoutToken">The <c>logout_token</c> form field (model-bound; a non-form POST binds null and is rejected).</param>
+    /// <returns>200 when a validated token revoked at least one session, else a uniform 400 with no cause detail.</returns>
+    [HttpPost("OID/backchannel-logout/{provider}")]
+    public async Task<ActionResult> OidBackChannelLogout(string provider, [FromForm(Name = "logout_token")] string? logoutToken = null)
+    {
+        if (RateLimitCheck(SsoRateLimitClass.Logout) is { } throttled)
+        {
+            return throttled;
+        }
+
+        // Read the master switch, the per-provider opt-in, AND the provider config in one lock acquisition.
+        // A disabled feature, a provider without the opt-in, an unknown provider, and a disabled provider all
+        // collapse to the ONE uniform 400 below, and NONE of them reads the untrusted token — so the signed-JWT
+        // sink is unreachable while the feature is off, and neither the feature state nor the provider set can
+        // be probed apart.
+        var (enabled, config) = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            (configuration.EnableSingleLogout, configuration.OidConfigs.TryGetValue(provider, out var oidConfig) ? oidConfig : null));
+
+        if (!enabled || config is not { Enabled: true, EnableBackChannelLogout: true })
+        {
+            return UniformBackChannelLogoutRejection();
+        }
+
+        // Read discovery for the JWKS + issuer, then validate signature + every §2.6 rule (events member, no
+        // nonce, sub/sid present, jti one-time-use) via the SAME hardened basis the id_token uses. On any
+        // failure the reason code is a FIXED constant (never token-derived) written only to the audit trail;
+        // the caller sees the uniform 400 with no branch-distinguishing detail (no subject oracle).
+        var result = await _oidc.ValidateBackChannelLogoutAsync(config, provider, logoutToken).ConfigureAwait(false);
+        if (!result.IsValid)
+        {
+            SsoAudit.LogoutRejected(_logger, provider, result.ReasonCode);
+            return UniformBackChannelLogoutRejection();
+        }
+
+        // Resolve the targeted sessions — strictly the SAME provider and subject (ordinal exact), AND only
+        // OpenID captures. FindByProviderSubject filters by (provider, subject) as the blast-radius bound; the
+        // Protocol filter keeps OpenID and SAML apart (an OpenID and a SAML provider can share a config name
+        // and a subject string). When the token names a sid, keep only entries whose captured SessionIndex
+        // matches; a token with sub but no sid targets every OpenID session of that subject for this provider
+        // (§2.4). A token with sid but no sub is matched by sid alone (subject is then whatever captured it).
+        var matches = SSOPlugin.Instance.ReadConfiguration(configuration =>
+            SessionLogoutStore
+                .FindByProviderSubject(configuration, provider, result.Subject ?? string.Empty, result.SessionIndex ?? string.Empty)
+                .Where(pair => string.Equals(pair.Value.Protocol, OpenIdProtocol, StringComparison.Ordinal))
+                .ToList());
+
+        // When the token carries no sub (sid-only), FindByProviderSubject's empty-subject guard returns
+        // nothing, so match on sid across this provider's OpenID captures directly.
+        if (result.Subject is null && result.SessionIndex is not null)
+        {
+            matches = SSOPlugin.Instance.ReadConfiguration(configuration =>
+                configuration.LogoutSessions
+                    .Where(pair =>
+                        string.Equals(pair.Value.Protocol, OpenIdProtocol, StringComparison.Ordinal)
+                        && string.Equals(pair.Value.Provider, provider, StringComparison.Ordinal)
+                        && string.Equals(pair.Value.SessionIndex, result.SessionIndex, StringComparison.Ordinal))
+                    .ToList());
+        }
+
+        // A validated token resolving NO session is the "unknown-subject" case: render the SAME uniform 400.
+        // An anonymous attacker can never produce a valid signature to reach here, so this discloses nothing;
+        // only the trusted IdP (which already knows its own subjects) can tell it from a 200, which is fine.
+        if (matches.Count == 0)
+        {
+            SsoAudit.LogoutRejected(_logger, provider, "no_matching_session");
+            return UniformBackChannelLogoutRejection();
+        }
+
+        // Revoke the tokens of each DISTINCT matched user — the SAME user-scoped fail-SAFE loop the inbound
+        // SAML logout uses: a revoke fault for one user must not abort the others, and only the entries whose
+        // user was actually revoked are consumed (a transient fault leaves the entry for a later retry).
+        var succeeded = new HashSet<Guid>();
+        foreach (var userId in matches.Select(pair => pair.Value.UserId).Distinct())
+        {
+            try
+            {
+                await _sessionManager.RevokeUserTokens(userId, null).ConfigureAwait(false);
+                succeeded.Add(userId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Revoking tokens during OpenID back-channel logout failed for one user; the remaining matched users are still logged out.");
+            }
+        }
+
+        var consumedKeys = matches.Where(pair => succeeded.Contains(pair.Value.UserId)).Select(pair => pair.Key).ToList();
+        if (consumedKeys.Count > 0)
+        {
+            SSOPlugin.Instance.MutateConfiguration(configuration =>
+            {
+                foreach (var key in consumedKeys)
+                {
+                    SessionLogoutStore.Remove(configuration, key);
+                }
+            });
+        }
+
+        if (succeeded.Count == 0)
+        {
+            SsoAudit.LogoutRejected(_logger, provider, "revoke_failed");
+            return UniformBackChannelLogoutRejection();
+        }
+
+        SsoAudit.LogoutRequested(_logger, provider, succeeded.Count);
+
+        // §2.7: a 200 with no body signals success. The IdP is the only party that can distinguish this from
+        // the uniform 400, and it already knows its own subjects — no oracle for an anonymous caller.
+        return Ok();
+    }
+
+    /// <summary>
     /// SP-initiated outbound SAML Single Logout (#727, SLO-3c). Ends the CALLER's local Jellyfin session, then
     /// — when Single Logout is enabled, the provider has a configured SLO endpoint, a signing key loads, and the
     /// caller has a captured SAML session with a NameID — redirects the browser to the identity provider's
@@ -1000,6 +1121,17 @@ public class SSOController : ControllerBase
     private static ContentResult UniformLogoutRejection() => new ContentResult
     {
         Content = "SAML logout request could not be processed",
+        ContentType = MediaTypeNames.Text.Plain,
+        StatusCode = StatusCodes.Status400BadRequest,
+    };
+
+    // The ONE response for every back-channel-logout failure (#962) — a disabled feature, a bad token, an
+    // unmatched subject, or a revoke fault all return this, so the anonymous caller learns nothing about which
+    // branch rejected it (no subject/feature/provider oracle). Distinct wording from the SAML rejection only
+    // because the protocols differ; both carry no cause detail.
+    private static ContentResult UniformBackChannelLogoutRejection() => new ContentResult
+    {
+        Content = "Logout token could not be processed",
         ContentType = MediaTypeNames.Text.Plain,
         StatusCode = StatusCodes.Status400BadRequest,
     };

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -28,16 +28,6 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// </summary>
 internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
 {
-    // Asymmetric signature algorithms only (RFC 7518): symmetric HS* would accept a token minted by
-    // anyone holding the shared client secret, and "none" is unauthenticated by definition — both are
-    // rejected regardless of what key material the discovery document advertises.
-    private static readonly string[] AllowedSignatureAlgorithms =
-    {
-        "RS256", "RS384", "RS512",
-        "PS256", "PS384", "PS512",
-        "ES256", "ES384", "ES512",
-    };
-
     /// <inheritdoc />
     public async Task<IdentityTokenValidationResult> ValidateAsync(string identityToken, OidcClientOptions options, CancellationToken cancellationToken = default)
     {
@@ -53,7 +43,7 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
             // types — the default mapping would rename "sub" and friends to SOAP-style URIs and break
             // every ordinal claim comparison downstream.
             var handler = new JsonWebTokenHandler { MapInboundClaims = false };
-            var result = await handler.ValidateTokenAsync(identityToken, BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
+            var result = await handler.ValidateTokenAsync(identityToken, OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
             if (!result.IsValid)
             {
                 return Reject(MapError(result.Exception));
@@ -89,30 +79,6 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
         }
     }
 
-    // Signature / issuer / audience / lifetime configuration for the handler: the discovery JWKS as the
-    // only signing keys, the asymmetric-only algorithm allowlist, the discovery issuer, the client id as
-    // the audience, and the client's clock skew. Signed + expiring tokens are required (fail closed).
-    private static TokenValidationParameters BuildValidationParameters(OidcClientOptions options, List<IDisposable> ephemeralKeys) =>
-        new()
-        {
-            ValidIssuer = options.ProviderInformation.IssuerName,
-            ValidAudience = options.ClientId,
-            IssuerSigningKeys = ConvertSigningKeys(options.ProviderInformation.KeySet, ephemeralKeys),
-            ValidAlgorithms = AllowedSignatureAlgorithms,
-            ClockSkew = options.ClockSkew,
-            RequireSignedTokens = true,
-            RequireExpirationTime = true,
-            // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
-            // legitimately differs from the discovery location; it relaxes ONLY the issuer match.
-            // Signature, audience and lifetime validation have no off switch.
-            ValidateIssuer = options.Policy.Discovery.ValidateIssuerName,
-            // The downstream claim scan compares raw JWT claim names ordinally ("preferred_username",
-            // "sub", the configured role-claim path), so the principal must carry the payload names
-            // verbatim — these two only name the identity's Name/Role accessors.
-            NameClaimType = "name",
-            RoleClaimType = "role",
-        };
-
     // azp (OIDC Core 3.1.3.7 rule 5): optional, but when present it MUST equal this client's id —
     // a token authorized for a different party must not log in here. Returns the rejection reason, or
     // null when the check passes.
@@ -146,135 +112,4 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
         null => "Identity token validation failed",
         _ => $"Identity token validation failed: {exception.GetType().Name}",
     };
-
-    // Converts the discovery JWKS into Microsoft.IdentityModel signing keys, mirroring the conversion
-    // of Duende's retired validator package: RSA from e/n, EC from crv/x/y, keys marked use!="sig"
-    // excluded. A malformed or unsupported advertised key is skipped rather than thrown on — one
-    // broken key in the set must not take down logins signed by a good one; if NO usable key remains,
-    // validation fails closed with the key-not-found path above. Each key's conversion is delegated to
-    // TryConvertSigningKey so this stays a plain filter-map over the advertised set.
-    private static List<SecurityKey> ConvertSigningKeys(Duende.IdentityModel.Jwk.JsonWebKeySet? keySet, List<IDisposable> ephemeralKeys)
-    {
-        var keys = new List<SecurityKey>();
-        if (keySet?.Keys == null)
-        {
-            return keys;
-        }
-
-        foreach (var webKey in keySet.Keys)
-        {
-            if (TryConvertSigningKey(webKey, ephemeralKeys, out var key))
-            {
-                keys.Add(key);
-            }
-        }
-
-        return keys;
-    }
-
-    // Converts one advertised JWK into a usable signing key, or reports that it is unusable (out false).
-    // The exclusions and the skip-on-malformed contract live here: a literal null entry (["keys":[null]])
-    // must be skipped rather than dereferenced (otherwise the whole login 500s), a key marked use!="sig"
-    // is not a signing key, and un-decodable/invalid key material is caught and skipped so one broken key
-    // in the set cannot take down logins signed by a good one. Returns false — never throws — on every
-    // reject path so the caller drops the key without aborting the scan.
-    private static bool TryConvertSigningKey(Duende.IdentityModel.Jwk.JsonWebKey? webKey, List<IDisposable> ephemeralKeys, [NotNullWhen(true)] out SecurityKey? key)
-    {
-        key = null;
-        if (webKey == null)
-        {
-            return false;
-        }
-
-        if (webKey.Use != null && !string.Equals(webKey.Use, "sig", StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        try
-        {
-            // RSA (e/n) is tried first; an EC (crv/x/y) key is only attempted when the key is not RSA-shaped,
-            // preserving the original else-if precedence. A decode/point failure throws out of the converter
-            // and is caught below as a skip.
-            key = (SecurityKey?)ConvertRsaSigningKey(webKey) ?? ConvertEcSigningKey(webKey, ephemeralKeys);
-        }
-        catch (FormatException)
-        {
-            // Un-decodable key material in one advertised key: skip it, the remaining keys decide.
-            return false;
-        }
-        catch (CryptographicException)
-        {
-            // Invalid EC point/curve combination: likewise skip.
-            return false;
-        }
-
-        return key != null;
-    }
-
-    // RSA signing key from the JWK e/n pair (RFC 7518). Returns null when the key does not carry both
-    // parameters (not RSA-shaped, so the EC conversion is tried instead) OR when the built key is below the
-    // minimum size floor (#733) — an under-strength RSA key from the discovery JWKS (or a compromised one) is
-    // as forgeable as a weak hash, so it is skipped exactly like a malformed key; the remaining advertised
-    // keys decide, and if none is usable the login fails via the key-not-found path. A non-base64url
-    // exponent/modulus throws FormatException, surfaced to TryConvertSigningKey's skip path.
-    private static RsaSecurityKey? ConvertRsaSigningKey(Duende.IdentityModel.Jwk.JsonWebKey webKey)
-    {
-        if (string.IsNullOrEmpty(webKey.E) || string.IsNullOrEmpty(webKey.N))
-        {
-            return null;
-        }
-
-        var key = new RsaSecurityKey(new RSAParameters
-        {
-            Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
-            Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
-        })
-        { KeyId = webKey.Kid };
-
-        return SigningKeyStrength.IsAcceptableRsaKeySize(key.KeySize) ? key : null;
-    }
-
-    // EC signing key from the JWK crv/x/y triple. Returns null when a coordinate is absent or the curve is
-    // unsupported (TryGetCurve false), so the key is skipped. The ECDsa instance is registered in
-    // ephemeralKeys for disposal by ValidateAsync. A non-base64url coordinate throws FormatException and an
-    // invalid point throws CryptographicException — both surfaced to TryConvertSigningKey's skip path.
-    private static ECDsaSecurityKey? ConvertEcSigningKey(Duende.IdentityModel.Jwk.JsonWebKey webKey, List<IDisposable> ephemeralKeys)
-    {
-        if (string.IsNullOrEmpty(webKey.X) || string.IsNullOrEmpty(webKey.Y) || !TryGetCurve(webKey.Crv, out var curve))
-        {
-            return null;
-        }
-
-        var ecdsa = ECDsa.Create(new ECParameters
-        {
-            Curve = curve,
-            Q = new ECPoint
-            {
-                X = Base64UrlEncoder.DecodeBytes(webKey.X),
-                Y = Base64UrlEncoder.DecodeBytes(webKey.Y),
-            },
-        });
-        ephemeralKeys.Add(ecdsa);
-        return new ECDsaSecurityKey(ecdsa) { KeyId = webKey.Kid };
-    }
-
-    private static bool TryGetCurve(string? crv, out ECCurve curve)
-    {
-        switch (crv)
-        {
-            case "P-256":
-                curve = ECCurve.NamedCurves.nistP256;
-                return true;
-            case "P-384":
-                curve = ECCurve.NamedCurves.nistP384;
-                return true;
-            case "P-521":
-                curve = ECCurve.NamedCurves.nistP521;
-                return true;
-            default:
-                curve = default;
-                return false;
-        }
-    }
 }

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -41,11 +41,13 @@ internal sealed class OidcLogoutTokenValidator
     /// </summary>
     /// <param name="logoutToken">The raw compact-serialized logout_token.</param>
     /// <param name="validationParameters">The signature/issuer/audience/lifetime parameters — the SAME basis the id_token uses.</param>
+    /// <param name="clockSkew">The validation clock skew (used for the jti-retention window; matches the parameters' ClockSkew).</param>
     /// <param name="nowUtc">The current time (injected for determinism).</param>
     /// <returns>The validation outcome.</returns>
     internal async Task<Result> ValidateAsync(
         string? logoutToken,
         TokenValidationParameters validationParameters,
+        TimeSpan clockSkew,
         DateTime nowUtc)
     {
         if (string.IsNullOrEmpty(logoutToken))
@@ -63,6 +65,22 @@ internal sealed class OidcLogoutTokenValidator
         }
 
         var token = (JsonWebToken)result.SecurityToken;
+
+        // azp / additional-audience restriction (OIDC Core 3.1.3.7 rules 3-5), the SAME check the id_token
+        // validator applies — §2.4 says the logout_token aud follows OpenID.Core, so the two token types
+        // must not drift on it: when azp is present it MUST equal this client's id, and a multi-audience
+        // token MUST carry azp (a token minted for a different party that merely co-lists this client is
+        // refused). ValidateAudience already confirmed this client is AMONG the audiences.
+        var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
+        if (azp != null && !string.Equals(azp, validationParameters.ValidAudience, StringComparison.Ordinal))
+        {
+            return new Result(false, null, null, RejectReason.Invalid);
+        }
+
+        if (azp == null && token.Audiences.Count() > 1)
+        {
+            return new Result(false, null, null, RejectReason.Invalid);
+        }
 
         // §2.4: a logout_token MUST NOT contain a nonce. Rejecting it here is what refuses an id_token
         // (which carries nonce) replayed at the back-channel endpoint.
@@ -92,7 +110,7 @@ internal sealed class OidcLogoutTokenValidator
         var jti = token.TryGetPayloadValue<string>("jti", out var j) && !string.IsNullOrEmpty(j)
             ? j
             : token.EncodedSignature;
-        var retention = ReplayCache.ComputeRetention(nowUtc, token.ValidTo == DateTime.MinValue ? null : token.ValidTo, TimeSpan.FromMinutes(5));
+        var retention = ReplayCache.ComputeRetention(nowUtc, token.ValidTo == DateTime.MinValue ? null : token.ValidTo, clockSkew);
         if (!LogoutTokenReplays.TryConsume(jti, retention, nowUtc, out _))
         {
             return new Result(false, null, null, RejectReason.Replay);

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// Validates an inbound OpenID Connect back-channel <c>logout_token</c> (OIDC Back-Channel Logout 1.0
+/// §2.4–§2.6, #962). The endpoint that calls this is ANONYMOUS — the token's signature is the only
+/// authenticator — so every §2.6 rule is fail-closed and each maps to a fixed reason code (never
+/// request-derived text, so a rejection leaves an audit trail without a subject-identifier oracle,
+/// mirroring the SAML inbound-logout validator). Signature/JWKS/algorithm verification goes through the
+/// SAME <see cref="OidcSignatureKeys"/> basis the id_token validator uses — there is no second, laxer
+/// verification path. On success it yields the (sub, sid) pair the revocation lookup keys on; the
+/// validator itself revokes nothing.
+/// </summary>
+internal sealed class OidcLogoutTokenValidator
+{
+    // The logout event the events claim MUST contain (§2.4). A member-presence check, not equality on the
+    // whole claim — the claim is a JSON object whose keys are event URIs.
+    private const string BackChannelLogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    // Distinct from the login-path id_token replay set and the SAML logout set: a consumed logout_token jti
+    // must not be redeemable twice (§2.6 rule the spec RECOMMENDS; here it is enforced as one-time-use so a
+    // captured valid token cannot churn revocations). Process-wide, bounded, fail-closed at capacity.
+    private static readonly ReplayCache LogoutTokenReplays = new ReplayCache();
+
+    /// <summary>Clears the replay set so a jti consumed in one test does not leak into a sibling.</summary>
+    internal static void ResetReplaysForTests() => LogoutTokenReplays.Clear();
+
+    /// <summary>
+    /// Parses and fully validates a <c>logout_token</c> for a provider.
+    /// </summary>
+    /// <param name="logoutToken">The raw compact-serialized logout_token.</param>
+    /// <param name="validationParameters">The signature/issuer/audience/lifetime parameters — the SAME basis the id_token uses.</param>
+    /// <param name="nowUtc">The current time (injected for determinism).</param>
+    /// <returns>The validation outcome.</returns>
+    internal async Task<Result> ValidateAsync(
+        string? logoutToken,
+        TokenValidationParameters validationParameters,
+        DateTime nowUtc)
+    {
+        if (string.IsNullOrEmpty(logoutToken))
+        {
+            return new Result(false, null, null, RejectReason.Malformed);
+        }
+
+        // Signature / issuer / audience / lifetime — the SAME hardened basis as the id_token (the caller
+        // builds validationParameters via OidcSignatureKeys); any failure is fail-closed.
+        var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+        var result = await handler.ValidateTokenAsync(logoutToken, validationParameters).ConfigureAwait(false);
+        if (!result.IsValid)
+        {
+            return new Result(false, null, null, RejectReason.Invalid);
+        }
+
+        var token = (JsonWebToken)result.SecurityToken;
+
+        // §2.4: a logout_token MUST NOT contain a nonce. Rejecting it here is what refuses an id_token
+        // (which carries nonce) replayed at the back-channel endpoint.
+        if (token.TryGetPayloadValue<string>("nonce", out var nonce) && !string.IsNullOrEmpty(nonce))
+        {
+            return new Result(false, null, null, RejectReason.ProhibitedNonce);
+        }
+
+        // §2.4/§2.6: the events claim MUST be a JSON object containing the back-channel-logout member.
+        if (!HasBackChannelLogoutEvent(token))
+        {
+            return new Result(false, null, null, RejectReason.NotALogoutToken);
+        }
+
+        var sub = token.TryGetPayloadValue<string>("sub", out var s) && !string.IsNullOrEmpty(s) ? s : null;
+        var sid = token.TryGetPayloadValue<string>("sid", out var i) && !string.IsNullOrEmpty(i) ? i : null;
+
+        // §2.4: at least one of sub / sid MUST be present.
+        if (sub is null && sid is null)
+        {
+            return new Result(false, null, null, RejectReason.NoSubjectOrSid);
+        }
+
+        // One-time-use on jti so a captured valid token cannot be replayed to churn revocations. A token
+        // without a jti is treated as non-replayable-once (fail-closed): give it a synthetic key derived
+        // from its signature so an identical token still collides, while distinct tokens do not.
+        var jti = token.TryGetPayloadValue<string>("jti", out var j) && !string.IsNullOrEmpty(j)
+            ? j
+            : token.EncodedSignature;
+        var retention = ReplayCache.ComputeRetention(nowUtc, token.ValidTo == DateTime.MinValue ? null : token.ValidTo, TimeSpan.FromMinutes(5));
+        if (!LogoutTokenReplays.TryConsume(jti, retention, nowUtc, out _))
+        {
+            return new Result(false, null, null, RejectReason.Replay);
+        }
+
+        return new Result(true, sub, sid, string.Empty);
+    }
+
+    // The events claim is a JSON object; presence of the back-channel-logout member is what makes this a
+    // logout_token. Read it as a JsonElement and require the member — a claim that is absent, not an object,
+    // or an object without the member is rejected. Any parse failure is a fail-closed "not a logout_token".
+    private static bool HasBackChannelLogoutEvent(JsonWebToken token)
+    {
+        if (!token.TryGetPayloadValue<JsonElement>("events", out var events))
+        {
+            return false;
+        }
+
+        return events.ValueKind == JsonValueKind.Object
+            && events.TryGetProperty(BackChannelLogoutEvent, out _);
+    }
+
+    /// <summary>
+    /// The outcome of validating a <c>logout_token</c>: on success the (sub, sid) pair the caller keys its
+    /// <c>FindByProviderSubject</c> lookup on (either may be null, but never both — §2.4); on failure a
+    /// fixed <see cref="RejectReason"/> code.
+    /// </summary>
+    /// <param name="IsValid">Whether the token is a valid logout_token.</param>
+    /// <param name="Subject">The token's <c>sub</c> claim on success, else null.</param>
+    /// <param name="SessionIndex">The token's <c>sid</c> claim on success, else null.</param>
+    /// <param name="ReasonCode">A fixed rejection reason code on failure, else empty.</param>
+    internal readonly record struct Result(bool IsValid, string? Subject, string? SessionIndex, string ReasonCode);
+
+    /// <summary>The fixed rejection reason codes — request-independent, safe to audit and never a subject oracle.</summary>
+    internal static class RejectReason
+    {
+        /// <summary>The token was absent, unparseable, or not a JWT.</summary>
+        internal const string Malformed = "malformed";
+
+        /// <summary>Signature, issuer, audience, algorithm, or lifetime validation failed (unsigned, wrong key, weak alg, expired).</summary>
+        internal const string Invalid = "signature_or_time_invalid";
+
+        /// <summary>The events claim is absent or does not contain the back-channel-logout event — this is not a logout_token.</summary>
+        internal const string NotALogoutToken = "not_a_logout_token";
+
+        /// <summary>The token carries a nonce, which §2.4 forbids (an id_token replayed as a logout_token).</summary>
+        internal const string ProhibitedNonce = "prohibited_nonce";
+
+        /// <summary>Neither sub nor sid is present — nothing to match a session on.</summary>
+        internal const string NoSubjectOrSid = "no_subject_or_sid";
+
+        /// <summary>The jti was already consumed — a replayed logout_token.</summary>
+        internal const string Replay = "replay";
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -41,8 +41,9 @@ internal static class OidcSignatureKeys
     /// </summary>
     /// <param name="options">The provider's client options (discovery issuer + JWKS, client id, skew, policy).</param>
     /// <param name="ephemeralKeys">Collects disposable ECDsa handles for the caller to release.</param>
+    /// <param name="requireExpiration">Whether an <c>exp</c> claim is mandatory. True for the id_token (OIDC Core 3.1.3.7 mandates exp); false for the back-channel logout_token, where OIDC Back-Channel Logout 1.0 §2.4 does NOT list exp among the required claims (replay is bounded by the jti one-time-use instead) — requiring it would silently no-op a spec-compliant exp-less IdP (#962).</param>
     /// <returns>The hardened validation parameters.</returns>
-    internal static TokenValidationParameters BuildValidationParameters(OidcClientOptions options, List<IDisposable> ephemeralKeys)
+    internal static TokenValidationParameters BuildValidationParameters(OidcClientOptions options, List<IDisposable> ephemeralKeys, bool requireExpiration = true)
     {
         ArgumentNullException.ThrowIfNull(options);
         return new TokenValidationParameters
@@ -53,7 +54,7 @@ internal static class OidcSignatureKeys
             ValidAlgorithms = AllowedSignatureAlgorithms,
             ClockSkew = options.ClockSkew,
             RequireSignedTokens = true,
-            RequireExpirationTime = true,
+            RequireExpirationTime = requireExpiration,
 
             // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
             // legitimately differs from the discovery location; it relaxes ONLY the issuer match.

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Crypto;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// The ONE OpenID signature-validation basis, shared by every token the plugin verifies against a
+/// provider's discovery JWKS — the id_token (<see cref="OidcIdTokenValidator"/>) and the back-channel
+/// <c>logout_token</c> (<see cref="OidcLogoutTokenValidator"/>, #962). Centralising the asymmetric-only
+/// algorithm allowlist and the JWK→<see cref="SecurityKey"/> conversion here means there is provably no
+/// second, laxer verification path: a token type cannot accidentally accept HS*, <c>none</c>, an
+/// under-strength key, or malformed key material that the other type rejects.
+/// </summary>
+internal static class OidcSignatureKeys
+{
+    /// <summary>
+    /// Gets the asymmetric signature algorithms the plugin accepts (RFC 7518). Symmetric HS* would accept a
+    /// token minted by anyone holding the shared client secret, and <c>none</c> is unauthenticated by
+    /// definition — both are rejected regardless of what the discovery document advertises.
+    /// </summary>
+    internal static string[] AllowedSignatureAlgorithms { get; } =
+    {
+        "RS256", "RS384", "RS512",
+        "PS256", "PS384", "PS512",
+        "ES256", "ES384", "ES512",
+    };
+
+    /// <summary>
+    /// Builds the signature/issuer/audience/lifetime validation parameters every JWT the plugin verifies
+    /// against a provider uses — the id_token and the back-channel logout_token share this ONE builder, so
+    /// their signature posture cannot drift apart. Signed + expiring tokens are required (fail closed); the
+    /// provider-level <c>DoNotValidateIssuerName</c> escape hatch relaxes ONLY the issuer match.
+    /// </summary>
+    /// <param name="options">The provider's client options (discovery issuer + JWKS, client id, skew, policy).</param>
+    /// <param name="ephemeralKeys">Collects disposable ECDsa handles for the caller to release.</param>
+    /// <returns>The hardened validation parameters.</returns>
+    internal static TokenValidationParameters BuildValidationParameters(OidcClientOptions options, List<IDisposable> ephemeralKeys)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        return new TokenValidationParameters
+        {
+            ValidIssuer = options.ProviderInformation.IssuerName,
+            ValidAudience = options.ClientId,
+            IssuerSigningKeys = Convert(options.ProviderInformation.KeySet, ephemeralKeys),
+            ValidAlgorithms = AllowedSignatureAlgorithms,
+            ClockSkew = options.ClockSkew,
+            RequireSignedTokens = true,
+            RequireExpirationTime = true,
+
+            // The provider-level escape hatch (DoNotValidateIssuerName) exists for IdPs whose issuer
+            // legitimately differs from the discovery location; it relaxes ONLY the issuer match.
+            // Signature, audience and lifetime validation have no off switch.
+            ValidateIssuer = options.Policy.Discovery.ValidateIssuerName,
+
+            // The downstream claim scan compares raw JWT claim names ordinally, so the principal must carry
+            // the payload names verbatim — these two only name the identity's Name/Role accessors.
+            NameClaimType = "name",
+            RoleClaimType = "role",
+        };
+    }
+
+    /// <summary>
+    /// Converts the advertised JWKS into usable signing keys, skipping any key that is null, not a signing
+    /// key (<c>use != "sig"</c>), under the RSA size floor (#733), or of un-decodable/invalid material — so
+    /// one broken key in the set cannot take down verification against a good one. Never throws.
+    /// </summary>
+    /// <param name="keySet">The advertised JSON Web Key Set (may be null/empty).</param>
+    /// <param name="ephemeralKeys">Collects disposable ECDsa handles for the caller to release.</param>
+    /// <returns>The usable signing keys (possibly empty).</returns>
+    internal static List<SecurityKey> Convert(Duende.IdentityModel.Jwk.JsonWebKeySet? keySet, List<IDisposable> ephemeralKeys)
+    {
+        ArgumentNullException.ThrowIfNull(ephemeralKeys);
+        var keys = new List<SecurityKey>();
+        if (keySet?.Keys == null)
+        {
+            return keys;
+        }
+
+        foreach (var webKey in keySet.Keys)
+        {
+            if (TryConvertSigningKey(webKey, ephemeralKeys, out var key))
+            {
+                keys.Add(key);
+            }
+        }
+
+        return keys;
+    }
+
+    // Converts one advertised JWK into a usable signing key, or reports that it is unusable (out false).
+    // The exclusions and the skip-on-malformed contract live here: a literal null entry (["keys":[null]])
+    // must be skipped rather than dereferenced (otherwise the whole verification 500s), a key marked
+    // use!="sig" is not a signing key, and un-decodable/invalid key material is caught and skipped so one
+    // broken key in the set cannot take down verification signed by a good one. Returns false — never
+    // throws — on every reject path so the caller drops the key without aborting the scan.
+    private static bool TryConvertSigningKey(Duende.IdentityModel.Jwk.JsonWebKey? webKey, List<IDisposable> ephemeralKeys, [NotNullWhen(true)] out SecurityKey? key)
+    {
+        key = null;
+        if (webKey == null)
+        {
+            return false;
+        }
+
+        if (webKey.Use != null && !string.Equals(webKey.Use, "sig", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            // RSA (e/n) is tried first; an EC (crv/x/y) key is only attempted when the key is not RSA-shaped,
+            // preserving the original else-if precedence. A decode/point failure throws out of the converter
+            // and is caught below as a skip.
+            key = (SecurityKey?)ConvertRsaSigningKey(webKey) ?? ConvertEcSigningKey(webKey, ephemeralKeys);
+        }
+        catch (FormatException)
+        {
+            // Un-decodable key material in one advertised key: skip it, the remaining keys decide.
+            return false;
+        }
+        catch (CryptographicException)
+        {
+            // Invalid EC point/curve combination: likewise skip.
+            return false;
+        }
+
+        return key != null;
+    }
+
+    // RSA signing key from the JWK e/n pair (RFC 7518). Returns null when the key does not carry both
+    // parameters (not RSA-shaped, so the EC conversion is tried instead) OR when the built key is below the
+    // minimum size floor (#733) — an under-strength RSA key from the discovery JWKS (or a compromised one) is
+    // as forgeable as a weak hash, so it is skipped exactly like a malformed key; the remaining advertised
+    // keys decide, and if none is usable verification fails via the key-not-found path. A non-base64url
+    // exponent/modulus throws FormatException, surfaced to TryConvertSigningKey's skip path.
+    private static RsaSecurityKey? ConvertRsaSigningKey(Duende.IdentityModel.Jwk.JsonWebKey webKey)
+    {
+        if (string.IsNullOrEmpty(webKey.E) || string.IsNullOrEmpty(webKey.N))
+        {
+            return null;
+        }
+
+        var key = new RsaSecurityKey(new RSAParameters
+        {
+            Exponent = Base64UrlEncoder.DecodeBytes(webKey.E),
+            Modulus = Base64UrlEncoder.DecodeBytes(webKey.N),
+        })
+        { KeyId = webKey.Kid };
+
+        return SigningKeyStrength.IsAcceptableRsaKeySize(key.KeySize) ? key : null;
+    }
+
+    // EC signing key from the JWK crv/x/y triple. Returns null when a coordinate is absent or the curve is
+    // unsupported (TryGetCurve false), so the key is skipped. The ECDsa instance is registered in
+    // ephemeralKeys for disposal by the caller. A non-base64url coordinate throws FormatException and an
+    // invalid point throws CryptographicException — both surfaced to TryConvertSigningKey's skip path.
+    private static ECDsaSecurityKey? ConvertEcSigningKey(Duende.IdentityModel.Jwk.JsonWebKey webKey, List<IDisposable> ephemeralKeys)
+    {
+        if (string.IsNullOrEmpty(webKey.X) || string.IsNullOrEmpty(webKey.Y) || !TryGetCurve(webKey.Crv, out var curve))
+        {
+            return null;
+        }
+
+        var ecdsa = ECDsa.Create(new ECParameters
+        {
+            Curve = curve,
+            Q = new ECPoint
+            {
+                X = Base64UrlEncoder.DecodeBytes(webKey.X),
+                Y = Base64UrlEncoder.DecodeBytes(webKey.Y),
+            },
+        });
+        ephemeralKeys.Add(ecdsa);
+        return new ECDsaSecurityKey(ecdsa) { KeyId = webKey.Kid };
+    }
+
+    private static bool TryGetCurve(string? crv, out ECCurve curve)
+    {
+        switch (crv)
+        {
+            case "P-256":
+                curve = ECCurve.NamedCurves.nistP256;
+                return true;
+            case "P-384":
+                curve = ECCurve.NamedCurves.nistP384;
+                return true;
+            case "P-521":
+                curve = ECCurve.NamedCurves.nistP521;
+                return true;
+            default:
+                curve = default;
+                return false;
+        }
+    }
+}

--- a/SSO-Auth/Api/RateLimit/ReplayCache.cs
+++ b/SSO-Auth/Api/RateLimit/ReplayCache.cs
@@ -3,18 +3,18 @@
 
 using System;
 using System.Collections.Concurrent;
-using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
-namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
+namespace Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 
 /// <summary>
-/// Tracks SAML assertion IDs that have already been used to mint a session, so a captured assertion
-/// cannot be replayed within its validity window. Entries are retained until the supplied expiry and
-/// reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
-/// bound (#452). It mirrors the sibling login-path caches (<see cref="SamlRequestCache"/>,
-/// <see cref="Jellyfin.Plugin.SSO_Auth.Api.Oidc.OidcStateStore"/>): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and a
-/// second <see cref="IntervalGate"/>-throttled signal that surfaces a cap refusal to the caller so a full
-/// replay cache is observable rather than silent (#470).
+/// A protocol-neutral one-time-use cache: tracks identifiers that have already been consumed (a SAML
+/// assertion ID that minted a session #452, an OIDC back-channel logout_token jti #962) so a captured
+/// message cannot be replayed within its validity window. Entries are retained until the supplied expiry
+/// and reclaimed by a throttled expired-entry sweep, and the set is hard-capped so it cannot grow without
+/// bound (#452). It mirrors the per-protocol login-path caches (the SAML request cache, the OIDC state
+/// store): an <see cref="IntervalGate"/>-throttled sweep plus a global cap, and a second
+/// <see cref="IntervalGate"/>-throttled signal that surfaces a cap refusal to the caller so a full replay
+/// cache is observable rather than silent (#470).
 ///
 /// The cap is applied differently from the siblings, on purpose. Recording a consumed assertion is what
 /// makes a replay detectable, so this cache must never drop a still-valid entry to free a slot — that
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 /// reached only after full XML-DSig signature validation, so it is not anonymously floodable; filling the
 /// cap requires a large volume of legitimately signed, rate-limited assertions.
 /// </summary>
-internal sealed class SamlReplayCache
+internal sealed class ReplayCache
 {
     // An approximate ceiling on retained consumed-assertion IDs, bounding memory (CWE-400 parity with the
     // siblings). Unlike the siblings this is not an anti-flood cap on an anonymous endpoint — TryConsume
@@ -61,10 +61,10 @@ internal sealed class SamlReplayCache
     private readonly IntervalGate _capWarnGate;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SamlReplayCache"/> class with the production cap and
+    /// Initializes a new instance of the <see cref="ReplayCache"/> class with the production cap and
     /// prune interval.
     /// </summary>
-    internal SamlReplayCache()
+    internal ReplayCache()
         : this(DefaultMaxEntries, DefaultPruneInterval)
     {
     }
@@ -73,12 +73,12 @@ internal sealed class SamlReplayCache
     // unit tests (the production values are unreachable there). IntervalGate rejects a non-positive interval.
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="SamlReplayCache"/> class with explicit bounds, so a unit
+    /// Initializes a new instance of the <see cref="ReplayCache"/> class with explicit bounds, so a unit
     /// test can reach the cap and prune-throttle paths the production values make unreachable.
     /// </summary>
     /// <param name="maxEntries">The global ceiling on retained consumed-assertion IDs.</param>
     /// <param name="pruneInterval">The minimum interval between expired-entry sweeps.</param>
-    internal SamlReplayCache(int maxEntries, TimeSpan pruneInterval)
+    internal ReplayCache(int maxEntries, TimeSpan pruneInterval)
     {
         _maxEntries = maxEntries;
         _pruneGate = new IntervalGate(pruneInterval);
@@ -92,21 +92,23 @@ internal sealed class SamlReplayCache
     internal void Clear() => _consumed.Clear();
 
     /// <summary>
-    /// Computes how long a just-consumed assertion must be retained for replay protection: the whole
-    /// window it would still be accepted - its NotOnOrAfter plus the validation clock skew - with a
-    /// one-hour floor that covers an assertion carrying no (or a very short) expiry.
+    /// Computes how long a just-consumed identifier must be retained for replay protection: the whole
+    /// window it would still be accepted - its expiry plus the validation clock skew - with a one-hour
+    /// floor that covers an identifier carrying no (or a very short) expiry. The skew is passed by the
+    /// caller so this stays protocol-neutral (SAML uses its assertion-time skew, OIDC its token skew).
     /// </summary>
     /// <param name="nowUtc">The current time.</param>
-    /// <param name="assertionExpiryUtc">The assertion's effective NotOnOrAfter, or null when it declares none.</param>
-    /// <returns>The UTC instant until which the assertion ID must be retained.</returns>
-    internal static DateTime ComputeRetention(DateTime nowUtc, DateTime? assertionExpiryUtc)
+    /// <param name="expiryUtc">The identifier's effective expiry, or null when it declares none.</param>
+    /// <param name="skew">The validation clock skew to add to the expiry.</param>
+    /// <returns>The UTC instant until which the identifier must be retained.</returns>
+    internal static DateTime ComputeRetention(DateTime nowUtc, DateTime? expiryUtc, TimeSpan skew)
     {
-        // The one-hour floor bounds retention when an assertion carries no (or a very short) expiry; the
+        // The one-hour floor bounds retention when an identifier carries no (or a very short) expiry; the
         // skew margin matches the clock skew the signature/time validation allows.
         var floor = nowUtc.AddHours(1);
-        if (assertionExpiryUtc.HasValue)
+        if (expiryUtc.HasValue)
         {
-            var expiryWithSkew = assertionExpiryUtc.Value + SamlAssertionTime.ClockSkew;
+            var expiryWithSkew = expiryUtc.Value + skew;
             if (expiryWithSkew > floor)
             {
                 return expiryWithSkew;

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -47,7 +47,7 @@ internal sealed class SamlAssertionValidator
     // One-time-use tracking for consumed SAML assertion IDs (replay protection). One process-wide instance,
     // like the outstanding-request cache the flow service keeps and the OpenID caches the sibling flow
     // service keeps — the two-step post-then-authenticate legs run across separate per-request instances.
-    private static readonly SamlReplayCache SamlReplays = new SamlReplayCache();
+    private static readonly ReplayCache SamlReplays = new ReplayCache();
 
     private readonly ILogger _logger;
 
@@ -134,7 +134,7 @@ internal sealed class SamlAssertionValidator
     internal bool TryConsumeReplay(SamlResponse samlResponse, string provider)
     {
         var samlNow = DateTime.UtcNow;
-        var replayRetention = SamlReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter());
+        var replayRetention = ReplayCache.ComputeRetention(samlNow, samlResponse.GetNotOnOrAfter(), SamlAssertionTime.ClockSkew);
         var assertionId = samlResponse.GetAssertionId();
         var replayKey = ProviderScopedKey.For(provider, assertionId);
         var consumed = SamlReplays.TryConsume(replayKey, replayRetention, samlNow, out var shouldWarnCapacity);

--- a/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlLogoutValidator.cs
@@ -14,7 +14,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Saml;
 /// consume of the request <c>ID</c>. It is the SAML-logout analogue of
 /// <see cref="SamlAssertionValidator"/> — it owns the process-wide replay cache as a <c>static readonly</c>
 /// field, so the controller endpoint that calls it holds no mutable static state, and reuses the SHARED
-/// <see cref="SamlReplayCache"/> primitive rather than a copy.
+/// ReplayCache primitive rather than a copy.
 /// </summary>
 /// <remarks>
 /// On success the caller receives the validated NameID and SessionIndex list; on failure it receives a
@@ -25,7 +25,7 @@ internal sealed class SamlLogoutValidator
 {
     // One-time-use tracking for consumed LogoutRequest IDs (replay protection), process-wide exactly like the
     // login-path SamlAssertionValidator.SamlReplays — a captured LogoutRequest must not revoke twice.
-    private static readonly SamlReplayCache LogoutReplays = new SamlReplayCache();
+    private static readonly ReplayCache LogoutReplays = new ReplayCache();
 
     /// <summary>
     /// Test-only. Clears the process-wide one-time replay cache between tests so a consumed request ID does
@@ -104,7 +104,7 @@ internal sealed class SamlLogoutValidator
         // endpoint additionally leaves the matched entries in the store on a revoke fault, so a fresh-ID retry
         // still finds and acts on them. Replay protection here is a hygiene/DoS bound, not a session-minting
         // gate, so single-use-regardless is the safe default.
-        var retention = SamlReplayCache.ComputeRetention(nowUtc, logoutRequest.GetNotOnOrAfter());
+        var retention = ReplayCache.ComputeRetention(nowUtc, logoutRequest.GetNotOnOrAfter(), SamlAssertionTime.ClockSkew);
         var resolvedRequestId = logoutRequest.GetRequestId();
         var replayKey = ProviderScopedKey.For(provider, resolvedRequestId);
         if (!LogoutReplays.TryConsume(replayKey, retention, nowUtc, out _))

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -200,6 +200,18 @@ public abstract class ProviderConfigBase
     public string? PostLogoutRedirectUri { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this provider accepts an inbound OpenID Connect back-channel
+    /// <c>logout_token</c> (OIDC Back-Channel Logout 1.0, #962), so an IdP-side session termination revokes
+    /// the matched Jellyfin sessions. Off by default (fail safe): while off, the anonymous back-channel
+    /// endpoint rejects every request for this provider without parsing the token. Requires
+    /// <see cref="PluginConfiguration.EnableSingleLogout"/> on (the same master switch that captures the
+    /// <c>sid</c> a logout_token is matched on). Note the deployment caveat: back-channel logout needs the
+    /// IdP to reach this server directly (server-to-server), which is often unavailable for a self-hosted
+    /// server behind NAT — RP-initiated logout (#727) covers the user-clicks-logout case regardless.
+    /// </summary>
+    public bool EnableBackChannelLogout { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
     /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
     /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a


### PR DESCRIPTION
## What & why

Closes #962. Adds inbound **OIDC Back-Channel Logout 1.0** so an IdP-side session termination revokes the matched Jellyfin sessions, protocol parity with SAML SLO (#727). **Threat-modelled with STRIDE before building** (model posted on the issue); its mitigations are the acceptance criteria and negative tests here.

## Design

- **`OidcLogoutTokenValidator`**, every §2.6 rule fail-closed, each with a fixed reason code (never token-derived, so a rejection is no subject oracle) and a negative test: signature/iss/aud/lifetime + **azp/multi-audience** via the SAME `OidcSignatureKeys` basis the id_token uses (**no second, laxer path**); the mandatory `backchannel-logout` events member; the forbidden `nonce` (refuses an id_token replayed here); at-least-one-of-sub/sid; `jti` one-time-use. `exp` is **not** required (§2.4 doesn't mandate it, replay is bounded by jti).
- **`OidcSignatureKeys`**, the id_token's signature/JWKS/alg basis extracted so both token types verify through one path (behaviour-preserving; id_token validator tests stay green).
- **`ReplayCache`**, `SamlReplayCache` moved to the RateLimit module as a protocol-neutral primitive (`ComputeRetention` takes the skew as a param), so the OIDC validator reuses it with **no new module edge**, the conformance test correctly refused an `Oidc→Saml` dependency.
- **Endpoint `OID/backchannel-logout/{provider}`**, anonymous, rate-limited on the Logout class, gated by `EnableSingleLogout` + per-provider `EnableBackChannelLogout` (off by default). Revocation reuses `FindByProviderSubject` + the SAME user-scoped fail-safe revoke loop the inbound SAML logout uses: never cross-provider, never a SAML capture, never another user. Uniform 400 for every failure; audits fixed codes only.

**Deployment caveat (documented):** back-channel needs the IdP to reach the server directly (server-to-server), often unavailable for self-hosted behind NAT; RP-initiated logout (#727) covers the user-clicks-logout case regardless.

## Review & verification

3-lens adversarial gate, **authz-bypass PASS** (no forged/cross-user/cross-provider/cross-protocol revoke; endpoint anonymous-safe), **correctness PASS** (extraction + move proven behaviour-preserving against `main`, every edge fail-closed), **availability NEEDS_IMPROVEMENT** → the one real finding (`exp` required but not spec-mandated → exp-less IdP silently no-op'd) **fixed**, plus the two low parity notes (azp, skew lock) **fixed**. Full suite **4040/4040** on net9.0+net10.0; all conformance/fitness tests green.
