### PR TITLE
Bound the post-logout return URL at a path segment boundary

### DIFF
--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -267,6 +267,43 @@ public class ProviderConfigValidatorTests
         Assert.Null(ex);
     }
 
+    // The containment boundary (#1181). The save gate delegates to OidcLogout.IsAllowedPostLogoutRedirect, so
+    // it must refuse exactly the set the runtime drops; these are the same four families pinned against the
+    // predicate in OidcLogoutTests, run through the second enforcement point.
+    private const string PostLogoutPathBase = "https://jf.example.com/jellyfin";
+
+    [Theory]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfinevil/x")] // prefix, not a segment prefix
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfinevil")]
+    [InlineData(PostLogoutBase, "https://jellyfin.example.com.evil.net/")] // suffix: a host the base is a prefix of
+    [InlineData(PostLogoutBase, "https://jellyfin.example.com.evil.net/web/")]
+    [InlineData(PostLogoutBase, "https://sub.jellyfin.example.com/")] // subdomain, both directions
+    [InlineData("https://sub.jellyfin.example.com", "https://jellyfin.example.com/")]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/JELLYFIN/x")] // path case: the path compare is ordinal
+    public void ValidatePostLogoutRedirectUri_OutsideTheBase_Throws(string baseUrlOverride, string postLogoutRedirectUri)
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", baseUrlOverride, postLogoutRedirectUri));
+
+        Assert.Equal("postLogoutRedirectUri", ex.ParamName);
+        Assert.Contains("not at or under the configured Base URL", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(postLogoutRedirectUri, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    // Host case is INTENDED to be accepted (DNS is case-insensitive); path case above is not.
+    [InlineData(PostLogoutBase, "https://JELLYFIN.EXAMPLE.COM/web/")]
+    [InlineData("https://JELLYFIN.example.com", "https://jellyfin.example.com/web/")]
+    [InlineData(PostLogoutPathBase, PostLogoutPathBase)] // the base itself, with a path base
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/web/index.html")] // below the path base
+    public void ValidatePostLogoutRedirectUri_AtOrUnderBase_IncludingADifferentlyCasedHost_DoesNotThrow(string baseUrlOverride, string postLogoutRedirectUri)
+    {
+        var ex = Record.Exception(() =>
+            ProviderConfigValidator.ValidatePostLogoutRedirectUri("OpenID", "idp", baseUrlOverride, postLogoutRedirectUri));
+
+        Assert.Null(ex);
+    }
+
     [Fact]
     public void ValidatePostLogoutRedirectUri_ControlCharacterInProvider_IsStrippedFromTheEchoedMessage()
     {

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -275,11 +275,17 @@ public class ProviderConfigValidatorTests
     [Theory]
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfinevil/x")] // prefix, not a segment prefix
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfinevil")]
-    [InlineData(PostLogoutBase, "https://jellyfin.example.com.evil.net/")] // suffix: a host the base is a prefix of
-    [InlineData(PostLogoutBase, "https://jellyfin.example.com.evil.net/web/")]
+    [InlineData(PostLogoutBase, "https://jellyfin.example.com.evil.net/web/")] // suffix, both readings of it
+    [InlineData(PostLogoutBase, "https://eviljellyfin.example.com/")]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/notjellyfin")]
     [InlineData(PostLogoutBase, "https://sub.jellyfin.example.com/")] // subdomain, both directions
     [InlineData("https://sub.jellyfin.example.com", "https://jellyfin.example.com/")]
     [InlineData(PostLogoutPathBase, "https://jf.example.com/JELLYFIN/x")] // path case: the path compare is ordinal
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/JELLYFIN")]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%2f..%2fevil")] // escaped separator
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/%2E%2E%2Fevil")]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%5C..%5Cevil")]
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..;/evil")] // segment parameter
     public void ValidatePostLogoutRedirectUri_OutsideTheBase_Throws(string baseUrlOverride, string postLogoutRedirectUri)
     {
         var ex = Assert.Throws<ArgumentException>(() =>
@@ -295,6 +301,7 @@ public class ProviderConfigValidatorTests
     [InlineData(PostLogoutBase, "https://JELLYFIN.EXAMPLE.COM/web/")]
     [InlineData("https://JELLYFIN.example.com", "https://jellyfin.example.com/web/")]
     [InlineData(PostLogoutPathBase, PostLogoutPathBase)] // the base itself, with a path base
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/")] // the base plus a trailing slash
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/web/index.html")] // below the path base
     public void ValidatePostLogoutRedirectUri_AtOrUnderBase_IncludingADifferentlyCasedHost_DoesNotThrow(string baseUrlOverride, string postLogoutRedirectUri)
     {

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -286,6 +286,9 @@ public class ProviderConfigValidatorTests
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/%2E%2E%2Fevil")]
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%5C..%5Cevil")]
     [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..;/evil")] // segment parameter
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%3b/evil")] // and its encoded form
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%252f..%252fevil")] // double-encoded
+    [InlineData(PostLogoutPathBase, "https://jf.example.com/jellyfin/..%c0%afevil")]
     public void ValidatePostLogoutRedirectUri_OutsideTheBase_Throws(string baseUrlOverride, string postLogoutRedirectUri)
     {
         var ex = Assert.Throws<ArgumentException>(() =>

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -132,12 +132,17 @@ public class OidcLogoutTests
     [InlineData(Base, "https://jellyfin.example.com.evil.net/web/")]
     [InlineData(Base, "https://eviljellyfin.example.com/")]
     [InlineData(PathBase, "https://jf.example.com/notjellyfin")]
-    // Escaped separators and a segment parameter: Uri leaves them intact, so without the guard on them a
-    // hop that decodes or strips them resolves the path outside the base after the check has passed.
+    // Escapes and segment parameters: Uri leaves them intact, so without the guard a hop that decodes or
+    // strips them resolves the path outside the base after the check has passed. Enumerating the dangerous
+    // ones is not enough, which is why the guard refuses the whole family - the double-encoded and
+    // encoded-semicolon rows below reach the same place one decoding hop further out.
     [InlineData(PathBase, "https://jf.example.com/jellyfin/..%2f..%2fevil")]
     [InlineData(PathBase, "https://jf.example.com/jellyfin/%2E%2E%2Fevil")]
     [InlineData(PathBase, "https://jf.example.com/jellyfin/..%5C..%5Cevil")]
     [InlineData(PathBase, "https://jf.example.com/jellyfin/..;/evil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..%3b/evil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..%252f..%252fevil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..%c0%afevil")]
     // Subdomain family, in both directions: neither contains the other.
     [InlineData(Base, "https://sub.jellyfin.example.com/")]
     [InlineData("https://sub.jellyfin.example.com", "https://jellyfin.example.com/")]
@@ -172,10 +177,12 @@ public class OidcLogoutTests
     }
 
     [Fact]
-    public void IsAllowedPostLogoutRedirect_PaddedCandidate_IsAcceptedTrimmed_SoWhatIsEmittedIsWhatWasChecked()
+    public void IsAllowedPostLogoutRedirect_PaddedCandidate_IsAcceptedWithThePaddingRemoved()
     {
-        // Uri.TryCreate parses the trimmed form, so the padding is not part of what the checks above ran on.
-        // Emitting it would break the OP's exact match against the registered URI.
+        // Uri.TryCreate parses the value with leading and trailing space, CR, LF and TAB removed, so that
+        // padding is not part of what the checks above ran on. Emitting it would break the OP's exact match
+        // against the registered URI. This narrows the gap between the checked and the emitted form rather
+        // than closing it: the emitted value is still the admin's string, not the canonicalized one.
         Assert.True(OidcLogout.IsAllowedPostLogoutRedirect("  " + Base + "/web/  ", Base, out var allowed));
         Assert.Equal(Base + "/web/", allowed);
     }

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -126,17 +126,27 @@ public class OidcLogoutTests
     // segment prefix of it. "/jellyfinevil" is a different application, not something under "/jellyfin".
     [InlineData(PathBase, "https://jf.example.com/jellyfinevil/x")]
     [InlineData(PathBase, "https://jf.example.com/jellyfinevil")]
-    // Suffix family: a host the base host is a leading substring of. Different authority, so it is refused
-    // by the host compare rather than by the path rule.
-    [InlineData(Base, "https://jellyfin.example.com.evil.net/")]
+    // Suffix family, both readings of it: a host carrying the base host plus a suffix, and a host or path
+    // that ENDS with the base string without being under it. Different authority in the host cases, so those
+    // are refused by the host compare rather than by the path rule.
     [InlineData(Base, "https://jellyfin.example.com.evil.net/web/")]
+    [InlineData(Base, "https://eviljellyfin.example.com/")]
+    [InlineData(PathBase, "https://jf.example.com/notjellyfin")]
+    // Escaped separators and a segment parameter: Uri leaves them intact, so without the guard on them a
+    // hop that decodes or strips them resolves the path outside the base after the check has passed.
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..%2f..%2fevil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/%2E%2E%2Fevil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..%5C..%5Cevil")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/..;/evil")]
     // Subdomain family, in both directions: neither contains the other.
     [InlineData(Base, "https://sub.jellyfin.example.com/")]
     [InlineData("https://sub.jellyfin.example.com", "https://jellyfin.example.com/")]
     // Case family, path half: URL paths are case-sensitive, the path compare is ordinal, and a
-    // differently-cased path segment is a different path. Pinned deliberately - the host half below is the
-    // opposite direction and is intended.
+    // differently-cased path segment is a different path - including the candidate that differs from the
+    // base in nothing but case. Pinned deliberately; the host half below is the opposite direction and is
+    // intended.
     [InlineData(PathBase, "https://jf.example.com/JELLYFIN/x")]
+    [InlineData(PathBase, "https://jf.example.com/JELLYFIN")]
     public void IsAllowedPostLogoutRedirect_OutsideTheBase_IsRejected_WithEmptyOut(string canonicalBase, string candidate)
     {
         Assert.False(OidcLogout.IsAllowedPostLogoutRedirect(candidate, canonicalBase, out var allowed));
@@ -144,8 +154,11 @@ public class OidcLogoutTests
     }
 
     [Theory]
-    // Case family, host half: the acceptance is INTENDED. DNS host names are case-insensitive and
-    // IsSameAuthority compares them OrdinalIgnoreCase, so a differently-cased host is the same server.
+    // Case family, host half: the acceptance is INTENDED. DNS host names are case-insensitive and a
+    // differently-cased host is the same server. What delivers the acceptance for these rows is Uri's own
+    // lower-casing of an ASCII host rather than the OrdinalIgnoreCase compare in IsSameAuthority, so these
+    // rows pin the observable behaviour and not that compare - from this entry point the compare cannot be
+    // falsified, because no ASCII host reaches it with its case intact.
     [InlineData(Base, "https://JELLYFIN.EXAMPLE.COM/web/")]
     [InlineData("https://JELLYFIN.example.com", "https://jellyfin.example.com/web/")]
     // A base with a path base contains itself and everything at a segment boundary below it.
@@ -156,6 +169,15 @@ public class OidcLogoutTests
     {
         Assert.True(OidcLogout.IsAllowedPostLogoutRedirect(candidate, canonicalBase, out var allowed));
         Assert.Equal(candidate, allowed);
+    }
+
+    [Fact]
+    public void IsAllowedPostLogoutRedirect_PaddedCandidate_IsAcceptedTrimmed_SoWhatIsEmittedIsWhatWasChecked()
+    {
+        // Uri.TryCreate parses the trimmed form, so the padding is not part of what the checks above ran on.
+        // Emitting it would break the OP's exact match against the registered URI.
+        Assert.True(OidcLogout.IsAllowedPostLogoutRedirect("  " + Base + "/web/  ", Base, out var allowed));
+        Assert.Equal(Base + "/web/", allowed);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
@@ -101,7 +101,7 @@ public class OidcLogoutTests
 
     [Theory]
     [InlineData("https://evil.example.net/steal")] // different authority
-    [InlineData("https://jellyfin.example.com.evil.net/")] // sibling-prefix host
+    [InlineData("https://jellyfin.example.com.evil.net/")] // suffix family: a host the base host is a prefix of
     [InlineData("not-a-url")] // not absolute
     [InlineData("ftp://jellyfin.example.com/x")] // not http(s)
     [InlineData("https://user:pass@jellyfin.example.com/")] // userinfo
@@ -110,6 +110,65 @@ public class OidcLogoutTests
     {
         Assert.False(OidcLogout.IsAllowedPostLogoutRedirect(candidate, Base, out var allowed));
         Assert.Equal(string.Empty, allowed);
+    }
+
+    // --- The containment boundary (#1181): prefix, suffix, subdomain and case ---
+    //
+    // Both the XML doc on the predicate and the admin-facing validator message promise a return URL "at or
+    // under this server's base URL". These rows are the four ways a candidate can look like it is under the
+    // base without being under it. The realistic deployment is a reverse proxy serving more than one app
+    // under one hostname, where the base carries a path base.
+
+    private const string PathBase = "https://jf.example.com/jellyfin";
+
+    [Theory]
+    // Prefix family: same authority, and the base path is a string prefix of the candidate path but not a
+    // segment prefix of it. "/jellyfinevil" is a different application, not something under "/jellyfin".
+    [InlineData(PathBase, "https://jf.example.com/jellyfinevil/x")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfinevil")]
+    // Suffix family: a host the base host is a leading substring of. Different authority, so it is refused
+    // by the host compare rather than by the path rule.
+    [InlineData(Base, "https://jellyfin.example.com.evil.net/")]
+    [InlineData(Base, "https://jellyfin.example.com.evil.net/web/")]
+    // Subdomain family, in both directions: neither contains the other.
+    [InlineData(Base, "https://sub.jellyfin.example.com/")]
+    [InlineData("https://sub.jellyfin.example.com", "https://jellyfin.example.com/")]
+    // Case family, path half: URL paths are case-sensitive, the path compare is ordinal, and a
+    // differently-cased path segment is a different path. Pinned deliberately - the host half below is the
+    // opposite direction and is intended.
+    [InlineData(PathBase, "https://jf.example.com/JELLYFIN/x")]
+    public void IsAllowedPostLogoutRedirect_OutsideTheBase_IsRejected_WithEmptyOut(string canonicalBase, string candidate)
+    {
+        Assert.False(OidcLogout.IsAllowedPostLogoutRedirect(candidate, canonicalBase, out var allowed));
+        Assert.Equal(string.Empty, allowed);
+    }
+
+    [Theory]
+    // Case family, host half: the acceptance is INTENDED. DNS host names are case-insensitive and
+    // IsSameAuthority compares them OrdinalIgnoreCase, so a differently-cased host is the same server.
+    [InlineData(Base, "https://JELLYFIN.EXAMPLE.COM/web/")]
+    [InlineData("https://JELLYFIN.example.com", "https://jellyfin.example.com/web/")]
+    // A base with a path base contains itself and everything at a segment boundary below it.
+    [InlineData(PathBase, PathBase)]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/")]
+    [InlineData(PathBase, "https://jf.example.com/jellyfin/web/index.html")]
+    public void IsAllowedPostLogoutRedirect_AtOrUnderBase_IncludingADifferentlyCasedHost_IsAllowed(string canonicalBase, string candidate)
+    {
+        Assert.True(OidcLogout.IsAllowedPostLogoutRedirect(candidate, canonicalBase, out var allowed));
+        Assert.Equal(candidate, allowed);
+    }
+
+    [Fact]
+    public void Build_PostLogoutRedirectSharingOnlyAPrefixOfTheBasePath_LeavesTheParameterAbsentEntirely()
+    {
+        var url = OidcLogout.BuildEndSessionUrl(EndSession, Issuer, "t", "c", "https://jf.example.com/jellyfinevil/x", PathBase);
+
+        // Absent, not present-and-empty: a bare "post_logout_redirect_uri=" is still a parameter the OP
+        // reads, and the whole value must be gone rather than blanked.
+        Assert.NotNull(url);
+        Assert.DoesNotContain("post_logout_redirect_uri", url, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("jellyfinevil", url, System.StringComparison.Ordinal);
+        Assert.Equal(EndSession + "?id_token_hint=t&client_id=c", url);
     }
 
     [Fact]

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -115,9 +115,9 @@ internal static class OidcLogout
     /// <item><description>the SAME authority - scheme, host (<c>OrdinalIgnoreCase</c>, which for the ASCII
     /// hosts Uri lower-cases makes host case irrelevant) and effective port - so a sibling host such as
     /// <c>base.example.com.evil.net</c> and any subdomain of the base are refused;</description></item>
-    /// <item><description>no escaped separator (<c>%2f</c>, <c>%5c</c>) and no <c>;</c> segment parameter in
-    /// the path, because Uri leaves those intact and a hop that decodes or strips them would resolve the
-    /// path outside the base after this check has passed;</description></item>
+    /// <item><description>no percent-escape and no <c>;</c> segment parameter anywhere in the path, because
+    /// Uri leaves both intact and a hop that decodes or strips them would resolve the path outside the base
+    /// after this check has passed;</description></item>
     /// <item><description>a path that EQUALS the base path or continues it at a SEGMENT boundary, compared
     /// ordinally, so URL path case is significant - under a base of <c>https://host/jellyfin</c>,
     /// <c>/jellyfin</c> and <c>/jellyfin/web</c> are under it while <c>/jellyfinevil/x</c> and
@@ -160,14 +160,13 @@ internal static class OidcLogout
         var candidatePath = candidateUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
 
         // The path is compared in the form Uri canonicalizes it to, and that form is only as good as what the
-        // NEXT hop does with it. Uri resolves literal and %2e dot segments here, but leaves an escaped
-        // separator escaped and keeps a ";" segment parameter, so "/jellyfin/..%2f..%2fevil" and
+        // NEXT hop does with it. Uri resolves literal and %2e dot segments here, but leaves every other
+        // escape escaped and keeps a ";" segment parameter, so "/jellyfin/..%2f..%2fevil" and
         // "/jellyfin/..;/evil" would satisfy the boundary rule below and still resolve outside the base at any
-        // proxy that decodes or strips them. A return URL to this server needs neither, so refuse both rather
-        // than guess how the next hop normalizes (#1181).
-        if (candidatePath.Contains("%2f", StringComparison.OrdinalIgnoreCase)
-            || candidatePath.Contains("%5c", StringComparison.OrdinalIgnoreCase)
-            || candidatePath.Contains(';'))
+        // proxy that decodes or strips them. Enumerating the dangerous escapes does not close that: %252f and
+        // %3b reach the same place one decoding hop further out. A return URL to this server needs no escape
+        // in its path at all, so refuse the whole family rather than guess how the next hop normalizes (#1181).
+        if (candidatePath.Contains('%') || candidatePath.Contains(';'))
         {
             return false;
         }

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -106,8 +106,13 @@ internal static class OidcLogout
 
     /// <summary>
     /// Whether a <c>post_logout_redirect_uri</c> candidate is allowed: it normalizes to a valid http(s) URL
-    /// with no userinfo and sits at or under this server's <paramref name="canonicalBaseUrl"/> (same origin +
-    /// path prefix), so a logout can only return the browser to this Jellyfin. The SINGLE source of truth for
+    /// with no userinfo and sits at or under this server's <paramref name="canonicalBaseUrl"/>, so a logout
+    /// can only return the browser to this Jellyfin. "At or under" is exactly two conditions: the SAME
+    /// authority as the base (scheme, host compared case-insensitively per DNS, and effective port - so a
+    /// sibling host such as <c>base.example.com.evil.net</c> and any subdomain of the base are refused), and
+    /// a path that EQUALS the base path or continues it at a SEGMENT boundary (ordinal, so URL path case is
+    /// significant - under a base of <c>https://host/jellyfin</c>, <c>/jellyfin/web</c> is under it while
+    /// <c>/jellyfinevil/x</c> and <c>/JELLYFIN/x</c> are not). The SINGLE source of truth for
     /// the return-URL rule - the runtime builder above and the save-time
     /// <c>ProviderConfigValidator.ValidatePostLogoutRedirectUri</c> both call it, so the config-page save
     /// rejects exactly the values the runtime would silently drop (no second, divergent URL rule). A blank
@@ -131,16 +136,21 @@ internal static class OidcLogout
             return false;
         }
 
-        // Same authority as the canonical base, and its path is under the base path - a prefix check on the
-        // canonicalized origin+path, so a sibling host or a path-traversal cannot slip through.
+        // Same authority as the canonical base, so a sibling host (a suffix of the base host) or a subdomain
+        // of it is a different server and cannot slip through.
         if (!IsSameAuthority(candidateUri, baseUri))
         {
             return false;
         }
 
+        // Then the path, compared on the canonicalized origin+path (a path-traversal is already resolved
+        // there): the candidate must EQUAL the base path or continue it at a SEGMENT boundary. A plain
+        // string prefix is not enough - under a base of "https://host/jellyfin" it would accept
+        // "https://host/jellyfinevil/x", a different application on the same reverse-proxied hostname (#1181).
         var basePath = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
         var candidatePath = candidateUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
-        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal))
+        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal)
+            || (candidatePath.Length != basePath.Length && candidatePath[basePath.Length] != '/'))
         {
             return false;
         }

--- a/SSO-Auth/Api/Oidc/OidcLogout.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogout.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
-using Jellyfin.Plugin.SSO_Auth.Api.Net;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
@@ -22,10 +21,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// defense mirroring the login path's issuer checks). A mismatch yields <c>null</c> (local-only logout).
 /// </description></item>
 /// <item><description>
-/// <b><c>post_logout_redirect_uri</c> allow-listing.</b> The return URL is included only when it normalizes
-/// (via <see cref="CanonicalBaseUrl"/>) and sits at or under this server's canonical base - so logout can
-/// only return the browser to this Jellyfin, never to an attacker site. An absent, malformed, or off-base
-/// value is simply omitted; the logout still happens, without a redirect back.
+/// <b><c>post_logout_redirect_uri</c> allow-listing.</b> The return URL is included only when
+/// <see cref="IsAllowedPostLogoutRedirect"/> accepts it, i.e. when it parses as an absolute http(s) URL and
+/// sits at or under this server's canonical base under the rule stated there - so logout returns the browser
+/// to this Jellyfin or nowhere. The value is admin-configured rather than request-supplied, and the OP
+/// matches it against its own registered URI as well, so this is the RP-side half of a two-sided check. An
+/// absent, malformed, or off-base value is simply omitted; the logout still happens, without a redirect back.
 /// </description></item>
 /// </list>
 /// A blank <c>end_session_endpoint</c> (the OP advertises none, or discovery was unreachable) yields
@@ -105,15 +106,27 @@ internal static class OidcLogout
             && a.Port == b.Port;
 
     /// <summary>
-    /// Whether a <c>post_logout_redirect_uri</c> candidate is allowed: it normalizes to a valid http(s) URL
+    /// Whether a <c>post_logout_redirect_uri</c> candidate is allowed: it parses as an absolute http(s) URL
     /// with no userinfo and sits at or under this server's <paramref name="canonicalBaseUrl"/>, so a logout
-    /// can only return the browser to this Jellyfin. "At or under" is exactly two conditions: the SAME
-    /// authority as the base (scheme, host compared case-insensitively per DNS, and effective port - so a
-    /// sibling host such as <c>base.example.com.evil.net</c> and any subdomain of the base are refused), and
-    /// a path that EQUALS the base path or continues it at a SEGMENT boundary (ordinal, so URL path case is
-    /// significant - under a base of <c>https://host/jellyfin</c>, <c>/jellyfin/web</c> is under it while
-    /// <c>/jellyfinevil/x</c> and <c>/JELLYFIN/x</c> are not). The SINGLE source of truth for
-    /// the return-URL rule - the runtime builder above and the save-time
+    /// can only return the browser to this Jellyfin. Both sides are reduced to the origin+path form
+    /// <see cref="Uri.GetLeftPart"/> canonicalizes to, with any trailing slash trimmed, and "at or under" is
+    /// then three conditions:
+    /// <list type="number">
+    /// <item><description>the SAME authority - scheme, host (<c>OrdinalIgnoreCase</c>, which for the ASCII
+    /// hosts Uri lower-cases makes host case irrelevant) and effective port - so a sibling host such as
+    /// <c>base.example.com.evil.net</c> and any subdomain of the base are refused;</description></item>
+    /// <item><description>no escaped separator (<c>%2f</c>, <c>%5c</c>) and no <c>;</c> segment parameter in
+    /// the path, because Uri leaves those intact and a hop that decodes or strips them would resolve the
+    /// path outside the base after this check has passed;</description></item>
+    /// <item><description>a path that EQUALS the base path or continues it at a SEGMENT boundary, compared
+    /// ordinally, so URL path case is significant - under a base of <c>https://host/jellyfin</c>,
+    /// <c>/jellyfin</c> and <c>/jellyfin/web</c> are under it while <c>/jellyfinevil/x</c> and
+    /// <c>/JELLYFIN/x</c> are not.</description></item>
+    /// </list>
+    /// A query and a fragment on the candidate are outside the containment check and ride along into the
+    /// emitted URL; they cannot move the target off this server, which is what the check exists for. The
+    /// value returned in <paramref name="allowed"/> is the candidate itself, trimmed. The SINGLE source of
+    /// truth for the return-URL rule - the runtime builder above and the save-time
     /// <c>ProviderConfigValidator.ValidatePostLogoutRedirectUri</c> both call it, so the config-page save
     /// rejects exactly the values the runtime would silently drop (no second, divergent URL rule). A blank
     /// candidate or blank base yields <see langword="false"/>.
@@ -143,19 +156,34 @@ internal static class OidcLogout
             return false;
         }
 
-        // Then the path, compared on the canonicalized origin+path (a path-traversal is already resolved
-        // there): the candidate must EQUAL the base path or continue it at a SEGMENT boundary. A plain
-        // string prefix is not enough - under a base of "https://host/jellyfin" it would accept
-        // "https://host/jellyfinevil/x", a different application on the same reverse-proxied hostname (#1181).
         var basePath = baseUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
         var candidatePath = candidateUri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+
+        // The path is compared in the form Uri canonicalizes it to, and that form is only as good as what the
+        // NEXT hop does with it. Uri resolves literal and %2e dot segments here, but leaves an escaped
+        // separator escaped and keeps a ";" segment parameter, so "/jellyfin/..%2f..%2fevil" and
+        // "/jellyfin/..;/evil" would satisfy the boundary rule below and still resolve outside the base at any
+        // proxy that decodes or strips them. A return URL to this server needs neither, so refuse both rather
+        // than guess how the next hop normalizes (#1181).
+        if (candidatePath.Contains("%2f", StringComparison.OrdinalIgnoreCase)
+            || candidatePath.Contains("%5c", StringComparison.OrdinalIgnoreCase)
+            || candidatePath.Contains(';'))
+        {
+            return false;
+        }
+
+        // Then the boundary itself: the candidate must EQUAL the base path or continue it at a SEGMENT
+        // boundary. A plain string prefix is not enough - under a base of "https://host/jellyfin" it would
+        // accept "https://host/jellyfinevil/x", a different application on the same reverse-proxied hostname.
         if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal)
             || (candidatePath.Length != basePath.Length && candidatePath[basePath.Length] != '/'))
         {
             return false;
         }
 
-        allowed = candidate;
+        // Trimmed, because Uri.TryCreate above parsed the trimmed form: a padded value would otherwise be
+        // emitted with its padding and fail the OP's exact match against the registered URI.
+        allowed = candidate.Trim();
         return true;
     }
 


### PR DESCRIPTION
# What & why

`OidcLogout.IsAllowedPostLogoutRedirect` decides whether `post_logout_redirect_uri`
is handed to the identity provider, and the same predicate is the save-time gate
behind `ProviderConfigValidator.ValidatePostLogoutRedirectUri`. Its XML doc and the
admin-facing validator message both promised a return URL at or under this server's
base URL. The path check was a bare `StartsWith` with no segment boundary, so with a
canonical base of `https://jf.example.com/jellyfin` the candidate
`https://jf.example.com/jellyfinevil/x` passed. Same authority, so this is not an
off-host open redirect; it is a broken containment claim on a reverse proxy serving
more than one application under one hostname.

The path must now equal the base path or continue it at a `/` boundary. The
adversarial review then found the boundary still half open: `Uri` canonicalizes
literal and `%2e` dot segments before the compare but leaves `%2f` and `%5c` escaped
and keeps a `;` segment parameter, so `https://jf.example.com/jellyfin/..%2f..%2fevil`
satisfied the boundary rule and was emitted verbatim, and the first hop that decodes
or strips those resolves the path outside the base. The predicate refuses an escaped
separator and a segment parameter in the path rather than guessing how the next hop
normalizes, and it returns the accepted value trimmed so what is emitted is what was
checked.

Failing closed is unchanged: a refused candidate is omitted, the logout still
happens, and the emitted end-session URL carries no `post_logout_redirect_uri` at all
rather than an empty one.

Four families are pinned against the predicate and again against the save gate, so
the two enforcement points refuse the same set: prefix, suffix or sibling host,
subdomain in both directions, and case. The two case directions are pinned
deliberately. A differently cased host is accepted, because DNS host names are case
insensitive; a differently cased path is refused, because the path compare is
ordinal.

Means: the change is C# in the plugin project and theory rows in the two existing
xUnit suites, because the defect is in a predicate that already lives there and both
enforcement points are already covered by those suites. It adds no language, runtime
or dependency, and the existing gate exercises it unchanged.

Closes #1181

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: every branch of the predicate returns false and the
      caller omits the parameter. Nothing in this change turns a refusal into an
      acceptance; the accepted set only shrinks.
- [x] No secrets logged; nothing here logs, and the rejected candidate is not echoed
      in the validator message.
- [x] A security review was performed. Six refute-by-default lenses read or executed
      against the first commit: availability and mass lockout, security bypass,
      correctness, integration, OIDC domain, and one that reviews by running rather
      than reading.
- [x] Review record, round one, on commit `d6d8fd0`. Every lens returned
      NEEDS_IMPROVEMENT. 34 findings raised, **CONFIRMED 33 / PLAUSIBLE 1**; two of
      the confirmed ones state their downstream exploit half as plausible rather than
      confirmed, because it depends on how a given proxy normalizes. After dedupe
      across lenses the distinct defects and their dispositions are:

      1. Escaped separator and segment parameter walk the boundary (`%2f`, `%5c`,
         `..;/`), raised by all six lenses, one with a probe against the built
         assembly. FIX in `fb34264`.
      2. The predicate checked the canonicalized URL and returned the raw candidate,
         so a padded value was emitted with its padding, raised by three lenses.
         FIX for the padding (the value is returned trimmed). DECLINE for emitting a
         re-canonicalized form: the provider matches the value against its registered
         URI by exact string, so rewriting it could break a working registration.
         The query and fragment stay outside the containment check and are now
         documented as such.
      3. The suffix family was pinned only in the direction where the base host is a
         leading substring of the candidate, two rows duplicated pre-existing rows,
         and no row differed from the base in nothing but case. FIX.
      4. The save gate's accept theory dropped the trailing-slash row the predicate
         theory had, so the two enforcement points were not exercised on the same
         rows, raised by five lenses. FIX.
      5. The class remarks named `CanonicalBaseUrl` as the normalizer, which the
         predicate never calls, and the rewritten rule omitted the trimmed origin and
         path form the compare actually runs on. FIX.
      6. The host-case accept rows are mutation dead: `Uri` lower-cases an ASCII host
         before `IsSameAuthority` sees it, so those rows pass whether the compare is
         `OrdinalIgnoreCase` or `Ordinal`. FIX as a stated limit in the test comment;
         the compare cannot be falsified from this entry point.
      7. `OidAdd` is a third admin write path that persists `PostLogoutRedirectUri`
         through `MutateConfiguration` with no post-logout gate, raised by two lenses.
         DEFER: `SSOController.cs` is outside this change's assigned files. Reported
         on #1181 for its own issue.
      8. No CHANGELOG entry, raised by four lenses. DECLINE for this change, for the
         reason under Notes; owed as a follow-up.
      9. A value legal before this change now fails the whole config-page save and a
         pre-change config import, because `Validate` throws on the first offending
         provider. Accepted: that is the feedback the save gate exists to give. The
         upgrade impact is under Notes.
      10. The ordinal path-case rule can drop the return hop when the base is derived
          from the request rather than pinned by a Base URL Override and the user
          entered a differently cased path. DECLINE: #1181 decides this direction
          deliberately, and the effect is a dropped return hop, never a redirect
          off-server.
      11. The builder can emit `post_logout_redirect_uri` with neither
          `id_token_hint` nor `client_id`, which RP-Initiated Logout 1.0 forbids,
          raised by one lens as PLAUSIBLE. DEFER: pre-existing and a different topic.
          Reported on #1181.

      Round two, on the fixed state `fb34264`, with four fresh lenses: security bypass,
      correctness, availability and mass lockout, and the one that runs rather than
      reads. Every one of the six items above came back ADDRESSED from every lens.
      Correctness and the executing lens returned PASS, the latter reporting a mutation
      matrix in which each clause of the guard is killed by a shipped row. Bypass and
      availability returned NEEDS_IMPROVEMENT on residuals of the new guard: 5 findings,
      **CONFIRMED 4 / PLAUSIBLE 1**.

      a. The guard refused `%2f` and `%5c` but only a raw `;`, so `..%3b/` passed, and
         `%252f` and `%c0%af` passed one decoding hop further out. FIX in `e3ea07d`:
         it now refuses any percent-escape and any segment parameter in the path,
         because a blocklist over encodings cannot be finished. Rows for all three
         added at both enforcement points.
      b. `candidate.Trim()` removes a wider whitespace class than `Uri` strips, and for
         everything else `Uri` normalizes the emitted value is still the raw string, so
         the test name over-claimed. FIX in `e3ea07d`: the test now says what the trim
         does and what it leaves open.
      c. The validator message reads "not at or under the configured Base URL" for a
         value that is under the base but carries a refused character, and the guard
         screens the candidate but never the base, so a base whose own path carried one
         would accept nothing. DECLINE here: `ProviderConfigValidator.cs` is outside
         this change's assigned files, and no Jellyfin path base legitimately carries
         `%` or `;`. Reported on #1181.
      d. Emitting a re-canonicalized value rather than the admin's string, raised again.
         DECLINE for the reason under item 2.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged here;
      this path logs nothing, and the validator strips line endings inline as before.

## Quality checklist

- [x] No duplicated logic. The rule stays in one predicate that both enforcement
      points call; the save gate delegates rather than restating it.
- [x] The change adds no more code than the problem requires: one boundary condition,
      one guard on escaped separators, one trim.
- [x] The code is self-documenting and the comments say why. It matches the target
      architecture; no module boundary moves.
- [x] Architecture-conformance tests pass as part of the suite. This change
      establishes no new structural property, so no rule is added there.
- [ ] Docs impact: not fully covered here. The XML doc is updated, but no CHANGELOG
      line and no admin help-text update is included, and no `documentation` issue is
      filed yet. See Notes.

## Verification

- [x] Build green with warnings promoted to errors on both target frameworks:
      `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 -p:JellyfinVersion=10.11.11 --warnaserror`
      and the same for `-f net10.0`, each reporting 0 warnings and 0 errors after a
      successful build.
- [x] Full suite green on both: 2260 tests, 0 failed, on `net9.0` and on `net10.0`.
- [x] Prettier: no `.js`, `.html`, `.md`, `.css` or `.scss` file is touched, so the
      format gate has nothing to check here.

Red before green, both times, quoted from the runs:

    // before the boundary change, targeted run
    SSO-Auth.Tests  Total: 51, Errors: 0, Failed: 5

    // after it
    SSO-Auth.Tests  Total: 51, Errors: 0, Failed: 0

    // with the escaped-separator guard removed from the fixed state
    SSO-Auth.Tests  Total: 65, Errors: 0, Failed: 8

    // with it in place
    SSO-Auth.Tests  Total: 65, Errors: 0, Failed: 0

    // after the guard was widened to any escape, both target frameworks
    SSO-Auth.Tests  Total: 2260, Errors: 0, Failed: 0

## Notes

- The CHANGELOG line is deliberately not in this change and is owed as a follow-up.
  A live checkout carries uncommitted changes to that file and two other changes in
  flight would each want a line in the same section, so a line here would collide.
  The admin help text on the config page still reads "at or under this server's base
  URL", which stays true, but it does not tell an admin hit by the tightened rule that
  a sibling path is the cause; that belongs with the same follow-up.
- Upgrade impact: a `PostLogoutRedirectUri` that shared only a prefix with the base
  path was accepted before and is refused now. At runtime the return hop is dropped
  and the logout still completes. On the config page the save is refused with the
  existing message until the field is corrected, and that refusal covers the whole
  save, not just that field. A configuration exported before this change and imported
  after it is refused the same way.
- Deferred out of this change and reported on #1181: the `OidAdd` write path, which
  persists this field with no gate; and the emission of `post_logout_redirect_uri`
  without `id_token_hint` or `client_id`.
- Residual, stated rather than closed: the value handed over is the admin's string
  rather than a re-canonicalized one, so a literal dot segment or an explicit `:443`
  is checked in one form and emitted in another. That cannot move the target off this
  server, because the authority is pinned either way, but it can miss the provider's
  exact match against its registered URI. The provider's own registered-URI match
  remains the other half of the check.
- Also refused now, and worth knowing before the next report of it: a return URL whose
  path carries a percent-escape or a `;`, whatever it encodes. That is deliberate.
  The refusal message does not distinguish this reason from an off-base value.


## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

The branch was merged onto the current mainline rather than rebased, so the three
commits are untouched. The head is `ebac232` and the scope is unchanged:

```
$ git diff --name-only origin/main...HEAD
SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
SSO-Auth.Tests/Oidc/OidcLogoutTests.cs
SSO-Auth/Api/Oidc/OidcLogout.cs
```

### The build gate at that commit

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 -p:JellyfinVersion=10.11.11 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
```

The suite total moved from the 2260 reported above to 2359, which is the mainline
this branch was merged onto rather than anything this change adds.

```
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2359, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 13,461s
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2359, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 12,241s
```

One thing that happened here belongs in the record rather than in a footnote. The
FIRST full `net9.0` run of the merged state reported 9 failures in 154 seconds,
against roughly 13 seconds for every clean run. The five runs after it were green,
and the failing names were not captured before the output was gone, so what caused
it is not established. What can be said is bounded. This branch touches
`OidcLogout` and two test files, none of which opens a socket or resolves a name,
and the targeted post-logout tests below are deterministic across every run. The
long runtime points at something waiting on a timeout somewhere in the merged
mainline, which now carries a DNS-resolving path. It is recorded here as an
unexplained flake seen once, not as a clean result and not as a diagnosis.

### Both refusals, deleted and restored

The two guards this change adds were each removed from the shipped file, rebuilt,
and the targeted suite re-run, so the rows are shown failing for the reason they
name rather than merely passing.

Removing the segment boundary, which is the exact code the issue quotes as the
defect:

```
-        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal)
-            || (candidatePath.Length != basePath.Length && candidatePath[basePath.Length] != '/'))
+        if (!candidatePath.StartsWith(basePath, StringComparison.Ordinal))

  SSO-Auth.Tests  Total: 71, Errors: 0, Failed: 5
```

The five are the prefix family at both enforcement points, `/jellyfinevil` and
`/jellyfinevil/x` against a base of `/jellyfin`, through the predicate, through
the save gate, and once through `BuildEndSessionUrl` proving the parameter is
absent from the emitted URL rather than merely emptied.

Neutralizing the escape and segment-parameter guard, leaving everything else in
place:

```
-        if (candidatePath.Contains('%') || candidatePath.Contains(';'))

  SSO-Auth.Tests  Total: 71, Errors: 0, Failed: 14
```

Fourteen, which is seven candidates at each of the two enforcement points:
`..%2f..%2f`, `%2E%2E%2F`, `..%5C..%5C`, `..;/`, `..%3b/`, `..%252f..%252f` and
`..%c0%af`. That is the round-two finding refusing all three of the shapes it
names, including the two that are one decoding hop further out, which is the
argument for refusing the family rather than a list.

Both edits were reverted, the tree is clean against the commit, and the targeted
run is back to `Total: 71, Failed: 0` on a build that succeeded with warnings
promoted to errors. Worth stating because the check is easy to fool: a build that
FAILS still prints a test summary from the previous binary, so each falsifier
above was confirmed to compile before its numbers were read.

### On the counts quoted higher up

The targeted numbers in the Verification section, 51 and 65, were measured at the
earlier commits they describe and do not reproduce at the head, where the same
filter selects 71. That is the rows the third commit added, not a discrepancy. The
review counts in the security checklist are that review's own record and were not
re-run here; nothing in this section restates them as reproduced.

### What is still owed after this merges

Unchanged and not closed by this re-run. The CHANGELOG line, the admin help-text
wording, the `OidAdd` write path with no gate, and the end-session URL that can
carry a return URI with neither `id_token_hint` nor `client_id`. All four are
recorded on #1181 and each still needs its own issue. The residual about emitting
the admin's string rather than a re-canonicalized one stands exactly as written.
