### PR TITLE
Bump the checkout and setup-dotnet pins off a branch that can gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,13 @@ jobs:
       attestations: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # JPRM builds the plugin; nothing pushes via git, so drop the persisted token.
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "${{ inputs.dotnet-version }}"
 
@@ -108,7 +108,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -117,7 +117,7 @@ jobs:
       # (matching the JF12 legs' dual-SDK setup) regardless of which single target a
       # given publish leg ships.
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             9.0.x

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).
@@ -81,7 +81,7 @@ jobs:
       # csharp with the right toolchain. Skipped for the buildless languages.
       - name: Setup .NET
         if: matrix.language == 'csharp'
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 9.0.x
 

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history so the base..head commit range is walkable; no push, so
           # drop the persisted token.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Dependency review

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,13 +27,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # No step pushes via git, so do not leave the GITHUB_TOKEN persisted in
         # .git/config (zizmor "artipacked" hardening — shrinks the credential blast radius).
         persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         # Both SDKs the multi-target build needs (#135): net9.0 for the Jellyfin 10.11 line, net10.0 for
         # the Jellyfin 12.0 line. `dotnet build`/`test` (no -f) build and test every TargetFramework, so
@@ -107,11 +107,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 9.0.x
     - name: Derive the targetAbi floor

--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -96,12 +96,12 @@ jobs:
       matrix: ${{ fromJSON(needs.select.outputs.matrix) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "9.0.x"
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -71,14 +71,14 @@ jobs:
       LIBFUZZER_DOTNET_REF: c33d28305eba24261ce1945a39576e659f437b90
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           # The harness targets net9.0; the referenced multi-target plugin also
           # has a net10.0 leg, so install both SDKs (as the .NET build job does)

--- a/.github/workflows/opengrep.yml
+++ b/.github/workflows/opengrep.yml
@@ -44,7 +44,7 @@ jobs:
       OPENGREP_SHA256: "9ac4aebb47ba3f7b0d8fc641ac8749cb6c2f253f616131a67d9631e00d4bea33"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         # Default checkout (the PR merge commit) — it is what should be linted,
         # and checking out head_ref made the job an untrusted-checkout finding.
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Prettify code

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -87,13 +87,13 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # The release/manifest steps authenticate with GITHUB_TOKEN via their action
         # inputs, not the git remote, so the persisted checkout token is unneeded.
         persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: 9.0.x
         # No NuGet cache here: this job publishes a release with contents:write,

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -89,11 +89,11 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         # Both SDKs: the multi-target restore/build needs net9.0, the JF12 package is net10.0.
         # No NuGet cache: this job publishes with contents:write, so a poisoned cache could reach

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -45,11 +45,11 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Setup .NET
-      uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         # Both SDKs: the multi-target restore/build needs net9.0, the JF12 package is net10.0.
         # No NuGet cache: this job publishes with contents:write, so a poisoned cache could reach the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,7 @@ jobs:
     steps:
     # Needed so the local actions below resolve; the manifest step itself talks to the
     # API and uses nothing else from the working tree.
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     # The plugin identity (guid, name, description, …) the manifest is built around comes

--- a/.github/workflows/regenerate-manifest.yml
+++ b/.github/workflows/regenerate-manifest.yml
@@ -52,7 +52,7 @@ jobs:
       contents: write
     steps:
     # Needed so the local composite actions below resolve; nothing else is read from the tree.
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
     - name: Refuse to repopulate the retired stable channel without explicit intent

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/stryker-mutation.yml
+++ b/.github/workflows/stryker-mutation.yml
@@ -84,14 +84,14 @@ jobs:
             mutate: "Api/Authz/RolePrivilegeMapper.cs,Api/Session/LoginStatusMapper.cs,Api/Linking/AdoptionEligibilityResolver.cs"
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in
           # .git/config (zizmor "artipacked" hardening).
           persist-credentials: false
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           # Both SDKs the multi-target build needs: net9.0 (Jellyfin 10.11 line)
           # and net10.0 (Jellyfin 12.0 line). Stryker mutates the net9.0 leg

--- a/.github/workflows/unicode-guard.yml
+++ b/.github/workflows/unicode-guard.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # No step pushes via git, so do not persist the GITHUB_TOKEN in .git/config.
           persist-credentials: false

--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Clone the wiki

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -48,7 +48,7 @@ jobs:
       ZIZMOR_VERSION: "1.26.1"
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Why this replaces #1022 and #1023

Both Dependabot PRs went fully green and neither could merge. The `main`
ruleset requires the code-scanning check `zizmor`, and `zizmor.yml`
deliberately skips its SARIF upload on Dependabot runs, those get a read-only
`GITHUB_TOKEN` and cannot write security events. The required check therefore
never reports, `mergeStateStatus` stays `BLOCKED`, and `--admin` is refused
with `Required status check "zizmor" is expected`.

Confirmed on the run for #1023's head: `Audit workflows (zizmor)` concluded
`success` with `Upload SARIF` `skipped`.

#1027 tracks fixing that properly. On a normal branch the upload runs, so this
PR can satisfy the same requirement the Dependabot ones structurally could not.

## What changed

32 lines across 19 workflow files, no plugin code:

| action                | from                  | to                    | sites |
| --------------------- | --------------------- | --------------------- | ----- |
| `actions/checkout`    | `9c091bb2` (v7.0.0)   | `3d3c42e5` (v7.0.1)   | 21    |
| `actions/setup-dotnet`| `26b0ec14` (`# v5`)   | `a98b5685` (v6.0.0)   | 11    |

They ride together because they are the same kind of change with no
interaction, one CI cycle instead of two.

## Verification

Both SHAs checked against upstream rather than taken from the Dependabot
bodies:

- `actions/checkout` tag `v7.0.1` → `3d3c42e5aac5ba805825da76410c181273ba90b1`
- `actions/setup-dotnet` tag `v6.0.0` → `a98b56852c35b8e3190ac28c8c2271da59106c68`

`setup-dotnet` v6.0.0 is a major release whose only substantive change is a
migration of the action's own code to ESM. Inputs and outputs are unchanged,
which is consistent with `build` and `ABI floor build` passing on #1022.

## One incidental fix

The `setup-dotnet` comment read `# v5`, a bare major. A bare-major comment
stops describing its pin the moment upstream moves the tag, and a comment that
has drifted from its SHA fails the zizmor gate on every later PR. It now names
the exact tag, matching every other pin in the tree.

Closes #1022
Closes #1023
