### PR TITLE
Read the call-site presence scan off code lines, not raw file text [#1122]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2973,7 +2973,7 @@ public class ArchitectureConformanceTests
         Assert.Equal(2, validators.Count);
 
         var missing = validators
-            .Where(path => !File.ReadAllText(path).Contains(Invocation, StringComparison.Ordinal))
+            .Where(path => !SourceCallsInCode(File.ReadAllText(path), Invocation))
             .Select(Path.GetFileName)
             .ToList();
 
@@ -2992,6 +2992,37 @@ public class ArchitectureConformanceTests
         Assert.True(
             localChecks.Count == 0,
             "A signature validator must not re-implement the reference-URI rule locally alongside the shared one (#1003): " + string.Join(" | ", localChecks));
+    }
+
+    // The presence half of the rule above, fed synthetic source. A commented-out invocation is the shape that
+    // defeats a whole-file text search, so it is pinned from both sides: every comment form the exclusion
+    // knows about reads as absent, and a real call reads as present even when a comment names it too (#1122).
+    [Theory]
+    [InlineData("var id = SamlSignatureReference.TryGetSameDocumentId(uri);", true)]
+    [InlineData("        var id = SamlSignatureReference.TryGetSameDocumentId(uri);", true)]
+    [InlineData("// dropped: SamlSignatureReference.TryGetSameDocumentId( is no longer called here", false)]
+    [InlineData("        // SamlSignatureReference.TryGetSameDocumentId(uri);", false)]
+    [InlineData("/* SamlSignatureReference.TryGetSameDocumentId(uri); */", false)]
+    [InlineData("     * SamlSignatureReference.TryGetSameDocumentId( - see the shared rule", false)]
+    [InlineData("nothing here", false)]
+    public void CallSitePresence_ReadsCodeLinesNotRawText(string line, bool expected)
+    {
+        Assert.Equal(expected, SourceCallsInCode(line, "SamlSignatureReference.TryGetSameDocumentId("));
+    }
+
+    [Fact]
+    public void CallSitePresence_ACommentDoesNotStandInForARemovedCall()
+    {
+        var source = string.Join(
+            "\n",
+            "internal static bool Validate(string uri)",
+            "{",
+            "    // SamlSignatureReference.TryGetSameDocumentId( was inlined below; see #1003.",
+            "    return uri.Length > 0 && uri[0] != '#';",
+            "}");
+
+        Assert.False(SourceCallsInCode(source, "SamlSignatureReference.TryGetSameDocumentId("));
+        Assert.True(source.Contains("SamlSignatureReference.TryGetSameDocumentId(", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -3139,6 +3170,13 @@ public class ArchitectureConformanceTests
     // non-empty token, so nothing matches it.
     private static IEnumerable<(int Number, string Text)> CodeLines(string path) =>
         CodeLinesOf(File.ReadAllText(path));
+
+    // Whether a source text CALLS something, as opposed to merely mentioning it. Comment lines are excluded,
+    // because the likeliest edit that breaks a call-site rule is removing the call and documenting the
+    // removal in a comment that names it - which reads as diligence and would turn a whole-file text search
+    // green (#1122). Takes source rather than a path so a fixture can feed it synthetic lines.
+    private static bool SourceCallsInCode(string source, string invocation) =>
+        CodeLinesOf(source).Any(l => l.Text.Contains(invocation, StringComparison.Ordinal));
 
     // The double-quoted string literals on a line, escapes honoured so a \" cannot end one early. Verbatim
     // (@"...") literals are not modelled: the SAML module uses none, and a markup literal spelled that way


### PR DESCRIPTION
# What & why

Closes #1122.

The presence half of `BothSignatureValidators_ResolveTheirReferenceThroughTheSharedRule`
searched the whole file text, comments included:

```csharp
.Where(path => !File.ReadAllText(path).Contains(Invocation, StringComparison.Ordinal))
```

while the local-re-implementation half of the same test already went through
`CodeLines`. The rule was therefore defeated by the likeliest edit that would
break it: drop the call, inline the check, and document the removal in a comment
that names the invocation.

It now reads code lines, through a source-text seam a fixture can reach:

```csharp
.Where(path => !SourceCallsInCode(File.ReadAllText(path), Invocation))

private static bool SourceCallsInCode(string source, string invocation) =>
    CodeLinesOf(source).Any(l => l.Text.Contains(invocation, StringComparison.Ordinal));
```

## Proof that the rule can go red, and that the old one could not

`SamlResponse.cs` was edited so the call is gone, the check is inlined, and a
comment names the invocation - the exact shape the issue describes:

```csharp
// Removed: SamlSignatureReference.TryGetSameDocumentId( is inlined here now, see #1003.
var uri = reference.Uri;
if (uri is null || uri.Length < 2 || !uri.StartsWith('#'))
{
    return false;
}

var referenceId = uri.Substring(1);
```

The inlined check is deliberately spelled to evade the local-re-implementation
half as well - `!uri.StartsWith('#')` rather than `uri[0] != '#'` - so the two
halves are isolated and the presence scan alone decides. On that one source
tree, the same test, two predicates:

```
OLD  .Contains on File.ReadAllText   ->  Total: 1, Failed: 0            (green: the rule is defeated)
NEW  SourceCallsInCode                ->  Total: 1, Failed: 1
     "Not calling it: SamlResponse.cs"
```

`SamlResponse.cs` was then restored; `git status --porcelain` names only the test
file in the diff.

The rule stays calibrated rather than merely stricter: against the tree as it
stands, both validators really do call the helper and
`BothSignatureValidators_ResolveTheirReferenceThroughTheSharedRule` passes.

## The fixtures

Eight rows pin the seam from both sides. The theory covers a plain call, an
indented call, a `//` line naming the invocation, an indented `//` line, a `/*`
line, a `*` continuation line, and a line with nothing on it. The fact holds a
whole method whose only occurrence sits in a comment, and asserts both halves of
the point: `SourceCallsInCode` says absent, while a raw `Contains` on the same
string says present.

```
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*CallSitePresence*"
Total: 8, Errors: 0, Failed: 0, Skipped: 0
```

## What this change does NOT prove

It does not touch the two other presence scans in the file - the rename sentinel
above it, and `AssertFactoryInvocationsConfinedTo` - and says nothing about
whether they read raw text. The issue scopes this to one scan and that scope is
kept.

It also does not prove the suite is green under load on this machine. Two of
five consecutive full-suite runs on this branch reported 18 failures, every one
of them a `FileNotFoundException` on a freshly written, GUID-unique key file
under `%TEMP%`, in `SecretStoreTests`, `ConfigSecretProtectionTests` and
`ConfigXmlLifecycleTests` - all classes this diff does not touch. A clean
checkout of `a59fbc3` was run twice in the same window and passed both times,
which is too few runs to place the fault anywhere: it neither clears this branch
nor implicates it. What is measured is that the failure is a file missing from
disk after the write that created it, and that no test in the suite deletes temp
files by pattern
(`grep -rn "Directory.Delete\|EnumerateFiles(Path.GetTempPath" SSO-Auth.Tests`
returns nothing), so the removal comes from outside the suite - which no line of
this diff is. Filed as #1218. The counts quoted below are from runs where it did
not fire, and they are not evidence that it cannot.

No second reader ran on this pull request. The A/B above stands in place of one:
the guard is shown going red on a real defect and green when the defect is
removed, with the counterfactual measured rather than asserted.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The change is confined to the test project and alters no production behaviour;
what it hardens is a conformance rule that guards the SAML signature path.

- [x] Fail-closed preserved: the rule now refuses a file whose only occurrence of
      the shared call is in prose, where it previously accepted one.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No lens review was run and the two boxes above are left unticked rather than
explained away. `SamlResponse.cs` and `SamlLogoutRequest.cs` are byte-identical
to `main` in this diff.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q  -> 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q  -> 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe   -> Total: 2414, Errors: 0, Failed: 0, Skipped: 0
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe  -> Total: 2414, Errors: 0, Failed: 0, Skipped: 0
git status --porcelain -- '*packages.lock.json'        -> (no output)
```

2406 before, 2414 after. The base is `a59fbc3`, measured on a clean checkout of
it rather than carried over from an earlier branch, and the eight added tests are
the theory's seven rows plus the fact.

## Notes

Refs #1013, #1003. The temp-file flake is #1218 and is not caused by this change.
