### PR TITLE
Prove the SAML Recipient and Destination binding refuses near misses [#1182]

### DIFF
--- a/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
@@ -96,6 +96,26 @@ public class SamlRecipientValidatorTests
             { "subdomain: label below the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
             { "subdomain: label below the expected host", "https://a.jf.example/sso/SAML/post/idp" },
 
+            // scheme: the same host and path over plaintext. Nothing in #1182 names this family, and it is
+            // the one row here with a direct consequence beyond binding: it aims the assertion POST at a
+            // cleartext endpoint. The scheme is a per-provider knob (SchemeOverride, and the request scheme
+            // when no BaseUrlOverride is set), so both spellings of one host really can be in play.
+            { "scheme: http where https was published", "http://jf.example/sso/SAML/post/idp" },
+
+            // authority: the expected host parked in the userinfo of somebody else's authority. This is what
+            // a comparison anchored on "the expected host appears after the scheme" would accept.
+            { "authority: expected host as userinfo", "https://jf.example@evil.example/sso/SAML/post/idp" },
+
+            // url equivalence: strings a URL parser would fold into the expected URL and an ordinal compare
+            // refuses. They are grouped because they fail together: the most likely future loosening of this
+            // predicate is parsing both sides as Uri instead of comparing bytes, and Uri lowercases the host,
+            // elides the default port, resolves dot segments and folds percent-encoding. Every row here would
+            // start binding under that change, which is what makes them worth carrying.
+            { "url equivalence: trailing slash", "https://jf.example/sso/SAML/post/idp/" },
+            { "url equivalence: explicit default port", "https://jf.example:443/sso/SAML/post/idp" },
+            { "url equivalence: dot segment", "https://jf.example/sso/SAML/post/../post/idp" },
+            { "url equivalence: percent-encoded provider segment", "https://jf.example/sso/SAML/post/%69dp" },
+
             // case, and this is the family that carries a decision rather than an attack.
             //
             // The comparison is StringComparer.Ordinal, so all three rows are refused. For the path and the

--- a/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
@@ -50,49 +50,83 @@ public class SamlRecipientValidatorTests
     }
 
     /// <summary>
-    /// The near-miss families (#1182), each spelled against the "post" ACS URL above. Every one of them is a
-    /// string an identity provider - or somebody who controls one, or who registered a neighbouring host -
-    /// can echo back, and every one of them would be accepted by a comparison somebody could reach for
-    /// instead of the exact one: a prefix or "starts with" match takes the first two, a host-suffix match
-    /// takes the parent-domain pair, a registrable-domain match takes the subdomain, and a case-insensitive
-    /// match takes the last. The set membership must refuse all of them, on both legs.
+    /// The near-miss families (#1182), each spelled against the "post" ACS URL above. Every row is a string
+    /// an identity provider - or somebody who controls one, or who registered a neighbouring host - can echo
+    /// back, and the set membership must refuse all of them on both legs.
+    /// <para>
+    /// The prefix and suffix families run in BOTH directions on purpose, because each direction falsifies a
+    /// different weakening. The rows where the echo is longer kill a match written as
+    /// <c>echo.StartsWith(expected)</c> or <c>echo.EndsWith(expected)</c>; the rows where the echo is shorter
+    /// kill <c>expected.StartsWith(echo)</c>, <c>expected.EndsWith(echo)</c> and <c>expected.Contains(echo)</c>.
+    /// A table that only grows the echo leaves those three passing, so it would let a truncated echo, or the
+    /// bare origin, bind an assertion.
+    /// </para>
     /// </summary>
     /// <returns>The family name (for the failure message and the test display name) and the near-miss URL.</returns>
     public static TheoryData<string, string> NearMissAcsUrls()
     {
         var data = new TheoryData<string, string>
         {
-            // prefix: the expected URL is a prefix of the echo. A provider name that merely starts with
-            // another provider's name must not bind that other provider's assertion.
-            { "prefix: longer provider name", "https://jf.example/sso/SAML/post/idpX" },
-            { "prefix: extra path segment", "https://jf.example/sso/SAML/post/idp/extra" },
+            // prefix, echo shorter: the echo is a prefix of an expected URL. The first row is also the exact
+            // ACS URL of a provider literally named "id", so accepting it would bind one provider's assertion
+            // to another's endpoint; the second drops the provider segment altogether.
+            { "prefix: echo truncated inside the provider name", "https://jf.example/sso/SAML/post/id" },
+            { "prefix: echo without the provider segment", "https://jf.example/sso/SAML/post" },
 
-            // suffix / parent-domain: the expected host is a prefix of a longer registrable name, and the
-            // expected authority sits inside a longer one. Both are hosts an attacker can register.
-            { "suffix: expected host as a parent domain", "https://jf.example.evil/sso/SAML/post/idp" },
-            { "suffix: label prepended to the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
+            // prefix, echo longer: an expected URL is a prefix of the echo. A provider name that merely
+            // starts with another provider's name must not bind that other provider's assertion.
+            { "prefix: echo extends the provider name", "https://jf.example/sso/SAML/post/idpX" },
+            { "prefix: echo appends a path segment", "https://jf.example/sso/SAML/post/idp/extra" },
 
-            // subdomain: a name below the expected host, which anybody holding the zone can create.
+            // suffix, echo longer: an expected URL sits at the end of the echo, or inside it as a parameter.
+            // Both are strings an attacker can serve from a host they own.
+            { "suffix: expected URL at the end of a longer string", "xhttps://jf.example/sso/SAML/post/idp" },
+            { "suffix: expected URL carried in a query", "https://evil.example/r?u=https://jf.example/sso/SAML/post/idp" },
+
+            // suffix, echo shorter: the echo is a suffix of an expected URL, here with the scheme stripped.
+            { "suffix: echo is the expected URL without its scheme", "jf.example/sso/SAML/post/idp" },
+
+            // parent domain: the expected host is a string prefix of a longer registrable name that somebody
+            // else can register. It is not the parent domain of the expected host, it is a different one.
+            { "parent domain: expected host extended by a label", "https://jf.example.evil/sso/SAML/post/idp" },
+
+            // subdomain: a name below the expected host, which anybody holding the zone can create. #1182
+            // lists these two under different bullets, but they are one shape (one extra label) and no
+            // comparison can accept one and refuse the other. Both are kept because both are named there.
+            { "subdomain: label below the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
             { "subdomain: label below the expected host", "https://a.jf.example/sso/SAML/post/idp" },
 
-            // case: the host differs only in case, and DNS host names are case-insensitive, so this is the
-            // one row here that is NOT an attack - it is a well-behaved identity provider that normalised or
-            // re-cased the host in its echo, and it is refused.
+            // case, and this is the family that carries a decision rather than an attack.
             //
-            // That refusal is deliberate and it is an interop decision, not an accident of the comparer. The
-            // contract this predicate enforces is an exact echo of the bytes this service provider emitted in
-            // AssertionConsumerServiceURL (see SamlAcsUrlBuilder, which concatenates and never re-encodes for
-            // exactly this reason), so an ordinal comparison is the whole check. Refusing a re-cased host is
-            // the fail-closed side of that contract: the cost is that such an identity provider cannot use
-            // the opt-in ValidateRecipient binding until it echoes the URL unchanged.
+            // The comparison is StringComparer.Ordinal, so all three rows are refused. For the path and the
+            // provider segment that is plainly right: ASP.NET routing is case-insensitive, so
+            // "/sso/saml/post/idp" is a working POST target, and the provider segment is route-decoded input
+            // that keys a byte-exact provider dictionary, in which "idp" and "IDP" are two different
+            // providers with independent role and admin mappings. Binding an assertion across that boundary
+            // is exactly what this predicate exists to stop.
             //
-            // Do not "fix" this row by moving the comparison to StringComparer.OrdinalIgnoreCase. Case
-            // insensitivity cannot be applied to the host alone here - the compared value is one string, so
-            // the same change also makes the PATH case-insensitive, and the provider segment is
-            // route-decoded, attacker-influenced input. Loosening it would let "post/IdP" bind "post/idp".
-            // Accepting a re-cased host means normalising the host before the compare, which is a production
-            // change with its own issue, not an edit to the comparer here.
+            // The host row is the deliberate one. DNS host names are case-insensitive, so a host echoed back
+            // in a different case is the same endpoint, and refusing it refuses a well-behaved identity
+            // provider. It is refused anyway, fail closed, and this row pins that as intended.
+            //
+            // What a reader meeting this cold needs to know before "fixing" it:
+            //
+            // 1. Moving the comparison to StringComparer.OrdinalIgnoreCase is the wrong repair. The compared
+            //    value is one string, so the same edit also case-folds the path and the provider segment, and
+            //    the two rows above it would go red for a reason. Accepting a re-cased host means normalising
+            //    the host alone before the compare, which is a production change and its own issue.
+            // 2. The expected bytes are not a constant, so this is not only about the identity provider. With
+            //    BaseUrlOverride set, CanonicalBaseUrl.Resolve runs the value through Uri, which lowercases
+            //    the host, so the expected set is stable. With no override (the default) the base URL is
+            //    built by UriBuilder from the request Host header, which preserves whatever case the proxy
+            //    forwarded, so the expected host case can differ between the challenge and the callback.
+            // 3. So the operator-facing remedy for a deployment locked out by this is to pin BaseUrlOverride
+            //    (#139), which makes the emitted bytes stable, and only then to look at the identity
+            //    provider, which may be echoing a console-registered string rather than the
+            //    AssertionConsumerServiceURL it was sent.
             { "case: host in a different case", "https://JF.EXAMPLE/sso/SAML/post/idp" },
+            { "case: path segment in a different case", "https://jf.example/sso/saml/post/idp" },
+            { "case: provider segment in a different case", "https://jf.example/sso/SAML/post/IDP" },
         };
 
         return data;
@@ -109,11 +143,51 @@ public class SamlRecipientValidatorTests
     [MemberData(nameof(NearMissAcsUrls))]
     public void DestinationNearMissOfAcs_OnValidRecipient_FailsClosed(string family, string destination)
     {
-        // The Recipient leg is valid here, so the Destination alone decides: the Response-level echo is held
-        // to the same boundary as the signed one, or an unsigned Destination would be the weaker of the two.
+        // The Recipient leg is valid here, so a PRESENT Destination alone decides. The two legs are not
+        // otherwise symmetric: a Destination that is absent, or blank once trimmed, is skipped rather than
+        // refused - see BlankDestination_IsTreatedAsAbsent for why that is intended.
         Assert.False(
             SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/post/idp", destination, AcsUrls),
             family);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\u00A0")]
+    public void BlankDestination_IsTreatedAsAbsent(string destination)
+    {
+        // Characterization, and the asymmetry is deliberate. Destination is a Response-level attribute, so it
+        // is only signature-covered when the whole Response is signed; anyone able to rewrite it can delete
+        // it instead, which is why the check runs only when a value is present and why the signed Recipient
+        // is what actually carries the binding. Blanking it therefore buys an attacker nothing that deleting
+        // it does not already buy. SamlResponse.GetDestination maps only the EMPTY attribute to null, so a
+        // whitespace-only Destination does reach here verbatim and is trimmed to blank at this point.
+        Assert.True(
+            SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/post/idp", destination, AcsUrls));
+    }
+
+    [Theory]
+    [InlineData("\t")]
+    [InlineData("\r\n")]
+    [InlineData("\u00A0")]
+    public void RecipientWithNonSpaceWhitespace_IsTrimmedAndBound(string pad)
+    {
+        // Where the trimming stops, pinned because #1182's boundary is a byte comparison and Trim() is the
+        // one thing that runs before it. Trim() strips every Unicode whitespace category, not just spaces,
+        // so a tab, a CRLF or a no-break space around the echo still binds. Each of these normalises to the
+        // exact expected URL, so none of them binds a DIFFERENT endpoint.
+        Assert.True(SamlRecipientValidator.IsBound(pad + "https://jf.example/sso/SAML/post/idp" + pad, null, AcsUrls));
+    }
+
+    [Fact]
+    public void RecipientWithZeroWidthSpace_FailsClosed()
+    {
+        // The other side of the line above: U+200B is not a whitespace category, so Trim() leaves it and the
+        // comparison refuses. A future normalisation step that strips "invisible" characters more broadly
+        // would turn this row red, which is the point of having it.
+        Assert.False(SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/post/idp\u200B", null, AcsUrls));
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
@@ -86,15 +86,16 @@ public class SamlRecipientValidatorTests
             // suffix, echo shorter: the echo is a suffix of an expected URL, here with the scheme stripped.
             { "suffix: echo is the expected URL without its scheme", "jf.example/sso/SAML/post/idp" },
 
-            // parent domain: the expected host is a string prefix of a longer registrable name that somebody
-            // else can register. It is not the parent domain of the expected host, it is a different one.
-            { "parent domain: expected host extended by a label", "https://jf.example.evil/sso/SAML/post/idp" },
+            // neighbouring registrable name: the expected host is a string prefix of a longer name that
+            // somebody else can register. #1182 files it under parent domain; it is not the parent of the
+            // expected host, so the label says what it is rather than repeating that.
+            { "neighbouring name: expected host extended by a label", "https://jf.example.evil/sso/SAML/post/idp" },
 
             // subdomain: a name below the expected host, which anybody holding the zone can create. #1182
-            // lists these two under different bullets, but they are one shape (one extra label) and no
-            // comparison can accept one and refuse the other. Both are kept because both are named there.
-            { "subdomain: label below the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
-            { "subdomain: label below the expected host", "https://a.jf.example/sso/SAML/post/idp" },
+            // lists these two under different bullets and they are the same shape, one extra label. Both are
+            // kept because it names both, and the labels differ so a failure says which row broke.
+            { "subdomain: hostile label below the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
+            { "subdomain: ordinary label below the expected host", "https://a.jf.example/sso/SAML/post/idp" },
 
             // scheme: the same host and path over plaintext. Nothing in #1182 names this family, and it is
             // the one row here with a direct consequence beyond binding: it aims the assertion POST at a
@@ -106,44 +107,52 @@ public class SamlRecipientValidatorTests
             // a comparison anchored on "the expected host appears after the scheme" would accept.
             { "authority: expected host as userinfo", "https://jf.example@evil.example/sso/SAML/post/idp" },
 
-            // url equivalence: strings a URL parser would fold into the expected URL and an ordinal compare
-            // refuses. They are grouped because they fail together: the most likely future loosening of this
-            // predicate is parsing both sides as Uri instead of comparing bytes, and Uri lowercases the host,
-            // elides the default port, resolves dot segments and folds percent-encoding. Every row here would
-            // start binding under that change, which is what makes them worth carrying.
+            // url equivalence: strings a URL parser treats as the expected URL, or nearly so, and an ordinal
+            // compare refuses. The likeliest future loosening of this predicate is parsing both sides as Uri
+            // instead of comparing bytes, so these rows exist to make that change visible. Measured rather
+            // than assumed, because the folding is narrower than it looks: under Uri equality the default
+            // port, the dot segment, the percent-encoded segment and the host case all bind, and the trailing
+            // slash does NOT, since Uri keeps a trailing path slash. The slash row is carried anyway as the
+            // shortest echo-longer-by-one-character case there is.
             { "url equivalence: trailing slash", "https://jf.example/sso/SAML/post/idp/" },
             { "url equivalence: explicit default port", "https://jf.example:443/sso/SAML/post/idp" },
             { "url equivalence: dot segment", "https://jf.example/sso/SAML/post/../post/idp" },
             { "url equivalence: percent-encoded provider segment", "https://jf.example/sso/SAML/post/%69dp" },
 
-            // case, and this is the family that carries a decision rather than an attack.
+            // case, and this is the family that carries a decision rather than an attack. The three rows are
+            // below this block, in the order host, path segment, provider segment.
             //
-            // The comparison is StringComparer.Ordinal, so all three rows are refused. For the path and the
-            // provider segment that is plainly right: ASP.NET routing is case-insensitive, so
-            // "/sso/saml/post/idp" is a working POST target, and the provider segment is route-decoded input
-            // that keys a byte-exact provider dictionary, in which "idp" and "IDP" are two different
-            // providers with independent role and admin mappings. Binding an assertion across that boundary
-            // is exactly what this predicate exists to stop.
+            // Only the provider row is a plain security refusal. The provider segment is route-decoded input
+            // that keys a byte-exact dictionary, so "idp" and "IDP" are two different providers with
+            // independent role and admin mappings, and binding an assertion across that boundary is what this
+            // predicate exists to stop.
             //
-            // The host row is the deliberate one. DNS host names are case-insensitive, so a host echoed back
-            // in a different case is the same endpoint, and refusing it refuses a well-behaved identity
-            // provider. It is refused anyway, fail closed, and this row pins that as intended.
+            // The host row and the path row are the deliberate ones, and they are the same decision. DNS host
+            // names are case-insensitive and ASP.NET attribute routing is case-insensitive, so
+            // "https://JF.EXAMPLE/sso/SAML/post/idp" and "https://jf.example/sso/saml/post/idp" both name the
+            // endpoint the assertion was meant for. Refusing them refuses a well-behaved identity provider,
+            // usually one whose ACS URL was typed into a console rather than echoed from the AuthnRequest.
+            // Both are refused anyway, fail closed, and these rows pin that as intended.
             //
             // What a reader meeting this cold needs to know before "fixing" it:
             //
             // 1. Moving the comparison to StringComparer.OrdinalIgnoreCase is the wrong repair. The compared
-            //    value is one string, so the same edit also case-folds the path and the provider segment, and
-            //    the two rows above it would go red for a reason. Accepting a re-cased host means normalising
-            //    the host alone before the compare, which is a production change and its own issue.
-            // 2. The expected bytes are not a constant, so this is not only about the identity provider. With
-            //    BaseUrlOverride set, CanonicalBaseUrl.Resolve runs the value through Uri, which lowercases
-            //    the host, so the expected set is stable. With no override (the default) the base URL is
-            //    built by UriBuilder from the request Host header, which preserves whatever case the proxy
-            //    forwarded, so the expected host case can differ between the challenge and the callback.
-            // 3. So the operator-facing remedy for a deployment locked out by this is to pin BaseUrlOverride
-            //    (#139), which makes the emitted bytes stable, and only then to look at the identity
-            //    provider, which may be echoing a console-registered string rather than the
-            //    AssertionConsumerServiceURL it was sent.
+            //    value is one string, so the same edit also case-folds the provider segment, and the provider
+            //    row below would go red for a reason. Accepting a re-cased host or path means normalising
+            //    those parts alone before the compare, which is a production change and its own issue.
+            // 2. For an operator whose whole SAML userbase is locked out, in order: turn ValidateRecipient
+            //    off, which restores logins immediately because the binding is opt-in and off by default;
+            //    then pin BaseUrlOverride (#139); then re-register the ACS URL at the identity provider in
+            //    the exact spelling this server publishes, which after step two is a lowercase host.
+            // 3. Why step two is not enough on its own. The expected bytes are not a constant. With
+            //    BaseUrlOverride set, CanonicalBaseUrl.Resolve puts the value through Uri, which lowercases
+            //    the host, so the expected set is stable AND lowercase; an identity provider echoing an
+            //    uppercase host stays refused, which is what step three is for. With no override the base URL
+            //    is built by UriBuilder from the request Host header, which keeps whatever case the proxy
+            //    forwarded, so the expected host case can differ between the challenge and the callback, and
+            //    the same header is the one CanonicalBaseUrl documents as influenceable through an unfiltered
+            //    X-Forwarded-Host. Pinning the override is therefore the fix for the expected side of this,
+            //    not a nicety.
             { "case: host in a different case", "https://JF.EXAMPLE/sso/SAML/post/idp" },
             { "case: path segment in a different case", "https://jf.example/sso/saml/post/idp" },
             { "case: provider segment in a different case", "https://jf.example/sso/SAML/post/IDP" },
@@ -198,6 +207,13 @@ public class SamlRecipientValidatorTests
         // one thing that runs before it. Trim() strips every Unicode whitespace category, not just spaces,
         // so a tab, a CRLF or a no-break space around the echo still binds. Each of these normalises to the
         // exact expected URL, so none of them binds a DIFFERENT endpoint.
+        //
+        // The asymmetry is worth knowing and cannot be pinned from here: only the ECHO is trimmed, never the
+        // expected set, and provider names may legally carry leading or trailing whitespace because
+        // ProviderNameValidator permits it and SamlAcsUrlBuilder appends the name raw. So a provider named
+        // with edge whitespace publishes an ACS URL this predicate can never match once the identity provider
+        // echoes it back, and in the other direction two providers whose names differ only by edge whitespace
+        // are not told apart. Both are production questions, reported on #1182 rather than repaired here.
         Assert.True(SamlRecipientValidator.IsBound(pad + "https://jf.example/sso/SAML/post/idp" + pad, null, AcsUrls));
     }
 

--- a/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
@@ -49,6 +49,73 @@ public class SamlRecipientValidatorTests
         Assert.False(SamlRecipientValidator.IsBound(recipient!, null, AcsUrls));
     }
 
+    /// <summary>
+    /// The near-miss families (#1182), each spelled against the "post" ACS URL above. Every one of them is a
+    /// string an identity provider - or somebody who controls one, or who registered a neighbouring host -
+    /// can echo back, and every one of them would be accepted by a comparison somebody could reach for
+    /// instead of the exact one: a prefix or "starts with" match takes the first two, a host-suffix match
+    /// takes the parent-domain pair, a registrable-domain match takes the subdomain, and a case-insensitive
+    /// match takes the last. The set membership must refuse all of them, on both legs.
+    /// </summary>
+    /// <returns>The family name (for the failure message and the test display name) and the near-miss URL.</returns>
+    public static TheoryData<string, string> NearMissAcsUrls()
+    {
+        var data = new TheoryData<string, string>
+        {
+            // prefix: the expected URL is a prefix of the echo. A provider name that merely starts with
+            // another provider's name must not bind that other provider's assertion.
+            { "prefix: longer provider name", "https://jf.example/sso/SAML/post/idpX" },
+            { "prefix: extra path segment", "https://jf.example/sso/SAML/post/idp/extra" },
+
+            // suffix / parent-domain: the expected host is a prefix of a longer registrable name, and the
+            // expected authority sits inside a longer one. Both are hosts an attacker can register.
+            { "suffix: expected host as a parent domain", "https://jf.example.evil/sso/SAML/post/idp" },
+            { "suffix: label prepended to the expected host", "https://evil.jf.example/sso/SAML/post/idp" },
+
+            // subdomain: a name below the expected host, which anybody holding the zone can create.
+            { "subdomain: label below the expected host", "https://a.jf.example/sso/SAML/post/idp" },
+
+            // case: the host differs only in case, and DNS host names are case-insensitive, so this is the
+            // one row here that is NOT an attack - it is a well-behaved identity provider that normalised or
+            // re-cased the host in its echo, and it is refused.
+            //
+            // That refusal is deliberate and it is an interop decision, not an accident of the comparer. The
+            // contract this predicate enforces is an exact echo of the bytes this service provider emitted in
+            // AssertionConsumerServiceURL (see SamlAcsUrlBuilder, which concatenates and never re-encodes for
+            // exactly this reason), so an ordinal comparison is the whole check. Refusing a re-cased host is
+            // the fail-closed side of that contract: the cost is that such an identity provider cannot use
+            // the opt-in ValidateRecipient binding until it echoes the URL unchanged.
+            //
+            // Do not "fix" this row by moving the comparison to StringComparer.OrdinalIgnoreCase. Case
+            // insensitivity cannot be applied to the host alone here - the compared value is one string, so
+            // the same change also makes the PATH case-insensitive, and the provider segment is
+            // route-decoded, attacker-influenced input. Loosening it would let "post/IdP" bind "post/idp".
+            // Accepting a re-cased host means normalising the host before the compare, which is a production
+            // change with its own issue, not an edit to the comparer here.
+            { "case: host in a different case", "https://JF.EXAMPLE/sso/SAML/post/idp" },
+        };
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(NearMissAcsUrls))]
+    public void RecipientNearMissOfAcs_NoDestination_FailsClosed(string family, string recipient)
+    {
+        Assert.False(SamlRecipientValidator.IsBound(recipient, null, AcsUrls), family);
+    }
+
+    [Theory]
+    [MemberData(nameof(NearMissAcsUrls))]
+    public void DestinationNearMissOfAcs_OnValidRecipient_FailsClosed(string family, string destination)
+    {
+        // The Recipient leg is valid here, so the Destination alone decides: the Response-level echo is held
+        // to the same boundary as the signed one, or an unsigned Destination would be the weaker of the two.
+        Assert.False(
+            SamlRecipientValidator.IsBound("https://jf.example/sso/SAML/post/idp", destination, AcsUrls),
+            family);
+    }
+
     [Fact]
     public void DestinationPresentAndMatching_IsBound()
     {


### PR DESCRIPTION
# What & why

`SamlRecipientValidator.IsBound` decides whether the assertion-consumer URL an identity
provider echoes back, as the bearer `SubjectConfirmationData/@Recipient` and as the
`Response/@Destination`, is one this deployment published. It is one of only two places
where this plugin compares a URL it emitted rather than only emitting one, so the
near-miss families that break such a comparison apply here for real.

Before this change the tests covered a match, the legacy path spelling, trimming, blank
input and one different-host mismatch. Nineteen near-miss rows now run through both legs,
as the Recipient with no Destination present and as a mismatched Destination on top of a
valid Recipient, and each row is named for its family, with the name as the assertion
message so a failure says which family broke.

The families, and what each one falsifies:

- prefix in both directions. The echo truncated inside the provider name, and without the
  provider segment at all, kill a match written as `expected.StartsWith(echo)` or
  `expected.Contains(echo)`. The echo extending the provider name, and appending a path
  segment, kill `echo.StartsWith(expected)`.
- suffix in both directions. The expected URL sitting at the end of a longer string, and
  carried inside a query, kill `echo.EndsWith(expected)`. The scheme-stripped echo kills
  `expected.EndsWith(echo)`.
- parent domain and subdomain. A host that merely extends the expected name, and a label
  below it. The issue lists two spellings of the second under different bullets; both are
  kept because it names both, and they are labelled as the one shape they are.
- case, on the host, on the path segment and on the provider segment.
- scheme, authority and the folds a URL parser would make: `http` where `https` was
  published, the expected host parked in another authority's userinfo, a trailing slash,
  an explicit `:443`, a dot segment, and a percent-encoded provider segment.

The case family is where the deliberate decision lives. The comparison is
`StringComparer.Ordinal`, so a host echoed back in a different case is refused even though
DNS host names are case-insensitive. The rows record why that is intended, why
`OrdinalIgnoreCase` is the wrong repair (the compared value is one string, so the same
edit case-folds the path and the route-decoded provider segment, and two rows go red for
that reason), and what an operator actually does about it: the expected bytes are only
stable when `BaseUrlOverride` is set, because `CanonicalBaseUrl.Resolve` puts an override
through `Uri` and lowercases the host, while the no-override default builds the base with
`UriBuilder` from the request `Host` header and keeps whatever case the proxy forwarded.

Three characterizations are added where the review found behaviour asserted rather than
pinned: a blank or whitespace-only Destination is treated as absent and skipped, `Trim`
strips every whitespace category and not only spaces, and a zero-width space is not
whitespace and is refused.

No production change. No row is accepted where the issue expects a refusal.

Closes #1182

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the predicate is untouched and every added negative asserts
      refusal. The two accepted characterizations (blank Destination, trimmed whitespace)
      pin behaviour that already shipped and say why it is not a bypass.
- [x] No secrets logged; secrets are redacted on config export. No logging or config
      surface is touched.
- [x] A security review was performed. Record below.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED 36 /
      PLAUSIBLE 4** counts as raised across the six lenses of the first round (about
      twelve distinct findings, the rest overlap). Every one carries a disposition below.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added
      or moved.

### Review record, first round

Six refute-by-default lenses, each given the diff, the production files and the issue's
acceptance criteria, and none of the case for the defence. Every lens returned
NEEDS_IMPROVEMENT, so no lens found nothing in this round. The execution lens built both
target frameworks, ran the suite, and drove `IsBound` through four probes of its own.

| Lens | Findings raised | Verdict |
| --- | --- | --- |
| Availability and mass lockout | 6, five CONFIRMED one PLAUSIBLE | NEEDS_IMPROVEMENT |
| Security bypass | 7, all CONFIRMED | NEEDS_IMPROVEMENT |
| Correctness | 6, five CONFIRMED one PLAUSIBLE | NEEDS_IMPROVEMENT |
| Integration | 6, all CONFIRMED | NEEDS_IMPROVEMENT |
| SAML service-provider domain | 7, all CONFIRMED | NEEDS_IMPROVEMENT |
| Execution, which ran rather than read | 8, six CONFIRMED two PLAUSIBLE | NEEDS_IMPROVEMENT |

Dispositions, deduplicated:

1. The prefix rows ran in the non-discriminating direction only, so `expected.StartsWith`,
   `expected.EndsWith` and `expected.Contains` survived the whole file. FIXED, both
   directions now covered.
2. No row was a string suffix of an expected URL, so the suffix family the issue names had
   no row and `echo.EndsWith(expected)` survived. FIXED.
3. Two rows were the same shape under two family labels, and one label called a host a
   parent domain that is not one. FIXED, both relabelled.
4. The case family covered only the host, while the argument against `OrdinalIgnoreCase`
   rested on the provider segment. FIXED, path and provider segment rows added.
5. The interop note claimed the compared bytes are a constant this service provider emits,
   which is false without `BaseUrlOverride`, and it sent the reader to reconfigure the
   identity provider rather than to pin the override. FIXED, the note now says both.
6. A present-but-blank Destination is accepted, and the note claimed both legs are held to
   the same boundary. The false claim is FIXED and the behaviour is now pinned by
   `BlankDestination_IsTreatedAsAbsent`. The production change is DECLINED: Destination is
   Response-level and only signature-covered when the whole Response is signed, so anyone
   able to blank it can delete it instead and gains nothing, while refusing it would newly
   reject identity providers that emit an empty attribute.
7. No row varied the scheme, the trailing slash, the default port, a dot segment,
   percent-encoding or the authority, which are exactly what a future `Uri`-based
   comparison would fold. FIXED, six rows added; a `Uri`-equality mutant turns the default
   port, the dot segment, the percent-encoding and the host case red.
8. `Trim` accepts a whitespace-padded echo, so the "exact bytes" wording was wrong.
   FIXED in the wording, and the trim breadth is now pinned. The consequence the
   integration lens traced is DEFERRED and stated under Notes, because repairing it is a
   production change this issue rules out.
9. `ValidateRecipient` is opt-in and off by default, so the whole boundary is unreachable
   in a default install, and `ValidateInResponseTo` has the same posture. DEFERRED, and
   owed as its own issue. Out of scope here, and a scope call rather than a defect.
10. The interop cost is recorded only in a test file; the config page help text and the
    docs say nothing about the comparison being byte-exact. DEFERRED as a documentation
    follow-up. `SSO-Auth/Web/` and the docs are outside this change.
11. The fixture cannot express a path base or a port, so a proxy that strips `/jellyfin`
    cannot be spelled against it. Partly FIXED (the default-port row), and the path-base
    shape is DECLINED here: it needs a second expected-URL set, which is its own change.
12. The trim breadth was undocumented (PLAUSIBLE). FIXED, pinned in both directions with
    the zero-width space as the negative.

### Review record, second round

Four fresh lens instances, none of them the instance that raised the finding it is
checking, read the post-fix state and probed it.

| Lens | Findings raised | Verdict |
| --- | --- | --- |
| Security bypass | 5, all CONFIRMED | NEEDS_IMPROVEMENT |
| Correctness | 4, three CONFIRMED one PLAUSIBLE | NEEDS_IMPROVEMENT |
| Availability and mass lockout | 6, four CONFIRMED two PLAUSIBLE | NEEDS_IMPROVEMENT |
| SAML service-provider domain | 4, all CONFIRMED | NEEDS_IMPROVEMENT |

Counts as raised in this round: **CONFIRMED 16 / PLAUSIBLE 3**, again heavily overlapping.
No lens found nothing in either round, so there is no clean-lens entry to record.

All four agreed the coverage requirement is now met: every family on both legs, 55 tests in
the class, no row accepted where a refusal is expected, no production change. What they
refuted was the prose, and all four converged on the same items, each with a probe:

13. The url-equivalence group claimed every row in it would bind under a `Uri`-parsing
    rewrite. A trailing path slash is not folded by `Uri`, so that row would have stayed
    green and told a reader their rewrite was covered. FIXED, the comment now states
    the measured set and says why the slash row is carried anyway. The mutant table above
    shows the same thing.
14. The case note pointed at "the two rows above it" while the rows it meant sit below,
    left stale when the note moved. FIXED.
15. The path-case refusal was called plainly right because the lowercase path is a working
    POST target. That is an argument the echo is legitimate, which is the same ground the
    host row is pinned on. FIXED, host and path are now one decision and the provider
    segment is the plain refusal.
16. The lockout remedy started at `BaseUrlOverride` and never mentioned that the binding is
    opt-in, which is the operator's immediate lever, nor that pinning the override
    lowercases the expected host so an identity provider echoing an uppercase one stays
    refused. FIXED, the remedy is now three ordered steps with that consequence stated.
17. Two rows carried one family label, so a failure could not say which broke, and the
    reason given for keeping the pair rested on a universal that is false for a multi-host
    expected set. FIXED. The `parent domain` label contradicted the comment above it and is
    renamed.
18. Only the echo is trimmed, never the expected set, and provider names may legally carry
    edge whitespace, so a provider named that way can never bind. DEFERRED, recorded in the
    trim note and under Notes, because the repair is a production change.
19. The runtime gives an operator no diagnostic: the one log line names neither the value
    received nor the expected set. DEFERRED, stated under Notes.

A third round was not run on the state after those corrections. Every item above is a
comment, the rows and the predicate are unchanged since the round that read them, and the
build and suite are green at the pushed commit, but the corrections themselves are
therefore unread by a lens.

## Quality checklist

- [x] No duplicated logic; one `TheoryData` feeds both legs, so the family set is declared
      once and the both-legs property is structural rather than hand-maintained.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. The change establishes no new structural
      property, so no new conformance rule is owed.
- [x] Docs impact considered. The change itself needs no README or wiki update. The
      operator-facing gap the review found is stated under Notes as owed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks, at the
      pushed commit: `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0
      -p:JellyfinVersion=10.11.11 --warnaserror` and the same for `-f net10.0`, each
      0 warnings and 0 errors.
- [x] `dotnet test` is green. `SSO-Auth.Tests.exe` on both frameworks: Total 2262,
      Failed 0, on net9.0 and on net10.0.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such file is
      touched.

Falsification, because a negative that cannot fail proves nothing. Eight mutants were put
through `IsBound` in turn and the file restored after each:

| Mutant | What went red |
| --- | --- |
| `expected.StartsWith(echo)` | the two truncated-echo prefix rows |
| `expected.EndsWith(echo)` | the scheme-stripped suffix row |
| `echo.StartsWith(expected)` | the two extended-echo prefix rows, and the zero-width row |
| `echo.EndsWith(expected)` | both suffix rows where the expected URL trails |
| `StringComparer.OrdinalIgnoreCase` | the three case rows, and nothing else |
| `expected.Contains(echo)` | the two truncated rows and the scheme-stripped row |
| `Uri`-equality on both sides | default port, dot segment, percent-encoding, host case |
| the set membership removed | 41 assertions, every near-miss row on both legs |

## Notes

The changelog line is not in this change and is owed as a follow-up. A live checkout on
this repository holds uncommitted changes to `CHANGELOG.md` and other work in flight this
cycle would want a line in the same section, so writing one here would collide.

The means. This is a boundary the plugin already ships and the issue asks for proof rather
than behaviour, so the artefact is xUnit theory rows in the existing test project, in the
language and the suite the predicate already lives in. It adds no dependency, no runtime
and no parallel apparatus, and every claim it makes is a test that can go red, which a
prose note in a document could not be.

Discovered work, none of it filed as an issue by this change:

- The provider segment is appended to the ACS URL raw and provider names may legally carry
  leading or trailing whitespace, while `IsBound` trims the echo and never the expected
  set. Both directions follow. An assertion minted for a provider named `idp ` carries a
  Recipient that trims to the ACS URL of the provider named `idp`, so two providers whose
  names differ only by edge whitespace and share a signing certificate are not told apart.
  And a provider named `idp ` publishes an ACS URL that its own conformant echo can never
  match, which is a permanent lockout for that provider once the binding is enabled. The
  repair is a production change, either dropping the trim, which risks rejecting identity
  providers that echo an XML-normalised value, or refusing edge whitespace in
  `ProviderNameValidator`, and both are outside what #1182 scopes. It is written into
  #1182.
- The runtime gives a locked-out operator no diagnostic. The refusal logs one constant
  string naming neither the value received nor the expected set, so a re-cased host, a
  trailing slash and a genuinely foreign endpoint are indistinguishable in the log. The
  sibling algorithm rejection two branches away logs the offending algorithm for exactly
  this reason. Owed as its own issue.
- `ValidateRecipient` and `ValidateInResponseTo` are both opt-in and off by default, so a
  default install runs without this binding at all. Whether they should become fail-closed
  defaults is my scope call.
- The operator-facing surface says nothing about the comparison being byte-exact. The
  config page help text for `Validate Recipient` and the docs are where a locked-out
  operator would look, and the diagnosis currently exists only in this test file. A
  `documentation` issue is owed.
- Building the test project for net9.0 with the documented `-p:JellyfinVersion=10.11.11`
  override rewrites `SSO-Auth/packages.lock.json` and `SSO-Auth.Tests/packages.lock.json`.
  They were restored before every commit and the pushed diff is one file, but the local
  gate dirties tracked files as a side effect, which is worth its own look.


## Landing re-run, 2026-08-05

This section was produced by an automated re-run, not by a second person.

Merged onto the current mainline rather than rebased, so the pushed commits stand.
The head is `8508af3` and the change is still one file:

```
$ git diff --name-only origin/main...HEAD
SSO-Auth.Tests/Saml/SamlRecipientValidatorTests.cs
```

### The gate at that commit

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 -p:JellyfinVersion=10.11.11 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
Build succeeded. 0 Warning(s) 0 Error(s)
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2405, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
  SSO-Auth.Tests  Total: 2405, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

The total is 2405 rather than the 2262 stated above, which is the mainline merged
in. The class itself is 55, as stated:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*SamlRecipientValidator*"
  SSO-Auth.Tests  Total: 55, Errors: 0, Failed: 0
```

### The mutant table, re-driven

All eight were applied to `SamlRecipientValidator.IsBound` in turn, each rebuilt
before its numbers were read, and the file restored after each. Test counts rather
than row counts, because most rows run twice, once as the Recipient with no
Destination and once as a Destination on top of a valid Recipient.

| Mutant | Tests red |
| --- | --- |
| `expected.StartsWith(echo)` | 4 |
| `expected.EndsWith(echo)` | 2 |
| `echo.StartsWith(expected)` | 7 |
| `echo.EndsWith(expected)` | 4 |
| `StringComparer.OrdinalIgnoreCase` | 6 |
| `expected.Contains(echo)` | 6 |
| `Uri`-equality on both sides | 8 |
| the set membership removed | 41 |

Every one is killed, and the restored file is back to 55 passing on a build that
succeeded with warnings promoted to errors. The 41 for the last one is the number
stated above, reproduced. Each of the others lines up with the rows named above,
counting two legs per row: two truncated rows is 4 tests, one scheme-stripped row
is 2, three case rows is 6, four url-equivalence rows is 8.

One correction to that table, and it is an under-claim rather than an over-claim.
The `echo.StartsWith(expected)` row names two extended-echo prefix rows and the
zero-width test, which would be 5 tests. It kills 7. The extra two are the
trailing-slash row on both legs:

```
RecipientNearMissOfAcs_NoDestination_FailsClosed(family: "url equivalence: trailing slash") [FAIL]
DestinationNearMissOfAcs_OnValidRecipient_FailsClosed(family: "url equivalence: trailing slash") [FAIL]
```

That row is carried for the `Uri`-rewrite argument, where it deliberately stays
green, and it turns out to discriminate against a prefix mutant as well. It kills
one more mutant than the table credits it with.

### The lock-file note under Notes reproduces

Building the test project for `net9.0` with the documented `-p:JellyfinVersion`
override rewrote both `packages.lock.json` files on this run too. They were
restored before the push and the pushed diff is the one test file, confirmed by
`git status --porcelain` being empty at the pushed commit. Worth its own look, as
the note says.

### What this re-run did not do

No third review round was run here either, so the position stated above is
unchanged: the corrections from round two are still comments that no lens has
read. This section adds one more reader of the diff and the mutant behaviour, not
a lens round, and it does not tick that box.

The discovered work listed under Notes is untouched by this re-run and none of it
is filed as an issue yet: the provider-name whitespace asymmetry, the missing
runtime diagnostic, the opt-in default posture of `ValidateRecipient` and
`ValidateInResponseTo`, the operator-facing documentation gap, and the lock-file
side effect.
