### PR TITLE
Add opt-in login-time deprovisioning on role-denied SSO logins

### DIFF
--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -109,6 +109,26 @@ public class SsoAuditTests
         Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void AccountDeprovisioned_LogsWarning_NamingProtocolAndProvider_ButNeverASubject()
+    {
+        var logger = new CapturingLogger();
+
+        // The provider is the only foreign value the signature accepts (there IS no subject/username
+        // parameter — the no-sensitive-data posture is structural, T-I1). A newline in it must not split
+        // the entry, and the fixed toggle name gives the operator the exact setting to check.
+        SsoAudit.AccountDeprovisioned(logger, "OpenID", "corp\r\nInjected");
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("corpInjected", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("DisableAccountOnRoleDenied", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("Administrators are never disabled", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -208,6 +228,7 @@ public class SsoAuditTests
         SsoAudit.LogoutRequested(off, "corp", 1);
         SsoAudit.ProvisionedPendingApproval(off, "OpenID", "corp", "u");
         SsoAudit.AccountAdopted(off, "OpenID", "corp", "u");
+        SsoAudit.AccountDeprovisioned(off, "OpenID", "corp");
         SsoAudit.PkceNotAdvertised(off, "corp");
         SsoAudit.LogoutRejected(off, "corp", "Replay");
 

--- a/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
@@ -62,11 +62,11 @@ public class SamlLoginServiceTests
     }
 
     [Fact]
-    public void Post_DisabledProvider_RejectsAsUnknownProvider()
+    public async Task Post_DisabledProvider_RejectsAsUnknownProvider()
     {
         var (service, context) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
 
-        var result = service.Callback("adfs", relayState: null, formSamlResponse: null, context.Request, context.Response);
+        var result = await service.CallbackAsync("adfs", relayState: null, formSamlResponse: null, context.Request, context.Response);
 
         AssertUnknownProvider(result);
     }

--- a/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerEndpointTests.cs
@@ -59,11 +59,11 @@ public class SSOControllerEndpointTests
     }
 
     [Fact]
-    public void SamlPost_UnknownProvider_RejectsWithUniform400()
+    public async Task SamlPost_UnknownProvider_RejectsWithUniform400()
     {
         var harness = new SsoControllerHarness();
 
-        var result = harness.Controller.SamlCallback("does-not-exist");
+        var result = await harness.Controller.SamlCallback("does-not-exist");
 
         AssertUnknownProvider(result);
     }

--- a/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
@@ -7,7 +7,9 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
+using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;
@@ -281,6 +283,54 @@ public class SSOControllerOidPostTests
     }
 
     [Fact]
+    public async Task OidPost_RoleDeniedWithDeprovisionOn_DisablesTheLinkedNonAdmin()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // #831 end-to-end: with an allow-list the id_token cannot satisfy (no matching role claim), the login
+        // is denied — and with the opt-in on, the account already linked under this subject is disabled so a
+        // user whose roles were revoked at the identity provider cannot keep logging in. The subject key is
+        // resolved on the denied path (it is derived independent of validity), so the linked account is found.
+        var linked = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        var user = TestUsers.Named("alice", linked);
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", tuneProvider: p =>
+        {
+            p.Roles = new[] { "only-admins" };
+            p.DisableAccountOnRoleDenied = true;
+            p.CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = linked };
+        });
+        harness.UserManager.GetUserById(linked).Returns(user);
+
+        var result = await harness.Controller.OidCallback("kc", "state-1");
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode); // still a clean denial
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled)); // the revoked account is deprovisioned
+        await harness.UserManager.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task OidPost_RoleDeniedWithDeprovisionOff_LeavesTheLinkedAccountEnabled()
+    {
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        // The default (opt-in off): the same denied login must NOT disable the linked account — deprovisioning
+        // is strictly opt-in, so an existing deployment sees no behavior change and a transient IdP role glitch
+        // cannot silently lock users out.
+        var linked = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        var user = TestUsers.Named("alice", linked);
+        var harness = ArrangeCallback(fixture, query: "?code=test-code&state=state-1", tuneProvider: p =>
+        {
+            p.Roles = new[] { "only-admins" };
+            p.CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = linked };
+        });
+        harness.UserManager.GetUserById(linked).Returns(user);
+
+        var result = await harness.Controller.OidCallback("kc", "state-1");
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled)); // untouched by default
+        await harness.UserManager.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
     public async Task OidChallengeToCallback_ResponseIssuerAdvertisedThenAbsent_Returns400()
     {
         using var fixture = new OidcTokenFixture(Authority, "jf");
@@ -411,7 +461,8 @@ public class SSOControllerOidPostTests
         string? bindingCookie = Binding,
         string? secondProvider = null,
         bool responseIssuerRequired = false,
-        bool doNotValidateIssuerName = false)
+        bool doNotValidateIssuerName = false,
+        Action<OidConfig>? tuneProvider = null)
     {
         idToken ??= fixture.IdToken(subject: "sub-1", username: "alice");
 
@@ -429,7 +480,9 @@ public class SSOControllerOidPostTests
         var harness = new SsoControllerHarness(
             c =>
             {
-                c.OidConfigs["kc"] = NewProvider();
+                var primary = NewProvider();
+                tuneProvider?.Invoke(primary); // e.g. an allow-list + a pre-existing canonical link (#831)
+                c.OidConfigs["kc"] = primary;
 
                 // A second enabled provider so a COAT test can hit its callback with a state minted for
                 // "kc" and isolate the provider-context binding from the unknown/disabled-provider guard.

--- a/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
@@ -80,13 +80,13 @@ public class SSOControllerRateLimitTests
     }
 
     [Fact]
-    public void SamlCallback_OverRateLimit_Returns429()
+    public async Task SamlCallback_OverRateLimit_Returns429()
     {
         var harness = Throttling(IPAddress.Parse("8.8.8.4"));
 
-        harness.Controller.SamlCallback("does-not-exist");
+        await harness.Controller.SamlCallback("does-not-exist");
 
-        AssertThrottled(harness, harness.Controller.SamlCallback("does-not-exist"));
+        AssertThrottled(harness, await harness.Controller.SamlCallback("does-not-exist"));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Http/SSOControllerSamlAuthTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlAuthTests.cs
@@ -91,7 +91,7 @@ public class SSOControllerSamlAuthTests
         var harness = ProvisioningHarness(fixture);
         SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
         SetSamlBindingCookie(harness, "a-different-browsers-binding-id");
 
         var result = Assert.IsType<ContentResult>(
@@ -114,7 +114,7 @@ public class SSOControllerSamlAuthTests
         var harness = ProvisioningHarness(fixture); // ValidateInResponseTo off (default)
         // No SeedSamlRequestForTests: the outstanding entry does not exist.
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
 
         var result = Assert.IsType<ContentResult>(
             await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
@@ -134,7 +134,7 @@ public class SSOControllerSamlAuthTests
         var fixture = SamlTestFactory.Create(nameId: "alice"); // no InResponseTo
         var harness = ProvisioningHarness(fixture, validateInResponseTo: true);
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
 
         var result = Assert.IsType<ContentResult>(
             await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));

--- a/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlPostTests.cs
@@ -1,8 +1,14 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -18,11 +24,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 public class SSOControllerSamlPostTests
 {
     [Fact]
-    public void SamlPost_DisabledProvider_Returns400()
+    public async Task SamlPost_DisabledProvider_Returns400()
     {
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig { Enabled = false });
 
-        var result = harness.Controller.SamlCallback("adfs", formSamlResponse: "irrelevant");
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: "irrelevant");
 
         // Shares the unknown-provider body now (the unique "No active providers found" wording is
         // retired), so a disabled provider cannot be told apart from an unknown one (#318).
@@ -32,7 +38,7 @@ public class SSOControllerSamlPostTests
     }
 
     [Fact]
-    public void SamlPost_SignedByAnotherCertificate_Returns400()
+    public async Task SamlPost_SignedByAnotherCertificate_Returns400()
     {
         var fixture = SamlTestFactory.Create();
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
@@ -42,13 +48,13 @@ public class SSOControllerSamlPostTests
             SamlCertificate = SamlFixture.ForeignCertificateBase64(),
         });
 
-        var result = harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
 
         Assert.Equal(400, Assert.IsType<ContentResult>(result).StatusCode);
     }
 
     [Fact]
-    public void SamlPost_RoleNotAllowed_Returns401()
+    public async Task SamlPost_RoleNotAllowed_Returns401()
     {
         var fixture = SamlTestFactory.Create(role: "jellyfin-users");
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
@@ -59,13 +65,41 @@ public class SSOControllerSamlPostTests
             Roles = new[] { "only-admins" },
         });
 
-        var result = harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
 
         Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode);
     }
 
     [Fact]
-    public void SamlPost_ValidSignedResponse_RendersTheAuthPage()
+    public async Task SamlPost_RoleDeniedWithDeprovisionOn_DisablesTheLinkedNonAdmin()
+    {
+        // #831 end-to-end on the SAML leg: a signed assertion whose role is not on the allow-list is denied,
+        // and with the opt-in on the account already linked under this NameID is disabled — the mirror of the
+        // OpenID deprovisioning path, pinned directly because the SAML callback resolves the subject key (the
+        // NameID) on its own denied branch.
+        var linked = Guid.Parse("77777777-7777-7777-7777-777777777777");
+        var user = TestUsers.Named("alice", linked);
+        var fixture = SamlTestFactory.Create(nameId: "alice", role: "jellyfin-users");
+        var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            SamlCertificate = fixture.CertificateBase64,
+            DoNotValidateAudience = true,
+            Roles = new[] { "only-admins" },
+            DisableAccountOnRoleDenied = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = linked },
+        });
+        harness.UserManager.GetUserById(linked).Returns(user);
+
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
+
+        Assert.Equal(401, Assert.IsType<ContentResult>(result).StatusCode); // still a clean denial
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled)); // the revoked account is deprovisioned
+        await harness.UserManager.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task SamlPost_ValidSignedResponse_RendersTheAuthPage()
     {
         var fixture = SamlTestFactory.Create(nameId: "alice");
         var harness = new SsoControllerHarness(c => c.SamlConfigs["adfs"] = new SamlConfig
@@ -75,7 +109,7 @@ public class SSOControllerSamlPostTests
             DoNotValidateAudience = true,
         });
 
-        var result = harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
+        var result = await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse());
 
         // A valid assertion renders the intermediate HTML auth page (which then posts to SamlAuth).
         var page = Assert.IsType<ContentResult>(result);

--- a/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlTokenTests.cs
@@ -68,7 +68,7 @@ public class SSOControllerSamlTokenTests
         var harness = ProvisioningHarness(fixture, out _);
 
         // The callback validates the assertion once and hands the page a token, not the base64 assertion.
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
 
         // Posting the token (never the assertion) mints the session — no re-parse, no second validation.
         var result = await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token });
@@ -90,7 +90,7 @@ public class SSOControllerSamlTokenTests
         harness.SessionManager.AuthenticateDirect(Arg.Any<AuthenticationRequest>())
             .Returns(new AuthenticationResult { SessionInfo = new SessionInfoDto { Id = "session-key-slo" } });
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
         Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
 
         Assert.True(harness.Configuration.LogoutSessions.ContainsKey("session-key-slo"));
@@ -105,7 +105,7 @@ public class SSOControllerSamlTokenTests
     {
         var fixture = SamlTestFactory.Create(nameId: "alice");
         var harness = ProvisioningHarness(fixture, out _);
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
 
         Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
 
@@ -156,11 +156,11 @@ public class SSOControllerSamlTokenTests
         var assertion = fixture.EncodeResponse();
 
         // The first callback validates and consumes the assertion's one-time id, minting a token.
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
 
         // Re-posting the SAME assertion to the callback is refused by the replay guard (its id was already
         // consumed at the first callback) — the token round-trip did not skip the one-time-use control.
-        var replayCallback = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        var replayCallback = Assert.IsType<ContentResult>(await harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
         Assert.Equal(400, replayCallback.StatusCode);
 
         // The token from the first, valid callback still mints exactly once.
@@ -210,19 +210,19 @@ public class SSOControllerSamlTokenTests
 
         // The callback is refused at the store cap — a fail-closed 500 — and the assertion's one-time replay
         // id is NOT consumed, because the reservation is checked ahead of the consume.
-        var refused = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        var refused = Assert.IsType<ContentResult>(await harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
         Assert.Equal(500, refused.StatusCode);
 
         // Drain the store (redeem the filler), then re-POST the SAME assertion. Because it was never burned,
         // the retry now validates, consumes the id, and renders a real token — the login was not lost.
         Assert.NotNull(store.TryRedeem(filler, "adfs", DateTime.UtcNow));
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
         Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
         await harness.UserManager.Received(1).CreateUserAsync("alice");
 
         // Replay protection is intact: re-POSTing the same assertion a third time (the store now has room) is
         // refused by the one-time replay guard, since the retry above consumed the id.
-        var replay = Assert.IsType<ContentResult>(harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
+        var replay = Assert.IsType<ContentResult>(await harness.Controller.SamlCallback("adfs", formSamlResponse: assertion));
         Assert.Equal(400, replay.StatusCode);
     }
 
@@ -240,7 +240,7 @@ public class SSOControllerSamlTokenTests
         var harness = ProvisioningHarness(fixture, out _);
         SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
         harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.SamlCookieName}={Binding}";
 
         Assert.IsType<OkObjectResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));
@@ -256,7 +256,7 @@ public class SSOControllerSamlTokenTests
         var harness = ProvisioningHarness(fixture, out _);
         SamlLoginService.SeedSamlRequestForTests("adfs", AuthnRequestId, Binding, DateTime.UtcNow.AddMinutes(15));
 
-        var token = ExtractToken(harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
+        var token = ExtractToken(await harness.Controller.SamlCallback("adfs", formSamlResponse: fixture.EncodeResponse()));
         // No binding cookie set.
 
         var result = Assert.IsType<ContentResult>(await harness.Controller.SamlAuth("adfs", new AuthResponse { Data = token }));

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -185,6 +185,204 @@ public class CanonicalLinkServiceTests
         Assert.False(service.IsAccountAwaitingApproval(Guid.NewGuid())); // a vanished user is left to the minter's null guard
     }
 
+    // --- DisableDeniedAccountAsync (#831): optional login-time deprovisioning of a linked account whose
+    //     roles no longer satisfy the allow-list. The mass-lockout fail-safe is that an administrator is
+    //     NEVER disabled, so a misconfigured allow-list can strand at most the non-admin accounts. ---
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_LinkedNonAdmin_DisablesItAndPersists()
+    {
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        var user = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(user);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.True(disabled); // reported so the caller audits the deprovisioning
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await users.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_SamlLinkedNonAdmin_DisablesIt()
+    {
+        // Both protocols share the gate; SAML keys on the NameID (TryGetLinks dispatches saml vs oid to
+        // different config dictionaries, so the SAML branch is pinned directly).
+        var (service, _, users, _) = Build(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice"] = Existing },
+        });
+        var user = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(user);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Saml, "adfs", "alice");
+
+        Assert.True(disabled);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await users.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_LinkedAdmin_IsNeverDisabled()
+    {
+        // THE break-glass guard: an administrator's denied login must NOT disable the account — otherwise a
+        // misconfigured allow-list or an identity provider that transiently drops group claims could lock the
+        // last admin out and strand the server. The admin stays enabled and nothing is persisted.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        var admin = AdminUserNamed("root", Existing);
+        users.GetUserById(Existing).Returns(admin);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.False(disabled);
+        Assert.False(admin.HasPermission(PermissionKind.IsDisabled)); // untouched
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_AlreadyDisabled_IsANoOp_AndNotReAudited()
+    {
+        // An already-disabled account is left untouched and reported false, so a hot denied-login loop for a
+        // revoked user neither re-persists nor re-audits the same deprovisioning every attempt.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        var user = TestUsers.Named("alice", Existing);
+        user.SetPermission(PermissionKind.IsDisabled, true);
+        users.GetUserById(Existing).Returns(user);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.False(disabled);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_NoLinkForKey_IsANoOp()
+    {
+        // A first-time denied login resolves no existing canonical link, so there is nothing to disable —
+        // deprovisioning acts only on an account that already SSO-linked and later lost its roles.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-unlinked");
+
+        Assert.False(disabled);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_DisabledProvider_FailsTheReadClosed_WithoutDisabling()
+    {
+        // The subject-keyed link is read requireEnabled:true, so a provider disabled between the login start
+        // and this call resolves no account and disables nothing — a fail-closed read, never a stray write.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = false,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.False(disabled);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_IssuerMismatch_NeverDisablesTheOtherIssuersAccount()
+    {
+        // The #186 issuer binding gates the disable exactly as it gates the mint: the link was stamped for
+        // IdP-A, but the denied login's token was issued by IdP-B (a repointed provider with a colliding
+        // sub). The resolved account belongs to the FIRST issuer's user — a denied login from the new
+        // issuer must not disable it (a targeted wrong-account disable the mint path already refuses).
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = "https://idp-a.example.com" },
+        });
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1", "https://idp-b.example.com");
+
+        Assert.False(disabled);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_IssuerMatch_DisablesTheLinkedNonAdmin()
+    {
+        // The positive binding case: the denied login's issuer equals the stamped one, so the link resolves
+        // and the (non-admin) account is disabled — the binding refuses only a FOREIGN issuer, it does not
+        // break deprovisioning for the provider that minted the link.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-1"] = "https://idp-a.example.com" },
+        });
+        var user = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(user);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1", "https://idp-a.example.com");
+
+        Assert.True(disabled);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await users.Received(1).UpdateUserAsync(user);
+    }
+
+    [Fact]
+    public async Task DisableDeniedAccountAsync_UnstampedLink_DisablesUnderTrustOnFirstUseParity()
+    {
+        // A legacy link with no stored issuer is Absent, not Mismatch — the same trust-on-first-use
+        // treatment the mint path applies (#186), so deprovisioning still works for links created before
+        // issuer stamping existed.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        var user = TestUsers.Named("alice", Existing);
+        users.GetUserById(Existing).Returns(user);
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", "sub-1", "https://idp-a.example.com");
+
+        Assert.True(disabled);
+        await users.Received(1).UpdateUserAsync(user);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DisableDeniedAccountAsync_BlankKey_IsANoOp(string? canonicalKey)
+    {
+        // Fail-closed belt: a null/blank subject key (a provider that returned no stable identifier) must
+        // never resolve or disable an account, even if a caller forgets its own guard.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Existing },
+        });
+        users.GetUserById(Existing).Returns(TestUsers.Named("alice", Existing));
+
+        var disabled = await service.DisableDeniedAccountAsync(ProviderMode.Oid, "kc", canonicalKey);
+
+        Assert.False(disabled);
+        await users.DidNotReceive().UpdateUserAsync(Arg.Any<User>());
+    }
+
     [Fact]
     public async Task ResolveOrCreateAsync_ExistingAccountAndAdoptionAllowed_AdoptsAndLinks()
     {

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -80,6 +80,28 @@ internal static class SsoAudit
             provider?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records an existing account being disabled by login-time deprovisioning (#831): its SSO login was
+    /// denied by the role allow-list and the provider opts into disabling on denial. Only non-sensitive
+    /// fields are logged — the protocol and provider name, never the subject/username (T-I1) — so an
+    /// offboarding (or a mass-disable incident from a misconfigured allow-list) leaves an operator trail.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    internal static void AccountDeprovisioned(ILogger logger, string protocol, string provider)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Account disabled by login-time deprovisioning: an SSO login via {Protocol} provider '{Provider}' was denied by the role allow-list and the account was disabled (DisableAccountOnRoleDenied). Administrators are never disabled by this path.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+    }
+
     /// <summary>Records a provider being added or updated.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -403,6 +403,17 @@ internal sealed class OidcLoginService
                     config.Roles);
             }
 
+            // Login-time deprovisioning (#831): when the provider opts in, a role-denied login disables the
+            // existing linked account (never an admin — the guard lives in the service). Runs only on a
+            // denied login that resolved a subject, so an unauthenticated caller can never trigger it. The
+            // validated id_token's issuer rides along so the link's issuer binding (#186) gates the disable
+            // exactly as it gates the mint — a colliding sub from a repointed provider resolves nothing.
+            if (config.DisableAccountOnRoleDenied
+                && await _canonicalLinks.DisableDeniedAccountAsync(ProviderMode.Oid, provider, derived.Subject, derived.Issuer).ConfigureAwait(false))
+            {
+                SsoAudit.AccountDeprovisioned(_logger, "OpenID", provider);
+            }
+
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());
         }
 

--- a/SSO-Auth/Api/Flows/SamlLoginService.cs
+++ b/SSO-Auth/Api/Flows/SamlLoginService.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Identity;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
 using Jellyfin.Plugin.SSO_Auth.Api.Logout;
@@ -183,7 +184,7 @@ internal sealed class SamlLoginService
     /// <param name="request">The current request; read for the assertion-consumer base URL.</param>
     /// <param name="response">The response the auth page's defensive headers are written to.</param>
     /// <returns>The rendered auth page on success, or a fail-closed rejection.</returns>
-    internal ActionResult Callback(string provider, string? relayState, string? formSamlResponse, HttpRequest request, HttpResponse response)
+    internal async Task<ActionResult> CallbackAsync(string provider, string? relayState, string? formSamlResponse, HttpRequest request, HttpResponse response)
     {
         // Unknown and disabled providers share one rejection so neither can be probed apart — this
         // retires the unique "No active providers found" wording that distinguished the disabled case
@@ -218,7 +219,7 @@ internal sealed class SamlLoginService
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.SamlResponseInvalid));
         }
 
-        // Own the parsed response for the rest of this synchronous method: it wraps the identity provider's
+        // Own the parsed response for the rest of this method: it wraps the identity provider's
         // signing-certificate unmanaged handle and must be disposed once fully read (#674). Every claim read
         // below completes before any return (the intermediate auth page's XML is rendered eagerly), and the
         // stored login outcome copies out only strings and the verified identity — never this object — so
@@ -239,6 +240,16 @@ internal sealed class SamlLoginService
                     samlResponse.GetNameID()?.ReplaceLineEndings(string.Empty),
                     assertionRoles.Select(r => r?.ReplaceLineEndings(string.Empty)),
                     config.Roles);
+            }
+
+            // Optional login-time deprovisioning (#831): when the operator has turned it on, a linked
+            // account whose roles no longer satisfy the allow-list is disabled so a revoked user cannot
+            // keep a live Jellyfin session. DisableDeniedAccountAsync never touches an administrator (the
+            // break-glass guard), so this can never strand the server. Audit records provider only.
+            if (config.DisableAccountOnRoleDenied
+                && await _canonicalLinks.DisableDeniedAccountAsync(ProviderMode.Saml, provider, samlResponse.GetNameID()).ConfigureAwait(false))
+            {
+                SsoAudit.AccountDeprovisioned(_logger, "SAML", provider);
             }
 
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Denied());

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -864,7 +864,7 @@ public class SSOController : ControllerBase
     /// <returns>A webpage that will complete the client-side flow.</returns>
     [HttpPost("SAML/p/{provider}")]
     [HttpPost("SAML/post/{provider}")]
-    public ActionResult SamlCallback(string provider, [FromQuery] string? relayState = null, [FromForm(Name = "SAMLResponse")] string? formSamlResponse = null)
+    public async Task<ActionResult> SamlCallback(string provider, [FromQuery] string? relayState = null, [FromForm(Name = "SAMLResponse")] string? formSamlResponse = null)
     {
         if (RateLimitCheck(SsoRateLimitClass.Callback) is { } throttled)
         {
@@ -875,7 +875,7 @@ public class SSOController : ControllerBase
         // signed response and, on a passing role gate, renders the security-headered intermediate auth
         // page on the response.
         // This endpoint is browser-navigated, so a plain-text rejection is restyled as an HTML page (#668).
-        return BrowserErrorPage.Wrap(_saml.Callback(provider, relayState, formSamlResponse, Request, Response), Request, Response);
+        return BrowserErrorPage.Wrap(await _saml.CallbackAsync(provider, relayState, formSamlResponse, Request, Response).ConfigureAwait(false), Request, Response);
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -542,6 +542,66 @@ internal sealed class CanonicalLinkService
         return user is not null && user.HasPermission(PermissionKind.IsDisabled);
     }
 
+    /// <summary>
+    /// Login-time deprovisioning (#831): when an SSO login is DENIED by the role allow-list, disable the
+    /// existing linked Jellyfin account so a user offboarded at the identity provider loses Jellyfin access
+    /// immediately, rather than keeping any session until a role change would otherwise apply. Opt-in per
+    /// provider (<see cref="ProviderConfigBase.DisableAccountOnRoleDenied"/>).
+    /// <para>
+    /// GUARD — the mass-lockout defense (T-D1): an <see cref="PermissionKind.IsAdministrator"/> account is
+    /// NEVER disabled by this path, which also covers the SSO-only break-glass admin (itself an admin). So a
+    /// misconfigured allow-list, or an identity provider that transiently drops group claims and denies every
+    /// login, can strand at most the non-admin accounts — an administrator (and the break-glass door) always
+    /// remains to recover. It acts only on the EXISTING subject-keyed canonical link; a first-time denied
+    /// login resolves no account and disables nothing. An already-disabled account is a no-op (not re-audited).
+    /// </para>
+    /// </summary>
+    /// <param name="mode">The provider protocol.</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="canonicalKey">The identity's stable subject key (OpenID sub / SAML NameID) whose login was denied.</param>
+    /// <param name="issuer">The denied login's token issuer (OpenID only; null for SAML), checked against the link's stored issuer binding (#186) so a colliding subject from a repointed identity provider cannot disable the prior provider's account.</param>
+    /// <returns><see langword="true"/> when an enabled non-admin account was actually disabled (so the caller audits it); otherwise <see langword="false"/>.</returns>
+    internal async Task<bool> DisableDeniedAccountAsync(ProviderMode mode, string provider, string? canonicalKey, string? issuer = null)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalKey))
+        {
+            return false;
+        }
+
+        // Resolve the existing subject-keyed link under the config lock; never a create, never the legacy
+        // name-keyed path (a denial must not adopt or mint). A disabled provider fails the read closed.
+        // The issuer binding is enforced exactly as on the mint path (RefuseRepointedIssuer, #186): a
+        // Mismatch means the denied login's subject collides with a link stamped for a DIFFERENT issuer
+        // (a repointed provider), so the resolved account belongs to someone else — never disable it.
+        var userId = _configStore.Read(configuration =>
+            TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links)
+                && links.TryGetValue(canonicalKey, out var linked)
+                && ClassifyIssuer(configuration, mode, provider, canonicalKey, issuer) != IssuerBinding.Mismatch
+                ? (Guid?)linked
+                : null);
+        if (userId is null)
+        {
+            return false;
+        }
+
+        var user = _userManager.GetUserById(userId.Value);
+        if (user is null)
+        {
+            return false;
+        }
+
+        // THE GUARD: an administrator is never disabled by SSO denial (covers the break-glass admin), so this
+        // path can never strand the server. An already-disabled account is left untouched (no re-audit).
+        if (user.HasPermission(PermissionKind.IsAdministrator) || user.HasPermission(PermissionKind.IsDisabled))
+        {
+            return false;
+        }
+
+        user.SetPermission(PermissionKind.IsDisabled, true);
+        await _userManager.UpdateUserAsync(user).ConfigureAwait(false);
+        return true;
+    }
+
     // Logs the name-taken refusal (distinguishing a pending migratable legacy link from an ordinary #95
     // collision) and RETURNS the exception the caller throws, so the terminal switch arm reads as the
     // refusal it is. The refusal throws on every login; only the WARNING is throttled through the shared

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -212,6 +212,18 @@ public abstract class ProviderConfigBase
     public bool EnableBackChannelLogout { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether an SSO login that is DENIED by the role allow-list disables
+    /// the existing linked Jellyfin account (login-time deprovisioning, #831), so a user offboarded at the
+    /// identity provider loses Jellyfin access immediately rather than keeping their session until a role
+    /// change would otherwise apply. Off by default (opt-in). Fail-safe against mass lockout: an
+    /// ADMINISTRATOR is NEVER disabled by this path (which also covers the SSO-only break-glass admin, itself
+    /// an admin), so a misconfigured allow-list or an identity provider that drops group claims can strand at
+    /// most the non-admin accounts — an admin always remains to recover. Acts only on an existing linked
+    /// account; a first-time denied login has nothing to disable.
+    /// </summary>
+    public bool DisableAccountOnRoleDenied { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
     /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
     /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a


### PR DESCRIPTION
# What & why

Closes #831 (the login-time half; the polling-sweep half is deferred to a follow-up issue).

Today a user removed from the required IdP group keeps a working Jellyfin account: a role-denied login is refused, but the account stays enabled. This adds **opt-in login-time deprovisioning**: when an SSO login is denied by the role allow-list and the provider has the new `DisableAccountOnRoleDenied` toggle on (off by default), the existing linked account is disabled, closing the offboarding window.

Design, per the STRIDE threat model posted on the issue and the guard rule settled there:

- **Mass-lockout fail-safe:** an administrator is **never** disabled by this path, which structurally covers the SSO-only break-glass admin (always an admin, enforced at designation). A misconfigured allow-list or an IdP transiently dropping group claims can strand at most non-admin accounts; an admin always remains to recover.
- **Correct-principal binding:** the disable resolves only the existing subject-keyed canonical link, read `requireEnabled`, under the same #186 issuer binding the mint path enforces, a colliding `sub` from a repointed provider resolves nothing (adversarial-review finding, fixed).
- **No-ops everywhere else:** already-disabled account, blank subject key, no existing link (first-time denied login), disabled provider. Nothing is created, adopted, or re-audited; no persist on the no-op paths.
- **Audit:** `[SSO Audit]` warning naming protocol + provider only, never the subject or username.
- Both protocols wired at their denial points, strictly after signature/token validation: OpenID passes the validated id_token's `sub` + `iss`; SAML the verified assertion's NameID. `SamlLoginService.Callback` becomes `CallbackAsync` for the async user update (controller + tests converted).

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the disable runs only after full response validation, on the denied branch; disabled provider / blank key / unknown link resolve nothing; a stamped issuer mismatch refuses; a persist failure leaves the login denied.
- [x] No secrets logged; the audit line carries protocol + provider only (never subject/username), CRLF-stripped inline.
- [x] A security review was performed: the adversarial 3-lens gate (availability/mass-lockout, bypass/fail-open, correctness) ran on the diff. Availability and correctness passed; the bypass lens found the missing #186 issuer binding on the deprovision resolution, FIXED (issuer rides into `DisableDeniedAccountAsync`, `ClassifyIssuer != Mismatch` in the same atomic config read) and the lens re-run passed on the fixed state.
- [x] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; the disable lives as one method on `CanonicalLinkService` reusing `TryGetLinks`/`ClassifyIssuer`; both flows call it.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments carry the security-why (mass-lockout guard, issuer binding, fail-closed reads).
- [x] Architecture-conformance tests pass; no new structural property is established (the method sits in the existing Linking module behind the existing module edges).
- [x] Docs impact considered: filed as a documentation follow-up issue (linked in Notes), wiki section for the toggle incl. the operator note that deprovisioned accounts need a manual admin re-enable (no self-heal after a transient IdP claim drop).

## Verification

- [x] `dotnet build --warnaserror` green on net9.0 and net10.0 (0 warnings).
- [x] `dotnet test` green: 2036/2036 on net9.0 and net10.0 (16 tests cover this feature: admin-never-disabled, already-disabled/no-link/blank-key/disabled-provider no-ops, issuer mismatch/match/TOFU-parity, audit shape + level gate, OIDC + SAML endpoint-level on/off).
- [x] Prettier: no `.js`/`.html`/`.md`/`.css` touched.

## Notes

- The availability lens raised one operator consideration (by design, not a defect): a deprovision-disabled non-admin does not self-heal on the next allowed login, the disabled-account gate refuses the session until an admin re-enables. Documented in the config XML-doc; goes into the wiki via the doc follow-up.
- Follow-ups filed: documentation issue for the toggle + runbook note; deferred polling-sweep half of #831 as its own tracked issue.
