### PR TITLE
Read one comment-form list from both conformance scans

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3025,6 +3025,29 @@ public class ArchitectureConformanceTests
         Assert.True(source.Contains("SamlSignatureReference.TryGetSameDocumentId(", StringComparison.Ordinal));
     }
 
+    // The two comment exclusions in this file, asked the same question about the same line. The argument-level
+    // scan (CallsTo, through IsOnACommentLine) reads the text ahead of a call; the line scan (CodeLinesOf)
+    // reads whole lines; only a shared form list makes them agree, and they did NOT agree about a line opening
+    // with /* until this row existed (#1214). Remove any form from OpensAComment and a row here goes red.
+    //
+    // The last row is the residual both of them carry: a comment opened part-way along a line hides nothing
+    // from either scan. That is the honest state, not an oversight this row waves through - it is pinned so
+    // that closing it later has to be a deliberate edit with a failing test in front of it.
+    [Theory]
+    [InlineData("document.Load(reader);", true)]
+    [InlineData("        document.Load(reader);", true)]
+    [InlineData("// document.Load(reader);", false)]
+    [InlineData("        // document.Load(reader);", false)]
+    [InlineData("/* document.Load(reader); */", false)]
+    [InlineData("        /* document.Load(reader); */", false)]
+    [InlineData("     * document.Load(reader); - the spelling before the hardened reader", false)]
+    [InlineData("var settings = Harden(); // document.Load(reader);", true)]
+    public void CommentExclusion_ReadsTheSameFormsForALineAndForACallSite(string line, bool isCode)
+    {
+        Assert.Equal(isCode, CallsTo(line, "Load").Any());
+        Assert.Equal(isCode, CodeLinesOf(line).Any(l => l.Text.Contains("Load(", StringComparison.Ordinal)));
+    }
+
     [Fact]
     public void SamlSignaturePath_ResolvesElementsNamespaceAware()
     {
@@ -3153,17 +3176,27 @@ public class ArchitectureConformanceTests
         return files;
     }
 
+    // Whether trimmed text opens a comment: a line comment, a block-comment opener, or the continuation line
+    // of a block or XML-doc comment. THE ONLY COPY of the form list - a fourth form added to one of two
+    // copies is how a rule silently stops covering the spelling it was written for, and the two consumers
+    // below had already drifted apart on the block-comment opener (#1214).
+    //
+    // It reads the FIRST characters of what it is given and nothing else, so a comment opened part-way along
+    // a line ("Load(x); // moved") is not a comment to either consumer, and a block comment is only seen on
+    // the lines that begin one. That limit is shared by both, which is the property the fixture pins.
+    private static bool OpensAComment(string trimmedText) =>
+        trimmedText.StartsWith("//", StringComparison.Ordinal)
+        || trimmedText.StartsWith("/*", StringComparison.Ordinal)
+        || trimmedText.StartsWith("*", StringComparison.Ordinal);
+
     // A source text's numbered CODE lines: comment and XML-doc lines are excluded, because prose can name a
-    // banned type or quote a piece of markup without any call site reaching for it. THE ONLY COPY of that
-    // exclusion - a fourth comment form added to one of two copies is how a rule silently stops covering the
-    // spelling it was written for. On CRLF input the trailing \r survives the split and is removed by the
-    // Trim, so a line's text does not depend on the checkout's line endings.
+    // banned type or quote a piece of markup without any call site reaching for it. On CRLF input the
+    // trailing \r survives the split and is removed by the Trim, so a line's text does not depend on the
+    // checkout's line endings.
     private static IEnumerable<(int Number, string Text)> CodeLinesOf(string source) =>
         source.Split('\n')
             .Select((line, index) => (Number: index + 1, Text: line.Trim()))
-            .Where(l => !l.Text.StartsWith("//", StringComparison.Ordinal)
-                && !l.Text.StartsWith("/*", StringComparison.Ordinal)
-                && !l.Text.StartsWith("*", StringComparison.Ordinal));
+            .Where(l => !OpensAComment(l.Text));
 
     // A file's numbered CODE lines, by the rule above and no second opinion. A file that ends in a newline
     // yields one extra entry past its last line, whose text is empty; every predicate above searches for a
@@ -3351,12 +3384,14 @@ public class ArchitectureConformanceTests
     }
 
     // Whether the call at index sits on a line whose code has already been commented out - the argument-level
-    // scan reads the whole file, so it needs the same comment exclusion CodeLines applies.
+    // scan reads the whole file, so it needs the same comment exclusion CodeLines applies. The two cannot be
+    // the same function: this one judges the text AHEAD OF a call index, which is what lets it decide about a
+    // call sitting part-way along a line, where CodeLinesOf judges a whole trimmed line. They share the form
+    // list instead, so the parity this comment claims is a call and not a coincidence.
     private static bool IsOnACommentLine(string source, int index)
     {
         var lineStart = source.LastIndexOf('\n', Math.Min(index, source.Length - 1)) + 1;
-        var prefix = source[lineStart..index].TrimStart();
-        return prefix.StartsWith("//", StringComparison.Ordinal) || prefix.StartsWith("*", StringComparison.Ordinal);
+        return OpensAComment(source[lineStart..index].TrimStart());
     }
 
     // obj/bin hold generated and compiled output; the source scans read hand-written source only.


### PR DESCRIPTION
# What & why

`IsOnACommentLine` (the comment exclusion the argument-level call-site scan applies) knew two comment forms where the shared line predicate `CodeLinesOf` knows three: the block-comment opener `/*` was missing, and the comment above it claimed the two agreed.

Both now read one predicate, `OpensAComment`, which holds the form list. They stay two functions because they judge different things: `CodeLinesOf` judges a whole trimmed line, `IsOnACommentLine` judges the text ahead of a call index, which is what lets it decide about a call sitting part-way along a line. Sharing the list is what makes the parity a call rather than a coincidence, and the comment now says which limit they share instead of claiming they are the same thing.

The disagreement made the argument-level scan over-report and never under-report, so no conformance rule failed open because of it. What it cost was a false positive the first time somebody comments a call out in block form, and a comment stating the opposite of what the code did.

Closes #1214

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: the change is confined to the test project's conformance scans and touches no login path, no crypto, no config persistence and no release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change. The falsifications below are what stands in its place, and they are reproducible from the diff.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror`, full suite:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2492, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 15,024s

dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2492, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 15,938s
```

`git status --porcelain -- '*packages.lock.json'` is empty after both builds. No `.js` / `.html` / `.md` / `.css` file is touched, so Prettier has nothing to say about this diff.

### The new row goes red when the rule is removed

Falsification 1, the shared form list loses `/*`:

```
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*CommentExclusion*"
  CommentExclusion_ReadsTheSameFormsForALineAndForACallSite(line: "/* document.Load(reader); */", isCode: False) [FAIL]
  CommentExclusion_ReadsTheSameFormsForALineAndForACallSite(line: "        /* document.Load(reader); */", isCode: False) [FAIL]
   SSO-Auth.Tests  Total: 8, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,116s
```

Falsification 2, the call-site predicate goes back to its own two-clause spelling while the shared list keeps all three. This is the disagreement the issue reports, reproduced:

```
  CommentExclusion_ReadsTheSameFormsForALineAndForACallSite(line: "/* document.Load(reader); */", isCode: False) [FAIL]
    Assert.Equal() Failure: Values differ
  CommentExclusion_ReadsTheSameFormsForALineAndForACallSite(line: "        /* document.Load(reader); */", isCode: False) [FAIL]
    Assert.Equal() Failure: Values differ
   SSO-Auth.Tests  Total: 8, Errors: 0, Failed: 2, Skipped: 0, Not Run: 0, Time: 0,120s
```

Restored to the committed state, the same eight rows pass.

## Notes

The last row of the theory pins a residual rather than a fix: a comment opened part-way along a line (`var settings = Harden(); // document.Load(reader);`) hides the call from neither scan. Both predicates read the first characters of what they are handed and nothing else, and neither tracks comment state across a line or across lines. That is asserted deliberately, so that closing it later is an edit somebody makes with a failing row in front of them rather than a silent widening.

No README or wiki text describes either predicate, so no documentation follow-up is filed.
