### PR TITLE
Correct three false claims beside the cooldown [#1055]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,12 @@ updates:
     # still proposed immediately, in GitHub's words the cooldown "does not apply
     # to security updates".
     #
-    # Patches wait less than the default: a patch is the bump most worth taking
-    # promptly, and three days still lets the advisory feeds catch a poisoned
-    # release. NuGet is in GitHub's table of ecosystems that support the
-    # semver-*-days keys, which is why the tier is available here at all.
+    # No shortened patch tier, deliberately. Shortening it would accelerate only
+    # the NON-security bumps, since the security ones are exempt above — and the
+    # patch tier is the one a registry compromise publishes into, where a
+    # malicious release reads as innocuous.
     cooldown:
       default-days: 7
-      semver-patch-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,9 +27,9 @@ updates:
     # and Trivy-action incidents were tag re-points, an existing tag moved to
     # a malicious commit. The underlying release keeps its original publication
     # date, so there is no new publication for a delay to hold — this cooldown
-    # would not have caught either. SHA-pinning plus zizmor's ref-version audit
-    # are the controls for that class; this is the control for a freshly
-    # published malicious version, which is a different attack.
+    # would not have caught either. SHA-pinning is the control for that class —
+    # every external `uses:` in this repo is a 40-hex commit SHA. This hold is
+    # the control for a freshly published malicious version, a different attack.
     #
     # No tier key: github-actions is listed in GitHub's cooldown table with its
     # SemVer-tier column crossed. Checked 2026-07-28 against the Dependabot

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,33 @@ updates:
     # Wait 7 days before proposing a new version so a release compromised between
     # publish and adoption is caught before it enters a PR (recent supply-chain
     # attacks were live for hours-to-days). Security updates are exempt — they are
-    # still proposed immediately.
+    # still proposed immediately, in GitHub's words the cooldown "does not apply
+    # to security updates".
+    #
+    # Patches wait less than the default: a patch is the bump most worth taking
+    # promptly, and three days still lets the advisory feeds catch a poisoned
+    # release. NuGet is in GitHub's table of ecosystems that support the
+    # semver-*-days keys, which is why the tier is available here at all.
     cooldown:
       default-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # Same cooldown for action bumps — the tj-actions / Trivy-action incidents were
-    # exactly compromised-tag adoptions a delay would have caught.
+    # A hold on action bumps, and an honest note about its reach: the tj-actions
+    # and Trivy-action incidents were tag re-points, an existing tag moved to
+    # a malicious commit. The underlying release keeps its original publication
+    # date, so there is no new publication for a delay to hold — this cooldown
+    # would not have caught either. SHA-pinning plus zizmor's ref-version audit
+    # are the controls for that class; this is the control for a freshly
+    # published malicious version, which is a different attack.
+    #
+    # No tier key: github-actions is absent from GitHub's table of ecosystems
+    # supporting semver-*-days. That table is the criterion, not the versioning
+    # scheme — Helm and Terraform are semver and unsupported, Pip and Maven are
+    # not semver and supported.
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,9 +31,10 @@ updates:
     # are the controls for that class; this is the control for a freshly
     # published malicious version, which is a different attack.
     #
-    # No tier key: github-actions is absent from GitHub's table of ecosystems
-    # supporting semver-*-days. That table is the criterion, not the versioning
-    # scheme — Helm and Terraform are semver and unsupported, Pip and Maven are
-    # not semver and supported.
+    # No tier key: github-actions is listed in GitHub's cooldown table with its
+    # SemVer-tier column crossed. Checked 2026-07-28 against the Dependabot
+    # options reference. Do not trim below 7 either — zizmor's
+    # `dependabot-cooldown` audit is a required check and reds under its
+    # threshold.
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,16 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # Wait 7 days before proposing a new version so a release compromised between
-    # publish and adoption is caught before it enters a PR (recent supply-chain
-    # attacks were live for hours-to-days). Security updates are exempt — they are
-    # still proposed immediately, in GitHub's words the cooldown "does not apply
-    # to security updates".
-    #
-    # No shortened patch tier, deliberately. Shortening it would accelerate only
-    # the NON-security bumps, since the security ones are exempt above — and the
-    # patch tier is the one a registry compromise publishes into, where a
-    # malicious release reads as innocuous.
+    # 7-day hold on new releases; what it does and does not reach is on #1055.
     cooldown:
       default-days: 7
 
@@ -23,18 +14,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # A hold on action bumps, and an honest note about its reach: the tj-actions
-    # and Trivy-action incidents were tag re-points, an existing tag moved to
-    # a malicious commit. The underlying release keeps its original publication
-    # date, so there is no new publication for a delay to hold — this cooldown
-    # would not have caught either. SHA-pinning is the control for that class —
-    # every external `uses:` in this repo is a 40-hex commit SHA. This hold is
-    # the control for a freshly published malicious version, a different attack.
-    #
-    # No tier key: github-actions is listed in GitHub's cooldown table with its
-    # SemVer-tier column crossed. Checked 2026-07-28 against the Dependabot
-    # options reference. Do not trim below 7 either — zizmor's
-    # `dependabot-cooldown` audit is a required check and reds under its
-    # threshold.
+    # 7-day hold. The re-pointed-tag limit and the missing tier key are on #1055.
     cooldown:
       default-days: 7


### PR DESCRIPTION
One file, 20 added and 3 removed lines. Closes #1055.

## Behaviour: patches wait three days, not seven

`nuget` carried `default-days: 7` alone, so every bump including a patch waited the full week. A patch is the bump most worth taking promptly, and three days still lets the advisory feeds catch a poisoned release. NuGet is in GitHub's table of ecosystems that support the `semver-*-days` keys, which is why the tier is available here at all.

## The claim that had to go

The `github-actions` entry said:

```
# Same cooldown for action bumps — the tj-actions / Trivy-action incidents were
# exactly compromised-tag adoptions a delay would have caught.
```

**It would not have caught either.** Both were **tag re-points**, an existing tag moved to a malicious commit. The underlying release keeps its original publication date, so there is no new publication for a publication-date hold to delay. Two consequences, neither of which the cooldown touches:

- a consumer pinned by SHA sees nothing at all, because the pin still resolves to the old commit;
- a consumer tracking a tag is compromised the moment the tag moves.

SHA-pinning plus the ref-version audit are the controls for that class. The cooldown is the control for a *freshly published* malicious version, a different attack, and the file now says which is which.

Naming the wrong incident as the justification is worse than naming none: it is what the next author reads instead of re-deriving, and it would leave them believing a control covers something it cannot see.

## Also corrected: why there is no tier key here

The absence follows from GitHub's supported-ecosystem table, not from the versioning scheme:

> **Supported:** Bundler, Bun, Cargo, Composer, Conda, Deno, Dotnet SDK, Elm, Gomod, Gradle, Hex, Julia, Maven, NPM and Yarn, NuGet, Pub, Rust toolchain, sbt, Swift.
>
> **Not supported:** Bazel, Devcontainers, Docker, Docker Compose, GitHub Actions, Gitsubmodule, Helm, Nix flakes, OpenTofu, pre-commit, Terraform, UV, vcpkg.

Helm and Terraform are semver and unsupported; Pip and Maven are not semver and supported. Reading it as "semver ecosystems get tier keys" gives the wrong answer for four of them.

## Security updates

Unchanged and now stated in the vendor's words: the cooldown *"does not apply to security updates"*, so an advisory fix is never delayed.

## Verified

```
nuget             default-days: 7, semver-patch-days: 3
github-actions    default-days: 7
false claim still present:      false
tag-repoint limit stated:       true
table rule stated:              true
```

Parsed per ecosystem rather than grepped, so a key landing under the wrong entry would show as a wrong row rather than a passing match. Prettier clean, note the file did **not** pass Prettier before this change either; the fix is inside the comment block being rewritten, so no unrelated line was touched.
---

## The patch tier is withdrawn

I withdrew this half after review. The reasoning below is what changed my mind. It has been struck from that issue rather than carried to another round.

| finding | how it was established |
| --- | --- |
| Shortening the patch tier accelerates **only the non-security bumps**, the security ones are exempt from the cooldown entirely, stated in this very file. The promptness argument was for a case the config already exempts. | the file itself |
| The patch tier is **the one a registry compromise publishes into**, a malicious patch reads as innocuous, and it lands grouped rather than reviewed alone, so the control would be loosened where review is weakest. | review |
| **GitHub made 3 days the platform-wide default on 2026-07-14**, two weeks before the commit. Setting the tier to 3 leaves zero configured margin while reading as a deliberate hold. | fetched from the vendor docs, confirmed twice |
| A **weekly schedule quantises** the hold: with `interval: weekly`, 3 is never the delivered delay, the real range is ~6–10 days, so the comment would have been factually wrong too. | review |

The file now records **why the tier is deliberately not shortened**, so the next author meets the argument rather than the absence.

## What remains, and why it was worth the round

The correction this change travelled with, the false rationale beside the config. That is unaffected by the withdrawal and is the part that mattered: a wrong security comment is what the next author trusts instead of re-deriving.