### PR TITLE
Prove the JWT algorithm, kid and claim posture with forgeries [#1004]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2617,22 +2617,45 @@ public class ArchitectureConformanceTests
     /// passing a bare <c>new() { … }</c> straight into <c>ValidateTokenAsync</c>, which names the type
     /// nowhere and is invisible to both scans (term 3 pins the handler entry points to the two validators).
     ///
-    /// WHAT THEY DO NOT CATCH, measured the same way, because a guard that overstates its reach is what the
-    /// next author trusts instead of re-deriving it. Two shapes produce output identical to a clean run.
-    /// Verification that never uses the library at all — splitting the JWS and calling <c>RSA.VerifyData</c>
-    /// directly — constructs no parameters and calls no handler, so no term applies. And a second, laxer
-    /// parameter set built INSIDE a file already on the two lists below is indistinguishable to a per-file
-    /// scan from the first one there. Both belong to review, not to this rule: a text scan has no notion of
-    /// "how many times in this file" and none of "does this reimplement the verifier", and the OIDC surface
-    /// is on the sensitive list where every change is reviewed before merge. Adding a fourth term for them
-    /// is the wrong repair — the terms enumerate spellings over an unbounded space, so each one added moves
-    /// the next evasion one identifier away rather than closing it.
+    /// WHAT THEY DO NOT CATCH, because a guard that overstates its reach is what the next author trusts
+    /// instead of re-deriving it. FOUR shapes, each verified by making the edit and running this rule over it,
+    /// not by reading the predicates:
+    ///
+    /// (a) Verification that never uses the library at all — splitting the JWS and calling
+    /// <c>RSA.VerifyData</c> directly. It constructs no parameters and calls no handler, so no term applies.
+    ///
+    /// (b) A second, laxer parameter set built INSIDE a file already on the two lists below. A per-file scan
+    /// cannot tell it from the first one there.
+    ///
+    /// (c) POST-BUILD MUTATION of what this builder returned, which is the cheapest of the four and sits at
+    /// the endpoint where the signature is the only authentication. The back-channel caller holds the result
+    /// as <c>var parameters = …BuildValidationParameters(…)</c> and hands it to the logout validator's own
+    /// <c>ValidateAsync</c>: that file names the type nowhere, constructs nothing, and calls no handler entry
+    /// point, so all three terms are silent about it. Measured: with <c>parameters.RequireSignedTokens =
+    /// false;</c> added after that call, this rule passes and the build emits zero warnings, while the
+    /// unsigned forgery is ACCEPTED and revokes a session. What turns red is one test —
+    /// <see cref="SSOControllerOidBackChannelLogoutTests.AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/>,
+    /// the row that drives that call site rather than a basis a test built.
+    ///
+    /// (d) The allowlist's WIRING, as against its content. The last assertion below reads
+    /// <c>AllowedSignatureAlgorithms</c> and pins what is in it; nothing here pins that the builder assigns it
+    /// to <c>ValidAlgorithms</c>. Measured: deleting <c>ValidAlgorithms = AllowedSignatureAlgorithms</c> from
+    /// the builder leaves this rule green and the build clean; what turns red is
+    /// <see cref="OidcTokenForgeryTests.AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify"/>.
+    ///
+    /// Adding a fourth term for any of them is the wrong repair — the terms enumerate spellings over an
+    /// unbounded space, so each one added moves the next evasion one identifier away rather than closing it,
+    /// and a text scan has no notion of "how many times in this file", of "does this reimplement the
+    /// verifier", or of what happens to a value after it is returned. (a) and (b) are review's, on a surface
+    /// where every change is reviewed before merge. (c) and (d) have a named test each, above — which is why
+    /// deleting one of those two rows is a larger change than it looks.
     ///
     /// One automated control does reach inside a file, and its boundary was measured rather than assumed:
     /// CA5404 is an ERROR here, so <c>ValidateIssuer</c>, <c>ValidateAudience</c> or <c>ValidateLifetime</c>
     /// set to false fails the build wherever it is written, this file included. It does NOT cover the two
-    /// disablements that matter most to the shape above — a missing <c>ValidAlgorithms</c> and
-    /// <c>RequireSignedTokens = false</c> each build clean with zero warnings.
+    /// disablements that matter most here — a missing <c>ValidAlgorithms</c> and
+    /// <c>RequireSignedTokens = false</c> each build clean with zero warnings, re-measured at the (c) and (d)
+    /// mutation sites above.
     /// </summary>
     [Fact]
     public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()
@@ -2658,6 +2681,13 @@ public class ArchitectureConformanceTests
         // this, a target-typed construction lands in a new file and the line-level check above has to be
         // trusted to have matched every way of spelling it; with it, any new file touching the type is a red
         // build that a human reads.
+        //
+        // OidcIdTokenValidator.cs is absent from the list ON PURPOSE, even though the rule blesses it as a
+        // validation call site below: it reaches the basis through the builder and names the type nowhere, so
+        // the list stays exactly the set of files that name it and cannot pass vacuously. The cost is that a
+        // behaviour-preserving hoist there (`TokenValidationParameters p = OidcSignatureKeys.Build…`) reds
+        // this assertion, and the repair is to add that file here — which gives up nothing, because
+        // CONSTRUCTION stays pinned to the basis file by the assertion above whatever this list says.
         var mentions = production
             .Where(path => CodeLines(path).Any(l => l.Text.Contains("TokenValidationParameters", StringComparison.Ordinal)))
             .Select(path => Path.GetRelativePath(RepoRoot(), path))
@@ -2669,7 +2699,7 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             mentions.SequenceEqual(allowedToNameTheType, StringComparer.Ordinal),
-            $"Exactly these files may name TokenValidationParameters, so that a target-typed construction cannot land unread in a new one (#1004). Expected: {string.Join(", ", allowedToNameTheType)}. Found: {string.Join(", ", mentions)}");
+            $"These files and no others may name TokenValidationParameters, so that a target-typed construction cannot land unread elsewhere (#1004). Expected: {string.Join(", ", allowedToNameTheType)}. Found: {string.Join(", ", mentions)}. The comparison is two-sided: an EXTRA file is the finding this rule exists for, while a MISSING one means a listed file was renamed or stopped naming the type — a rename, not a bypass, and the repair is to update the list. OidcIdTokenValidator.cs appearing here is the other benign case: it consumes the basis through the builder, so adding it to the list gives up nothing the construction assertion above does not still hold.");
 
         // Term 3: the handler entry points that consume those parameters. A `new() { … }` written straight
         // into one of these calls names the type nowhere and neither scan above can see it — but the call
@@ -2687,7 +2717,7 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             validationCallSites.SequenceEqual(allowedToValidate, StringComparer.Ordinal),
-            $"Exactly these files may call a handler token-validation entry point, which is what closes a bare `new() {{ … }}` passed straight into one (#1004). Expected: {string.Join(", ", allowedToValidate)}. Found: {string.Join(", ", validationCallSites)}");
+            $"These files and no others may call a handler token-validation entry point, which is what closes a bare `new() {{ … }}` passed straight into one (#1004). Expected: {string.Join(", ", allowedToValidate)}. Found: {string.Join(", ", validationCallSites)}. Two-sided as well: an EXTRA file is a verification path no forgery test drives, while a MISSING one means a validator was renamed or merged — update the list.");
 
         // The allowlist's CONTENT, read off the production type rather than re-stated here. Symmetric HS* would
         // accept a token minted by anyone holding the shared client secret (the RS256-public-key-as-HMAC-key

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2697,7 +2697,8 @@ public class ArchitectureConformanceTests
     /// <c>ValidateAsync</c>: that file names the type nowhere, constructs nothing, and calls no handler entry
     /// point, so all three terms are silent about it. Measured: with <c>parameters.RequireSignedTokens =
     /// false;</c> added after that call, this rule passes and the build emits zero warnings, while the
-    /// unsigned forgery is ACCEPTED and revokes a session. What turns red is one test —
+    /// unsigned forgery is ACCEPTED — the endpoint answers <c>OkResult</c>, which on that path is reachable
+    /// only once a captured session has been revoked. What turns red is one test —
     /// <see cref="SSOControllerOidBackChannelLogoutTests.AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/>,
     /// the row that drives that call site rather than a basis a test built.
     ///

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2564,6 +2564,70 @@ public class ArchitectureConformanceTests
             "The harness-usage scan matched fewer than 10 files — SsoControllerHarness was renamed; update this rule.");
     }
 
+    /// <summary>
+    /// Threat model (#1004). There is no adversary here; the loss is a security test that silently stops
+    /// testing. Asset: the process-wide replay caches — <see cref="OidcLogoutTokenValidator"/>,
+    /// <c>SamlAssertionValidator</c> and <c>SamlLogoutValidator</c> each keep one, and each backs a
+    /// one-time-use property (a captured token must not be redeemable a second time). A test class that
+    /// exercises one clears it in its constructor and again on dispose, so a consumed id cannot leak into a
+    /// sibling. xUnit runs a class carrying no <c>[Collection]</c> in its own implicit collection, IN PARALLEL
+    /// with the serialized one — so an un-attributed class clearing a cache can wipe it mid-run of a class
+    /// asserting that a replay is REFUSED, and that assertion then passes because there was nothing left to
+    /// replay. Green, no longer testing the property, and intermittently, which is the worst way to find out.
+    ///
+    /// What this rule holds is exactly one thing: a test class whose OWN code lines call a
+    /// <c>ResetReplaysForTests</c> hook carries the attribute. It does not follow a base type into another
+    /// file, and it says nothing about the other doors to process-wide state — the harness (the rule above)
+    /// and the <c>ResetOidStateForTests</c> / <c>ResetSaml*ForTests</c> hooks. Deriving the door set rather
+    /// than naming one, and closing the base-class route, is #1044. This rule exists so that the collection
+    /// memberships this change needed are held by the build instead of by hand.
+    /// </summary>
+    [Fact]
+    public void EveryTestClassClearingAReplayCache_IsInTheNonParallelControllerCollection()
+    {
+        var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
+        var resetHookUsers = new List<string>();
+        var offenders = new List<string>();
+        foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            // Skip THIS file: it carries the scanned literals inside the rule itself, not a real use.
+            if (IsBuildOutput(src) || Path.GetFileName(src) == "ArchitectureConformanceTests.cs")
+            {
+                continue;
+            }
+
+            // CODE lines only, so prose naming the hook cannot inflate the liveness floor below while
+            // covering nothing. The [Fact]/[Theory] requirement excludes the support types that clear the
+            // same caches without being scheduled by xUnit at all — the harness clears three of them, and it
+            // is the classes CONSTRUCTING it that need the attribute (the rule above), not the file itself.
+            var lines = CodeLines(src).Select(l => l.Text).ToList();
+            var clearsAReplayCache = lines.Any(text => text.Contains("ResetReplaysForTests(", StringComparison.Ordinal));
+            var isTestClass = lines.Any(text =>
+                text.Contains("[Fact]", StringComparison.Ordinal) || text.Contains("[Theory]", StringComparison.Ordinal));
+            if (!clearsAReplayCache || !isTestClass)
+            {
+                continue;
+            }
+
+            resetHookUsers.Add(Path.GetFileName(src));
+            if (!lines.Any(text => text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal)))
+            {
+                offenders.Add(Path.GetFileName(src));
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "Every test class clearing a process-wide replay cache must carry [Collection(\"SSOController\")] — a class outside that collection runs in parallel WITH it, and clearing the cache under a sibling asserting a replay is refused turns that assertion green while it tests nothing (#1004). Missing in: " + string.Join(", ", offenders));
+
+        // Liveness sentinel for the ONE door this rule scans. Five classes call a ResetReplaysForTests hook
+        // today; a rename of the hooks would drop the scan to zero offenders and read as compliance, so the
+        // floor is what turns that into a red build naming this rule.
+        Assert.True(
+            resetHookUsers.Count >= 5,
+            $"The replay-reset scan matched only {resetHookUsers.Count} test classes — the ResetReplaysForTests hooks were renamed; update this rule. Matched: " + string.Join(", ", resetHookUsers));
+    }
+
     [Fact]
     public void EverySourceFile_CarriesTheSpdxHeader()
     {

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2526,45 +2526,27 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
-    public void EveryTestClassMutatingProcessWideState_IsInTheNonParallelControllerCollection()
+    public void EveryHarnessUsingTestClass_IsInTheNonParallelControllerCollection()
     {
         // The SsoControllerHarness constructor swaps the process-wide SSOPlugin.Instance and resets the
         // OIDC/SAML static caches — two harness-based classes running in parallel therefore race each
         // other (the exact intermittent 429→400 failure that motivated this rule, #928 U4). The
         // "SSOController" collection (DisableParallelization) is the existing convention; this makes it
-        // self-enforcing: a NEW test class that mutates that state without joining the collection is
+        // self-enforcing: a NEW test class that constructs the harness without joining the collection is
         // a red build naming the file, not a flaky suite three weeks later.
-        //
-        // The harness is not the only door to that state, and keying the rule on it alone left the other one
-        // unguarded (#1004): a `*ForTests()` reset hook clears the SAME process-wide replay caches and state
-        // stores directly. A class in the serialized collection is serialized against the others IN it, never
-        // against a class outside it — xUnit runs an un-attributed class in its own implicit collection, in
-        // parallel with this one — so any class calling a reset hook must join too, or it races the harness
-        // classes that reset the same static.
         var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
         var offenders = new List<string>();
-        var harnessUsers = 0;
-        var resetHookUsers = 0;
         foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
         {
-            // Skip THIS file: it carries the scanned literals inside the rule itself, not a real use.
+            // Skip THIS file: it carries the scanned literal inside the rule itself, not a harness use.
             if (IsBuildOutput(src) || Path.GetFileName(src) == "ArchitectureConformanceTests.cs")
             {
                 continue;
             }
 
             var text = File.ReadAllText(src);
-            var isTestClass = text.Contains("[Fact]", StringComparison.Ordinal) || text.Contains("[Theory]", StringComparison.Ordinal);
-            var usesHarness = text.Contains("new SsoControllerHarness", StringComparison.Ordinal);
-            var usesResetHook = text.Contains("ForTests()", StringComparison.Ordinal);
-            if (!isTestClass || (!usesHarness && !usesResetHook))
-            {
-                continue;
-            }
-
-            harnessUsers += usesHarness ? 1 : 0;
-            resetHookUsers += usesResetHook ? 1 : 0;
-            if (!text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
+            if (text.Contains("new SsoControllerHarness", StringComparison.Ordinal)
+                && !text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
             {
                 offenders.Add(Path.GetFileName(src));
             }
@@ -2572,14 +2554,14 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             offenders.Count == 0,
-            "Every test class that constructs SsoControllerHarness or calls a *ForTests() reset hook must carry [Collection(\"SSOController\")] (both mutate process-wide statics; classes outside the collection run in parallel with it). Missing in: " + string.Join(", ", offenders));
+            "Every test class constructing SsoControllerHarness must carry [Collection(\"SSOController\")] (the harness swaps process-wide statics; parallel classes race). Missing in: " + string.Join(", ", offenders));
 
-        // Liveness sentinel, ONE FLOOR PER SCANNED LITERAL. A single combined count is the same conjunction
-        // defect this rule exists to catch: renaming SsoControllerHarness would drop 27 classes and still
-        // clear a combined floor the reset-hook classes alone carried, leaving the scan blind while reading
-        // as live. Each literal has to prove it still matches something on its own.
-        Assert.True(harnessUsers >= 20, $"The harness scan matched only {harnessUsers} test classes — SsoControllerHarness was renamed; update this rule.");
-        Assert.True(resetHookUsers >= 3, $"The reset-hook scan matched only {resetHookUsers} test classes — the *ForTests() hooks were renamed; update this rule.");
+        // Liveness sentinel: the scan must actually see the known harness users, or a harness rename has
+        // silently blinded it.
+        Assert.True(
+            Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories)
+                .Count(f => !IsBuildOutput(f) && File.ReadAllText(f).Contains("new SsoControllerHarness", StringComparison.Ordinal)) >= 10,
+            "The harness-usage scan matched fewer than 10 files — SsoControllerHarness was renamed; update this rule.");
     }
 
     [Fact]
@@ -2628,14 +2610,23 @@ public class ArchitectureConformanceTests
     /// algorithm-confusion class in a single line; one without <c>RequireSignedTokens</c> re-opens
     /// <c>alg: none</c>. STRIDE: spoofing. ASVS 5.0 V9.2 (token signature and algorithm verification).
     ///
-    /// The guard is a source scan, and its LIMIT is the reason it has three terms rather than one. A scan
-    /// cannot resolve a target type, so a substring search for <c>new TokenValidationParameters</c> alone is
-    /// walked past by <c>TokenValidationParameters p = new()</c> — house style in this repo. Term 1 catches
-    /// the explicit spelling, term 2 the target-typed one (a <c>= new(</c>/<c>= new {</c> on a line that names
-    /// the type), and term 3 closes the only construction a source scan cannot see at all: a bare
-    /// <c>new() { … }</c> passed straight into a parameter of that type, which names the type nowhere. Such a
-    /// call must still reach a handler validation entry point, and term 3 pins those to the two validators.
-    /// Verifying a provider JWT without tripping any of the three would take reflection.
+    /// WHAT THE THREE TERMS CATCH, established by running those mutants rather than by reading the
+    /// predicates: a NEW file constructing the type explicitly (<c>new TokenValidationParameters</c>, term 1);
+    /// a NEW file constructing it target-typed (<c>TokenValidationParameters p = new();</c>, term 2 — the
+    /// spelling a substring search for term 1 walks past, and house style in this repo); and a NEW file
+    /// passing a bare <c>new() { … }</c> straight into <c>ValidateTokenAsync</c>, which names the type
+    /// nowhere and is invisible to both scans (term 3 pins the handler entry points to the two validators).
+    ///
+    /// WHAT THEY DO NOT CATCH, measured the same way, because a guard that overstates its reach is what the
+    /// next author trusts instead of re-deriving it. Two shapes produce output identical to a clean run.
+    /// Verification that never uses the library at all — splitting the JWS and calling <c>RSA.VerifyData</c>
+    /// directly — constructs no parameters and calls no handler, so no term applies. And a second, laxer
+    /// parameter set built INSIDE a file already on the two lists below is indistinguishable to a per-file
+    /// scan from the first one there. Both belong to review, not to this rule: a text scan has no notion of
+    /// "how many times in this file" and none of "does this reimplement the verifier", and the OIDC surface
+    /// is on the sensitive list where every change is reviewed before merge. Adding a fourth term for them
+    /// is the wrong repair — the terms enumerate spellings over an unbounded space, so each one added moves
+    /// the next evasion one identifier away rather than closing it.
     /// </summary>
     [Fact]
     public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()
@@ -2655,7 +2646,7 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             constructionSites.Count == 1 && string.Equals(constructionSites[0], SignatureBasisRelativePath, StringComparison.Ordinal),
-            $"TokenValidationParameters must be constructed in exactly one file ({SignatureBasisRelativePath}) — a second construction site is a second verification path the forgery tests never reach, and one built without ValidAlgorithms trusts the token header's own `alg` (#1004). Found: " + string.Join(", ", constructionSites));
+            $"TokenValidationParameters must be constructed in exactly one FILE ({SignatureBasisRelativePath}) — a construction in a second file is a second verification path the forgery tests never drive, and one built without ValidAlgorithms trusts the token header's own `alg` (#1004). A second construction inside a file already listed is invisible here and is review's to catch. Found: " + string.Join(", ", constructionSites));
 
         // Term 2's precondition: only the basis and the logout validator may NAME the type at all. Without
         // this, a target-typed construction lands in a new file and the line-level check above has to be
@@ -2664,11 +2655,15 @@ public class ArchitectureConformanceTests
         var mentions = production
             .Where(path => CodeLines(path).Any(l => l.Text.Contains("TokenValidationParameters", StringComparison.Ordinal)))
             .Select(path => Path.GetRelativePath(RepoRoot(), path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+        var allowedToNameTheType = new[] { SignatureBasisRelativePath, LogoutValidatorRelativePath }
+            .OrderBy(path => path, StringComparer.Ordinal)
             .ToList();
 
-        Assert.Equal(
-            new[] { SignatureBasisRelativePath, LogoutValidatorRelativePath }.OrderBy(p => p, StringComparer.Ordinal),
-            mentions.OrderBy(p => p, StringComparer.Ordinal));
+        Assert.True(
+            mentions.SequenceEqual(allowedToNameTheType, StringComparer.Ordinal),
+            $"Exactly these files may name TokenValidationParameters, so that a target-typed construction cannot land unread in a new one (#1004). Expected: {string.Join(", ", allowedToNameTheType)}. Found: {string.Join(", ", mentions)}");
 
         // Term 3: the handler entry points that consume those parameters. A `new() { … }` written straight
         // into one of these calls names the type nowhere and neither scan above can see it — but the call
@@ -2678,11 +2673,15 @@ public class ArchitectureConformanceTests
                 l.Text.Contains("ValidateTokenAsync(", StringComparison.Ordinal)
                 || l.Text.Contains("ValidateToken(", StringComparison.Ordinal)))
             .Select(path => Path.GetRelativePath(RepoRoot(), path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+        var allowedToValidate = new[] { IdTokenValidatorRelativePath, LogoutValidatorRelativePath }
+            .OrderBy(path => path, StringComparer.Ordinal)
             .ToList();
 
-        Assert.Equal(
-            new[] { IdTokenValidatorRelativePath, LogoutValidatorRelativePath }.OrderBy(p => p, StringComparer.Ordinal),
-            validationCallSites.OrderBy(p => p, StringComparer.Ordinal));
+        Assert.True(
+            validationCallSites.SequenceEqual(allowedToValidate, StringComparer.Ordinal),
+            $"Exactly these files may call a handler token-validation entry point, which is what closes a bare `new() {{ … }}` passed straight into one (#1004). Expected: {string.Join(", ", allowedToValidate)}. Found: {string.Join(", ", validationCallSites)}");
 
         // The allowlist's CONTENT, read off the production type rather than re-stated here. Symmetric HS* would
         // accept a token minted by anyone holding the shared client secret (the RS256-public-key-as-HMAC-key

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2674,53 +2674,18 @@ public class ArchitectureConformanceTests
     /// algorithm-confusion class in a single line; one without <c>RequireSignedTokens</c> re-opens
     /// <c>alg: none</c>. STRIDE: spoofing. ASVS 5.0 V9.2 (token signature and algorithm verification).
     ///
-    /// WHAT THE THREE TERMS CATCH, established by running those mutants rather than by reading the
-    /// predicates: a NEW file constructing the type explicitly (<c>new TokenValidationParameters</c>, term 1);
-    /// a NEW file constructing it target-typed (<c>TokenValidationParameters p = new();</c>, term 2 — the
-    /// spelling a substring search for term 1 walks past, and house style in this repo); and a NEW file
-    /// passing a bare <c>new() { … }</c> straight into <c>ValidateTokenAsync</c>, which names the type
-    /// nowhere and is invisible to both scans (term 3 pins the handler entry points to the two validators).
+    /// WHAT THE THREE TERMS CATCH, each established by writing that file and running this rule over it rather
+    /// than by reading the predicates: a NEW file constructing the type explicitly
+    /// (<c>new TokenValidationParameters</c>); a NEW file constructing it target-typed
+    /// (<c>TokenValidationParameters p = new();</c>, house style in this repo); and a NEW file passing a bare
+    /// <c>new() { … }</c> straight into <c>ValidateTokenAsync</c>, which names the type nowhere and is
+    /// invisible to both of the first two.
     ///
-    /// WHAT THEY DO NOT CATCH, because a guard that overstates its reach is what the next author trusts
-    /// instead of re-deriving it. FOUR shapes, each verified by making the edit and running this rule over it,
-    /// not by reading the predicates:
-    ///
-    /// (a) Verification that never uses the library at all — splitting the JWS and calling
-    /// <c>RSA.VerifyData</c> directly. It constructs no parameters and calls no handler, so no term applies.
-    ///
-    /// (b) A second, laxer parameter set built INSIDE a file already on the two lists below. A per-file scan
-    /// cannot tell it from the first one there.
-    ///
-    /// (c) POST-BUILD MUTATION of what this builder returned, which is the cheapest of the four and sits at
-    /// the endpoint where the signature is the only authentication. The back-channel caller holds the result
-    /// as <c>var parameters = …BuildValidationParameters(…)</c> and hands it to the logout validator's own
-    /// <c>ValidateAsync</c>: that file names the type nowhere, constructs nothing, and calls no handler entry
-    /// point, so all three terms are silent about it. Measured: with <c>parameters.RequireSignedTokens =
-    /// false;</c> added after that call, this rule passes and the build emits zero warnings, while the
-    /// unsigned forgery is ACCEPTED — the endpoint answers <c>OkResult</c>, which on that path is reachable
-    /// only once a captured session has been revoked. What turns red is one test —
-    /// <see cref="SSOControllerOidBackChannelLogoutTests.AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/>,
-    /// the row that drives that call site rather than a basis a test built.
-    ///
-    /// (d) The allowlist's WIRING, as against its content. The last assertion below reads
-    /// <c>AllowedSignatureAlgorithms</c> and pins what is in it; nothing here pins that the builder assigns it
-    /// to <c>ValidAlgorithms</c>. Measured: deleting <c>ValidAlgorithms = AllowedSignatureAlgorithms</c> from
-    /// the builder leaves this rule green and the build clean; what turns red is
-    /// <see cref="OidcTokenForgeryTests.AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify"/>.
-    ///
-    /// Adding a fourth term for any of them is the wrong repair — the terms enumerate spellings over an
-    /// unbounded space, so each one added moves the next evasion one identifier away rather than closing it,
-    /// and a text scan has no notion of "how many times in this file", of "does this reimplement the
-    /// verifier", or of what happens to a value after it is returned. (a) and (b) are review's, on a surface
-    /// where every change is reviewed before merge. (c) and (d) have a named test each, above — which is why
-    /// deleting one of those two rows is a larger change than it looks.
-    ///
-    /// One automated control does reach inside a file, and its boundary was measured rather than assumed:
-    /// CA5404 is an ERROR here, so <c>ValidateIssuer</c>, <c>ValidateAudience</c> or <c>ValidateLifetime</c>
-    /// set to false fails the build wherever it is written, this file included. It does NOT cover the two
-    /// disablements that matter most here — a missing <c>ValidAlgorithms</c> and
-    /// <c>RequireSignedTokens = false</c> each build clean with zero warnings, re-measured at the (c) and (d)
-    /// mutation sites above.
+    /// What it does not reach is not listed here, because such a list claims completeness over the space of
+    /// evasions and has been wrong every time it was written: this is a source scan over FILES, so it cannot
+    /// see what a caller does with the parameters after the builder has returned them, nor a path that
+    /// verifies a JWS without the token library at all — review owns that, and the shapes measured so far are
+    /// recorded on #1050.
     /// </summary>
     [Fact]
     public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2568,19 +2568,23 @@ public class ArchitectureConformanceTests
     /// Threat model (#1004). There is no adversary here; the loss is a security test that silently stops
     /// testing. Asset: the process-wide replay caches — <see cref="OidcLogoutTokenValidator"/>,
     /// <c>SamlAssertionValidator</c> and <c>SamlLogoutValidator</c> each keep one, and each backs a
-    /// one-time-use property (a captured token must not be redeemable a second time). A test class that
-    /// exercises one clears it in its constructor and again on dispose, so a consumed id cannot leak into a
-    /// sibling. xUnit runs a class carrying no <c>[Collection]</c> in its own implicit collection, IN PARALLEL
-    /// with the serialized one — so an un-attributed class clearing a cache can wipe it mid-run of a class
-    /// asserting that a replay is REFUSED, and that assertion then passes because there was nothing left to
-    /// replay. Green, no longer testing the property, and intermittently, which is the worst way to find out.
+    /// one-time-use property (a captured token must not be redeemable a second time). A class exercising one
+    /// clears it around its own tests, so a consumed id cannot leak into a sibling. xUnit parallelizes test
+    /// classes that do not share a collection, and this collection is declared with
+    /// <c>DisableParallelization</c>. Measured on this stack rather than reasoned about: two classes left OUT
+    /// of the collection DO overlap each other, while two classes IN it do not overlap. So the race is
+    /// between two un-attributed clearers — one empties the cache mid-run of the other's assertion that a
+    /// replay is REFUSED, and that assertion then passes because there was nothing left to replay. Green, no
+    /// longer testing the property, and intermittently, which is the worst way to find out.
     ///
-    /// What this rule holds is exactly one thing: a test class whose OWN code lines call a
-    /// <c>ResetReplaysForTests</c> hook carries the attribute. It does not follow a base type into another
-    /// file, and it says nothing about the other doors to process-wide state — the harness (the rule above)
-    /// and the <c>ResetOidStateForTests</c> / <c>ResetSaml*ForTests</c> hooks. Deriving the door set rather
-    /// than naming one, and closing the base-class route, is #1044. This rule exists so that the collection
-    /// memberships this change needed are held by the build instead of by hand.
+    /// What this rule holds is exactly one thing, and it holds it per FILE rather than per class: a file that
+    /// carries a <c>[Fact]</c> or <c>[Theory]</c> and calls a <c>ResetReplaysForTests</c> hook on a code line
+    /// also spells the attribute somewhere in that same file. A file declaring two types is one unit to it.
+    /// It does not follow a base type into another file, and it says nothing about the other doors to
+    /// process-wide state — the harness (the rule above) and the <c>ResetOidStateForTests</c> /
+    /// <c>ResetSaml*ForTests</c> hooks. Deriving the door set rather than naming one, and closing the
+    /// base-class route, is #1044. This rule exists so that the collection memberships this change needed are
+    /// held by the build instead of by hand.
     /// </summary>
     [Fact]
     public void EveryTestClassClearingAReplayCache_IsInTheNonParallelControllerCollection()
@@ -2618,14 +2622,14 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             offenders.Count == 0,
-            "Every test class clearing a process-wide replay cache must carry [Collection(\"SSOController\")] — a class outside that collection runs in parallel WITH it, and clearing the cache under a sibling asserting a replay is refused turns that assertion green while it tests nothing (#1004). Missing in: " + string.Join(", ", offenders));
+            "Every test class clearing a process-wide replay cache must carry [Collection(\"SSOController\")] — two classes left outside that collection run in parallel with EACH OTHER, and clearing the cache under a sibling asserting a replay is refused turns that assertion green while it tests nothing (#1004). Missing in: " + string.Join(", ", offenders));
 
-        // Liveness sentinel for the ONE door this rule scans. Five classes call a ResetReplaysForTests hook
+        // Liveness sentinel for the ONE door this rule scans. Five files call a ResetReplaysForTests hook
         // today; a rename of the hooks would drop the scan to zero offenders and read as compliance, so the
         // floor is what turns that into a red build naming this rule.
         Assert.True(
             resetHookUsers.Count >= 5,
-            $"The replay-reset scan matched only {resetHookUsers.Count} test classes — the ResetReplaysForTests hooks were renamed; update this rule. Matched: " + string.Join(", ", resetHookUsers));
+            $"The replay-reset scan matched only {resetHookUsers.Count} test files — the ResetReplaysForTests hooks were renamed; update this rule. Matched: " + string.Join(", ", resetHookUsers));
     }
 
     [Fact]
@@ -3116,10 +3120,10 @@ public class ArchitectureConformanceTests
     private static readonly string IdTokenValidatorRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcIdTokenValidator.cs");
     private static readonly string LogoutValidatorRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcLogoutTokenValidator.cs");
 
-    // Whether a code line constructs TokenValidationParameters, in either spelling C# offers: the explicit
-    // `new TokenValidationParameters`, or a target-typed `= new()` / `= new {` on a line that names the type
+    // Whether ONE code line constructs TokenValidationParameters: the explicit `new TokenValidationParameters`,
+    // or a target-typed `= new()` / `= new {` on a line that also names the type
     // (`TokenValidationParameters p = new();`). The second is what a substring scan for the first walks past,
-    // and `= new()` is house style in this repo.
+    // and `= new()` is house style in this repo. The predicate sees one line at a time and nothing wider.
     private static bool ConstructsValidationParameters(string line) =>
         line.Contains("new TokenValidationParameters", StringComparison.Ordinal)
         || (line.Contains("TokenValidationParameters", StringComparison.Ordinal)

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2602,6 +2602,42 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()
+    {
+        // #1004. Every JWT the plugin verifies against a provider — the id_token and the back-channel
+        // logout_token — is validated from parameters built in ONE place, so their posture cannot drift apart.
+        // The property that makes the forgery battery in OidcTokenForgeryTests meaningful is exactly this: a
+        // SECOND `new TokenValidationParameters` anywhere would be a verification path those tests never reach,
+        // and one constructed without ValidAlgorithms accepts whatever the token header's `alg` claims — the
+        // algorithm-confusion class in one line. The rule is a source scan rather than a type-level rule
+        // because the defect is a construction site, which reflection cannot see.
+        //
+        // Sentinel against a vacuous pass: the count is pinned to EXACTLY one, not "at most one". A rule that
+        // tolerates zero passes just as happily after the builder is renamed or the scan is pointed at the
+        // wrong tree, and would then be protecting nothing while reading as protection.
+        var constructionSites = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path => CodeLines(path).Any(l => l.Text.Contains("new TokenValidationParameters", StringComparison.Ordinal)))
+            .Select(path => Path.GetRelativePath(RepoRoot(), path))
+            .ToList();
+
+        Assert.True(
+            constructionSites.Count == 1 && string.Equals(constructionSites[0], SignatureBasisRelativePath, StringComparison.Ordinal),
+            $"TokenValidationParameters must be constructed in exactly one file ({SignatureBasisRelativePath}) — a second construction site is a second verification path the forgery tests never reach, and one built without ValidAlgorithms trusts the token header's own `alg` (#1004). Found: " + string.Join(", ", constructionSites));
+
+        // The allowlist's CONTENT, read off the production type rather than re-stated here. Symmetric HS* would
+        // accept a token minted by anyone holding the shared client secret (the RS256-public-key-as-HMAC-key
+        // forgery), and `none` is unauthenticated by definition; both are refused whatever the discovery
+        // document advertises. Casing is compared insensitively because the JWS `alg` header is matched by the
+        // handler, and an entry spelled "hs256" would be exactly as accepting.
+        var algorithms = OidcSignatureKeys.AllowedSignatureAlgorithms;
+        Assert.NotEmpty(algorithms);
+        Assert.DoesNotContain(algorithms, a => a.StartsWith("HS", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(algorithms, a => string.Equals(a, "none", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void SamlSignaturePath_UsesOneXmlStackEndToEnd()
     {
         // #1003. XML signature wrapping against a SAML assertion is a full authentication bypass, and the way
@@ -2950,6 +2986,9 @@ public class ArchitectureConformanceTests
     // The SAML module's location, as a repo-relative path, so the module-scope rules and the out-of-module
     // rule cannot disagree about where the boundary is.
     private static readonly string SamlModuleRelativePath = Path.Combine("SSO-Auth", "Api", "Saml");
+
+    // The ONE file allowed to construct TokenValidationParameters — the shared OpenID signature basis (#1004).
+    private static readonly string SignatureBasisRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcSignatureKeys.cs");
 
     // Every XML stack that is NOT the one the SAML signature path is allowed to use (#1003). ONE list, shared
     // by the in-module ban and the out-of-module ban: a hand-rolled subset in either place is how a rule

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2526,27 +2526,43 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
-    public void EveryHarnessUsingTestClass_IsInTheNonParallelControllerCollection()
+    public void EveryTestClassMutatingProcessWideState_IsInTheNonParallelControllerCollection()
     {
         // The SsoControllerHarness constructor swaps the process-wide SSOPlugin.Instance and resets the
         // OIDC/SAML static caches — two harness-based classes running in parallel therefore race each
         // other (the exact intermittent 429→400 failure that motivated this rule, #928 U4). The
         // "SSOController" collection (DisableParallelization) is the existing convention; this makes it
-        // self-enforcing: a NEW test class that constructs the harness without joining the collection is
+        // self-enforcing: a NEW test class that mutates that state without joining the collection is
         // a red build naming the file, not a flaky suite three weeks later.
+        //
+        // The harness is not the only door to that state, and keying the rule on it alone left the other one
+        // unguarded (#1004): a `*ForTests()` reset hook clears the SAME process-wide replay caches and state
+        // stores directly. A class in the serialized collection is serialized against the others IN it, never
+        // against a class outside it — xUnit runs an un-attributed class in its own implicit collection, in
+        // parallel with this one — so any class calling a reset hook must join too, or it races the harness
+        // classes that reset the same static.
         var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
         var offenders = new List<string>();
+        var mutators = 0;
         foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
         {
-            // Skip THIS file: it carries the scanned literal inside the rule itself, not a harness use.
+            // Skip THIS file: it carries the scanned literals inside the rule itself, not a real use.
             if (IsBuildOutput(src) || Path.GetFileName(src) == "ArchitectureConformanceTests.cs")
             {
                 continue;
             }
 
             var text = File.ReadAllText(src);
-            if (text.Contains("new SsoControllerHarness", StringComparison.Ordinal)
-                && !text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
+            var isTestClass = text.Contains("[Fact]", StringComparison.Ordinal) || text.Contains("[Theory]", StringComparison.Ordinal);
+            var mutatesProcessWideState = text.Contains("new SsoControllerHarness", StringComparison.Ordinal)
+                || text.Contains("ForTests()", StringComparison.Ordinal);
+            if (!isTestClass || !mutatesProcessWideState)
+            {
+                continue;
+            }
+
+            mutators++;
+            if (!text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
             {
                 offenders.Add(Path.GetFileName(src));
             }
@@ -2554,14 +2570,11 @@ public class ArchitectureConformanceTests
 
         Assert.True(
             offenders.Count == 0,
-            "Every test class constructing SsoControllerHarness must carry [Collection(\"SSOController\")] (the harness swaps process-wide statics; parallel classes race). Missing in: " + string.Join(", ", offenders));
+            "Every test class that constructs SsoControllerHarness or calls a *ForTests() reset hook must carry [Collection(\"SSOController\")] (both mutate process-wide statics; classes outside the collection run in parallel with it). Missing in: " + string.Join(", ", offenders));
 
-        // Liveness sentinel: the scan must actually see the known harness users, or a harness rename has
-        // silently blinded it.
-        Assert.True(
-            Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories)
-                .Count(f => !IsBuildOutput(f) && File.ReadAllText(f).Contains("new SsoControllerHarness", StringComparison.Ordinal)) >= 10,
-            "The harness-usage scan matched fewer than 10 files — SsoControllerHarness was renamed; update this rule.");
+        // Liveness sentinel: the scan must actually see the known mutators, or a rename has silently blinded
+        // it. The floor covers the harness users alone, so it stays meaningful if the reset hooks are renamed.
+        Assert.True(mutators >= 14, $"The process-wide-state scan matched only {mutators} test classes — SsoControllerHarness or the *ForTests() hooks were renamed; update this rule.");
     }
 
     [Fact]
@@ -2601,30 +2614,70 @@ public class ArchitectureConformanceTests
             "Every C# source file must open with the SPDX copyright + GPL-3.0-only header (#747). Missing or incorrect in: " + string.Join(", ", offenders));
     }
 
+    /// <summary>
+    /// Threat model (#1004). Adversary: anyone who can present a JWT to the OIDC callback or to the anonymous
+    /// back-channel logout endpoint. Asset: the decision that a provider token is authentic. The threat this
+    /// rule exists for is not a bad allowlist but a SECOND verification path — parameters built somewhere
+    /// other than <see cref="OidcSignatureKeys"/>, reached by a token the forgery battery never drives, and
+    /// missing a field the basis sets. One such construction without <c>ValidAlgorithms</c> re-opens the
+    /// algorithm-confusion class in a single line; one without <c>RequireSignedTokens</c> re-opens
+    /// <c>alg: none</c>. STRIDE: spoofing. ASVS 5.0 V9.2 (token signature and algorithm verification).
+    ///
+    /// The guard is a source scan, and its LIMIT is the reason it has three terms rather than one. A scan
+    /// cannot resolve a target type, so a substring search for <c>new TokenValidationParameters</c> alone is
+    /// walked past by <c>TokenValidationParameters p = new()</c> — house style in this repo. Term 1 catches
+    /// the explicit spelling, term 2 the target-typed one (a <c>= new(</c>/<c>= new {</c> on a line that names
+    /// the type), and term 3 closes the only construction a source scan cannot see at all: a bare
+    /// <c>new() { … }</c> passed straight into a parameter of that type, which names the type nowhere. Such a
+    /// call must still reach a handler validation entry point, and term 3 pins those to the two validators.
+    /// Verifying a provider JWT without tripping any of the three would take reflection.
+    /// </summary>
     [Fact]
     public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()
     {
-        // #1004. Every JWT the plugin verifies against a provider — the id_token and the back-channel
-        // logout_token — is validated from parameters built in ONE place, so their posture cannot drift apart.
-        // The property that makes the forgery battery in OidcTokenForgeryTests meaningful is exactly this: a
-        // SECOND `new TokenValidationParameters` anywhere would be a verification path those tests never reach,
-        // and one constructed without ValidAlgorithms accepts whatever the token header's `alg` claims — the
-        // algorithm-confusion class in one line. The rule is a source scan rather than a type-level rule
-        // because the defect is a construction site, which reflection cannot see.
-        //
-        // Sentinel against a vacuous pass: the count is pinned to EXACTLY one, not "at most one". A rule that
-        // tolerates zero passes just as happily after the builder is renamed or the scan is pointed at the
-        // wrong tree, and would then be protecting nothing while reading as protection.
-        var constructionSites = Directory
+        // Sentinel against a vacuous pass: each set is pinned to EXACTLY the expected files, not to "at most".
+        // A rule that tolerates zero passes just as happily after the builder is renamed or the scan is
+        // pointed at the wrong tree, and would then be protecting nothing while reading as protection.
+        var production = Directory
             .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
             .Where(path => !IsBuildOutput(path))
-            .Where(path => CodeLines(path).Any(l => l.Text.Contains("new TokenValidationParameters", StringComparison.Ordinal)))
+            .ToList();
+
+        var constructionSites = production
+            .Where(path => CodeLines(path).Any(l => ConstructsValidationParameters(l.Text)))
             .Select(path => Path.GetRelativePath(RepoRoot(), path))
             .ToList();
 
         Assert.True(
             constructionSites.Count == 1 && string.Equals(constructionSites[0], SignatureBasisRelativePath, StringComparison.Ordinal),
             $"TokenValidationParameters must be constructed in exactly one file ({SignatureBasisRelativePath}) — a second construction site is a second verification path the forgery tests never reach, and one built without ValidAlgorithms trusts the token header's own `alg` (#1004). Found: " + string.Join(", ", constructionSites));
+
+        // Term 2's precondition: only the basis and the logout validator may NAME the type at all. Without
+        // this, a target-typed construction lands in a new file and the line-level check above has to be
+        // trusted to have matched every way of spelling it; with it, any new file touching the type is a red
+        // build that a human reads.
+        var mentions = production
+            .Where(path => CodeLines(path).Any(l => l.Text.Contains("TokenValidationParameters", StringComparison.Ordinal)))
+            .Select(path => Path.GetRelativePath(RepoRoot(), path))
+            .ToList();
+
+        Assert.Equal(
+            new[] { SignatureBasisRelativePath, LogoutValidatorRelativePath }.OrderBy(p => p, StringComparer.Ordinal),
+            mentions.OrderBy(p => p, StringComparer.Ordinal));
+
+        // Term 3: the handler entry points that consume those parameters. A `new() { … }` written straight
+        // into one of these calls names the type nowhere and neither scan above can see it — but the call
+        // itself must be spelled, and only the two validators may spell it.
+        var validationCallSites = production
+            .Where(path => CodeLines(path).Any(l =>
+                l.Text.Contains("ValidateTokenAsync(", StringComparison.Ordinal)
+                || l.Text.Contains("ValidateToken(", StringComparison.Ordinal)))
+            .Select(path => Path.GetRelativePath(RepoRoot(), path))
+            .ToList();
+
+        Assert.Equal(
+            new[] { IdTokenValidatorRelativePath, LogoutValidatorRelativePath }.OrderBy(p => p, StringComparer.Ordinal),
+            validationCallSites.OrderBy(p => p, StringComparer.Ordinal));
 
         // The allowlist's CONTENT, read off the production type rather than re-stated here. Symmetric HS* would
         // accept a token minted by anyone holding the shared client secret (the RS256-public-key-as-HMAC-key
@@ -2987,8 +3040,20 @@ public class ArchitectureConformanceTests
     // rule cannot disagree about where the boundary is.
     private static readonly string SamlModuleRelativePath = Path.Combine("SSO-Auth", "Api", "Saml");
 
-    // The ONE file allowed to construct TokenValidationParameters — the shared OpenID signature basis (#1004).
+    // The ONE file allowed to construct TokenValidationParameters — the shared OpenID signature basis (#1004)
+    // — and the two validators allowed to consume them at a handler entry point.
     private static readonly string SignatureBasisRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcSignatureKeys.cs");
+    private static readonly string IdTokenValidatorRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcIdTokenValidator.cs");
+    private static readonly string LogoutValidatorRelativePath = Path.Combine("SSO-Auth", "Api", "Oidc", "OidcLogoutTokenValidator.cs");
+
+    // Whether a code line constructs TokenValidationParameters, in either spelling C# offers: the explicit
+    // `new TokenValidationParameters`, or a target-typed `= new()` / `= new {` on a line that names the type
+    // (`TokenValidationParameters p = new();`). The second is what a substring scan for the first walks past,
+    // and `= new()` is house style in this repo.
+    private static bool ConstructsValidationParameters(string line) =>
+        line.Contains("new TokenValidationParameters", StringComparison.Ordinal)
+        || (line.Contains("TokenValidationParameters", StringComparison.Ordinal)
+            && Regex.IsMatch(line, @"=\s*new\s*[({]"));
 
     // Every XML stack that is NOT the one the SAML signature path is allowed to use (#1003). ONE list, shared
     // by the in-module ban and the out-of-module ban: a hand-rolled subset in either place is how a rule

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2627,6 +2627,12 @@ public class ArchitectureConformanceTests
     /// is on the sensitive list where every change is reviewed before merge. Adding a fourth term for them
     /// is the wrong repair — the terms enumerate spellings over an unbounded space, so each one added moves
     /// the next evasion one identifier away rather than closing it.
+    ///
+    /// One automated control does reach inside a file, and its boundary was measured rather than assumed:
+    /// CA5404 is an ERROR here, so <c>ValidateIssuer</c>, <c>ValidateAudience</c> or <c>ValidateLifetime</c>
+    /// set to false fails the build wherever it is written, this file included. It does NOT cover the two
+    /// disablements that matter most to the shape above — a missing <c>ValidAlgorithms</c> and
+    /// <c>RequireSignedTokens = false</c> each build clean with zero warnings.
     /// </summary>
     [Fact]
     public void OidcTokenValidation_UsesTheSingleHardenedParameterBuilder()

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2543,7 +2543,8 @@ public class ArchitectureConformanceTests
         // classes that reset the same static.
         var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
         var offenders = new List<string>();
-        var mutators = 0;
+        var harnessUsers = 0;
+        var resetHookUsers = 0;
         foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
         {
             // Skip THIS file: it carries the scanned literals inside the rule itself, not a real use.
@@ -2554,14 +2555,15 @@ public class ArchitectureConformanceTests
 
             var text = File.ReadAllText(src);
             var isTestClass = text.Contains("[Fact]", StringComparison.Ordinal) || text.Contains("[Theory]", StringComparison.Ordinal);
-            var mutatesProcessWideState = text.Contains("new SsoControllerHarness", StringComparison.Ordinal)
-                || text.Contains("ForTests()", StringComparison.Ordinal);
-            if (!isTestClass || !mutatesProcessWideState)
+            var usesHarness = text.Contains("new SsoControllerHarness", StringComparison.Ordinal);
+            var usesResetHook = text.Contains("ForTests()", StringComparison.Ordinal);
+            if (!isTestClass || (!usesHarness && !usesResetHook))
             {
                 continue;
             }
 
-            mutators++;
+            harnessUsers += usesHarness ? 1 : 0;
+            resetHookUsers += usesResetHook ? 1 : 0;
             if (!text.Contains("[Collection(\"SSOController\")]", StringComparison.Ordinal))
             {
                 offenders.Add(Path.GetFileName(src));
@@ -2572,9 +2574,12 @@ public class ArchitectureConformanceTests
             offenders.Count == 0,
             "Every test class that constructs SsoControllerHarness or calls a *ForTests() reset hook must carry [Collection(\"SSOController\")] (both mutate process-wide statics; classes outside the collection run in parallel with it). Missing in: " + string.Join(", ", offenders));
 
-        // Liveness sentinel: the scan must actually see the known mutators, or a rename has silently blinded
-        // it. The floor covers the harness users alone, so it stays meaningful if the reset hooks are renamed.
-        Assert.True(mutators >= 14, $"The process-wide-state scan matched only {mutators} test classes — SsoControllerHarness or the *ForTests() hooks were renamed; update this rule.");
+        // Liveness sentinel, ONE FLOOR PER SCANNED LITERAL. A single combined count is the same conjunction
+        // defect this rule exists to catch: renaming SsoControllerHarness would drop 27 classes and still
+        // clear a combined floor the reset-hook classes alone carried, leaving the scan blind while reading
+        // as live. Each literal has to prove it still matches something on its own.
+        Assert.True(harnessUsers >= 20, $"The harness scan matched only {harnessUsers} test classes — SsoControllerHarness was renamed; update this rule.");
+        Assert.True(resetHookUsers >= 3, $"The reset-hook scan matched only {resetHookUsers} test classes — the *ForTests() hooks were renamed; update this rule.");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -121,9 +121,9 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
     {
         // The one forgery driven END TO END: the endpoint, the discovery/JWKS read, and the validation
         // parameters OidcLoginService builds at its own call site. The rest of the battery
-        // (OidcTokenForgeryTests) hands the validator parameters the TEST constructed, which establishes what
-        // the library refuses rather than what this endpoint refuses; those are different claims and only one
-        // of them is about production.
+        // (OidcTokenForgeryTests) submits against parameters the TEST built, which establishes what the token
+        // library refuses under that basis rather than what this endpoint refuses; those are different claims
+        // and only one of them is about production.
         //
         // alg:none is the shape chosen for it because it is the one needing no key material at all: the
         // header declares the token needs no signature and the third segment is empty, so anyone who can

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -10,6 +10,7 @@ using Jellyfin.Plugin.SSO_Auth;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using NSubstitute;
 using Xunit;
 
@@ -21,6 +22,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// fail-closed contract: the feature and per-provider opt-in gate reject WITHOUT reading the token; a valid
 /// token revokes only the matched user's OpenID sessions for that provider (never cross-provider, never a
 /// SAML capture); and every rejection is the uniform 400 with no subject oracle.
+///
+/// <see cref="AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/> belongs to the
+/// JWT forgery battery (<see cref="OidcTokenForgeryTests"/>) and lives here because this is where the
+/// production path is reachable: it is the one forged shape that crosses the real endpoint and the real
+/// parameter-building call site, instead of a basis a test built (#1004).
 /// </summary>
 [Collection("SSOController")]
 public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
@@ -111,6 +117,43 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
     }
 
     [Fact]
+    public async Task AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes()
+    {
+        // The one forgery driven END TO END: the endpoint, the discovery/JWKS read, and the validation
+        // parameters OidcLoginService builds at its own call site. The rest of the battery
+        // (OidcTokenForgeryTests) hands the validator parameters the TEST constructed, which establishes what
+        // the library refuses rather than what this endpoint refuses; those are different claims and only one
+        // of them is about production.
+        //
+        // alg:none is the shape chosen for it because it is the one needing no key material at all: the
+        // header declares the token needs no signature and the third segment is empty, so anyone who can
+        // reach this anonymous URL can mint it, and acceptance would revoke a chosen user's sessions. It is
+        // also the shape a mutation of the parameters AFTER the builder returns re-opens, at a call site the
+        // conformance rule cannot see (the endpoint's `var parameters = ...` names no type and calls no
+        // handler entry point — that rule's doc comment enumerates the gap). This row is what notices.
+        //
+        // The genuine token goes through the SAME harness afterwards and must be ACCEPTED. Without that
+        // control the rejection would prove nothing: an unserved discovery document, a misspelled provider
+        // or a wrong audience all produce the identical uniform 400.
+        var harness = Harness(c =>
+        {
+            c.EnableSingleLogout = true;
+            c.OidConfigs["kc"] = Provider(backChannel: true);
+            c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+        });
+
+        var refused = await harness.Controller.OidBackChannelLogout("kc", AlgNoneLogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(refused);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+
+        var accepted = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        Assert.IsType<OkResult>(accepted);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+    }
+
+    [Fact]
     public async Task NeverRevokesASamlCaptureWithTheSameSubject()
     {
         var harness = Harness(c =>
@@ -191,6 +234,21 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
 
         AssertUniform400(result);
         await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    // An unsigned logout_token whose every claim is acceptable — this provider's issuer and audience, the
+    // mandatory events member, a sub/sid pair that matches a captured session — so the empty signature is the
+    // only thing left to refuse it on. Composed by hand because a token handler will not emit an `alg` the
+    // JWS spec forbids.
+    private string AlgNoneLogoutToken(string subject, string sessionIndex)
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var payload = "{\"iss\":\"" + Authority + "\",\"aud\":\"" + _fixture.ClientId + "\",\"sub\":\"" + subject + "\","
+            + "\"sid\":\"" + sessionIndex + "\",\"jti\":\"" + Guid.NewGuid() + "\","
+            + "\"iat\":" + (now - 60) + ",\"exp\":" + (now + 300) + ","
+            + "\"events\":{\"http://schemas.openid.net/event/backchannel-logout\":{}}}";
+        return Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes("{\"alg\":\"none\",\"typ\":\"JWT\"}"))
+            + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payload)) + ".";
     }
 
     private static void AssertUniform400(ActionResult result)

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -129,8 +129,8 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
         // header declares the token needs no signature and the third segment is empty, so anyone who can
         // reach this anonymous URL can mint it, and acceptance would revoke a chosen user's sessions. It is
         // also the shape a mutation of the parameters AFTER the builder returns re-opens, at a call site the
-        // conformance rule cannot see (the endpoint's `var parameters = ...` names no type and calls no
-        // handler entry point — that rule's doc comment enumerates the gap). This row is what notices.
+        // conformance rule cannot see: the endpoint's `var parameters = ...` names no type and calls no
+        // handler entry point. This row is what notices (#1050).
         //
         // The genuine token goes through the SAME harness afterwards and must be ACCEPTED. Without that
         // control the rejection would prove nothing: an unserved discovery document, a misspelled provider

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
@@ -200,6 +200,71 @@ public sealed class OidcIdTokenValidatorTests : IDisposable
     }
 
     [Fact]
+    public async Task SymmetricJwksKey_IsNeverConvertedToASigningKey()
+    {
+        // #1004. The counterpart to the algorithm allowlist, from the other direction: the allowlist stops a
+        // token DECLARING HS256, and this stops symmetric key material ever becoming an issuer signing key in
+        // the first place. It matters because a shared secret is not secret the way a signing key is — a
+        // provider advertising an oct key hands out something every party holding that secret could mint
+        // tokens with. The token here is MAC'd with exactly the advertised secret, so converting the key would
+        // mean accepting the token; the conversion never yields one, and the login fails closed on the
+        // key-not-found path.
+        var secret = new byte[32];
+        var options = Options(jwks: $$"""
+            {"keys":[{"kty":"oct","use":"sig","kid":"{{KeyId}}","alg":"HS256",
+              "k":"{{Base64UrlEncoder.Encode(secret)}}"}]}
+            """);
+        var descriptor = Descriptor();
+        descriptor.SigningCredentials = new SigningCredentials(
+            new SymmetricSecurityKey(secret) { KeyId = KeyId }, SecurityAlgorithms.HmacSha256);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, options, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Null(result.User);
+    }
+
+    [Fact]
+    public async Task AudienceArrayWithoutTheClientId_IsRejected()
+    {
+        // #1004, OIDC Core 3.1.3.7 rule 3. The single-string wrong-audience case is covered above; this is the
+        // ARRAY form, so a token legitimately minted for two other parties cannot log in here merely because
+        // the audience claim is a list rather than a string.
+        var descriptor = Descriptor();
+        descriptor.Audience = null;
+        descriptor.Audiences.Add("other-api");
+        descriptor.Audiences.Add("third-party");
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("Audience", result.Error, StringComparison.Ordinal);
+        Assert.Null(result.User);
+    }
+
+    [Fact]
+    public async Task MultiAudience_WithMismatchedAzp_IsRejected()
+    {
+        // #1004, OIDC Core 3.1.3.7 rule 5 in its multi-audience form. The existing azp-mismatch test uses a
+        // single audience, where the audience check alone would also have caught a foreign token. Here our
+        // client IS among the audiences, so that check passes and azp is the ONLY thing between a token
+        // authorized for another party and a login — the case the rule exists for.
+        var descriptor = Descriptor(claims: new Dictionary<string, object> { ["sub"] = "user-1", ["azp"] = "someone-else" });
+        descriptor.Audience = null;
+        descriptor.Audiences.Add(ClientId);
+        descriptor.Audiences.Add("other-api");
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("azp", result.Error, StringComparison.Ordinal);
+        Assert.Null(result.User);
+    }
+
+    [Fact]
     public async Task NullEntryInJwks_IsSkipped_GoodKeyStillValidates()
     {
         // A JWKS carrying a literal null entry must not 500 the login (skip-on-malformed contract).

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
@@ -206,14 +206,28 @@ public sealed class OidcIdTokenValidatorTests : IDisposable
         // token DECLARING HS256, and this stops symmetric key material ever becoming an issuer signing key in
         // the first place. It matters because a shared secret is not secret the way a signing key is — a
         // provider advertising an oct key hands out something every party holding that secret could mint
-        // tokens with. The token here is MAC'd with exactly the advertised secret, so converting the key would
-        // mean accepting the token; the conversion never yields one, and the login fails closed on the
-        // key-not-found path.
+        // tokens with.
+        //
+        // The CONVERSION is asserted first and on its own. Driving only the validator would make this a
+        // conjunction — the conversion refuses the key OR the allowlist refuses the algorithm — and a
+        // conjunction passes while the half it is named after is false: a converter that started yielding
+        // symmetric keys leaves the end-to-end rejection intact, because the allowlist still catches the
+        // token. Reading the converter's output directly is what puts the named property under test.
         var secret = new byte[32];
-        var options = Options(jwks: $$"""
+        var jwks = $$"""
             {"keys":[{"kty":"oct","use":"sig","kid":"{{KeyId}}","alg":"HS256",
               "k":"{{Base64UrlEncoder.Encode(secret)}}"}]}
-            """);
+            """;
+        var ephemeralKeys = new List<IDisposable>();
+
+        var converted = OidcSignatureKeys.Convert(new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks), ephemeralKeys);
+
+        Assert.Empty(converted);
+        Assert.Empty(ephemeralKeys);
+
+        // And end to end: the token is MAC'd with exactly the advertised secret, so a converter that yielded
+        // that key would hand the verifier everything it needs. The login fails closed instead.
+        var options = Options(jwks: jwks);
         var descriptor = Descriptor();
         descriptor.SigningCredentials = new SigningCredentials(
             new SymmetricSecurityKey(secret) { KeyId = KeyId }, SecurityAlgorithms.HmacSha256);

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -21,6 +21,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// member, the forbidden nonce (an id_token replayed as a logout_token), the at-least-one-of-sub/sid rule,
 /// and jti one-time-use. Each rejection carries a fixed reason code and never a subject identifier.
 /// </summary>
+[Collection("SSOController")]
 public sealed class OidcLogoutTokenValidatorTests : IDisposable
 {
     private const string Issuer = "https://idp.example.test";

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -21,6 +21,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// member, the forbidden nonce (an id_token replayed as a logout_token), the at-least-one-of-sub/sid rule,
 /// and jti one-time-use. Each rejection carries a fixed reason code and never a subject identifier.
 /// </summary>
+// Clears the process-wide logout_token replay cache, the same one the forgery battery clears; serialized so
+// that a class running in parallel cannot empty it while the jti one-time-use assertions here are mid-run
+// and leave them passing vacuously (#1004).
 [Collection("SSOController")]
 public sealed class OidcLogoutTokenValidatorTests : IDisposable
 {

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -204,8 +204,10 @@ public class OidcRoundTripTests
         // Asserted empirically on the real flow rather than by scanning source for a token variable, because a
         // source scan proves only that one spelling of the leak is absent. Here the token is a known string and
         // all THREE places it could escape are inspected directly: the HTML the callback hands the browser,
-        // every field of the AuthenticationRequest handed to Jellyfin's session manager, and the body returned
-        // to the client. The callback page is inspected because it is the first thing that reaches the browser
+        // the string-carrying fields of the AuthenticationRequest handed to Jellyfin's session manager — listed
+        // one by one below rather than claimed wholesale, so a field arriving in a Jellyfin update is inspected
+        // once someone adds it there and not before — and the body returned to the client. The callback page is
+        // inspected because it is the first thing that reaches the browser
         // and the only one an operator would not see in an API response — an id_token embedded in that markup
         // leaks to anything that can read the page. The only credential that may cross any of the three
         // boundaries is the session Jellyfin itself mints.

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Jellyfin.Database.Implementations.Entities;
 using Jellyfin.Plugin.SSO_Auth;
@@ -12,6 +14,8 @@ using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Session;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NSubstitute;
@@ -109,6 +113,134 @@ public class OidcRoundTripTests
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Invalid or expired state", content.Content);
         await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Challenge_SendsNoNonce_AndBindsTheCodeWithPkceS256()
+    {
+        // #1004. The plugin sends no OIDC nonce — neither OidcClient leg (6.0.1 on net9.0, 7.1.0 on net10.0)
+        // emits one for the code flow, and the plugin adds none — so RFC 9700's PKCE binding is what ties the
+        // code to this authorization request. That is a coherent posture, since OIDC Core 3.1.3.7 rule 11
+        // requires validating a nonce only when one was sent; but it is coherent only as a PAIR, and the pair
+        // is what this pins. The absence is READ OFF the real authorize URL rather than assumed, so the
+        // property is established per TFM instead of resting on a claim about one library version.
+        //
+        // The regression it guards against is the shape of CVE-2026-42206: a nonce generated on the
+        // authorization request and never validated on the callback, which is ID-token replay with a decorative
+        // parameter attached. Adding a `nonce` to the authorize URL would fail no other test in this suite, so
+        // without this assertion that lands silently. If a nonce is ever wanted, this test failing is the
+        // prompt to build its validator in the same change.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+
+        Assert.Equal(string.Empty, QueryValue(challenge.Url, "nonce"));
+        Assert.NotEqual(string.Empty, QueryValue(challenge.Url, "code_challenge"));
+        Assert.Equal("S256", QueryValue(challenge.Url, "code_challenge_method"));
+    }
+
+    [Fact]
+    public async Task TokenRequest_RepeatsTheChallengeRedirectUriByteForByte()
+    {
+        // #1004, RFC 6749 §4.1.3. Exact-string redirect_uri matching is the authorization server's check, and
+        // the relying party's obligation is the input to it: the redirect_uri on the token request must be
+        // byte-identical to the one on the authorization request, or the server refuses the exchange. Builder
+        // equality is already pinned by OidcRedirectUriBuilderTests; that compares what the two builder methods
+        // RETURN, while this compares what actually leaves the process — the authorize URL against the token
+        // POST body.
+        //
+        // What supplies the wire value was measured, not assumed: today it comes from OidcClient replaying the
+        // redirect_uri stored on the AuthorizeState at challenge time, NOT from the callback-side builder. So a
+        // divergence introduced in CallbackRedirectUri alone is invisible here (verified: a trailing slash
+        // added to that builder fails the builder tests and leaves this one green). The regression this DOES
+        // catch is the dangerous one — the callback-built value reaching the token request while disagreeing
+        // with the challenge's, which is what a library upgrade that honours options.RedirectUri would cause.
+        // Verified by making exactly that assignment: the test fails on the trailing slash.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        string? tokenRequestBody = null;
+        var harness = BuildHarness(fixture, request =>
+        {
+            if (request.RequestUri!.AbsoluteUri == fixture.TokenUrl)
+            {
+                tokenRequestBody = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            }
+
+            return ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice"));
+        });
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111116"));
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(user.Id).Returns(user);
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+        var state = QueryValue(challenge.Url, "state");
+        var binding = BindingCookie(harness.Controller.Response);
+        var challengeRedirectUri = QueryValue(challenge.Url, "redirect_uri");
+
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
+
+        Assert.NotNull(tokenRequestBody);
+        Assert.NotEqual(string.Empty, challengeRedirectUri);
+        Assert.Equal(challengeRedirectUri, FormValue(tokenRequestBody, "redirect_uri"));
+    }
+
+    [Fact]
+    public async Task RedeemResponse_NeverContainsTheIdToken_OnlyTheLocallyMintedSession()
+    {
+        // #1004. The id_token is a proof of authentication addressed to this plugin, not a bearer credential
+        // for anything: handing it to the browser, or storing it as a session token, turns a one-shot login
+        // assertion into something replayable against this server and against any other relying party that
+        // trusts the same issuer without pinning the audience.
+        //
+        // Asserted empirically on the real flow rather than by scanning source for a token variable, because a
+        // source scan proves only that one spelling of the leak is absent. Here the token is a known string and
+        // the two places it could escape are inspected directly: every field of the AuthenticationRequest
+        // handed to Jellyfin's session manager, and the body returned to the client. The only credential that
+        // may cross either boundary is the session Jellyfin itself mints.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken));
+        var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111117"));
+        harness.UserManager.CreateUserAsync("alice").Returns(user);
+        harness.UserManager.GetUserById(user.Id).Returns(user);
+
+        // The session manager is stubbed to return a REAL result carrying a distinctive access token. An
+        // unstubbed substitute returns null, and a "the response does not contain the id_token" assertion over
+        // a null body passes without inspecting anything — the assertion would read as protection while
+        // testing nothing. Pinning the minted token instead makes the test prove both halves: the id_token is
+        // absent AND the credential that IS returned is the one Jellyfin minted.
+        const string MintedToken = "minted-session-token";
+        AuthenticationRequest? mintRequest = null;
+        harness.SessionManager
+            .AuthenticateDirect(Arg.Do<AuthenticationRequest>(r => mintRequest = r))
+            .Returns(new AuthenticationResult { AccessToken = MintedToken });
+
+        var (state, binding) = await DriveChallenge(harness);
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
+
+        var authed = Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+
+        // The mint really happened and really belongs to this login, so the field scan below is not walking an
+        // empty object.
+        Assert.NotNull(mintRequest);
+        Assert.Equal("alice", mintRequest.Username);
+        foreach (var field in new[]
+        {
+            mintRequest.Username, mintRequest.App, mintRequest.AppVersion,
+            mintRequest.DeviceId, mintRequest.DeviceName, mintRequest.RemoteEndPoint, mintRequest.Password,
+        })
+        {
+            Assert.DoesNotContain(idToken, field ?? string.Empty, StringComparison.Ordinal);
+        }
+
+        // The body handed back to the client is the minted Jellyfin session and nothing else.
+        var body = JsonSerializer.Serialize(authed.Value);
+        Assert.Contains(MintedToken, body, StringComparison.Ordinal);
+        Assert.DoesNotContain(idToken, body, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -465,6 +597,23 @@ public class OidcRoundTripTests
             if (kv.Length == 2 && kv[0] == key)
             {
                 return Uri.UnescapeDataString(kv[1]);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    // Reads a single value out of an application/x-www-form-urlencoded request body (the token POST). Kept
+    // separate from QueryValue because the body is not a URL: the parse must not depend on a Uri that a
+    // malformed body would make un-constructible, and the test would then fail for the wrong reason.
+    private static string FormValue(string body, string key)
+    {
+        foreach (var pair in body.Split('&'))
+        {
+            var kv = pair.Split('=', 2);
+            if (kv.Length == 2 && kv[0] == key)
+            {
+                return Uri.UnescapeDataString(kv[1].Replace('+', ' '));
             }
         }
 

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -142,14 +142,20 @@ public class OidcRoundTripTests
     }
 
     [Fact]
-    public async Task TokenRequest_RepeatsTheChallengeRedirectUriByteForByte()
+    public async Task TokenRequest_RepeatsTheChallengeRedirectUriValue()
     {
         // #1004, RFC 6749 §4.1.3. Exact-string redirect_uri matching is the authorization server's check, and
-        // the relying party's obligation is the input to it: the redirect_uri on the token request must be
-        // byte-identical to the one on the authorization request, or the server refuses the exchange. Builder
+        // the relying party's obligation is the input to it: the redirect_uri on the token request must be the
+        // same value as the one on the authorization request, or the server refuses the exchange. Builder
         // equality is already pinned by OidcRedirectUriBuilderTests; that compares what the two builder methods
         // RETURN, while this compares what actually leaves the process — the authorize URL against the token
         // POST body.
+        //
+        // The comparison is of DECODED values, not of the wire bytes, and the test claims no more than that: a
+        // URL query and an application/x-www-form-urlencoded body legitimately encode the same value
+        // differently (a space is %20 in one and + in the other), so a byte-wise comparison across the two
+        // carriers would fail on an identical value. What the AS compares is the decoded string, which is what
+        // is compared here.
         //
         // What supplies the wire value was measured, not assumed: today it comes from OidcClient replaying the
         // redirect_uri stored on the AuthorizeState at challenge time, NOT from the callback-side builder. So a
@@ -197,9 +203,12 @@ public class OidcRoundTripTests
         //
         // Asserted empirically on the real flow rather than by scanning source for a token variable, because a
         // source scan proves only that one spelling of the leak is absent. Here the token is a known string and
-        // the two places it could escape are inspected directly: every field of the AuthenticationRequest
-        // handed to Jellyfin's session manager, and the body returned to the client. The only credential that
-        // may cross either boundary is the session Jellyfin itself mints.
+        // all THREE places it could escape are inspected directly: the HTML the callback hands the browser,
+        // every field of the AuthenticationRequest handed to Jellyfin's session manager, and the body returned
+        // to the client. The callback page is inspected because it is the first thing that reaches the browser
+        // and the only one an operator would not see in an API response — an id_token embedded in that markup
+        // leaks to anything that can read the page. The only credential that may cross any of the three
+        // boundaries is the session Jellyfin itself mints.
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
         var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken));
@@ -220,7 +229,10 @@ public class OidcRoundTripTests
 
         var (state, binding) = await DriveChallenge(harness);
         RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
-        Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
+        var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
+        Assert.Equal("text/html", callback.ContentType);
+        Assert.NotNull(callback.Content);
+        Assert.DoesNotContain(idToken, callback.Content, StringComparison.Ordinal);
 
         var authed = Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
 

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -54,6 +54,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// because "rejected" and "rejected without leaking an identity the caller might act on" are different
 /// properties and only the second is worth having.
 /// </summary>
+// Clears the process-wide logout_token replay cache, so it runs serialized against every other class that
+// touches one: clearing it under a sibling that is asserting a replay is REFUSED would turn that assertion
+// green while it tested nothing (#1004, EveryTestClassClearingAReplayCache_IsInTheNonParallelControllerCollection).
 [Collection("SSOController")]
 public sealed class OidcTokenForgeryTests : IDisposable
 {

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -15,33 +15,45 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// The JWT forgery battery (#1004): the token shapes an attacker actually submits, each asserted to be
-/// rejected on BOTH paths that verify a provider JWT — the login id_token
-/// (<see cref="OidcIdTokenValidator"/>) and the anonymous back-channel <c>logout_token</c>
-/// (<see cref="OidcLogoutTokenValidator"/>), which share the one
+/// The JWT forgery battery (#1004): token shapes an attacker can compose, each asserted to be rejected on
+/// BOTH paths that verify a provider JWT — the login id_token (<see cref="OidcIdTokenValidator"/>) and the
+/// anonymous back-channel <c>logout_token</c> (<see cref="OidcLogoutTokenValidator"/>), which share the one
 /// <see cref="OidcSignatureKeys"/> basis that <c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>
 /// pins as the only one.
 ///
-/// These tokens are assembled BY HAND rather than through <see cref="JsonWebTokenHandler"/>. That is the
-/// point of the file: the handler is a well-behaved issuer and will not emit an <c>alg</c> the JWS spec
-/// forbids, a case-mangled header, or a stripped signature, so a test that mints its "forgeries" through it
-/// proves only that the library declines to attack itself. Composing the three base64url segments directly
-/// is what puts the attacker's actual bytes on the wire.
+/// Tokens are assembled BY HAND rather than through <see cref="JsonWebTokenHandler"/> wherever the shape
+/// requires it: the handler is a well-behaved issuer and will not emit an <c>alg</c> the JWS spec forbids, a
+/// case-mangled header, or a stripped signature, so a "forgery" minted through it proves only that the
+/// library declines to attack itself.
 ///
-/// Every test asserts the same two things — the result is an error, and NO principal or subject identity
-/// comes back — because "rejected" and "rejected without leaking an identity the caller might act on" are
-/// different properties, and only the second is worth having.
+/// What each rejection is ATTRIBUTABLE to is not uniform, and the file does not pretend otherwise. Most of
+/// these shapes are refused by the key/signature layer, and would still be refused with the algorithm
+/// allowlist deleted — they establish that the posture holds, not which term holds it. The tests that isolate
+/// a single term carry their own in-test control, which fails if that term stops deciding:
+/// <see cref="AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify"/> for the allowlist and
+/// <see cref="HostileKidValues_DecideNothing_AndNeverThrow"/> for <c>kid</c> handling.
+///
+/// Every rejection asserts two things — an error, and NO principal or subject identity coming back —
+/// because "rejected" and "rejected without leaking an identity the caller might act on" are different
+/// properties and only the second is worth having.
 /// </summary>
+[Collection("SSOController")]
 public sealed class OidcTokenForgeryTests : IDisposable
 {
     private const string Issuer = "https://idp.example.test";
     private const string ClientId = "jellyfin-client";
     private const string KeyId = "test-signing-key";
+    private const string SharedSecretKeyId = "advertised-shared-secret";
     private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
 
     private static readonly TimeSpan Skew = TimeSpan.FromMinutes(5);
 
     private readonly RSA _rsa = RSA.Create(2048);
+
+    // The disposal contract BuildValidationParameters imposes on its caller, honoured here exactly as both
+    // production callers honour it: an EC key advertised in a JWKS yields a native ECDsa handle that is the
+    // caller's to release.
+    private readonly List<IDisposable> _ephemeralKeys = new List<IDisposable>();
     private readonly OidcIdTokenValidator _idTokenValidator = new();
     private readonly OidcLogoutTokenValidator _logoutTokenValidator = new();
 
@@ -49,6 +61,11 @@ public sealed class OidcTokenForgeryTests : IDisposable
 
     public void Dispose()
     {
+        foreach (var key in _ephemeralKeys)
+        {
+            key.Dispose();
+        }
+
         _rsa.Dispose();
         OidcLogoutTokenValidator.ResetReplaysForTests();
     }
@@ -59,8 +76,8 @@ public sealed class OidcTokenForgeryTests : IDisposable
     {
         // The oldest forgery in the catalogue: claims that are byte-for-byte acceptable (right issuer,
         // audience and lifetime), a header declaring the token needs no signature, and an empty third
-        // segment. It is refused because the allowlist is asymmetric-only and RequireSignedTokens is set —
-        // the accepted algorithms are decided by us, never read off the header the attacker wrote.
+        // segment. RequireSignedTokens is what refuses it — measured, not assumed: with ValidAlgorithms
+        // removed it still rejects, so this row pins the fail-closed outcome and not the allowlist.
         var forged = Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", IdTokenPayload(), signature: string.Empty);
 
         await AssertIdTokenRejected(forged);
@@ -76,9 +93,8 @@ public sealed class OidcTokenForgeryTests : IDisposable
     {
         // The bypass for a validator that compares the header against a denylist ordinally: JWS `alg` values
         // are case-sensitive, so "None" is not the registered "none" and slips past a check spelled that way.
-        // An ALLOWLIST is immune by construction — every one of these is simply not in it — and that immunity
-        // is what this theory pins, since it is the reason the code carries no `alg == "none"` comparison at
-        // all and a reviewer might otherwise "helpfully" add one.
+        // The plugin carries no `alg == "none"` comparison at all, and this theory is why a reviewer must not
+        // "helpfully" add one — an allowlist is immune to the whole family by construction.
         var forged = Jws($"{{\"alg\":\"{alg}\",\"typ\":\"JWT\"}}", IdTokenPayload(), signature: string.Empty);
 
         await AssertIdTokenRejected(forged);
@@ -88,17 +104,55 @@ public sealed class OidcTokenForgeryTests : IDisposable
     [Trait("Spec", "RFC 7518")]
     public async Task IdToken_Rs256PublicKeyReplayedAsHs256Mac_IsRejected()
     {
-        // Algorithm confusion, the forgery that makes the asymmetric-only allowlist load-bearing. The RSA
-        // public key is published in the JWKS, so the attacker HAS it; declaring HS256 invites the verifier to
-        // treat that public material as an HMAC secret, which the attacker can also compute over. The token
-        // then verifies against the provider's own advertised key. Both spellings of the key material are
-        // tried — the SPKI DER bytes and the modulus, the two an implementation would plausibly hand the HMAC
-        // — because a defence that stops one and not the other is not a defence.
+        // Algorithm confusion as an attacker can actually mount it here: the RSA public key is published in
+        // the JWKS, so the attacker HAS it, and declaring HS256 invites a verifier to treat that public
+        // material as an HMAC secret. Both spellings are tried — SPKI DER bytes and the bare modulus — since
+        // a defence that stops one and not the other is not a defence. On this stack the refusal comes from
+        // key typing (an RsaSecurityKey is never handed to an HMAC), NOT from the allowlist; the allowlist's
+        // own load-bearing case is the test below.
         var publicKey = _rsa.ExportSubjectPublicKeyInfo();
         var modulus = _rsa.ExportParameters(false).Modulus!;
 
-        await AssertIdTokenRejected(Hs256(IdTokenPayload(), publicKey));
-        await AssertIdTokenRejected(Hs256(IdTokenPayload(), modulus));
+        await AssertIdTokenRejected(Hs256(IdTokenPayload(), publicKey, KeyId));
+        await AssertIdTokenRejected(Hs256(IdTokenPayload(), modulus, KeyId));
+    }
+
+    [Fact]
+    [Trait("Spec", "RFC 7518")]
+    public async Task AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify()
+    {
+        // The shape where ValidAlgorithms is the DECIDING term, which none of the rows above is: a token
+        // whose signature the advertised key set can verify, refused only because HS256 is not on the list.
+        // The symmetric key is placed into the key set by hand because today's JWK conversion never yields
+        // one — that is a separate property, pinned by SymmetricJwksKey_IsNeverConvertedToASigningKey — and
+        // the allowlist is the second layer that has to hold when the first fails, which is one "our IdP
+        // wants HS256" commit away. A secret advertised in a JWKS is held by every party that reads it, so
+        // anyone could mint this token.
+        var secret = RandomNumberGenerator.GetBytes(32);
+        var forged = Hs256(IdTokenPayload(), secret, SharedSecretKeyId);
+        var keys = new List<SecurityKey>(Params().IssuerSigningKeys)
+        {
+            new SymmetricSecurityKey(secret) { KeyId = SharedSecretKeyId },
+        };
+
+        var hardened = Params();
+        hardened.IssuerSigningKeys = keys;
+
+        // The control that makes the assertion load-bearing rather than one more rejection of unknown cause:
+        // the SAME token against the SAME keys with ONLY ValidAlgorithms removed is ACCEPTED. That pins the
+        // refusal to that one field — deleting it from OidcSignatureKeys turns this test red, which is
+        // exactly what the rest of the battery does not do.
+        var withoutAllowlist = Params();
+        withoutAllowlist.IssuerSigningKeys = keys;
+        withoutAllowlist.ValidAlgorithms = null;
+
+        var refused = await new JsonWebTokenHandler().ValidateTokenAsync(forged, hardened);
+        var accepted = await new JsonWebTokenHandler().ValidateTokenAsync(forged, withoutAllowlist);
+
+        Assert.False(refused.IsValid, "The HS256 forgery was accepted under the hardened basis.");
+        Assert.True(
+            accepted.IsValid,
+            "The control did not verify, so the forgery is being refused by something other than the allowlist and this test proves nothing about it.");
     }
 
     [Fact]
@@ -106,13 +160,11 @@ public sealed class OidcTokenForgeryTests : IDisposable
     public async Task IdToken_SignatureStripped_IsRejected()
     {
         // A genuine, correctly signed token whose signature segment is deleted in transit. The header still
-        // says RS256, so an allowlist check alone passes — what refuses it is that the signature must actually
-        // verify. Covers the gap between "the algorithm is acceptable" and "the token is authentic".
-        var signed = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor());
-        var parts = signed.Split('.');
-        var stripped = parts[0] + "." + parts[1] + ".";
+        // says RS256, so an allowlist check alone passes — what refuses it is that the signature must
+        // actually verify. Covers the gap between "the algorithm is acceptable" and "the token is authentic".
+        var parts = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor()).Split('.');
 
-        await AssertIdTokenRejected(stripped);
+        await AssertIdTokenRejected(parts[0] + "." + parts[1] + ".");
     }
 
     [Fact]
@@ -120,16 +172,30 @@ public sealed class OidcTokenForgeryTests : IDisposable
     public async Task IdToken_ForgedSignature_ClaimingTheTrustedKid_IsRejected()
     {
         // The header's `kid` names the key the JWKS advertises, but the token is signed by the attacker's own
-        // RSA key. A `kid` is an unauthenticated routing hint written by whoever composed the token; it
-        // selects which key verifies, and can never itself vouch for a signature. The rejection also maps to
-        // the "invalid_signature" contract, which is what makes OidcClient refresh the JWKS and retry once —
-        // so this asserts a forgery lands on the same benign path a genuine key rotation does, rather than
-        // being distinguishable from it.
+        // RSA key. The rejection maps to the "invalid_signature" contract, which is what makes OidcClient
+        // refresh the JWKS and retry once — so a forgery lands on the same benign path a genuine key rotation
+        // does, rather than being distinguishable from it.
         using var attacker = RSA.Create(2048);
-        var forged = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor(signingKey: attacker));
+        var forged = SignedWith(IdTokenDescriptor(), attacker, KeyId);
 
         var result = await AssertIdTokenRejected(forged);
         Assert.Equal("invalid_signature", result.Error);
+    }
+
+    [Fact]
+    [Trait("Spec", "RFC 7515")]
+    public async Task IdToken_HeaderSuppliedKeyMaterial_IsNeverConsulted()
+    {
+        // Real JWS header injection, RFC 7515 §4.1.2/§4.1.5/§4.1.6: `jku` and `x5u` name a URL a verifier
+        // could fetch a key from and `x5c` carries one inline. The token is signed by the attacker's key and
+        // the header hands that same key over all three ways, so a verifier that consulted ANY of them would
+        // accept it — which is what makes the rejection attributable to the header material being ignored
+        // rather than to the signature. Consulting it is not something to acquire by accident later: an
+        // IssuerSigningKeyResolver that reads x5c turns this test red.
+        using var attacker = RSA.Create(2048);
+        var forged = HeaderInjected(IdTokenPayload(), attacker);
+
+        await AssertIdTokenRejected(forged);
     }
 
     [Theory]
@@ -143,25 +209,29 @@ public sealed class OidcTokenForgeryTests : IDisposable
     [InlineData("' OR '1'='1")]
     [InlineData("\"><script>alert(1)</script>")]
     [InlineData("{\"jku\":\"https://attacker.example/keys\"}")]
-    public async Task IdToken_HostileKidValues_NeverAuthenticate_AndNeverThrow(string kid)
+    public async Task HostileKidValues_DecideNothing_AndNeverThrow(string kid)
     {
         // The `kid` injection class: path traversal, a null byte, quote/SQL and markup metacharacters, and a
-        // nested-JSON smuggling attempt. Each is carried on a token the attacker signed with their own key, so
-        // the ONLY thing that could let it in is the header value being treated as something other than an
-        // opaque lookup hint.
+        // nested-JSON smuggling attempt. Asserting only that a hostile `kid` is rejected would be
+        // unfalsifiable — the token carries an attacker signature, which can never verify whatever the kid
+        // handling does. So two tokens are submitted that differ ONLY in who signed them: the provider-signed
+        // one is ACCEPTED and the foreign-signed one is REJECTED, for every hostile spelling. That difference
+        // is the property — the value decides nothing, opening no path and closing none.
         //
-        // Two properties, not one. Rejection is the obvious half. The other half is that it must be a clean
-        // error rather than an exception: the id_token validator runs inside the OIDC callback, where a throw
-        // surfaces as a 500 — an attacker-triggerable oracle that distinguishes hostile input from an ordinary
-        // bad signature, and a denial-of-service lever on the login path. Awaiting the call outside any
-        // assertion is what proves it: an exception fails the test on its own.
+        // The second property is that neither is an exception. The id_token validator runs inside the OIDC
+        // callback, where a throw surfaces as a 500: an attacker-triggerable oracle distinguishing hostile
+        // input from an ordinary bad signature, and a denial-of-service lever on the login path. Awaiting
+        // both calls outside any assertion is what proves it.
+        //
+        // The acceptance half deliberately flips if the `kid` allowlist of #1029 lands — that change must be
+        // a conscious one, not a silent posture shift.
         using var attacker = RSA.Create(2048);
-        var descriptor = IdTokenDescriptor(signingKey: attacker);
-        descriptor.SigningCredentials = new SigningCredentials(
-            new RsaSecurityKey(attacker) { KeyId = kid }, SecurityAlgorithms.RsaSha256);
-        var forged = new JsonWebTokenHandler().CreateToken(descriptor);
 
-        await AssertIdTokenRejected(forged);
+        var accepted = await _idTokenValidator.ValidateAsync(
+            SignedWith(IdTokenDescriptor(), _rsa, kid), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(accepted.IsError, accepted.Error);
+        await AssertIdTokenRejected(SignedWith(IdTokenDescriptor(), attacker, kid));
     }
 
     [Theory]
@@ -176,13 +246,13 @@ public sealed class OidcTokenForgeryTests : IDisposable
     {
         // The back-channel endpoint is ANONYMOUS — the signature is the only thing authenticating the caller,
         // and a token accepted here revokes a user's sessions. It shares the id_token's validation basis, and
-        // the whole value of sharing is that the two cannot drift; a shared builder proves that only while
-        // BOTH paths are actually driven through the same attacks. So every forgery above is re-run here
-        // rather than reasoned about.
+        // a shared builder proves the two cannot drift only while BOTH paths are actually driven through the
+        // same attacks, so every forgery above is re-run here rather than reasoned about.
         //
-        // The assertion pins the fixed reason code as well as the rejection: these codes are written to the
-        // audit trail and are deliberately request-independent, so a forgery must not be reportable in a way
-        // that distinguishes it from any other invalid token (no subject-identifier oracle).
+        // The reason code is pinned as the current contract, not as a claim that one code is the right
+        // answer: all six shapes report the same code, so the audit trail cannot tell alg-none from a
+        // stripped signature. Token shape carries no subject identifier, so the "no subject-identifier
+        // oracle" rationale does not by itself justify collapsing them — separating the codes is #1039.
         var forged = LogoutForgery(kind);
 
         var result = await _logoutTokenValidator.ValidateAsync(forged, Params(), Skew, DateTime.UtcNow);
@@ -197,10 +267,10 @@ public sealed class OidcTokenForgeryTests : IDisposable
     [Trait("Spec", "OIDC-Backchannel-Logout-1.0")]
     public async Task LogoutToken_GenuinelySigned_Succeeds_ProvingTheForgeryBatteryIsNotVacuous()
     {
-        // The positive control the battery needs to mean anything. Every test above asserts a rejection, and a
-        // validation path that rejected EVERYTHING — a broken JWKS, a wrong audience constant in the fixture —
-        // would pass all of them while proving nothing about forgeries. One genuinely signed token, built by
-        // the same helpers with the same parameters, has to be accepted for the rejections to carry weight.
+        // The positive control the battery needs to mean anything. Every test above asserts a rejection, and
+        // a validation path that rejected EVERYTHING — a broken JWKS, a wrong audience constant in the
+        // fixture — would pass all of them while proving nothing. One genuinely signed token, built by the
+        // same helpers with the same parameters, has to be accepted for the rejections to carry weight.
         var genuine = new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor());
 
         var result = await _logoutTokenValidator.ValidateAsync(genuine, Params(), Skew, DateTime.UtcNow);
@@ -258,30 +328,37 @@ public sealed class OidcTokenForgeryTests : IDisposable
         return result;
     }
 
-    // Builds the requested forgery over a valid logout_token payload.
-    private string LogoutForgery(ForgeryKind kind)
+    // Builds the requested forgery over a valid logout_token payload. A switch EXPRESSION with a throwing
+    // default: a seventh ForgeryKind added without a case here fails loudly instead of being silently tested
+    // as whichever shape a catch-all arm happened to build.
+    private string LogoutForgery(ForgeryKind kind) => kind switch
     {
-        switch (kind)
-        {
-            case ForgeryKind.AlgNone:
-                return Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty);
-            case ForgeryKind.AlgNoneMixedCase:
-                return Jws("{\"alg\":\"None\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty);
-            case ForgeryKind.Hs256WithPublicKey:
-                return Hs256(LogoutTokenPayload(), _rsa.ExportSubjectPublicKeyInfo());
-            case ForgeryKind.SignatureStripped:
-                var signed = new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor()).Split('.');
-                return signed[0] + "." + signed[1] + ".";
-            default:
-                using (var attacker = RSA.Create(2048))
-                {
-                    var descriptor = LogoutTokenDescriptor();
-                    descriptor.SigningCredentials = new SigningCredentials(
-                        new RsaSecurityKey(attacker) { KeyId = kind == ForgeryKind.HostileKid ? "../../../etc/passwd" : KeyId },
-                        SecurityAlgorithms.RsaSha256);
-                    return new JsonWebTokenHandler().CreateToken(descriptor);
-                }
-        }
+        ForgeryKind.AlgNone => Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty),
+        ForgeryKind.AlgNoneMixedCase => Jws("{\"alg\":\"None\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty),
+        ForgeryKind.Hs256WithPublicKey => Hs256(LogoutTokenPayload(), _rsa.ExportSubjectPublicKeyInfo(), KeyId),
+        ForgeryKind.SignatureStripped => StripSignature(new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor())),
+        ForgeryKind.ForeignKeyWithTrustedKid => ForeignKeySignedLogoutToken(KeyId),
+        ForgeryKind.HostileKid => ForeignKeySignedLogoutToken("../../../etc/passwd"),
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "No forgery is defined for this kind."),
+    };
+
+    private string ForeignKeySignedLogoutToken(string kid)
+    {
+        using var attacker = RSA.Create(2048);
+        return SignedWith(LogoutTokenDescriptor(), attacker, kid);
+    }
+
+    private static string SignedWith(SecurityTokenDescriptor descriptor, RSA key, string kid)
+    {
+        descriptor.SigningCredentials = new SigningCredentials(
+            new RsaSecurityKey(key) { KeyId = kid }, SecurityAlgorithms.RsaSha256);
+        return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    private static string StripSignature(string token)
+    {
+        var parts = token.Split('.');
+        return parts[0] + "." + parts[1] + ".";
     }
 
     // A compact JWS from its three parts, with the header and payload base64url-encoded here rather than by a
@@ -291,15 +368,27 @@ public sealed class OidcTokenForgeryTests : IDisposable
         + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson))
         + "." + signature;
 
-    // An HS256-signed token over the given payload, MAC'd with the supplied key material — the algorithm-
-    // confusion forgery, where that material is the provider's PUBLIC key.
-    private static string Hs256(string payloadJson, byte[] key)
+    // An HS256-signed token, MAC'd with the supplied key material under the supplied `kid`.
+    private static string Hs256(string payloadJson, byte[] key, string kid)
     {
-        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes("{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"" + KeyId + "\"}"))
+        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes("{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"" + kid + "\"}"))
             + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
         using var hmac = new HMACSHA256(key);
-        var mac = hmac.ComputeHash(Encoding.UTF8.GetBytes(signingInput));
-        return signingInput + "." + Base64UrlEncoder.Encode(mac);
+        return signingInput + "." + Base64UrlEncoder.Encode(hmac.ComputeHash(Encoding.UTF8.GetBytes(signingInput)));
+    }
+
+    // An RS256 token signed by the given key, whose header advertises that same key three ways — inline in
+    // x5c and by URL in jku and x5u. Hand-composed because JsonWebTokenHandler emits none of those members.
+    private static string HeaderInjected(string payloadJson, RSA key)
+    {
+        var header = "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"kid\":\"" + KeyId + "\","
+            + "\"jku\":\"https://attacker.example/jwks.json\","
+            + "\"x5u\":\"https://attacker.example/cert.pem\","
+            + "\"x5c\":[\"" + Convert.ToBase64String(key.ExportSubjectPublicKeyInfo()) + "\"]}";
+        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(header))
+            + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
+        var signature = key.SignData(Encoding.UTF8.GetBytes(signingInput), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return signingInput + "." + Base64UrlEncoder.Encode(signature);
     }
 
     // An id_token payload whose every claim is acceptable, so the signature is the only thing left to reject
@@ -321,7 +410,7 @@ public sealed class OidcTokenForgeryTests : IDisposable
             + "\"events\":{\"" + LogoutEvent + "\":{}}}";
     }
 
-    private SecurityTokenDescriptor IdTokenDescriptor(RSA? signingKey = null)
+    private SecurityTokenDescriptor IdTokenDescriptor()
     {
         var now = DateTime.UtcNow;
         return new SecurityTokenDescriptor
@@ -333,7 +422,7 @@ public sealed class OidcTokenForgeryTests : IDisposable
             Expires = now + TimeSpan.FromMinutes(5),
             Claims = new Dictionary<string, object> { ["sub"] = "user-1" },
             SigningCredentials = new SigningCredentials(
-                new RsaSecurityKey(signingKey ?? _rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+                new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
         };
     }
 
@@ -380,5 +469,5 @@ public sealed class OidcTokenForgeryTests : IDisposable
     // The logout path's parameters, built through the SAME shared basis with the back-channel's
     // requireExpiration:false posture, so these tests validate exactly what the endpoint validates.
     private TokenValidationParameters Params() =>
-        OidcSignatureKeys.BuildValidationParameters(Options(), new List<IDisposable>(), requireExpiration: false);
+        OidcSignatureKeys.BuildValidationParameters(Options(), _ephemeralKeys, requireExpiration: false);
 }

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The JWT forgery battery (#1004): the token shapes an attacker actually submits, each asserted to be
+/// rejected on BOTH paths that verify a provider JWT — the login id_token
+/// (<see cref="OidcIdTokenValidator"/>) and the anonymous back-channel <c>logout_token</c>
+/// (<see cref="OidcLogoutTokenValidator"/>), which share the one
+/// <see cref="OidcSignatureKeys"/> basis that <c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>
+/// pins as the only one.
+///
+/// These tokens are assembled BY HAND rather than through <see cref="JsonWebTokenHandler"/>. That is the
+/// point of the file: the handler is a well-behaved issuer and will not emit an <c>alg</c> the JWS spec
+/// forbids, a case-mangled header, or a stripped signature, so a test that mints its "forgeries" through it
+/// proves only that the library declines to attack itself. Composing the three base64url segments directly
+/// is what puts the attacker's actual bytes on the wire.
+///
+/// Every test asserts the same two things — the result is an error, and NO principal or subject identity
+/// comes back — because "rejected" and "rejected without leaking an identity the caller might act on" are
+/// different properties, and only the second is worth having.
+/// </summary>
+public sealed class OidcTokenForgeryTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    private static readonly TimeSpan Skew = TimeSpan.FromMinutes(5);
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcIdTokenValidator _idTokenValidator = new();
+    private readonly OidcLogoutTokenValidator _logoutTokenValidator = new();
+
+    public OidcTokenForgeryTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    [Trait("Spec", "RFC 7518")]
+    public async Task IdToken_AlgNoneWithEmptySignature_IsRejected()
+    {
+        // The oldest forgery in the catalogue: claims that are byte-for-byte acceptable (right issuer,
+        // audience and lifetime), a header declaring the token needs no signature, and an empty third
+        // segment. It is refused because the allowlist is asymmetric-only and RequireSignedTokens is set —
+        // the accepted algorithms are decided by us, never read off the header the attacker wrote.
+        var forged = Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", IdTokenPayload(), signature: string.Empty);
+
+        await AssertIdTokenRejected(forged);
+    }
+
+    [Theory]
+    [Trait("Spec", "RFC 7518")]
+    [InlineData("None")]
+    [InlineData("NONE")]
+    [InlineData("nOnE")]
+    [InlineData("nonE")]
+    public async Task IdToken_AlgNoneCaseVariants_AreRejected(string alg)
+    {
+        // The bypass for a validator that compares the header against a denylist ordinally: JWS `alg` values
+        // are case-sensitive, so "None" is not the registered "none" and slips past a check spelled that way.
+        // An ALLOWLIST is immune by construction — every one of these is simply not in it — and that immunity
+        // is what this theory pins, since it is the reason the code carries no `alg == "none"` comparison at
+        // all and a reviewer might otherwise "helpfully" add one.
+        var forged = Jws($"{{\"alg\":\"{alg}\",\"typ\":\"JWT\"}}", IdTokenPayload(), signature: string.Empty);
+
+        await AssertIdTokenRejected(forged);
+    }
+
+    [Fact]
+    [Trait("Spec", "RFC 7518")]
+    public async Task IdToken_Rs256PublicKeyReplayedAsHs256Mac_IsRejected()
+    {
+        // Algorithm confusion, the forgery that makes the asymmetric-only allowlist load-bearing. The RSA
+        // public key is published in the JWKS, so the attacker HAS it; declaring HS256 invites the verifier to
+        // treat that public material as an HMAC secret, which the attacker can also compute over. The token
+        // then verifies against the provider's own advertised key. Both spellings of the key material are
+        // tried — the SPKI DER bytes and the modulus, the two an implementation would plausibly hand the HMAC
+        // — because a defence that stops one and not the other is not a defence.
+        var publicKey = _rsa.ExportSubjectPublicKeyInfo();
+        var modulus = _rsa.ExportParameters(false).Modulus!;
+
+        await AssertIdTokenRejected(Hs256(IdTokenPayload(), publicKey));
+        await AssertIdTokenRejected(Hs256(IdTokenPayload(), modulus));
+    }
+
+    [Fact]
+    [Trait("Spec", "OIDC-Core-1.0")]
+    public async Task IdToken_SignatureStripped_IsRejected()
+    {
+        // A genuine, correctly signed token whose signature segment is deleted in transit. The header still
+        // says RS256, so an allowlist check alone passes — what refuses it is that the signature must actually
+        // verify. Covers the gap between "the algorithm is acceptable" and "the token is authentic".
+        var signed = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor());
+        var parts = signed.Split('.');
+        var stripped = parts[0] + "." + parts[1] + ".";
+
+        await AssertIdTokenRejected(stripped);
+    }
+
+    [Fact]
+    [Trait("Spec", "RFC 7515")]
+    public async Task IdToken_ForgedSignature_ClaimingTheTrustedKid_IsRejected()
+    {
+        // The header's `kid` names the key the JWKS advertises, but the token is signed by the attacker's own
+        // RSA key. A `kid` is an unauthenticated routing hint written by whoever composed the token; it
+        // selects which key verifies, and can never itself vouch for a signature. The rejection also maps to
+        // the "invalid_signature" contract, which is what makes OidcClient refresh the JWKS and retry once —
+        // so this asserts a forgery lands on the same benign path a genuine key rotation does, rather than
+        // being distinguishable from it.
+        using var attacker = RSA.Create(2048);
+        var forged = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor(signingKey: attacker));
+
+        var result = await AssertIdTokenRejected(forged);
+        Assert.Equal("invalid_signature", result.Error);
+    }
+
+    [Theory]
+    [Trait("Spec", "RFC 7515")]
+    [InlineData("../../../etc/passwd")]
+    [InlineData("..\\..\\windows\\win.ini")]
+    [InlineData("/dev/null")]
+    [InlineData("\\\\server\\share")]
+    [InlineData("%2e%2e%2f%2e%2e%2f")]
+    [InlineData("key\0injected")]
+    [InlineData("' OR '1'='1")]
+    [InlineData("\"><script>alert(1)</script>")]
+    [InlineData("{\"jku\":\"https://attacker.example/keys\"}")]
+    public async Task IdToken_HostileKidValues_NeverAuthenticate_AndNeverThrow(string kid)
+    {
+        // The `kid` injection class: path traversal, a null byte, quote/SQL and markup metacharacters, and a
+        // nested-JSON smuggling attempt. Each is carried on a token the attacker signed with their own key, so
+        // the ONLY thing that could let it in is the header value being treated as something other than an
+        // opaque lookup hint.
+        //
+        // Two properties, not one. Rejection is the obvious half. The other half is that it must be a clean
+        // error rather than an exception: the id_token validator runs inside the OIDC callback, where a throw
+        // surfaces as a 500 — an attacker-triggerable oracle that distinguishes hostile input from an ordinary
+        // bad signature, and a denial-of-service lever on the login path. Awaiting the call outside any
+        // assertion is what proves it: an exception fails the test on its own.
+        using var attacker = RSA.Create(2048);
+        var descriptor = IdTokenDescriptor(signingKey: attacker);
+        descriptor.SigningCredentials = new SigningCredentials(
+            new RsaSecurityKey(attacker) { KeyId = kid }, SecurityAlgorithms.RsaSha256);
+        var forged = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        await AssertIdTokenRejected(forged);
+    }
+
+    [Theory]
+    [Trait("Spec", "OIDC-Backchannel-Logout-1.0")]
+    [InlineData(ForgeryKind.AlgNone)]
+    [InlineData(ForgeryKind.AlgNoneMixedCase)]
+    [InlineData(ForgeryKind.Hs256WithPublicKey)]
+    [InlineData(ForgeryKind.SignatureStripped)]
+    [InlineData(ForgeryKind.ForeignKeyWithTrustedKid)]
+    [InlineData(ForgeryKind.HostileKid)]
+    public async Task LogoutToken_SameForgeries_AreRejected(ForgeryKind kind)
+    {
+        // The back-channel endpoint is ANONYMOUS — the signature is the only thing authenticating the caller,
+        // and a token accepted here revokes a user's sessions. It shares the id_token's validation basis, and
+        // the whole value of sharing is that the two cannot drift; a shared builder proves that only while
+        // BOTH paths are actually driven through the same attacks. So every forgery above is re-run here
+        // rather than reasoned about.
+        //
+        // The assertion pins the fixed reason code as well as the rejection: these codes are written to the
+        // audit trail and are deliberately request-independent, so a forgery must not be reportable in a way
+        // that distinguishes it from any other invalid token (no subject-identifier oracle).
+        var forged = LogoutForgery(kind);
+
+        var result = await _logoutTokenValidator.ValidateAsync(forged, Params(), Skew, DateTime.UtcNow);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Null(result.Subject);
+        Assert.Null(result.SessionIndex);
+    }
+
+    [Fact]
+    [Trait("Spec", "OIDC-Backchannel-Logout-1.0")]
+    public async Task LogoutToken_GenuinelySigned_Succeeds_ProvingTheForgeryBatteryIsNotVacuous()
+    {
+        // The positive control the battery needs to mean anything. Every test above asserts a rejection, and a
+        // validation path that rejected EVERYTHING — a broken JWKS, a wrong audience constant in the fixture —
+        // would pass all of them while proving nothing about forgeries. One genuinely signed token, built by
+        // the same helpers with the same parameters, has to be accepted for the rejections to carry weight.
+        var genuine = new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor());
+
+        var result = await _logoutTokenValidator.ValidateAsync(genuine, Params(), Skew, DateTime.UtcNow);
+
+        Assert.True(result.IsValid);
+        Assert.Equal("user-1", result.Subject);
+    }
+
+    [Fact]
+    [Trait("Spec", "OIDC-Core-1.0")]
+    public async Task IdToken_GenuinelySigned_Succeeds_ProvingTheForgeryBatteryIsNotVacuous()
+    {
+        // The same positive control for the login path.
+        var genuine = new JsonWebTokenHandler().CreateToken(IdTokenDescriptor());
+
+        var result = await _idTokenValidator.ValidateAsync(genuine, Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+    }
+
+    /// <summary>The forgery shapes replayed against the back-channel logout path.</summary>
+    public enum ForgeryKind
+    {
+        /// <summary>A header declaring <c>alg: none</c> with an empty signature segment.</summary>
+        AlgNone,
+
+        /// <summary>The same, spelled <c>None</c> — the case bypass for an ordinal denylist.</summary>
+        AlgNoneMixedCase,
+
+        /// <summary>An HS256 MAC keyed with the advertised RSA public key (algorithm confusion).</summary>
+        Hs256WithPublicKey,
+
+        /// <summary>A genuinely signed token with its signature segment removed.</summary>
+        SignatureStripped,
+
+        /// <summary>A token signed by a foreign key whose header claims the trusted <c>kid</c>.</summary>
+        ForeignKeyWithTrustedKid,
+
+        /// <summary>A foreign-key signature carrying a path-traversal <c>kid</c>.</summary>
+        HostileKid,
+    }
+
+    // --- helpers ---
+
+    // Drives the id_token validator and asserts the two properties every forgery must have: an error, and no
+    // principal. A validator that "rejected" while still handing back a ClaimsPrincipal would leave the
+    // caller one missed if-check away from logging the attacker in.
+    private async Task<Duende.IdentityModel.OidcClient.Results.IdentityTokenValidationResult> AssertIdTokenRejected(string token)
+    {
+        var result = await _idTokenValidator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError, "The forged token was accepted.");
+        Assert.Null(result.User);
+        return result;
+    }
+
+    // Builds the requested forgery over a valid logout_token payload.
+    private string LogoutForgery(ForgeryKind kind)
+    {
+        switch (kind)
+        {
+            case ForgeryKind.AlgNone:
+                return Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty);
+            case ForgeryKind.AlgNoneMixedCase:
+                return Jws("{\"alg\":\"None\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty);
+            case ForgeryKind.Hs256WithPublicKey:
+                return Hs256(LogoutTokenPayload(), _rsa.ExportSubjectPublicKeyInfo());
+            case ForgeryKind.SignatureStripped:
+                var signed = new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor()).Split('.');
+                return signed[0] + "." + signed[1] + ".";
+            default:
+                using (var attacker = RSA.Create(2048))
+                {
+                    var descriptor = LogoutTokenDescriptor();
+                    descriptor.SigningCredentials = new SigningCredentials(
+                        new RsaSecurityKey(attacker) { KeyId = kind == ForgeryKind.HostileKid ? "../../../etc/passwd" : KeyId },
+                        SecurityAlgorithms.RsaSha256);
+                    return new JsonWebTokenHandler().CreateToken(descriptor);
+                }
+        }
+    }
+
+    // A compact JWS from its three parts, with the header and payload base64url-encoded here rather than by a
+    // token handler — the handler would refuse to emit most of what this file needs to submit.
+    private static string Jws(string headerJson, string payloadJson, string signature) =>
+        Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(headerJson))
+        + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson))
+        + "." + signature;
+
+    // An HS256-signed token over the given payload, MAC'd with the supplied key material — the algorithm-
+    // confusion forgery, where that material is the provider's PUBLIC key.
+    private static string Hs256(string payloadJson, byte[] key)
+    {
+        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes("{\"alg\":\"HS256\",\"typ\":\"JWT\",\"kid\":\"" + KeyId + "\"}"))
+            + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
+        using var hmac = new HMACSHA256(key);
+        var mac = hmac.ComputeHash(Encoding.UTF8.GetBytes(signingInput));
+        return signingInput + "." + Base64UrlEncoder.Encode(mac);
+    }
+
+    // An id_token payload whose every claim is acceptable, so the signature is the only thing left to reject
+    // it on — otherwise a test could pass because of an expired token rather than the forgery under test.
+    private static string IdTokenPayload()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        return "{\"iss\":\"" + Issuer + "\",\"aud\":\"" + ClientId + "\",\"sub\":\"user-1\","
+            + "\"iat\":" + (now - 60) + ",\"nbf\":" + (now - 60) + ",\"exp\":" + (now + 300) + "}";
+    }
+
+    // The logout_token equivalent, carrying the mandatory events member and a sub, so §2.4's own rules cannot
+    // be what rejects it.
+    private static string LogoutTokenPayload()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        return "{\"iss\":\"" + Issuer + "\",\"aud\":\"" + ClientId + "\",\"sub\":\"user-1\","
+            + "\"jti\":\"" + Guid.NewGuid() + "\",\"iat\":" + (now - 60) + ",\"exp\":" + (now + 300) + ","
+            + "\"events\":{\"" + LogoutEvent + "\":{}}}";
+    }
+
+    private SecurityTokenDescriptor IdTokenDescriptor(RSA? signingKey = null)
+    {
+        var now = DateTime.UtcNow;
+        return new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(
+                new RsaSecurityKey(signingKey ?? _rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        };
+    }
+
+    private SecurityTokenDescriptor LogoutTokenDescriptor()
+    {
+        var now = DateTime.UtcNow;
+        return new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = new Dictionary<string, object>
+            {
+                ["sub"] = "user-1",
+                ["jti"] = Guid.NewGuid().ToString(),
+                ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
+            },
+            SigningCredentials = new SigningCredentials(
+                new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        };
+    }
+
+    // The client options carrying this fixture's JWKS — the same shape the login path builds from discovery.
+    private OidcClientOptions Options()
+    {
+        var p = _rsa.ExportParameters(false);
+        var jwks = $$"""
+            {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """;
+        return new OidcClientOptions
+        {
+            ClientId = ClientId,
+            ProviderInformation = new ProviderInformation
+            {
+                IssuerName = Issuer,
+                KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
+            },
+        };
+    }
+
+    // The logout path's parameters, built through the SAME shared basis with the back-channel's
+    // requireExpiration:false posture, so these tests validate exactly what the endpoint validates.
+    private TokenValidationParameters Params() =>
+        OidcSignatureKeys.BuildValidationParameters(Options(), new List<IDisposable>(), requireExpiration: false);
+}

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -22,6 +22,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <see cref="OidcSignatureKeys"/> basis that <c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>
 /// pins as the only one.
 ///
+/// WHAT THIS FILE DRIVES: every row below calls a validator directly with parameters this file builds through
+/// that shared builder. What it therefore establishes is the posture of the BASIS — a caller that mutated the
+/// parameters after the builder returned them, or that reached a validator some other way, would still pass
+/// every row here. One shape is driven end to end through the production path instead, where the endpoint,
+/// the discovery read and the caller's own parameter handling are all live:
+/// <see cref="SSOControllerOidBackChannelLogoutTests.AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/>.
+/// It sits in that class because that is where the endpoint is reachable, and it carries an in-test
+/// acceptance control for the same reason the rows here do.
+///
 /// Every SHAPE the login path submits has a <see cref="ForgeryKind"/> counterpart on the logout path, which is
 /// the parity that matters: the back-channel endpoint is anonymous, so a shape refused only on the login side
 /// would be refused by nothing where it costs most. The parity is per shape, not per row — the login side

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,11 +16,18 @@ using Xunit;
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
-/// The JWT forgery battery (#1004): token shapes an attacker can compose, each asserted to be rejected on
-/// BOTH paths that verify a provider JWT — the login id_token (<see cref="OidcIdTokenValidator"/>) and the
-/// anonymous back-channel <c>logout_token</c> (<see cref="OidcLogoutTokenValidator"/>), which share the one
+/// The JWT forgery battery (#1004): token shapes an attacker can compose against the two paths that verify a
+/// provider JWT — the login id_token (<see cref="OidcIdTokenValidator"/>) and the anonymous back-channel
+/// <c>logout_token</c> (<see cref="OidcLogoutTokenValidator"/>), which share the one
 /// <see cref="OidcSignatureKeys"/> basis that <c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>
 /// pins as the only one.
+///
+/// Every SHAPE the login path submits has a <see cref="ForgeryKind"/> counterpart on the logout path, which is
+/// the parity that matters: the back-channel endpoint is anonymous, so a shape refused only on the login side
+/// would be refused by nothing where it costs most. The parity is per shape, not per row — the login side
+/// additionally fans each shape out over its spellings (four <c>alg</c> casings, two key encodings, nine
+/// hostile <c>kid</c> values), and those fan-outs are not repeated here, because what they vary is how the
+/// header is written and both paths hand the same header to the same handler through the same basis.
 ///
 /// Tokens are assembled BY HAND rather than through <see cref="JsonWebTokenHandler"/> wherever the shape
 /// requires it: the handler is a well-behaved issuer and will not emit an <c>alg</c> the JWS spec forbids, a
@@ -241,24 +249,38 @@ public sealed class OidcTokenForgeryTests : IDisposable
     [InlineData(ForgeryKind.Hs256WithPublicKey)]
     [InlineData(ForgeryKind.SignatureStripped)]
     [InlineData(ForgeryKind.ForeignKeyWithTrustedKid)]
-    [InlineData(ForgeryKind.HostileKid)]
+    [InlineData(ForgeryKind.ForeignKeyWithTraversalKid)]
+    [InlineData(ForgeryKind.HeaderSuppliedKeyMaterial)]
     public async Task LogoutToken_SameForgeries_AreRejected(ForgeryKind kind)
     {
         // The back-channel endpoint is ANONYMOUS — the signature is the only thing authenticating the caller,
         // and a token accepted here revokes a user's sessions. It shares the id_token's validation basis, and
         // a shared builder proves the two cannot drift only while BOTH paths are actually driven through the
-        // same attacks, so every forgery above is re-run here rather than reasoned about.
+        // same attacks, so every SHAPE above is re-run here rather than reasoned about (the class doc says
+        // which spellings of each are not, and why).
         //
-        // The reason code is pinned as the current contract, not as a claim that one code is the right
-        // answer: all six shapes report the same code, so the audit trail cannot tell alg-none from a
-        // stripped signature. Token shape carries no subject identifier, so the "no subject-identifier
-        // oracle" rationale does not by itself justify collapsing them — separating the codes is #1039.
+        // What the reason code is asserted to be is the LAYER the refusal came from, not one fixed string.
+        // Every shape here must die in signature/lifetime validation, before any logout_token claim-shape
+        // check runs — that is the security property, and it is what the codes below would contradict.
+        // Today all of them report one code, which is why an operator cannot tell alg-none from a stripped
+        // signature (separating them is #1039); pinning that one string as well would make that separation
+        // arrive as a red test in this file, which is not a claim this test is entitled to make.
+        var pastSignatureValidation = new[]
+        {
+            OidcLogoutTokenValidator.RejectReason.NotALogoutToken,
+            OidcLogoutTokenValidator.RejectReason.ProhibitedNonce,
+            OidcLogoutTokenValidator.RejectReason.NoSubjectOrSid,
+            OidcLogoutTokenValidator.RejectReason.Replay,
+        };
         var forged = LogoutForgery(kind);
 
         var result = await _logoutTokenValidator.ValidateAsync(forged, Params(), Skew, DateTime.UtcNow);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.False(string.IsNullOrEmpty(result.ReasonCode), "A rejection must carry a reason code — it is the only thing the audit trail records.");
+        Assert.False(
+            pastSignatureValidation.Contains(result.ReasonCode, StringComparer.Ordinal),
+            $"The forgery was refused as '{result.ReasonCode}', a code only reachable once signature validation has already PASSED.");
         Assert.Null(result.Subject);
         Assert.Null(result.SessionIndex);
     }
@@ -310,8 +332,25 @@ public sealed class OidcTokenForgeryTests : IDisposable
         /// <summary>A token signed by a foreign key whose header claims the trusted <c>kid</c>.</summary>
         ForeignKeyWithTrustedKid,
 
-        /// <summary>A foreign-key signature carrying a path-traversal <c>kid</c>.</summary>
-        HostileKid,
+        /// <summary>
+        /// The same foreign-key forgery under a path-traversal <c>kid</c>. It differs from
+        /// <see cref="ForeignKeyWithTrustedKid"/> only in that string, and both die on the signature, so this
+        /// row does NOT show that the <c>kid</c> decides nothing — there is no acceptance control on this path
+        /// to show it against, and <see cref="HostileKidValues_DecideNothing_AndNeverThrow"/> is where that
+        /// property is established, differentially, on the login path. What this row holds is narrower and
+        /// still worth the line: a traversal <c>kid</c> at the ANONYMOUS endpoint is REFUSED, not thrown on.
+        /// A throw there is an unauthenticated 500 — an oracle separating hostile input from an ordinary bad
+        /// signature, and a denial-of-service lever — and it is exactly what a <c>kid</c> sanitiser added
+        /// later would produce.
+        /// </summary>
+        ForeignKeyWithTraversalKid,
+
+        /// <summary>
+        /// A foreign-key signature whose header hands that same key over in <c>jku</c>, <c>x5u</c> and
+        /// <c>x5c</c>. The shape that matters most here: a verifier consulting header-supplied key material
+        /// would accept it, and on this endpoint the signature is the only thing authenticating the caller.
+        /// </summary>
+        HeaderSuppliedKeyMaterial,
     }
 
     // --- helpers ---
@@ -329,8 +368,8 @@ public sealed class OidcTokenForgeryTests : IDisposable
     }
 
     // Builds the requested forgery over a valid logout_token payload. A switch EXPRESSION with a throwing
-    // default: a seventh ForgeryKind added without a case here fails loudly instead of being silently tested
-    // as whichever shape a catch-all arm happened to build.
+    // default: a new ForgeryKind added without a case here fails loudly instead of being silently tested as
+    // whichever shape a catch-all arm happened to build.
     private string LogoutForgery(ForgeryKind kind) => kind switch
     {
         ForgeryKind.AlgNone => Jws("{\"alg\":\"none\",\"typ\":\"JWT\"}", LogoutTokenPayload(), signature: string.Empty),
@@ -338,7 +377,8 @@ public sealed class OidcTokenForgeryTests : IDisposable
         ForgeryKind.Hs256WithPublicKey => Hs256(LogoutTokenPayload(), _rsa.ExportSubjectPublicKeyInfo(), KeyId),
         ForgeryKind.SignatureStripped => StripSignature(new JsonWebTokenHandler().CreateToken(LogoutTokenDescriptor())),
         ForgeryKind.ForeignKeyWithTrustedKid => ForeignKeySignedLogoutToken(KeyId),
-        ForgeryKind.HostileKid => ForeignKeySignedLogoutToken("../../../etc/passwd"),
+        ForgeryKind.ForeignKeyWithTraversalKid => ForeignKeySignedLogoutToken("../../../etc/passwd"),
+        ForgeryKind.HeaderSuppliedKeyMaterial => HeaderInjectedLogoutToken(),
         _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "No forgery is defined for this kind."),
     };
 
@@ -346,6 +386,12 @@ public sealed class OidcTokenForgeryTests : IDisposable
     {
         using var attacker = RSA.Create(2048);
         return SignedWith(LogoutTokenDescriptor(), attacker, kid);
+    }
+
+    private static string HeaderInjectedLogoutToken()
+    {
+        using var attacker = RSA.Create(2048);
+        return HeaderInjected(LogoutTokenPayload(), attacker);
     }
 
     private static string SignedWith(SecurityTokenDescriptor descriptor, RSA key, string kid)

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -32,9 +32,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// It sits in that class because that is where the endpoint is reachable, and it carries an in-test
 /// acceptance control for the same reason this file keeps positive controls at all.
 ///
-/// Every SHAPE the login path submits has a <see cref="ForgeryKind"/> counterpart on the logout path, which is
-/// the parity that matters: the back-channel endpoint is anonymous, so a shape refused only on the login side
-/// would be refused by nothing where it costs most. The parity is per shape, not per row — the login side
+/// Every SHAPE the login path submits has a <see cref="ForgeryKind"/> counterpart on the logout path but one:
+/// <see cref="AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify"/> has no logout row. The
+/// parity is what matters — the back-channel endpoint is anonymous, so a shape refused only on the login side
+/// would be refused by nothing where it costs most. It is per shape, not per row: the login side
 /// additionally fans each shape out over its spellings (four <c>alg</c> casings, two key encodings, nine
 /// hostile <c>kid</c> values), and those fan-outs are not repeated here, because what they vary is how the
 /// header is written and both paths hand the same header to the same handler through the same basis.

--- a/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenForgeryTests.cs
@@ -22,14 +22,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <see cref="OidcSignatureKeys"/> basis that <c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>
 /// pins as the only one.
 ///
-/// WHAT THIS FILE DRIVES: every row below calls a validator directly with parameters this file builds through
-/// that shared builder. What it therefore establishes is the posture of the BASIS — a caller that mutated the
-/// parameters after the builder returned them, or that reached a validator some other way, would still pass
-/// every row here. One shape is driven end to end through the production path instead, where the endpoint,
-/// the discovery read and the caller's own parameter handling are all live:
+/// WHAT THIS FILE DRIVES: every row below submits its token in-process against parameters this file built
+/// through that shared builder — through one of the two validators, and in the allowlist row through the token
+/// handler directly. What that establishes is the posture of the BASIS: a caller that mutated the parameters
+/// after the builder returned them, or that reached a validator some other way, would still pass every row
+/// here. One shape is driven end to end through the production path instead, where the endpoint, the
+/// discovery read and the caller's own parameter handling are all live:
 /// <see cref="SSOControllerOidBackChannelLogoutTests.AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes"/>.
 /// It sits in that class because that is where the endpoint is reachable, and it carries an in-test
-/// acceptance control for the same reason the rows here do.
+/// acceptance control for the same reason this file keeps positive controls at all.
 ///
 /// Every SHAPE the login path submits has a <see cref="ForgeryKind"/> counterpart on the logout path, which is
 /// the parity that matters: the back-channel endpoint is anonymous, so a shape refused only on the login side

--- a/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
@@ -18,6 +18,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// allow-list and threads that list in here, so the privilege derivation must consume the roles it is
 /// PASSED rather than re-reading the assertion — the property the dedup relies on.
 /// </summary>
+// Clears the process-wide SAML assertion replay cache; serialized so that a class running in parallel cannot
+// empty it while the one-time-use assertions here are mid-run (#1004).
 [Collection("SSOController")]
 public class SamlAssertionValidatorTests
 {

--- a/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAssertionValidatorTests.cs
@@ -18,6 +18,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// allow-list and threads that list in here, so the privilege derivation must consume the roles it is
 /// PASSED rather than re-reading the assertion — the property the dedup relies on.
 /// </summary>
+[Collection("SSOController")]
 public class SamlAssertionValidatorTests
 {
     private static SamlResponse SignedResponse(string role)

--- a/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
@@ -14,6 +14,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// returns a FIXED reason code per fail-closed branch. The reason codes are what the audit trail records;
 /// the endpoint collapses them all to one uniform 400.
 /// </summary>
+// Clears the process-wide inbound-LogoutRequest replay cache; serialized so that a class running in parallel
+// cannot empty it while the one-time-use assertions here are mid-run (#1004).
 [Collection("SSOController")]
 public class SamlLogoutValidatorTests : IDisposable
 {

--- a/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutValidatorTests.cs
@@ -14,6 +14,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// returns a FIXED reason code per fail-closed branch. The reason codes are what the audit trail records;
 /// the endpoint collapses them all to one uniform 400.
 /// </summary>
+[Collection("SSOController")]
 public class SamlLogoutValidatorTests : IDisposable
 {
     public SamlLogoutValidatorTests() => SamlLogoutValidator.ResetReplaysForTests();

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -17,10 +17,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// §2.4–§2.6, #962). The endpoint that calls this is ANONYMOUS — the token's signature is the only
 /// authenticator — so every §2.6 rule is fail-closed and each maps to a fixed reason code (never
 /// request-derived text, so a rejection leaves an audit trail without a subject-identifier oracle,
-/// mirroring the SAML inbound-logout validator). Signature/JWKS/algorithm verification goes through the
-/// SAME <see cref="OidcSignatureKeys"/> basis the id_token validator uses — there is no second, laxer
-/// verification path. On success it yields the (sub, sid) pair the revocation lookup keys on; the
-/// validator itself revokes nothing.
+/// mirroring the SAML inbound-logout validator). Signature/JWKS/algorithm verification runs on the
+/// parameters the CALLER passes in, and the one production caller builds them from the same
+/// <see cref="OidcSignatureKeys"/> basis the id_token validator uses — which puts that caller inside this
+/// signature trust boundary rather than outside it. On success it yields the (sub, sid) pair the revocation
+/// lookup keys on; the validator itself revokes nothing.
 /// </summary>
 internal sealed class OidcLogoutTokenValidator
 {

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -21,15 +21,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 ///
 /// That is a property of the code as it stands, held by a conformance rule
 /// (<c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>), by the forgery battery and by review —
-/// not a proof that no second path can exist. The rule is a source scan over FILES, and FOUR shapes are
-/// measured to pass it: a second parameter set built inside this file or its sibling validator; a path that
-/// verifies a JWS without the token library at all; a CALLER that mutates what this builder returns before
-/// using it (a scan cannot follow a returned value, and the back-channel caller holds it in a <c>var</c>);
-/// and the deletion of a field from the builder below — the rule pins what
-/// <see cref="AllowedSignatureAlgorithms"/> CONTAINS, never that it is assigned to <c>ValidAlgorithms</c>.
-/// The last two are held by one named forgery test each instead. That rule's own doc comment enumerates all
-/// four with the measurement behind them; this sentence is not a stronger guarantee than the one over there
-/// (#1004).
+/// not a proof that no second path can exist, since a rule that scans source files decides nothing about what
+/// a caller does with these parameters afterwards or about a verifier written without the token library
+/// (#1004). What has actually been measured to slip past it is recorded on #1050, not enumerated here.
 /// </summary>
 internal static class OidcSignatureKeys
 {

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -20,11 +20,16 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// the other rejects, because both read this one basis.
 ///
 /// That is a property of the code as it stands, held by a conformance rule
-/// (<c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>) and by review — not a proof that no
-/// second path can exist. The rule is a source scan over FILES: it does not see a second parameter set built
-/// inside this file or its sibling validator, and it sees nothing at all in a path that verifies a JWS
-/// without the token library. That rule's own doc comment states the limit; this sentence is not a stronger
-/// guarantee than the one over there (#1004).
+/// (<c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>), by the forgery battery and by review —
+/// not a proof that no second path can exist. The rule is a source scan over FILES, and FOUR shapes are
+/// measured to pass it: a second parameter set built inside this file or its sibling validator; a path that
+/// verifies a JWS without the token library at all; a CALLER that mutates what this builder returns before
+/// using it (a scan cannot follow a returned value, and the back-channel caller holds it in a <c>var</c>);
+/// and the deletion of a field from the builder below — the rule pins what
+/// <see cref="AllowedSignatureAlgorithms"/> CONTAINS, never that it is assigned to <c>ValidAlgorithms</c>.
+/// The last two are held by one named forgery test each instead. That rule's own doc comment enumerates all
+/// four with the measurement behind them; this sentence is not a stronger guarantee than the one over there
+/// (#1004).
 /// </summary>
 internal static class OidcSignatureKeys
 {

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -15,9 +15,16 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// The ONE OpenID signature-validation basis, shared by every token the plugin verifies against a
 /// provider's discovery JWKS — the id_token (<see cref="OidcIdTokenValidator"/>) and the back-channel
 /// <c>logout_token</c> (<see cref="OidcLogoutTokenValidator"/>, #962). Centralising the asymmetric-only
-/// algorithm allowlist and the JWK→<see cref="SecurityKey"/> conversion here means there is provably no
-/// second, laxer verification path: a token type cannot accidentally accept HS*, <c>none</c>, an
-/// under-strength key, or malformed key material that the other type rejects.
+/// algorithm allowlist and the JWK→<see cref="SecurityKey"/> conversion here is what keeps the two token
+/// types from drifting apart: neither can accept an HS*, <c>none</c>, under-strength or malformed key that
+/// the other rejects, because both read this one basis.
+///
+/// That is a property of the code as it stands, held by a conformance rule
+/// (<c>OidcTokenValidation_UsesTheSingleHardenedParameterBuilder</c>) and by review — not a proof that no
+/// second path can exist. The rule is a source scan over FILES: it does not see a second parameter set built
+/// inside this file or its sibling validator, and it sees nothing at all in a path that verifies a JWS
+/// without the token library. That rule's own doc comment states the limit; this sentence is not a stronger
+/// guarantee than the one over there (#1004).
 /// </summary>
 internal static class OidcSignatureKeys
 {


### PR DESCRIPTION
Closes #1004 (partially, the `kid` allowlist bullet is tracked separately as #1029).

It pins the OpenID JWT validation posture the plugin already has: one hardened `TokenValidationParameters` basis for both provider tokens, an asymmetric-only algorithm allowlist, `kid` treated as an unauthenticated hint, and the id_token never leaving as a credential.

**No longer strictly test-only.** Two production files changed, by 21 lines (14 added, 7 removed), all of them class doc comments, see "The claim I had to weaken in production" below, and round 4's item 4. No behaviour changed anywhere.

## What round 4 changed about this PR

Round 4 returned NEEDS_IMPROVEMENT with four measurably false claims, all of them in prose and none in shipped behaviour: the guards are live, three probes confirmed them load-bearing, 4,412 tests pass on both TFMs. That is now the fourth round in a row whose findings are about the written map rather than the territory, and the third of them about the same paragraph.

So the rule changes, not the paragraph. **A guard's doc comment states what it CHECKS. It does not enumerate what it misses.** A gap list claims completeness over the space of evasions, the same unbounded-enumeration defect that makes a text scanner lose to a reviewer, run in reverse. It was wrong with two entries, rewritten, and wrong again with four; the next revision would be wrong at five, not through carelessness but because the claim's shape cannot be true. The full reasoning and the four measured gaps are #1050, where they are dated, attributable to the round that found them, and closable.

**1. The lettered enumeration is gone**, from the conformance rule and from `OidcSignatureKeys` alike, replaced in each file by one sentence in that file's own voice: a source scan cannot follow a value after it is returned, nor see a verifier written without the token library; review owns the rest, and what has actually been measured to slip past is on #1050. What stays is what each guard checks, and the three positive claims were re-established by execution this round (M6–M8), not carried over on trust.

**2. The CA5404 sentence went with it, because it was false as written.** It licensed leaving audience/issuer/lifetime disablement untested, on the claim that the analyzer "fails the build wherever it is written". Measured (M1–M4): CA5404 fires on a **literal** false, the post-build `parameters.ValidateAudience = false;` at the back-channel call site is three CA5404 errors, so the round-4 counter-example does not reproduce in that form, but the same property assigned a non-constant false builds clean with zero warnings. The universal quantifier was the false part, and no weaker version of the sentence is worth shipping.

**3. The parallelism rationale is corrected to the mechanism that exists.** The threat model said xUnit runs an un-attributed class in parallel with the serialized collection. It does not. Reproduced here on the identical stack (M5): two classes outside the collection overlap each other on every run, two inside it never overlap, and the collection never overlapped the outside pair. The rule was right for the wrong reason, the race it closes is un-attributed against un-attributed, and a rationale a future author will trust has to be the real one.

**4. Three further claims narrowed.** The `logout_token` validator still carried verbatim the "no second, laxer verification path" absolute that round 3 weakened one file over, on the anonymous endpoint, where it is least defensible; it takes caller-supplied parameters, so what holds is that its one production caller builds them from the shared basis. The battery's per-shape login↔logout parity claim now names its one exception, the allowlist row (I declined this in round 3; three lenses independently disagreed and they are right, the exemption I wrote covers spelling fan-outs, and that row is a shape). And the construction predicate no longer claims both spellings C# offers: it reads one line, and a construction wrapped across two is neither.

### Measurements run this round

Every sentence rewritten below was measured first. All mutations ran in a **throwaway clone of the branch**, never in the work tree, so `git status --porcelain` was empty throughout and there is no revert to trust.

| #   | Measurement                                                                                                | Result                                                          | What it establishes                                                              |
| --- | ---------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| M1  | `parameters.ValidateAudience / ValidateIssuer / ValidateLifetime = false` after the builder call at the back-channel call site | **3 × CA5404 errors**                                             | CA5404 does reach a post-build literal; that half of the sentence was sound        |
| M2  | the same property assigned a non-constant false (`bool.Parse("false")`)                                    | builds clean, **0 warnings**                                      | CA5404 is literal-only, "wherever it is written" is the false part                |
| M3  | `RequireSignedTokens = false` in the builder                                                               | builds clean, **0 warnings**                                      | the analyzer never licensed leaving the signature disablements untested            |
| M4  | delete `ValidAlgorithms = AllowedSignatureAlgorithms` from the builder                                     | builds clean, **0 warnings**                                      | same, for algorithm confusion                                                      |
| M5  | isolated probe, `xunit.v3.mtp-v2` 3.2.2 / net10.0 / defaults: one `DisableParallelization` collection with two classes in it, two classes outside; five runs | outside pair overlaps **every run**; the two inside never overlap, and neither overlapped the outside pair | the documented mechanism was false; the race is un-attributed ⟷ un-attributed      |
| M6  | a NEW file with `new TokenValidationParameters { … }`                                                      | rule **RED**, message naming the file                             | term 1 still bites                                                                 |
| M7  | a NEW file with `TokenValidationParameters p = new();`                                                     | rule **RED**                                                      | the target-typed spelling still bites                                              |
| M8  | a NEW file passing a bare `new() { … }` straight into `ValidateTokenAsync`                                 | rule **RED**                                                      | term 3 still bites                                                                 |

### Round-4 dispositions

| Dim   | Finding                                                                                          | Disposition                                                                                                                                                                                     |
| ----- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1, 9  | The CA5404 coverage claim is false (CONFIRMED)                                                     | **FIXED by removal**, with M1–M4 behind it. It went out with the enumeration it licensed rather than being rewritten smaller                                                                       |
| 2, 23 | The threat model contradicts `DisableParallelization` (CONFIRMED by reproduction)                  | **FIXED by correction**, re-reproduced here as M5. Doc comment and failure message both now state the un-attributed ⟷ un-attributed race                                                            |
| 2, 13 | The rule is file-scoped while its contract reads per class, and multi-type files exist here        | **FIXED by weakening.** The doc says per FILE, and that a file declaring two types is one unit to the scan. Moving the scan to class scope would be a new guard, so it is not in this round         |
| 2     | `ConstructsValidationParameters` misses the multi-line target-typed spelling its own comment claims | **FIXED by weakening the comment.** No fourth scanning term, the predicate reads one line and now says only that                                                                                  |
| 2     | Two unfalsifiable assertions                                                                       | **NOT ACTIONED.** The adjudication does not name them and the per-lens blocks are not in the record I hold. Strengthening an assertion is outside this round's remit either way; it carries forward |
| 3     | The login↔logout per-shape parity claim is false for the allowlist row (three lenses)              | **FIXED by weakening**, reversing my round-3 decline. The exemption I wrote covers spelling fan-outs; that row is a shape, so the exception is named                                               |
| 4     | The deliverable is a guard set plus its written map, and the map overstates the guard set          | **FIXED**, that is what this round is, end to end                                                                                                                                                |
| 7     | 1,069 lines against the ~400 target; splits into three units                                       | **PARTLY.** The prose removal takes it to 1,042. The one remaining lever is dropping the `OidcRoundTrip` trio, which removes coverage round 4 credits under dim 16, so it stays and the size decision stands recorded below |
| 8     | ~30 RSA keygens on the serial collection; two serialized classes clear different caches            | **DECLINED.** Re-measured: 21.9 s / 23.4 s for 4,412 tests. The membership is required by the rule, so removing it would red the build                                                             |
| 10    | Two-sided exact-equality pins turn a benign rename into a hard build stop (PLAUSIBLE)              | **DECLINED, already documented.** Round 3 rewrote both failure messages to say which direction they differ in and that a missing file is a rename, not a bypass                                     |
| 11    | The stated ctor/dispose invariant is false for `SamlAssertionValidatorTests`                       | **FIXED by weakening.** It clears inside three `[Fact]` bodies and declares neither, so the doc says clears "around its own tests"                                                                 |
| 11    | The liveness floor sits at exactly the current count, with zero headroom                           | **DECLINED, that is the design.** The floor exists to red on a rename that would otherwise read as compliance; headroom would blunt exactly that                                                  |
| 11    | Bare method-name substrings scanned tree-wide                                                      | **STATED, not changed.** The doc now says what the scan reads: code lines, one file at a time                                                                                                     |
| 13    | The logout theory's oracle is a four-element denylist                                              | **DECLINED, as in round 3.** It is the spec-derived partition of codes reachable only after signature validation; #1039 rewrites it when it separates the codes                                     |
| 14    | The weakening applied in `OidcSignatureKeys` survives verbatim in `OidcLogoutTokenValidator`        | **FIXED by weakening**, in that file's own terms, it validates on parameters the caller passes in                                                                                                 |
| 6     | `CVE-2026-42206`, cited in a comment, was not verifiable from the review environment               | **VERIFIED and kept.** The record is an OIDC nonce generated on the authorization request and never validated on the callback (CWE-345, ID-token replay), the shape the comment names             |
| 5, 12, 15–22, 24, 25 | PASS or n/a                                                                       | No action                                                                                                                                                                                         |

## What round 3 changed about this PR

Round 3 returned NEEDS_IMPROVEMENT with three CONFIRMED findings, all of them in the assurance artifact rather than in the shipped posture: no mutation any lens ran made a forged token validate. Three rounds is where a deliverable goes back to planning by default. **I overrode that, and recorded the override on #1004 rather than leaving it implicit**, because the reviewer's own adjudication put the remaining work at three bounded items and two of them are corrections of a claim, subtraction, not the growth the rule exists to stop. The override covers exactly those three. Anything that turned out to need more than it looked would have been the signal the override was wrong; none of them did.

**1. One forgery now crosses the production endpoint.** Every row of the battery hands a validator parameters the test built through the shared builder, so what it establishes is what the token library refuses under that basis, not what the endpoint refuses. `AlgNoneForgery_IsRefusedByTheProductionPath_WhileTheGenuineTokenStillRevokes` submits an unsigned `logout_token` to the anonymous back-channel endpoint against in-process discovery and JWKS, and the genuine token goes through the same harness afterwards and must still be accepted, without that control the rejection would prove nothing, since an unserved discovery document or a misspelled provider produces the identical uniform 400. `alg: none` is the pick because it is the one shape needing no key material at all: anyone who can reach that URL can mint it. It lives beside the endpoint's other tests, where the harness and responder already exist, rather than as a fifth near-copy of the discovery responder inside the battery; both class docs say which file holds which claim.

**2. The gap enumeration was wrong by one, and is now four.** The rule's doc comment shipped an explicitly measured, closed list of what the three scan terms miss, and it omitted the cheapest evasion of the lot. Both doc comments now enumerate four shapes, each verified by making the edit and running the rule over it. The two new ones are (c) post-build mutation of what the builder returns, and (d) the allowlist's wiring as against its content, enumerated separately because (d) is not an evasion at all but a limit on what the rule asserts about a file it does read. **No fourth scanning term was added**, which is the whole point: what changed is the claim, and each of (c) and (d) now names the one test that does notice it, so deleting that test reads as the larger change it is.

**3. The replay-cache collection membership is held by the build.** The four `[Collection("SSOController")]` attributes were hand-applied; the existing rule keys on `new SsoControllerHarness` and sees nothing else. `EveryTestClassClearingAReplayCache_IsInTheNonParallelControllerCollection` closes that one door: a test class whose own code lines call a `ResetReplaysForTests` hook carries the attribute, or the build is red naming the file. Code lines only, `[Fact]`/`[Theory]` required, its own liveness floor. Deriving the whole door set and closing the base-class route stays #1044, and the doc comment says so instead of implying a reach the scan has not got; #1044 is updated with what this now covers.

### Weakenings run this round

Five. Each applied, **proved landed by printing the patched region**, built with `--warnaserror`, run, reverted, with `git status --porcelain` asserted empty on both sides, the discipline exists because a weakening that silently fails to apply comes back green and is indistinguishable from a caught mutant, which happened on this branch in round 2.

| #   | Weakening                                                                                                       | Result                                                                                                                                          | What it establishes                                                                          |
| --- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| W9  | `parameters.RequireSignedTokens = false;` inserted after the builder call in `OidcLoginService.ValidateBackChannelLogoutAsync` | rule **GREEN**, build **0 warnings**; `AlgNoneForgery_…` **RED** - the unsigned forgery was accepted, returning 200 and revoking a session | Gap (c) is real, and the new endpoint row is the one thing that notices it                     |
| W10 | Delete `ValidAlgorithms = AllowedSignatureAlgorithms` from the builder                                          | rule **GREEN**, build clean; `AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify` **RED**; `AlgNoneForgery_…` still green      | Gap (d) is real and is a different miss from (c) - the endpoint row does not cover it          |
| W11 | Hoist `OidcIdTokenValidator`'s inlined builder call into an explicitly typed local                              | term 2 **RED** with the new message; terms 1 and 3 unaffected                                                                                    | The naming-list exclusion behaves as documented, and the message now names this benign case    |
| W12 | Strip `[Collection("SSOController")]` from `SamlLogoutValidatorTests`                                           | new rule **RED** - "Missing in: SamlLogoutValidatorTests.cs"                                                                                     | The ratchet catches the shape it exists for                                                    |
| W13 | Rename `ResetReplaysForTests` → `ClearReplaysForTests` across all 9 files                                       | liveness floor **RED**, "matched only 0 test classes"                                                                                           | The scan cannot go blind and read as compliance                                                |

W9 and W10 are the measurements behind the two new enumeration items; they are quoted in the doc comment with their outcomes rather than described.

### Round-3 dispositions

| Dim   | Finding                                                                                      | Disposition                                                                                                                                                                                                                                                                                                                                                    |
| ----- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1     | The three terms are blind to post-build mutation, and that shape exists at the back-channel caller (CONFIRMED ×3 lenses) | **FIXED by weakening.** Enumerated as (c) in both doc comments with W9's outcome. No fourth term. The structural closure, validators that derive their basis instead of accepting one, is **DEFERRED → #1049**                                                                                                                                              |
| 2     | Deleting `ValidAlgorithms` from the builder leaves the rule green (CONFIRMED)                 | **FIXED by weakening.** Enumerated as (d), separately from (c), because it is a limit on what the rule asserts rather than an evasion of what it scans. W10 names the test that does notice                                                                                                                                                                    |
| 2     | `QueryValue` returns `""` for absent, empty and valueless alike (PLAUSIBLE)                   | **DECLINED.** The assertion's stated regression is a nonce **value** attached to the authorize URL, and any real nonce is non-empty by construction, so it still reds on the shape the comment names. Distinguishing the three states would not change a verdict                                                                                               |
| 2     | The logout theory's oracle is a hand-copied negative list of reason codes (PLAUSIBLE)         | **DECLINED, with the expiry named.** The list is the codes reachable only after signature validation has passed, a spec-derived partition, not an enumeration of the enum. #1039 separates those codes and rewrites this assertion with them; until then a new post-signature code is a two-line edit in the same file the code is added from                    |
| 3     | No forgery crosses the production endpoint (CONFIRMED)                                       | **FIXED**, see item 1 above                                                                                                                                                                                                                                                                                                                                   |
| 3     | `AlgorithmAllowlist_…` has no `ForgeryKind` counterpart, contradicting the parity claim       | **DECLINED.** The claim is scoped to shapes the login path **submits**, and that test submits nothing through either validator: it drives the handler directly against a symmetric key placed into the key set by hand, because today's JWK conversion never yields one. There is no shape for a counterpart to mirror                                            |
| 4     | Four `[Collection]` additions with no comment and no `#1004` annotation                       | **FIXED.** One line on each saying which cache the class clears and why the collection is load-bearing, and the new rule now requires the attribute, so they are no longer four hand-applied lines                                                                                                                                                            |
| 7     | Term 2's `SequenceEqual` forbids a file the rule blesses from naming the type                 | **JUDGED INTENDED, and now said so.** Keeping the list to exactly the files that name the type is what stops it passing vacuously; the cost is that a behaviour-preserving hoist reds it, and W11 measures that it reds that one assertion only. Both the comment and the failure message now name this case and say the repair gives up nothing, since construction stays pinned by the assertion above |
| 11    | The logout validator accepts caller-supplied parameters; `AllowedSignatureAlgorithms` is a mutable shared array | **DEFERRED → #1049.** Both are the same theme as (c): the hardened basis is mutable once it leaves the builder. The fix changes production signatures on the sensitive OIDC surface, which is not what an override scoped to correcting claims should carry                                                                                                     |
| 13    | The ratchet gap                                                                              | **FIXED**, see item 3 above, measured by W12 and W13                                                                                                                                                                                                                                                                                                          |
| 13    | `RedeemResponse_…`'s seven hand-enumerated fields behind an "every field" claim               | **FIXED.** Same defect class as the enumeration: the comment now says the scan covers the string-carrying fields, listed one by one, and that a field arriving in a Jellyfin update is inspected only once someone adds it there. One comment, beyond the three items, recorded here rather than folded in quietly                                               |
| 13    | `HostileKidValues_…` pins the permissive key-fallback posture as the green state              | **DECLINED, already declared.** The acceptance half is documented as flipping deliberately when the `kid` allowlist (#1029) lands - that is the point of it: the posture change must be a conscious edit, not a silent drift                                                                                                                                    |
| 14    | The replacement doc comment ships an explicitly "measured", closed gap list that is wrong by one | **FIXED**, see item 2 above                                                                                                                                                                                                                                                                                                                                   |
| 19    | Two failure messages misdescribe the defect they fire on                                      | **FIXED.** Both set comparisons are two-sided; each message now says which direction it differs in, what that means, and what the repair is - an extra file is the finding, a missing one is a rename                                                                                                                                                            |
| 23    | The `[Collection]` set is hand-applied; nothing keeps it complete                             | **FIXED**, see item 3 above. The general door-set derivation and the base-class route stay #1044, which is updated with what this rule now covers                                                                                                                                                                                                             |
| 5, 6, 8, 10, 12, 15–18, 20–22, 24, 25 | PASS or n/a                                                                    | No action. Dim 6's absent shapes were already deferred to #1047 and #1038 in round 2                                                                                                                                                                                                                                                                           |

## What round 2 changed about this PR

The gate's central finding was that **both guards this PR adds fail to enforce what their own doc comments and failure messages claim**, proved by execution. Two shapes evade all three terms of the parameter-builder rule with output identical to a clean run: a hand-rolled verifier that never touches the token library, and a second, laxer parameter set built inside a file already on the rule's own lists. The comment said evading all three "would take reflection".

The remedy is to weaken the claim to what is held, not to add a fourth term. A text scanner enumerates spellings over an unbounded space, so a fourth term moves the next evasion one identifier away rather than closing it, and this PR is exactly the fix-loop that rule would start. So: **no new scanning term, no new literal, no new guard code.** The doc comment now states what the three terms catch, what they do not, and names review as the control that owns the remainder.

### A unit left the PR

Round 2 measured the diff at 750 changed lines against the ~400 target and observed that it divides into four units. I took one out rather than argue for it.

**Removed: the test-parallelism rule widening → #1044.** Widening `EveryHarnessUsingTestClass_…` to the `*ForTests()` reset hooks fixes a defect that predates this work and belongs to none of #1004's acceptance criteria. It also arrived carrying three findings of its own, a third scanned literal instead of a derived door set, no `<summary>` threat model while the rule added beside it has one, and two demonstrated escapes (a test base class; a comment-only match). #1044 carries all of that as its contract, including the measured detail that the wiki already forbids test base classes with nothing enforcing it.

What stayed is the collection membership **this branch's own new class needs**: `OidcTokenForgeryTests` and `OidcLogoutTokenValidatorTests` both call `OidcLogoutTokenValidator.ResetReplaysForTests()`, so leaving either out re-opens a race this PR creates. The two SAML classes' membership stayed too, it is correct and it is two lines; deliberately re-opening a real race to purify the scope would be the rule taken past sense. Making it *enforced* is #1044's job.

**Nothing else honestly leaves.** Each remaining file maps to a named #1004 bullet: the parameter-builder rule is acceptance criterion 1 verbatim; the forgery battery is the deliverable; the round-trip additions are the id_token-never-a-session-token, redirect-URI and nonce criteria; the id-token validator additions are the claim-validation negatives.

## The claim I had to weaken in production

While probing the rule I found the same defect one file over. `OidcSignatureKeys`' class doc said centralising the allowlist and key conversion "means there is **provably** no second, laxer verification path". W3 and W4 below refute the word. What is true is narrower, and is what it says now: both token types read this one basis, so neither can accept key material the other rejects, a property of the code as it stands, held by a conformance rule and by review, not a proof that no second path can exist. It now points at that rule's own statement of its limit instead of promising more.

#1004 exists because nothing locked that basis in and nothing proved it empirically. A doc comment asserting the proof already existed is the first thing that had to go.

## Weakenings run this round

Eight. Each was applied, **proved landed by printing the patched region**, built, run against the full suite, and reverted with `git status` asserted empty on both sides. One attempt (W4, first try) silently failed to apply because the tool it used was unavailable, it came back green and was indistinguishable from a caught mutant until the printed region turned up empty. That run was discarded, which is the entire reason the region is printed.

| # | Weakening | Result | What it establishes |
|---|---|---|---|
| W1 | Target-typed `TokenValidationParameters p = new()` in a NEW file | **CAUGHT**, rule red, naming `ProbeParamsBuilder.cs` | Term 2 bites; the spelling a substring scan walks past is closed |
| W2 | Bare `new() { … }` passed straight into `ValidateTokenAsync` in a NEW file | **CAUGHT**, 2 failures, rule only | Term 3 bites; the construction that names the type nowhere is closed |
| W3 | Hand-rolled verifier (`jwt.Split('.')` + `RSA.VerifyData`) in a NEW file under `Api/Oidc/` | **NOT CAUGHT**, 4408 tests, **0 failures** | The rule sees nothing in a path that bypasses the library. Review's, not the rule's |
| W4 | A second, laxer parameter set inside `OidcLogoutTokenValidator.cs`, `new()` wrapped onto its own line | **NOT CAUGHT**, 4408 tests, **0 failures** | Per-file granularity cannot distinguish a second construction from the first |
| W5 | Signature failure reports a code only reachable after validation passed | **CAUGHT**, 28 failures incl. `LogoutToken_SameForgeries_AreRejected` | The loosened reason-code assertion still bites |
| W6 | `IssuerSigningKeyResolver` consults the header's own `x5c` | **CAUGHT**, `LogoutToken_SameForgeries_AreRejected(kind: HeaderSuppliedKeyMaterial)` red | The new logout row is not vacuous |
| W7 | Delete `ValidAlgorithms = AllowedSignatureAlgorithms` | **CAUGHT**, `AlgorithmAllowlist_RefusesAnHs256TokenTheKeySetWouldOtherwiseVerify` red | Round 1's headline fix survives this round's edits |
| W8 | `RequireSignedTokens = false` | **builds clean, 0 warnings** | Bounds CA5404's reach (below) |

W3 and W4 are the two the doc comment now names as out of reach. W1 and W2 are the positive controls that keep it from being a blanket disclaimer.

**A second control I did not know about, found by W2's first attempt failing to build:** CA5404 is an **error** in this repo, so `ValidateIssuer`, `ValidateAudience` or `ValidateLifetime` set to `false` fails the build wherever it is written, including inside a file the scan already allows. Its boundary is measured, not assumed: W7 and W8 show it does **not** cover a missing `ValidAlgorithms` or `RequireSignedTokens = false`, the two disablements that matter most here. That boundary is now in the rule's doc comment.

> **Corrected in round 4.** "Wherever it is written" is false: CA5404 fires on a **literal** `false` only, and the same property assigned a non-constant builds clean (M1, M2). The sentence is out of the doc comment, not rewritten smaller.

## Round-2 dispositions

Every finding in the round's verdict table. The raw per-lens blocks behind the summarised counts were not retained by my review driver, a gap on my process side, not in this diff; the dispositions below are against the recorded verdict.

| Dim | Finding | Disposition |
|---|---|---|
| 1 | Both guards over-claim; hand-rolled verifier evades all three terms (CONFIRMED) | **FIXED** by weakening. Doc comment now states catch/not-catch and names review as owner. W1–W4 |
| 2 | Per-file scoping of the parameter-builder guard | **FIXED** by weakening, the failure message itself now says a second construction inside a listed file is invisible here and is review's to catch |
| 3 | `ForgeryKind` carries 6 shapes against 8 on the login path; class doc claims full parity | **FIXED both ways.** The header-injection shape (`jku`/`x5u`/`x5c`) is added, it is the one that matters most on an anonymous endpoint where the signature is the only authenticator. The claim is weakened to what remains: parity is **per shape, not per spelling**, and the doc says which fan-outs are login-path-only and why |
| 4 | UNJUDGEABLE, acceptance criteria not in the supplied material | **Not a contract gap.** Verified: #1004 carries a seven-bullet scope list, seven acceptance criteria, and names its conformance test (`OidcTokenValidation_UsesTheSingleHardenedParameterBuilder`) explicitly. The three deferral targets are real, triaged issues, not comments: #1029 (`priority:low`, `area: oidc`, P8), #1038 and #1039 (both `security`, `priority:low`, Future/Post-1.0). The gate could not see any of it, a material-supply defect in my review driver, fixed on my process side |
| 5 | Product fit | PASS, no action |
| 6 | `crit`, JWE/nested JWT, `typ` confusion absent | **DEFERRED → #1047** (JWE/nested + `typ`). `crit` was already #1038. Each needs its own weakening run to be worth having |
| 7 | 750 lines; third literal not a derived door set; 3,349-line conformance file; `FormValue` a near-copy | **Split four ways.** Third literal → **REMOVED** with its rule (#1044). Conformance-file size → **DEFERRED → #1045**. Parse-loop duplication → **DEFERRED → #1046**, and it is **eight** copies, not four, measured, with file and line for each. Size → recorded below |
| 8 | 4 classes added to the serialized lane; RSA keygen cost | **DECLINED.** Now 2 classes, not 4 (the SAML pair no longer needs the lane for a rule this PR removed). Measured this round: `net9.0` 20.1 s, `net10.0` 22.2 s for 4,408 tests. Proportionate for a security battery |
| 9 | Renamed parallelism rule carries no `<summary>` threat model | **RESOLVED BY REMOVAL**, the rename is gone; the rule is byte-identical to mainline again. The obligation travels to #1044, where it is an acceptance criterion |
| 10 | Availability, the merge gate itself and suite wall-clock | **DECLINED**, see dim 8. No production, boot, migration or lockout path touched |
| 11 / 19 | Two `Assert.Equal` set comparisons ship with no failure message | **FIXED.** Both are now `Assert.True` over `SequenceEqual` with a message printing the expected and found sets. xUnit's collection `Assert.Equal` has no message overload, so this is the only shape that can carry one |
| 12 | Audit integrity | n/a, no tamper-evident trail in this repo |
| 13 | `HostileKid` and `ForeignKeyWithTrustedKid` differ only in a `kid` string; the row kills nothing | **FIXED by weakening, and the finding is partly refuted.** Renamed `ForeignKeyWithTraversalKid` and documented for what it holds: it does *not* show the `kid` decides nothing (no acceptance control on this path, the login path's differential is where that lives), but it is not empty either. Deleting it *would* lose coverage: it holds that a traversal `kid` at the anonymous endpoint is **refused, not thrown on**, and a throw there is an unauthenticated 500 oracle and a DoS lever, exactly what a `kid` sanitiser added later would produce |
| 14 | Wiki Coding-Standards is the single home for structural rules; update unverified | **DEFERRED → #1048.** I could reach the wiki this time and checked: the page states rule *families* and names fitness functions as examples; it does not enumerate them, and the pre-existing `SamlSignaturePath_UsesOneXmlStackEndToEnd` is absent from it too. So the gap is one missing **family**, "one implementation per security-critical primitive", covering both rules. The wiki has no PR flow, so per `CONTRIBUTING.md` the tracking is an issue on the current-release milestone |
| 15 | i18n | n/a, no user-visible strings |
| 16 | Privacy | PASS, no action |
| 17 | Supply chain | PASS, no dependency, toolchain or lockfile change |
| 18 | Compatibility / migration | n/a, no persisted format, config shape or ABI touched |
| 20 | Accessibility | n/a, no web UI diff |
| 21 | Licensing | PASS, SPDX header on every touched file |
| 22 | Six fail-closed branches collapse to one reason code, and the diff *pins* the collapse | **FIXED.** The theory no longer pins the exact string. It asserts the **layer** the refusal came from, a forgery must die in signature validation, before any claim-shape check, so separating the codes will not arrive as a red test in this file. W5 proves the loosened form still bites, and the run also confirms the exact-string contract stays pinned where it belongs, in `OidcLogoutTokenValidatorTests` |
| 23 | Parallelism guard has demonstrated escapes; the class has no structural owner | **RESOLVED BY REMOVAL → #1044**, which carries both escapes as acceptance criteria. Recording the ownership gap rather than treating lens silence as clearance is the reason it is an issue and not a note |
| 24 | No row exercises the `RejectReason.Malformed` branch | **DECLINED with evidence.** The branch is covered, `OidcLogoutTokenValidatorTests.cs:88` asserts it directly. The forgery battery submits well-formed tokens by construction, which is the point of it; adding a malformed row there would duplicate a covered branch in the wrong file |
| 25 | Rollout / flags | n/a, nothing gated, phased or deprecated |

### Still deferred from round 1

| Finding | Issue |
|---|---|
| One reason code for six forgery shapes | #1039. Production reason-code contract + audit trail; outside a diff this size |
| `crit` header accepted (found while probing round 1) | #1038. Pinning today's behaviour would enshrine a spec deviation |
| `kid` allowlist (an acceptance criterion of #1004) | #1029, pre-existing. The hostile-`kid` test's acceptance half deliberately flips when it lands |

### Deferred from round 3

| Finding | Issue |
| --- | --- |
| The hardened basis is mutable once it leaves the builder, a caller may change it, the logout validator accepts one it did not build, and the allowlist is a shared mutable array | #1049. It closes gaps (c) and (d) structurally instead of by enumeration, and changes production signatures on the sensitive OIDC surface |

## Size, a recorded decision

`git diff --shortstat origin/main...HEAD` at `04b0508`: **10 files, 1,035 insertions, 7 deletions, 1,042 changed lines**. It **shrank by 27** this round, which is the direction a round of removals and claim corrections has to move: 57 lines of enumeration out against 16 of replacement prose, plus the corrections. Round 4 measured 1,069 at `e775eed`; round 3 measured 889 at `3a2c1ea`; round 2 measured 750 at `d846712`.

**It grew by 180 this round, and here is where every line of it went**, because a size figure with no account of it is not a measurement:

- **+67**, the endpoint-driven forgery: the test, the hand-composed `alg: none` token helper, and the two class-doc paragraphs saying which file now holds which claim. Round 3's dim 3 finding is not fixable in fewer lines than a test.
- **+35 net** (54 added, 19 removed), the corrected gap enumeration in both doc comments, the two rewritten failure messages, and the note on the naming list. This is the round's central remedy and it is entirely prose: an over-claim is repaired by writing down what is held, which costs lines and buys the one thing the finding was about.
- **+74**, the replay-cache ratchet: 30 lines of rule, 25 of threat-model doc comment, 11 of attribute comments on the four memberships, the rest structure.
- **+2**, the id_token leak-scan comment.
- **+2**, narrowing three claims in this round's own comments, found by re-reading them against the code the way every other claim here was checked: the battery's class doc said "every row calls a validator" when the allowlist row drives the handler directly; "an in-test acceptance control for the same reason the rows here do" implied every row carries one; and the enumeration said the mutated endpoint "revokes a session" when what was observed is `OkResult` where the uniform 400 belongs, with the revoke following from the endpoint's contract.

The alternative to the growth was to leave three CONFIRMED findings open or to reopen the deliverable, and the reviewer's own adjudication said the work was small and belonged here. I recorded that judgement as a break-glass on #1004 instead of absorbing it silently.

Round 2's growth of 139 stands as previously recorded, with the same reasoning: Removing the parallelism unit took 25 lines out. The round's remedies added 164, and almost all of that is **prose**: the remedy for a guard that over-claims is a written statement of its limit, which costs lines and buys the one thing the finding was about. The two new set-comparison messages, the enum documentation, and the two doc comments are the bulk; the only new executable lines are one `ForgeryKind` arm, one helper, one `InlineData` row and the reason-code assertion.

I am not claiming the "genuinely does not divide" exemption. It divides, I removed one unit and looked hard at the other three, and each maps to a named acceptance criterion of #1004, so removing any of them ships #1004 incomplete rather than smaller.

**The real defect is upstream and it is mine.** #1004 lists seven scope bullets and seven acceptance criteria. An issue that size cannot close in a 400-line PR, and the ceiling should have bitten when I *wrote* it, by splitting it into three issues, not at review time. That is the durable correction, not a smaller PR here.

## Verification

- `dotnet build --warnaserror`, success, **0 warnings, 0 errors**, both TFMs, run again after the last comment edit.
- `dotnet test --no-build`, **4,412 total, 0 failed, 0 skipped** (2,206 per TFM) on `net9.0` and `net10.0`. Unchanged by this round, which touches only prose. Wall clock 21.9 s / 23.4 s.
- Twenty-one measurements across four rounds, eight of them this round (M1–M8 above). Rounds 1–3 ran their weakenings in the work tree, printed and reverted with `git status --porcelain` asserted empty on both sides; round 4 ran every one of them in a throwaway clone of the branch instead, so the work tree was never modified at all.
- SPDX header on every touched `.cs`; DCO sign-off on all commits.
- The `-p:JellyfinVersion=…` flag was **not** passed (#1031).

## Not done

- Not marked ready, not merged, no tags pushed, nothing posted to this thread.
- Two production files changed, comment-only, 21 lines. No mutation this round ran in the work tree.
- No guard, scanning term, test or explanatory paragraph was added this round. Everything in it is a removal or a claim narrowed to what is held.


