### PR TITLE
Make the documented Prettier command honest on a Windows checkout [#1066]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,8 +151,15 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 dotnet restore                               # once on a fresh clone; the --no-restore flags below assume it
 dotnet build --no-restore --warnaserror      # warnings are errors, exactly as in CI
 dotnet test --no-build --verbosity normal    # the xUnit project SSO-Auth.Tests must stay green
-npx prettier --check "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
+npx prettier --check --end-of-line auto "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
 ```
+
+`--end-of-line auto` is not optional on Windows. Prettier's default is `lf`,
+CI checks out on Linux, and a Windows checkout under `core.autocrlf=true` is
+CRLF - so without it the command reports every tracked Markdown and web file as
+failing on a tree with no modifications at all, and a real formatting defect in
+your change is indistinguishable from the noise. On Linux the flag changes
+nothing.
 
 `dotnet test` requires the **.NET 10 SDK**: the repo's `global.json` selects the
 SDK's Microsoft.Testing.Platform mode of `dotnet test` (#718), which older SDKs
@@ -214,7 +221,7 @@ The architecture, comment/documentation, and object-oriented rules a change is h
 
 ### HTML/CSS/JS/Markdown
 
-We use [Prettier](https://prettier.io) to format these files. Run `npx prettier --write "**/*.{js,html,md,css,scss}"` before committing, and `npx prettier --check "**/*.{js,html,md,css,scss}"` to confirm - CI enforces the check (only `*.min.js` is exempt).
+We use [Prettier](https://prettier.io) to format these files. Run `npx prettier --write --end-of-line auto "**/*.{js,html,md,css,scss}"` before committing, and `npx prettier --check --end-of-line auto "**/*.{js,html,md,css,scss}"` to confirm - CI enforces the check (only `*.min.js` is exempt). Keep `--end-of-line auto` on both: it is what makes the check honest on a CRLF working copy, and it stops `--write` rewriting the line endings of every file you did not touch.
 
 Not every file under `SSO-Auth/Web` is project code. Check the provenance header before editing: `emby-restyle.css` and the minified `jellyfin-apiClient.esm.min.js` are **vendored** from jellyfin-web - update them by re-copying from upstream, not by editing in place - whereas `ApiClient.js` is **project-maintained** code (loosely based on the linked upstream) that carries our own security logic and is edited here directly.
 


### PR DESCRIPTION
# What & why

Closes #1066.

Both places `CONTRIBUTING.md` gives the Prettier command now pass
`--end-of-line auto`, and the checklist copy carries a short paragraph saying
why it is there.

## The defect, reproduced

On a clean Windows checkout, `git status --porcelain` empty, the command exactly
as it was documented:

```
npx prettier --check "**/*.{js,html,md,css,scss}"
Checking formatting...
[warn] .github/pull_request_template.md
[warn] CHANGELOG.md
[warn] CODE_OF_CONDUCT.md
[warn] CONTRIBUTING.md
[warn] docs/README.md
[warn] docs/SECURITY-REMEDIATION-POLICY.md
[warn] GOVERNANCE.md
[warn] README.md
[warn] SECURITY.md
[warn] SSO-Auth.Fuzz/README.md
[warn] SSO-Auth/Web/ApiClient.js
[warn] SSO-Auth/Web/config.js
[warn] SSO-Auth/Web/configPage.html
[warn] SSO-Auth/Web/emby-restyle.css
[warn] SSO-Auth/Web/i18n.js
[warn] SSO-Auth/Web/linking.html
[warn] SSO-Auth/Web/linking.js
[warn] SSO-Auth/Web/style.css
[warn] test/e2e/README.md
[warn] Code style issues found in 19 files. Run Prettier with --write to fix.
```

19 files, none of them modified. And the command as it now reads, on the same
tree:

```
npx prettier --check --end-of-line auto "**/*.{js,html,md,css,scss}"
Checking formatting...
All matched files use Prettier code style!
```

There is no `.prettierrc` in the tree, so `endOfLine` is the default `lf`, while
the working copy is CRLF. CI checks out on Linux and runs the flagless spelling
from `.github/workflows/prettier.yml`, which is why the same files pass there.

## Which option, and why

**Option 1**, the documented command. It is a one-line change per occurrence, it
is a no-op wherever the working copy is already LF - which is every CI run - so
the gate does not move, and it makes the instruction we give a contributor
produce the result we told them to expect.

**Option 2**, a repository-wide `* text=auto eol=lf`, is declined. It forces an
LF working copy on every checkout to remove a divergence that surfaces in one
command, it rewrites the line endings of every tracked text file, and it now has
a second cost the issue could not have known about: `.gitattributes` exists since
#1080 and declares `*.sln text eol=crlf`, because Visual Studio rewrites that
file with CRLF on every use. A blanket `eol=lf` sets the repository against the
tools its contributors actually run.

A third option was considered and rejected on a sharper ground: a `.prettierrc`
setting `endOfLine: auto` would fix every invocation without touching the docs,
but it applies to CI as well, and CI is the one place that currently pins the
committed bytes to LF. Fixing a documentation defect by relaxing the only
enforcing check is the wrong trade.

`--end-of-line auto` is added to the `--write` command too. Without it, `--write`
on a CRLF working copy rewrites the endings of every matched file, including
every file the contributor did not touch.

## What this change does NOT prove

It does not prove anything about a Linux or macOS checkout; neither was
exercised. The claim that the flag is a no-op there rests on the working copy
already being LF, which is a property of those checkouts rather than something
measured here.

It does not change any check. The `prettier` CI job still runs the flagless
spelling and still enforces LF in the committed bytes; nothing in this diff
loosens it.

No second reader ran on this pull request. The before/after above stands in
place of one, run on the same clean tree with only the flag differing.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable. The diff is one documentation file.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The command appears in `CONTRIBUTING.md` only. `README.md` and the wiki give no
Prettier invocation, so no second home needed the same edit.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The two build lines are left unticked: no `.cs` file is in the diff and no build
was run for this change. Prettier is ticked against the committed bytes rather
than the working copy, which is what CI reads:

```
git cat-file -p :CONTRIBUTING.md > ciview/CONTRIBUTING.md
tr -dc '\r' < ciview/CONTRIBUTING.md | wc -c   ->  0
npx prettier --check CONTRIBUTING.md           ->  All matched files use Prettier code style!
```

## Notes

Nothing enforces the flag's presence in the documented command; a later edit can
drop it and no check will notice, because the string lives in prose. That is the
same shape as the defect being fixed, one level up.
