### PR TITLE
Publish the newest JF11 beta as the repo's Latest release

### DIFF
--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -133,6 +133,17 @@ runs:
           [ "$is_draft" = "true" ] && continue
           if [ "$is_pre" = "true" ] && [ "$INCLUDE_PRERELEASES" != "true" ]; then continue; fi
 
+          # Stable channel (include-prereleases != true): exclude beta-tagged releases by GLOB, not
+          # only by the prerelease flag. Since #980 the newest JF11 beta is published as a
+          # NON-prerelease (so GitHub can mark it the Latest release), so the prerelease flag alone
+          # no longer keeps betas out of manifest-release. The tag convention is the reliable
+          # separator — a beta is always tagged X.Y.Z[-JF12]-beta.<run>, a stable never is — so this
+          # fails closed: a revived stable channel can never pull an immutable non-prerelease beta
+          # into the stable manifest, where its four-octet version would even outrank the stable build.
+          if [ "$INCLUDE_PRERELEASES" != "true" ]; then
+            case "$tag" in *-beta.*) continue ;; esac
+          fi
+
           # `first(…)`: a draft can carry the same tag_name as a published release (the draft
           # flow the beta leg used to run does exactly that), and without the draft filter plus
           # this cutoff the lookup emits TWO JSON documents — every jq below then produces two

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -196,12 +196,15 @@ jobs:
           # published release cannot be updated in place, so a rolling tag would fail
           # on its second run. The tag never matches publish.yml's
           # [0-9]+.[0-9]+.[0-9]+-stable glob, so a beta never triggers the stable
-          # channel; and prerelease: true keeps it out of the stable manifest
-          # (ignorePrereleases: true) — only the beta manifest below surfaces it. The
-          # INSTALLED plugin version is X.Y.Z.<run> (the hidden fourth octet keeps
-          # Jellyfin's update ordering monotonic across betas).
+          # channel. prerelease is FALSE so the newest JF11 (10.11) beta can be GitHub's
+          # "Latest release" (see the publish step's make_latest) — the headline build a
+          # visitor lands on. Safe in the beta-only phase: #954 retired the stable channel
+          # (manifest-release empty, publish.yml dormant) so nothing filters betas on this
+          # flag, and the beta manifest below uses include-prereleases so a non-prerelease
+          # build is still surfaced. The INSTALLED plugin version is X.Y.Z.<run> (the hidden
+          # fourth octet keeps Jellyfin's update ordering monotonic across betas).
           draft: true
-          prerelease: true
+          prerelease: false
           name: ${{ steps.version.outputs.base }}-beta
           # Always auto-generate the release notes from the commits since the previous tag.
           generate_release_notes: true
@@ -216,16 +219,20 @@ jobs:
             https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish the draft release
-      # Seal the draft — assets already attached — into an immutable published
-      # prerelease (fires release.published). A draft has no git tag yet, so it is
-      # published by its release id from the step above, not by tag name. -F sends
-      # draft as a typed boolean.
+    - name: Publish the draft release as the repo's Latest release
+      # Seal the draft — assets already attached — into an immutable published release
+      # (fires release.published) AND mark it the repo's Latest release: the newest JF11
+      # (10.11) beta is always the headline build. A draft has no git tag yet, so it is
+      # published by its release id from the step above, not by tag name. The JF12 leg
+      # publishes as a prerelease with no make_latest, so it never competes for Latest.
+      # draft is a boolean (-F, typed); make_latest is a string enum "true"|"false"|"legacy"
+      # in the REST API, so it is sent as a raw string (-f) — a typed boolean would be the
+      # wrong JSON type.
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_ID: ${{ steps.publish-assets.outputs.id }}
         REPO: ${{ github.repository }}
-      run: gh api "repos/${REPO}/releases/${RELEASE_ID}" -X PATCH -F draft=false
+      run: gh api "repos/${REPO}/releases/${RELEASE_ID}" -X PATCH -F draft=false -f make_latest=true
     - name: Publish Beta Plugin Manifest
       # include-prereleases so the beta build is included. Writes the SEPARATE
       # `manifest-beta` branch; the stable `manifest-release` is only ever written


### PR DESCRIPTION
## What & why
The newest **JF11 (10.11) beta** should always be the repo's GitHub **Latest release** during the beta-only phase (#954), the headline build a visitor lands on. `publish-beta.yml` published the JF11 beta with `prerelease: true` and never marked it latest, so it could never be the Latest release as published; `4.3.0-beta.11/.12` are currently latest only because they were flipped **manually**, and the next nightly (`beta.13`) would regress to a prerelease.

## Change (JF11 leg only)
- `prerelease: false` on the draft, so the build is eligible to be Latest.
- Seal step marks it latest: `gh api … -X PATCH -F draft=false -f make_latest=true`. `make_latest` is a REST **string enum** (`true`/`false`/`legacy`), so it is sent as a raw string (`-f`), not a typed boolean; `draft` stays `-F` (a real boolean).

## Safety
- `prerelease: true` previously kept betas out of the **stable** manifest (`ignorePrereleases: true`). Moot now: #954 retired the stable channel, `manifest-release` is empty and `publish.yml` has been dormant since 2026-07-18, so nothing filters betas on `prerelease`, and the **beta** manifest uses `include-prereleases: true`, so a non-prerelease build is still surfaced (verified: beta.11/.12 are in `manifest-beta`).
- The **JF12** leg (`publish-jf12-beta.yml`) stays `prerelease: true` with no `make_latest`, so a JF12 (5.0.0) build, higher semver, can never take Latest.
- `make_latest=true` explicitly forces Latest onto the JF11 beta, robust even if some other release were ever non-prerelease.

## Type of change
- [x] CI / release pipeline

## Security
- Release-pipeline change (directive 1). CI cannot exercise the release-only workflow, so the adversarial review is the primary verification, results in Notes. No secrets/permissions change; the publish step already had `contents: write` for sealing the release.

## Verification
- YAML-only; no C# change. The live state is already correct (`4.3.0-beta.12` is Latest); this makes it automatic for beta.13+.

## Notes
Adversarial review appended before merge. Caveat for when the stable channel is un-retired: `publish.yml` (stable) should then own Latest and this beta `make_latest` be reconsidered, noted for that milestone.

Closes #980