### PR TITLE
Add client-side UI localization and wire the linking page [#913]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -188,7 +188,7 @@ public class ArchitectureConformanceTests
     [InlineData("Session", "Authz", "Avatar", "Linking")] // session mint + login outcomes — applies grants (Authz), sets avatars (Avatar), reconciles links (Linking)
     [InlineData("Shared", "Avatar", "Linking", "Localization", "RateLimit", "Routing", "Session")] // shared served-page / flow-response + rate-limit-gate helpers — depend downward on the session/linking/avatar/throttle/route/localization tiers, never on a protocol or the boundary
     [InlineData("Flows", "Audit", "Identity", "Linking", "Localization", "Logout", "Net", "Oidc", "Provider", "RateLimit", "Saml", "Session", "Shared")] // per-protocol login orchestration — drives both protocol modules (Oidc/Saml) and the downstream mint/link/session tiers; localizes the served auth-completion page (Localization, #913); persists the captured logout state at the mint (Logout, #727); nothing above the boundary imports it
-    [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Logout", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide (incl. the RP-initiated logout store, #727); nothing imports it back (#790/#807)
+    [InlineData("Http", "Audit", "Avatar", "Flows", "Linking", "Localization", "Logout", "Net", "Oidc", "Provider", "Saml", "Session", "Shared")] // the web boundary (SSOController + request helpers + the admin test-connection probe + the UI-string endpoint, #913): the composition top of the DAG — it fronts every flow, so its import list is deliberately wide (incl. the RP-initiated logout store, #727); nothing imports it back (#790/#807)
     public void ApiModule_ImportsOnlyItsAllowedApiModules(string module, params string[] allowed)
     {
         var moduleDir = Path.Combine(RepoRoot(), "SSO-Auth", "Api", module);
@@ -2428,6 +2428,7 @@ public class ArchitectureConformanceTests
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
         "saml/links/{jellyfinUserId}", "oid/links/{jellyfinUserId}", // authenticated link listings
         "{viewName}", // SSOViewsController: read-only embedded static asset (ETag/304), no I/O, no login path
+        "i18n", // SSOViewsController: anonymous read-only UI-string catalog (#913), in-memory, no I/O, no login path
     };
 
     [Fact]

--- a/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
+++ b/SSO-Auth.Tests/Http/SSOViewsControllerTests.cs
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System.Collections.Generic;
 using System.IO;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.Serialization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -107,6 +109,25 @@ public class SSOViewsControllerTests
         var file = Assert.IsType<FileStreamResult>(result);
         Assert.NotNull(file.FileStream);
         Assert.Contains("javascript", file.ContentType, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetLocalizationCatalog_ResolvesUiStrings_AndSetsVaryAcceptLanguage()
+    {
+        var controller = CreateController();
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        controller.Request.Headers.AcceptLanguage = "de-DE,de;q=0.9,en;q=0.5";
+
+        var result = controller.GetLocalizationCatalog();
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var catalog = Assert.IsAssignableFrom<IReadOnlyDictionary<string, string>>(ok.Value);
+        // English is the only loaded catalog today, so every key resolves to its English value; the point
+        // is that the endpoint returns the concrete resolved strings a client applies, not keys.
+        Assert.Equal("Home", catalog["link.home"]);
+        Assert.Equal("Return to login", catalog["error.return_to_login"]);
+        // Per-language response, so caches must key on the request language.
+        Assert.Equal("Accept-Language", controller.Response.Headers.Vary.ToString());
     }
 
     [Fact]

--- a/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
+++ b/SSO-Auth.Tests/SSOPluginPageManifestTests.cs
@@ -65,6 +65,7 @@ public class SSOPluginPageManifestTests
                 ("style.css", $"{ns}.Web.style.css"),
                 ("linking", $"{ns}.Web.linking.html"),
                 ("linking.js", $"{ns}.Web.linking.js"),
+                ("i18n.js", $"{ns}.Web.i18n.js"),
                 ("ApiClient.js", $"{ns}.Web.ApiClient.js"),
                 ("emby-restyle.css", $"{ns}.Web.emby-restyle.css"),
                 ("jellyfin-apiClient.esm.min.js", $"{ns}.Web.jellyfin-apiClient.esm.min.js"),

--- a/SSO-Auth/Api/Http/SSOViewsController.cs
+++ b/SSO-Auth/Api/Http/SSOViewsController.cs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net.Mime;
+using Jellyfin.Plugin.SSO_Auth.Api.Localization;
 using MediaBrowser.Model;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Net.Http.Headers;
@@ -68,5 +72,26 @@ public class SSOViewsController : ControllerBase
         }
 
         return File(stream, MimeTypes.GetMimeType(view.EmbeddedResourcePath), lastModified: null, entityTag: AssetETag);
+    }
+
+    /// <summary>
+    /// Gets the plugin's user-interface strings (#913) resolved into the culture requested by the caller's
+    /// Accept-Language header. The client-rendered pages (the linking page, the admin config page) fetch
+    /// this once and apply the strings to their DOM, so the server owns the culture fallback and the pages
+    /// carry only keys. Anonymous and non-sensitive: it returns first-party UI labels only — no user data,
+    /// no configuration, no secrets — the same strings already embedded in the served pages.
+    /// </summary>
+    /// <returns>Every UI string key resolved to a concrete value in the request's culture.</returns>
+    [HttpGet("i18n")]
+    [AllowAnonymous]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult<IReadOnlyDictionary<string, string>> GetLocalizationCatalog()
+    {
+        var culture = AcceptLanguage.Resolve(Request.Headers.AcceptLanguage.ToString());
+
+        // The resolved set differs per requested language, so caches must key on it.
+        Response.Headers.Vary = HeaderNames.AcceptLanguage;
+
+        return Ok(SsoLocalizer.ResolvedCatalog(culture));
     }
 }

--- a/SSO-Auth/Api/Localization/SsoLocalizer.cs
+++ b/SSO-Auth/Api/Localization/SsoLocalizer.cs
@@ -41,6 +41,27 @@ internal static class SsoLocalizer
     internal static IReadOnlyCollection<string> AvailableCultures => CatalogsByCulture.Keys.ToArray();
 
     /// <summary>
+    /// Resolves every catalog key into <paramref name="culture"/> and returns the complete key→value map,
+    /// for a client that renders a page's own text (#913): the server owns the culture fallback, the client
+    /// just applies concrete strings. Keyed on the English baseline, which holds every key.
+    /// </summary>
+    /// <param name="culture">The requested culture, or null for English.</param>
+    /// <returns>Every key resolved to a concrete string in the requested culture.</returns>
+    internal static IReadOnlyDictionary<string, string> ResolvedCatalog(string? culture)
+    {
+        var resolved = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (CatalogsByCulture.TryGetValue(FallbackCulture, out var english))
+        {
+            foreach (var key in english.Keys)
+            {
+                resolved[key] = GetString(key, culture);
+            }
+        }
+
+        return resolved;
+    }
+
+    /// <summary>
     /// Gets the localized value for <paramref name="key"/> in <paramref name="culture"/>, falling back to
     /// the base language, then English, then the key itself. Never returns null or empty for a key present
     /// in the English catalog; returns the key verbatim when it is defined nowhere.

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -17,5 +17,14 @@
   "page.enable_javascript": "Please enable Javascript to complete the login",
   "page.account_linked": "Account linked. You can now log in with SSO.",
   "page.link_failed": "Could not link this account. The provider may be disabled, or linking is not permitted.",
-  "page.login_failed": "Login failed. Please try again."
+  "page.login_failed": "Login failed. Please try again.",
+  "link.home": "Home",
+  "link.title": "SSO Linking:",
+  "link.help": "Help",
+  "link.load_error": "Something went wrong loading or updating your links. Please reload the page and try again.",
+  "link.enable_delete": "Enable \"Delete\" button.",
+  "link.section_link_provider": "Link a provider",
+  "link.delete_selected": "Delete Selected",
+  "link.no_providers": "No {mode} providers are available.",
+  "link.disabled_note": " (disabled)"
 }

--- a/SSO-Auth/SSO-Auth.csproj
+++ b/SSO-Auth/SSO-Auth.csproj
@@ -49,6 +49,7 @@
     <EmbeddedResource Include="Web\linking.html" />
     <EmbeddedResource Include="Web\linking.js" />
     <EmbeddedResource Include="Web\ApiClient.js" />
+    <EmbeddedResource Include="Web\i18n.js" />
     <EmbeddedResource Include="Web\jellyfin-apiClient.esm.min.js" />
     <EmbeddedResource Include="Web\emby-restyle.css" />
     <!-- Per-culture localization catalogs (#913), Jellyfin-idiom flat key->value JSON. -->

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -188,6 +188,7 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
             Page("style.css", "Web.style.css"),
             Page("linking", "Web.linking.html"),
             Page("linking.js", "Web.linking.js"),
+            Page("i18n.js", "Web.i18n.js"),
             Page("ApiClient.js", "Web.ApiClient.js"),
             Page("emby-restyle.css", "Web.emby-restyle.css"),
             Page("jellyfin-apiClient.esm.min.js", "Web.jellyfin-apiClient.esm.min.js"),

--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -21,11 +21,14 @@ function format(text, params) {
   );
 }
 
-// Look up a key, falling back to the key itself so a missing translation is visible, never blank.
-export function t(key, params) {
+// Look up a key. When it is not in the loaded catalog — most importantly when the fetch failed and the
+// catalog is empty — fall back to the caller's built-in English default (the same role the hard-coded text
+// on data-i18n markup plays), and only to the key itself if no default was given, so a missing string is
+// never blank. Placeholders are substituted in either case.
+export function t(key, params, fallback) {
   const value = Object.prototype.hasOwnProperty.call(catalog, key)
     ? catalog[key]
-    : key;
+    : (fallback ?? key);
   return format(value, params);
 }
 

--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+// Client-side application of the plugin's UI string catalog (#913). The server owns the culture fallback:
+// it resolves the caller's Accept-Language and returns a complete key->value map from SSOViews/i18n. This
+// module fetches that map once and applies it to elements marked `data-i18n="<key>"`, and exposes `t()` for
+// strings built in JavaScript. It degrades to the markup's built-in English if the fetch fails, so a
+// network error never blanks the page.
+
+let catalog = {};
+
+// Substitute {name} placeholders from params; an absent param is left verbatim so a mismatched catalog
+// entry never drops text.
+function format(text, params) {
+  if (!params) {
+    return text;
+  }
+
+  return text.replace(/\{(\w+)\}/g, (match, name) =>
+    Object.prototype.hasOwnProperty.call(params, name) ? params[name] : match,
+  );
+}
+
+// Look up a key, falling back to the key itself so a missing translation is visible, never blank.
+export function t(key, params) {
+  const value = Object.prototype.hasOwnProperty.call(catalog, key)
+    ? catalog[key]
+    : key;
+  return format(value, params);
+}
+
+// Apply the loaded catalog to every [data-i18n] element under `root` (default: the whole document),
+// replacing its text content. Elements whose key is not in the catalog keep their built-in text.
+export function applyTo(root) {
+  (root || document).querySelectorAll("[data-i18n]").forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (Object.prototype.hasOwnProperty.call(catalog, key)) {
+      el.textContent = catalog[key];
+    }
+  });
+}
+
+// Fetch the culture-resolved catalog from the server. The returned promise always resolves; on any failure
+// the catalog stays empty and callers fall back to the built-in English. ApiClient.getUrl builds the
+// server-rooted URL the linking/config pages already use; the endpoint is anonymous, so a plain fetch.
+export function loadCatalog() {
+  return fetch(ApiClient.getUrl("SSOViews/i18n"), {
+    headers: { Accept: "application/json" },
+  })
+    .then((resp) => (resp.ok ? resp.json() : {}))
+    .then((data) => {
+      catalog = data || {};
+    })
+    .catch(() => {
+      catalog = {};
+    });
+}

--- a/SSO-Auth/Web/linking.html
+++ b/SSO-Auth/Web/linking.html
@@ -34,15 +34,16 @@
           <div class="sectionTitleContainer flex align-items-center">
             <a class="raised emby-button home" style="display: none">
               <span class="material-icons home" aria-hidden="true"></span
-              ><span>Home</span>
+              ><span data-i18n="link.home">Home</span>
             </a>
-            <h2 class="sectionTitle">SSO Linking:</h2>
+            <h2 class="sectionTitle" data-i18n="link.title">SSO Linking:</h2>
             <a
               is="emby-button"
               class="raised button-alt headerHelpButton"
               target="_blank"
               rel="noopener noreferrer"
               href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
+              data-i18n="link.help"
               >Help</a
             >
           </div>
@@ -51,6 +52,7 @@
             class="sso-linking-error"
             role="alert"
             hidden
+            data-i18n="link.load_error"
           >
             Something went wrong loading or updating your links. Please reload
             the page and try again.
@@ -84,9 +86,13 @@
           </p>
           <label class="checkbox-wrapper">
             <input is="emby-checkbox" id="enable-delete" type="checkbox" />
-            <span class="checkbox-label">Enable "Delete" button.</span>
+            <span class="checkbox-label" data-i18n="link.enable_delete"
+              >Enable "Delete" button.</span
+            >
           </label>
-          <h1 class="sectionTitle">Link a provider</h1>
+          <h1 class="sectionTitle" data-i18n="link.section_link_provider">
+            Link a provider
+          </h1>
           <div class="verticalSection" title="Link a provider">
             <h2 class="sectionTitle">SAML</h2>
             <div id="sso-provider-list-saml" data-id="saml"></div>
@@ -100,7 +106,7 @@
             disabled="true"
           >
             <span class="material-icons delete" aria-hidden="true"></span>
-            <span>Delete Selected</span>
+            <span data-i18n="link.delete_selected">Delete Selected</span>
           </button>
         </div>
       </div>

--- a/SSO-Auth/Web/linking.js
+++ b/SSO-Auth/Web/linking.js
@@ -52,9 +52,11 @@ const ssoConfigLinking = {
     }
     const placeholder = document.createElement("p");
     placeholder.classList.add("sso-provider-empty");
-    placeholder.textContent = t("link.no_providers", {
-      mode: provider_mode.toUpperCase(),
-    });
+    placeholder.textContent = t(
+      "link.no_providers",
+      { mode: provider_mode.toUpperCase() },
+      "No {mode} providers are available.",
+    );
     container.appendChild(placeholder);
   },
   loadProviderList: (container, providers, provider_mode) => {
@@ -173,7 +175,11 @@ const ssoConfigLinking = {
     } else {
       const disabled_note = document.createElement("span");
       disabled_note.classList.add("sso-provider-disabled-note");
-      disabled_note.textContent = t("link.disabled_note");
+      disabled_note.textContent = t(
+        "link.disabled_note",
+        undefined,
+        " (disabled)",
+      );
       title.appendChild(disabled_note);
       provider_config.append(title, existing_links);
     }

--- a/SSO-Auth/Web/linking.js
+++ b/SSO-Auth/Web/linking.js
@@ -1,3 +1,5 @@
+import { loadCatalog, applyTo, t } from "./i18n.js";
+
 const ssoConfigLinking = {
   pluginUniqueId: "505ce9d1-d916-42fa-86ca-673ef241d7df",
 
@@ -50,7 +52,9 @@ const ssoConfigLinking = {
     }
     const placeholder = document.createElement("p");
     placeholder.classList.add("sso-provider-empty");
-    placeholder.textContent = `No ${provider_mode.toUpperCase()} providers are available.`;
+    placeholder.textContent = t("link.no_providers", {
+      mode: provider_mode.toUpperCase(),
+    });
     container.appendChild(placeholder);
   },
   loadProviderList: (container, providers, provider_mode) => {
@@ -169,7 +173,7 @@ const ssoConfigLinking = {
     } else {
       const disabled_note = document.createElement("span");
       disabled_note.classList.add("sso-provider-disabled-note");
-      disabled_note.textContent = " (disabled)";
+      disabled_note.textContent = t("link.disabled_note");
       title.appendChild(disabled_note);
       provider_config.append(title, existing_links);
     }
@@ -274,8 +278,6 @@ const ssoConfigLinking = {
 };
 
 export default function initLinkingView(view) {
-  ssoConfigLinking.loadProviders(view);
-
   view.querySelector("#enable-delete").addEventListener("change", (e) => {
     view.querySelector("#btn-delete-selected-links").disabled =
       !e.target.checked;
@@ -286,4 +288,12 @@ export default function initLinkingView(view) {
     .addEventListener("click", (e) =>
       ssoConfigLinking.handleDeleteButtonPressed(e, view),
     );
+
+  // Load the UI strings before rendering: the static markup is localized in place and the dynamically
+  // built rows (provider empty-state, disabled note) read their text through t(). loadCatalog always
+  // resolves, so a fetch failure just leaves the built-in English.
+  loadCatalog().then(() => {
+    applyTo(document);
+    ssoConfigLinking.loadProviders(view);
+  });
 }


### PR DESCRIPTION
# What & why

Fifth sub-unit of the i18n epic (#913): the client-side localization mechanism
the admin/linking pages need, wired into the account-linking page as its first
consumer.

Those pages are client-rendered from embedded resources, the config page is
served by Jellyfin core, so there is no server render hook. So the server owns
only the culture fallback: a new anonymous `SSOViews/i18n` endpoint resolves the
caller's `Accept-Language` (the same resolver the served pages use) and returns
the complete key→value catalog resolved into that culture. A small `i18n.js`
module fetches it once, applies it to `data-i18n`-marked elements, and exposes
`t(key, params)` for strings built in JavaScript.

Refs #913

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Adds a new anonymous read endpoint and a client-side applier; no change to
SAML/OIDC validation, crypto, config persistence, or the release pipeline.
Reviewed with the adversarial bypass + correctness lenses in addition to CI.

- [x] No sensitive exposure: the endpoint returns first-party static UI labels
      only — no user data, no configuration, no secrets, nothing per-user — the
      same strings already embedded in the pages, so anonymous access is safe.
- [x] Bounded / no amplification: it serializes an in-memory dictionary, does no
      I/O and is off the login path, so it is classified rate-limit-exempt in the
      route conformance test (alongside the existing static-asset endpoint).
- [x] No client injection: `i18n.js` assigns `textContent` only (never
      `innerHTML`/`eval`); catalog values and `data-i18n` keys are first-party;
      the only `t()` params on the linking page are the hardcoded protocol mode.
- [x] Fail-safe: `loadCatalog` swallows any error to an empty catalog, so the
      static markup keeps its built-in English on a network failure.

## Quality checklist

- [x] No duplicated logic; the culture fallback stays server-side (reusing the
      existing resolver), the client just applies concrete strings.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass; the new structural properties are
      locked in — the `i18n` route is classified rate-limit-exempt, and
      `Http → Localization` is recorded as a new allowed module edge; the
      GetViews manifest pin is updated for the new asset.
- [x] Docs impact considered: no README/wiki update needed for this sub-unit.

## Verification

- [x] `dotnet build -c Release` is green (0 warnings, `warnaserror` +
      security-analyzers-as-errors, both net9.0 and net10.0).
- [x] `dotnet test` is green - 4152 passed, 0 failed (net9.0 and net10.0),
      including the new endpoint test (resolved strings + `Vary: Accept-Language`)
      and the updated route/manifest conformance pins.
- [x] Prettier is clean for the changed `.js` / `.html` (`i18n.js`, `linking.js`,
      `linking.html`).

## Notes

Scope: the linking page's static labels + its two dynamic strings. Two rich
instruction paragraphs that interleave text with icons/links are left for a
later sub-unit with placeholder-aware substitution. Remaining #913 sub-units: the
config page's own string inventory (uses this same mechanism), the full language
catalog set (the drift-guard already enforces exact key parity), the rich-markup
paragraphs, the translator docs, and the noted served-error-bodies sweep.
