### PR TITLE
Run the wiki lint on every push to main [#1151]

### DIFF
--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -8,16 +8,19 @@ name: Wiki Lint
 # Triggers: a weekly sweep, a manual run, and every push to main (so a merge that
 # moves a file the wiki links to is caught right away). Deliberately NOT on
 # pull_request: a pre-existing wiki typo must not red-X every unrelated code PR.
+#
+# The push trigger carries no paths filter, and it must not grow one. The dead
+# source link check resolves wiki links against the set of TRACKED paths, so the
+# lint's input is the whole repository and changes even when no source file is
+# edited: un-tracking a file through .gitignore alone is enough to break it. Any
+# enumeration of source locations therefore skips the very pushes that break the
+# lint, and leaves the failure to land on the next unrelated merge (#1151).
 on:
   schedule:
     - cron: "0 5 * * 1" # Mondays 05:00 UTC
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      - "SSO-Auth/**"
-      - "scripts/wiki-lint.py"
-      - ".github/workflows/wiki-lint.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
# What & why

Closes #1151.

`.github/workflows/wiki-lint.yml` gated its push trigger on a `paths:` list of
three entries. One of the lint's three checks, `check_dead_source_links`,
resolves `blob/<ref>/<path>` targets against the set of tracked paths, so the
lint's input is the whole repository. That set changes on pushes that edit none
of the three listed paths: `3a5a033` un-tracked `docs/ARCHITECTURE.md` through
`.gitignore`, so the lint did not fire on the merge that broke it, and the next
nine unrelated merges to `main` were red-X'd for a defect none of them
introduced.

The filter is dropped rather than lengthened. A longer enumeration is the same
defect with a longer list, and a deny-list that is wrong fails open. The header
comment now carries the property instead of the incident, so the next person
changing the trigger reads why the trigger cannot be path-filtered.

The resulting `on` block, at the pushed commit:

```yaml
on:
  schedule:
    - cron: "0 5 * * 1" # Mondays 05:00 UTC
  workflow_dispatch:
  push:
    branches: [main]
```

`git show HEAD:.github/workflows/wiki-lint.yml` produced it. There is no
`paths:` key and no `paths-ignore:` key in the file:

```
git grep -nE '^\s*paths(-ignore)?:' HEAD -- .github/workflows/wiki-lint.yml
(no output, exit 1)
```

## What this change does NOT prove

It does not prove the trigger fires. `on.push` fires on pushes to `main`, and a
pull request cannot exercise it: the checks below run under `pull_request`
triggers of other workflows, and `Wiki Lint` itself is deliberately not among
them. Nothing on this pull request is evidence that a push to `main` schedules a
`Wiki Lint` run. The first real proof is the first merge to `main` after this
lands, and whoever lands it reads that run:

```
gh run list -w "Wiki Lint" --branch main --limit 3
```

The constraint #1151 states also survives this: once the trigger is unfiltered,
the two live `docs/ARCHITECTURE.md` citations in the wiki will fail every `main`
push until the wiki is corrected. That is the same visible state as today,
attached to the right cause. Fixing the wiki is the follow-up; re-adding a
filter to hide it is not.

## The means

The workflow trigger the file already uses. The change removes four lines of
YAML from an existing `on.push` block and adds no language, no runtime and no
dependency. The alternative shapes considered were a longer `paths:` list and a
`paths-ignore:` deny-list; both were rejected in #1151 for the same reason, that
they enumerate a set which is the whole tracked tree and cannot be enumerated
correctly.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

The defect is in a CI trigger rather than in the plugin. It changes no shipped
code path.

## Security checklist

This change does not touch the login path, crypto, config persistence or the
release pipeline, so the section does not apply and none of its boxes are
ticked.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No review record: no adversarial review was run on this change, and no line
below claims one was. In the direction the trigger moves, a wrong verdict is a
job that runs more often than before and blocks nothing that was not already
blocked, since `Wiki Lint` is not a required check.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The first three read against a four-line deletion and a six-line comment: there
is no logic here to duplicate, the diff is the removal itself, and the comment
states why rather than what. The conformance box is left unticked because I did
not run the suite locally; `ArchitectureConformanceTests` reads C# structure and
this change touches no C#, so the suite's verdict comes from the `build` check
below rather than from me. The wiki correction #1151 names is tracked on that
issue and is not part of this change.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The two dotnet boxes are unticked because I did not run either command. This
change edits one YAML file and no C#, so a local run would prove nothing about
the diff; what covers them is CI on this pull request, whose result is quoted
below and is a command the reader can re-run. Prettier is ticked as vacuous: the
diff contains no `.js`, `.html`, `.md`, `.css` or `.scss` file.

## Notes

The workflow still parses and the job still runs. Local parse at the pushed
commit:

```
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/wiki-lint.yml')); print(d[True])"
{'schedule': [{'cron': '0 5 * * 1'}], 'workflow_dispatch': None, 'push': {'branches': ['main']}}
```

That is a local parse and not GitHub's. GitHub's own reading of the file, and
the state of every other check, are quoted from `gh pr checks` in the section
that follows once CI has finished; a check quoted before it has run would be a
prediction rather than a measurement.

Territory, at the pushed commit:

```
git diff --name-only origin/main...HEAD
.github/workflows/wiki-lint.yml
```

`scripts/wiki-lint.py` is deliberately untouched. It sits inside open pull
request #1203, and writing to it from here would put a conflict into a change
that is not this one:

```
gh api --paginate repos/iderex/jellyfin-plugin-sso/pulls/1203/files --jq '.[].filename' | grep -E 'wiki-lint'
scripts/wiki-lint.py
```

`.github/workflows/wiki-lint.yml` is not in that set.
