### PR TITLE
Read the manifest via jq --rawfile so the beta publish survives arg-length growth

### DIFF
--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -345,8 +345,13 @@ runs:
           fi
         fi
 
+        # Base64 the manifest into a file and read it with jq --rawfile: the encoded blob outgrows the
+        # OS per-argument limit (MAX_ARG_STRLEN, ~128 KB) as the version list grows, which made jq abort
+        # with "Argument list too long" (E2BIG) once the manifest crossed it (#978). A file input is not
+        # subject to that limit; base64 -w0 emits no trailing newline, so $c is exactly the encoded blob.
+        base64 -w0 < "$work/manifest.json" > "$work/manifest.b64"
         payload="$(jq -nc --arg m "Regenerate Jellyfin plugin repository." --arg b "$BRANCH" \
-          --arg c "$(base64 -w0 < "$work/manifest.json")" --arg s "${current_sha:-}" \
+          --rawfile c "$work/manifest.b64" --arg s "${current_sha:-}" \
           '{message:$m, branch:$b, content:$c} + (if $s == "" then {} else {sha:$s} end)')"
         printf '%s' "$payload" | gh api -X PUT "repos/${REPO}/contents/${MANIFEST_FILE}" --input - >/dev/null
         echo "committed $final_total versions to ${BRANCH}/${MANIFEST_FILE}"


### PR DESCRIPTION
## What & why

The daily beta publish (`publish-beta.yml` run 29985551542, 2026-07-23 06:36) failed at step **Publish Beta Plugin Manifest** with `jq: Argument list too long` (E2BIG, exit 126). The `manifest-beta` commit never ran, so `4.3.0-beta.12` (and `5.0.0-JF12-beta.26`) do not appear in Jellyfin, the manifest is stuck at `5.0.0.25` / `4.3.0.11`.

Root cause (`.github/actions/generate-manifest/action.yml`): the contents-API PUT payload was built by passing the **whole base64-encoded manifest as a jq command-line argument** (`--arg c "$(base64 -w0 < manifest.json)"`). That single argument crossed the Linux per-argument limit (`MAX_ARG_STRLEN`, ~128 KB) as the version list grew between beta.11 and beta.12. The manifest itself was computed correctly in-memory (the entries print shows `10.11.0.0: 15 (newest 4.3.0.12)`); only the commit could not run.

Fix: write the base64 blob to a file and read it with `jq --rawfile`, file inputs are not subject to the argument-length limit. Verified `base64 -w0` emits no trailing newline, so the `--rawfile` binding is byte-identical to the previous command-substitution binding (same `$c`, same payload), only without the size ceiling. The action is shared by `publish-beta`, `publish-jf12-beta`, and `regenerate-manifest`, so this fixes every manifest-publishing path. After merge I will dispatch `regenerate-manifest.yml` to rebuild `manifest-beta` so 4.3.0.12 lands.

## Type of change
- [x] Bug fix (release pipeline)

## Security
- No security-decision surface changes. Release-pipeline change (directive 1), CI cannot exercise release-only workflows, so the adversarial review is the primary verification; results under Notes.

## Quality
- [x] Minimal, mechanical change (arg → `--rawfile`); no behaviour change to the produced manifest.

## Verification
- Empirically confirmed `base64 -w0` (GNU coreutils, same on the runner) emits **no** trailing newline (last byte `=`), and the arg-substitution length equals the file length, so `--rawfile` binds `$c` byte-identically to the old `--arg "$(...)"`, without the ARG_MAX ceiling.
- No C# change; the dotnet build/test gate is unaffected.

## Notes
Adversarial review (integration/correctness lens): results appended as a comment before merge. Follow-up: the `sbom.cyclonedx.md5` sidecar stopped publishing between beta.10 and beta.11 (unrelated; load-bearing plugin-zip MD5 is present), noted in #978 for a separate look.

Closes #978