### PR TITLE
Record that the OIDC redirect_uri builder only emits, never compares [#1180]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcRedirectUriBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRedirectUriBuilderTests.cs
@@ -12,6 +12,26 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// 4.1.3 equality), so the pins here are the primary evidence that refactors change nothing - the
 /// end-to-end suites assert only URL prefixes and parameter presence, not full bytes.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This file holds a TRANSMISSION property - the bytes sent equal the configured ones - and deliberately
+/// no REJECTION property. There are no "variant is refused" negatives here because
+/// <see cref="OidcRedirectUriBuilder"/> refuses nothing: it concatenates, and the comparison that would
+/// refuse a variant belongs to the authorization server (RFC 6749 section 3.1.2, OIDC Core section
+/// 3.1.2.1). A client cannot test another party's enforcement, so an absent negative here is the correct
+/// shape rather than a gap (#1180, #1051).
+/// </para>
+/// <para>
+/// Redirect-URI comparison that this plugin DOES own - a URL this deployment published, checked against
+/// one arriving from outside - lives at exactly two sites, and the negatives belong with them:
+/// <c>OidcLogout.IsAllowedPostLogoutRedirect</c> (origin equality plus base-path prefix, reused at save
+/// time by <c>ProviderConfigValidator.ValidatePostLogoutRedirectUri</c>), and
+/// <c>SamlRecipientValidator.IsBound</c> (ordinal set membership of the assertion Recipient and the
+/// Response Destination against <c>SamlAcsUrlBuilder.ExpectedAcsUrls</c>). Other URL comparisons in the
+/// plugin test a scheme or a host against a constant, or a path-segment spelling, which is policy on an
+/// inbound value rather than a check against something this deployment emitted.
+/// </para>
+/// </remarks>
 public class OidcRedirectUriBuilderTests
 {
     private const string Base = "https://jf.example.com";

--- a/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs
@@ -11,6 +11,13 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// re-encoded, since encoding would change the bytes identity providers already have registered.
 /// (Split out of the kernel SsoUrlBuilder in #790 so the OIDC half lives in the Oidc module.)
 /// </summary>
+/// <remarks>
+/// This type only EMITS a redirect_uri; it never compares one, and it is not where a redirect-URI
+/// variant would be refused. That comparison is the authorization server's, and the two places this
+/// plugin compares a URL it published against one arriving from outside are
+/// <see cref="OidcLogout.IsAllowedPostLogoutRedirect"/> and
+/// <see cref="Saml.SamlRecipientValidator.IsBound"/> (#1180).
+/// </remarks>
 internal static class OidcRedirectUriBuilder
 {
     /// <summary>Builds the challenge-time redirect_uri; the spelling follows the route the login started on.</summary>


### PR DESCRIPTION
# What & why

Closes #1180. Part of #1051.

`OidcRedirectUriBuilderTests` pins the exact bytes the builder produces and
carries no "a variant is refused" negative. That is correct and it read as a
gap. The class doc now says which of the two properties the file holds, and one
line of the same answer is mirrored onto `OidcRedirectUriBuilder` so a reader
arriving from the source side is not sent to the test file for it.

The type refuses nothing. Its whole body is:

```csharp
private static string Build(string baseUrl, string segment, string provider) =>
    baseUrl + "/sso/OID/" + segment + "/" + provider;
```

The comparison that would refuse a redirect_uri variant is the authorization
server's, per RFC 6749 section 3.1.2 and OIDC Core section 3.1.2.1, and a client
cannot test another party's enforcement.

## The enumeration, and where it needed sharpening

The issue states the plugin compares a redirect URI at "exactly two sites". That
is true only under a precise predicate, and the record now carries the precise
one: **a URL this deployment published, checked against one arriving from
outside**. The two sites are

1. `SSO-Auth/Api/Oidc/OidcLogout.cs:138` `IsAllowedPostLogoutRedirect` - origin
   equality plus base-path prefix, reused at save time by
   `ProviderConfigValidator.ValidatePostLogoutRedirectUri`;
2. `SSO-Auth/Api/Saml/SamlRecipientValidator.cs:31,39` `IsBound` - ordinal set
   membership of the assertion `Recipient` and the `Response/@Destination`
   against `SamlAcsUrlBuilder.ExpectedAcsUrls`.

The looser reading is falsifiable, which is why the doc does not use it. Scanning
the plugin for comparison primitives over URI-bearing identifiers:

```
grep -rnE "(Uri|Url|Redirect|Acs|Destination|Recipient)[A-Za-z]*\s*(==|!=)|\.(Equals|StartsWith|EndsWith|Contains|SequenceEqual)\(" \
  --include=*.cs SSO-Auth | grep -iE "uri|url|redirect|acs|destination|recipient"
```

also returns scheme and host checks in `AvatarUrlValidator`,
`SamlMetadataImporter`, `CanonicalBaseUrl` and `OidcLogout`'s end-session parse;
a path-segment spelling comparison in `OidcCallbackPath`; and
`SamlSpMetadataBuilder:120`, which compares two URLs the plugin itself builds so
the metadata does not list a duplicate. None of those is a check against
something this deployment emitted, and the doc says so rather than leaving the
count to be re-derived.

## What this change does NOT prove

It adds no assertion and changes no behaviour, so it proves nothing about the
builder that was not already proved. The suite total is unmoved at 2468 on both
frameworks.

It does not retire anything on #1004 by itself. The issue asks for a comment
there retiring the redirect-URI-negatives criterion for the emission path and
naming the two comparison sites that inherit it; that comment goes on #1004 once
this lands, so the retirement points at a record on `main` rather than at a
branch.

Nothing enforces the enumeration. A third comparison site added tomorrow makes
the doc wrong and no check will notice - the same standing-assertion shape #1050
argues against for gap lists. It is written as of this commit and names the scan
that reproduces it, which is the most a comment can carry.

No second reader ran on this pull request. The scan above stands in place of
one: the claim in the doc is the output of a command anybody can re-run, not a
reading.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Documentation only; no executable line changes.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The comment explains why the negatives are absent, which is the one thing the
code cannot say about itself.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q  -> 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q  -> 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe   -> Total: 2468, Errors: 0, Failed: 0, Skipped: 0
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe  -> Total: 2468, Errors: 0, Failed: 0, Skipped: 0
```

The `--warnaserror` build is what checks the two `<see cref>` targets resolve; a
dangling one would be CS1574 and would fail the build rather than ship a doc
pointing nowhere.

## Notes

Prettier is unticked because no file it reads is in the diff.
