### PR TITLE
Resolve wiki source links against the git index, not the filesystem [#1152]

### DIFF
--- a/scripts/wiki-lint.py
+++ b/scripts/wiki-lint.py
@@ -12,6 +12,11 @@ creep back:
                                 cite modules and type names, never paths that move.
   3. Dead source links        - a blob/<ref>/<path> link to a file not in the tree.
 
+Check 3 resolves against the code repository's git INDEX, so a local run and a CI run
+reach the same verdict on the same wiki: a file the repository ignores but a developer
+still has on disk is not scored live. Point it at a git work tree; if it is not one, the
+run says so and falls back to the filesystem.
+
 Usage: wiki-lint.py <wiki_dir> <code_repo_dir>
 Exit code 1 (with a report) on any finding; 0 when clean.
 """
@@ -19,6 +24,7 @@ Exit code 1 (with a report) on any finding; 0 when clean.
 from __future__ import annotations
 
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -89,12 +95,49 @@ def check_file_line_citations(wiki: Path) -> list[str]:
 _BLOB = re.compile(r"github\.com/[^/]+/[^/]+/blob/[^/]+/([^)#\s]+)")
 
 
+def tracked_paths(code: Path) -> set[str] | None:
+    """The repo-relative POSIX paths git has in its index, plus every directory they imply.
+
+    Returns None when `code` is not a git work tree, or git is unavailable - the caller then
+    falls back to the filesystem and says so, rather than scoring every link dead.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(code), "ls-files", "-z"],
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    live = {p.decode("utf-8", "surrogateescape") for p in out.split(b"\0") if p}
+    for path in list(live):
+        parts = path.split("/")
+        live.update("/".join(parts[:i]) for i in range(1, len(parts)))
+    return live
+
+
 def check_dead_source_links(wiki: Path, code: Path) -> list[str]:
+    # Resolved against the INDEX, not the filesystem. A file the repository ignores can still sit in a
+    # developer's working checkout, and .exists() scores it live - so the same wiki linted clean locally
+    # and reported findings in CI, where actions/checkout materialises tracked files only (#1152).
+    tracked = tracked_paths(code)
+    if tracked is None:
+        print(
+            f"warning: '{code}' is not a readable git work tree - source links are checked against the "
+            "filesystem, so an ignored-but-present file will score live and this verdict may differ from CI.",
+            file=sys.stderr,
+        )
+
+    def is_live(rel: str) -> bool:
+        rel = rel.rstrip("/")
+        return (code / rel).exists() if tracked is None else rel in tracked
+
     findings: list[str] = []
     for path in wiki.glob("*.md"):
         for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
             for rel in _BLOB.findall(line):
-                if not (code / rel).exists():
+                if not is_live(rel):
                     findings.append(f"{path.name}:{n}: dead source link '{rel}' (not in the code tree)")
     return findings
 


### PR DESCRIPTION
# What & why

Closes #1152. Part of #1014.

`check_dead_source_links` tested `(code / rel).exists()`. In CI that is right by
accident - `actions/checkout` materialises tracked files only. On a working
checkout it is wrong: a file the repository ignores can still be on disk, and
`.exists()` scores it live. The same wiki therefore linted clean locally and
reported findings in CI, with nothing in the output saying which tree the answer
applied to.

It now resolves against the git index.

## Reproduced, on a live example

The path the issue names, `docs/ARCHITECTURE.md`, is no longer on disk on this
machine, so the reproduction uses another ignored-but-present path rather than
being reported from the issue text. `CLAUDE.md` is ignored
(`git check-ignore -v CLAUDE.md` reports `.gitignore:459`) and present in a
working clone. One fixture wiki page:

```markdown
[operating manual](https://github.com/iderex/jellyfin-plugin-sso/blob/main/CLAUDE.md)
[readme](https://github.com/iderex/jellyfin-plugin-sso/blob/main/README.md)
```

Before the change, same script, same wiki, two trees of the same commit:

```
python scripts/wiki-lint.py <wiki> <working clone>
Wiki lint: clean.                                                   exit 0

git archive origin/main | tar -x -C archived
python scripts/wiki-lint.py <wiki> archived
Wiki lint found 1 issue(s):
  - Home.md:4: dead source link 'CLAUDE.md' (not in the code tree)   exit 1
```

After the change the working clone reports it too:

```
python scripts/wiki-lint.py <wiki> <working clone>
Wiki lint found 1 issue(s):
  - Home.md:4: dead source link 'CLAUDE.md' (not in the code tree)   exit 1
```

## Which option, and why

**Option 1**, resolve against the index. It removes the trap instead of
documenting it, and it is the option the issue prefers.

The set comes from `git ls-files -z`, and every directory those paths imply is
added to it. That last part is deliberate: `.exists()` accepted a link whose
target is a directory, and a file-only membership test would have turned such a
link into a new finding on the real wiki - a stricter rule smuggled in under a
fix for a different defect.

Where the code path is not a readable git work tree, the run prints one line to
stderr and falls back to the filesystem:

```
warning: '<path>' is not a readable git work tree - source links are checked against the
filesystem, so an ignored-but-present file will score live and this verdict may differ from CI.
```

That is the honest degradation: the old behaviour, with the ambiguity named,
rather than a run that scores every link dead because `git` was missing.

## Behaviour where CI runs is unchanged

Measured rather than asserted. On a tracked-only checkout, the old and the new
implementation were run over the same fixture set - including two links whose
target is a directory (`SSO-Auth/Api/Oidc` and `SSO-Auth/Web/`) and one that is
genuinely gone:

```
old:  2 issue(s)  - Dirs.md:10 'SSO-Auth/Api/DoesNotExist.cs'  |  Home.md:4 'CLAUDE.md'
new:  2 issue(s)  - Dirs.md:10 'SSO-Auth/Api/DoesNotExist.cs'  |  Home.md:4 'CLAUDE.md'
```

Identical. Both accept the directory targets; both refuse the missing file. The
only input on which the two disagree is the one this change is about.

`.github/workflows/wiki-lint.yml:45` passes `${GITHUB_WORKSPACE}`, which
`actions/checkout` leaves as a git work tree, so CI takes the index path rather
than the fallback.

## What this change does NOT prove

It was not run against the real wiki. The wiki is a separate repository and is
not checked out here, so every run above used a fixture built for the
reproduction. The first evidence about the real wiki is the next `Wiki Lint` run
on `main`, and whoever lands this reads it:

```
gh run list -w "Wiki Lint" --branch main --limit 3
```

There is also no test around the script. This repository has no Python test
harness, and adding one for a 130-line lint would be a bigger change than the
defect. The verification is the four runs quoted above, each with its command;
nothing in the tree will notice if a later edit reintroduces the filesystem
test.

No second reader ran on this pull request. The before/after and the
old-versus-new comparison stand in place of one.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable. The diff is a documentation lint that reads two directories and
writes nothing.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

The subprocess call is a fixed argument vector with no shell, and its only
variable is the code directory the caller already passed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The module docstring now states which tree check 3 resolves against, so the
answer is in `--help` as well as in the code.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

All three are unticked and none was run: the diff is one `.py` file, no `.cs`
file is touched, and Prettier's globs do not include Python. `python -m py_compile
scripts/wiki-lint.py` succeeds, and the four functional runs are quoted above.

## Notes

`--help` (the no-argument path) still prints the docstring and exits 2.
