### PR TITLE
Resolve the served-page culture from Accept-Language [#913]

### DIFF
--- a/SSO-Auth.Tests/Localization/AcceptLanguageTests.cs
+++ b/SSO-Auth.Tests/Localization/AcceptLanguageTests.cs
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Plugin.SSO_Auth.Api.Localization;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AcceptLanguage"/> — picking the best loaded culture from a request's
+/// Accept-Language header (#913): q-ordering, base-language fallback, q=0 rejection, wildcard, and the
+/// safe null result that sends the caller to the English fallback.
+/// </summary>
+public class AcceptLanguageTests
+{
+    private static readonly string[] Available = ["en", "de", "fr"];
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_NullOrBlankHeader_ReturnsNull(string? header)
+    {
+        Assert.Null(AcceptLanguage.Resolve(header, Available));
+    }
+
+    [Fact]
+    public void Resolve_ExactTag_IsPicked()
+    {
+        Assert.Equal("de", AcceptLanguage.Resolve("de", Available));
+    }
+
+    [Fact]
+    public void Resolve_HighestQualityWins()
+    {
+        // fr is listed first but de outranks it on quality.
+        Assert.Equal("de", AcceptLanguage.Resolve("fr;q=0.5, de;q=0.9", Available));
+    }
+
+    [Fact]
+    public void Resolve_EqualQuality_KeepsHeaderOrder()
+    {
+        // Both default to q=1.0; the header's left-to-right order breaks the tie.
+        Assert.Equal("de", AcceptLanguage.Resolve("de, fr", Available));
+    }
+
+    [Fact]
+    public void Resolve_RegionalVariant_FallsBackToBaseLanguage()
+    {
+        // No "de-CH" catalog, but the base language "de" is available.
+        Assert.Equal("de", AcceptLanguage.Resolve("de-CH", Available));
+    }
+
+    [Fact]
+    public void Resolve_HigherRankedUnavailable_FallsToNextAvailable()
+    {
+        // es (unavailable, top q) is skipped; fr (available, lower q) wins over the base of es.
+        Assert.Equal("fr", AcceptLanguage.Resolve("es;q=0.9, fr;q=0.4", Available));
+    }
+
+    [Fact]
+    public void Resolve_NoAvailableLanguage_ReturnsNull()
+    {
+        Assert.Null(AcceptLanguage.Resolve("es, it", Available));
+    }
+
+    [Fact]
+    public void Resolve_QualityZero_RejectsThatLanguage()
+    {
+        // de is explicitly refused (q=0); en is the only remaining choice.
+        Assert.Equal("en", AcceptLanguage.Resolve("de;q=0, en;q=0.5", Available));
+    }
+
+    [Fact]
+    public void Resolve_Wildcard_IsNotMatchedToASpecificCulture()
+    {
+        Assert.Null(AcceptLanguage.Resolve("*", Available));
+    }
+
+    [Fact]
+    public void Resolve_IsCaseInsensitive()
+    {
+        Assert.Equal("de", AcceptLanguage.Resolve("DE-de", Available));
+    }
+
+    [Fact]
+    public void Resolve_MalformedHeader_ReturnsNullNeverThrows()
+    {
+        // A garbage header parses to nothing usable; the caller falls back to English, never a crash.
+        Assert.Null(AcceptLanguage.Resolve(";;;===", Available));
+    }
+}

--- a/SSO-Auth.Tests/Shared/BrowserErrorPageTests.cs
+++ b/SSO-Auth.Tests/Shared/BrowserErrorPageTests.cs
@@ -47,6 +47,22 @@ public class BrowserErrorPageTests
     }
 
     [Fact]
+    public void Wrap_ResolvesLangFromAcceptLanguage_FallsToEnglishWhileEnglishIsTheOnlyCatalog()
+    {
+        // The lang attribute is driven by the request's Accept-Language (#913). With only the English
+        // catalog loaded, a German preference resolves to English — the wiring must not throw on a real
+        // header, and the page must stay a valid, English-tagged document.
+        var ctx = Context("text/html");
+        ctx.Request.Headers.AcceptLanguage = "de-DE,de;q=0.9,en;q=0.5";
+
+        var result = Assert.IsType<ContentResult>(
+            BrowserErrorPage.Wrap(PlainError(400, "Invalid or expired state"), ctx.Request, ctx.Response));
+
+        Assert.Contains("<html lang='en'>", result.Content);
+        Assert.Contains("Return to login", result.Content);
+    }
+
+    [Fact]
     public void Wrap_HtmlEncodesTheMessage_SoIdpSuppliedTextCannotInjectMarkup()
     {
         // A callback error body can interpolate an identity-provider error_description; a hostile value

--- a/SSO-Auth/Api/Localization/AcceptLanguage.cs
+++ b/SSO-Auth/Api/Localization/AcceptLanguage.cs
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Net.Http.Headers;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Localization;
+
+/// <summary>
+/// Resolves the best available culture from a request's Accept-Language header (#913). It parses the
+/// weighted language list, orders by q-value (a missing q defaults to 1.0 per RFC 9110; equal q keeps the
+/// header's own order), and returns the highest-preference tag that has a loaded catalog — an exact BCP-47
+/// tag or its base language, so a "de-CH" preference is served by a "de" catalog. It returns null when the
+/// header is absent, malformed, or names no available language, so the caller falls back to English through
+/// the <see cref="SsoLocalizer"/> chain. A "q=0" entry explicitly rejects a language and a "*" wildcard
+/// expresses no specific preference — both are skipped rather than matched.
+/// </summary>
+internal static class AcceptLanguage
+{
+    /// <summary>
+    /// Picks the best culture in <paramref name="available"/> for the given Accept-Language header value.
+    /// </summary>
+    /// <param name="headerValue">The raw Accept-Language header (may hold several comma-separated, weighted tags).</param>
+    /// <param name="available">The loaded cultures to choose among, lower-invariant (see <see cref="SsoLocalizer.AvailableCultures"/>).</param>
+    /// <returns>The best available culture, or null to fall back to English.</returns>
+    internal static string? Resolve(string? headerValue, IReadOnlyCollection<string> available)
+    {
+        if (string.IsNullOrWhiteSpace(headerValue)
+            || !StringWithQualityHeaderValue.TryParseList(new[] { headerValue }, out var parsed)
+            || parsed is not { Count: > 0 })
+        {
+            return null;
+        }
+
+        // q=0 explicitly rejects a language; drop it. OrderByDescending is stable, so equal-q tags keep the
+        // header's own left-to-right preference order.
+        var ranked = parsed
+            .Where(value => (value.Quality ?? 1.0) > 0.0)
+            .OrderByDescending(value => value.Quality ?? 1.0);
+
+        foreach (var value in ranked)
+        {
+            var tag = value.Value.ToString().ToLowerInvariant();
+            if (tag.Length == 0 || string.Equals(tag, "*", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (available.Contains(tag))
+            {
+                return tag;
+            }
+
+            var dash = tag.IndexOf('-', StringComparison.Ordinal);
+            if (dash > 0 && available.Contains(tag[..dash]))
+            {
+                return tag[..dash];
+            }
+        }
+
+        return null;
+    }
+}

--- a/SSO-Auth/Api/Shared/BrowserErrorPage.cs
+++ b/SSO-Auth/Api/Shared/BrowserErrorPage.cs
@@ -40,6 +40,7 @@ internal static class BrowserErrorPage
         }
 
         var nonce = Convert.ToBase64String(RandomNumberGenerator.GetBytes(16));
+        var culture = AcceptLanguage.Resolve(request.Headers.AcceptLanguage.ToString(), SsoLocalizer.AvailableCultures);
 
         // A script-less page: only the nonce'd <style> is authorized, default-src 'none' denies scripts,
         // fetch, frames and everything else. Same defensive headers the auth-completion page sets.
@@ -53,7 +54,7 @@ internal static class BrowserErrorPage
 
         return new ContentResult
         {
-            Content = Render(nonce, message),
+            Content = Render(nonce, message, culture),
             ContentType = MediaTypeNames.Text.Html,
             StatusCode = status,
         };
@@ -91,9 +92,11 @@ internal static class BrowserErrorPage
     // The message is HTML-encoded because a few plain-text errors interpolate identity-provider-supplied
     // text (an OpenID error/error_description on the callback), which must not break out of the markup.
     // The "Return to login" link is a same-origin relative path, so no request-host derivation is needed.
-    private static string Render(string nonce, string message) =>
+    // The lang attribute carries the resolved culture (#913) so assistive tech announces the localized label
+    // in the right language; it is a catalog-derived token but attribute-encoded as defense-in-depth.
+    private static string Render(string nonce, string message, string? culture) =>
         "<!DOCTYPE html>\n"
-        + "<html lang='en'><head>\n"
+        + "<html lang='" + HtmlEncoder.Default.Encode(culture ?? SsoLocalizer.FallbackCulture) + "'><head>\n"
         + "<meta name='viewport' content='width=device-width, initial-scale=1'>\n"
         + "<style nonce='" + nonce + "'>\n"
         + "  body { background: #101010; color: #d1cfce; font-family: Noto Sans, Noto Sans HK, Noto Sans JP, Noto Sans KR, Noto Sans SC, Noto Sans TC, sans-serif; margin: 2rem; }\n"
@@ -101,8 +104,8 @@ internal static class BrowserErrorPage
         + "</style>\n"
         + "</head><body>\n"
         + "<p>" + HtmlEncoder.Default.Encode(message) + "</p>\n"
-        // The link label comes from the localization catalog (#913). Culture resolution from the request
-        // (Accept-Language) is wired in a later sub-unit; until then it resolves to the English fallback.
-        + "<a href='/web/index.html'>" + HtmlEncoder.Default.Encode(SsoLocalizer.GetString("error.return_to_login", null)) + "</a>\n"
+        // The link label comes from the localization catalog (#913), in the culture resolved from the
+        // request's Accept-Language header (English until a matching catalog is loaded).
+        + "<a href='/web/index.html'>" + HtmlEncoder.Default.Encode(SsoLocalizer.GetString("error.return_to_login", culture)) + "</a>\n"
         + "</body></html>";
 }


### PR DESCRIPTION
# What & why

Second sub-unit of the i18n epic (#913): the culture-resolution mechanism the
anonymous served pages need, wired into the browser error page as its first
consumer.

`AcceptLanguage.Resolve` parses the request's weighted `Accept-Language` list,
orders by q-value (a missing q defaults to 1.0 per RFC 9110; equal q keeps the
header's own order), and returns the highest-preference tag that has a loaded
catalog, an exact BCP-47 tag or its base language, so a `de-CH` preference is
served by a `de` catalog. A `q=0` entry (explicit rejection) and a `*` wildcard
(no specific preference) are skipped. It returns null, never throws, when the
header is absent, malformed, or names no available language, so the caller falls
back to English through the localizer chain.

The browser error page now derives its `<html lang>` and its "Return to login"
label from the resolved culture instead of a hardcoded `en`. While English is
the only loaded catalog every request still resolves to English; the behaviour
becomes observable as the language set lands.

Scope note (agreed): the rendered error message body, the `LoginStatusMapper`
plain text, byte-identical to the XHR/API wire form and deliberately uniform per
category (no provider/roles oracle), stays canonical English here and localizes
in a later sub-unit via key-tagging. The larger script-driven auth-completion
page (`WebResponse`) is its own following sub-unit.

Refs #913

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Touches one served HTML surface (the browser error page); no change to
SAML/OIDC validation, crypto, config persistence, or the release pipeline.

- [x] Fail-closed preserved: the resolver never throws - an absent, malformed, or
      unmatched header returns null and the page falls back to English; the error
      response status and body are unchanged.
- [x] No wire-contract change: the plain-text error body `LoginStatusMapper`
      emits is untouched (still canonical English, byte-identical for XHR/API);
      only the browser HTML re-render's `lang` and return-link label are derived
      from the culture, both encoded (attribute / HTML).
- [x] No user-controlled value reaches a catalog key; the resolved tag is chosen
      only from the plugin's own loaded culture set.
- [ ] N/A, no logging change.

## Quality checklist

- [x] New logic lives in a small, pure, single-purpose unit (`AcceptLanguage`)
      with focused unit tests.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; `AcceptLanguage` stays within the
      `Localization` leaf module (imports no other Api module), so the module DAG
      is unchanged.
- [x] Docs impact considered: no README/wiki update needed for this sub-unit.

## Verification

- [x] `dotnet build -c Release` is green (0 warnings, `warnaserror` +
      security-analyzers-as-errors, both net9.0 and net10.0).
- [x] `dotnet test` is green - 4132 passed, 0 failed (net9.0 and net10.0),
      including the new `AcceptLanguage` unit tests and the browser-page
      regression test.
- [ ] N/A, no `.js` / `.html` / `.css` / `.md` change.

## Notes

Following sub-units of #913: the auth-completion page (`WebResponse`) chrome,
then the error message bodies via key-tagging, then the config/linking admin UI,
then the full language catalog set (the catalog drift-guard already enforces that
each future non-English catalog carries exactly the English key set), then the
translator docs.
