### PR TITLE
Bump scorecard-action to v2.4.4 off a branch that can gate

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Why this replaces #1077

Same pin, redone on an ordinary branch. #1077 is green on every check it runs
and still reports `mergeable=MERGEABLE`, `state=BLOCKED`: the ruleset requires
the `zizmor` status check, and that context is published only by the SARIF
upload step, which is deliberately skipped for Dependabot's read-only token.
The ruleset lists no bypass actors. Tracked in #1199.

## What changed

One pin in `scorecard.yml`, `4eaacf05` (v2.4.3) to `2d114668` (v2.4.4). The
diff is identical to #1077's, the `uses:` lines were extracted from both and
compared, not eyeballed.

## Verification

**Pin.** Checked against upstream rather than taken from the Dependabot body:

```
gh api repos/ossf/scorecard-action/git/ref/tags/v2.4.4 -q '.object.sha'
# 55891bbd73f2425e97637d96e306fc9d491d0b21   (annotated tag object)
gh api repos/ossf/scorecard-action/git/tags/55891bbd73f2425e97637d96e306fc9d491d0b21 -q '.object.sha'
# 2d1146689b8cda280b9bc96326124645441f03bc   -> matches the pin in this diff
```

**Behaviour change in the action.** v2.4.4 carries "log POST failures instead
of failing entire action" (ossf/scorecard-action#1625). `scorecard.yml` sets
`publish_results: true`, so this repository is on that path: a failure to
publish the score to the OpenSSF API will no longer red the job, only appear
in the log. The SARIF write and the separate `upload-sarif` step are
unaffected, so a scanning or upload failure still reds the job. Accepted, the
weakened signal is about badge publication, not about scanning. It does mean a
silently stale public badge is now possible, which is worth knowing.

**Behaviour change in the engine.** v2.4.4 moves the Scorecard engine from
v5.3.0 to v5.5.0. The one that matters here is v5.5.0's "Scorecard will now
skip checks that don't apply to the current repo type" (ossf/scorecard#5000) - 
a check that stops running is exactly the failure this bump has to be held
against, and the upstream note asks that unexpected disappearances be
reported. Also in range:

- Branch-Protection now honours rulesets without include patterns (v5.4.0,
  ossf/scorecard#4835) and falls back to rulesets when classic protection is
  inaccessible (v5.5.0). This repository is governed by a ruleset, so the
  `supply-chain/branch-protection` result may legitimately change.
- Dangerous-Workflow gains `toJSON(github.event)` detection (v5.5.0). No
  workflow here uses it, `grep -rn "toJSON(github.event" .github/workflows/`
  returns nothing, so no new finding is expected from it.
- Pinned-Dependencies gains an empty-`uses:` check (v5.4.0).
  `grep -rn "uses:\s*$" .github/workflows/` returns nothing.
- Fuzzing gains .NET property-based fuzz detection (v5.5.0). `SSO-Auth.Fuzz/`
  exists, so this check may start passing where it did not.

**What this pull request's checks do NOT cover.** `scorecard.yml` has no
`pull_request` trigger, by design, that path cannot publish. So no check on
this pull request runs `scorecard-action` at all; the green ticks below come
from the other workflows. The bump is first exercised by the push-triggered
run on `main` after merge, and that run is read from the code-scanning API - 
categories present, `rules_count` non-zero so the job is known to have
actually scanned, rather than from the badge.

Baseline to compare against, read on `main` at 2026-08-03T11:55:38Z with
scorecard-action v2.4.3 (engine v5.3.0):

| category                         | rules | results |
| -------------------------------- | ----- | ------- |
| `supply-chain/online-scm`        | 11    | 3       |
| `supply-chain/local`             | 6     | 0       |
| `supply-chain/branch-protection` | 1     | 1       |

The post-merge numbers are read from the same API and recorded below before
this is called done.

Closes #1077

---

## Post-merge result

Merged as `2cb5ba52290c8a73e0fd9f24da7c8c383adb09ea`. The push-triggered
Scorecard run succeeded and the engine is on v5.5.0 as expected.

The category counts moved, which on its own looks exactly like coverage
disappearing:

| category                         | v5.3.0 rules/results | v5.5.0 rules/results |
| -------------------------------- | -------------------- | -------------------- |
| `supply-chain/online-scm`        | 11 / 3               | 6 / 2                |
| `supply-chain/local`             | 6 / 0                | 11 / 0               |
| `supply-chain/branch-protection` | 1 / 1                | 1 / 1                |

Totals are 18 rules either side, but an equal total can just as easily hide one
check dropping and another appearing, so the rule **sets** were compared rather
than the counts. The raw SARIF from both runs was pulled and diffed by rule id:

```
gh run download 30811420071 --name "SARIF file" --dir old   # v5.3.0, commit 9541e195
gh run download 30812160159 --name "SARIF file" --dir new   # v5.5.0, commit 2cb5ba52

rule COUNT   old=18  new=18
rule SET identical: true
DROPPED: (none)
ADDED:   (none)
```

So no check stopped running. v5.5.0's "skip checks that don't apply to the
current repo type" did not remove anything here. The count swap is a
re-categorisation - five checks moved from `online-scm` to `local`:

```
FuzzingID, PackagingID, SASTID, SecurityPolicyID, VulnerabilitiesID
  supply-chain/online-scm -> supply-chain/local
```

One finding cleared, none appeared:

```
FINDINGS old: BranchProtectionID, CodeReviewID, FuzzingID, MaintainedID
FINDINGS new: BranchProtectionID, CodeReviewID, MaintainedID
RESOLVED:   FuzzingID
NEW ALERTS: (none)
```

`FuzzingID` clearing is explained by the changelog rather than assumed benign:
v5.5.0 adds .NET property-based fuzz detection (ossf/scorecard#4860), and
`SSO-Auth.Fuzz/` exists, so the check now recognises what was already there.
`BranchProtectionID` still fires at the same count despite the two ruleset
scoring fixes in range.

This section was produced by an automated re-run, not by a second person.
