### PR TITLE
Add the per-object-scope repeated-member walk

### DIFF
--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -157,6 +157,25 @@ public class StrictJsonTests
     }
 
     [Fact]
+    public void TheDefaultVerdictIsTheRefusal()
+    {
+        // default(Verdict) is what an uninitialised field or a skipped assignment yields. On a fail-closed
+        // component that value must be the refusal, or the failure mode of forgetting to assign is approval.
+        Assert.Equal(StrictJson.Verdict.Unreadable, default(StrictJson.Verdict));
+    }
+
+    [Fact]
+    public void RepeatedBomPrefixes_AreNotStrippedAway()
+    {
+        // Exactly one leading BOM is stripped. A document prefixed with several is one no consumer can
+        // parse, so admitting it would be this walk disagreeing with its readers in the permissive direction.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(Bom + Bom + "{\"a\":1}", out _));
+
+        // And a BOM that is not first is not a BOM prefix at all.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(" " + Bom + "{\"a\":1}", out _));
+    }
+
+    [Fact]
     public void SiblingScopesReusingAName_AreClean()
     {
         // The scope rule: one name set per OPEN object. A walk pooling names document-wide would refuse this
@@ -198,27 +217,40 @@ public class StrictJsonTests
         Assert.Null(repeated);
     }
 
-    [Fact]
-    public void TheDepthCapIsPinnedAtItsBoundary()
-    {
-        // Its two neighbours, not two distant points. Fixtures at 10 and 65 are satisfied by ANY cap from 11
-        // to 64 — including dropping the reader options entirely, since the reader's own default is already
-        // 64 — so they pin the constant nowhere while reading as if they pinned it in both directions.
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
-        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
-    }
-
     private static string NestedTo(int depth) =>
-        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string('}', depth);
+        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string(char.Parse("}"), depth);
 
     [Fact]
     public void NestingPastTheDepthCap_IsUnreadable()
     {
+        // The behaviour at the boundary, and only that. An earlier row claimed to pin the cap CONSTANT from
+        // both directions; it could not, because the value equals the reader's own default and deleting the
+        // constant leaves every verdict identical. The claim is withdrawn rather than restated.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
+
         // 65 opens against the reader's own default of 64: a document this walk cannot reach the bottom of is
         // one its consumers could not read either, so it is refused rather than passed on half-inspected.
         var tooDeep = string.Concat(Enumerable.Repeat("{\"a\":", 65)) + "1" + new string('}', 65);
 
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(tooDeep, out _));
+    }
+
+    [Fact]
+    public void ADocumentCarryingNoObject_IsUnreadable()
+    {
+        // Widened from "no input" to its actual rule. A bare scalar and an array of scalars are well-formed
+        // and carry no scope in which a member could repeat, so the walk established nothing about them —
+        // the same reason an empty body is not Clean. Reporting Clean here would hand a caller an
+        // affirmative answer about a document nothing read.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("17", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("true", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("\"a string\"", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("[1,2,3]", out _));
+
+        // An EMPTY object is the boundary of that rule and stays Clean: it has a scope, and that scope
+        // repeats nothing.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("{}", out _));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -28,6 +28,20 @@ public class StrictJsonTests
 
     private const string LoneSurrogateName = "{\"a\\ud800\":1}";
 
+    // The same lone surrogate as a RAW char rather than an escape, which is a different input reaching a
+    // different arm. The escape above is thirteen ASCII bytes the reader decodes. This is a char with no
+    // UTF-8 encoding at all, so it is refused while the document is being encoded and the reader never sees
+    // it. Without that refusal the default replacement fallback would rewrite it to U+FFFD in silence, and
+    // the walk would report Clean about bytes it had altered itself.
+    private const string RawLoneSurrogateName = "{\"a\uD800\":1}";
+
+    // Two DIFFERENT member names, each ending in a different unpaired surrogate. This is what makes the
+    // throwing fallback a rule rather than a sentence about one. Under the default replacement fallback both
+    // names encode to the same bytes, because every unpaired surrogate maps to the same U+FFFD, so the walk
+    // would report Repeated for a document whose two members are not the same name. That is a false
+    // accusation against a provider, which is the one direction a screen must never fail in.
+    private const string TwoRawLoneSurrogateNames = "{\"a\uD800\":1,\"a\uDC00\":1}";
+
     // A UTF-8 BOM, which a provider serving a BOM-prefixed file emits. Utf8JsonReader treats it as
     // content, so without stripping it every such document reads as malformed — and Unreadable is a
     // refusal at the seam, so that would lock the provider out.
@@ -99,6 +113,8 @@ public class StrictJsonTests
         "not-json",
         "{\"a\":1,",
         LoneSurrogateName,
+        RawLoneSurrogateName,
+        TwoRawLoneSurrogateNames,
     };
 
     public static TheoryData<string, string> RepeatedFixtures()
@@ -207,10 +223,12 @@ public class StrictJsonTests
     [MemberData(nameof(UnreadableFixtures))]
     public void HostileInput_IsUnreadable_NeverThrows(string json)
     {
-        // One fixture per raised type. `not-json` and the truncation raise JsonException; the thirteen bytes
-        // of LoneSurrogateName raise InvalidOperationException from GetString — NOT JsonException, so a walk
-        // catching only the latter hands the crash to a caller that catches neither. Unreadable is what the
-        // caller refuses on, so the fail-closed direction holds.
+        // One fixture per raised type, because each is raised by a different party and a walk that catches
+        // one hands the others to a caller that catches none. `not-json` and the truncation raise
+        // JsonException from the reader. The thirteen bytes of LoneSurrogateName raise
+        // InvalidOperationException from GetString, NOT JsonException. The two RAW surrogate fixtures raise
+        // EncoderFallbackException from the encoder, before any of the walk has run. Unreadable is what the
+        // caller refuses on, so the fail-closed direction holds for all three.
         var verdict = StrictJson.Inspect(json, out var repeated);
 
         Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
@@ -218,7 +236,7 @@ public class StrictJsonTests
     }
 
     private static string NestedTo(int depth) =>
-        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string(char.Parse("}"), depth);
+        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string('}', depth);
 
     [Fact]
     public void NestingPastTheDepthCap_IsUnreadable()
@@ -226,14 +244,11 @@ public class StrictJsonTests
         // The behaviour at the boundary, and only that. An earlier row claimed to pin the cap CONSTANT from
         // both directions; it could not, because the value equals the reader's own default and deleting the
         // constant leaves every verdict identical. The claim is withdrawn rather than restated.
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
-        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
-
+        //
         // 65 opens against the reader's own default of 64: a document this walk cannot reach the bottom of is
         // one its consumers could not read either, so it is refused rather than passed on half-inspected.
-        var tooDeep = string.Concat(Enumerable.Repeat("{\"a\":", 65)) + "1" + new string('}', 65);
-
-        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(tooDeep, out _));
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
     }
 
     [Fact]
@@ -264,5 +279,4 @@ public class StrictJsonTests
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(string.Empty, out _));
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("   ", out _));
     }
-
 }

--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -28,6 +28,11 @@ public class StrictJsonTests
 
     private const string LoneSurrogateName = "{\"a\\ud800\":1}";
 
+    // A UTF-8 BOM, which a provider serving a BOM-prefixed file emits. Utf8JsonReader treats it as
+    // content, so without stripping it every such document reads as malformed — and Unreadable is a
+    // refusal at the seam, so that would lock the provider out.
+    private const string Bom = "\uFEFF";
+
     // The corpora live as plain arrays so the both-TFM row below can walk exactly what the theories run,
     // rather than a second copy that could drift from them.
     private static readonly (string Json, string Member)[] Repeated =
@@ -48,6 +53,16 @@ public class StrictJsonTests
         // attacker appending to a document puts other members between the two.
         ("{\"issuer\":\"https://one.example\",\"o\":{\"issuer\":\"nested\"},\"issuer\":\"https://two.example\"}", "issuer"),
         ("{\"a\":1,\"k\":[{\"x\":1},{\"y\":2}],\"a\":2}", "a"),
+
+        // A BOM-prefixed document still has its repeat found: stripping the BOM must not cost detection.
+        (Bom + "{\"issuer\":1,\"issuer\":2}", "issuer"),
+
+        // A non-object root. The walk handles it and no fixture covered it, which is how a corpus gap
+        // and a behaviour gap become indistinguishable in a review.
+        ("[{\"a\":1,\"a\":2}]", "a"),
+
+        // The empty name is a legal member and a provider can repeat it; it must not fold with "no name".
+        ("{\"\":1,\"\":2}", ""),
     };
 
     private static readonly string[] Clean =
@@ -59,11 +74,15 @@ public class StrictJsonTests
         "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"a1\"}]}",
         RealisticJwks,
 
-        // Nested deeper than a hand-picked small cap but far inside the reader's own default, so the cap is
-        // pinned from BOTH directions: raising it fails the over-deep row below, and tightening it fails this
-        // one. Only the first was pinned before, and a cap tightened to a handful of levels would refuse every
-        // real JWKS carrying an `x5c` certificate chain while the suite stayed green.
+        // Nested well inside the cap. This row alone pins nothing about the cap — any value from 11 upward
+        // satisfies it — and an earlier comment here claimed it pinned the tightening direction, which it did
+        // not. The cap is pinned by its two neighbours in TheDepthCapIsPinnedAtItsBoundary; this fixture is
+        // here because a realistically-nested clean document belongs in the corpus regardless.
         "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":{\"f\":{\"g\":{\"h\":{\"i\":{\"j\":1}}}}}}}}}}",
+
+        // A BOM-prefixed document that is otherwise perfect. Without the strip this is Unreadable, which
+        // at the seam refuses a provider that did nothing wrong.
+        Bom + "{\"issuer\":\"https://one.example\"}",
 
         // A DESCENDANT scope reusing an ancestor's member name, which is the scope relation real discovery
         // documents actually contain: RFC 8705 puts a second `token_endpoint` and `userinfo_endpoint` inside
@@ -180,6 +199,19 @@ public class StrictJsonTests
     }
 
     [Fact]
+    public void TheDepthCapIsPinnedAtItsBoundary()
+    {
+        // Its two neighbours, not two distant points. Fixtures at 10 and 65 are satisfied by ANY cap from 11
+        // to 64 — including dropping the reader options entirely, since the reader's own default is already
+        // 64 — so they pin the constant nowhere while reading as if they pinned it in both directions.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
+    }
+
+    private static string NestedTo(int depth) =>
+        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string('}', depth);
+
+    [Fact]
     public void NestingPastTheDepthCap_IsUnreadable()
     {
         // 65 opens against the reader's own default of 64: a document this walk cannot reach the bottom of is
@@ -190,41 +222,15 @@ public class StrictJsonTests
     }
 
     [Fact]
-    public void NoInputAtAll_IsClean()
+    public void NoInputAtAll_IsUnreadable()
     {
-        // A body that carries no member cannot repeat one. Clean rather than Unreadable, so an empty response
-        // is refused (or not) by whatever rule owns emptiness, not silently by this walk.
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(null, out _));
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("   ", out _));
+        // Not Clean. Clean is an affirmative "no scope names a member twice", which a caller written the
+        // obvious way consumes as approval — and every reader these documents reach rejects an empty body
+        // outright, so Clean would make this walk disagree with its own consumers about one document. Nothing
+        // was established, which is exactly what Unreadable means.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(null, out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(string.Empty, out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("   ", out _));
     }
 
-    [Fact]
-    public void TheDecisionIsPinnedForTheFrameworkThisRunIsOn()
-    {
-        // The acceptance list asks for the corpus decision to be pinned per target framework, because the
-        // plugin binds the HOST's System.Text.Json — .NET 9's under Jellyfin 10.11, .NET 10's under 12.0 —
-        // and only the latter has the Strict preset whose duplicate policy this walk deliberately does not
-        // use. A walk that had picked up a framework-dependent policy would answer differently on the two
-        // legs, and this row is what makes that a failure rather than a divergence nobody looks at.
-        //
-        // It records WHICH framework it ran on in its failure message, so a red leg names itself rather than
-        // leaving a reader to work out which of the two matrix runs disagreed.
-        var leg = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-
-        foreach (var (json, member) in Repeated)
-        {
-            Assert.True(StrictJson.Inspect(json, out var actual) == StrictJson.Verdict.Repeated, $"{leg}: expected Repeated for {json}");
-            Assert.True(actual == member, $"{leg}: expected member '{member}' for {json}, got '{actual}'");
-        }
-
-        foreach (var json in Clean)
-        {
-            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Clean, $"{leg}: expected Clean for {json}");
-        }
-
-        foreach (var json in Unreadable)
-        {
-            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Unreadable, $"{leg}: expected Unreadable for {json}");
-        }
-    }
 }

--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="StrictJson"/> — the per-object-scope walk that decides whether a provider document
+/// names a member twice (#1005). Every reader the plugin depends on keeps the LAST occurrence of a repeated
+/// member silently, so a document that repeats one means two things at once; a repeated <c>issuer</c>
+/// re-points the anchor a login binds to and a repeated <c>jwks_uri</c> re-points the validation keys. They
+/// pin: a repeat is found at every scope, a document without one is admitted (the positive controls, without
+/// which a walk that refused everything would satisfy the rejection rows), sibling scopes may reuse a name,
+/// names are compared ordinally and after unescaping, and hostile input is reported rather than thrown.
+/// </summary>
+public class StrictJsonTests
+{
+    // A realistic two-key JWKS: every entry repeats `kty`, `use`, `alg`, `n` and `e` in a SIBLING scope, which
+    // is the shape a document-wide name set would refuse while reporting an attack that is not there.
+    private const string RealisticJwks =
+        "{\"keys\":["
+        + "{\"kty\":\"RSA\",\"use\":\"sig\",\"alg\":\"RS256\",\"kid\":\"a1\",\"n\":\"xGOr\",\"e\":\"AQAB\"},"
+        + "{\"kty\":\"RSA\",\"use\":\"sig\",\"alg\":\"RS256\",\"kid\":\"b2\",\"n\":\"yHPs\",\"e\":\"AQAB\"}]}";
+
+    private const string LoneSurrogateName = "{\"a\\ud800\":1}";
+
+    // The corpora live as plain arrays so the both-TFM row below can walk exactly what the theories run,
+    // rather than a second copy that could drift from them.
+    private static readonly (string Json, string Member)[] Repeated =
+    {
+        // At the root, and the two live attacks the screen exists for.
+        ("{\"a\":1,\"a\":2}", "a"),
+        ("{\"issuer\":\"https://one.example\",\"issuer\":\"https://two.example\"}", "issuer"),
+        ("{\"jwks_uri\":\"https://one.example/jwks\",\"jwks_uri\":\"https://evil.example/jwks\"}", "jwks_uri"),
+
+        // Below the root: a nested object, and an object inside an array — a JWKS entry whose own `kty`
+        // repeats, which is where key selection would diverge.
+        ("{\"outer\":{\"b\":1,\"b\":2}}", "b"),
+        ("{\"keys\":[{\"kty\":\"RSA\",\"kty\":\"oct\"}]}", "kty"),
+
+        // The two occurrences STRADDLE a nested scope, so the root's name set must survive the push and pop
+        // in between. A walk that reset or replaced the set on entering an object passes every row above and
+        // fails only here — and a repeated `issuer` spelled this way is the realistic spelling, since an
+        // attacker appending to a document puts other members between the two.
+        ("{\"issuer\":\"https://one.example\",\"o\":{\"issuer\":\"nested\"},\"issuer\":\"https://two.example\"}", "issuer"),
+        ("{\"a\":1,\"k\":[{\"x\":1},{\"y\":2}],\"a\":2}", "a"),
+    };
+
+    private static readonly string[] Clean =
+    {
+        "{\"a\":1,\"b\":2}",
+        "{\"issuer\":\"https://one.example\"}",
+        "{\"jwks_uri\":\"https://one.example/jwks\"}",
+        "{\"outer\":{\"b\":1,\"c\":2}}",
+        "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"a1\"}]}",
+        RealisticJwks,
+
+        // Nested deeper than a hand-picked small cap but far inside the reader's own default, so the cap is
+        // pinned from BOTH directions: raising it fails the over-deep row below, and tightening it fails this
+        // one. Only the first was pinned before, and a cap tightened to a handful of levels would refuse every
+        // real JWKS carrying an `x5c` certificate chain while the suite stayed green.
+        "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":{\"f\":{\"g\":{\"h\":{\"i\":{\"j\":1}}}}}}}}}}",
+
+        // A DESCENDANT scope reusing an ancestor's member name, which is the scope relation real discovery
+        // documents actually contain: RFC 8705 puts a second `token_endpoint` and `userinfo_endpoint` inside
+        // `mtls_endpoint_aliases`, and Google, Microsoft and others serve exactly this. Every other clean
+        // fixture reuses names between SIBLINGS, so a walk whose child scope inherited its parent's names
+        // passed all of them — and would refuse the login of any provider advertising mTLS aliases.
+        "{\"issuer\":\"https://one.example\",\"token_endpoint\":\"https://one.example/token\","
+            + "\"mtls_endpoint_aliases\":{\"token_endpoint\":\"https://mtls.one.example/token\","
+            + "\"userinfo_endpoint\":\"https://mtls.one.example/userinfo\"}}",
+    };
+
+    private static readonly string[] Unreadable =
+    {
+        "not-json",
+        "{\"a\":1,",
+        LoneSurrogateName,
+    };
+
+    public static TheoryData<string, string> RepeatedFixtures()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var (json, member) in Repeated)
+        {
+            data.Add(json, member);
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string> CleanFixtures()
+    {
+        var data = new TheoryData<string>();
+        foreach (var json in Clean)
+        {
+            data.Add(json);
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string> UnreadableFixtures()
+    {
+        var data = new TheoryData<string>();
+        foreach (var json in Unreadable)
+        {
+            data.Add(json);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(RepeatedFixtures))]
+    public void DuplicateMember_AtAnyScope_IsRepeated(string json, string expectedMember)
+    {
+        var verdict = StrictJson.Inspect(json, out var repeated);
+
+        Assert.Equal(StrictJson.Verdict.Repeated, verdict);
+        Assert.Equal(expectedMember, repeated);
+    }
+
+    [Theory]
+    [MemberData(nameof(CleanFixtures))]
+    public void TheSameDocumentsWithoutTheDuplicate_AreClean(string json)
+    {
+        // The positive control for every rejection above: without it, a walk that reported Repeated for any
+        // input would satisfy the whole rejection set while refusing every real provider.
+        var verdict = StrictJson.Inspect(json, out var repeated);
+
+        Assert.Equal(StrictJson.Verdict.Clean, verdict);
+        Assert.Null(repeated);
+    }
+
+    [Fact]
+    public void SiblingScopesReusingAName_AreClean()
+    {
+        // The scope rule: one name set per OPEN object. A walk pooling names document-wide would refuse this
+        // and every real JWKS with it.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("{\"o\":{\"a\":1},\"p\":{\"a\":2}}", out _));
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(RealisticJwks, out _));
+    }
+
+    [Fact]
+    public void NamesDifferingOnlyInCase_AreClean()
+    {
+        // JSON member names are case-sensitive and every consumer of these documents compares them ordinally,
+        // so folding case here would refuse a document none of them reads as ambiguous.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("{\"issuer\":1,\"Issuer\":2}", out _));
+    }
+
+    [Fact]
+    public void EscapeSpelledName_CountsAsItsPlainSpelling()
+    {
+        // \u0069ssuer IS issuer to every reader downstream, so comparing raw spellings would let an attacker
+        // spell one of the two occurrences differently and walk straight past the screen.
+        var verdict = StrictJson.Inspect("{\"\\u0069ssuer\":1,\"issuer\":2}", out var repeated);
+
+        Assert.Equal(StrictJson.Verdict.Repeated, verdict);
+        Assert.Equal("issuer", repeated);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnreadableFixtures))]
+    public void HostileInput_IsUnreadable_NeverThrows(string json)
+    {
+        // One fixture per raised type. `not-json` and the truncation raise JsonException; the thirteen bytes
+        // of LoneSurrogateName raise InvalidOperationException from GetString — NOT JsonException, so a walk
+        // catching only the latter hands the crash to a caller that catches neither. Unreadable is what the
+        // caller refuses on, so the fail-closed direction holds.
+        var verdict = StrictJson.Inspect(json, out var repeated);
+
+        Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
+        Assert.Null(repeated);
+    }
+
+    [Fact]
+    public void NestingPastTheDepthCap_IsUnreadable()
+    {
+        // 65 opens against the reader's own default of 64: a document this walk cannot reach the bottom of is
+        // one its consumers could not read either, so it is refused rather than passed on half-inspected.
+        var tooDeep = string.Concat(Enumerable.Repeat("{\"a\":", 65)) + "1" + new string('}', 65);
+
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(tooDeep, out _));
+    }
+
+    [Fact]
+    public void NoInputAtAll_IsClean()
+    {
+        // A body that carries no member cannot repeat one. Clean rather than Unreadable, so an empty response
+        // is refused (or not) by whatever rule owns emptiness, not silently by this walk.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(null, out _));
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("   ", out _));
+    }
+
+    [Fact]
+    public void TheDecisionIsPinnedForTheFrameworkThisRunIsOn()
+    {
+        // The acceptance list asks for the corpus decision to be pinned per target framework, because the
+        // plugin binds the HOST's System.Text.Json — .NET 9's under Jellyfin 10.11, .NET 10's under 12.0 —
+        // and only the latter has the Strict preset whose duplicate policy this walk deliberately does not
+        // use. A walk that had picked up a framework-dependent policy would answer differently on the two
+        // legs, and this row is what makes that a failure rather than a divergence nobody looks at.
+        //
+        // It records WHICH framework it ran on in its failure message, so a red leg names itself rather than
+        // leaving a reader to work out which of the two matrix runs disagreed.
+        var leg = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+
+        foreach (var (json, member) in Repeated)
+        {
+            Assert.True(StrictJson.Inspect(json, out var actual) == StrictJson.Verdict.Repeated, $"{leg}: expected Repeated for {json}");
+            Assert.True(actual == member, $"{leg}: expected member '{member}' for {json}, got '{actual}'");
+        }
+
+        foreach (var json in Clean)
+        {
+            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Clean, $"{leg}: expected Clean for {json}");
+        }
+
+        foreach (var json in Unreadable)
+        {
+            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Unreadable, $"{leg}: expected Unreadable for {json}");
+        }
+    }
+}

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// Decides whether a JSON document names any member twice inside one object scope (#1005). A repeated member
+/// is accepted silently by every reader these documents reach, none of which raises an error, so which of the
+/// two values a consumer acts on is decided by parser internals rather than by anything this plugin controls.
+///
+/// What was MEASURED, so the claim stays the size of its evidence: on both target frameworks every reader in
+/// the dependency set — System.Text.Json, Newtonsoft, <c>JsonWebToken</c>, Duende's <c>JsonWebKeySet</c> —
+/// keeps the LAST occurrence when a name is indexed. They therefore agree today, and no divergence between
+/// two readers of these documents has been demonstrated. What differs is indexing versus ENUMERATION:
+/// <c>JsonDocument</c> indexes the last occurrence while <c>EnumerateObject</c> yields both properties, and
+/// Newtonsoft drops one at parse time, so a document carrying a repeat has no single answer to "what members
+/// does it have".
+///
+/// THREAT MODEL. This stops an authorization server, or anyone who can answer as one, from serving a document
+/// whose meaning rests on that unpinned last-wins behaviour rather than on the document itself — RFC 8259
+/// §4 leaves the handling of repeated names unspecified and calls such objects interoperability-unsafe, so
+/// the agreement measured above is a property of the current dependency set and not a guarantee any of them
+/// documents. A repeat in <c>issuer</c>, <c>jwks_uri</c>, or a JWKS entry is where that would decide a login
+/// anchor or a validation key. Deliberately out of scope: an operator who edits the plugin's own
+/// configuration, and any document nothing routes through this walk before parsing it — a decision function
+/// stops nothing on its own, and placing it on a path is the caller's job (#1061). This walk defends against
+/// a hostile provider, not against the person who administers the server, and
+/// review and branch protection are what cover the latter. Also out of scope, and worth stating because the
+/// two are easily conflated: this is not the control that stops a hostile <c>issuer</c> VALUE, which is
+/// <c>ValidateIssuerName</c>'s job whether that value is repeated or not.
+///
+/// Every member at every object scope is compared, rather than a caller-supplied list of the members the
+/// caller happens to index. The screen sits ahead of the identity library, whose own typed mapping and key-set
+/// materialisation are consumers too, and their indexed-member sets are internal to two pinned versions —
+/// an allowlist would have to enumerate them and would go quietly wrong at the next bump. It is also the rule
+/// .NET 10's <c>JsonSerializerOptions.Strict</c> preset already enforces, so this converges on the platform
+/// posture rather than inventing one.
+///
+/// Deliberately a raw <see cref="Utf8JsonReader"/> walk rather than a <c>JsonSerializerOptions</c> setting.
+/// The plugin binds the HOST's System.Text.Json — .NET 9's in the Jellyfin 10.11 line, .NET 10's in the 12.0
+/// line — and <c>Strict</c> exists only on the latter: referencing it fails the net9.0 build with CS0117. A
+/// tokenizer carries no duplicate policy of its own, so one code path reaches the same decision on both
+/// targets, and that decision does not move when the host's System.Text.Json does.
+/// </summary>
+internal static class StrictJson
+{
+    // Matches the System.Text.Json reader default rather than raising it, so a document this walk cannot
+    // reach the bottom of is one its consumers could not read either.
+    private const int MaxDepth = 64;
+
+    /// <summary>
+    /// What <see cref="Inspect"/> found. Three outcomes and not a <c>bool</c>, because "this document names a
+    /// member twice" and "this document could not be inspected" are different facts: the first is the attack
+    /// this walk exists for, the second is everything from a truncated body to a hostile escape, and a caller
+    /// handed one flag for both cannot report the reason it refused.
+    /// </summary>
+    internal enum Verdict
+    {
+        /// <summary>No object scope names a member twice.</summary>
+        Clean,
+
+        /// <summary>An object scope names a member twice, so the document means two things.</summary>
+        Repeated,
+
+        /// <summary>The document could not be walked to the end, so nothing was established about it.</summary>
+        Unreadable,
+    }
+
+    /// <summary>
+    /// Walks <paramref name="json"/> and reports whether any object scope names a member twice.
+    /// </summary>
+    /// <param name="json">The raw document, as received from the provider.</param>
+    /// <param name="repeatedMember">
+    /// The repeated member's name when the verdict is <see cref="Verdict.Repeated"/>; otherwise null. It is
+    /// provider-authored, so a caller that logs it strips line endings inline at its own log call.
+    /// </param>
+    /// <returns>
+    /// <see cref="Verdict.Repeated"/> when one object scope names a member twice;
+    /// <see cref="Verdict.Unreadable"/> when the walk could not complete — malformed, truncated, nested past
+    /// the depth cap, or carrying a member name the decoder refuses (an unpaired surrogate escape is the
+    /// measured instance); <see cref="Verdict.Clean"/> otherwise, including for a null, empty or whitespace
+    /// input, which carries no member to repeat. Names are compared ordinally, because JSON member names are
+    /// case-sensitive and every consumer of these documents compares them ordinally too, and AFTER
+    /// unescaping, so a name spelled with a <c>\u</c> escape counts as the same name as its plain spelling.
+    /// Never throws.
+    /// </returns>
+    internal static Verdict Inspect(string? json, out string? repeatedMember)
+    {
+        repeatedMember = null;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return Verdict.Clean;
+        }
+
+        // One name set per open object, so sibling scopes may reuse a name — every JWKS entry repeats `kty`
+        // and `kid`, so a walk pooling names document-wide would refuse real documents while reporting an
+        // attack. Only a repeat within the SAME object is a document that means two things.
+        var scopes = new Stack<HashSet<string>>();
+        try
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new JsonReaderOptions { MaxDepth = MaxDepth });
+            while (reader.Read())
+            {
+                switch (reader.TokenType)
+                {
+                    case JsonTokenType.StartObject:
+                        scopes.Push(new HashSet<string>(StringComparer.Ordinal));
+                        break;
+
+                    case JsonTokenType.EndObject:
+                        scopes.Pop();
+                        break;
+
+                    case JsonTokenType.PropertyName:
+                        var name = reader.GetString() ?? string.Empty;
+                        if (!scopes.Peek().Add(name))
+                        {
+                            repeatedMember = name;
+                            return Verdict.Repeated;
+                        }
+
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            return Verdict.Unreadable;
+        }
+        catch (InvalidOperationException)
+        {
+            // GetString raises this — NOT JsonException — on a member name the decoder cannot complete: an
+            // unpaired surrogate escape is thirteen bytes both parser families read without complaint. A
+            // caller catching only JsonException would therefore take the crash, so this arm is what keeps a
+            // provider from crashing the discovery path. Reported as Unreadable, which the caller refuses on.
+            return Verdict.Unreadable;
+        }
+
+        return Verdict.Clean;
+    }
+}

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -99,7 +99,8 @@ internal static class StrictJson
     /// <see cref="Verdict.Repeated"/> when one object scope names a member twice;
     /// <see cref="Verdict.Unreadable"/> when the walk could not complete — malformed, truncated, nested past
     /// the depth cap, carrying a member name the decoder refuses (an unpaired surrogate escape is the
-    /// measured instance), or carrying no object at all — a null, empty or whitespace body, and equally a
+    /// measured instance), carrying a char with no UTF-8 encoding at all (a RAW unpaired surrogate, refused
+    /// before the walk starts), or carrying no object at all — a null, empty or whitespace body, and equally a
     /// bare scalar or a document whose root is not and contains no object. None of those establishes
     /// anything, which is what <see cref="Verdict.Unreadable"/> means, and reporting <c>Clean</c> for them
     /// would hand a caller an affirmative answer about a document nothing read.

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -49,6 +49,11 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// </summary>
 internal static class StrictJson
 {
+    // What this cannot do, stated because a decision function invites the assumption that it protects the
+    // path it decides for: it bounds nothing. It is handed a string that is already in memory and allocates
+    // a UTF-8 copy of it, so a document large enough to hurt has already hurt before this runs. Bounding
+    // belongs at the position that reads the bytes, which is the caller's, and #1041 owns it there.
+
     // Matches the System.Text.Json reader default rather than raising it, so a document this walk cannot
     // reach the bottom of is one its consumers could not read either.
     private const int MaxDepth = 64;
@@ -87,6 +92,15 @@ internal static class StrictJson
     /// input, which carries no member to repeat. Names are compared ordinally, because JSON member names are
     /// case-sensitive and every consumer of these documents compares them ordinally too, and AFTER
     /// unescaping, so a name spelled with a <c>\u</c> escape counts as the same name as its plain spelling.
+    ///
+    /// Ordinal is a decision about THIS plugin's readers, not a fact about JSON consumers in general, and the
+    /// difference matters: a deserializer configured case-insensitively — which is what
+    /// <c>JsonSerializerDefaults.Web</c> gives you — resolves <c>ISSUER</c> onto <c>Issuer</c> and keeps the
+    /// last occurrence, while an indexing reader over the same bytes returns the first. The plugin's own
+    /// discovery readers index, so a case-variant pair is unambiguous to them and refusing it would take a
+    /// working provider offline; whether that holds for every consumer this walk may acquire is not settled
+    /// here and is tracked separately.
+    ///
     /// Never throws.
     /// </returns>
     internal static Verdict Inspect(string? json, out string? repeatedMember)
@@ -94,8 +108,20 @@ internal static class StrictJson
         repeatedMember = null;
         if (string.IsNullOrWhiteSpace(json))
         {
-            return Verdict.Clean;
+            // Nothing was established about a body carrying no members, so this is Unreadable and not Clean.
+            // Clean is an affirmative "no scope names a member twice", which a caller reads as approval —
+            // and every reader these documents reach rejects an empty body outright, so reporting Clean would
+            // make this walk disagree with its own consumers about one document, which is what it exists to
+            // prevent.
+            return Verdict.Unreadable;
         }
+
+        // A UTF-8 BOM is a provider's to emit and Utf8JsonReader treats it as content, so a document that is
+        // otherwise perfect reads as malformed and — since Unreadable is a refusal at every seam that
+        // consumes this — locks that provider out. Stripped here rather than left to the caller: the one
+        // caller that exists today happens to strip it while decoding, but that is an undocumented property
+        // of a consumer this function does not have and cannot require.
+        var document = json!.TrimStart('\uFEFF');
 
         // One name set per open object, so sibling scopes may reuse a name — every JWKS entry repeats `kty`
         // and `kid`, so a walk pooling names document-wide would refuse real documents while reporting an
@@ -103,7 +129,7 @@ internal static class StrictJson
         var scopes = new Stack<HashSet<string>>();
         try
         {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new JsonReaderOptions { MaxDepth = MaxDepth });
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(document), new JsonReaderOptions { MaxDepth = MaxDepth });
             while (reader.Read())
             {
                 switch (reader.TokenType)
@@ -117,6 +143,9 @@ internal static class StrictJson
                         break;
 
                     case JsonTokenType.PropertyName:
+                        // GetString returns null only for a JSON null, which cannot be a member name, so the fallback is
+                        // unreachable — but folding it to "" would make the empty name and "no name" the same
+                        // key, and the empty name is a legal member a provider can repeat.
                         var name = reader.GetString() ?? string.Empty;
                         if (!scopes.Peek().Add(name))
                         {
@@ -137,6 +166,12 @@ internal static class StrictJson
         }
         catch (InvalidOperationException)
         {
+            // This arm is broader than its main cause, and the breadth is deliberate rather than
+            // overlooked: it also covers a stack operation on an empty stack, which would be a defect in
+            // this walk rather than anything the provider did. A walk bug therefore reports as an
+            // uninspectable document — the fail-closed direction, which is why the breadth is acceptable,
+            // but it does mean a verdict of Unreadable is not by itself evidence about the document.
+            //
             // GetString raises this — NOT JsonException — on a member name the decoder cannot complete: an
             // unpaired surrogate escape is thirteen bytes both parser families read without complaint. A
             // caller catching only JsonException would therefore take the crash, so this arm is what keeps a

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -56,6 +56,12 @@ internal static class StrictJson
 
     // Matches the System.Text.Json reader default rather than raising it, so a document this walk cannot
     // reach the bottom of is one its consumers could not read either.
+    //
+    // Because it EQUALS that default, no behavioural test can tell this constant from its absence: deleting
+    // it and the reader options leaves every verdict identical. It is kept for what it pins against — a
+    // future runtime moving its default — and that is a property no test in this repository can observe, so
+    // none claims to. An earlier test asserted it was pinned "from both directions"; it was not, and the
+    // claim is gone rather than reworded.
     private const int MaxDepth = 64;
 
     /// <summary>
@@ -66,14 +72,19 @@ internal static class StrictJson
     /// </summary>
     internal enum Verdict
     {
+        /// <summary>
+        /// Nothing was established about the document — it could not be walked to the end, or it carries no
+        /// object to walk. Deliberately the ZERO value: <c>default(Verdict)</c> is what an uninitialised
+        /// field or a silently skipped assignment produces, and on a fail-closed component that default must
+        /// be the refusal rather than the approval.
+        /// </summary>
+        Unreadable,
+
         /// <summary>No object scope names a member twice.</summary>
         Clean,
 
         /// <summary>An object scope names a member twice, so the document means two things.</summary>
         Repeated,
-
-        /// <summary>The document could not be walked to the end, so nothing was established about it.</summary>
-        Unreadable,
     }
 
     /// <summary>
@@ -87,11 +98,14 @@ internal static class StrictJson
     /// <returns>
     /// <see cref="Verdict.Repeated"/> when one object scope names a member twice;
     /// <see cref="Verdict.Unreadable"/> when the walk could not complete — malformed, truncated, nested past
-    /// the depth cap, or carrying a member name the decoder refuses (an unpaired surrogate escape is the
-    /// measured instance); <see cref="Verdict.Clean"/> otherwise, including for a null, empty or whitespace
-    /// input, which carries no member to repeat. Names are compared ordinally, because JSON member names are
-    /// case-sensitive and every consumer of these documents compares them ordinally too, and AFTER
-    /// unescaping, so a name spelled with a <c>\u</c> escape counts as the same name as its plain spelling.
+    /// the depth cap, carrying a member name the decoder refuses (an unpaired surrogate escape is the
+    /// measured instance), or carrying no object at all — a null, empty or whitespace body, and equally a
+    /// bare scalar or a document whose root is not and contains no object. None of those establishes
+    /// anything, which is what <see cref="Verdict.Unreadable"/> means, and reporting <c>Clean</c> for them
+    /// would hand a caller an affirmative answer about a document nothing read.
+    /// <see cref="Verdict.Clean"/> otherwise. Names are compared ordinally — a decision about this plugin's
+    /// readers rather than a fact about consumers, see below — and AFTER unescaping, so a name spelled with a
+    /// <c>\u</c> escape counts as the same name as its plain spelling.
     ///
     /// Ordinal is a decision about THIS plugin's readers, not a fact about JSON consumers in general, and the
     /// difference matters: a deserializer configured case-insensitively — which is what
@@ -121,20 +135,31 @@ internal static class StrictJson
         // consumes this — locks that provider out. Stripped here rather than left to the caller: the one
         // caller that exists today happens to strip it while decoding, but that is an undocumented property
         // of a consumer this function does not have and cannot require.
-        var document = json!.TrimStart('\uFEFF');
+        // ONE leading BOM, not a run of them: TrimStart would strip any number, and a document prefixed
+        // with several is one no consumer can parse, so admitting it would be this walk disagreeing with its
+        // readers in the permissive direction. A BOM that is not first — after whitespace, say — is left
+        // alone and the document reads as malformed, which is the honest answer for it.
+        var document = json!.StartsWith('\uFEFF') ? json.Substring(1) : json;
 
         // One name set per open object, so sibling scopes may reuse a name — every JWKS entry repeats `kty`
         // and `kid`, so a walk pooling names document-wide would refuse real documents while reporting an
         // attack. Only a repeat within the SAME object is a document that means two things.
         var scopes = new Stack<HashSet<string>>();
+        var sawObject = false;
         try
         {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(document), new JsonReaderOptions { MaxDepth = MaxDepth });
+            // Throw-on-invalid rather than the default replacement fallback: replacement maps every unpaired
+            // surrogate to U+FFFD, so two genuinely different member names would re-encode to the same key and
+            // the walk would report a repeat in a document that has none. The throw is caught below and
+            // reported as Unreadable, which is the honest answer for bytes that cannot round-trip.
+            var bytes = new UTF8Encoding(false, true).GetBytes(document);
+            var reader = new Utf8JsonReader(bytes, new JsonReaderOptions { MaxDepth = MaxDepth });
             while (reader.Read())
             {
                 switch (reader.TokenType)
                 {
                     case JsonTokenType.StartObject:
+                        sawObject = true;
                         scopes.Push(new HashSet<string>(StringComparer.Ordinal));
                         break;
 
@@ -164,6 +189,12 @@ internal static class StrictJson
         {
             return Verdict.Unreadable;
         }
+        catch (EncoderFallbackException)
+        {
+            // The document cannot be re-encoded without loss, so no verdict about its members would be about
+            // the document the consumer sees.
+            return Verdict.Unreadable;
+        }
         catch (InvalidOperationException)
         {
             // This arm is broader than its main cause, and the breadth is deliberate rather than
@@ -179,6 +210,9 @@ internal static class StrictJson
             return Verdict.Unreadable;
         }
 
-        return Verdict.Clean;
+        // A well-formed document that contains no object at all — a bare scalar, an array of scalars — has
+        // no scope in which a member could repeat, so the walk established nothing about it and says so. An
+        // EMPTY object is different and stays Clean: it has a scope, and that scope genuinely repeats nothing.
+        return sawObject ? Verdict.Clean : Verdict.Unreadable;
     }
 }


### PR DESCRIPTION
# What & why

A decision function over a JSON document: does any object scope name a member twice? Returns Clean, Repeated or Unreadable, reports the repeated name, does no I/O and never throws. Closes #1070.

It exists because a repeated member is accepted silently by every reader these documents reach and none of them raises an error, so which of the two values a consumer acts on is decided by parser internals rather than by the document. RFC 8259 leaves that unspecified and calls such objects interoperability-unsafe.

**This unit is the walk only.** The transport seam that puts it on the discovery and JWKS path is #1061; what a provider-authored string may do to the log is #1068. The split is deliberate: together they measured 958 changed lines against a 500-line target, and the review surface, not any individual defect, is what three rounds could not converge on.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: every failure mode reports `Unreadable`, which a consumer refuses on. There is no accept-by-default branch left, a body carrying no members now reports `Unreadable` rather than `Clean`, because nothing was established about it.
- [x] No secrets logged; nothing is logged here at all.
- [x] A security review was performed, the canonical gate over six lenses, plus three rounds and a plan review on this code while it lived inside the larger unit.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED 4 / PLAUSIBLE 26** as raised. Every finding carries a disposition below.
- [x] Log inputs from the IdP are sanitized inline at the log call, n/a, this unit writes no log entry.

## Quality checklist

- [x] No duplicated logic; one walk, one decision.
- [x] The change adds no more code than the problem requires. A row with no available falsifier was **deleted** rather than reworded, after the gate and the plan review reached that independently.
- [x] Self-documenting; each comment states a security-why or a measurement. Three claims were weakened this round to what is actually established.
- [x] Architecture-conformance tests pass. This unit establishes no new structural property; the source-scan rule that this walk names no framework-dependent API is #1062's.
- [x] Docs impact: none, no operator-visible behaviour. The documentation for the refusal it will eventually cause is #1063.

## Verification

Re-run at `b4d0b4e`, the commit this pull request points at, using the repository's own CI commands from `.github/workflows/dotnet.yml` rather than a local variant of them. The toolchain here reports in German, so each line carries its output verbatim.

- [x] `dotnet restore --locked-mode` clean.
- [x] `dotnet build --no-restore --warnaserror` on both target frameworks: `Der Buildvorgang wurde erfolgreich ausgeführt. 0 Warnung(en), 0 Fehler`.
- [x] `dotnet test --no-build --verbosity normal`: `gesamt: 4402, fehlgeschlagen: 0, erfolgreich: 4402` across the two frameworks, so **2201 per framework**.
- [x] Prettier: `npx prettier --check --end-of-line crlf "**/*.{js,html,md,css,scss}"` reports `All matched files use Prettier code style!`.

The **2197** stated here before was measured after the first gate round and never re-run after the second changed the corpus. The figure for `main` is derived rather than measured directly, and the derivation is: `SSO-Auth.Tests.exe -method "*StrictJson*"` reports `Total: 32`, and `git diff --name-only origin/main...HEAD` lists `SSO-Auth.Tests/Oidc/StrictJsonTests.cs` as the branch's only test file, so `main` carries 2201 − 32 = **2169** per framework. That matches the 2169 stated here before, which is the one number on this line that survived.

The load-dependent conformance row noted here before (#1072) did not appear at this commit: `dotnet test --no-build` was run twice on the clean tree and reported `fehlgeschlagen: 0` both times.

On the Prettier line, `--end-of-line crlf` is load-bearing and is not a way of dodging the gate. Without it the same command reports 19 files, none of them touched by this branch and every one of them a line-ending difference from a Windows checkout, which is #1066 and not this change. The CI check sees LF and is green.

### Kill conditions, re-run at the pushed commit

Every mutation below was applied to `StrictJson.cs` by a script that reports a non-matching anchor as `PATCH DID NOT APPLY` and never reaches the test run, so an unapplied mutation cannot be read as a caught one. Counts are rows red in `StrictJsonTests` on net9.0, out of 32.

| mutation | rows red | stated before |
| -------- | -------- | ------------- |
| screen the root scope only | 2 | 3 |
| pool names document-wide | 4 | 5 |
| child scope seeded from its parent | 2 | 3 |
| compare `OrdinalIgnoreCase` | 1 | 1 |
| compare raw spellings, no unescape | 2 | 3 |
| `InvalidOperationException` → `Clean` | 1 | 2 |
| `JsonException` → `Clean` | 4 | 4 |
| the repeated name misreported | 11 | 9 |
| the BOM strip removed | 2 | 2 |
| `TrimStart` an unbounded run of BOMs | 1 | not stated |
| `Clean` as the zero value of the verdict | 1 | not stated |
| a body carrying no object reports `Clean` | 1 | not stated |
| an empty body reports `Clean` | 1 | not stated |
| depth cap 64 → 128 | 1 | not stated |
| depth cap 64 → 16 | 1 | 1 |
| depth cap 64 → 3 | 2 | not stated |
| **the replacement encoder fallback** | **2**, was **0** | not stated |
| **the `EncoderFallbackException` arm deleted** | **2**, was **0** | not stated |
| the cap constant and the reader options both deleted | **0**, deliberately | not stated |

Every count in the first eight rows moved. Five were off by one and one by two, because the table was written after the first gate round and the second round changed the corpus underneath it without the table being re-run. That is the same defect class the second round's own commit message names, one level up: a claim about a check is only worth the last time the check was run.

**The two bold rows are why this round exists.** Before it, both mutations left every row green: the throwing `UTF8Encoding` fallback and the arm that catches it were a comment with nothing refusing its violation. A RAW unpaired surrogate in the document text has no UTF-8 encoding at all, so the default replacement fallback rewrites it to U+FFFD before the walk sees anything, and two member names ending in two different unpaired surrogates then collapse onto one key. The walk would report `Repeated` against a provider whose document repeats nothing, which is a false accusation and the one direction a screen must not fail in. Two fixtures refuse that now, and both mutations turn both of them red.

**The last row is a deliberate zero, not a gap.** The cap constant equals the reader's own default, so deleting it together with the reader options changes no verdict, and the constant's own comment already says no behavioural test in this repository can observe it. Measured and left alone, rather than covered by a test that would only be asserting the framework default back to itself.

The issue's eight kill conditions all hold at this commit. Two are written there in the plural and are singular in fact: mapping `InvalidOperationException` to `Clean` reds one row, and comparing raw spellings reds the escape row plus the escaped-surrogate row. Three of them red more rows than the issue claims, because `NestedTo` reuses the member name `a` at every nesting level, so any mutation of the scope rule also reds the depth-cap row.

## Notes

### What the first gate round found

Thirty findings. Four were measured before being accepted, and three are real defects in the decision function that three earlier rounds over this same code inside the larger unit never found:

- **A UTF-8 BOM made every document `Unreadable`**, including a perfect one, and `Unreadable` is a refusal at the seam, so a provider serving a BOM-prefixed discovery document would have been locked out. What saved it was the one caller stripping the BOM while decoding: an undocumented property of a consumer this function does not have and cannot require. Stripped here now.
- **Blank, whitespace and null bodies were reported `Clean`**, an affirmative pass on bytes every real reader rejects outright, which is the walk disagreeing with its own consumers about one document.
- **The depth cap was not pinned as a boundary**, while the comment claimed both directions. The mutations previously published (64→128, 64→3) do die, which is exactly the trap: mutants enumerated from the implementation rather than from the claim.

**One finding is refuted by measurement** and the corpus gains its fixture anyway: a root array carrying a duplicate is detected, only the coverage was missing.

### Claims weakened to what holds

- Ordinal comparison is a decision about **this plugin's readers**, not a fact about JSON consumers. A case-insensitive deserializer resolves `ISSUER` onto `Issuer` and keeps the last occurrence where an indexing reader returns the first, so the universal form was false. The remaining design question is #1073.
- The `InvalidOperationException` arm is broader than its stated cause and also covers a break of this walk's own stack invariant, so an `Unreadable` verdict is not by itself evidence about the document. The breadth is deliberate, fail-closed, and now stated.
- The walk **bounds nothing**. It is handed a string already in memory, so a document large enough to hurt has done so before this runs; the bound belongs at the position that reads the bytes, which is #1041's.

### Declined, with reasons

- **No caller, the diff ships dead code.** Unanimous across five lenses, and correct: this is my split decision of 2026-07-31, taken because the combined unit measured 958 lines against a 500 target. The lenses cannot see that decision, the gate passes them the diff and the touched files, never the PR body, which is the bias control working as designed. #1061 follows immediately.
- **No input bound.** A pure decision function cannot bound what it is handed. Stated in the doc comment rather than left implicit.

### Deferred, each with an owner

**#1073**, whether a case variant or an invalid-escape variant counts as the same member name; guard semantics with an availability cost either way. **#1036**, registering this walk in the fuzz harness. **#1041**, the size bound at the position that can hold it. **#1072**, the load-dependent conformance row, unrelated to this change.


### This round, and what it has not had

The change pushed at `b4d0b4e` is two test fixtures, one line of the `returns` contract, and two corpus redundancies removed. It has not itself been through the adversarial gate: every round recorded above ran against an earlier state of this branch. The gate on this delta is the review that lands this pull request.

---

## Independent verification at `b4d0b4e`

**This section was produced by an automated re-run, not by a second person.** It
re-executes the repository's own CI commands from `.github/workflows/dotnet.yml`
and an independently written mutation script, and reports what they printed. It
is evidence that the stated numbers reproduce. It is NOT a human second opinion,
and the security-review checkbox above refers to the gate described under it
rather than to this section.

Every number below was measured on a clean tree at `b4d0b4e`, the commit this pull request points at, with the repository's own CI commands from `.github/workflows/dotnet.yml` and with an independent mutation script rather than the one this branch used.

### The gate, re-run

`origin/main` at `a307d3c`, for the baseline the derived figures rest on:

```
dotnet restore --locked-mode        ->  All projects are up-to-date for restore.
dotnet build --no-restore --warnaserror
    ->  Build succeeded.  0 Warning(s)  0 Error(s)
dotnet test --no-build --verbosity normal
    ->  total: 4338, failed: 0, succeeded: 4338, skipped: 0
```

`b4d0b4e`:

```
dotnet restore --locked-mode        ->  All projects are up-to-date for restore.
dotnet build --no-restore --warnaserror
    ->  Build succeeded.  0 Warning(s)  0 Error(s)
dotnet test --no-build --verbosity normal
    ->  total: 4402, failed: 0, succeeded: 4402, skipped: 0
npx prettier --check --end-of-line crlf "**/*.{js,html,md,css,scss}"
    ->  All matched files use Prettier code style!
```

4402 and 4338 are both across the two frameworks, so 2201 and 2169 per framework, and the difference is 64, which is 32 rows twice. The 32 is measured directly, not derived:

```
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -class "Jellyfin.Plugin.SSO_Auth.Tests.StrictJsonTests"
    ->  Total: 32, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

So the three figures this pull request states, 4402, 2201 and 2169, all hold, and the derivation of the last one is sound.

### The mutation table, reproduced independently

A separate script applied one edit at a time to `SSO-Auth/Api/Oidc/StrictJson.cs`, rebuilt the net9.0 test leg and ran only `StrictJsonTests`. It reports a non-matching anchor as `EDIT DID NOT APPLY` and never reaches the test run, so an unapplied edit cannot be misread as a caught one. Every row of the table above reproduced exactly:

| mutation | stated | measured here |
| -------- | ------ | ------------- |
| screen the root scope only | 2 | 2 |
| pool names document-wide | 4 | 4 |
| child scope seeded from its parent | 2 | 2 |
| compare `OrdinalIgnoreCase` | 1 | 1 |
| compare raw spellings, no unescape | 2 | 2 |
| `InvalidOperationException` to `Clean` | 1 | 1 |
| `JsonException` to `Clean` | 4 | 4 |
| the repeated name misreported | 11 | 11 |
| the BOM strip removed | 2 | 2 |
| `TrimStart` an unbounded run of BOMs | 1 | 1 |
| `Clean` as the zero value of the verdict | 1 | 1 |
| a body carrying no object reports `Clean` | 1 | 1 |
| an empty body reports `Clean` | 1 | 1 |
| depth cap 64 to 128 | 1 | 1 |
| depth cap 64 to 16 | 1 | 1 |
| depth cap 64 to 3 | 2 | 2 |
| the replacement encoder fallback | 2 | 2 |
| the `EncoderFallbackException` arm deleted | 2 | 2 |
| the cap constant and the reader options both deleted | 0 | 0 |

Two mutations were run here that the table does not list, both killed: returning `Clean` from the `EncoderFallbackException` arm rather than deleting it reds 2, and returning `Clean` instead of `Repeated` on the detected repeat reds 11.

One note on the first row, because it is the row that is easiest to get wrong and it changed my own first answer. A "root scope only" edit that stops pushing scopes at all is not that mutation, it is the document-wide pool, and it reds 4. The faithful edit keeps the push and the pop and only screens at `scopes.Count == 1`, and it reds exactly 2, which are the two rows the issue names:

```
DuplicateMember_AtAnyScope_IsRepeated(json: "{\"outer\":{\"b\":1,\"b\":2}}", expectedMember: "b") [FAIL]
DuplicateMember_AtAnyScope_IsRepeated(json: "{\"keys\":[{\"kty\":\"RSA\",\"kty\":\"oct\"}]}", expectedMember: "kty") [FAIL]
```

### What is not covered, stated plainly

Two things in this file survive their own deletion with the suite green. Both are declared as such by the change itself rather than found here, which is the difference between an admitted gap and a false claim, but a reader deserves the list:

1. `MaxDepth` and the `JsonReaderOptions` that carry it. Deleting both reds nothing, because 64 is the reader's own default. The constant's comment says exactly that.
2. The `?? string.Empty` fallback on `reader.GetString()`. Replacing it with the null-forgiving `reader.GetString()!` reds nothing. The comment on that line says the fallback is unreachable, and it is: `GetString` returns null only on a JSON null, which cannot be a property-name token.

Neither can fail open. Neither is claimed to be pinned.

### An independent attack on the walk

Twenty-four inputs the corpus does not contain were run through `Inspect` directly. Nothing threw, and nothing reached `Clean` by a route that should have refused it:

- trailing data after a complete root value, `{"a":1}{"b":2,"b":3}`, is `Unreadable`, so a second document cannot be smuggled past the screen;
- a comment before the first member, a trailing comma, `NaN`, a leading zero and a bare `nan` are all `Unreadable`, so a tolerant-parser spelling does not buy an attacker anything here;
- `{"A":1,"A":2}`, `{"a\/b":1,"a/b":2}` and `{"a":1,"a":2}` are all `Repeated`, so an escape spelling does not evade the comparison;
- an astral pair spelled as a surrogate escape and spelled raw both compare as the same name and are `Repeated`, so the throwing encoder does not misfire on a legal pair;
- a lone BOM, a BOM followed only by whitespace, two BOMs, and a BOM after a non-breaking space are all `Unreadable`, while `﻿{}` is `Clean`.

One asymmetry worth recording rather than fixing: a lone surrogate ESCAPE in a member VALUE, `{"a":"\ud800"}`, is `Clean`, while the same surrogate raw in a value is `Unreadable`. That is consistent with the returns contract, which scopes the decoder-refusal case to member names, and `Clean` here is the honest answer to the only question this function asks. It is noted so the seam does not read `Clean` as "this document parses".

### Verdict

The behaviour survives the attack, the numbers survive re-measurement, and the two uncovered items are the ones the change already declares. Merging.
