### PR TITLE
Classify why the role-claim walk produced no roles

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
@@ -19,13 +19,13 @@ public class OidcRoleExtractorTests
     public void SingleSegment_ReturnsRawClaimValueAsOneRole()
     {
         // A one-segment path is not JSON: the claim value itself is the single role.
-        Assert.Equal(new List<string> { "jellyfin-admin" }, OidcRoleExtractor.ExtractRoles(new[] { "Role" }, "jellyfin-admin", false));
+        Assert.Equal(new List<string> { "jellyfin-admin" }, Roles(new[] { "Role" }, "jellyfin-admin", false));
     }
 
     [Fact]
     public void TwoSegments_ReadsTerminalArray()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\",\"admins\"]}", false);
+        var roles = Roles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\",\"admins\"]}", false);
         Assert.Equal(new List<string> { "users", "admins" }, roles);
     }
 
@@ -33,7 +33,7 @@ public class OidcRoleExtractorTests
     public void NestedSegments_WalkTheJsonPath()
     {
         var value = "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]}}}";
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
+        var roles = Roles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
         Assert.Equal(new List<string> { "media" }, roles);
     }
 
@@ -42,28 +42,28 @@ public class OidcRoleExtractorTests
     {
         // The intermediate "jellyfin" key is absent inside resource_access, so the walk stops short.
         var value = "{\"resource_access\":{\"other\":{\"roles\":[\"x\"]}}}";
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
+        var roles = Roles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void IntermediateNodeNotAnObject_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}", false);
+        var roles = Roles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}", false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void TerminalNotAnArray_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}", false);
+        var roles = Roles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}", false);
         Assert.Empty(roles);
     }
 
     [Fact]
     public void MissingTerminalKey_ReturnsEmpty()
     {
-        var roles = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}", false);
+        var roles = Roles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}", false);
         Assert.Empty(roles);
     }
 
@@ -71,7 +71,7 @@ public class OidcRoleExtractorTests
     public void JsonNull_ReturnsEmpty()
     {
         // A literal JSON null deserializes to a null dictionary → no roles (not a throw).
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "null", false));
+        Assert.Empty(Roles(new[] { "realm_access", "roles" }, "null", false));
     }
 
     [Fact]
@@ -79,7 +79,7 @@ public class OidcRoleExtractorTests
     {
         // #216: a multi-segment path over a malformed (non-JSON) claim value fails CLOSED to no roles
         // instead of throwing an unhandled 500 on the public callback.
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json", false));
+        Assert.Empty(Roles(new[] { "realm_access", "roles" }, "not-json", false));
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class OidcRoleExtractorTests
     {
         // #216: a terminal array mixing strings with objects/numbers must not throw; only the string
         // elements are taken as roles.
-        var roles = OidcRoleExtractor.ExtractRoles(
+        var roles = Roles(
             new[] { "realm_access", "roles" },
             "{\"roles\":[\"users\",1,{\"nested\":true},\"admins\"]}",
             false);
@@ -99,7 +99,7 @@ public class OidcRoleExtractorTests
     {
         // #934: Zitadel's shape. The claim value IS the terminal object, and its property NAMES are the
         // roles; the values are the granting org's id→domain bookkeeping and are deliberately not read.
-        var roles = OidcRoleExtractor.ExtractRoles(
+        var roles = Roles(
             new[] { "urn:zitadel:iam:org:project:roles" },
             "{\"jellyfin-access\":{\"orgid\":\"example.com\"},\"jellyfin-admin\":{\"orgid\":\"example.com\"}}",
             true);
@@ -110,7 +110,7 @@ public class OidcRoleExtractorTests
     public void ObjectMap_NestedPath_ReadsTheTerminalObjectsPropertyNames()
     {
         var value = "{\"resource_access\":{\"jellyfin\":{\"roles\":{\"media\":{\"x\":1}}}}}";
-        var roles = OidcRoleExtractor.ExtractRoles(
+        var roles = Roles(
             new[] { "claim", "resource_access", "jellyfin", "roles" },
             value,
             true);
@@ -122,14 +122,14 @@ public class OidcRoleExtractorTests
     {
         // An empty map must mean NO roles, never "any role" - the allow-list check would otherwise be
         // satisfiable by a provider that granted the user nothing.
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "{}", true));
+        Assert.Empty(Roles(new[] { "urn:zitadel:iam:org:project:roles" }, "{}", true));
     }
 
     [Fact]
     public void ObjectMap_ArrayTerminal_ReturnsEmpty()
     {
         // The flag names the shape; a mismatched terminal is no roles, not a fallback guess.
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\"]}", true));
+        Assert.Empty(Roles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\"]}", true));
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class OidcRoleExtractorTests
     {
         // A single-segment object-map path no longer takes the raw value as a role: a provider that
         // regressed to emitting a plain string must grant nothing, not a role literally named "users".
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "users", true));
+        Assert.Empty(Roles(new[] { "urn:zitadel:iam:org:project:roles" }, "users", true));
     }
 
     [Fact]
@@ -145,13 +145,13 @@ public class OidcRoleExtractorTests
     {
         // Deserializing a JSON array into the object shape throws inside the try - it must fail closed to
         // no roles, never an unhandled 500 on the public callback (#216).
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "[\"users\"]", true));
+        Assert.Empty(Roles(new[] { "urn:zitadel:iam:org:project:roles" }, "[\"users\"]", true));
     }
 
     [Fact]
     public void ObjectMap_MalformedClaimValue_ReturnsEmpty()
     {
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "not-json", true));
+        Assert.Empty(Roles(new[] { "urn:zitadel:iam:org:project:roles" }, "not-json", true));
     }
 
     [Theory]
@@ -171,7 +171,7 @@ public class OidcRoleExtractorTests
         // callback, so no shape may escape as an unhandled exception (a 500). The method catches JsonException
         // only, so this pins that nothing else - a duplicate-key dictionary populate, an empty key, a scalar
         // or array root - throws something outside it.
-        Assert.NotNull(OidcRoleExtractor.ExtractRoles(new[] { "roles" }, claimValue, true));
+        Assert.NotNull(Roles(new[] { "roles" }, claimValue, true));
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public class OidcRoleExtractorTests
             deep.Append('}');
         }
 
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "roles" }, deep.ToString(), true));
+        Assert.Empty(Roles(new[] { "roles" }, deep.ToString(), true));
     }
 
     [Fact]
@@ -199,6 +199,137 @@ public class OidcRoleExtractorTests
     {
         // The pre-#934 behaviour is unchanged for every provider that does not opt in: an object terminal
         // read in array mode yields no roles rather than silently adopting the new shape.
-        Assert.Empty(OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":{\"users\":{}}}", false));
+        Assert.Empty(Roles(new[] { "realm_access", "roles" }, "{\"roles\":{\"users\":{}}}", false));
     }
+
+    // --- the classified outcome (#1147) ---
+    //
+    // Every assertion above is about the role STRINGS and is unchanged by this step: the walk grants and
+    // denies exactly what it granted and denied before. What follows pins the REASON, which was previously
+    // unavailable - a mistyped path and a provider that legitimately sent no roles both produced an empty
+    // list, and nothing downstream could tell them apart.
+
+    [Theory]
+    [InlineData("not-json")]
+    [InlineData("")]
+    [InlineData("null")]
+    [InlineData("\"scalar\"")]
+    [InlineData("123")]
+    [InlineData("[\"users\"]")]
+    public void ValueThatIsNotAJsonObject_IsValueNotJson(string claimValue)
+    {
+        // The claim value never became an object to walk. A literal JSON null deserializes to a null
+        // dictionary and belongs in the same class: nothing was parsed that a path could be applied to.
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, claimValue, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.ValueNotJson, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    [Fact]
+    public void MissingIntermediateKey_IsPathNotResolved()
+    {
+        var value = "{\"resource_access\":{\"other\":{\"roles\":[\"x\"]}}}";
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "jellyfin", "roles" }, value, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.PathNotResolved, result.Outcome);
+    }
+
+    [Fact]
+    public void NonObjectIntermediateNode_IsPathNotResolved()
+    {
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "claim", "resource_access", "roles" }, "{\"resource_access\":\"not-an-object\"}", false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.PathNotResolved, result.Outcome);
+    }
+
+    [Fact]
+    public void MissingTerminalKey_IsPathNotResolved()
+    {
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"other\":[\"x\"]}", false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.PathNotResolved, result.Outcome);
+    }
+
+    [Fact]
+    public void ArrayPathOverANonArrayTerminal_IsTerminalWrongShape()
+    {
+        // The terminal WAS reached; it is the wrong shape. Distinct from a path that never got there,
+        // because the operator fix is different: one is a mistyped path, the other a mis-set mode flag.
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"single-string\"}", false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.TerminalWrongShape, result.Outcome);
+    }
+
+    [Fact]
+    public void ObjectMapPathOverANonObjectTerminal_IsTerminalWrongShape()
+    {
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\"]}", true);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.TerminalWrongShape, result.Outcome);
+    }
+
+    [Fact]
+    public void EmptyTerminalArray_IsResolved_NotARefusal()
+    {
+        // The three cases below are the ones a reason code must NOT report as broken. They resolved; the
+        // provider simply granted nothing. Reporting them as refusals would bury a real misconfiguration
+        // under noise from every correctly-configured provider with a role-less user.
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[]}", false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    [Fact]
+    public void EmptyObjectMap_IsResolved_NotARefusal()
+    {
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "{}", true);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    [Fact]
+    public void ArrayOfOnlyNonStrings_IsResolved_NotARefusal()
+    {
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[1,{\"a\":2},null]}", false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    [Fact]
+    public void EverySuccessfulShape_IsResolved()
+    {
+        // The positive controls, so a change that classified everything as a refusal could not pass.
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, OidcRoleExtractor.ExtractRoles(new[] { "Role" }, "jellyfin-admin", false).Outcome);
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":[\"users\"]}", false).Outcome);
+        Assert.Equal(
+            OidcRoleExtractor.Outcome.Resolved,
+            OidcRoleExtractor.ExtractRoles(new[] { "urn:zitadel:iam:org:project:roles" }, "{\"jellyfin-access\":{}}", true).Outcome);
+    }
+
+    [Fact]
+    public void EveryRefusalCarriesNoRoles()
+    {
+        // A reason and a role set travel together, so a later reason cannot be added with roles attached.
+        var refusals = new[]
+        {
+            OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "not-json", false),
+            OidcRoleExtractor.ExtractRoles(new[] { "claim", "a", "roles" }, "{\"b\":{}}", false),
+            OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, "{\"roles\":\"x\"}", false),
+        };
+
+        Assert.All(refusals, refusal =>
+        {
+            Assert.NotEqual(OidcRoleExtractor.Outcome.Resolved, refusal.Outcome);
+            Assert.Empty(refusal.Roles);
+        });
+    }
+
+    // The role STRINGS, for every assertion written before the outcome existed - so those assertions read
+    // exactly as they did and this step is visibly a classification rather than a behaviour change.
+    private static List<string> Roles(string[] roleClaimSegments, string claimValue, bool terminalIsObjectMap) =>
+        OidcRoleExtractor.ExtractRoles(roleClaimSegments, claimValue, terminalIsObjectMap).Roles;
 }

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -217,7 +217,10 @@ internal static class OidcAuthorizeStateBuilder
 
             if (roleClaimSegments.Length > 0 && string.Equals(claim.Type, roleClaimSegments[0], StringComparison.Ordinal))
             {
-                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value, config.RoleClaimIsObjectMap));
+                // The walk now says WHY it produced what it produced (#1147). This step reads only the roles
+                // and discards the reason deliberately: reporting it is #1149's step, and folding the two
+                // together would put a behaviour change behind a pure classification.
+                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value, config.RoleClaimIsObjectMap).Roles);
             }
         }
 

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -20,6 +20,34 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 internal static class OidcRoleExtractor
 {
     /// <summary>
+    /// Why a walk produced the role set it produced (#1147). Before this existed every failure collapsed to
+    /// an empty list, which an operator could not tell from a provider that legitimately sent no roles - so
+    /// a mistyped path and a correct path over an empty array looked identical from outside.
+    /// <para>
+    /// The set is deliberately OPEN: a later reason may be added (a repeated member inside the role claim,
+    /// #1053) without the existing members changing meaning. Only <see cref="Resolved"/> is not a refusal.
+    /// </para>
+    /// </summary>
+    internal enum Outcome
+    {
+        /// <summary>
+        /// The path resolved to the configured shape. The role set may still be EMPTY and that is not a
+        /// refusal: an empty terminal array, an empty object map, and an array whose elements are all
+        /// non-strings all resolved correctly and simply carry no roles.
+        /// </summary>
+        Resolved,
+
+        /// <summary>The claim value did not parse as a JSON object, or parsed to null.</summary>
+        ValueNotJson,
+
+        /// <summary>An intermediate key was missing, an intermediate node was not an object, or the terminal key was absent.</summary>
+        PathNotResolved,
+
+        /// <summary>The terminal node was reached but is not the configured shape - a non-array where an array was expected, or a non-object in object-map mode.</summary>
+        TerminalWrongShape,
+    }
+
+    /// <summary>
     /// Extracts the role values from a claim value for the given role-claim path.
     /// </summary>
     /// <param name="roleClaimSegments">
@@ -33,20 +61,22 @@ internal static class OidcRoleExtractor
     /// every call site has to state which shape it reads.
     /// </param>
     /// <returns>
-    /// The extracted roles: for an array terminal, the string elements of the array reached by walking the
-    /// JSON path (non-string elements are ignored); for an object-map terminal, that object's property
-    /// names; and, only when the path is one segment and the terminal is not an object map, the raw claim
-    /// value as a single role. Returns an empty list when the path does not resolve to the expected shape
-    /// (missing segment, non-object node, wrong terminal type) and when the claim value is malformed
-    /// JSON - a parse failure fails closed to no roles rather than throwing (#216).
+    /// The extracted roles and why (#1147): for an array terminal, the string elements of the array reached
+    /// by walking the JSON path (non-string elements are ignored); for an object-map terminal, that object's
+    /// property names; and, only when the path is one segment and the terminal is not an object map, the raw
+    /// claim value as a single role. Every non-resolving shape (missing segment, non-object node, wrong
+    /// terminal type) and a malformed claim value carry no roles AND a refusal reason - a parse failure
+    /// fails closed rather than throwing (#216). The refusal reasons exist so a caller can tell a broken
+    /// path from a provider that legitimately sent no roles; the ROLE SET this returns is exactly the one
+    /// the previous bare-list version returned, for every input.
     /// </returns>
-    internal static List<string> ExtractRoles(string[] roleClaimSegments, string claimValue, bool terminalIsObjectMap)
+    internal static Result ExtractRoles(string[] roleClaimSegments, string claimValue, bool terminalIsObjectMap)
     {
         // A single-segment path is not JSON: the claim value itself is the role. An object-map claim is the
         // exception - there the claim value IS the terminal object, so it falls through to the parse below.
         if (roleClaimSegments.Length == 1 && !terminalIsObjectMap)
         {
-            return new List<string> { claimValue };
+            return Resolved(new List<string> { claimValue });
         }
 
         // Everything else parses the claim value as a JSON object and walks it. The claim value is
@@ -59,14 +89,15 @@ internal static class OidcRoleExtractor
             var json = JsonConvert.DeserializeObject<IDictionary<string, object>>(claimValue);
             if (json is null)
             {
-                return new List<string>();
+                return Refused(Outcome.ValueNotJson);
             }
 
             // A one-segment object-map path has no key to look under: the parsed claim value IS the terminal
-            // object, so its property names are the roles. An empty object yields NO roles, never "any role".
+            // object, so its property names are the roles. An empty object yields NO roles, never "any role"
+            // - and it RESOLVED, so it is not a refusal.
             if (roleClaimSegments.Length == 1)
             {
-                return json.Keys.ToList();
+                return Resolved(json.Keys.ToList());
             }
 
             // Walk the intermediate segments; any missing key or non-object node yields no roles.
@@ -75,39 +106,54 @@ internal static class OidcRoleExtractor
                 var segment = roleClaimSegments[i];
                 if (!json.TryGetValue(segment, out var nextToken) || nextToken is not JObject nextObject)
                 {
-                    return new List<string>();
+                    return Refused(Outcome.PathNotResolved);
                 }
 
                 json = nextObject.ToObject<IDictionary<string, object>>();
                 if (json is null)
                 {
-                    return new List<string>();
+                    return Refused(Outcome.PathNotResolved);
                 }
             }
 
             if (!json.TryGetValue(roleClaimSegments[^1], out var rolesToken))
             {
-                return new List<string>();
+                return Refused(Outcome.PathNotResolved);
             }
 
-            // The terminal must resolve to the configured shape - anything else is no roles, not a guess.
+            // The terminal must resolve to the configured shape - anything else is no roles, not a guess,
+            // and it is a distinct refusal from a path that never reached a terminal at all.
             if (terminalIsObjectMap)
             {
                 // Property NAMES only: the values are provider bookkeeping (Zitadel puts the granting org
                 // there), and reading them, or recursing, would turn unrelated data into granted roles.
                 return rolesToken is JObject rolesObject
-                    ? rolesObject.Properties().Select(property => property.Name).ToList()
-                    : new List<string>();
+                    ? Resolved(rolesObject.Properties().Select(property => property.Name).ToList())
+                    : Refused(Outcome.TerminalWrongShape);
             }
 
             // Take only the array's string elements so a terminal array of objects or numbers cannot throw.
+            // An array with no string elements RESOLVED and carries no roles; it is not a refusal.
             return rolesToken is JArray rolesArray
-                ? rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()!).ToList()
-                : new List<string>();
+                ? Resolved(rolesArray.Where(token => token.Type == JTokenType.String).Select(token => token.Value<string>()!).ToList())
+                : Refused(Outcome.TerminalWrongShape);
         }
         catch (JsonException)
         {
-            return new List<string>();
+            return Refused(Outcome.ValueNotJson);
         }
     }
+
+    private static Result Resolved(List<string> roles) => new(Outcome.Resolved, roles);
+
+    // Every refusal carries an EMPTY role set, in one place, so no future reason can be added with roles
+    // attached to it by accident.
+    private static Result Refused(Outcome outcome) => new(outcome, new List<string>());
+
+    /// <summary>
+    /// The classified result of a role-claim walk: the roles it produced, and why.
+    /// </summary>
+    /// <param name="Outcome">Whether the walk resolved, and if not, what refused it.</param>
+    /// <param name="Roles">The extracted role strings; empty on every refusal, and possibly empty on a resolution.</param>
+    internal readonly record struct Result(Outcome Outcome, List<string> Roles);
 }


### PR DESCRIPTION
# What & why

Closes #1147. Parent #1042. First of two steps: pure classification, no logger, no audit.

`OidcRoleExtractor.ExtractRoles` returns a `Result` carrying an `Outcome` instead of a
bare `List<string>`. Before this, all of these produced the same empty list and were
indistinguishable from outside:

- the claim value is not JSON, or deserializes to null,
- an intermediate key is missing, an intermediate node is not an object, the terminal key
  is absent,
- the terminal is the wrong shape for the configured mode,
- and, crucially, a correct path over a terminal array that is legitimately empty.

## Three refusal reasons, not two

The issue asks for at least "value was not JSON" and "path did not resolve". It carries
three, because its own list of shapes has three, and because the operator fix differs:

- `ValueNotJson` - nothing was parsed that a path could be applied to.
- `PathNotResolved` - a key or an intermediate object was missing; the walk never reached
  a terminal. A mistyped path.
- `TerminalWrongShape` - the terminal WAS reached and is a non-array where an array was
  expected, or a non-object in object-map mode. A mis-set `RoleClaimIsObjectMap`.

The set is open by construction, so #1053 can add a repeat reason without any existing
member changing meaning. Nothing here implements a repeat reason; there is no duplicate
screen on the role path today.

## The three empty-but-correct cases stay Resolved

An empty terminal array, an empty object map, and an array whose elements are all
non-strings resolved correctly and simply carry no roles. Classifying them as refusals
would bury a real misconfiguration under noise from every correctly-configured provider
that has a role-less user, and #1042's positive control depends on them staying silent.

## Both weakenings the issue names were run

Collapsing the two refusal reasons into one (`Refused(Outcome.PathNotResolved)` becomes
`Refused(Outcome.ValueNotJson)`):

```
MissingTerminalKey_IsPathNotResolved [FAIL]
NonObjectIntermediateNode_IsPathNotResolved [FAIL]
MissingIntermediateKey_IsPathNotResolved [FAIL]
Total: 45, Errors: 0, Failed: 3
```

Classifying the empty-array terminal as a refusal:

```
ArrayOfOnlyNonStrings_IsResolved_NotARefusal [FAIL]
EmptyTerminalArray_IsResolved_NotARefusal [FAIL]
Total: 45, Errors: 0, Failed: 2
```

Both weakenings were reverted; neither is in the diff. `grep -c RefuseWhenEmpty` on the
committed file returns `0`.

## Nothing grants or denies differently

Every existing assertion about the role STRINGS is unchanged. They now read through a
`Roles(...)` helper in the test class that takes `.Roles` off the result, so the diff
shows a classification rather than a rewrite of what each case asserts.

`OidcAuthorizeStateBuilder.ScanClaims` reads `.Roles` and discards the reason, with a
comment saying so. Reporting it is #1149's step; folding the two together would put a
behaviour change behind a pure classification and neither would be reviewable alone.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This sits on the login path (the role walk feeds the allow-list and the privilege
mapping), so the checklist is answered rather than skipped, and the answer is that the
step is deliberately behaviour-free.

- [x] Fail-closed preserved: every refusal carries an EMPTY role set, constructed in ONE
      private helper so a later reason cannot be added with roles attached by accident.
      `EveryRefusalCarriesNoRoles` pins that. The #216 never-throw properties (hostile
      claim values, the depth bomb) are untouched and still green.
- [x] No secrets logged; secrets are redacted on config export. Unchanged - this step
      adds no logging at all, which is the point of splitting it from #1149.
- [ ] A security review was performed. **No adversarial review was run on this change**,
      and this line is the disclosure rather than a waiver.
- [ ] Review record. **None exists. Nothing here was read by a second person.**
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added.
      The `Outcome` is an enum, so when #1149 does report it, the value that reaches a log
      line cannot be provider-controlled text.

## Quality checklist

- [x] No duplicated logic; the two result constructors are one line each and every return
      goes through them.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; the comments say why a case is or is not a refusal, not what the
      code does.
- [x] Architecture-conformance tests pass. No new structural property is established.
- [x] Docs impact considered: nothing user-facing changes yet - no log line, no admin
      surface, no config. The operator-visible half arrives with #1149 and the docs belong
      with it.

## Verification

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 \
    -p:JellyfinVersion=10.11.11 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2430, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2430, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*OidcRoleExtractor*"
   Total: 45, Errors: 0, Failed: 0
```

- [x] `dotnet build --warnaserror` green on both target frameworks.
- [x] `dotnet test` green on both target frameworks.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is in the diff.

## Notes

**Sent for review to nobody.** There is no second reader on this change; the evidence
above stands in place of one.

The reason is produced and then thrown away by the only caller. That is the intended end
state of THIS step and not an oversight: until #1149 lands, an operator sees exactly what
they saw before. If #1149 does not land, this change buys nothing at runtime, which is the
argument for taking them in order rather than the argument against the split.
