### PR TITLE
Alert on failed scheduled publish + check manifest freshness

### DIFF
--- a/.github/workflows/manifest-freshness.yml
+++ b/.github/workflows/manifest-freshness.yml
@@ -1,0 +1,103 @@
+name: Manifest freshness
+
+# Defence in depth for the release channel (#982). The publish workflow can report success yet leave a
+# channel manifest un-updated — the 2026-07-23 beta.12 incident: the release was created but the manifest
+# commit failed on a jq arg-length error, so the "successful" publish shipped nothing installable. A
+# green publish run is therefore not proof the channel is fresh.
+#
+# This scheduled check closes that gap: it asserts the newest published beta release for each generation
+# (JF10.11 and JF12) is actually listed in the manifest-beta manifest.json, so a silent manifest gap
+# becomes a red check even when the publish reported success. A failure here is picked up by
+# publish-failure-alert.yml (which watches this workflow) and raised as a tracking issue.
+#
+# Read-only: curl for the public manifest, gh for the release list, jq (present on the runner) for the
+# comparison. No third-party action, so nothing to SHA-pin.
+
+on:
+  schedule:
+    # 12:00 UTC — hours after the 04:00 nightly publish (releases observed ~06:40), leaving a wide margin
+    # so a schedule-delayed publish cannot race the freshness check and raise a false STALE.
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+# Deny-all at the workflow level; the job opts into the single read grant it needs.
+permissions: {}
+
+concurrency:
+  group: manifest-freshness
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Assert manifest-beta lists the newest beta release per generation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Check manifest-beta freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # The public beta manifest, exactly as a Jellyfin server would fetch it. -f makes curl exit
+          # non-zero on an HTTP error, and set -e turns that into a fail-closed run (never a silent pass).
+          curl -fsSL "https://raw.githubusercontent.com/${REPO}/manifest-beta/manifest.json" -o manifest.json
+
+          # Fetch the FULL release list once, fail-closed: --paginate so the numerically-newest beta can
+          # never age off a single page (the sibling gate in publish-jf12-beta.yml hit exactly that bug),
+          # and an explicit guard so a transient API error reds the run instead of yielding an empty list
+          # that a later "no release found" branch would wave through as fresh.
+          if ! releases_json=$(gh api --paginate "repos/${REPO}/releases?per_page=100" --slurp); then
+            echo "::error::could not fetch the release list from the GitHub API — failing closed rather than assuming the channel is fresh"
+            exit 1
+          fi
+          # --slurp wraps the paginated pages in an outer array; flatten back to a flat release array.
+          releases_json=$(printf '%s' "$releases_json" | jq 'add // .')
+
+          fail=0
+
+          # For one generation: find the newest published beta release matching tag_re, derive the numeric
+          # manifest version from its tag with strip_re, and assert the manifest lists that version FOR
+          # THIS GENERATION (both generations share one versions[] array and are told apart ONLY by
+          # targetAbi; a JF10.11 `X.Y.Z-beta.N` and a JF12 `X.Y.Z-JF12-beta.N` derive to the same version
+          # string, so without the targetAbi predicate a stale generation is masked by the other).
+          # The tag regexes use [.] rather than \. so no backslash survives the shell -> jq string trip.
+          check_line() {
+            label="$1"; tag_re="$2"; strip_re="$3"; abi_prefix="$4"
+            tag=$(printf '%s' "$releases_json" \
+              | jq -r "[.[] | select(.tag_name | test(\"${tag_re}\"))] | sort_by(.published_at) | last | .tag_name // empty")
+            if [ -z "$tag" ]; then
+              # Fail closed PER GENERATION: a zero match means either the release tag scheme drifted (and
+              # this check is silently no longer verifying this generation) or this generation genuinely
+              # has no published beta. Both current generations always publish, so treat zero as a defect
+              # rather than skipping — a single total-drift guard would let one generation's match mask the
+              # other's silent drift.
+              echo "::error::no ${label} beta release matched ${tag_re} — the release tag scheme may have changed, or this generation has no published beta; failing closed rather than skipping verification."
+              fail=1
+              return
+            fi
+            ver=$(printf '%s' "$tag" | sed -E "$strip_re")
+            if printf '%s' "$manifest_json" \
+              | jq -e --arg v "$ver" --arg abi "$abi_prefix" \
+                  'any(.[].versions[]; .version == $v and (.targetAbi | startswith($abi)))' >/dev/null; then
+              echo "OK (${label}): newest release ${tag} -> manifest lists ${ver} (targetAbi ${abi_prefix}*)"
+            else
+              echo "::error::${label} channel STALE: the newest release is ${tag} (version ${ver}, targetAbi ${abi_prefix}*) but manifest-beta does not list it. Either a publish created the release without committing the manifest, or the manifest could not be parsed — the channel ships nothing installable for this generation until re-published."
+              fail=1
+            fi
+          }
+
+          # Read the manifest once; a parse failure here fails closed (set -e on the substitution's jq).
+          manifest_json=$(jq -c '.' manifest.json)
+
+          check_line "JF10.11" '^[0-9]+[.][0-9]+[.][0-9]+-beta[.][0-9]+$'      's/^([0-9]+\.[0-9]+\.[0-9]+)-beta\.([0-9]+)$/\1.\2/'      '10.11'
+          check_line "JF12"    '^[0-9]+[.][0-9]+[.][0-9]+-JF12-beta[.][0-9]+$' 's/^([0-9]+\.[0-9]+\.[0-9]+)-JF12-beta\.([0-9]+)$/\1.\2/' '12.'
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Manifest freshness check FAILED (see the errors above)."
+            exit 1
+          fi
+          echo "All beta channels are fresh: each generation's newest release is present in manifest-beta."

--- a/.github/workflows/nightly-betas.yml
+++ b/.github/workflows/nightly-betas.yml
@@ -35,6 +35,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh workflow run publish-beta.yml --repo "$REPO" --ref main
       - name: Trigger the JF12 beta (main)
+        # Dispatch the JF12 leg even if the JF10.11 dispatch above failed, so one API hiccup cannot
+        # silently take out both generations' nightly build. The job still fails if either dispatch
+        # failed, and "Publish failure alert" watches this workflow, so the failure is surfaced (#982).
+        if: ${{ !cancelled() }}
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -13,7 +13,14 @@ name: Publish failure alert
 # A workflow_run workflow always runs from the default branch with the default-branch definition, which
 # is why it can react to a failure in a workflow that itself runs on a schedule.
 
-on:
+# Documented accept for the zizmor `dangerous-triggers` finding on the workflow_run trigger below:
+# workflow_run is flagged because it runs with the elevated default-branch token and secrets, which is
+# dangerous ONLY when a workflow then checks out or executes the triggering run's (attacker-influenceable)
+# code or artifacts. This watchdog does neither: it never checks out any ref, downloads no artifact, and
+# only reads the public release list and files/updates an issue whose body is built entirely from
+# env-passed values (no ${{ }} shell splicing). Its token is least-privilege (issues: write). So the
+# audit's precondition for exploitability is absent here.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows:
       - "Nightly betas" # the scheduler: if it dies, no beta is dispatched at all

--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -1,0 +1,98 @@
+name: Publish failure alert
+
+# Release-channel watchdog (#982). A scheduled or dispatched publish that fails does NOT email me the
+# way a push failure to the author does, so a broken release channel can go unnoticed — the 2026-07-23
+# beta.12 incident: the GitHub release was created but the manifest commit failed on a jq arg-length
+# error, and nothing alerted, so the build silently never reached Jellyfin until a user noticed.
+#
+# This watches the nightly scheduler, the release-publish workflows, and the manifest-freshness check
+# and, on any non-success outcome, opens or updates a single tracking issue (label release-alert)
+# naming the failed run — turning a silent failure into an active, visible signal.
+#
+# Uses only the built-in gh CLI with the workflow token; no third-party action, so nothing to SHA-pin.
+# A workflow_run workflow always runs from the default branch with the default-branch definition, which
+# is why it can react to a failure in a workflow that itself runs on a schedule.
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly betas" # the scheduler: if it dies, no beta is dispatched at all
+      - "Publish Beta"
+      - "Publish JF12 Beta"
+      - "Publish Release"
+      - "Publish JF12 Stable"
+      - "Manifest freshness" # the freshness monitor: its own failure must also surface
+    types: [completed]
+
+# Deny-all at the workflow level; the job opts into the single grant it needs.
+permissions: {}
+
+# Never run two alert jobs at once; never cancel one mid-flight (it may be creating/commenting an issue).
+# Serializing also closes the two-runs-fail race: run B sees the issue run A created and comments on it
+# instead of creating a duplicate.
+concurrency:
+  group: publish-failure-alert
+  cancel-in-progress: false
+
+jobs:
+  alert:
+    name: Open or update the release-failure tracking issue
+    # Fire on any non-success terminal outcome — expressed as a DENYLIST so a new/rare conclusion class is
+    # caught by default rather than silently dropped. The beta.12 mode (release created, then the job dies
+    # before the manifest commit) can surface as `failure`, `timed_out`, or `startup_failure` (a YAML/
+    # config error), and GitHub also has `neutral` / `action_required` / `stale` — all of which should
+    # alert. Only `success` and `skipped` (e.g. the gate job short-circuits an unchanged day) are no-ops;
+    # `cancelled` is treated as an intentional human action and is not alerted.
+    if: >-
+      ${{ github.event.workflow_run.conclusion != 'success'
+       && github.event.workflow_run.conclusion != 'skipped'
+       && github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only permission needed: file/update an issue (and its label). No contents, no actions.
+    permissions:
+      issues: write
+    steps:
+      - name: File or update the alert issue
+        # All run inputs are passed via env, never spliced into the shell as ${{ }}.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          WF_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          EVENT: ${{ github.event.workflow_run.event }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+
+          # Self-provision the dedup label so the alerter never dies on a missing/deleted label (the
+          # create path is the first-fire path). --force makes it idempotent; failure here is non-fatal.
+          gh label create release-alert --repo "$REPO" --color B60205 \
+            --description "Automated alert: a release channel may be broken/stale (see #982)" \
+            --force >/dev/null 2>&1 || true
+
+          title="Release publish/monitoring failed — a channel may be silently stale"
+          body="The **${WF_NAME}** workflow run ended with conclusion \`${CONCLUSION}\` (trigger: ${EVENT}).
+
+          A scheduled publish or monitoring failure is not emailed, so a release channel may not have
+          updated and installs can go stale unnoticed.
+
+          Failed run: ${RUN_URL}
+
+          What to check: whether a GitHub release was created but its channel manifest was not committed
+          (the beta.12 failure mode). Fix the cause, re-run the publish, then confirm the channel
+          manifest lists the newest release. Close this issue once the channel is fresh again.
+
+          Refs #982."
+
+          # The release-alert label is the dedup key: one open tracking issue, updated by comment, so a
+          # run of failures does not spam a new issue each night.
+          num=$(gh issue list --repo "$REPO" --state open --label release-alert \
+            --json number --jq '.[0].number // empty')
+          if [ -n "${num:-}" ]; then
+            echo "Updating existing alert issue #${num}"
+            gh issue comment "$num" --repo "$REPO" --body "$body"
+          else
+            echo "No open alert issue; creating one"
+            gh issue create --repo "$REPO" --title "$title" --label release-alert --body "$body"
+          fi


### PR DESCRIPTION
## What & why
Closes #982. A scheduled publish failure produces a red run nobody watches, the 2026-07-23 beta.12 incident: the GitHub release was created but the `manifest-beta` commit failed (jq arg-length), so the build silently never reached Jellyfin and **nothing alerted**. This adds two release-channel monitors (built-in `gh` CLI only, no third-party action to SHA-pin):

- **`publish-failure-alert.yml`**, `on: workflow_run` over the nightly scheduler, the four publish workflows, and the freshness check; on any non-success terminal conclusion (denylist, so `timed_out`/`startup_failure` are caught) it opens or updates **one** tracking issue (label `release-alert`, self-provisioned).
- **`manifest-freshness.yml`**, a daily (12:00 UTC) defence-in-depth check asserting the newest published beta release per generation is listed in `manifest-beta`, matched by **version AND targetAbi** so a stale generation can't be masked by the other. Fails closed on any API/parse error, on a per-generation zero regex match (tag-scheme drift), and paginates so the newest never ages off a page.
- **`nightly-betas.yml`**, dispatch the JF12 leg even if the JF10.11 dispatch failed; the job still fails (now watched) so the failure surfaces.

## Type of change
CI / release-pipeline reliability (monitoring only, no change to the publish logic itself).

## Security & quality, the adversarial review IS the primary verification
CI cannot exercise `workflow_run`/`schedule` triggers, so per the release-pipeline policy the multi-lens `/security-review` is the gate. The four core lenses ran; **availability PASS**; every correctness / bypass / integration finding was fixed and re-verified:
- targetAbi-aware freshness (was a cross-generation false-fresh), validated empirically against the live manifest + release list;
- full conclusion coverage (was `== failure` only, missing `timed_out`/`startup_failure`);
- pagination + per-generation zero-match fail-closed (was a silent pass on tag-scheme drift);
- label self-provision (was a missing-label death of the alerter);
- the nightly scheduler is now watched and dispatches both legs independently.

Least-privilege permissions (`issues: write` / `contents: read`), all untrusted `workflow_run.*` values env-passed (no `${{ }}` shell splicing).

## Note
`workflow_run`, `schedule`, and the `release-alert` label take effect only once this lands on the default branch; a `workflow_dispatch` on `manifest-freshness` can smoke-test it after merge.