### PR TITLE
Localize the three unsubstituted template placeholders in the config page

### DIFF
--- a/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
+++ b/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
@@ -54,6 +54,12 @@ public class LocalizationCatalogTests
     // A text-marked element together with its tag name, so the element's own content can be located.
     private static readonly Regex MarkedElementPattern = new(@"<(?<tag>[a-z0-9]+)(?:\s[^>]*?)?\sdata-i18n=""(?<key>[^""]+)""[^>]*>", RegexOptions.Compiled);
 
+    // A script element with its content, so markup can be inspected without reading JavaScript.
+    private static readonly Regex ScriptBlockPattern = new(@"<script\b[^>]*>.*?</script>", RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+
+    // A `${…}` template placeholder of the shape the upstream markup used for its own substitution pass.
+    private static readonly Regex TemplatePlaceholderPattern = new(@"\$\{[^}]*\}", RegexOptions.Compiled);
+
     // The catalog namespaces the web assets own; everything else is server-side (see the orphan test).
     private static readonly string[] UiKeyPrefixes = ["config.", "link."];
 
@@ -245,6 +251,31 @@ public class LocalizationCatalogTests
         }
 
         Assert.True(problems.Count == 0, "These text markers do not sit on an element whose content is a single text node: " + string.Join(" | ", problems));
+    }
+
+    [Fact]
+    public void ShippedMarkup_CarriesNoUnsubstitutedTemplatePlaceholder()
+    {
+        // `title="${Add}"` and `>${Help}</a>` sat in the configuration page, carried over from the upstream
+        // markup and its substitution pass. Nothing on this side substitutes them, so the browser rendered
+        // the literal text `${Add}` as a button tooltip and `${Help}` as a link label (#1011). Review does
+        // not catch it because the shape reads like a binding some layer resolves, and the localization
+        // scans above cannot see it either - an unmarked placeholder references no catalog key, so it is
+        // invisible to every key-parity check. Scoped to the HTML assets, and to the markup OUTSIDE
+        // <script>, because `${…}` inside a script is an ordinary JavaScript template literal and this rule
+        // must not forbid one.
+        var html = FirstPartyWebAssets()
+            .Where(name => name.EndsWith(".html", System.StringComparison.Ordinal))
+            .ToList();
+        Assert.True(html.Count > 0, "no embedded HTML asset was found - the placeholder scan would pass without inspecting anything");
+
+        var offenders = html
+            .SelectMany(resource => TemplatePlaceholderPattern
+                .Matches(ScriptBlockPattern.Replace(ReadResourceText(resource), string.Empty))
+                .Select(match => $"{resource}: {match.Value}"))
+            .ToList();
+
+        Assert.True(offenders.Count == 0, "These template placeholders reach the browser as literal text: " + string.Join(" | ", offenders));
     }
 
     [Fact]

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -35,6 +35,7 @@
   "config.saml_providers": "SAML providers",
   "config.add_oidc_provider": "Add OIDC provider",
   "config.add_saml_provider": "Add SAML provider",
+  "config.add_button": "Add",
   "config.no_oidc_providers": "No SSO providers yet",
   "config.no_saml_providers": "No SAML providers yet",
   "config.loaded_provider": "Loaded provider",

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -20,7 +20,8 @@
               target="_blank"
               rel="noopener noreferrer"
               href="https://github.com/iderex/jellyfin-plugin-sso/wiki"
-              >${Help}</a
+              data-i18n="link.help"
+              >Help</a
             >
           </div>
 
@@ -1222,7 +1223,8 @@
                         id="AddRoleMapping"
                         type="button"
                         class="fab btnAddFolder submit"
-                        title="${Add}"
+                        title="Add"
+                        data-i18n-title="config.add_button"
                         aria-label="Add role mapping"
                       >
                         <span
@@ -2669,7 +2671,8 @@
                         id="saml-AddRoleMapping"
                         type="button"
                         class="fab btnAddFolder submit"
-                        title="${Add}"
+                        title="Add"
+                        data-i18n-title="config.add_button"
                         aria-label="Add role mapping"
                       >
                         <span


### PR DESCRIPTION
# What & why

Closes #1011. Refs #913.

`SSO-Auth/Web/configPage.html` shipped three placeholders that nothing on this side
substitutes, so a browser rendered them as literal text:

```
$ git grep -n '\${' 1b36e79 -- SSO-Auth/Web/configPage.html
1b36e79:SSO-Auth/Web/configPage.html:23:              >${Help}</a
1b36e79:SSO-Auth/Web/configPage.html:1225:                        title="${Add}"
1b36e79:SSO-Auth/Web/configPage.html:2672:                        title="${Add}"
```

`${Add}` was the tooltip of both role-mapping add buttons, `${Help}` the text of the
header help link. They were carried over from the upstream markup, which ran a
substitution pass this plugin does not.

Both buttons now take one shared `config.add_button` key through the existing
allowlisted attribute path (`data-i18n-title`, and `title` is already on
`LOCALIZABLE_ATTRIBUTES`), rather than an OIDC key and a SAML twin. The help link
reuses the existing `link.help` (value `Help`) rather than minting a second key with
the same value, which `EnglishCatalog_HasNoDuplicateValues` would refuse anyway.
Each marked element keeps its built-in English in the markup, so the rendering
without a catalog is the correct word rather than a blank.

## The guard, and the proof it bites

`ShippedMarkup_CarriesNoUnsubstitutedTemplatePlaceholder` in
`SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs`. The existing key-parity
scans could not have caught this defect and still cannot: an unmarked placeholder
references no catalog key, so it is invisible to every one of them.

Deleted the fix, kept the guard. One placeholder restored, everything else fixed
(the one-character mistake somebody actually makes, not a wholesale revert):

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe \
    -method "*ShippedMarkup_CarriesNoUnsubstitutedTemplatePlaceholder*"
  LocalizationCatalogTests.ShippedMarkup_CarriesNoUnsubstitutedTemplatePlaceholder [FAIL]
    These template placeholders reach the browser as literal text:
    Jellyfin.Plugin.SSO_Auth.Web.configPage.html: ${Add}
  Total: 1, Errors: 0, Failed: 1
```

Calibrated in the other direction too, which is the half that decides whether the
rule survives contact with real work. `${…}` inside a `<script>` is an ordinary
JavaScript template literal and must not be refused, so the scan strips script
blocks first. With `document.querySelector("#sso-config-page")` in `linking.html`
rewritten to `` document.querySelector(`#${"sso-config-page"}`) ``:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe \
    -method "*ShippedMarkup_CarriesNoUnsubstitutedTemplatePlaceholder*"
  Total: 1, Errors: 0, Failed: 0
```

Both near-misses were reverted; neither is in the diff.

## Type of change

- [x] Bug fix
- [ ] Security hardening / vulnerability fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

**No security review was run on this change, and this is the disclosure rather than
a waiver.** `configPage.html` is on the surface CLAUDE.md directive 1 names, so the
omission is stated rather than assumed away. What the diff does inside that file is
three markup attributes: two `data-i18n-title` markers and one `data-i18n` marker,
plus one catalog string. It adds no script, no endpoint, no validation and no
persisted field.

What a reviewer would look at, stated so the next reader does not have to rederive
it:

- `data-i18n-title` writes through `LOCALIZABLE_ATTRIBUTES`, an allowlist of inert
  attributes that `AttributeLocalization_StaysRestrictedToInertAttributes` pins; the
  marker cannot reach `href`, `src` or a handler.
- `data-i18n` sets `textContent`, never `innerHTML`, so a catalog value is text.
- The help anchor's `href` is untouched and is not localizable.
- `TextMarkers_OnlySitOnElementsWithoutChildMarkup` passes on the new anchor marker,
  so no child markup is destroyed when the catalog resolves.

- [ ] Fail-closed preserved. Not applicable: no acceptance decision is in the diff.
- [x] No secrets logged; secrets are redacted on config export. Unchanged.
- [ ] A security review was performed. **No** - see above.
- [ ] Review record. **None exists.** Nothing here was read by a second person.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; the
      diff logs nothing.

## Quality checklist

- [x] No duplicated logic; one shared key for both add buttons, one reused key for
      the help link.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. The new structural property (no
      unsubstituted placeholder reaches the shipped markup) is locked in as a rule,
      in `LocalizationCatalogTests` where the other markup scans live rather than in
      `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki page shows or names these strings,
      and the translation-contribution docs are #1155's scope. Nothing to update.

## Verification

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 \
    -p:JellyfinVersion=10.11.11 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2406, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2406, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

- [x] `dotnet build --warnaserror` is green on both target frameworks.
- [x] `dotnet test` is green on both target frameworks.
- [x] Prettier is clean for the changed markup:

```
$ npx prettier --check --end-of-line auto SSO-Auth/Web/configPage.html SSO-Auth/Localization/en.json
All matched files use Prettier code style!
```

`--end-of-line auto` is needed locally and only locally: this clone has
`core.autocrlf=true` and the tree declares no `.gitattributes`, so a plain
`--check` reports every CRLF file in the repository, including eighteen this
change does not touch. The CI checkout is LF and its `prettier` job is the
authoritative run.

## Notes

**Sent for review to nobody.** There is no second reader on this change; the
evidence above stands in place of one.

Not covered here, and deliberately: the two `aria-label="Add role mapping"`
attributes on the same buttons are still hard-coded English. `aria-label` is on the
allowlist, so localizing them is the same mechanism, but they are not `${…}`
placeholders and not what #1011 asks for. They belong with the wider #913 sweep.
