### PR TITLE
Stop two workflow headers asserting a required-check set they get wrong

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,17 @@
 # Hardened per the repo's workflow policy (see zizmor.yml): every action is
 # SHA-pinned with a version comment, checkout runs with persist-credentials:false,
 # permissions are deny-all at the top level and the job grants only the CodeQL
-# minimum (security-events:write, contents:read, actions:read). CodeQL is a
-# NON-required check - no ruleset depends on this workflow's check-run name.
+# minimum (security-events:write, contents:read, actions:read).
+#
+# The check-run names this workflow produces ARE depended on: the branch ruleset
+# requires `CodeQL` and `Analyze (csharp)`, so renaming the workflow or a matrix
+# language removes a required context instead of renaming one. This header
+# claimed the opposite until #1027. Do not restate the required set here, where
+# it drifts unnoticed; print it:
+#
+#   gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
+#     --jq '.[] | select(.type=="required_status_checks")
+#           | .parameters.required_status_checks[].context'
 name: CodeQL
 
 on:

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -8,10 +8,19 @@
 # this reasons about the *pull request* (its linkage, size, and changelog/test
 # co-changes) - a class none of them cover.
 #
-# This workflow is deliberately ADVISORY: it is NOT wired into the "Protect main"
-# required-status-check ruleset, so it never blocks a merge. It surfaces a
-# deterministic hygiene signal for me; I keep the final say. The
-# checks are tiered by confidence so it does not red-flag reasonable PRs:
+# This workflow BLOCKS a merge on its FAIL tier. Its job name, "Deterministic
+# PR-hygiene checks", is in the branch ruleset's required set, so a red run holds
+# the merge and only the WARN tier below is advisory. This header claimed the
+# whole workflow was advisory and never blocked anything, and reading it sent an
+# investigation of a blocked merge down the wrong path before the live ruleset
+# was queried (#1199). Do not restate the required set here, where it drifts
+# unnoticed; print it:
+#
+#   gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
+#     --jq '.[] | select(.type=="required_status_checks")
+#           | .parameters.required_status_checks[].context'
+#
+# The checks are tiered by confidence so it does not red-flag reasonable PRs:
 #   - FAIL  (high confidence, near-zero false-positive):
 #       * PR body carries an issue reference (Closes/Refs #N) - skipped for bots.
 #       * a build.yaml version bump also touches CHANGELOG.md.


### PR DESCRIPTION
# What & why

Closes #1027.

Two workflow headers assert what the branch ruleset requires, and both get it
wrong. `.github/workflows/codeql.yml` said

> CodeQL is a NON-required check - no ruleset depends on this workflow's
> check-run name.

and `.github/workflows/pr-hygiene.yml` said

> This workflow is deliberately ADVISORY: it is NOT wired into the "Protect main"
> required-status-check ruleset, so it never blocks a merge.

Against the live ruleset, both are false:

```
$ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
    --jq '.[] | select(.type=="required_status_checks")
          | .parameters.required_status_checks[].context'
build
ABI floor build
Package (JPRM) / Build package
Package (JPRM) / Generate SBOM
CodeQL
Analyze (csharp)
DCO sign-off
Deterministic PR-hygiene checks
Enforce greppable invariants
Reject Trojan Source Unicode
Audit workflows (zizmor)
prettier
dependency-review
```

`CodeQL` and `Analyze (csharp)` are both required, so renaming this workflow or a
matrix language removes a required context rather than renaming one. `Deterministic
PR-hygiene checks` is required, so the FAIL tier in that workflow holds a merge and
only its WARN tier is advisory.

The repair is not a corrected list. A list in a header drifts against the ruleset
exactly the way these two did, and nothing reads it. Each header now states only
the property that editing that file can break, and carries the command above so a
reader gets the live set instead of a remembered one.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable. The diff is two comment blocks in workflow files; it touches no
login path, no crypto, no config persistence and no release pipeline step. No
security review was run, and this line is the disclosure rather than a waiver.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (comments explain why, not what) and matches the
      target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No structural property is established; comments are not policed by that suite.
- [x] Docs impact considered: no README or wiki page states the required set, so
      nothing else needs editing.

## Verification

```
$ git diff --name-only origin/main...HEAD
.github/workflows/codeql.yml
.github/workflows/pr-hygiene.yml
$ git diff origin/main...HEAD -- . | grep -c '^[-+][^-+]' 
30
```

Every changed line is inside a `#` comment block; no `on:`, `jobs:`, `permissions:`
or step key is touched, so the workflows' behaviour is unchanged by construction and
the checks on this pull request are the proof they still parse and run.

- [ ] `dotnet build --no-restore --warnaserror` is green. Not run: no C# file is in
      the diff. The `build` check on this pull request runs it.
- [ ] `dotnet test` is green. Not run, same reason.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such file
      is in the diff; `--check **/*.{js,html,md,css,scss}` does not read `.yml`.

## Notes

**This ships no guard, and nothing refuses either header going stale again.** The
only mechanism that would is a check comparing a header's claim against the live
ruleset, which needs a network call from a test and is not built here. What the
change buys is that the next reader is pointed at the command instead of at a
sentence.

**Sent for review to nobody.** This repository has no second reader on this change,
so the evidence above stands in place of one; nothing in it was confirmed by another
person.

Two things found while establishing the above, neither in this diff:

- The `CLAUDE.md` half of the same drift (#1199 records it: "required checks are
  ours only: `build`, `prettier`, `dependency-review`, DCO") cannot be repaired by a
  pull request. `git check-ignore -v CLAUDE.md` returns `.gitignore:459`, so the path
  is untracked and no change to it lands here.
- `zizmor` is no longer in the required set, which is the substantive half of #1027
  and was repaired at the ruleset while clearing #1210. The evidence for that, and
  for every required context now being producible on a Dependabot head, is written
  into #1027 rather than here.
