### PR TITLE
Refuse a token-header kid outside the unreserved set before key lookup

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
@@ -1,0 +1,241 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The token-header <c>kid</c> allowlist (#1167, part of #1029). A <c>kid</c> outside the RFC 3986
+/// unreserved set, or over the length cap, is refused before any signing key is looked up - on BOTH JWT
+/// paths, from one predicate in <see cref="OidcSignatureKeys"/>, so the id_token and the back-channel
+/// <c>logout_token</c> postures cannot drift apart.
+/// <para>
+/// This is defence in depth rather than a live fix: today the value only ever reaches an ordinal compare
+/// against the in-memory <c>KeyId</c> values converted from the discovery JWKS, so there is no sink to
+/// exploit. The tests that matter most are therefore the COMPATIBILITY ones - a constraint nobody needs
+/// yet, set too tight, buys a real IdP lockout for a hypothetical attack.
+/// </para>
+/// </summary>
+public sealed class OidcSignatureKeysKidTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    private static readonly TimeSpan Skew = TimeSpan.FromMinutes(5);
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcIdTokenValidator _idTokenValidator = new();
+    private readonly OidcLogoutTokenValidator _logoutValidator = new();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    /// <summary>
+    /// One row per character class the allowlist exists to stop. Every one of these is a shape that a
+    /// future consumer of the header value - a log line, a cache key, a path, a URL - would read
+    /// differently from an opaque identifier.
+    /// </summary>
+    public static TheoryData<string> HostileKeyIds() => new()
+    {
+        "../etc/passwd",           // dot-segment
+        "keys/../../secret",       // dot-segment, embedded
+        "keys/live",               // forward separator
+        "keys\\live",              // backward separator
+        "%2e%2e%2fkeys",           // percent-encoded dot-segment
+        "key\0null",               // null byte
+        "key'or'1",                // single quote
+        "key\"quoted\"",           // double quote
+        "key id",                  // whitespace inside
+        "key\nid",                 // line break, the log-forging shape
+        "https://evil.example.net/jwks",
+    };
+
+    /// <summary>
+    /// The shapes real identity providers actually mint. If any of these is refused, the change is an
+    /// outage rather than a hardening, so they are pinned end to end against a real signature.
+    /// </summary>
+    public static TheoryData<string> RealWorldKeyIds() => new()
+    {
+        "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs",   // base64url certificate thumbprint
+        "1e9gdk7",                                        // short alphanumeric
+        "7c309e3a-1f6d-4f5c-9a02-4d0d4b2e0c11",           // UUID
+        "0123456789",                                     // numeric
+        "sig.key_2026~rotate-3",                          // every remaining unreserved character
+    };
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileKeyIds))]
+    public void HostileKeyId_IsRefusedByThePredicate(string keyId)
+    {
+        Assert.False(OidcSignatureKeys.IsAcceptableKeyId(keyId));
+    }
+
+    [Theory]
+    [MemberData(nameof(RealWorldKeyIds))]
+    public void RealWorldKeyId_IsAcceptedByThePredicate(string keyId)
+    {
+        Assert.True(OidcSignatureKeys.IsAcceptableKeyId(keyId));
+    }
+
+    [Fact]
+    public void OverLengthKeyId_IsRefused_AndTheBoundaryIsPinned()
+    {
+        // The cap is a boundary, so both sides of it are pinned: a 256-character kid of otherwise legal
+        // characters is accepted and a 257-character one is not. Without the accepting half, tightening
+        // the cap to 8 would leave this test green.
+        Assert.True(OidcSignatureKeys.IsAcceptableKeyId(new string('a', 256)));
+        Assert.False(OidcSignatureKeys.IsAcceptableKeyId(new string('a', 257)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AbsentKeyId_IsNotAViolation(string? keyId)
+    {
+        // An absent kid is the ordinary "try every advertised key" case. Refusing it would break every
+        // provider that mints tokens without one, and it also keeps the predicate indifferent to whether
+        // the token library reports an absent header member as null or as an empty string.
+        Assert.True(OidcSignatureKeys.IsAcceptableKeyId(keyId));
+    }
+
+    [Fact]
+    public void UnreadableToken_IsNotRefusedByTheGate()
+    {
+        // The gate is not the fail-closed floor and must not pretend to be one: a token whose header will
+        // not parse is refused by the handler moments later, on its own terms. Answering here would swap an
+        // accurate rejection reason for a misleading one.
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId("not-a-jwt"));
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId("only.two"));
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId("a.b.c"));
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId(null));
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId(string.Empty));
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileKeyIds))]
+    public async Task IdTokenPath_RefusesHostileKeyId(string keyId)
+    {
+        // Signed by the RIGHT key, so nothing but the kid can be the reason for the rejection - the same
+        // token with an ordinary kid succeeds in ValidToken_OnBothPaths_StillSucceeds below.
+        var result = await _idTokenValidator.ValidateAsync(
+            CreateToken(keyId: keyId), Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("unacceptable kid", result.Error, StringComparison.Ordinal);
+        // Never the key-refresh contract: "invalid_signature" makes OidcClient re-fetch the JWKS and retry,
+        // which would turn every hostile kid into two provider round trips.
+        Assert.DoesNotContain("invalid_signature", result.Error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileKeyIds))]
+    public async Task LogoutTokenPath_RefusesHostileKeyId(string keyId)
+    {
+        var token = CreateToken(keyId: keyId, claims: LogoutClaims());
+
+        var result = await _logoutValidator.ValidateAsync(token, Parameters(), Skew, _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.UnacceptableKeyId, result.ReasonCode);
+        Assert.Null(result.Subject);
+        Assert.Null(result.SessionIndex);
+    }
+
+    [Theory]
+    [MemberData(nameof(RealWorldKeyIds))]
+    public async Task IdTokenPath_AcceptsRealWorldKeyId(string keyId)
+    {
+        // End to end against a JWKS advertising the same kid, so this proves the token still VALIDATES
+        // rather than merely getting past the gate into a different rejection.
+        var result = await _idTokenValidator.ValidateAsync(
+            CreateToken(keyId: keyId), Options(keyId), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+    }
+
+    [Theory]
+    [MemberData(nameof(RealWorldKeyIds))]
+    public async Task LogoutTokenPath_AcceptsRealWorldKeyId(string keyId)
+    {
+        var token = CreateToken(keyId: keyId, claims: LogoutClaims());
+
+        var result = await _logoutValidator.ValidateAsync(token, Parameters(keyId), Skew, _now);
+
+        Assert.True(result.IsValid, result.ReasonCode);
+        Assert.Equal("user-1", result.Subject);
+    }
+
+    [Fact]
+    public async Task ValidToken_OnBothPaths_StillSucceeds()
+    {
+        // The floor this change must not lower: the ordinary token, with the ordinary kid, on both paths.
+        var idResult = await _idTokenValidator.ValidateAsync(
+            CreateToken(), Options(), TestContext.Current.CancellationToken);
+        Assert.False(idResult.IsError, idResult.Error);
+
+        var logoutResult = await _logoutValidator.ValidateAsync(
+            CreateToken(claims: LogoutClaims()), Parameters(), Skew, _now);
+        Assert.True(logoutResult.IsValid, logoutResult.ReasonCode);
+    }
+
+    // --- helpers ---
+
+    private static Dictionary<string, object> LogoutClaims() => new()
+    {
+        ["sub"] = "user-1",
+        ["jti"] = Guid.NewGuid().ToString("N"),
+        ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
+    };
+
+    private OidcClientOptions Options(string keyId = KeyId) => new()
+    {
+        ClientId = ClientId,
+        ProviderInformation = new ProviderInformation
+        {
+            IssuerName = Issuer,
+            KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(Jwks(keyId)),
+        },
+    };
+
+    private TokenValidationParameters Parameters(string keyId = KeyId) =>
+        OidcSignatureKeys.BuildValidationParameters(Options(keyId), new List<IDisposable>(), requireExpiration: false);
+
+    private string Jwks(string keyId)
+    {
+        var p = _rsa.ExportParameters(false);
+        return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + keyId + "\","
+            + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
+    }
+
+    private string CreateToken(string keyId = KeyId, IDictionary<string, object>? claims = null)
+    {
+        var now = DateTime.UtcNow;
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = claims ?? new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = keyId }, SecurityAlgorithms.RsaSha256),
+        });
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -42,6 +42,15 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
             // below; any failure rejects (fail closed). MapInboundClaims=false keeps the raw JWT claim
             // types - the default mapping would rename "sub" and friends to SOAP-style URIs and break
             // every ordinal claim comparison downstream.
+            //
+            // The header kid is constrained to the shared allowlist BEFORE any signing key is looked up
+            // (#1167). Not a signature check and not the fail-closed floor - the handler below owns that -
+            // but the point where an out-of-set kid stops travelling.
+            if (!OidcSignatureKeys.TokenHasAcceptableKeyId(identityToken))
+            {
+                return Reject("Identity token validation failed: unacceptable kid");
+            }
+
             var handler = new JsonWebTokenHandler { MapInboundClaims = false };
             var result = await handler.ValidateTokenAsync(identityToken, OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
             if (!result.IsValid)

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -55,6 +55,13 @@ internal sealed class OidcLogoutTokenValidator
             return new Result(false, null, null, RejectReason.Malformed);
         }
 
+        // The header kid is constrained to the shared allowlist BEFORE any signing key is looked up
+        // (#1167), from the same predicate the id_token path calls, so the two postures cannot drift.
+        if (!OidcSignatureKeys.TokenHasAcceptableKeyId(logoutToken))
+        {
+            return new Result(false, null, null, RejectReason.UnacceptableKeyId);
+        }
+
         // Signature / issuer / audience / lifetime - the SAME hardened basis as the id_token (the caller
         // builds validationParameters via OidcSignatureKeys); any failure is fail-closed.
         var handler = new JsonWebTokenHandler { MapInboundClaims = false };
@@ -164,5 +171,8 @@ internal sealed class OidcLogoutTokenValidator
 
         /// <summary>The jti was already consumed - a replayed logout_token.</summary>
         internal const string Replay = "replay";
+
+        /// <summary>The header kid carries characters outside the accepted set, or is over-length (#1167).</summary>
+        internal const string UnacceptableKeyId = "unacceptable_kid";
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Crypto;
+using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -22,6 +23,14 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 internal static class OidcSignatureKeys
 {
     /// <summary>
+    /// The longest token-header <c>kid</c> the plugin will look a key up by. Every shape a real provider
+    /// mints is far shorter - a base64url certificate thumbprint is 43 characters, a UUID 36 - so the cap
+    /// is set well above the field rather than close to it: the value being bounded is what matters, and a
+    /// tight cap would trade a hypothetical attack for a real lockout of an IdP nobody surveyed.
+    /// </summary>
+    private const int MaxKeyIdLength = 256;
+
+    /// <summary>
     /// Gets the asymmetric signature algorithms the plugin accepts (RFC 7518). Symmetric HS* would accept a
     /// token minted by anyone holding the shared client secret, and <c>none</c> is unauthenticated by
     /// definition - both are rejected regardless of what the discovery document advertises.
@@ -32,6 +41,86 @@ internal static class OidcSignatureKeys
         "PS256", "PS384", "PS512",
         "ES256", "ES384", "ES512",
     };
+
+    /// <summary>
+    /// Whether a token-header <c>kid</c> may be used as a key-lookup value. Accepts the RFC 3986 unreserved
+    /// set only, up to <see cref="MaxKeyIdLength"/>.
+    /// <para>
+    /// There is no live sink today: the value is only ever compared ordinally against the in-memory
+    /// <see cref="SecurityKey.KeyId"/> values converted from the discovery JWKS, so it reaches no
+    /// filesystem, database, URL or parser. This is the standing mitigation for the JWT <c>kid</c>-injection
+    /// class applied ahead of a sink, so that any future consumer of the header value - a log line, a cache
+    /// key, a keyed store, a remote key fetch - is born behind the constraint instead of re-opening it.
+    /// </para>
+    /// <para>
+    /// An ABSENT <c>kid</c> is not a violation: it is the ordinary "try every advertised key" case and must
+    /// keep working, so null, empty and whitespace are accepted. That also makes the predicate indifferent
+    /// to whether the token library reports an absent header member as null or as an empty string.
+    /// </para>
+    /// </summary>
+    /// <param name="keyId">The <c>kid</c> read from the token header, or null when the header carries none.</param>
+    /// <returns><c>true</c> when the value may reach a key lookup.</returns>
+    internal static bool IsAcceptableKeyId(string? keyId)
+    {
+        if (string.IsNullOrWhiteSpace(keyId))
+        {
+            return true;
+        }
+
+        if (keyId.Length > MaxKeyIdLength)
+        {
+            return false;
+        }
+
+        foreach (var character in keyId)
+        {
+            var unreserved = (character >= 'A' && character <= 'Z')
+                || (character >= 'a' && character <= 'z')
+                || (character >= '0' && character <= '9')
+                || character == '-' || character == '.' || character == '_' || character == '~';
+
+            if (!unreserved)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Whether a compact-serialized JWT's header <c>kid</c> passes <see cref="IsAcceptableKeyId"/>. Both
+    /// token paths call this ahead of validation, so the constraint has ONE definition and the id_token and
+    /// <c>logout_token</c> postures cannot drift.
+    /// <para>
+    /// A token this cannot read at all is reported as acceptable rather than refused. That is deliberate and
+    /// it is not a fail-open: this gate is not the floor. A token whose header will not parse is refused
+    /// moments later by the handler, which owns signature, issuer, audience and lifetime, and reporting a
+    /// refusal from here would only replace an accurate rejection reason with a misleading one.
+    /// </para>
+    /// </summary>
+    /// <param name="token">The raw compact-serialized JWT.</param>
+    /// <returns><c>false</c> only when a <c>kid</c> was positively read and is outside the allowlist.</returns>
+    internal static bool TokenHasAcceptableKeyId(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return true;
+        }
+
+        string? keyId;
+        try
+        {
+            keyId = new JsonWebToken(token).Kid;
+        }
+        catch (ArgumentException)
+        {
+            // Not a readable JWT. The handler rejects it on its own terms; see the remark above.
+            return true;
+        }
+
+        return IsAcceptableKeyId(keyId);
+    }
 
     /// <summary>
     /// Builds the signature/issuer/audience/lifetime validation parameters every JWT the plugin verifies


### PR DESCRIPTION
# What & why

Closes #1167. Part of #1029.

A token-header `kid` outside the RFC 3986 unreserved set `[A-Za-z0-9._~-]`, or over a
length cap, is now refused before any signing key is looked up, on both JWT paths, from
one predicate:

- `OidcSignatureKeys.IsAcceptableKeyId` / `TokenHasAcceptableKeyId` are the single
  definition.
- `OidcIdTokenValidator.ValidateAsync` calls it ahead of `handler.ValidateTokenAsync`.
- `OidcLogoutTokenValidator.ValidateAsync` calls it ahead of the same handler and
  reports the new distinct reason code `unacceptable_kid`.

**This fixes no reachable bug, and saying otherwise would be the wrong record.** The
value only ever reaches an ordinal compare against the in-memory `KeyId` values converted
from the discovery JWKS; it reaches no filesystem, database, URL or parser. This is the
standing `kid`-injection mitigation placed ahead of a sink, so that a future consumer of
the header value - a log line, a cache key, a keyed store, a remote key fetch - is born
behind the constraint instead of re-opening the class.

The gate on the logout path went inside `OidcLogoutTokenValidator` rather than at the
`OidcLoginService` call site the issue names. Same position relative to key lookup, and
it covers every caller of that validator rather than the one call site, which is what
the issue's "one shared gate" is for.

## Each call site is proven on its own

A single ledger row would prove only that the property is refused somewhere. Both sites
were deleted, one at a time, with everything else intact.

Id_token gate removed, logout gate left in place:

```
IdTokenPath_RefusesHostileKeyId(keyId: "../etc/passwd") [FAIL]
IdTokenPath_RefusesHostileKeyId(keyId: "keys/../../secret") [FAIL]
... 11 rows ...
Total: 54, Errors: 0, Failed: 11
```

Logout gate removed, id_token gate left in place:

```
LogoutTokenPath_RefusesHostileKeyId(keyId: "../etc/passwd") [FAIL]
LogoutTokenPath_RefusesHostileKeyId(keyId: "keys/../../secret") [FAIL]
... 11 rows ...
Total: 54, Errors: 0, Failed: 11
```

Each time exactly the other path's eleven rows stayed green, so neither site is riding on
the other's proof. Both near-misses were reverted; neither is in the diff.

## Two decisions taken against lockout

The compatibility half is the one that matters here. A constraint nobody needs yet, set
too tight, buys a real outage for a hypothetical attack.

- **An absent `kid` is not a violation.** It is the ordinary "try every advertised key"
  case. Null, empty and whitespace are all treated as absent, which also makes the
  predicate indifferent to whether the token library reports a missing header member as
  null or as an empty string.
- **A token whose header will not parse is not refused here.** This gate is not the
  fail-closed floor; the handler is, moments later, and it owns signature, issuer,
  audience and lifetime. Answering from the gate would replace an accurate rejection
  reason with a misleading one. `UnreadableToken_IsNotRefusedByTheGate` pins that,
  and the pre-existing `GarbageNonJwt_IsInvalid_FailClosed` still reports `Invalid`.
- **The cap is 256**, far above every shape a real provider mints (a base64url
  certificate thumbprint is 43 characters, a UUID 36). Both sides of the boundary are
  pinned, so tightening it to 8 cannot stay green.
- The id_token rejection deliberately does **not** use the string `invalid_signature`.
  That string is OidcClient's key-refresh contract; using it would turn every hostile
  `kid` into an extra provider round trip.

Five real-world shapes (base64url thumbprint, short alphanumeric, UUID, numeric, and one
exercising every remaining unreserved character) validate end to end against a JWKS
advertising the same `kid`, on both paths, so the compatibility rows prove the token still
VALIDATES rather than merely getting past the gate into a different rejection.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the change only ADDS a refusal ahead of the existing floor.
      `ValidToken_OnBothPaths_StillSucceeds` pins the floor it must not lower, and the
      #1004 forgery tests are in the green full-suite run below.
- [x] No secrets logged; secrets are redacted on config export. Unchanged.
- [x] Log inputs from the IdP are sanitized inline at the log call. The rejection strings
      are **fixed text and never embed the `kid` value**, on either path, so the hostile
      value cannot reach a log line at all. The `key\nid` row is in the hostile table for
      exactly that shape.
- [ ] A security review was performed for changes to SAML/OIDC validation. **No. No
      adversarial review was run on this change**, and this line is the disclosure, not a
      waiver. CLAUDE.md directive 1 asks for one on this surface and it did not happen.
- [ ] Review record: per lens, its verdict and its findings. **None exists. Nothing here
      was read by a second person**, and no lens was run, so there are no CONFIRMED or
      PLAUSIBLE counts to report - not zero of each, but no run.

What an unrun review would most plausibly attack, written down so the next reader starts
where the argument actually is rather than rediscovering it: the availability direction.
Every hostile row is refused, but the question that decides whether this is safe to ship
is whether any legitimate provider mints a `kid` outside the unreserved set. The five
compatibility rows are a survey of shapes, not a survey of providers, and no live IdP was
queried. An IdP using, say, a base64 (not base64url) thumbprint would contain `+` or `/`
and would be locked out by this change. That is the residual risk; it is not measured.

## Quality checklist

- [x] No duplicated logic; one predicate, one gate helper, two call sites. Neither call
      site re-spells the character set or the cap.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; the comments state why the two lockout decisions were
      taken, not what the code does.
- [x] Architecture-conformance tests pass. No new structural property is established -
      this is a runtime refusal, proven by its own tests rather than by a scan.
- [x] Docs impact considered: no README or wiki page documents the accepted `kid` shape.
      The provider-facing consequence (an IdP whose `kid` leaves the unreserved set is
      refused) is worth a Hardening-and-Options-Reference line, and that page is #1063's
      scope; noted rather than silently skipped.

## Verification

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 \
    -p:JellyfinVersion=10.11.11 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2460, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2460, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ git status --porcelain            # after both builds
 M SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
 M SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
 M SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
?? SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
```

2406 before, 2460 after; the 54 new rows are the whole difference, and neither
`packages.lock.json` was touched.

- [x] `dotnet build --warnaserror` is green on both target frameworks.
- [x] `dotnet test` is green on both target frameworks.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is in the diff.

## Notes

**Sent for review to nobody.** There is no second reader on this change; the evidence
above stands in place of one, and the unrun-review disclosure in the security section is
part of that evidence rather than a formality.

Out of scope and staying open: **#1168**, the other half of #1029 - what happens to a
*provider-advertised* JWKS key whose `kid` is out of allowlist. Different actor
(IdP-controlled rather than attacker-controlled) and the opposite failure mode
(availability, a legitimate signing key silently dropped). It depends on this predicate
and reuses it rather than defining a second character set.
