### PR TITLE
Require a reproduction artifact before a lens finding is fix-required

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,10 +19,10 @@ persistence, or the release pipeline.
 - [ ] No secrets logged; secrets are redacted on config export.
 - [ ] A security review was performed for changes to SAML/OIDC validation,
       config persistence, or the release pipeline.
-- [ ] Review-gate ledger: **CONFIRMED __ / PLAUSIBLE __ / not-CI-exercisable
-      __**. Every CONFIRMED finding is fixed; every other one carries a
-      disposition (reasoned DECLINE, or DEFER as its own issue). A finding
-      without a reproduction artifact is never counted as CONFIRMED.
+- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
+      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
+      reproduction was produced). Every finding of either kind carries a
+      disposition — FIX, a reasoned DECLINE, or DEFER as its own issue.
 - [ ] Log inputs from the IdP are sanitized inline at the log call.
 
 ## Quality checklist

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@ persistence, or the release pipeline.
 - [ ] No secrets logged; secrets are redacted on config export.
 - [ ] A security review was performed for changes to SAML/OIDC validation,
       config persistence, or the release pipeline.
+- [ ] Review-gate ledger: **CONFIRMED __ / PLAUSIBLE __ / not-CI-exercisable
+      __**. Every CONFIRMED finding is fixed; every other one carries a
+      disposition (reasoned DECLINE, or DEFER as its own issue). A finding
+      without a reproduction artifact is never counted as CONFIRMED.
 - [ ] Log inputs from the IdP are sanitized inline at the log call.
 
 ## Quality checklist


### PR DESCRIPTION
## What & why

Closes #1016

A lens finding became fix-required on the strength of its argument, and nothing said what "evidence" had to mean. This makes the floor explicit and adds a way to say a finding was actually demonstrated.

- **`EVIDENCE:` is mandatory for every finding**, in every dimension: the quote, the lines, the reasoning traced through the code.
- **`REPRODUCTION:` sits beside it and is what earns CONFIRMED** - and it must have been produced, not described. Without one the finding is PLAUSIBLE.
- **Both are fix-required when the defect is real.** PLAUSIBLE states how much the claim has been paid for, not whether it counts.
- The spec now tells a lens explicitly **not to withhold a finding it cannot execute**. Structural, architectural, requirements and documentation defects have no failing run by nature, and most real review findings are of that kind.
- The PR template records **CONFIRMED / PLAUSIBLE counts as raised**, transcribed from the reports, plus a disposition for every finding of either kind.

## What this PR is not

An earlier revision of this branch made a reproduction **mandatory**, made only CONFIRMED findings fix-required, and added a `not CI-exercisable` escape tag. Its own four-lens panel returned 1 FAIL and 3 NEEDS_IMPROVEMENT: the rule demoted the two-thirds of review dimensions that have no executable artifact, and the tag was a self-service demotion pointed at the release pipeline and out-of-process components - the surfaces where the review is the primary verification. None of that is in this diff. There is no tag, no mandatory reproduction, and no automated ledger. The reasoning is kept in the handbook so the next person to have the idea reads the refutation first; the incident is `improvement/rca/2026-07-reproduction-gate-over-applied.md` in the operating handbook.

## Review record

Two rounds, fresh lenses each time, full dimension coverage per the canonical list. Round 1 on the rejected design: 1 FAIL, 3 NEEDS_IMPROVEMENT, ~40 confirmed findings. Round 2 on this design: findings were confined to the PR prose, which is what this body now fixes.

CONFIRMED / PLAUSIBLE for this PR are recorded in the merge comment, from the round-2 reports.

## Verification

- Text-only diff in this repo: no code, no CI, no workflow change.
- The canonical rule lives in the operating handbook's review-gate chapter, "Evidence and promotion".

## Notes

Rolled out under the cross-repo issue agent-operations#3, whose checklist tracks the other three repos.