### PR TITLE
Move every codeql-action pin to v4.37.1 in one step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,7 +86,7 @@ jobs:
           dotnet-version: 9.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -94,6 +94,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Surface the findings in the code-scanning tab, alongside CodeQL and zizmor.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -73,7 +73,7 @@ jobs:
         # skip the "Fail on actionable findings" step below.
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
## Why this replaces three Dependabot PRs

Dependabot opens one PR per action path. That put the `codeql-action` bump
into three separate PRs:

| PR    | action path                    |
| ----- | ------------------------------ |
| #1024 | `codeql-action/init`           |
| #1025 | `codeql-action/analyze`        |
| #1021 | `codeql-action/upload-sarif`   |

CodeQL requires `init` and `analyze` to run the same version. Merging #1024
or #1025 alone puts the pair on different releases, which is why all three
arrived red with exactly three failures each, `Analyze (csharp)`,
`Analyze (javascript-typescript)`, `Analyze (actions)`.

Before this PR all four call sites were on one SHA. They move to one SHA
together, which is the only shape that preserves the invariant.

## What changed

Four pins, `99df26d4` (v4.37.0) to `7188fc36` (v4.37.1):

- `codeql.yml`, `init`, `analyze`
- `scorecard.yml`, `upload-sarif`
- `zizmor.yml`, `upload-sarif`

## Verification

The SHA is checked against upstream rather than taken from the Dependabot
bodies: tag `v4.37.1` is the annotated tag `bb16b9ba`, which dereferences to
commit `7188fc363630916deb702c7fdcf4e481b751f97a`.

The comment names the exact tag rather than the bare major on purpose. `v4`
currently resolves to `e4fba868`, and a `# v4`-style comment that drifts away
from its pin fails the zizmor gate on every later PR.

Closes #1021
Closes #1024
Closes #1025
