### PR TITLE
Freeze the OpenID signature-algorithm allowlist [#1190]

### DIFF
--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using Duende.IdentityModel.OidcClient;
@@ -26,12 +27,18 @@ internal static class OidcSignatureKeys
     /// token minted by anyone holding the shared client secret, and <c>none</c> is unauthenticated by
     /// definition - both are rejected regardless of what the discovery document advertises.
     /// </summary>
-    internal static string[] AllowedSignatureAlgorithms { get; } =
-    {
+    /// <remarks>
+    /// Immutable, not just get-only: the same instance is handed by reference into the validation parameters
+    /// of BOTH token types, so a writable array would let one in-assembly write to element zero change what
+    /// the id_token and the back-channel logout_token accept, at once, with nothing else noticing. Freezing
+    /// the collection makes that write a compile error rather than a control nobody is watching (#1190).
+    /// </remarks>
+    internal static ImmutableArray<string> AllowedSignatureAlgorithms { get; } =
+    [
         "RS256", "RS384", "RS512",
         "PS256", "PS384", "PS512",
         "ES256", "ES384", "ES512",
-    };
+    ];
 
     /// <summary>
     /// Builds the signature/issuer/audience/lifetime validation parameters every JWT the plugin verifies


### PR DESCRIPTION
# What & why

Closes #1190. Part of #1049.

`OidcSignatureKeys.AllowedSignatureAlgorithms` was a `string[]` behind a get-only
property. `{ get; }` freezes the property, not the array. The same instance is
handed by reference into `ValidAlgorithms` on every basis the builder produces,
for the id_token and for the back-channel `logout_token`, so one in-assembly
write to element zero would have changed what both token types accept at once,
with nothing else in the tree noticing. It is now an `ImmutableArray<string>`.

## Proof that the freeze bites

Written as the mutation rather than argued from the type. The same line, in the
same place inside `BuildValidationParameters`, against both declarations:

```csharp
ArgumentNullException.ThrowIfNull(options);
AllowedSignatureAlgorithms[0] = "HS256";
```

Against the previous `string[]` declaration:

```
dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0 --nologo -v q
0 Warnung(en)
0 Fehler
```

It compiled. Against this one:

```
dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0 --nologo -v q
SSO-Auth/Api/Oidc/OidcSignatureKeys.cs(56,9): error CS0200: ... "ImmutableArray<string>.this[int]"
  ... eine Zuweisung nicht möglich. Sie sind schreibgeschützt.
1 Fehler
```

CS0200, the property or indexer cannot be assigned to because it is read-only.
That is the whole guard: the compiler, not a test that a later edit could
delete. The mutation was removed again and the diff carries only the
declaration.

## What did not change

The accepted set. RS/PS/ES at 256, 384 and 512; no `HS*`; no `none`; regardless
of what the discovery document advertises. This is the type, not the membership.

The wiring. `TokenValidationParameters.ValidAlgorithms` is an
`IEnumerable<string>` in the pinned Microsoft.IdentityModel.JsonWebTokens, so
the collection is assigned as it stands - no `.ToArray()` on the way in, which
would have handed out a fresh mutable copy and reopened the same hole one frame
later.

Both references in the tree are in this one file, before and after:

```
grep -rn "AllowedSignatureAlgorithms" --include=*.cs . | grep -v /obj/ | grep -v /bin/
./SSO-Auth/Api/Oidc/OidcSignatureKeys.cs:29:    internal static ImmutableArray<string> AllowedSignatureAlgorithms { get; } =
./SSO-Auth/Api/Oidc/OidcSignatureKeys.cs:54:            ValidAlgorithms = AllowedSignatureAlgorithms,
```

`System.Collections.Immutable` is in the base class library; no package
reference is added, and `packages.lock.json` is untouched.

## What this change does NOT prove

It does not prove the allowlist is still wired in. The issue expects an existing
allowlist-wiring behaviour test to keep passing; there is none:

```
grep -rn "ValidAlgorithms" --include=*.cs SSO-Auth.Tests
(no output, exit 1)
```

So deleting the line `ValidAlgorithms = AllowedSignatureAlgorithms` still leaves
the whole suite green, and this change does not close that. The collection can
no longer be edited; whether it is handed to the handler at all remains
unguarded. #1050 owns that gap and it is not silently absorbed here.

The issue also asks that the frozen type stay enumerable for the reflection rule
on PR #1030. That pull request is CLOSED and unmerged, so nothing in the tree
reads the member by reflection today and no such rule was exercised. What is
measured is that the plugin and the full suite build and pass with the frozen
type; a future rule that reads it as `IEnumerable<string>` will work, and one
that casts it to `string[]` will not.

No second reader ran on this pull request. The compile-error A/B above stands in
place of one.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the accepted algorithm set is unchanged and still
      excludes every symmetric algorithm and `none`.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No lens review was run. The two boxes stay unticked rather than explained away;
the parent issue calls this hardening rather than a live vulnerability, because
nothing in the tree writes through the reference today.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The structural property is locked in by the compiler rather than by a
conformance rule, which is the stronger of the two: a rule can be edited, a type
error cannot be argued with.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q  -> 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q  -> 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe   -> Total: 2406, Errors: 0, Failed: 0, Skipped: 0
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe  -> Total: 2406, Errors: 0, Failed: 0, Skipped: 0
git status --porcelain -- '*packages.lock.json'        -> (no output)
```

Prettier is unticked because no file it reads is in the diff.

## Notes

The temp-file flake recorded in #1218 did not fire on the runs quoted above. It
is unrelated to this diff and is not evidence for or against it.
