### PR TITLE
Update README with holiday pause and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > [!NOTE]
 >
+> **Paused for 2 Weeks bc of Holidays :)
 > **Status: Release Candidate** — the fourth rung of the maturity ladder (In-Development → Alpha → Beta → Release Candidate → Full Release). Install it by adding this plugin's own repository to Jellyfin — see [Installing](#installing).
 
 <h1 align="center">Community SSO for Jellyfin</h1>


### PR DESCRIPTION
# What & why

Adds one line to the note callout at the top of `README.md`, announcing a
two-week pause.

```diff
 > [!NOTE]
 >
+> **Paused for 2 Weeks bc of Holidays :)
 > **Status: Release Candidate** — the fourth rung of the maturity ladder ...
```

**Left open deliberately.** The mechanical problems below are fixable, but the
substance, how long, and what exactly is paused, is not something that can be
settled from the diff. Guessing at it in the README of a security plugin that
outside users install would be worse than asking. Four questions at the bottom.

## Blocked, mechanically

`Deterministic PR-hygiene checks` is red, and it **is** a required check in the
"Protect main and 5.0 branch" ruleset, so this cannot merge in its current
shape. Two of its FAIL-tier rules are tripped:

1. The pull-request body carries no issue reference. (Until this edit the body
   was the unfilled template, placeholder comments and all.)
2. The commit subject `Update README with holiday pause and status` does not end
   with a bracketed issue reference. The convention is `... [#N]`.

Worth flagging separately: the header comment in `.github/workflows/pr-hygiene.yml`
states the workflow "is NOT wired into the 'Protect main' required-status-check
ruleset, so it never blocks a merge". That is no longer true, it is in the
required list, and it is blocking this pull request. Recorded in #1199.

## What a visitor actually sees

The `**` is opened and never closed, so it does not render as bold, it renders
as two literal asterisks. Checked through GitHub's own renderer rather than by
eye:

```
$ gh api -X POST markdown --input - <<< '{"text":"> [!NOTE]\n>\n> **Paused for 2 Weeks bc of Holidays :)\n> **Status: Release Candidate** — ...","mode":"gfm"}'

<p>**Paused for 2 Weeks bc of Holidays :)<br>
<strong>Status: Release Candidate</strong> — the fourth rung of the maturity ladder ...
```

So the first line of the README reads, literally:

> \*\*Paused for 2 Weeks bc of Holidays :)

The `Status: Release Candidate` line below it is unaffected, it still bolds
correctly, so the damage is contained to the new line, but that new line is
now the first thing anyone sees on the project's front page.

## Four things only you can decide

1. **Until when?** "2 Weeks" has no anchor. A reader in October cannot tell
   whether it is over, and nothing will update it. An explicit end date
   ("paused until 2026-08-17") stays true on its own, or goes visibly stale
   instead of quietly stale.

2. **What is paused?** Unqualified "paused" on an authentication plugin reads,
   to someone deciding whether to deploy it, as though security reports may go
   unanswered too. `SECURITY.md` currently promises "an initial response within
   a few days". If that promise still holds through the pause, saying so in the
   same breath costs one clause and removes the worst reading. If it does not
   hold, `SECURITY.md` is the file that needs the edit, not just this one.

3. **Register.** "bc" and ":)" are informal for the primary status callout of a
   security plugin. Your call entirely, but it is the one line every new
   visitor reads before deciding to trust the plugin.

4. **Does it belong in the README at all?** A pause is temporary; the README is
   the permanent front page and nothing prompts anyone to remove the line
   afterwards. A pinned issue or a release note expires on its own. If it does
   belong here, it needs an owner for taking it back out.

## Also inaccurate as described

The title and the previous body say the status was clarified. The diff does not
touch the status line, it only adds a line above it. Nothing about the status
changed.

## To unblock, once the wording is settled

- Close the `**`, or drop it.
- Give the commit subject a bracketed issue reference, and reference that issue
  here, so the hygiene gate passes.
- `npx prettier --check "**/*.{js,html,md,css,scss}"` covers `.md`, so run it
  before pushing.

This section was produced by an automated re-run, not by a second person.
