### PR TITLE
Add a served-surface string localizer with the English baseline catalog [#913]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -177,6 +177,7 @@ public class ArchitectureConformanceTests
     [InlineData("Crypto")] // leaf — the shared asymmetric signing-key strength policy (min RSA bits / approved EC curves), referenced by both protocol paths so they cannot drift (#733)
     [InlineData("LoginButtons")] // leaf — login-page button rendering (#722): pure injector/builder over the config + a branding-sync hosted service; imports no other Api module
     [InlineData("Logout")] // leaf — Single Logout session-state store (#727): pure bounded operations over the config's LogoutSessions map; imports no other Api module
+    [InlineData("Localization")] // leaf — served-surface string localizer (#913): loads embedded per-culture JSON catalogs and resolves keys through a fallback chain; imports no other Api module
 
 
     [InlineData("Provider", "Net", "RateLimit")] // provider config/test/naming — validates URLs (Net) and keys throttles (RateLimit)
@@ -185,7 +186,7 @@ public class ArchitectureConformanceTests
     [InlineData("Oidc", "Authz", "Avatar", "Crypto", "Identity", "Logout", "Net", "Provider", "RateLimit", "Routing")] // OIDC flow — mints the keystone (Identity), orchestrates roles, avatar, net, provider, throttle; reads its callback path through the Routing suffix reader; enforces the signing-key floor (Crypto); carries the captured logout context (Logout, #727)
     [InlineData("Identity", "Authz", "Provider")] // the identity keystone — grants (Authz) + link mode (Provider); decoupled from the protocols by #790
     [InlineData("Session", "Authz", "Avatar", "Linking")] // session mint + login outcomes — applies grants (Authz), sets avatars (Avatar), reconciles links (Linking)
-    [InlineData("Shared", "Avatar", "Linking", "RateLimit", "Routing", "Session")] // shared served-page / flow-response + rate-limit-gate helpers — depend downward on the session/linking/avatar/throttle/route tiers, never on a protocol or the boundary
+    [InlineData("Shared", "Avatar", "Linking", "Localization", "RateLimit", "Routing", "Session")] // shared served-page / flow-response + rate-limit-gate helpers — depend downward on the session/linking/avatar/throttle/route/localization tiers, never on a protocol or the boundary
     [InlineData("Flows", "Audit", "Identity", "Linking", "Logout", "Net", "Oidc", "Provider", "RateLimit", "Saml", "Session", "Shared")] // per-protocol login orchestration — drives both protocol modules (Oidc/Saml) and the downstream mint/link/session tiers; persists the captured logout state at the mint (Logout, #727); nothing above the boundary imports it
     [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Logout", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide (incl. the RP-initiated logout store, #727); nothing imports it back (#790/#807)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)

--- a/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
+++ b/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Api.Localization;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Conformance guard for the localization catalogs (#913). English is the invariant baseline that the
+/// fallback chain terminates on, so every embedded catalog must be a flat string→string map with no blank
+/// values, and every non-English catalog must carry EXACTLY the English key set — a missing key would blank
+/// (it falls back, but a translator's catalog claiming completeness must be complete), an orphan key is dead
+/// data. This is the standing drift guard for when the full language set lands (a later sub-unit).
+/// </summary>
+public class LocalizationCatalogTests
+{
+    private const string ResourcePrefix = "Jellyfin.Plugin.SSO_Auth.Localization.";
+    private const string ResourceSuffix = ".json";
+    private const string EnglishResource = ResourcePrefix + "en" + ResourceSuffix;
+
+    // Any type in the plugin assembly anchors GetManifestResourceStream to the resource-bearing assembly.
+    private static readonly Assembly PluginAssembly = typeof(SsoLocalizer).Assembly;
+
+    private static IEnumerable<string> CatalogResources() =>
+        PluginAssembly.GetManifestResourceNames()
+            .Where(name => name.StartsWith(ResourcePrefix, System.StringComparison.Ordinal)
+                && name.EndsWith(ResourceSuffix, System.StringComparison.Ordinal));
+
+    private static Dictionary<string, string> ReadCatalog(string resourceName)
+    {
+        using var stream = PluginAssembly.GetManifestResourceStream(resourceName);
+        Assert.NotNull(stream);
+        using var reader = new StreamReader(stream!);
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(reader.ReadToEnd());
+        Assert.NotNull(parsed);
+        return parsed!;
+    }
+
+    [Fact]
+    public void EnglishCatalog_ExistsAndIsNonEmpty()
+    {
+        Assert.Contains(EnglishResource, CatalogResources());
+        Assert.NotEmpty(ReadCatalog(EnglishResource));
+    }
+
+    [Fact]
+    public void EveryCatalog_HasNoBlankValues()
+    {
+        foreach (var resource in CatalogResources())
+        {
+            Assert.All(
+                ReadCatalog(resource),
+                entry => Assert.False(
+                    string.IsNullOrWhiteSpace(entry.Value),
+                    $"{resource}: key '{entry.Key}' has a blank value"));
+        }
+    }
+
+    [Fact]
+    public void EveryNonEnglishCatalog_HasExactlyTheEnglishKeySet()
+    {
+        var englishKeys = ReadCatalog(EnglishResource).Keys.ToHashSet();
+
+        foreach (var resource in CatalogResources().Where(name => name != EnglishResource))
+        {
+            var keys = ReadCatalog(resource).Keys.ToHashSet();
+
+            var missing = englishKeys.Except(keys).ToList();
+            var orphan = keys.Except(englishKeys).ToList();
+
+            Assert.True(missing.Count == 0, $"{resource}: missing keys: {string.Join(", ", missing)}");
+            Assert.True(orphan.Count == 0, $"{resource}: orphan keys not in English: {string.Join(", ", orphan)}");
+        }
+    }
+}

--- a/SSO-Auth.Tests/Localization/SsoLocalizerTests.cs
+++ b/SSO-Auth.Tests/Localization/SsoLocalizerTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Plugin.SSO_Auth.Api.Localization;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="SsoLocalizer"/> — the string localizer for the plugin's served surfaces (#913).
+/// The lookup resolves through a fallback chain that never blanks: requested culture → base language →
+/// English → the key itself.
+/// </summary>
+public class SsoLocalizerTests
+{
+    [Fact]
+    public void GetString_KnownKey_English_ReturnsTheEnglishValue()
+    {
+        Assert.Equal("Return to login", SsoLocalizer.GetString("error.return_to_login", "en"));
+        Assert.Equal("No matching provider found", SsoLocalizer.GetString("error.no_matching_provider", "en"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetString_NullOrBlankCulture_ResolvesToEnglish(string? culture)
+    {
+        Assert.Equal("Invalid or expired state", SsoLocalizer.GetString("error.invalid_state", culture));
+    }
+
+    [Fact]
+    public void GetString_UnknownCulture_FallsBackToEnglishNeverBlank()
+    {
+        var value = SsoLocalizer.GetString("error.return_to_login", "xx-YY");
+
+        Assert.Equal("Return to login", value);
+    }
+
+    [Fact]
+    public void GetString_RegionalVariant_FallsThroughBaseLanguageToEnglish()
+    {
+        // "en-GB" has no catalog of its own yet; the base-language then English fallback still yields a value.
+        Assert.Equal("Return to login", SsoLocalizer.GetString("error.return_to_login", "en-GB"));
+    }
+
+    [Fact]
+    public void GetString_CultureCaseInsensitive()
+    {
+        // BCP-47 tags are matched case-insensitively (lower-invariant catalog keys).
+        Assert.Equal("Return to login", SsoLocalizer.GetString("error.return_to_login", "EN"));
+    }
+
+    [Fact]
+    public void GetString_MissingKey_ReturnsTheKeyVerbatim()
+    {
+        // A key defined in no catalog returns itself — a missing translation is visible, never a blank.
+        Assert.Equal("no.such.key", SsoLocalizer.GetString("no.such.key", "en"));
+    }
+
+    [Fact]
+    public void AvailableCultures_IncludesTheEnglishBaseline()
+    {
+        Assert.Contains(SsoLocalizer.FallbackCulture, SsoLocalizer.AvailableCultures);
+    }
+}

--- a/SSO-Auth/Api/Localization/SsoLocalizer.cs
+++ b/SSO-Auth/Api/Localization/SsoLocalizer.cs
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Localization;
+
+/// <summary>
+/// Minimal string localizer for the plugin's user-facing served surfaces, in Jellyfin's own idiom
+/// (#913). It loads flat per-culture key→value JSON catalogs — embedded resources named by BCP-47
+/// culture, the shape of Jellyfin core's
+/// <c>Emby.Server.Implementations/Localization/Core/&lt;culture&gt;.json</c> — and resolves a key
+/// through a fallback chain that never blanks: the requested culture, then its base language, then
+/// English (the invariant fallback), then the key itself. The plugin cannot register its catalogs into
+/// core's <c>ILocalizationManager</c> (core owns that surface), so it keeps its own; the format and the
+/// <c>GetString(key, culture)</c> lookup mirror Jellyfin so a translator sees a familiar file.
+///
+/// Catalogs are DATA and are treated fail-closed: a catalog that is missing, is not a JSON object, is not
+/// a flat string→string map, or carries a null value is skipped at load (its keys fall through the chain
+/// to English), never fatal. No user-controlled value is ever used as a key.
+/// </summary>
+internal static class SsoLocalizer
+{
+    /// <summary>
+    /// The invariant fallback culture. Every key is guaranteed to exist here, so the chain never blanks.
+    /// </summary>
+    internal const string FallbackCulture = "en";
+
+    private const string ResourcePrefix = "Jellyfin.Plugin.SSO_Auth.Localization.";
+    private const string ResourceSuffix = ".json";
+
+    // culture (lower-invariant) -> (key -> non-null value). Immutable snapshot built once at load.
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> CatalogsByCulture = Load();
+
+    /// <summary>Gets the BCP-47 cultures that loaded a valid catalog (lower-invariant). For tests/diagnostics.</summary>
+    internal static IReadOnlyCollection<string> AvailableCultures => CatalogsByCulture.Keys.ToArray();
+
+    /// <summary>
+    /// Gets the localized value for <paramref name="key"/> in <paramref name="culture"/>, falling back to
+    /// the base language, then English, then the key itself. Never returns null or empty for a key present
+    /// in the English catalog; returns the key verbatim when it is defined nowhere.
+    /// </summary>
+    /// <param name="key">The catalog key. Never a user-controlled value.</param>
+    /// <param name="culture">The requested BCP-47 culture, or null/empty to use the fallback.</param>
+    /// <returns>The best available translation, or the key itself.</returns>
+    internal static string GetString(string key, string? culture)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        foreach (var candidate in CultureFallbackChain(culture))
+        {
+            if (CatalogsByCulture.TryGetValue(candidate, out var catalog)
+                && catalog.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+        }
+
+        // Defined nowhere: return the key so a missing translation is visible, never a blank.
+        return key;
+    }
+
+    // The requested culture, then its base language ("de-CH" -> "de"), then English — lower-invariant,
+    // de-duplicated in order.
+    private static IEnumerable<string> CultureFallbackChain(string? culture)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var candidate in Candidates(culture))
+        {
+            var normalized = candidate.ToLowerInvariant();
+            if (seen.Add(normalized))
+            {
+                yield return normalized;
+            }
+        }
+    }
+
+    private static IEnumerable<string> Candidates(string? culture)
+    {
+        if (!string.IsNullOrWhiteSpace(culture))
+        {
+            var trimmed = culture.Trim();
+            yield return trimmed;
+
+            var dash = trimmed.IndexOf('-', StringComparison.Ordinal);
+            if (dash > 0)
+            {
+                yield return trimmed[..dash];
+            }
+        }
+
+        yield return FallbackCulture;
+    }
+
+    private static Dictionary<string, IReadOnlyDictionary<string, string>> Load()
+    {
+        var result = new Dictionary<string, IReadOnlyDictionary<string, string>>(StringComparer.Ordinal);
+        var assembly = typeof(SsoLocalizer).Assembly;
+
+        foreach (var resourceName in assembly.GetManifestResourceNames())
+        {
+            if (!resourceName.StartsWith(ResourcePrefix, StringComparison.Ordinal)
+                || !resourceName.EndsWith(ResourceSuffix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var culture = resourceName[ResourcePrefix.Length..^ResourceSuffix.Length].ToLowerInvariant();
+            var catalog = TryReadCatalog(assembly, resourceName);
+            if (catalog != null)
+            {
+                result[culture] = catalog;
+            }
+        }
+
+        return result;
+    }
+
+    // A catalog is DATA: a stream that is missing, is not a JSON object, is not a flat string->string map,
+    // or carries a null value is skipped (its keys fall through the chain to English), never fatal.
+    private static Dictionary<string, string>? TryReadCatalog(Assembly assembly, string resourceName)
+    {
+        try
+        {
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using var reader = new StreamReader(stream);
+            var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(reader.ReadToEnd());
+            if (parsed == null || parsed.Values.Any(value => value == null))
+            {
+                return null;
+            }
+
+            return parsed;
+        }
+        catch (JsonException)
+        {
+            // Malformed catalog (not an object, wrong value shape): fail closed to the fallback chain.
+            return null;
+        }
+    }
+}

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net.Mime;
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
+using Jellyfin.Plugin.SSO_Auth.Api.Localization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
@@ -100,6 +101,8 @@ internal static class BrowserErrorPage
         + "</style>\n"
         + "</head><body>\n"
         + "<p>" + HtmlEncoder.Default.Encode(message) + "</p>\n"
-        + "<a href='/web/index.html'>Return to login</a>\n"
+        // The link label comes from the localization catalog (#913). Culture resolution from the request
+        // (Accept-Language) is wired in a later sub-unit; until then it resolves to the English fallback.
+        + "<a href='/web/index.html'>" + HtmlEncoder.Default.Encode(SsoLocalizer.GetString("error.return_to_login", null)) + "</a>\n"
         + "</body></html>";
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -1,0 +1,11 @@
+{
+  "error.return_to_login": "Return to login",
+  "error.no_matching_provider": "No matching provider found",
+  "error.rate_limited": "Too many attempts. Please wait a moment and try again.",
+  "error.invalid_state": "Invalid or expired state",
+  "error.sso_response_invalid": "SSO response validation failed",
+  "error.saml_response_invalid": "SAML response validation failed",
+  "error.pkce_not_supported": "The identity provider does not advertise the required PKCE (S256) support.",
+  "error.awaiting_approval": "Your account is not active. It is awaiting administrator approval.",
+  "error.auth_too_old": "You authenticated too long ago; please sign in again."
+}

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -51,6 +51,8 @@
     <EmbeddedResource Include="Web\ApiClient.js" />
     <EmbeddedResource Include="Web\jellyfin-apiClient.esm.min.js" />
     <EmbeddedResource Include="Web\emby-restyle.css" />
+    <!-- Per-culture localization catalogs (#913), Jellyfin-idiom flat key->value JSON. -->
+    <EmbeddedResource Include="Localization\*.json" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# What & why

First sub-unit of the i18n epic (#913): the foundation that lets the plugin's
user-facing served surfaces move off hardcoded English, without yet touching
every surface.

It lands a string localizer in Jellyfin's own idiom, flat per-culture
key→value JSON catalogs, embedded by BCP-47 culture name, the shape of core's
`Emby.Server.Implementations/Localization/Core/<culture>.json`. The plugin
cannot register its catalogs into core's `ILocalizationManager` (core owns that
surface), so it keeps its own; the format and the `GetString(key, culture)`
lookup mirror core so a translator sees a familiar file.

Resolution runs a fallback chain that never blanks: the requested culture, then
its base language (`de-CH` → `de`), then English (the invariant baseline), then
the key itself so a missing translation is visible rather than an empty string.

The English baseline catalog and the first wired call site (the browser error
page's "Return to login" label) are included as the proof of the mechanism.
Culture resolution from the request (`Accept-Language`) and wiring the remaining
surfaces are the following sub-units.

Refs #913

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This change does not touch SAML/OIDC validation, crypto, config persistence, or
the release pipeline. It does touch one served HTML surface (the browser error
page), so the relevant items:

- [x] Fail-closed preserved: catalogs are DATA - a resource that is missing, is
      not a flat string→string object, or carries a null value is skipped at
      load, never fatal; a key defined nowhere returns the key, never a blank.
- [x] No user-controlled value is ever used as a catalog key; catalog values are
      first-party trusted data.
- [x] The served error page keeps HTML-encoding: the localized label and the
      rendered message both pass through `HtmlEncoder.Default.Encode`, so the
      existing XSS guard (the IdP-supplied message must not break out of the
      markup) is unchanged and still covered by `BrowserErrorPageTests`.
- [ ] N/A, no logging change.

## Quality checklist

- [x] New logic lives in a small, single-purpose unit (`SsoLocalizer`) with
      focused unit tests.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the new structural property is locked
      in — `Localization` is registered as a leaf module in the module-dependency
      DAG, and `Shared → Localization` is recorded as a new allowed edge.
- [x] Docs impact considered: no README/wiki update needed for this foundation
      sub-unit (the translator/i18n docs land with a later sub-unit of #913).

## Verification

- [x] `dotnet build -c Release` is green (0 warnings, `warnaserror` +
      security-analyzers-as-errors, both net9.0 and net10.0).
- [x] `dotnet test` is green - 4104 passed, 0 failed (net9.0 and net10.0),
      including the new localizer unit + catalog conformance tests and the
      unchanged `BrowserErrorPageTests`.
- [ ] N/A, no `.js` / `.html` / `.css` change; no `.md` change.

## Notes

Scope is deliberately narrow: the localizer + the English catalog + one wired
label. The next sub-units add `Accept-Language` culture resolution and wire the
remaining served strings (the login status messages, the config/linking UI),
then the full language-set catalogs and the drift-guard payload, then the docs.
The catalog conformance test already enforces that every future non-English
catalog carries exactly the English key set.
