### PR TITLE
Add a changelog entry for the managed login-page buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   never the values, never nested objects — and every other claim shape still
   fails closed to no roles. The option is **off by default**, so no existing
   provider changes behaviour.
+- **Managed login-page buttons (#722).** An opt-in global option, **Manage
+  login-page buttons** (off by default), keeps a "Sign in with …" button block
+  on Jellyfin's login page in sync with the configured, enabled providers — so a
+  configured provider surfaces a button without hand-crafted branding HTML. The
+  managed region is spliced into the login branding disclaimer and removed
+  cleanly when the option is turned off, preserving any surrounding admin
+  disclaimer text; provider names and labels are HTML-encoded. Per provider,
+  **Hide login button** omits one provider's button and **Login button text**
+  overrides its label.
 
 ### Changed
 


### PR DESCRIPTION
## What & why
The auto-managed login-page "Sign in with …" buttons (#722, `ManageLoginPageButtons`, per-provider `HideLoginButton` / `LoginButtonText`, the `LoginButtons` module + branding-sync hosted service) are on `main` but were never recorded in the changelog. Add the entry under Unreleased → Added.

## Type of change
- [x] Documentation

## Notes
Docs-only, no code. Part of #722'\''s remaining doc criteria; the hide-password recipe + managed-buttons reference already landed in the wiki (single home: Hardening & Options Reference). The auto-redirect recipe, the Installation/Provider-Setup manual-branding cleanup, and the live-server screenshots stay open on #722 for a live-server session.

Refs #722