### PR TITLE
Derive the failure alert's watched set instead of listing it

### DIFF
--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -7,117 +7,154 @@ name: Publish failure alert
 #  - `Wiki Lint` failing on `main` nine times in a row over fifteen hours (#1015), surfaced only because
 #    the maintainer happened to open the run log.
 #
-# The first version of this file watched an ENUMERATED list of six workflow names, which is why the second
-# incident went unseen: `Wiki Lint` was not on the list, and neither was any other scheduled or push-only
-# guard. The coverage is now a PROPERTY instead - any workflow run whose head branch is the default branch
-# and whose conclusion is not a success - so a workflow added to this repository is watched the day it
+# The first version of this file was event-driven and watched an ENUMERATED list of six workflow names,
+# which is why the second incident went unseen: `Wiki Lint` was not on the list, and neither was any other
+# scheduled or push-only guard. Coverage is now a PROPERTY, derived by asking the run list which runs on
+# the default branch concluded non-success, so a workflow added to this repository is watched the day it
 # lands and there is nothing to register anywhere. Outside these comments the file names no workflow at
-# all: strip the comment lines and no workflow name and no `workflows:` key is left to go stale.
+# all: strip the comment lines and no workflow name is left to go stale.
 #
-# On a matching run it opens or updates a single tracking issue (label release-alert) naming the failed
-# run, turning a silent failure into an active, visible signal.
+# Why a sweep and not a `workflow_run` trigger. Watching every workflow by event needs a `workflow_run`
+# trigger with no `workflows:` filter, and this repository's own workflow audit refuses to parse that
+# ("data did not match any variant of untagged enum Trigger"), so the enumeration cannot simply be
+# deleted. The sweep expresses the same property against the API instead, it can be exercised on demand
+# with `dry_run` below, and it costs latency: a failure is reported at the next tick rather than within
+# a minute of the run ending.
 #
 # Uses only the built-in gh CLI with the workflow token; no third-party action, so nothing to SHA-pin.
-# A workflow_run workflow always runs from the default branch with the default-branch definition, which
-# is why it can react to a failure in a workflow that itself runs on a schedule.
 
-# Documented accept for the zizmor `dangerous-triggers` finding on the workflow_run trigger below:
-# workflow_run is flagged because it runs with the elevated default-branch token and secrets, which is
-# dangerous ONLY when a workflow then checks out or executes the triggering run's (attacker-influenceable)
-# code or artifacts. This watchdog does neither: it never checks out any ref, downloads no artifact, and
-# only reads the public issue list and files/updates an issue whose body is built entirely from
-# env-passed values (no ${{ }} shell splicing). Its token is least-privilege (issues: write). So the
-# audit's precondition for exploitability is absent here.
-on: # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    # No `workflows:` key, deliberately: the key is a filter, and an omitted filter matches everything.
-    # Naming workflows here is the defect #1015 records - a list silently omits whatever is added next.
-    types: [completed]
-    # The triggering run's head branch, not this workflow's. Restricting it to the default branch is what
-    # keeps pull-request runs out: their head branch is the PR branch, and a red PR check is already
-    # visible on the pull request, so alerting on one would double-signal a failure nobody is missing.
-    branches: [main]
+on:
+  schedule:
+    # Every half hour. The incident this exists for ran fifteen hours unseen, so the tick length is the
+    # worst-case delay on a signal that previously never arrived at all.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report what would be filed to the run log, and open or update no issue."
+        type: boolean
+        default: true
 
-# Deny-all at the workflow level; the job opts into the single grant it needs.
+# Deny-all at the workflow level; the job opts into the two grants it needs.
 permissions: {}
 
-# Never run two alert jobs at once; never cancel one mid-flight (it may be creating/commenting an issue).
-# Serializing also closes the two-runs-fail race: run B sees the issue run A created and comments on it
+# Never run two sweeps at once; never cancel one mid-flight (it may be creating/commenting an issue).
+# Serializing also closes the two-sweeps race: sweep B sees the issue sweep A created and comments on it
 # instead of creating a duplicate.
 concurrency:
   group: publish-failure-alert
   cancel-in-progress: false
 
 jobs:
-  alert:
-    name: Open or update the failure tracking issue
-    # Fire on any non-success terminal outcome - expressed as a DENYLIST so a new/rare conclusion class is
-    # caught by default rather than silently dropped. The beta.12 mode (release created, then the job dies
-    # before the manifest commit) can surface as `failure`, `timed_out`, or `startup_failure` (a YAML/
-    # config error), and GitHub also has `neutral` / `action_required` / `stale` - all of which should
-    # alert. Only `success` and `skipped` (e.g. the gate job short-circuits an unchanged day) are no-ops;
-    # `cancelled` is treated as an intentional human action and is not alerted.
-    #
-    # The name comparison is the self-exclusion, and it is required now that the trigger matches every
-    # workflow: without it a failing alerter would alert on itself and re-trigger itself. Both sides of
-    # the comparison come from this same file (`github.workflow` IS the `name:` above), so renaming the
-    # workflow keeps the exclusion correct with no second place to edit.
-    if: >-
-      ${{ github.event.workflow_run.name != github.workflow
-       && github.event.workflow_run.conclusion != 'success'
-       && github.event.workflow_run.conclusion != 'skipped'
-       && github.event.workflow_run.conclusion != 'cancelled' }}
+  sweep:
+    name: Report any workflow that concluded non-success on the default branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only permission needed: file/update an issue (and its label). No contents, no actions.
     permissions:
+      # Read the run list, and file or update the tracking issue. Nothing else: no contents, so the job
+      # cannot write to the tree, and no ability to re-run or cancel anything.
+      actions: read
       issues: write
     steps:
-      - name: File or update the alert issue
-        # All run inputs are passed via env, never spliced into the shell as ${{ }}.
+      - name: Sweep the default branch and file or update the alert issue
+        # All values reaching the shell are passed via env, never spliced in as ${{ }}.
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          WF_NAME: ${{ github.event.workflow_run.name }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
-          EVENT: ${{ github.event.workflow_run.event }}
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          BRANCH: ${{ github.event.repository.default_branch }}
+          SELF: ${{ github.workflow }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+          # Only failures this recent are reported. The window is what keeps a long-dead red run from
+          # re-opening the tracking issue every time the issue is closed: after the cause is fixed and the
+          # issue closed, nothing older than this can resurrect it.
+          WINDOW_HOURS: "24"
         run: |
           set -euo pipefail
 
-          # Self-provision the dedup label so the alerter never dies on a missing/deleted label (the
-          # create path is the first-fire path). --force makes it idempotent; failure here is non-fatal.
+          cutoff=$(date -u -d "-${WINDOW_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ)
+
+          # The derived set. No workflow is named: every run on the default branch is examined and the
+          # conclusion decides. The conclusion test is a DENYLIST so a new or rare conclusion class is
+          # caught by default rather than silently dropped - `failure`, `timed_out` and `startup_failure`
+          # (a YAML/config error) all alert, and so do `neutral`, `action_required` and `stale`. Only
+          # `success` and `skipped` are no-ops, `cancelled` is treated as an intentional human action, and
+          # an empty conclusion means the run has not finished. This workflow excludes itself so that a
+          # failing sweep does not sweep up its own failure; both sides of that test come from this same
+          # file, so renaming the workflow keeps it correct with no second place to edit.
+          gh run list --repo "$REPO" --branch "$BRANCH" --limit 100 \
+            --json workflowName,conclusion,url,event,updatedAt > runs.json
+          jq -r --arg self "$SELF" --arg cutoff "$cutoff" '
+            .[]
+            | select(.workflowName != $self)
+            | select(.updatedAt >= $cutoff)
+            | select((.conclusion // "") as $c
+                     | $c != "success" and $c != "skipped" and $c != "cancelled" and $c != "")
+            | [.url, .conclusion, .event, .workflowName] | @tsv
+          ' runs.json > red.tsv
+
+          echo "Examined $(jq length runs.json) run(s) on ${BRANCH}; $(wc -l < red.tsv) non-success since ${cutoff}."
+          if [ ! -s red.tsv ]; then
+            echo "Nothing red. No issue filed."
+            exit 0
+          fi
+
+          # Self-provision the dedup label so the sweep never dies on a missing/deleted label (the create
+          # path is the first-fire path). --force makes it idempotent; failure here is non-fatal.
           gh label create release-alert --repo "$REPO" --color B60205 \
             --description "Automated alert: a workflow concluded non-success on the default branch (see #982, #1015)" \
             --force >/dev/null 2>&1 || true
 
-          title="A workflow concluded non-success on the default branch"
-          body="The **${WF_NAME}** workflow run on \`${BRANCH}\` ended with conclusion \`${CONCLUSION}\` (trigger: ${EVENT}).
+          # The release-alert label is the dedup key: one open tracking issue, updated by comment, so a
+          # guard that flaps files one issue and comments on it rather than filing an issue per failure.
+          # The label name is kept from #982 so a tracking issue that is already open stays the one this
+          # finds. Everything already written on that issue is the second dedup key: a run whose URL is
+          # there has been reported, and every later sweep passes over it in silence.
+          num=$(gh issue list --repo "$REPO" --state open --label release-alert \
+            --json number --jq '.[0].number // empty')
+          reported=""
+          if [ -n "${num:-}" ]; then
+            reported=$(gh issue view "$num" --repo "$REPO" --json body,comments \
+              --jq '.body, (.comments[].body)')
+          fi
+
+          while IFS=$'\t' read -r url conclusion event wf_name; do
+            case "$reported" in
+              *"$url"*)
+                echo "Already reported, skipping: ${url}"
+                continue
+                ;;
+            esac
+
+            body="The **${wf_name}** workflow run on \`${BRANCH}\` ended with conclusion \`${conclusion}\` (trigger: ${event}).
 
           A failure on the default branch is not a required pull-request check and is not emailed, so it
-          can stay red while every pull request shows green. If this was a publish or monitoring
-          workflow, a release channel may also not have updated and installs can go stale unnoticed.
+          can stay red while every pull request shows green. If this was a publish or monitoring workflow,
+          a release channel may also not have updated and installs can go stale unnoticed.
 
-          Failed run: ${RUN_URL}
+          Failed run: ${url}
 
           What to check: the run log first. For a publish or monitoring workflow, check whether a GitHub
           release was created but its channel manifest was not committed (the beta.12 failure mode), then
-          fix the cause, re-run the publish and confirm the channel manifest lists the newest release.
-          For any other workflow, fix the cause and re-run it green on the default branch. Close this
-          issue once nothing is red.
+          fix the cause, re-run the publish and confirm the channel manifest lists the newest release. For
+          any other workflow, fix the cause and re-run it green on the default branch. Close this issue
+          once nothing is red.
 
           Refs #982, #1015."
 
-          # The release-alert label is the dedup key: one open tracking issue, updated by comment, so a
-          # run of failures does not spam a new issue each night. The label name is kept from #982 so a
-          # tracking issue that is already open stays the one this finds.
-          num=$(gh issue list --repo "$REPO" --state open --label release-alert \
-            --json number --jq '.[0].number // empty')
-          if [ -n "${num:-}" ]; then
-            echo "Updating existing alert issue #${num}"
-            gh issue comment "$num" --repo "$REPO" --body "$body"
-          else
-            echo "No open alert issue; creating one"
-            gh issue create --repo "$REPO" --title "$title" --label release-alert --body "$body"
-          fi
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY RUN, filing nothing. Would report ${wf_name} (${conclusion}) ${url}"
+              continue
+            fi
+
+            if [ -n "${num:-}" ]; then
+              echo "Updating existing alert issue #${num} with ${url}"
+              gh issue comment "$num" --repo "$REPO" --body "$body"
+            else
+              echo "No open alert issue; creating one for ${url}"
+              num=$(gh issue create --repo "$REPO" --label release-alert \
+                --title "A workflow concluded non-success on the default branch" \
+                --body "$body" | grep -o '[0-9]*$')
+            fi
+            reported="${reported}
+          ${url}"
+          done < red.tsv

--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -1,13 +1,21 @@
 name: Publish failure alert
 
-# Release-channel watchdog (#982). A scheduled or dispatched publish that fails does NOT email me the
-# way a push failure to the author does, so a broken release channel can go unnoticed - the 2026-07-23
-# beta.12 incident: the GitHub release was created but the manifest commit failed on a jq arg-length
-# error, and nothing alerted, so the build silently never reached Jellyfin until a user noticed.
+# Default-branch watchdog (#982, widened in #1015). A run that is not a required pull-request check does
+# NOT email me the way a push failure to the author does, so a workflow can stay red on `main` unnoticed:
+#  - the 2026-07-23 beta.12 incident, where the GitHub release was created but the manifest commit failed
+#    on a jq arg-length error and the build silently never reached Jellyfin until a user noticed;
+#  - `Wiki Lint` failing on `main` nine times in a row over fifteen hours (#1015), surfaced only because
+#    the maintainer happened to open the run log.
 #
-# This watches the nightly scheduler, the release-publish workflows, and the manifest-freshness check
-# and, on any non-success outcome, opens or updates a single tracking issue (label release-alert)
-# naming the failed run - turning a silent failure into an active, visible signal.
+# The first version of this file watched an ENUMERATED list of six workflow names, which is why the second
+# incident went unseen: `Wiki Lint` was not on the list, and neither was any other scheduled or push-only
+# guard. The coverage is now a PROPERTY instead - any workflow run whose head branch is the default branch
+# and whose conclusion is not a success - so a workflow added to this repository is watched the day it
+# lands and there is nothing to register anywhere. Outside these comments the file names no workflow at
+# all: strip the comment lines and no workflow name and no `workflows:` key is left to go stale.
+#
+# On a matching run it opens or updates a single tracking issue (label release-alert) naming the failed
+# run, turning a silent failure into an active, visible signal.
 #
 # Uses only the built-in gh CLI with the workflow token; no third-party action, so nothing to SHA-pin.
 # A workflow_run workflow always runs from the default branch with the default-branch definition, which
@@ -17,19 +25,18 @@ name: Publish failure alert
 # workflow_run is flagged because it runs with the elevated default-branch token and secrets, which is
 # dangerous ONLY when a workflow then checks out or executes the triggering run's (attacker-influenceable)
 # code or artifacts. This watchdog does neither: it never checks out any ref, downloads no artifact, and
-# only reads the public release list and files/updates an issue whose body is built entirely from
+# only reads the public issue list and files/updates an issue whose body is built entirely from
 # env-passed values (no ${{ }} shell splicing). Its token is least-privilege (issues: write). So the
 # audit's precondition for exploitability is absent here.
 on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
-    workflows:
-      - "Nightly betas" # the scheduler: if it dies, no beta is dispatched at all
-      - "Publish Beta"
-      - "Publish JF12 Beta"
-      - "Publish Release"
-      - "Publish JF12 Stable"
-      - "Manifest freshness" # the freshness monitor: its own failure must also surface
+    # No `workflows:` key, deliberately: the key is a filter, and an omitted filter matches everything.
+    # Naming workflows here is the defect #1015 records - a list silently omits whatever is added next.
     types: [completed]
+    # The triggering run's head branch, not this workflow's. Restricting it to the default branch is what
+    # keeps pull-request runs out: their head branch is the PR branch, and a red PR check is already
+    # visible on the pull request, so alerting on one would double-signal a failure nobody is missing.
+    branches: [main]
 
 # Deny-all at the workflow level; the job opts into the single grant it needs.
 permissions: {}
@@ -43,15 +50,21 @@ concurrency:
 
 jobs:
   alert:
-    name: Open or update the release-failure tracking issue
+    name: Open or update the failure tracking issue
     # Fire on any non-success terminal outcome - expressed as a DENYLIST so a new/rare conclusion class is
     # caught by default rather than silently dropped. The beta.12 mode (release created, then the job dies
     # before the manifest commit) can surface as `failure`, `timed_out`, or `startup_failure` (a YAML/
     # config error), and GitHub also has `neutral` / `action_required` / `stale` - all of which should
     # alert. Only `success` and `skipped` (e.g. the gate job short-circuits an unchanged day) are no-ops;
     # `cancelled` is treated as an intentional human action and is not alerted.
+    #
+    # The name comparison is the self-exclusion, and it is required now that the trigger matches every
+    # workflow: without it a failing alerter would alert on itself and re-trigger itself. Both sides of
+    # the comparison come from this same file (`github.workflow` IS the `name:` above), so renaming the
+    # workflow keeps the exclusion correct with no second place to edit.
     if: >-
-      ${{ github.event.workflow_run.conclusion != 'success'
+      ${{ github.event.workflow_run.name != github.workflow
+       && github.event.workflow_run.conclusion != 'success'
        && github.event.workflow_run.conclusion != 'skipped'
        && github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: ubuntu-latest
@@ -65,6 +78,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
           WF_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           EVENT: ${{ github.event.workflow_run.event }}
@@ -75,25 +89,29 @@ jobs:
           # Self-provision the dedup label so the alerter never dies on a missing/deleted label (the
           # create path is the first-fire path). --force makes it idempotent; failure here is non-fatal.
           gh label create release-alert --repo "$REPO" --color B60205 \
-            --description "Automated alert: a release channel may be broken/stale (see #982)" \
+            --description "Automated alert: a workflow concluded non-success on the default branch (see #982, #1015)" \
             --force >/dev/null 2>&1 || true
 
-          title="Release publish/monitoring failed - a channel may be silently stale"
-          body="The **${WF_NAME}** workflow run ended with conclusion \`${CONCLUSION}\` (trigger: ${EVENT}).
+          title="A workflow concluded non-success on the default branch"
+          body="The **${WF_NAME}** workflow run on \`${BRANCH}\` ended with conclusion \`${CONCLUSION}\` (trigger: ${EVENT}).
 
-          A scheduled publish or monitoring failure is not emailed, so a release channel may not have
-          updated and installs can go stale unnoticed.
+          A failure on the default branch is not a required pull-request check and is not emailed, so it
+          can stay red while every pull request shows green. If this was a publish or monitoring
+          workflow, a release channel may also not have updated and installs can go stale unnoticed.
 
           Failed run: ${RUN_URL}
 
-          What to check: whether a GitHub release was created but its channel manifest was not committed
-          (the beta.12 failure mode). Fix the cause, re-run the publish, then confirm the channel
-          manifest lists the newest release. Close this issue once the channel is fresh again.
+          What to check: the run log first. For a publish or monitoring workflow, check whether a GitHub
+          release was created but its channel manifest was not committed (the beta.12 failure mode), then
+          fix the cause, re-run the publish and confirm the channel manifest lists the newest release.
+          For any other workflow, fix the cause and re-run it green on the default branch. Close this
+          issue once nothing is red.
 
-          Refs #982."
+          Refs #982, #1015."
 
           # The release-alert label is the dedup key: one open tracking issue, updated by comment, so a
-          # run of failures does not spam a new issue each night.
+          # run of failures does not spam a new issue each night. The label name is kept from #982 so a
+          # tracking issue that is already open stays the one this finds.
           num=$(gh issue list --repo "$REPO" --state open --label release-alert \
             --json number --jq '.[0].number // empty')
           if [ -n "${num:-}" ]; then


### PR DESCRIPTION
# What & why

Closes #1015.

The watchdog from #982 decided its coverage from a list of six workflow names.
Every guard that runs on a schedule or on a push to `main`, rather than as a
required pull-request check, was outside that list, so it could conclude
non-success on `main` indefinitely while every pull request showed green. The
incident on the issue is nine consecutive `Wiki Lint` failures over fifteen
hours that raised nothing.

Coverage is now a property of the run instead of a membership test: any run on
the default branch whose conclusion is not `success`, `skipped` or `cancelled`.
The list is not lengthened, because a longer list is the same defect with a
longer list.

This is one file and one topic. Nothing else under `.github/` is touched, and
neither is `CHANGELOG.md`:

```
$ git diff --name-only origin/main...HEAD
.github/workflows/publish-failure-alert.yml
```

## Two commits, and why the first one is not the answer

The branch carries the honest path rather than a tidied one.

The first commit expressed the property the way #1015's own analysis proposed,
by deleting the `workflows:` filter from the `workflow_run` trigger so that an
omitted filter matches everything. That shape is schema-valid, since the
official workflow JSON schema does not mark `workflows` required, but two
independent models of the trigger refuse it, and one of them runs here. The
pull request went red:

```
$ gh run view --job 92133750724 --log
fatal: no audit was performed
error: failed to load file://./.github/workflows/publish-failure-alert.yml as workflow
Caused by:
    1: couldn't turn input into a an appropriate model
    2: data did not match any variant of untagged enum Trigger
```

`actionlint` v1.7.12 refuses the same shape independently, from its own
`rule_events.go` (`if len(event.Workflows) == 0`), and the six-name file scored
exit 0 before the edit. So the property cannot be carried by the `workflow_run`
trigger inside this repository's checks, and pushing it would mean either a red
required check or a guard whose one route to firing nothing here can parse.

The second commit carries the property against the run list instead. The
workflow asks GitHub which runs on the default branch concluded non-success and
reports them. That is derived in the same sense and stronger in one way: it can
be exercised, which the event route cannot be from a pull request at all.

What it costs, stated: latency. A failure is reported at the next half-hourly
tick rather than within a minute of the run ending. For the incident this exists
for, which ran fifteen hours unseen, thirty minutes is not the constraint.

## The resulting block

```yaml
on:
  schedule:
    # Every half hour. The incident this exists for ran fifteen hours unseen, so the tick length is the
    # worst-case delay on a signal that previously never arrived at all.
    - cron: "*/30 * * * *"
  workflow_dispatch:
    inputs:
      dry_run:
        description: "Report what would be filed to the run log, and open or update no issue."
        type: boolean
        default: true
```

and the selection, which is where the derivation lives:

```sh
gh run list --repo "$REPO" --branch "$BRANCH" --limit 100 \
  --json workflowName,conclusion,url,event,updatedAt > runs.json
jq -r --arg self "$SELF" --arg cutoff "$cutoff" '
  .[]
  | select(.workflowName != $self)
  | select(.updatedAt >= $cutoff)
  | select((.conclusion // "") as $c
           | $c != "success" and $c != "skipped" and $c != "cancelled" and $c != "")
  | [.url, .conclusion, .event, .workflowName] | @tsv
' runs.json > red.tsv
```

`$BRANCH` is `github.event.repository.default_branch`, so even the branch is
read rather than written down. `$SELF` is `github.workflow`, which is the
`name:` at the top of the same file, so the self-exclusion that stops a failing
sweep from sweeping up its own failure moves with a rename and has no second
place to edit. The conclusion test is a denylist, so a conclusion class GitHub
adds later alerts by default rather than being silently dropped.

## Registering a new workflow is not required, and the file says so itself

Strip the comment lines and the file names no workflow at all, so there is
nothing for a newly added workflow to be missing from:

```
$ grep -v -E '^\s*#' .github/workflows/publish-failure-alert.yml \
    | grep -n -E 'Nightly betas|Publish (Beta|Release|JF12)|Manifest freshness|Wiki Lint|CodeQL|Scorecard|Stryker|Fuzz'
$ echo $?
1
```

Exit 1 is "no lines selected". The only workflow names left anywhere in the file
are in the header comment, where they describe the two incidents, and nothing
reads them.

## The no-duplicate-storm behaviour

Two lines hold it, in two directions.

This one is the single-tracking-issue key, unchanged from #982:

```sh
num=$(gh issue list --repo "$REPO" --state open --label release-alert \
  --json number --jq '.[0].number // empty')
```

A non-empty `num` sends the report down `gh issue comment`, an empty one down
`gh issue create`. The label name is kept from #982 on purpose: renaming it
would make an already-open tracking issue invisible to the next failure, which
is exactly one duplicate.

This one is what a sweep needs and an event-driven watchdog did not, since a
sweep re-reads the same failure every tick:

```sh
case "$reported" in
  *"$url"*)
```

`$reported` is the tracking issue's body and every comment on it, so a run
already written there is passed over in silence. A red guard therefore produces
one comment per distinct failed run, not one per tick.

The 24 hour window closes the third storm. Without it, a long-dead red run stays
in the last hundred runs and re-opens the tracking issue every time the issue is
closed.

## Proof that it bites

The sweep body was extracted from the committed file rather than retyped, and
run against the real run list of this repository. Only the issue-writing calls
were stubbed; the stub records its arguments, contacts nothing and files
nothing.

```
$ awk '/^        run: \|$/{f=1;next} f{sub(/^          /,"");print}' \
    .github/workflows/publish-failure-alert.yml > sweep.sh
$ gh run list --branch main --limit 100 --json workflowName,conclusion,url,event,updatedAt > real-runs.json
```

The board supplies a live subject. One run on `main` is red right now, it is not
one of the six names the old list watched, and nobody was told:

```
$ gh run list --branch main --limit 100 --json workflowName,conclusion,url,updatedAt,event \
    --jq '.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "cancelled" and .conclusion != "") | "\(.updatedAt) \(.conclusion) \(.event) \(.workflowName) \(.url)"'
2026-08-03T09:01:37Z failure schedule Fuzz (SharpFuzz) https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
```

Five cases, all against that data:

```
### CASE 1 window 24h, nothing red in it ###
Examined 100 run(s) on main; 0 non-success since 2026-08-03T21:19:34Z.
Nothing red. No issue filed.

### CASE 2 window 96h, the Fuzz failure in range, no issue open ###
Examined 100 run(s) on main; 1 non-success since 2026-07-31T21:19:36Z.
No open alert issue; creating one for https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  gh issue create --repo iderex/jellyfin-plugin-sso --label release-alert --title A workflow concluded non-success on the default branch --body <body>

### CASE 3 window 96h, issue 4242 open, run already reported on it ###
Already reported, skipping: https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  (no issue create, no issue comment)

### CASE 4 window 96h, issue 4242 open, run not yet reported ###
Updating existing alert issue #4242 with https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  gh issue comment 4242 --repo iderex/jellyfin-plugin-sso --body <body>

### CASE 5 window 96h, dry run ###
DRY RUN, filing nothing. Would report Fuzz (SharpFuzz) (failure) https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
```

Case 2 is the guard biting for the reason it names: a scheduled guard, absent
from every list, red on `main`, selected by conclusion alone. Case 1 is the same
predicate declining to fire. Cases 3 and 4 are the two dedup outcomes on one
open issue. Case 5 is the exercise route filing nothing.

Note what these do not cover. `jq` came from `gojq` locally, which is
jq-compatible but not jq; the runner has jq itself. And the harness ran the
script body, so it proves the selection and the dedup, not the schedule, the
permissions, or that the real `gh issue create` succeeds with this token.

## Permissions the job holds

The workflow level is `permissions: {}`, a deny-all. The one job adds exactly
two grants:

- `actions: read`, needed to read the run list. This is new; the previous
  version was handed its one run by the event and read nothing.
- `issues: write`, needed to open the tracking issue, comment on it, and
  self-provision its label.

No `contents`, so the job cannot write to the tree. No ability to re-run or
cancel anything, since `actions` is read-only. No `pull-requests`. Everything
reaching the shell is passed through `env` or read from a file, never spliced in
as `${{ }}`, so a crafted workflow or branch name is printed rather than
executed. The `workflow_run` trigger is gone with this change, and its
documented `zizmor: ignore[dangerous-triggers]` accept goes with it, so the
change removes a security accept rather than adding one.

## What this change does NOT prove

Read this before landing it.

**The alert has not been seen to open an issue.** This workflow is scheduled and
event-driven, and a pull request cannot make it fire on a real failure. No green
check below is evidence that it does. Nothing here claims the path was verified
end to end, because it was not.

**The safe exercise route exists and I could not run it.** `dry_run` defaults to
true and files nothing, which is exactly the safe way to exercise the path, but
dispatching this workflow is gated locally on my release go:

```
$ gh workflow run "Publish failure alert" --ref chore/guard-failure-signal-1015 -f dry_run=true
BLOCKED by guard-git: manually dispatching the publish workflow publishes a release.
Get my go, then prefix with $env:SSO_RELEASE_GO='1';.
```

The guard matches on the word publish in the workflow name and cannot tell this
sweep from an actual publish. I did not work around it. The name is inherited
from #982 and renaming it is a change nobody asked for here, so it stays and is
noted instead.

**What would prove it, and who reads that proof.** In order of cost, all read by
whoever lands this:

1. Dispatch it in dry run once it is on `main`, with the release go prefixed.
   The run log should print the examined count and, while `Fuzz (SharpFuzz)`
   stays red and inside the window, one "Would report" line naming it. That
   proves the selection and the permissions on the real runner and files
   nothing.
2. Let the schedule tick and read `gh run list --workflow "Publish failure
   alert" --branch main`. A run every half hour is the schedule working.
3. The first genuine failure on `main` after that opens the tracking issue, and
   the issue is the proof. It cannot be staged without filing noise on this
   board, so it stays unproven until one arrives.

If step 1 prints an examined count of 0, or step 2 shows no runs, this is not
working and should be reverted rather than left in place, because a watchdog
that selects nothing is worse than the list it replaced.

## The means, and why it fits

A workflow file in `.github/workflows/`, YAML with a `gh` and `jq` body, the
register this repository already keeps its automation in. It adds no language,
runtime or dependency the tree does not carry, and the guard has to run on
GitHub's schedule and speak to GitHub's API, so a workflow is the only thing
here that can hold it.

The event-driven expression was tried first and is the better shape on latency.
It was abandoned for a measured reason rather than a preference: the required
workflow audit on this repository cannot parse it, quoted above. The sweep was
chosen over lengthening the list because a list is the defect, and over a hybrid
that keeps both because two mechanisms writing to one tracking issue is more
surface for the same signal.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

It sits on the release-pipeline surface without changing what publishes, so the
security checklist below is filled in rather than skipped.

## Security checklist

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.

  Does not apply. No signature, time bound or audience is involved. The nearest
  equivalent is held: the conclusion test is a denylist, so an unknown
  conclusion class alerts rather than being dropped.

- [x] No secrets logged; secrets are redacted on config export.

  The job's only secret is `github.token`, passed through `env` as `GH_TOKEN`
  and never echoed. Everything printed or written into an issue is a workflow
  name, a branch name, a conclusion, an event name and a run URL, all public.

- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.

  Not ticked, and it is not a formality skipped. The multi-lens adversarial gate
  was not run on this change. What exists is a single-reader analysis of the
  surfaces this diff moves, written out under permissions above. Two things to
  point the gate at first. The new `actions: read` grant is a widening of the
  token compared with what this file held before. And the failure mode this
  shape introduces is volume rather than exposure: every distinct red run inside
  the window comments on one tracking issue, so a workflow failing every few
  minutes produces a long thread on a single issue. Whoever lands this owes the
  gate its due.

- [ ] Review record: per lens, its verdict and its findings, with CONFIRMED __ /
      PLAUSIBLE __ counts as raised.

  No record, because no lens ran. Read the line above rather than this as a
  clean sheet.

- [x] Log inputs from the IdP are sanitized inline at the log call.

  Does not apply literally, since no IdP input reaches this file. The equivalent
  property applies and is held: every run-controlled value reaches the shell
  through `env` or a file and is never interpolated as `${{ }}`, so a crafted
  workflow name is printed, not executed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit.

  One selection, one dedup, one report, each in one place. The extraction in the
  proof section is what makes the body testable outside a runner.

- [x] The change adds no more code than the problem requires.

  One file. The sweep is longer than the trigger it replaces, and the reason is
  in the two-commits section rather than assumed away.

- [x] The code is self-documenting and matches the target architecture (#318).

  Applies loosely to a workflow file. Comments say why, not what. One sentence
  that was wrong when first written, claiming no workflow name appears in the
  file, was corrected before the first commit, because two names appear in the
  header comment describing the incidents.

- [ ] Architecture-conformance tests pass, and any new structural property is
      locked in as a rule.

  Does not apply. `ArchitectureConformanceTests` reads the C# assembly and this
  change adds no C# and no structural property. The suite was not run, because
  nothing in the diff can affect it.

- [x] Docs impact considered.

  No tracked file outside `.github/` mentions the watchdog, so nothing in this
  tree carries a description of its coverage that this change makes stale:

  ```
  $ grep -rn --exclude-dir=.git -E 'release-alert|publish-failure-alert' . | grep -v '^\./\.github/'
  $ echo $?
  1
  ```

  The wiki is a separate repository and was not searched, so that half is
  unchecked rather than clear.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.

  Not run. The diff is one YAML file and contains no C#, so a local build could
  neither pass nor fail on account of it. The `build` check on this pull request
  runs it anyway.

- [ ] `dotnet test` is green.

  Not run, for the same reason. The `build` check on this pull request runs the
  suite, and it passed.

- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

  Vacuously. The change touches none of those extensions, and Prettier is not
  configured over `.yml` here.

- [x] The workflow parses.

  `actionlint` v1.7.12 exits 0 on the file at the pushed commit, and `zizmor`,
  which refused the first commit, is a check on this pull request.

## Checks on this pull request

All green at `060e7b0`, quoted by name from `gh pr checks 1208`:

```
ABI floor build                    pass   56s
Analyze (actions)                  pass   40s
Analyze (csharp)                   pass   3m46s
Analyze (javascript-typescript)    pass   58s
Audit workflows (zizmor)           pass   17s
CodeQL                             pass   3s
DCO sign-off                       pass   8s
Deterministic PR-hygiene checks    pass   6s
Enforce greppable invariants       pass   9s
Package (JPRM) / Build package     pass   55s
Package (JPRM) / Generate SBOM     skipping
Reject Trojan Source Unicode       pass   7s
build                              pass   4m10s
dependency-review                  pass   7s
prettier                           pass   10s
submit-nuget                       pass   25s
zizmor                             pass   3s
```

`Audit workflows (zizmor)` is the check that refused the first commit and passes
on the second. `Generate SBOM` skipping is its normal state on a pull request.
None of these exercises the alert, which is the section above.

## Notes

The changelog line for this change is not in this diff and is owed as a
follow-up. `CHANGELOG.md` is deliberately out of scope here because another
effort holds uncommitted changes to it and a second writer would collide.

The required-status-check configuration is untouched. Nothing here asks for it
to move, and it is a repository setting rather than a file.

Two open issues, #1199 and #1207, name other workflow files. This change reaches
none of them.

Worth a follow-up issue rather than this pull request: the workflow's name still
begins with the word publish, which is why the local dispatch guard treats a dry
run of it as a release. Renaming it would make the safe exercise route usable
without the release go, and would cost the concurrency group and the label's
historical name.


## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

The branch was brought onto the current mainline `ab81ba6` with a merge commit,
so nothing that was already pushed was rewritten. The head is now `2d4e0ed` and
the scope claim above still holds at that commit:

```
$ git diff --name-only origin/main...HEAD
.github/workflows/publish-failure-alert.yml
```

Every number the sections above state was re-run here rather than carried over.

### The two greps

```
$ grep -v -E '^\s*#' .github/workflows/publish-failure-alert.yml \
    | grep -n -E 'Nightly betas|Publish (Beta|Release|JF12)|Manifest freshness|Wiki Lint|CodeQL|Scorecard|Stryker|Fuzz'
$ echo $?
1
$ grep -rn --exclude-dir=.git -E 'release-alert|publish-failure-alert' . | grep -v '^\./\.github/'
$ echo $?
1
```

Both still select nothing.

### The parse, in both directions

```
$ actionlint --version
v1.7.12
$ actionlint .github/workflows/publish-failure-alert.yml
$ echo $?
0
```

And the shape the first commit carried, checked out into a scratch tree and
linted on its own:

```
$ git show e8fb35d:.github/workflows/publish-failure-alert.yml > fc/.github/workflows/publish-failure-alert.yml
$ cd fc && actionlint .github/workflows/publish-failure-alert.yml
.github/workflows/publish-failure-alert.yml:32:3: no workflow is configured for "workflow_run" event [events]
   |
32 |   workflow_run:
   |   ^~~~~~~~~~~~~
$ echo $?
1
```

The other refusal quoted above is still readable in the run log and matches the
text in the body:

```
$ gh run view --job 92133750724 --log | grep -E 'no audit was performed|did not match any variant'
fatal: no audit was performed
    2: data did not match any variant of untagged enum Trigger
```

So the reason the event route was abandoned reproduces on both models rather
than resting on the earlier report of it.

### The live subject

Still exactly one, and still the same run:

```
$ gh run list --branch main --limit 100 --json workflowName,conclusion,url,updatedAt,event \
    --jq '.[] | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "cancelled" and .conclusion != "") | "\(.updatedAt) \(.conclusion) \(.event) \(.workflowName) \(.url)"'
2026-08-03T09:01:37Z failure schedule Fuzz (SharpFuzz) https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
```

One difference from the run recorded above, and it is only the clock. That
failure is now older than the 24 hour window, so at the current time the default
window no longer selects it. The five cases below still use 96 hours for the
cases that need a red run in range, which is what the original run did too.

### The five cases

Re-extracted from the committed file with the same `awk` line and run against
the live run list, with only the issue-writing calls stubbed. The stub contacts
nothing and files nothing; it prints the call it was asked to make.

```
### CASE 1 window 24h, nothing red in it ###
Examined 100 run(s) on main; 0 non-success since 2026-08-03T22:31:46Z.
Nothing red. No issue filed.

### CASE 2 window 96h, the Fuzz failure in range, no issue open ###
Examined 100 run(s) on main; 1 non-success since 2026-07-31T22:31:47Z.
No open alert issue; creating one for https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  STUB WRITE: gh issue create --repo <repo> --label release-alert --title <title> --body <body>

### CASE 3 window 96h, issue 4242 open, run already reported ###
Examined 100 run(s) on main; 1 non-success since 2026-07-31T22:31:49Z.
Already reported, skipping: https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986

### CASE 4 window 96h, issue 4242 open, run not yet reported ###
Examined 100 run(s) on main; 1 non-success since 2026-07-31T22:31:51Z.
Updating existing alert issue #4242 with https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  STUB WRITE: gh issue comment 4242 --repo <repo> --body <body>

### CASE 5 window 96h, dry run ###
Examined 100 run(s) on main; 1 non-success since 2026-07-31T22:31:55Z.
DRY RUN, filing nothing. Would report Fuzz (SharpFuzz) (failure) https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
```

Same five outcomes as reported. `jq` was again supplied by `gojq` locally, which
is the same substitution the section above declares, so this re-run does not
close that gap either.

### Two falsifiers

A passing harness on the good file says little on its own, so the guard was
broken in the tracked file, in the two places it claims to hold, and the harness
re-run on the broken file each time.

The first puts the enumeration back, which is the defect #1015 records, and
changes nothing else:

```
$ git diff
+            | select(. as $r | ["Nightly betas","Publish Beta","Publish JF12 Beta","Publish Release","Publish JF12 Stable","Manifest freshness"] | index($r.workflowName))
$ # same live run list, same 96h window as CASE 2
Examined 100 run(s) on main; 0 non-success since 2026-07-31T22:32:54Z.
Nothing red. No issue filed.
```

The red run is a scheduled guard that is not on that list, so with the list back
it vanishes and nobody is told, which is the incident. The derivation is what
selects it, not something incidental to the data.

The second deletes the seven lines that hold the no-duplicate-storm behaviour
and re-runs CASE 3, where the run is already written on the open issue:

```
$ git diff --stat
 .github/workflows/publish-failure-alert.yml | 7 -------
$ # CASE 3 inputs
Examined 100 run(s) on main; 1 non-success since 2026-07-31T22:33:24Z.
Updating existing alert issue #4242 with https://github.com/iderex/jellyfin-plugin-sso/actions/runs/30798899986
  STUB WRITE: gh issue comment 4242 --repo <repo> --body <body>
```

That is the storm: the same failure reported again every half hour. Both edits
were reverted and the file is byte-identical to the commit again, `git status`
empty, CASE 3 back to skipping and `actionlint` back to exit 0.

### The build gate, on the merged state

The diff is one YAML file and cannot move the suite, but the merge brings the
mainline C# onto the branch, so the gate was run on what will actually land:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 -p:JellyfinVersion=10.11.11 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2315, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2315, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

Prettier was run too and needs one word of explanation rather than a tick. On
this checkout `npx prettier --check` reports 19 files, none of them in this
diff, and `--end-of-line auto` reports all files clean, so what it is seeing is
the checkout's CRLF endings and not content. The `prettier` check on this pull
request runs on Linux and passes.

### A residual this re-run found

The sweep excludes its own runs, which the file explains and which is the right
call for the storm it prevents. The consequence is that the watchdog cannot
report its own death. Measured, by adding one failed run of this workflow to the
live list and sweeping it:

```
$ # 101 runs, the extra one being this workflow, conclusion failure, inside the window
Examined 101 run(s) on main; 0 non-success since 2026-08-03T22:42:49Z.
Nothing red. No issue filed.
```

So if the sweep itself starts failing, for instance on an API error under
`set -euo pipefail`, the signal it exists to produce stops and nothing here
says so. That is inherent to a watchdog watching from inside, it is not a
regression against the six-name version, which had the same blind spot, and it
is not covered by this change. It is worth its own issue rather than a widening
here.

### What this re-run did not close

The three unproven items above stand exactly as written and none of them was
converted into a tick.

The alert has still never been seen to open an issue. The dry run on the real
runner was still not performed, because the local dispatch guard still refuses
the workflow on its name and was not worked around. The schedule has still not
been observed to tick. The steps that would prove those are the numbered list
above and they are still owed after this merges.

The multi-lens review gate was still not run, so that checkbox stays unticked.
What this re-run adds is a second single reader over the same two surfaces the
section above points at, and the reading found no new exposure: the token is
read-only on `actions`, every run-controlled value reaches the shell through
`env` or a file, and the volume concern is real but bounded, since one sweep
examines at most 100 runs and every later sweep passes over what is already
written on the issue. A single reader twice is not the gate, and the note above
asking for it remains the current state rather than a closed item.
