### PR TITLE
Cover the back-channel logout discovery fail-closed branches

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -148,6 +148,51 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
         await harness.SessionManager.DidNotReceive().RevokeUserTokens(UserB, Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task DiscoveryUnavailable_RejectsFailClosed_MintsNoRevoke()
+    {
+        // Feature + per-provider opt-in ON, so the endpoint reaches the validator — but discovery is
+        // unreachable (no HTTP responder). ValidateBackChannelLogoutAsync must fail closed
+        // (discovery_unavailable -> uniform 400), never a 500 and never a session revoke.
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        }, withResponder: false);
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task MalformedEndpoint_RejectsFailClosed_MintsNoRevoke()
+    {
+        // The configured endpoint is not a usable URL, so OidcDiscoveryOptions.Build throws while the
+        // validator prepares discovery — caught as a fail-closed reject (discovery_unavailable), never a 500
+        // and never a session revoke.
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = "not-a-usable-url",
+                OidClientId = "jf",
+                EnableBackChannelLogout = true,
+            };
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        }, withResponder: false);
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(result);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
     private static void AssertUniform400(ActionResult result)
     {
         var content = Assert.IsType<ContentResult>(result);


### PR DESCRIPTION
## What & why
Coverage gap surfaced by the #928 audit (the class was at ~30% branch). `OidcLoginService.ValidateBackChannelLogoutAsync` (#962) has two fail-closed branches that no test exercised:
- a **malformed configured endpoint**, `OidcDiscoveryOptions.Build` does `new Uri(OidEndpoint)`, which throws `UriFormatException`, caught and returned as `discovery_unavailable`;
- **unreachable discovery**, `discovery.Available == false` → `discovery_unavailable`.

The existing tests covered the happy path, the feature + per-provider opt-in gates, unknown provider, a forged token, and cross-protocol isolation, but not these two discovery failures.

Adds two negative tests. Each reaches the validator (feature + opt-in on) and must **fail closed**: the uniform `400` (`Logout token could not be processed`), **no 500**, and **no session revoke**, the tracked `LogoutSession` survives.

## Type of change
- [x] Tests

## Verification
- Test-only, no production code. Builds `--warnaserror` 0/0 on net9.0 + net10.0; the two new tests pass (net10.0 run; the net9.0 test-host launch is blocked locally by Windows Smart App Control, a known machine quirk, CI runs net9.0).

Refs #962, #928