### PR TITLE
Express the comment-exclusion rule once in the conformance tests [#1124]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3122,8 +3122,11 @@ public class ArchitectureConformanceTests
         return files;
     }
 
-    // A source text's numbered CODE lines - the same exclusion as CodeLines, for the rules whose fixtures feed
-    // synthetic source rather than a file on disk.
+    // A source text's numbered CODE lines: comment and XML-doc lines are excluded, because prose can name a
+    // banned type or quote a piece of markup without any call site reaching for it. THE ONLY COPY of that
+    // exclusion - a fourth comment form added to one of two copies is how a rule silently stops covering the
+    // spelling it was written for. On CRLF input the trailing \r survives the split and is removed by the
+    // Trim, so a line's text does not depend on the checkout's line endings.
     private static IEnumerable<(int Number, string Text)> CodeLinesOf(string source) =>
         source.Split('\n')
             .Select((line, index) => (Number: index + 1, Text: line.Trim()))
@@ -3131,14 +3134,11 @@ public class ArchitectureConformanceTests
                 && !l.Text.StartsWith("/*", StringComparison.Ordinal)
                 && !l.Text.StartsWith("*", StringComparison.Ordinal));
 
-    // A file's numbered CODE lines: comment and XML-doc lines are excluded, because prose can name a banned
-    // type or quote a piece of markup without any call site reaching for it.
+    // A file's numbered CODE lines, by the rule above and no second opinion. A file that ends in a newline
+    // yields one extra entry past its last line, whose text is empty; every predicate above searches for a
+    // non-empty token, so nothing matches it.
     private static IEnumerable<(int Number, string Text)> CodeLines(string path) =>
-        File.ReadAllLines(path)
-            .Select((line, index) => (Number: index + 1, Text: line.Trim()))
-            .Where(l => !l.Text.StartsWith("//", StringComparison.Ordinal)
-                && !l.Text.StartsWith("/*", StringComparison.Ordinal)
-                && !l.Text.StartsWith("*", StringComparison.Ordinal));
+        CodeLinesOf(File.ReadAllText(path));
 
     // The double-quoted string literals on a line, escapes honoured so a \" cannot end one early. Verbatim
     // (@"...") literals are not modelled: the SAML module uses none, and a markup literal spelled that way


### PR DESCRIPTION
# What & why

Closes #1124.

`CodeLines(string path)` and `CodeLinesOf(string source)` each carried the same
three-clause comment exclusion, so a fourth comment form added to one of them
would leave the other stricter or looser, silently. `CodeLines` now reads the
file and delegates; the predicate is written once.

```
git grep -c 'StartsWith("//", StringComparison.Ordinal)' HEAD   -- SSO-Auth.Tests/ArchitectureConformanceTests.cs
HEAD:SSO-Auth.Tests/ArchitectureConformanceTests.cs:2
git grep -c 'StartsWith("//", StringComparison.Ordinal)' HEAD~1 -- SSO-Auth.Tests/ArchitectureConformanceTests.cs
HEAD~1:SSO-Auth.Tests/ArchitectureConformanceTests.cs:3
```

Three before, two after. The one that remains is not a copy of this predicate;
it is a third, differently-shaped one, and it is the finding below rather than
part of this change.

## Line numbering, measured rather than argued

The Done-when asks that the numbering survive, since `l.Number` is what a
conformance failure points a reader at. The two spellings are not identical
functions: `File.ReadAllLines` drops the empty entry past a trailing newline and
also treats a lone `\r` as a terminator; `source.Split('\n')` keeps the empty
entry and does not split on a lone `\r`.

A probe ran both enumerations over every `.cs` file in the tree, excluding
`obj/` and `bin/`, and compared the `(Number, Text)` sequences element by
element:

```
PROBE files=287 identical=0 trailingEmptyOnly=287 realDiff=0
```

287 files, zero with any difference other than one extra entry past the last
line whose text is empty. Every real line keeps its number and its text,
including on CRLF files, where the surviving `\r` is removed by the existing
`.Trim()`.

The lone-`\r` difference cannot arise on today's tree, and that is measured too,
over the tracked set rather than the working tree:

```
git ls-files '*.cs'  ->  286 files
  with a lone CR (a \r not followed by \n):  0
  without a trailing newline:                0
```

The extra empty entry is unreachable by every predicate that consumes these
lines. All four call sites search for a non-empty token - `Contains("IndexOf(")`
and its siblings, `Contains("new XmlDocument")`, `Contains("referenceUri.Substring(1)")`,
`Regex.IsMatch(l.Text, @"\[0\]\s*!=\s*'#'")`, and `\bTypeName\b` in
`XmlStackUsages` - so none of them can match `""`. That is stated in the comment
on `CodeLines` so the next reader does not have to rediscover it.

## A third copy of this rule exists, and it has already drifted

`IsOnACommentLine(source, index)` at the foot of the same file carries a third
spelling, and its own comment claims parity: "it needs the same comment
exclusion CodeLines applies". It does not have it. It tests `//` and `*` and
omits `/*`.

Reproduced against both functions on one line, `/* SelectNodes("a") */`:

```
PROBE blockCommentLine: CodeLinesOf keeps it = False, IsOnACommentLine says comment = False
```

The line-based rules skip that line as a comment. The argument-level scan, which
uses `IsOnACommentLine`, reads it as code and would inspect the call inside it.
The disagreement over-reports rather than under-reports, so no rule fails open
because of it, and a commented-out call written in block form is a false
positive waiting for whoever writes one.

It is left alone here. Folding it in changes what a rule means, which this issue
excludes by name, and the two predicates do not have the same shape anyway - one
tests a trimmed whole line, the other the prefix ahead of a call index. Filed
separately as #1214.

## What this change does NOT prove

The probes above are not in the suite. They were temporary facts, run and
removed, so nothing in the tree will notice if a future edit reintroduces the
divergence they measured. #1214 carries the durable version of that question.

No second reader ran on this pull request. The evidence above stands in place of
one: every number is quoted with the command that produced it, and the one claim
about drift is a reproduction rather than a reading.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. The change is confined to two private helpers in the test
project and touches no login path, no crypto, no config persistence and no
release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Prettier is unticked because no file it reads is in the diff. The rest, on this
branch, both target frameworks, with no conformance fixture edited:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q  -> 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q  -> 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe   -> Total: 2405, Errors: 0, Failed: 0, Skipped: 0
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe  -> Total: 2405, Errors: 0, Failed: 0, Skipped: 0
git status --porcelain -- '*packages.lock.json'        -> (no output)
```

## Notes

Refs #1013, #1003. The `dotnet build` line in the checklist is ticked against
the two framework-scoped commands quoted above rather than the bare form in the
template, because the bare form builds one framework only.
