### PR TITLE
Allow an OIDC provider on a private network, per provider and opt-in [#1058]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **OpenID providers on a private network (#1058).** A new per-provider option,
+  **Allow Private Network Addresses**, lets a provider's backchannel
+  (discovery, JWKS, token, userinfo, back-channel logout) reach an identity
+  provider that lives on the administrator's own network. Previously the
+  outbound SSRF / DNS-rebind guard refused every non-public address with no way
+  to say a provider was deliberately internal, so the standard self-hosted shape
+  (Authelia or Keycloak on a `10.x`/`192.168.x` address behind a reverse proxy)
+  failed discovery with _"The outbound host resolves only to blocked
+  addresses"_, and the existing insecure toggles did not help because they relax
+  discovery policy rather than the transport. The option is **off by default**
+  and scoped to the one provider it is set on: it permits RFC 1918, carrier-grade
+  NAT and IPv6 unique-local only, while loopback, link-local and the cloud
+  metadata ranges (`169.254.169.254`, `192.0.0.192`) stay blocked regardless.
+  Every other provider, the avatar fetch and the SAML metadata importer keep the
+  full guard. Enabling it is surfaced as a security downgrade in the config page
+  and recorded in the insecure-toggle audit log.
 - **OpenID role claims carried as an object map.** A new per-provider option,
   **Role claim is an object map**, reads the roles from the property _names_ of
   a JSON object instead of from a list of strings. Zitadel needs it: it emits

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1420,6 +1420,7 @@ public class ArchitectureConformanceTests
         {
             "EnableAuthorization", "OidSecret", "DisableHttps", "DisablePushedAuthorization",
             "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
+            "AllowPrivateNetworkAddresses",
             "DoNotLoadProfile", "RequirePkce", "AllowExistingAccountLink",
             "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
             "RequireAcr", "AcrValues",
@@ -1487,10 +1488,11 @@ public class ArchitectureConformanceTests
             "RequirePkce", "AllowExistingAccountLink", "ProvisionNewUsersDisabled", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
             "AcrValues", "Prompt", "MaxAge", "RequireAcr",
             "DisableHttps", "DisablePushedAuthorization", "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
+            "AllowPrivateNetworkAddresses",
             "HideLoginButton", "LoginButtonText", "PostLogoutRedirectUri",
         };
 
-        Assert.Equal(44, expected.Length);
+        Assert.Equal(45, expected.Length);
         var missing = expected.Where(id => !markedIds.Contains(id)).ToList();
         Assert.True(
             missing.Count == 0,
@@ -1905,7 +1907,7 @@ public class ArchitectureConformanceTests
             body);
 
         // The flag / auto-expand trigger set must contain only settings whose ENABLED state is a downgrade or
-        // an attack-surface widening: the five insecure toggles and AllowExistingAccountLink. It must NOT
+        // an attack-surface widening: the six insecure toggles and AllowExistingAccountLink. It must NOT
         // contain the fail-closed hardening toggles (RequireVerifiedEmailForAdoption/ForLogin, RequirePkce),
         // which are OFF by default and whose ON state is MORE secure - flagging those is backwards (#689
         // re-review). Scoped to the two array literals so a stray mention elsewhere cannot mask a regression.
@@ -1915,7 +1917,8 @@ public class ArchitectureConformanceTests
         foreach (var id in new[]
         {
             "DisableHttps", "DisablePushedAuthorization", "DoNotValidateEndpoints",
-            "DoNotValidateIssuerName", "DoNotValidateResponseIssuer", "AllowExistingAccountLink",
+            "DoNotValidateIssuerName", "DoNotValidateResponseIssuer", "AllowPrivateNetworkAddresses",
+            "AllowExistingAccountLink",
         })
         {
             Assert.Contains("\"" + id + "\"", trigger, StringComparison.Ordinal);

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -590,6 +590,42 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void OutboundConnectGuard_ResolvesTheHostOnce_AndConnectsToTheAddressItJudged()
+    {
+        // The guard is only worth anything if the address it judged is the address the socket reaches. A
+        // second name resolution between the check and the connect, or a connect aimed at the host name
+        // instead of the validated address, reopens DNS rebinding exactly: the attacker's name resolves to
+        // a public address for the check and to an internal one for the connect. That property lives in
+        // three lines of ConnectToAllowedAddressAsync and no runtime test can observe it without a
+        // controllable resolver, so pin it at the source - the same way this file pins the other
+        // call-level invariants.
+        var source = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Net", "SsoHttp.cs"));
+
+        // Exactly one resolution, and the host name is read only to perform it.
+        Assert.Equal(1, CountOccurrences(source, "GetHostAddressesAsync"));
+        Assert.Equal(1, CountOccurrences(source, "context.DnsEndPoint.Host"));
+
+        // The value that is judged and the value that is connected to are the same local.
+        Assert.Contains("IpAddressClassifier.IsBlockedAddress(address, policy)", source, StringComparison.Ordinal);
+        Assert.Contains("socket.ConnectAsync(address, context.DnsEndPoint.Port", source, StringComparison.Ordinal);
+
+        // The tier comes from the handler that captured it, never from the request, so a redirect hop is
+        // judged under the tier the connection started on.
+        Assert.Contains("ConnectToAllowedAddressAsync(context, policy, cancellationToken)", source, StringComparison.Ordinal);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0; i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    [Fact]
     public void PrivateNetworkRelaxation_NeverReachesTheAvatarFetchOrTheSamlMetadataImporter()
     {
         // #1179's stated failure mode is a leak of the private-network relaxation to a caller that never

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -590,6 +590,61 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void PrivateNetworkRelaxation_NeverReachesTheAvatarFetchOrTheSamlMetadataImporter()
+    {
+        // #1179's stated failure mode is a leak of the private-network relaxation to a caller that never
+        // opted in. Two files are named on the issue as out of scope for #1058 and must stay strict: the
+        // avatar fetch, which builds its own handler and would otherwise let an IdP-supplied picture URL
+        // reach the admin's LAN, and the SAML metadata importer, which resolves the named outbound client
+        // and must keep resolving the strict one. SsoHttp's strict-by-default signature is what makes them
+        // correct today, but a default protects nothing against someone later passing the flag explicitly -
+        // so pin the call sites, not just the default. A source scan because this is a call-level property.
+        foreach (var relativePath in new[]
+        {
+            Path.Combine("SSO-Auth", "Api", "Avatar", "AvatarService.cs"),
+            Path.Combine("SSO-Auth", "Api", "Http", "SamlMetadataImporter.cs"),
+        })
+        {
+            var source = File.ReadAllText(Path.Combine(RepoRoot(), relativePath));
+
+            Assert.DoesNotContain("PrivateNetworkPermitted", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("PrivateOutboundClientName", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("allowPrivateNetworkAddresses", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("AllowPrivateNetworkAddresses", source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void PrivateNetworkRelaxation_IsSelectedOnlyByTheOidcBackchannelAndItsComposition()
+    {
+        // The other direction: enumerate every file that may name the relaxation at all, so a new caller
+        // wiring itself to the private-permitted tier has to be added here deliberately rather than
+        // arriving unnoticed. The roster is the OIDC backchannel (the login flow, the discovery reader and
+        // the admin "Test connection" probe), the config surface that stores and audits the flag, and the
+        // transport plus its composition root that define and register the two tiers.
+        var allowed = new[]
+        {
+            "AddressPolicy.cs", "IpAddressClassifier.cs", "SsoHttp.cs", "SsoOnlyServiceRegistrator.cs",
+            "OidcLoginService.cs", "OidcDiscoveryReader.cs", "ProviderConnectionTester.cs",
+            "PluginConfiguration.cs", "OidcInsecureToggles.cs",
+        }.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var strays = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path => !allowed.Contains(Path.GetFileName(path)))
+            .Where(path => File.ReadAllText(path).Contains("PrivateNetworkAddresses", StringComparison.Ordinal)
+                || File.ReadAllText(path).Contains("PrivateNetworkPermitted", StringComparison.Ordinal)
+                || File.ReadAllText(path).Contains("PrivateOutboundClientName", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.True(
+            strays.Count == 0,
+            "The private-network relaxation (#1058) must reach only the OIDC backchannel, its config surface and the transport; found named in: " + string.Join(", ", strays));
+    }
+
+    [Fact]
     public void Controller_NeverTouchesProviderLinkMaps()
     {
         // Locked in by the link/unlink admin-surface extraction (#372) and completed by #383: the two

--- a/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
@@ -112,6 +112,38 @@ public class ConfigExportImportTests
     }
 
     [Fact]
+    public void Import_RoundTrip_CarriesAllowPrivateNetworkAddresses_AndDefaultsItOffWhenAbsent()
+    {
+        // The private-network opt-in (#1178) is ordinary non-secret provider config, so it must survive an
+        // export/import cycle like any other toggle. The absent case matters more: a document written
+        // before the field existed must land as false, keeping the safe default rather than inheriting a
+        // relaxed transport the exporting admin never chose.
+        var source = new PluginConfiguration();
+        source.OidConfigs["lan-idp"] = new OidConfig
+        {
+            OidEndpoint = "https://authelia.internal.example",
+            OidClientId = "client-1",
+            AllowPrivateNetworkAddresses = true,
+        };
+        source.OidConfigs["public-idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp.example.com",
+            OidClientId = "client-2",
+        };
+
+        var target = new PluginConfiguration();
+        ConfigImport.Apply(target, WireRoundTrip(ConfigExport.Build(source)));
+
+        Assert.True(target.OidConfigs["lan-idp"].AllowPrivateNetworkAddresses);
+
+        // Flipping it on one provider leaves every other provider strict.
+        Assert.False(target.OidConfigs["public-idp"].AllowPrivateNetworkAddresses);
+
+        // A brand-new OidConfig - the shape a pre-#1178 saved config deserializes into - is off.
+        Assert.False(new OidConfig().AllowPrivateNetworkAddresses);
+    }
+
+    [Fact]
     public void Import_SamlProvider_KeepsTargetSigningKeys_WhenImportRedacted()
     {
         var source = new PluginConfiguration();

--- a/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigExportImportTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
 
@@ -141,6 +142,35 @@ public class ConfigExportImportTests
 
         // A brand-new OidConfig - the shape a pre-#1178 saved config deserializes into - is off.
         Assert.False(new OidConfig().AllowPrivateNetworkAddresses);
+    }
+
+    [Fact]
+    public void Import_DocumentOmittingAllowPrivateNetworkAddresses_LandsOff_EvenOverAnEnabledTarget()
+    {
+        // The import arrival path for a document that has no opinion at all about the flag - a backup taken
+        // before the option existed, or a hand-edited document. The test above covers a document that
+        // carries it; this one removes the property outright, which is the case that would otherwise fall
+        // through to whatever the importing instance already had.
+        var source = new PluginConfiguration();
+        source.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://idp.example.com", OidClientId = "client-1" };
+
+        var json = JsonSerializer.Serialize(ConfigExport.Build(source));
+        var node = JsonNode.Parse(json)!;
+        var provider = node["Configuration"]!["OidConfigs"]!["idp"]!.AsObject();
+
+        // Prove the property is there to remove, so a rename cannot turn this test into a no-op.
+        Assert.True(provider.Remove("AllowPrivateNetworkAddresses"));
+
+        var wire = JsonSerializer.Deserialize<ConfigExportDocument>(node.ToJsonString())!;
+
+        // The target already has the provider relaxed. An omitted field must not be read as "keep what you
+        // had": the document is the authority for what it describes, and it describes a strict provider.
+        var target = new PluginConfiguration();
+        target.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://idp.example.com", AllowPrivateNetworkAddresses = true };
+
+        ConfigImport.Apply(target, wire);
+
+        Assert.False(target.OidConfigs["idp"].AllowPrivateNetworkAddresses);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigPreservationTests.cs
@@ -144,6 +144,35 @@ public class ConfigPreservationTests
     }
 
     [Fact]
+    public void AllowPrivateNetworkAddresses_AbsentFromAStoredConfig_DeserializesOff()
+    {
+        // The upgrade arrival path (#1178): a config.xml written before the field existed carries no element
+        // for it, and every installation that upgrades takes exactly this path. An absent element leaves the
+        // property at the type's default, which is why the flag is named positively - a negatively named one
+        // would have defaulted to the relaxed transport on every existing installation at once.
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, new OidConfig { OidClientId = "client", AllowPrivateNetworkAddresses = true });
+        var xml = writer.ToString();
+
+        // Prove the element is present before it is removed, so the removal below cannot be a silent no-op
+        // that would let this test pass against a config that never had the flag serialized at all.
+        const string Element = "<AllowPrivateNetworkAddresses>true</AllowPrivateNetworkAddresses>";
+        Assert.Contains(Element, xml, StringComparison.Ordinal);
+
+        using var reader = new System.IO.StringReader(xml.Replace(Element, string.Empty, StringComparison.Ordinal));
+        using var xmlReader = System.Xml.XmlReader.Create(
+            reader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var restored = (OidConfig)serializer.Deserialize(xmlReader)!;
+
+        Assert.False(restored.AllowPrivateNetworkAddresses);
+
+        // The rest of the stored provider still loads, so this is the upgrade path and not a parse failure.
+        Assert.Equal("client", restored.OidClientId);
+    }
+
+    [Fact]
     public void CanonicalLinkIssuers_AreOmittedFromJson_ButKeptInXml()
     {
         // The issuer map is server-managed exactly like CanonicalLinks (#186/#157): withheld from JSON so it

--- a/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
+++ b/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
@@ -137,6 +139,40 @@ public class ProviderConnectionTesterTests
         var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
 
         AssertNoSecret(result, OidSecretSentinel);
+    }
+
+    [Fact]
+    public async Task TestOidcAsync_SelectsTheTransportTier_PerProvider_OnOneInstance()
+    {
+        // The claim of #1179 is that the relaxation reaches exactly the provider that asked for it. The
+        // transport tests prove a flag selects a client name; this proves the SELECTION, with two providers
+        // configured on one instance differing only in the opt-in, at a real backchannel call site.
+        //
+        // It closes the one leak the conformance roster cannot see: that roster lists the files allowed to
+        // name the relaxation, and every backchannel file is on it, so a call site passing a literal true
+        // instead of the provider's own setting would relax every provider and stay green. Here it makes
+        // the two halves below disagree.
+        var requested = new List<string>();
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(call =>
+        {
+            requested.Add(call.Arg<string>() ?? string.Empty);
+            return new HttpClient(new StubHttpMessageHandler(Serve(FullDiscovery(Authority))));
+        });
+
+        var strict = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
+        var optedIn = new OidConfig { OidEndpoint = Authority, OidClientId = "jf", AllowPrivateNetworkAddresses = true };
+
+        await ProviderConnectionTester.TestOidcAsync(strict, "public-idp", factory, Logger());
+
+        Assert.NotEmpty(requested);
+        Assert.All(requested, name => Assert.Equal(SsoHttp.OutboundClientName, name));
+
+        requested.Clear();
+        await ProviderConnectionTester.TestOidcAsync(optedIn, "lan-idp", factory, Logger());
+
+        Assert.NotEmpty(requested);
+        Assert.All(requested, name => Assert.Equal(SsoHttp.PrivateOutboundClientName, name));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
+++ b/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
@@ -65,4 +65,96 @@ public class IpAddressClassifierTests
     {
         Assert.False(IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(ip)));
     }
+
+    /// <summary>
+    /// The relaxed tier permits exactly the private, admin-routable ranges an on-premises identity
+    /// provider actually lives on (#1177): RFC 1918, carrier-grade NAT, and IPv6 unique-local.
+    /// </summary>
+    /// <param name="ip">The address to classify.</param>
+    [Theory]
+    [InlineData("10.1.2.3")]
+    [InlineData("10.255.255.255")]
+    [InlineData("172.16.0.1")]
+    [InlineData("172.31.255.255")]
+    [InlineData("192.168.0.1")]
+    [InlineData("192.168.255.255")]
+    [InlineData("100.64.0.1")] // CGNAT
+    [InlineData("100.127.255.255")] // CGNAT (upper half)
+    [InlineData("fc00::1")] // IPv6 unique-local
+    [InlineData("fd12:3456:789a::1")] // IPv6 unique-local (the fd00::/8 half in practical use)
+    [InlineData("::ffff:10.1.2.3")] // IPv4-mapped form of an RFC 1918 address
+    [InlineData("64:ff9b::a00:5")] // NAT64 embedding 10.0.0.5
+    [InlineData("2002:c0a8:101::")] // 6to4 embedding 192.168.1.1
+    public void IsBlockedAddress_PrivateNetworkPermitted_AllowsPrivateRanges(string ip)
+    {
+        Assert.False(IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(ip), AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
+    /// The never-relaxable ranges stay blocked under the relaxed tier too - loopback, link-local
+    /// (where the cloud metadata service lives), the IETF protocol assignments, site-local, the
+    /// unspecified address and multicast/reserved/broadcast. This is the constraint stated on #1058
+    /// that no config setting may negotiate away, including via a transition-address wrapper.
+    /// </summary>
+    /// <param name="ip">The address to classify.</param>
+    [Theory]
+    [InlineData("127.0.0.1")]
+    [InlineData("127.1.2.3")]
+    [InlineData("::1")]
+    [InlineData("169.254.0.1")] // link-local
+    [InlineData("169.254.169.254")] // cloud metadata service
+    [InlineData("fe80::1")] // IPv6 link-local
+    [InlineData("192.0.0.192")] // Oracle Cloud metadata (192.0.0.0/24 protocol assignments)
+    [InlineData("0.0.0.0")]
+    [InlineData("::")]
+    [InlineData("fec0::1")] // deprecated IPv6 site-local
+    [InlineData("224.0.0.1")] // multicast
+    [InlineData("239.255.255.250")] // multicast (SSDP)
+    [InlineData("240.0.0.1")] // reserved
+    [InlineData("255.255.255.255")] // broadcast
+    [InlineData("192.0.2.10")] // TEST-NET-1
+    [InlineData("198.51.100.10")] // TEST-NET-2
+    [InlineData("203.0.113.10")] // TEST-NET-3
+    [InlineData("198.18.0.1")] // benchmarking 198.18.0.0/15
+    [InlineData("192.88.99.1")] // 6to4 relay anycast
+    [InlineData("::ffff:127.0.0.1")] // IPv4-mapped loopback
+    [InlineData("::ffff:169.254.169.254")] // IPv4-mapped metadata service
+    [InlineData("64:ff9b::7f00:1")] // NAT64 embedding 127.0.0.1
+    [InlineData("64:ff9b::a9fe:a9fe")] // NAT64 embedding 169.254.169.254
+    [InlineData("2002:7f00:1::")] // 6to4 embedding 127.0.0.1
+    [InlineData("2002:a9fe:a9fe::")] // 6to4 embedding 169.254.169.254
+    [InlineData("::7f00:1")] // deprecated IPv4-compatible ::127.0.0.1
+    [InlineData("::a9fe:a9fe")] // deprecated IPv4-compatible ::169.254.169.254
+    public void IsBlockedAddress_PrivateNetworkPermitted_StillBlocksNeverRelaxableRanges(string ip)
+    {
+        Assert.True(IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(ip), AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
+    /// A public address stays reachable under the relaxed tier - widening the policy must not narrow it.
+    /// </summary>
+    /// <param name="ip">The address to classify.</param>
+    [Theory]
+    [InlineData("8.8.8.8")]
+    [InlineData("172.32.0.1")]
+    [InlineData("100.63.255.255")]
+    [InlineData("2606:4700:4700::1111")]
+    public void IsBlockedAddress_PrivateNetworkPermitted_StillAllowsPublicAddresses(string ip)
+    {
+        Assert.False(IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(ip), AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
+    /// The tier defaults to strict, so the three existing callers keep byte-identical behaviour without
+    /// naming a policy at their call sites (#1177).
+    /// </summary>
+    [Fact]
+    public void IsBlockedAddress_DefaultPolicy_IsStrict()
+    {
+        var privateAddress = IPAddress.Parse("10.1.2.3");
+
+        Assert.True(IpAddressClassifier.IsBlockedAddress(privateAddress));
+        Assert.True(IpAddressClassifier.IsBlockedAddress(privateAddress, AddressPolicy.Strict));
+        Assert.False(IpAddressClassifier.IsBlockedAddress(privateAddress, AddressPolicy.PrivateNetworkPermitted));
+    }
 }

--- a/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
+++ b/SSO-Auth.Tests/Net/IpAddressClassifierTests.cs
@@ -145,6 +145,84 @@ public class IpAddressClassifierTests
     }
 
     /// <summary>
+    /// The first and last address of every range the relaxed tier moves. A range written one octet wide of
+    /// its definition is the classic way a partition goes wrong, and it is invisible to a test that only
+    /// samples the middle: each of these must be blocked under strict and permitted under relaxed.
+    /// </summary>
+    /// <param name="ip">The boundary address to classify.</param>
+    [Theory]
+    [InlineData("10.0.0.0")] // 10.0.0.0/8, first
+    [InlineData("10.255.255.255")] // 10.0.0.0/8, last
+    [InlineData("172.16.0.0")] // 172.16.0.0/12, first
+    [InlineData("172.31.255.255")] // 172.16.0.0/12, last
+    [InlineData("192.168.0.0")] // 192.168.0.0/16, first
+    [InlineData("192.168.255.255")] // 192.168.0.0/16, last
+    [InlineData("100.64.0.0")] // 100.64.0.0/10, first
+    [InlineData("100.127.255.255")] // 100.64.0.0/10, last
+    [InlineData("fc00::")] // fc00::/7, first
+    [InlineData("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")] // fc00::/7, last
+    public void IsBlockedAddress_RangeBoundaries_MoveTierTogetherWithTheirRange(string ip)
+    {
+        var address = IPAddress.Parse(ip);
+
+        Assert.True(IpAddressClassifier.IsBlockedAddress(address, AddressPolicy.Strict));
+        Assert.False(IpAddressClassifier.IsBlockedAddress(address, AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
+    /// The address immediately outside each moved range, on both sides. These are ordinary public
+    /// addresses and must stay reachable under both tiers - a range that leaked one address wider or
+    /// narrower than its definition shows up here rather than in production.
+    /// </summary>
+    /// <param name="ip">The just-outside address to classify.</param>
+    [Theory]
+    [InlineData("9.255.255.255")] // just below 10.0.0.0/8
+    [InlineData("11.0.0.0")] // just above 10.0.0.0/8
+    [InlineData("172.15.255.255")] // just below 172.16.0.0/12
+    [InlineData("172.32.0.0")] // just above 172.16.0.0/12
+    [InlineData("192.167.255.255")] // just below 192.168.0.0/16
+    [InlineData("192.169.0.0")] // just above 192.168.0.0/16
+    [InlineData("100.63.255.255")] // just below 100.64.0.0/10
+    [InlineData("100.128.0.0")] // just above 100.64.0.0/10
+    [InlineData("fbff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")] // just below fc00::/7
+    public void IsBlockedAddress_JustOutsideAMovedRange_IsPublicUnderBothTiers(string ip)
+    {
+        var address = IPAddress.Parse(ip);
+
+        Assert.False(IpAddressClassifier.IsBlockedAddress(address, AddressPolicy.Strict));
+        Assert.False(IpAddressClassifier.IsBlockedAddress(address, AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
+    /// A wrapped address reaches the same verdict as the same address unwrapped, under the relaxed tier,
+    /// for every transition form the classifier unwraps. The two theories above assert the wrapped and the
+    /// bare forms separately, which stays green if one of them silently stops being classified at all;
+    /// this asserts the equality itself, which is the property that keeps a wrapper from being a way in.
+    /// </summary>
+    /// <param name="wrapped">The transition-wrapped address.</param>
+    /// <param name="bare">The same address written plainly.</param>
+    [Theory]
+    [InlineData("::ffff:127.0.0.1", "127.0.0.1")] // IPv4-mapped
+    [InlineData("::ffff:169.254.169.254", "169.254.169.254")] // IPv4-mapped
+    [InlineData("::ffff:192.0.0.192", "192.0.0.192")] // IPv4-mapped
+    [InlineData("::ffff:10.1.2.3", "10.1.2.3")] // IPv4-mapped, a relaxable address
+    [InlineData("64:ff9b::7f00:1", "127.0.0.1")] // NAT64
+    [InlineData("64:ff9b::a9fe:a9fe", "169.254.169.254")] // NAT64
+    [InlineData("64:ff9b::a00:5", "10.0.0.5")] // NAT64, a relaxable address
+    [InlineData("2002:7f00:1::", "127.0.0.1")] // 6to4
+    [InlineData("2002:a9fe:a9fe::", "169.254.169.254")] // 6to4
+    [InlineData("2002:c0a8:101::", "192.168.1.1")] // 6to4, a relaxable address
+    [InlineData("::7f00:1", "127.0.0.1")] // deprecated IPv4-compatible
+    [InlineData("::a9fe:a9fe", "169.254.169.254")] // deprecated IPv4-compatible
+    [InlineData("::a01:203", "10.1.2.3")] // deprecated IPv4-compatible, a relaxable address
+    public void IsBlockedAddress_PrivateNetworkPermitted_WrappedVerdictEqualsUnwrappedVerdict(string wrapped, string bare)
+    {
+        Assert.Equal(
+            IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(bare), AddressPolicy.PrivateNetworkPermitted),
+            IpAddressClassifier.IsBlockedAddress(IPAddress.Parse(wrapped), AddressPolicy.PrivateNetworkPermitted));
+    }
+
+    /// <summary>
     /// The tier defaults to strict, so the three existing callers keep byte-identical behaviour without
     /// naming a policy at their call sites (#1177).
     /// </summary>

--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -6,9 +6,12 @@ using System.Net;
 using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using MediaBrowser.Controller;
+using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
 
@@ -187,6 +190,44 @@ public class SsoHttpTests
         Assert.True(listener.Accepted, "the private-permitted guard did not reach the private-address listener");
     }
 
+    [Fact]
+    public async Task CompositionRoot_GivesEachOutboundName_ItsOwnTier()
+    {
+        // Which tier a name carries is decided in SsoOnlyServiceRegistrator, and until now nothing read that
+        // decision back. The conformance rosters allow that file to name the relaxation, and the tests above
+        // build handlers directly - so registering the STRICT name with the relaxed policy would have
+        // relaxed every caller that names no tier, including the SAML metadata importer, with the whole
+        // suite still green. This drives the two registered names at a real socket instead.
+        var privateAddress = FindLocalPrivateAddress();
+        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        new SsoOnlyServiceRegistrator().RegisterServices(services, Substitute.For<IServerApplicationHost>());
+        await using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+
+        using var listener = new PrivateListener(privateAddress!);
+        var target = $"http://{privateAddress}:{listener.Port}/";
+
+        using (var strict = factory.CreateClient(SsoHttp.OutboundClientName))
+        {
+            strict.Timeout = TimeSpan.FromSeconds(10);
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(
+                () => strict.GetAsync(target, TestContext.Current.CancellationToken));
+
+            Assert.Contains("The outbound host resolves only to blocked addresses.", ex.Message, StringComparison.Ordinal);
+            Assert.False(listener.Accepted, "the registered strict client connected to a private address");
+        }
+
+        using var relaxed = factory.CreateClient(SsoHttp.PrivateOutboundClientName);
+        relaxed.Timeout = TimeSpan.FromSeconds(10);
+        using var response = await relaxed.GetAsync(target, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(listener.Accepted, "the registered private-permitted client did not reach the private-address listener");
+    }
+
     // This machine's own RFC 1918 / CGNAT interface address, or null when it has none (a container on a
     // public address, or loopback-only) - the test skips rather than asserting on an absent network. Read
     // from the interfaces rather than by resolving the host name, which is not resolvable on every machine.
@@ -254,6 +295,111 @@ public class SsoHttpTests
                     var buffer = new byte[2048];
                     await conn.ReceiveAsync(buffer, SocketFlags.None, token).ConfigureAwait(false);
                     var response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"u8.ToArray();
+                    await conn.SendAsync(response, SocketFlags.None, token).ConfigureAwait(false);
+                    conn.Shutdown(SocketShutdown.Both);
+                }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException or SocketException)
+            {
+                // Listener torn down - expected on dispose.
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _socket.Dispose();
+            _cts.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback()
+    {
+        // A redirect is a second connection to a host the first response chose, so the guard has to run on
+        // it too - otherwise a permitted first hop becomes an open door to whatever it points at, which is
+        // the DNS-rebind/SSRF shape the guard exists for. Until now the handler's redirect settings were
+        // asserted as properties (AllowAutoRedirect, MaxAutomaticRedirections) but nothing proved a hop was
+        // actually judged.
+        //
+        // The first hop must be an address the tier permits, and the only such address that can be bound
+        // locally is this machine's own private one - so this test needs a private interface address and
+        // skips without one. It runs where the feature matters; the skip is recorded rather than hidden.
+        var privateAddress = FindLocalPrivateAddress();
+        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+
+        using var blocked = new BlockedListener();
+        using var redirector = new RedirectingListener(privateAddress!, _ => $"http://127.0.0.1:{blocked.Port}/");
+        using var handler = SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync($"http://{privateAddress}:{redirector.Port}/", TestContext.Current.CancellationToken));
+
+        // The first hop was allowed and reached, so the refusal below is the redirect hop being judged and
+        // not the request failing before it ever started.
+        Assert.True(redirector.Requests >= 1, "the private-permitted guard did not reach the permitted first hop");
+        Assert.Contains("blocked address", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(blocked.Accepted, "a redirect hop reached a loopback listener the guard must refuse");
+    }
+
+    [Fact]
+    public async Task PrivatePermittedHandler_StopsAtTheRedirectBoundTheHandlerSets()
+    {
+        // The hop-by-hop guard above is only bounded if the redirect chain is: an IdP that redirects
+        // forever would otherwise spin the connect guard indefinitely. MaxAutomaticRedirections is 5, so a
+        // listener that always redirects to itself must be asked exactly 6 times (the original request plus
+        // five hops) and the client must hand back the last redirect rather than following it.
+        var privateAddress = FindLocalPrivateAddress();
+        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+
+        using var redirector = new RedirectingListener(privateAddress!, port => $"http://{privateAddress}:{port}/next");
+        using var handler = SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+        using var response = await client.GetAsync($"http://{privateAddress}:{redirector.Port}/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal(6, redirector.Requests);
+    }
+
+    // A TCP listener bound to a given address that answers every request with a 302 to a caller-chosen
+    // location, and counts how many requests it was asked - so a test can prove both that a hop was taken
+    // and how many were.
+    private sealed class RedirectingListener : IDisposable
+    {
+        private readonly Socket _socket;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Func<int, string> _location;
+        private int _requests;
+
+        internal RedirectingListener(IPAddress address, Func<int, string> location)
+        {
+            _location = location;
+            _socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            _socket.Bind(new IPEndPoint(address, 0));
+            _socket.Listen(16);
+            Port = ((IPEndPoint)_socket.LocalEndPoint!).Port;
+            _ = AcceptLoopAsync(_cts.Token);
+        }
+
+        internal int Port { get; }
+
+        internal int Requests => Volatile.Read(ref _requests);
+
+        private async Task AcceptLoopAsync(CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    using var conn = await _socket.AcceptAsync(token).ConfigureAwait(false);
+                    var buffer = new byte[2048];
+                    await conn.ReceiveAsync(buffer, SocketFlags.None, token).ConfigureAwait(false);
+                    Interlocked.Increment(ref _requests);
+
+                    var response = Encoding.ASCII.GetBytes(
+                        $"HTTP/1.1 302 Found\r\nLocation: {_location(Port)}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
                     await conn.SendAsync(response, SocketFlags.None, token).ConfigureAwait(false);
                     conn.Shutdown(SocketShutdown.Both);
                 }

--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -85,6 +86,190 @@ public class SsoHttpTests
         Assert.Contains("blocked address", ex.Message, StringComparison.OrdinalIgnoreCase);
         // And nothing reached the socket: the listener never accepted a connection.
         Assert.False(listener.Accepted, "the SSRF guard let a socket reach the blocked loopback listener");
+    }
+
+    [Fact]
+    public void CreateClient_WithoutTheOptIn_ResolvesTheStrictNamedClient()
+    {
+        // Strict by default is the whole safety property of #1179: SamlMetadataImporter and any future
+        // caller pass no flag, so they must keep landing on the fully-guarded client. A default that
+        // leaked the other way would relax the guard for callers that never asked.
+        using var factoryClient = new HttpClient();
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(SsoHttp.OutboundClientName).Returns(factoryClient);
+
+        Assert.Same(factoryClient, SsoHttp.CreateClient(factory));
+        Assert.Same(factoryClient, SsoHttp.CreateClient(factory, allowPrivateNetworkAddresses: false));
+
+        factory.Received(2).CreateClient(SsoHttp.OutboundClientName);
+        factory.DidNotReceive().CreateClient(SsoHttp.PrivateOutboundClientName);
+    }
+
+    [Fact]
+    public void CreateClient_WithTheOptIn_ResolvesThePrivatePermittedNamedClient()
+    {
+        // The relaxation is baked into WHICH client is resolved, not carried as an ambient per-request
+        // mode: the handlers are long-lived and shared across concurrent logins, so a mode that is not part
+        // of the client's identity could leak to a provider that never opted in.
+        using var factoryClient = new HttpClient();
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(SsoHttp.PrivateOutboundClientName).Returns(factoryClient);
+
+        var client = SsoHttp.CreateClient(factory, allowPrivateNetworkAddresses: true);
+
+        Assert.Same(factoryClient, client);
+        factory.Received(1).CreateClient(SsoHttp.PrivateOutboundClientName);
+        factory.DidNotReceive().CreateClient(SsoHttp.OutboundClientName);
+        Assert.Equal(SsoHttp.UserAgent, client.DefaultRequestHeaders.UserAgent.ToString());
+    }
+
+    [Fact]
+    public void TheTwoOutboundClientNames_AreDistinct()
+    {
+        // If these ever collide, one registration silently wins and every caller shares whichever tier that
+        // was - the leak this whole design exists to prevent.
+        Assert.NotEqual(SsoHttp.OutboundClientName, SsoHttp.PrivateOutboundClientName);
+    }
+
+    [Theory]
+    [InlineData("http://127.0.0.1")] // IPv4 loopback literal
+    [InlineData("http://[::1]")] // IPv6 loopback literal
+    [InlineData("http://169.254.169.254")] // link-local cloud metadata endpoint
+    [InlineData("http://[fe80::1]")] // IPv6 link-local
+    [InlineData("http://192.0.0.192")] // IETF protocol assignments (Oracle Cloud metadata)
+    [InlineData("http://localhost")] // a NAME that resolves to loopback
+    public async Task PrivatePermittedHandler_StillRefusesTheNeverRelaxableAddresses(string baseUrl)
+    {
+        // The opt-in widens the guard to the admin's own network - it must not open the ranges #1058 said
+        // stay closed regardless. The live loopback listener again proves the refusal happens BEFORE any
+        // socket reaches it.
+        using var listener = new BlockedListener();
+        using var handler = SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+        var target = $"{baseUrl}:{listener.Port}/";
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetAsync(target, TestContext.Current.CancellationToken));
+
+        Assert.Contains("blocked address", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.False(listener.Accepted, "the private-permitted guard let a socket reach a never-relaxable listener");
+    }
+
+    [Fact]
+    public async Task PrivatePermittedHandler_ConnectsToAnRfc1918Address_WhereTheStrictOneRefuses()
+    {
+        // The reproduction from #1058, at the socket layer: an IdP on the admin's own LAN. Bind a real
+        // listener to this machine's own private-range interface address and drive both handlers at it -
+        // the strict one must refuse before connecting, the private-permitted one must get through.
+        var privateAddress = FindLocalPrivateAddress();
+        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+
+        using var listener = new PrivateListener(privateAddress!);
+        var target = $"http://{privateAddress}:{listener.Port}/";
+
+        using (var strictHandler = SsoHttp.CreateHardenedHandler())
+        using (var strictClient = new HttpClient(strictHandler) { Timeout = TimeSpan.FromSeconds(10) })
+        {
+            var ex = await Assert.ThrowsAsync<HttpRequestException>(
+                () => strictClient.GetAsync(target, TestContext.Current.CancellationToken));
+
+            // The exact failure the reporter saw, from SsoHttp's own diagnostics.
+            Assert.Contains("The outbound host resolves only to blocked addresses.", ex.Message, StringComparison.Ordinal);
+            Assert.False(listener.Accepted, "the strict guard connected to a private address");
+        }
+
+        using var handler = SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted);
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(10) };
+
+        using var response = await client.GetAsync(target, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.True(listener.Accepted, "the private-permitted guard did not reach the private-address listener");
+    }
+
+    // This machine's own RFC 1918 / CGNAT interface address, or null when it has none (a container on a
+    // public address, or loopback-only) - the test skips rather than asserting on an absent network. Read
+    // from the interfaces rather than by resolving the host name, which is not resolvable on every machine.
+    private static IPAddress? FindLocalPrivateAddress()
+    {
+        foreach (var nic in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (nic.OperationalStatus != OperationalStatus.Up || nic.NetworkInterfaceType == NetworkInterfaceType.Loopback)
+            {
+                continue;
+            }
+
+            foreach (var info in nic.GetIPProperties().UnicastAddresses)
+            {
+                var address = info.Address;
+                if (address.AddressFamily != AddressFamily.InterNetwork || IPAddress.IsLoopback(address))
+                {
+                    continue;
+                }
+
+                var b = address.GetAddressBytes();
+                var isPrivate = b[0] == 10
+                    || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+                    || (b[0] == 192 && b[1] == 168)
+                    || (b[0] == 100 && b[1] >= 64 && b[1] <= 127);
+                if (isPrivate)
+                {
+                    return address;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    // A minimal HTTP listener bound to a private-range address - it answers 204, so a successful response
+    // proves the connection actually completed rather than merely not being refused at the guard.
+    private sealed class PrivateListener : IDisposable
+    {
+        private readonly Socket _socket;
+        private readonly CancellationTokenSource _cts = new();
+
+        internal PrivateListener(IPAddress address)
+        {
+            _socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            _socket.Bind(new IPEndPoint(address, 0));
+            _socket.Listen(16);
+            Port = ((IPEndPoint)_socket.LocalEndPoint!).Port;
+            _ = AcceptLoopAsync(_cts.Token);
+        }
+
+        internal int Port { get; }
+
+        internal bool Accepted { get; private set; }
+
+        private async Task AcceptLoopAsync(CancellationToken token)
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    using var conn = await _socket.AcceptAsync(token).ConfigureAwait(false);
+                    Accepted = true;
+
+                    var buffer = new byte[2048];
+                    await conn.ReceiveAsync(buffer, SocketFlags.None, token).ConfigureAwait(false);
+                    var response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"u8.ToArray();
+                    await conn.SendAsync(response, SocketFlags.None, token).ConfigureAwait(false);
+                    conn.Shutdown(SocketShutdown.Both);
+                }
+            }
+            catch (Exception ex) when (ex is OperationCanceledException or ObjectDisposedException or SocketException)
+            {
+                // Listener torn down - expected on dispose.
+            }
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _socket.Dispose();
+            _cts.Dispose();
+        }
     }
 
     // A loopback TCP listener that would accept any connection reaching it - so a passing test proves the

--- a/SSO-Auth.Tests/Oidc/OidcInsecureTogglesTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcInsecureTogglesTests.cs
@@ -51,17 +51,34 @@ public class OidcInsecureTogglesTests
     }
 
     [Fact]
-    public void Enabled_AllFour_ReportsAll_MostSevereFirst()
+    public void Enabled_AllowPrivateNetworkAddresses_ReportsIt()
+    {
+        Assert.Equal(new[] { "AllowPrivateNetworkAddresses" }, OidcInsecureToggles.Enabled(new OidConfig { AllowPrivateNetworkAddresses = true }));
+    }
+
+    [Fact]
+    public void Enabled_AllowPrivateNetworkAddressesClear_OmitsIt()
+    {
+        Assert.DoesNotContain("AllowPrivateNetworkAddresses", OidcInsecureToggles.Enabled(new OidConfig { DisableHttps = true }));
+    }
+
+    [Fact]
+    public void Enabled_AllFive_ReportsAll_MostSevereFirst()
     {
         var config = new OidConfig
         {
             DisableHttps = true,
             DoNotValidateIssuerName = true,
             DoNotValidateEndpoints = true,
+            AllowPrivateNetworkAddresses = true,
             DoNotValidateResponseIssuer = true,
         };
+
+        // AllowPrivateNetworkAddresses sits after DoNotValidateEndpoints and before
+        // DoNotValidateResponseIssuer: it widens where the backchannel may connect, but switches off no
+        // signature, issuer or transport check (#1178).
         Assert.Equal(
-            new[] { "DisableHttps", "DoNotValidateIssuerName", "DoNotValidateEndpoints", "DoNotValidateResponseIssuer" },
+            new[] { "DisableHttps", "DoNotValidateIssuerName", "DoNotValidateEndpoints", "AllowPrivateNetworkAddresses", "DoNotValidateResponseIssuer" },
             OidcInsecureToggles.Enabled(config));
     }
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -169,7 +169,7 @@ internal sealed class OidcLoginService
             return secretError;
         }
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger).ConfigureAwait(false);
+        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
         if (!discovery.Available)
         {
             // Fail closed (#450): the discovery document the login itself needs could not be read, so there
@@ -688,9 +688,12 @@ internal sealed class OidcLoginService
 
         options.ClientId = config.OidClientId?.Trim();
         options.LoggerFactory = _loggerFactory;
-        options.HttpClientFactory = _ => SsoHttp.CreateClient(_httpClientFactory);
+        // Every backchannel leg of this provider - the JWKS fetch below and its discovery read - goes over the
+        // provider's OWN transport tier (#1179). A provider that did not opt in resolves the strict client
+        // exactly as before.
+        options.HttpClientFactory = _ => SsoHttp.CreateClient(_httpClientFactory, config.AllowPrivateNetworkAddresses);
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger).ConfigureAwait(false);
+        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
         if (!discovery.Available)
         {
             return new OidcLogoutTokenValidator.Result(false, null, null, "discovery_unavailable");
@@ -735,7 +738,8 @@ internal sealed class OidcLoginService
         options.DisablePushedAuthorization = config.DisablePushedAuthorization;
         options.LoggerFactory = _loggerFactory;
         options.LoadProfile = !config.DoNotLoadProfile;
-        options.HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory);
+        // The token and userinfo legs of the login, over this provider's own transport tier (#1179).
+        options.HttpClientFactory = o => SsoHttp.CreateClient(_httpClientFactory, config.AllowPrivateNetworkAddresses);
 
         // OidcClient 7.x validates nothing about the id_token unless a validator is supplied (its
         // fallback only base64-decodes the payload). Signature validation is required and has no

--- a/SSO-Auth/Api/Http/ProviderConnectionTester.cs
+++ b/SSO-Auth/Api/Http/ProviderConnectionTester.cs
@@ -62,7 +62,9 @@ internal static class ProviderConnectionTester
             return ProviderTestResult.Failure("The configured OpenID Endpoint is not a valid absolute URL (for example https://idp.example.com).");
         }
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, httpClientFactory, logger).ConfigureAwait(false);
+        // The probe uses the provider's own transport tier, so "Test connection" reports what the login will
+        // actually do - an opted-in provider on the admin's LAN must not fail here and then succeed at login.
+        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, httpClientFactory, logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
         if (!discovery.Available)
         {
             // The reader already logged the fail-closed warning (with the library error, never a secret).

--- a/SSO-Auth/Api/Net/AddressPolicy.cs
+++ b/SSO-Auth/Api/Net/AddressPolicy.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
+
+/// <summary>
+/// Selects which tier of <see cref="IpAddressClassifier"/>'s address policy a caller is asking for. The
+/// tiers differ only in the private, admin-routable ranges; the ranges that can never be a deliberate
+/// destination - loopback, link-local (where the cloud metadata service lives), the IETF protocol
+/// assignments, site-local, unspecified, and multicast/reserved/broadcast - are blocked by both (#1058).
+/// </summary>
+internal enum AddressPolicy
+{
+    /// <summary>
+    /// Block every address that is not public and externally reachable. This is the only tier any
+    /// client-facing or unconfigured path may use, and it is the default so a caller gets it by omission.
+    /// </summary>
+    Strict,
+
+    /// <summary>
+    /// Additionally permit the private ranges an on-premises service legitimately lives on: RFC 1918
+    /// (<c>10.0.0.0/8</c>, <c>172.16.0.0/12</c>, <c>192.168.0.0/16</c>), carrier-grade NAT
+    /// (<c>100.64.0.0/10</c>), and IPv6 unique-local (<c>fc00::/7</c>). Selected only where an
+    /// administrator has explicitly opted a single provider in.
+    /// </summary>
+    PrivateNetworkPermitted,
+}

--- a/SSO-Auth/Api/Net/IpAddressClassifier.cs
+++ b/SSO-Auth/Api/Net/IpAddressClassifier.cs
@@ -11,13 +11,22 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 /// Classifies a client-supplied or connection IP address as public or blocked (loopback, private,
 /// carrier-grade NAT, link-local, unique/site-local, unspecified, reserved, or multicast), and unwraps the
 /// IPv4 address embedded in an IPv4-in-IPv6 transition form (6to4, NAT64, the deprecated IPv4-compatible
-/// form). Two unrelated callers share this one definition so they can never disagree on what counts as a
-/// public address: the avatar-fetch SSRF guard (AvatarUrlValidator) rejects a blocked target
-/// before fetching it, and the login rate limiter (SsoRateLimiter.NormalizeClientKey) exempts a
-/// blocked/non-public connection address from throttling entirely. Neither caller's own file is the right
-/// home for this shared invariant - tuning the avatar SSRF policy must never silently change which clients
-/// the login rate limiter exempts, and vice versa (#370).
+/// form). Several unrelated callers share this one definition so they can never disagree on what counts as
+/// a public address: the avatar-fetch SSRF guard (AvatarUrlValidator) rejects a blocked target
+/// before fetching it, the login rate limiter (SsoRateLimiter.NormalizeClientKey) exempts a
+/// blocked/non-public connection address from throttling entirely, and the outbound connect guard (SsoHttp)
+/// refuses to open a socket to one. No caller's own file is the right home for this shared invariant -
+/// tuning the avatar SSRF policy must never silently change which clients the login rate limiter exempts,
+/// and vice versa (#370).
 /// </summary>
+/// <remarks>
+/// The policy has two tiers, selected per call by <see cref="AddressPolicy"/> and defaulting to
+/// <see cref="AddressPolicy.Strict"/> so a caller that names no tier gets the full guard. Only the private,
+/// admin-routable ranges move between them; the ranges that can never be a deliberate destination stay
+/// blocked in both (#1058). The tier is threaded through every recursive re-check - the IPv4-mapped path
+/// and each IPv4-in-IPv6 transition form - so a wrapper such as <c>[64:ff9b::7f00:1]</c> cannot smuggle
+/// <c>127.0.0.1</c> past the relaxed tier either.
+/// </remarks>
 internal static class IpAddressClassifier
 {
     /// <summary>
@@ -26,9 +35,14 @@ internal static class IpAddressClassifier
     /// unspecified).
     /// </summary>
     /// <param name="address">The address to classify.</param>
+    /// <param name="policy">
+    /// Which tier to classify under. Defaults to <see cref="AddressPolicy.Strict"/>, so an existing caller
+    /// that names no tier keeps the full guard unchanged.
+    /// </param>
     /// <returns>True when the address is blocked.</returns>
-    internal static bool IsBlockedAddress(IPAddress address)
+    internal static bool IsBlockedAddress(IPAddress address, AddressPolicy policy = AddressPolicy.Strict)
     {
+        // Loopback is never relaxable, so it is refused before the tier is consulted at all.
         if (IPAddress.IsLoopback(address))
         {
             return true;
@@ -36,10 +50,10 @@ internal static class IpAddressClassifier
 
         return address.AddressFamily switch
         {
-            AddressFamily.InterNetwork => IsBlockedIPv4(address.GetAddressBytes()),
-            AddressFamily.InterNetworkV6 => IsBlockedIPv6(address),
+            AddressFamily.InterNetwork => IsBlockedIPv4(address.GetAddressBytes(), policy),
+            AddressFamily.InterNetworkV6 => IsBlockedIPv6(address, policy),
 
-            // Unknown address family: block by default.
+            // Unknown address family: block by default, under either tier.
             _ => true,
         };
     }
@@ -95,8 +109,31 @@ internal static class IpAddressClassifier
         return false;
     }
 
-    private static bool IsBlockedIPv4(byte[] b)
+    /// <summary>
+    /// The RFC 1918 and carrier-grade-NAT ranges - the only IPv4 ranges the relaxed tier permits. An
+    /// on-premises identity provider behind a reverse proxy lives on one of these; nothing else an admin
+    /// would deliberately point a provider at does.
+    /// </summary>
+    /// <param name="b">The four bytes of the IPv4 address.</param>
+    /// <returns>True when the address is in a relaxable private range.</returns>
+    private static bool IsRelaxableIPv4(byte[] b)
     {
+        // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC 1918) and 100.64.0.0/10 (CGNAT).
+        return b[0] == 10
+            || (b[0] == 172 && b[1] >= 16 && b[1] <= 31)
+            || (b[0] == 192 && b[1] == 168)
+            || (b[0] == 100 && b[1] >= 64 && b[1] <= 127);
+    }
+
+    private static bool IsBlockedIPv4(byte[] b, AddressPolicy policy)
+    {
+        // The relaxed tier permits exactly the private ranges above. Every other blocked range below is
+        // still refused, so 169.254.169.254 and 192.0.0.192 stay unreachable under both tiers (#1058).
+        if (policy == AddressPolicy.PrivateNetworkPermitted && IsRelaxableIPv4(b))
+        {
+            return false;
+        }
+
         // 0.0.0.0/8 (this network), 10.0.0.0/8, 100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local),
         // 172.16.0.0/12, 192.0.0.0/24 (IETF protocol assignments incl. the 192.0.0.192 cloud-metadata
         // address), 192.0.2.0/24 / 198.51.100.0/24 / 203.0.113.0/24 (TEST-NET-1/2/3), 192.88.99.0/24
@@ -117,11 +154,13 @@ internal static class IpAddressClassifier
             || b[0] >= 224;
     }
 
-    private static bool IsBlockedIPv6(IPAddress address)
+    private static bool IsBlockedIPv6(IPAddress address, AddressPolicy policy)
     {
+        // Both re-check paths below pass the caller's own tier down, never a widened one: an IPv4-mapped
+        // or transition-wrapped address is classified under exactly the policy the outer call asked for.
         if (address.IsIPv4MappedToIPv6)
         {
-            return IsBlockedAddress(address.MapToIPv4());
+            return IsBlockedAddress(address.MapToIPv4(), policy);
         }
 
         var bytes = address.GetAddressBytes();
@@ -131,14 +170,19 @@ internal static class IpAddressClassifier
         // re-check, so e.g. [64:ff9b::7f00:1] cannot smuggle 127.0.0.1 past the filter.
         if (TryExtractEmbeddedIPv4(bytes, out var embedded))
         {
-            return IsBlockedAddress(embedded);
+            return IsBlockedAddress(embedded, policy);
         }
 
-        // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth.
+        // fec0::/10 is the deprecated site-local range (RFC 3879); block it as defense-in-depth. It is NOT
+        // relaxable: unlike fc00::/7 it is a withdrawn range no current deployment should be addressed on.
         var siteLocal = bytes[0] == 0xfe && (bytes[1] & 0xc0) == 0xc0;
 
+        // Unique-local (fc00::/7) is the IPv6 counterpart of RFC 1918, and the only IPv6 range the relaxed
+        // tier permits. Link-local, multicast, site-local and :: stay blocked under both tiers.
+        var uniqueLocal = address.IsIPv6UniqueLocal && policy != AddressPolicy.PrivateNetworkPermitted;
+
         return address.IsIPv6LinkLocal
-            || address.IsIPv6UniqueLocal
+            || uniqueLocal
             || address.IsIPv6Multicast
             || siteLocal
             || IPAddress.IPv6Any.Equals(address);

--- a/SSO-Auth/Api/Net/SsoHttp.cs
+++ b/SSO-Auth/Api/Net/SsoHttp.cs
@@ -12,15 +12,30 @@ using System.Threading.Tasks;
 namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 /// <summary>
-/// The one home for the plugin's outbound HTTP policy: the User-Agent, and the single SSRF-hardened
-/// transport every server-to-provider call is built on. Both the OpenID discovery / token / JWKS backchannel
-/// (through <see cref="CreateClient"/>, which resolves the named <see cref="OutboundClientName"/> client) and
-/// the avatar fetch (which builds its own long-lived client on <see cref="CreateHardenedHandler"/>) share the
-/// same connect-time guard, so a provider or avatar URL resolving to a private/loopback address is rejected
-/// at the transport layer in one place (#370, #755). The named client's hardened handler is registered in the
-/// composition root; a test's stub/loopback factory supplies its own handler for that name, so integration
-/// tests reach their in-process IdP while production stays fail-closed.
+/// The one home for the plugin's outbound HTTP policy: the User-Agent, and the SSRF-hardened transport every
+/// server-to-provider call is built on. The OpenID discovery / token / JWKS backchannel (through
+/// <see cref="CreateClient"/>, which resolves a named client from the factory) and the avatar fetch (which
+/// builds its own long-lived client on <see cref="CreateHardenedHandler"/>) share the same connect-time
+/// guard, so a provider or avatar URL resolving to a private/loopback address is rejected at the transport
+/// layer in one place (#370, #755). The named clients' hardened handlers are registered in the composition
+/// root; a test's stub/loopback factory supplies its own handler for a name, so integration tests reach their
+/// in-process IdP while production stays fail-closed.
 /// </summary>
+/// <remarks>
+/// <para>
+/// There are two registered outbound tiers, not one (#1179). <see cref="OutboundClientName"/> carries the
+/// full guard and is what every caller gets by default. <see cref="PrivateOutboundClientName"/> additionally
+/// permits the private, admin-routable ranges, and is resolved <em>only</em> for an OpenID provider whose
+/// <c>AllowPrivateNetworkAddresses</c> is set - the opt-in for an identity provider that deliberately lives
+/// on the administrator's own network (#1058).
+/// </para>
+/// <para>
+/// The relaxation is baked into which client is resolved rather than carried as an ambient per-request mode.
+/// Both handlers are long-lived and shared across concurrent logins, so a mode that was not part of the
+/// client's identity could leak the relaxation to a provider that never opted in. Callers that name no tier
+/// - the SAML metadata importer, the avatar fetch, and any future one - stay strict by construction.
+/// </para>
+/// </remarks>
 internal static class SsoHttp
 {
     /// <summary>
@@ -31,22 +46,37 @@ internal static class SsoHttp
     internal const string OutboundClientName = "sso-outbound";
 
     /// <summary>
+    /// The <see cref="IHttpClientFactory"/> name of the outbound client whose guard additionally permits the
+    /// private, admin-routable ranges (RFC 1918, carrier-grade NAT, IPv6 unique-local). The composition root
+    /// registers this name with the same hardened handler under
+    /// <see cref="AddressPolicy.PrivateNetworkPermitted"/>; loopback, link-local and the cloud-metadata
+    /// ranges are refused here too. Resolved only for an OpenID provider that opted in (#1058).
+    /// </summary>
+    internal const string PrivateOutboundClientName = "sso-outbound-private";
+
+    /// <summary>
     /// The plugin's outbound User-Agent: product token, assembly file version, and project URL.
     /// </summary>
     internal static readonly string UserAgent =
         $"Jellyfin-Plugin-SSO-Auth +{FileVersionInfo.GetVersionInfo(typeof(SsoHttp).Assembly.Location).FileVersion} (https://github.com/iderex/jellyfin-plugin-sso)";
 
     /// <summary>
-    /// Returns the SSRF-hardened outbound client (the named <see cref="OutboundClientName"/> client from the
-    /// factory, whose primary handler is <see cref="CreateHardenedHandler"/> in production) with
-    /// <see cref="UserAgent"/> applied. Used for the OpenID discovery / token / JWKS fetches, so a provider
-    /// endpoint that resolves to a private/loopback address cannot be reached (#755).
+    /// Returns an SSRF-hardened outbound client from the factory (whose primary handler is
+    /// <see cref="CreateHardenedHandler"/> in production) with <see cref="UserAgent"/> applied. Used for the
+    /// OpenID discovery / token / JWKS fetches, so a provider endpoint that resolves to a private/loopback
+    /// address cannot be reached (#755).
     /// </summary>
     /// <param name="factory">The shared HTTP client factory.</param>
+    /// <param name="allowPrivateNetworkAddresses">
+    /// Pass the opted-in provider's <c>AllowPrivateNetworkAddresses</c> to resolve the
+    /// <see cref="PrivateOutboundClientName"/> client instead. Defaults to <see langword="false"/>, so a
+    /// caller that names no tier gets the fully-guarded <see cref="OutboundClientName"/> client - the
+    /// relaxation reaches exactly the provider that asked for it and no other caller (#1179).
+    /// </param>
     /// <returns>A client with the plugin User-Agent applied over the hardened transport.</returns>
-    internal static HttpClient CreateClient(IHttpClientFactory factory)
+    internal static HttpClient CreateClient(IHttpClientFactory factory, bool allowPrivateNetworkAddresses = false)
     {
-        var client = factory.CreateClient(OutboundClientName);
+        var client = factory.CreateClient(allowPrivateNetworkAddresses ? PrivateOutboundClientName : OutboundClientName);
         client.DefaultRequestHeaders.UserAgent.ParseAdd(UserAgent);
         return client;
     }
@@ -57,14 +87,21 @@ internal static class SsoHttp
     /// and DNS-rebinding vectors. Redirects stay enabled but bounded; the system proxy is disabled so the
     /// guard validates the real host, not a proxy; and a pooled connection is recycled periodically so DNS
     /// changes are honoured despite reuse. The one implementation shared by the OpenID backchannel (via the
-    /// named outbound client) and the avatar fetch.
+    /// named outbound clients) and the avatar fetch.
     /// </summary>
+    /// <param name="policy">
+    /// Which address tier the connect guard classifies under. Defaults to <see cref="AddressPolicy.Strict"/>,
+    /// so the avatar fetch and the strict named client keep the full guard unchanged;
+    /// <see cref="AddressPolicy.PrivateNetworkPermitted"/> builds the handler behind
+    /// <see cref="PrivateOutboundClientName"/>. The policy is captured per handler rather than read
+    /// per-request, so a shared handler cannot serve two tiers (#1179).
+    /// </param>
     /// <returns>A hardened <see cref="SocketsHttpHandler"/>.</returns>
-    internal static SocketsHttpHandler CreateHardenedHandler() => new()
+    internal static SocketsHttpHandler CreateHardenedHandler(AddressPolicy policy = AddressPolicy.Strict) => new()
     {
         AllowAutoRedirect = true,
         MaxAutomaticRedirections = 5,
-        ConnectCallback = ConnectToAllowedAddressAsync,
+        ConnectCallback = (context, cancellationToken) => ConnectToAllowedAddressAsync(context, policy, cancellationToken),
 
         // A system proxy would be the connection target, so the connect callback would validate the proxy's
         // address rather than the real host's - bypassing the guard.
@@ -75,9 +112,13 @@ internal static class SsoHttp
         PooledConnectionLifetime = TimeSpan.FromMinutes(2),
     };
 
-    // Resolves the target host and connects only to a non-blocked (public) address, so a hostname that
-    // resolves to an internal address - including via DNS rebinding on a redirect hop - cannot be reached.
-    private static async ValueTask<Stream> ConnectToAllowedAddressAsync(SocketsHttpConnectionContext context, CancellationToken cancellationToken)
+    // Resolves the target host and connects only to an address the handler's own policy allows, so a hostname
+    // that resolves to an internal address - including via DNS rebinding on a redirect hop - cannot be
+    // reached. Under the strict policy that means public addresses only; under the private-permitted policy
+    // the admin's own network is additionally reachable, while loopback, link-local and the cloud-metadata
+    // ranges stay refused. The policy comes from the handler that captured it, never from the request, so a
+    // redirect hop is re-checked under the same tier the connection started on.
+    private static async ValueTask<Stream> ConnectToAllowedAddressAsync(SocketsHttpConnectionContext context, AddressPolicy policy, CancellationToken cancellationToken)
     {
         var addresses = await System.Net.Dns.GetHostAddressesAsync(context.DnsEndPoint.Host, cancellationToken).ConfigureAwait(false);
 
@@ -88,7 +129,7 @@ internal static class SsoHttp
         var attempted = false;
         foreach (var address in addresses)
         {
-            if (IpAddressClassifier.IsBlockedAddress(address))
+            if (IpAddressClassifier.IsBlockedAddress(address, policy))
             {
                 continue;
             }

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -55,12 +55,16 @@ internal static class OidcDiscoveryReader
     /// <param name="provider">The provider name, for the failure warning only.</param>
     /// <param name="httpClientFactory">The shared HTTP client factory the outbound fetch is built over.</param>
     /// <param name="logger">The logger for the fail-closed read-failure warning.</param>
+    /// <param name="allowPrivateNetworkAddresses">
+    /// The provider's <c>AllowPrivateNetworkAddresses</c> opt-in, selecting the private-permitted outbound
+    /// transport for this one read (#1179). Defaults to <see langword="false"/> - the full guard.
+    /// </param>
     /// <returns>The facts and provider metadata from the one discovery response, or <see cref="OidcDiscoveryResult.Unavailable"/>.</returns>
-    internal static async Task<OidcDiscoveryResult> ReadAsync(OidcClientOptions options, string provider, IHttpClientFactory httpClientFactory, ILogger logger)
+    internal static async Task<OidcDiscoveryResult> ReadAsync(OidcClientOptions options, string provider, IHttpClientFactory httpClientFactory, ILogger logger, bool allowPrivateNetworkAddresses = false)
     {
         try
         {
-            using var client = SsoHttp.CreateClient(httpClientFactory);
+            using var client = SsoHttp.CreateClient(httpClientFactory, allowPrivateNetworkAddresses);
             client.Timeout = FetchTimeout;
 
             var discovery = await client.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest

--- a/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
+++ b/SSO-Auth/Api/Oidc/OidcInsecureToggles.cs
@@ -45,6 +45,14 @@ internal static class OidcInsecureToggles
             enabled.Add(nameof(OidConfig.DoNotValidateEndpoints));
         }
 
+        // Ordered after DoNotValidateEndpoints and before DoNotValidateResponseIssuer (#1178): it widens
+        // where the backchannel is allowed to connect, but switches off no signature, issuer or transport
+        // check - a smaller downgrade than the three above it, a larger one than the mix-up defence below.
+        if (config.AllowPrivateNetworkAddresses)
+        {
+            enabled.Add(nameof(OidConfig.AllowPrivateNetworkAddresses));
+        }
+
         // RFC 9207 response-iss check (#125): last because it is defence-in-depth on top of the
         // per-provider callback binding, which already resists the classic mix-up on its own.
         if (config.DoNotValidateResponseIssuer)

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -717,6 +717,19 @@ public class OidConfig : ProviderConfigBase
     public bool DoNotValidateEndpoints { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether this provider's backchannel (discovery, JWKS, token,
+    /// userinfo, back-channel logout) may connect to a private network address. Off by default, so the
+    /// outbound SSRF/DNS-rebind guard refuses every non-public address as before; a config saved before
+    /// this field existed deserializes to <see langword="false"/> and keeps the full guard. Set it for an
+    /// identity provider that deliberately lives on the administrator's own network - the standard
+    /// self-hosted shape of an IdP on an RFC 1918 address behind a reverse proxy (#1058). Enabling it
+    /// permits only RFC 1918, carrier-grade NAT and IPv6 unique-local, and only for this provider;
+    /// loopback, link-local and the cloud-metadata ranges stay blocked regardless, and every other
+    /// provider - plus the avatar fetch and the SAML metadata importer - keeps the full guard.
+    /// </summary>
+    public bool AllowPrivateNetworkAddresses { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether the OpenID issuer name is validated.
     /// </summary>
     public bool DoNotValidateIssuerName { get; set; }

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -39,12 +39,24 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // private/loopback address is rejected at the transport layer - the same connect-time guard the
         // avatar fetch uses (SsoHttp.CreateHardenedHandler). A test's stub or loopback factory supplies its
         // own handler for this name, so an in-process test IdP stays reachable while production is fail-closed.
+        // This is the tier every caller gets by default, including the SAML metadata importer.
         serviceCollection.AddHttpClient(SsoHttp.OutboundClientName)
-            .ConfigurePrimaryHttpMessageHandler(SsoHttp.CreateHardenedHandler)
+            .ConfigurePrimaryHttpMessageHandler(() => SsoHttp.CreateHardenedHandler())
             // The hardened handler manages its own connection freshness via PooledConnectionLifetime, so the
             // factory need not also rotate (and rebuild) the handler on its default 2-minute cadence - the
             // documented pattern when you own PooledConnectionLifetime. Keeps one long-lived hardened handler
             // (the ConnectCallback still fires on every connect) instead of churning a new one every 2 minutes.
+            .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
+
+        // The second outbound tier (#1179): the same hardened handler, but its connect guard additionally
+        // permits the private, admin-routable ranges. Only an OpenID provider with AllowPrivateNetworkAddresses
+        // set resolves this name, and only for its own backchannel - that is the supported answer for an IdP
+        // that deliberately lives on the administrator's network (#1058). Loopback, link-local and the
+        // cloud-metadata ranges are refused here too. Registering it as a separate NAME rather than as a mode
+        // over the shared handler is deliberate: the handler below is long-lived and shared across concurrent
+        // logins, so a relaxation that was not part of the client's identity could leak to another provider.
+        serviceCollection.AddHttpClient(SsoHttp.PrivateOutboundClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted))
             .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
     }
 }

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -185,6 +185,7 @@ const ssoConfigurationPage = {
     "DoNotValidateEndpoints",
     "DoNotValidateIssuerName",
     "DoNotValidateResponseIssuer",
+    "AllowPrivateNetworkAddresses",
   ],
   // The non-insecure settings whose ENABLED state is still a downgrade / attack-surface widening, so they
   // are surfaced the same way as the insecure toggles (card "Review" flag + auto-expand the enclosing

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -1848,6 +1848,32 @@
                         <label>
                           <input
                             is="emby-checkbox"
+                            id="AllowPrivateNetworkAddresses"
+                            name="AllowPrivateNetworkAddresses"
+                            type="checkbox"
+                            class="sso-toggle"
+                          />
+                          <span
+                            >Allow Private Network Addresses (Insecure)</span
+                          >
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">
+                          ⚠ Insecure: relaxes the outbound SSRF / DNS-rebind
+                          guard for this provider, allowing connection to an
+                          OIDC provider hosted on a private network. Permits RFC
+                          1918, CGNAT and IPv6 unique-local addresses. Loopback,
+                          link-local and cloud-metadata ranges remain blocked.
+                          Leave off for any provider reachable on the public
+                          internet. Enabling it is recorded as an audit warning.
+                        </div>
+                      </div>
+
+                      <div
+                        class="checkboxContainer checkboxContainer-withDescription"
+                      >
+                        <label>
+                          <input
+                            is="emby-checkbox"
                             id="DoNotValidateIssuerName"
                             name="DoNotValidateIssuerName"
                             type="checkbox"


### PR DESCRIPTION
# What and Why

This PR adds a provider-specific insecure setting that relaxes the DNS rebind protection to allow private network addresses. This enables the use of OIDC providers that are self-hosted on a private network. Loopback, link-local and the cloud-metadata ranges stay blocked.

I noticed there was a recently merged PR that replaced em dashes with hyphens and I made sure that the changes in this PR did not introduce any new em dashes.

Closes #1058. Implements #1177, #1178, #1179 - one commit each, in dependency order, plus a fourth that locks in the structural property.

### Carrier-grade NAT, and providers reached over Tailscale

The relaxed tier permits the CGNAT range `100.64.0.0/10` alongside RFC 1918 and IPv6 unique-local. That range is part of the partition the parent issues decided rather than something added beyond it: #1058 named "RFC 1918, CGNAT, ULA" when the design was settled, and #1177 lists `100.64.0.0/10` (CGNAT) under "Relaxable". [Tailscale addresses its network overlays out of that range](https://tailscale.com/docs/concepts/tailscale-ip-addresses), so a provider reached over Tailscale is covered by the same opt-in without the set of permitted networks having to grow.

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

Those two boxes are unticked because the thing they describe does not exist for this change. No security review has been run against it and no review record was produced, and this is a change that relaxes an outbound security boundary. Read the two boxes as the open item they are.

Design points that carry the security argument:

- **The never-relaxable set is not negotiable by config.** Loopback, link-local
  (`169.254.169.254`), the IETF protocol assignments (`192.0.0.192`),
  site-local, unspecified and multicast/reserved/broadcast are refused under
  both tiers. The relaxed tier adds only RFC 1918, CGNAT and IPv6 unique-local.
- **The tier is threaded through every recursive re-check** - the IPv4-mapped
  path and each IPv4-in-IPv6 transition unwrap (6to4, NAT64, IPv4-compatible) -
  so `[64:ff9b::7f00:1]` cannot smuggle `127.0.0.1` past the relaxed tier.
  Covered by explicit test cases for each wrapped form of `127.0.0.1` and
  `169.254.169.254`, and by an equality check that a wrapped address reaches
  the same verdict as the same address written plainly.
- **The relaxation is baked into which client is resolved,** not carried as an
  ambient per-request mode. Both handlers are long-lived
  (`SetHandlerLifetime(Timeout.InfiniteTimeSpan)`) and shared across concurrent
  logins, so a mode that was not part of the client's identity could leak the
  relaxation to a provider that never opted in.
- **Strict is the default at every boundary.** `IsBlockedAddress` defaults to
  `AddressPolicy.Strict` and `SsoHttp.CreateClient` with no flag returns the
  `sso-outbound` client, so `SamlMetadataImporter` and `AvatarService` stay
  strict without changing.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: `CHANGELOG.md` carries the user-visible entry. The
      per-option reference lives in the wiki (Hardening & Options Reference), not
      in-repo - see Notes.

The fourth commit is that conformance rule. `CreateClient` being strict-by-default
pins the default, not the call sites - nothing would fail if someone later passed
the flag explicitly at the avatar fetch. So two fitness functions were added: one
asserts `AvatarService` and `SamlMetadataImporter` never name the relaxation at
all, and one enumerates every file that may, so a new caller wiring itself to the
private-permitted tier has to join the roster deliberately. Both were falsified
before landing - pointing the avatar fetch at the private-permitted tier turns
both red.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green. SEE BELOW
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

I had 1 test failure against both frameworks when running `dotnet test`, but had the same failures on the main branch and the code under test is unrelated to this PR. The failing test, `SamlCertificateTests.HasAcceptableSigningKey_NonApprovedEcCurve_False`, fails on macOS because Apple's crypto backend cannot generate a secp256k1 key. It fails identically on a clean checkout of `main` on this machine, before any change here. I expect PR checks to pass since GHA is running on Linux.

That expectation is still an expectation: no checks have run on this branch, so nothing has verified the change on Linux or anywhere else automatically. What has been measured is a local run on Windows against the merged state, where both target frameworks build with `--warnaserror` and 0 warnings and the full suite passes 2315 tests with 0 failed and 0 skipped, `SamlCertificateTests.HasAcceptableSigningKey_NonApprovedEcCurve_False` included. That is one platform, by hand, and it is not a substitute for the checks.

## Notes (from Claude)

**Out of scope, per the parent issue.** The SAML metadata importer resolves the same named outbound client and keeps the full guard; the avatar fetch is unaffected. Both are now pinned by conformance test rather than by convention.

**No preset pre-checks the flag.** It is deliberately absent from `OIDC_PRESET_MANAGED_TOGGLES` - no shipped preset should make a decision about an admin's own network - while being present in `insecureFieldIds`, so loading a provider with it set auto-expands the insecure list and flags the card.

## Added on top

The commits after the merge of `main` add tests only, no behaviour. They cover properties the change was asserting that nothing would have noticed breaking. Each was watched failing against a deliberately broken version of its property and passing against this one.

- **The outbound connect guard.** That the address judged is the address connected to and the host is resolved once, pinned at the source because no runtime test can see it without a controllable resolver. That every redirect hop is judged, under the tier the connection started on, and that the chain stops at the handler's bound. That each registered client name carries its own tier, read back from a built service provider and driven at a real socket, which is the one place a swapped registration would have relaxed every caller that names no tier.
- **The classifier partition.** The first and last address of each of the five ranges the relaxed tier moves, the address immediately outside each of them on both sides, and the wrapped-equals-unwrapped equality for every transition form.
- **The configuration arrival paths.** An upgrade that reads a stored config written before the field existed, and an import of a document that omits the field entirely applied over an instance where the provider was already relaxed.
- **The per-provider selection.** Two providers on one instance differing only in the opt-in, asserted to get different transport tiers at a real backchannel call site. This is the one leak the conformance roster cannot see, since every backchannel file is on that roster and a call site passing a literal `true` would relax every provider on the instance and leave the roster green.

Two of the new tests bind a listener to this machine's own RFC 1918 or CGNAT address, because that is the only address a test can bind that the relaxed tier permits, and they skip on a machine that has none. They ran here. On a host without a private interface address they would report as skipped rather than as failed, so their result is worth looking at rather than assuming.


---

## Landing

Merged after a full run of the checks on `fbe8cba`: fourteen successes, one
skipped by its own condition (SBOM generation), one superseded run cancelled
by a newer one. Nothing failed.

What was verified before landing, beyond the checks: the contributor's four
commits are byte-identical to what they pushed and carry their author field;
the later commits are separate and carry theirs; the branch moved forward
only, never rewritten. The relaxation reaches one provider's backchannel and
no other caller, and a test now proves that with two providers on one
instance rather than by reading. The ranges that can never be a deliberate
destination stay blocked in both tiers, through every IPv4-in-IPv6 transition
form.

One limit stated rather than left implied: the leg that proves a guard by
weakening it deliberately was not re-run at this head. The guard's behaviour
is covered by the added tests; the weakening leg remains open work and is
tracked on this board.
