### PR TITLE
Move every codeql-action pin to v4.37.3 in one step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,7 +86,7 @@ jobs:
           dotnet-version: 9.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -94,6 +94,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -89,7 +89,7 @@ jobs:
 
       # Surface the findings in the code-scanning tab, alongside CodeQL and zizmor.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
           category: scorecard

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -73,7 +73,7 @@ jobs:
         # skip the "Fail on actionable findings" step below.
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
## Why this replaces three Dependabot pull requests

Dependabot opens one pull request per action path. That split the
`codeql-action` bump three ways:

| PR    | action path                  | file(s)                       |
| ----- | ---------------------------- | ----------------------------- |
| #1076 | `codeql-action/init`         | `codeql.yml`                  |
| #1075 | `codeql-action/analyze`      | `codeql.yml`                  |
| #1078 | `codeql-action/upload-sarif` | `scorecard.yml`, `zizmor.yml` |

CodeQL refuses to run when `init` and `analyze` are on different releases, so
#1075 and #1076 are not merely unreviewed on their own, they are broken. Both
arrived red with the same three failures, `Analyze (csharp)`,
`Analyze (javascript-typescript)` and `Analyze (actions)`, and the same cause:

```
##[warning] Not all workflow steps that use `github/codeql-action` actions use the same version.
##[error]   Loaded a configuration file for version '4.37.3', but running version '4.37.1'
```

Symmetrically on #1075, which bumps `analyze` and leaves `init` behind:

```
##[error]   Loaded a configuration file for version '4.37.1', but running version '4.37.3'
```

All four call sites were on one SHA and move to one SHA together, which is the
only shape that keeps that invariant. This is the same shape as #1026, which
replaced #1021/#1024/#1025 for the previous bump.

## The second reason a Dependabot pull request cannot land here

Even green, none of these five Dependabot pull requests can merge. The
"Protect main and 5.0 branch" ruleset requires the status check `zizmor`. That
context is the code-scanning analysis check, published by the "Upload SARIF"
step in `zizmor.yml` - a step deliberately skipped for Dependabot, whose token
is read-only:

```
if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')
```

So the required context never reports on a Dependabot head, the pull request
stays `BLOCKED`, and the ruleset lists no bypass actors. Measured rather than
inferred - the check-run set on #1077's head against #1074's:

```
gh api repos/iderex/jellyfin-plugin-sso/commits/<head>/check-runs -q '.check_runs[].name'
#1077 (Dependabot): ... Audit workflows (zizmor)          <- no `zizmor` context
#1074 (branch):     ... Audit workflows (zizmor), zizmor  <- present
```

This is why the bump is redone on an ordinary branch, which can gate. It is
tracked separately in #1199 so the workaround does not stay folklore.

## What changed

Four pins, `7188fc36` (v4.37.1) to `e4fba868` (v4.37.3):

- `codeql.yml`, `init`, `analyze`
- `scorecard.yml`, `upload-sarif`
- `zizmor.yml`, `upload-sarif`

The diff is byte-identical to the union of the three Dependabot diffs, the
`uses:` lines were extracted from both sides and compared, not eyeballed.

## Verification

The SHA is checked against upstream rather than taken from the Dependabot
bodies. Tag `v4.37.3` is the annotated tag `c54b30b7`, which dereferences to
commit `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`:

```
gh api repos/github/codeql-action/git/ref/tags/v4.37.3 -q '.object.sha'
# c54b30b7df092240050e69945842bc67aee0f0f4   (annotated tag object)
gh api repos/github/codeql-action/git/tags/c54b30b7df092240050e69945842bc67aee0f0f4 -q '.object.sha'
# e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81   -> matches every pin in this diff
```

The comment names the exact tag rather than the bare major on purpose: a
`# v4`-style comment that drifts from its pin fails the zizmor gate on every
later pull request.

**Changelog between the two versions.** v4.37.2 carries the only user-facing
change, the new `config-file` address format, now on by default, and a
private-registry lookup for remote configuration. No workflow in this
repository passes `config-file` (`grep -rn "config-file" .github/workflows/`
returns nothing), so that change does not reach this tree. v4.37.3 records
"No user facing changes."

**The failure this bump has to be checked against** is a scanner that stops
scanning quietly. A green job is not evidence of that; a job that produced
results is. Baseline on `main` before this change, read from the
code-scanning API at 2026-08-03T10:52:01Z, with the analyses this bump must
still produce afterwards:

| category                        | tool version | rules | results |
| ------------------------------- | ------------ | ----- | ------- |
| `/language:csharp`              | CodeQL 2.26.2 | 63   | 5       |
| `/language:javascript-typescript` | CodeQL 2.26.2 | 103 | 0       |
| `/language:actions`             | CodeQL 2.26.2 | 23   | 0       |
| `zizmor`                        | zizmor 1.26.1 | 0    | 0       |
| `supply-chain/online-scm`       | Scorecard v5.3.0 | 11 | 3      |
| `supply-chain/local`            | Scorecard v5.3.0 | 6  | 0      |
| `supply-chain/branch-protection`| Scorecard v5.3.0 | 1  | 1      |

The post-merge numbers are read from the same API and recorded below before
this is called done.

Closes #1075
Closes #1076
Closes #1078

---

## Post-merge result

Merged as `9541e195e3b755bd54f9956a86f86ca1cf74d70d`. Read back from the
code-scanning API at that exact commit, not from the badge and not from the
job's green tick:

```
gh api "repos/iderex/jellyfin-plugin-sso/code-scanning/analyses?ref=refs/heads/main" \
  -q '.[] | select(.commit_sha=="9541e195e3b755bd54f9956a86f86ca1cf74d70d")
      | "\(.tool.name) \(.tool.version)  \(.category)  rules=\(.rules_count)  results=\(.results_count)"'
```

| category                          | tool version     | rules | results | vs. baseline |
| --------------------------------- | ---------------- | ----- | ------- | ------------ |
| `/language:csharp`                | CodeQL 2.26.2    | 63    | 5       | unchanged    |
| `/language:javascript-typescript` | CodeQL 2.26.2    | 103   | 0       | unchanged    |
| `/language:actions`               | CodeQL 2.26.2    | 23    | 0       | unchanged    |
| `zizmor`                          | zizmor 1.26.1    | 0     | 0       | unchanged    |
| `supply-chain/online-scm`         | Scorecard v5.3.0 | 11    | 3       | unchanged    |
| `supply-chain/local`              | Scorecard v5.3.0 | 6     | 0       | unchanged    |
| `supply-chain/branch-protection`  | Scorecard v5.3.0 | 1     | 1       | unchanged    |

All seven analyses are present at the merge commit and every rule count is
identical to the pre-merge baseline, so the bump did not quietly narrow or
disable a scan. The five `csharp` results are the pre-existing alerts, not
new ones, the same five, at the same count, as before the bump.

Scorecard still reports engine v5.3.0 here because `scorecard-action` itself
is a separate pin, still on v2.4.3 at this commit; only its `upload-sarif`
step moved. That pin is #1077.

This section was produced by an automated re-run, not by a second person.
