### PR TITLE
Skip the PR-hygiene fail tier for authors outside the repository [#1207]

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -22,8 +22,12 @@
 #
 # The checks are tiered by confidence so it does not red-flag reasonable PRs:
 #   - FAIL  (high confidence, near-zero false-positive):
-#       * PR body carries an issue reference (Closes/Refs #N) - skipped for bots.
+#       * PR body carries an issue reference (Closes/Refs #N).
+#       * every commit subject carries a bracketed issue reference.
 #       * a build.yaml version bump also touches CHANGELOG.md.
+#     The whole FAIL tier is skipped for bots and for authors from outside this
+#     repository; the two skips have different reasons and both are written at
+#     the check, not only here (#1207).
 #   - WARN  (soft convention, annotation only - never fails):
 #       * the diff is large (>=400 changed lines) - advisory; a feature, doc
 #         migration, or bulk rename legitimately exceeds any cap, so size never reds.
@@ -83,16 +87,54 @@ jobs:
             const labels = (pr.labels || []).map((l) => l.name);
             const isBot = pr.user && pr.user.type === "Bot";
 
+            // --- Who the FAIL tier is for (#1207) --------------------------------
+            // The issue convention this tier enforces is OURS. Somebody arriving
+            // from outside has no way to know the issue numbers this board expects
+            // before they file, and often no issue exists yet - so failing their
+            // contribution on it is a gatekeeping ritual, not a caught slip.
+            // Applied to work from inside the repository the same check catches a
+            // real one, which is why the tier is narrowed by audience rather than
+            // removed.
+            //
+            // This is NOT the bot reason. A bot cannot know the convention; a
+            // person can, and is simply not the one who owes it here.
+            //
+            // `author_association` reports the author's relationship to THIS
+            // repository, so an occasional outside collaborator who is later added
+            // as a member stops being exempt from that moment - correct, and worth
+            // knowing rather than discovering. COLLABORATOR is deliberately NOT in
+            // the inside set: the issue asks for member-or-owner.
+            //
+            // The linkage itself is still wanted for an outside contribution - it
+            // moves to whoever handles it, and the annotation below says so on the
+            // pull request, where that person will meet it. Read this skip as
+            // "not their obligation", never as "linkage does not matter here".
+            const INSIDE_ASSOCIATIONS = ["OWNER", "MEMBER"];
+            const isOutside = !INSIDE_ASSOCIATIONS.includes(
+              pr.author_association || "NONE",
+            );
+            const failTierApplies = !isBot && !isOutside;
+            if (isOutside && !isBot) {
+              warnings.push(
+                "Author is outside this repository " +
+                  `(author_association: ${pr.author_association || "NONE"}), so the ` +
+                  "FAIL-tier hygiene checks are skipped. The issue linkage is still " +
+                  "wanted: whoever handles this contribution supplies the issue " +
+                  "reference, and files the issue where none exists yet.",
+              );
+            }
+
             // --- Check 1: PR body references an issue (Closes/Refs #N) ----------
             // Directive: every change is issue-driven and linked. Bots (Dependabot)
-            // open PRs with no issue, so they are exempt. A bare `#123`, a keyword
+            // open PRs with no issue, so they are exempt; so is an outside author,
+            // for the separate reason written above. A bare `#123`, a keyword
             // form (`Closes #123`), or a full issue URL all satisfy it - lenient on
             // purpose so a legitimately-linked PR is never flagged on phrasing.
             const body = pr.body || "";
             const hasIssueRef =
               /(^|[^\w])#\d+\b/.test(body) ||
               /github\.com\/[^\/\s]+\/[^\/\s]+\/issues\/\d+/i.test(body);
-            if (!isBot && !hasIssueRef) {
+            if (failTierApplies && !hasIssueRef) {
               failures.push(
                 "PR body has no issue reference. Link the issue it addresses " +
                   "(e.g. `Closes #123` or `Refs #123`).",
@@ -105,9 +147,9 @@ jobs:
             // PR-body link (check 1) is not enough. The reference lives in the
             // subject, bracketed, one bracket per issue: `Fix the thing [#12][#34]`.
             // (GitHub's auto-close keywords still go in the body - `[#N]` in a
-            // subject does not close anything.) Bots and merge commits (subject
-            // starts with "Merge ") are exempt; merge commits are machine-generated
-            // and inherit the merged PR's own linkage.
+            // subject does not close anything.) Bots, outside authors and merge
+            // commits (subject starts with "Merge ") are exempt; merge commits are
+            // machine-generated and inherit the merged PR's own linkage.
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -126,7 +168,7 @@ jobs:
                 !authorIsBot && !isMerge && !subjectHasBracketedRef(c.commit.message)
               );
             });
-            if (!isBot && unlinked.length > 0) {
+            if (failTierApplies && unlinked.length > 0) {
               const list = unlinked
                 .map((c) => `${c.sha.slice(0, 7)} ("${c.commit.message.split("\n")[0]}")`)
                 .join(", ");
@@ -140,13 +182,16 @@ jobs:
             // --- Check 2: a build.yaml version bump must touch CHANGELOG.md -----
             // The version field only changes in a release PR, which must also record
             // the release in CHANGELOG.md. Near-zero false-positive: a non-release PR
-            // never edits the `version:` line, so this stays silent for it.
+            // never edits the `version:` line, so this stays silent for it. It is in
+            // the FAIL tier, so it takes the same audience narrowing as checks 1 and
+            // 1b - the tier is skipped as a whole rather than per check, so a later
+            // reader does not have to work out which failures a skip covered.
             const buildYaml = files.find((f) => f.filename === "build.yaml");
             const versionBumped =
               buildYaml &&
               buildYaml.patch &&
               /^\+\s*version:/m.test(buildYaml.patch);
-            if (versionBumped && !changed.includes("CHANGELOG.md")) {
+            if (failTierApplies && versionBumped && !changed.includes("CHANGELOG.md")) {
               failures.push(
                 "build.yaml `version:` changed but CHANGELOG.md was not updated. " +
                   "Record the release in CHANGELOG.md.",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,8 @@ We are always open to better docs! The main place documentation could be improve
 
 Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); explain the _why_ in the body. **Every commit subject ends with its issue reference(s) in brackets** - `Add SAML replay cache [#123]`, multiple issues as `[#123][#456]` - so the link survives `git blame`/`bisect`/`log`, which show only the subject. GitHub's auto-close keywords (`Closes #N`) additionally go in the body when the commit resolves the issue. The PR-hygiene gate enforces the bracketed subject reference per commit (bots and merge commits exempt).
 
+If you are contributing from outside this repository, the gate's failing checks do not apply to you: the issue convention is ours, and you have no way to know a number before the issue exists. Send the change; the linkage is not dropped, it moves to me - I add the issue reference, and file the issue where none exists yet, as part of handling the contribution.
+
 ### Sign Your Work (DCO)
 
 This project uses the [Developer Certificate of Origin](DCO) (DCO 1.1) - a lightweight, standard way to certify that you wrote or otherwise have the right to submit the code you contribute, under the project's GPL-3.0 license. It is not a copyright-assignment CLA; you keep your copyright.


### PR DESCRIPTION
# What & why

Closes #1207.

The FAIL tier of `.github/workflows/pr-hygiene.yml` enforces an issue convention that
belongs to this board. Somebody arriving from outside has no way to know a number before
the issue exists, and frequently no issue exists yet, so the same check that catches a
real slip in work from inside the repository turns into a red X on a first contribution.

The tier is narrowed by audience rather than removed:

```js
const INSIDE_ASSOCIATIONS = ["OWNER", "MEMBER"];
const isOutside = !INSIDE_ASSOCIATIONS.includes(pr.author_association || "NONE");
const failTierApplies = !isBot && !isOutside;
```

`failTierApplies` now gates all three failing checks - the body issue reference, the
per-commit bracketed reference, and the build.yaml/CHANGELOG pair. The tier is skipped as
a whole rather than per check, so a later reader does not have to work out which failures
a given skip covered. The WARN tier is untouched: annotations inform, they do not judge.

`COLLABORATOR` is outside on purpose. The issue asks for member-or-owner, and its own
closing note wants an occasional outside collaborator to stop being exempt at the moment
they are added as a member.

The skip's reason is written at the check, in full, and it says explicitly that it is not
the bot reason: a bot cannot know the convention, a person can and is simply not the one
who owes it here.

## The linkage duty moves, it is not dropped

An exempt pull request now gets a warning annotation on itself naming who owes the
linkage:

```
Author is outside this repository (author_association: FIRST_TIME_CONTRIBUTOR), so the
FAIL-tier hygiene checks are skipped. The issue linkage is still wanted: whoever handles
this contribution supplies the issue reference, and files the issue where none exists yet.
```

That is the "where whoever handles them will meet it" the issue asks for - it lands on the
pull request being handled rather than in a document nobody opens at that moment.
`CONTRIBUTING.md` carries the contributor-facing half in the commit-message section, next
to the bracketed-reference rule it exempts them from.

## A correction to the issue's premise

The issue says this workflow "is not wired into the required-status-check ruleset and never
blocks a merge". That was true when the workflow header said the same thing; #1199 found
the header wrong and corrected it. Read at the live ruleset today:

```
$ gh api repos/iderex/jellyfin-plugin-sso/rules/branches/main \
    --jq '.[] | select(.type=="required_status_checks") | .parameters.required_status_checks[].context'
build
ABI floor build
Package (JPRM) / Build package
Package (JPRM) / Generate SBOM
CodeQL
Analyze (csharp)
DCO sign-off
Deterministic PR-hygiene checks
Enforce greppable invariants
Reject Trojan Source Unicode
Audit workflows (zizmor)
prettier
dependency-review
```

`Deterministic PR-hygiene checks` is in the required set. So a red FAIL tier holds an
outside contribution's merge rather than merely decorating it, which makes the exemption
more load-bearing than the issue assumed, not less. The header comment in the file already
states this correctly and was not touched.

## Type of change

- [x] Refactor / code quality / docs

(It is a CI change. Nothing in the plugin, the login path, crypto, config persistence or
the release pipeline is touched.)

## Security checklist

Not applicable by subject: the diff is one workflow file and one paragraph of
`CONTRIBUTING.md`. No login path, no crypto, no config persistence, no release pipeline.

- [ ] A security review was performed. **No adversarial review was run on this change.**
      This line is the disclosure, not a waiver.
- [ ] Review record. **None exists. Nothing here was read by a second person.** The
      evidence below stands in place of one.

One security-adjacent property is worth stating rather than leaving to be discovered. The
predicate treats a missing `author_association` as outside, so if that field were ever
absent from the payload the FAIL tier would go quiet for everybody instead of failing
loudly. That direction is deliberate - the whole point of the issue is not to gatekeep on
a convention - and the cost is bounded because this tier is a linkage lint, not a control
over what the code may do. The field is present on every `pull_request` payload today;
the row is in the table below so the behaviour is recorded rather than assumed.

## Quality checklist

- [x] No duplicated logic: one predicate, three call sites, no regex or association list
      repeated.
- [x] The change adds no more code than the problem requires - three lines of predicate
      and one annotation.
- [x] Comments say why, not what, and the "why" is the part the issue insisted must not be
      lost.
- [x] Architecture-conformance tests: unaffected, no C# in the diff.
- [x] Docs impact: included here (`CONTRIBUTING.md`). No README or wiki page describes the
      hygiene tiers.

## Verification

The predicate was lifted out of the committed file as text and executed over every
`author_association` value GitHub sends, plus the bot case and the absent-field case. It
is read from the file rather than restated, so the table is about what is committed:

```
$ node scratch/assoc-probe.js .github/workflows/pr-hygiene.yml
--- predicate as committed ---
const INSIDE_ASSOCIATIONS = ["OWNER", "MEMBER"];
const isOutside = !INSIDE_ASSOCIATIONS.includes(pr.author_association || "NONE",);
const failTierApplies = !isBot && !isOutside;

OWNER                    user=User  FAIL tier applies: true
MEMBER                   user=User  FAIL tier applies: true
COLLABORATOR             user=User  FAIL tier applies: false
CONTRIBUTOR              user=User  FAIL tier applies: false
FIRST_TIME_CONTRIBUTOR   user=User  FAIL tier applies: false
FIRST_TIMER              user=User  FAIL tier applies: false
MANNEQUIN                user=User  FAIL tier applies: false
NONE                     user=User  FAIL tier applies: false
OWNER                    user=Bot   FAIL tier applies: false
(absent)                 user=User  FAIL tier applies: false
```

The near-miss is one extra string in the list - the mistake somebody makes when they read
"contributor" as "one of us". Adding `"CONTRIBUTOR"` to `INSIDE_ASSOCIATIONS` and re-running
the same probe flips exactly the row that matters and nothing else:

```
CONTRIBUTOR              user=User  FAIL tier applies: true
```

The near-miss copy was written to a scratch file, measured and deleted; it is not in the
diff.

**What that proof does not cover, stated plainly.** It executes the predicate, not the
workflow. There is no harness in this repository that runs `github-script` bodies, so
nothing here proves the three `if` statements read `failTierApplies` correctly once
GitHub evaluates them - that is read from the diff by a person. The end-to-end half is
this pull request itself: it runs the modified workflow from its own head, authored by
`OWNER`, so the FAIL tier must apply and must pass. A green `Deterministic PR-hygiene
checks` on this PR is therefore evidence for the inside branch. The outside branch has no
execution behind it and cannot get one until an outside contribution arrives.

- [x] `dotnet build`: not run and not applicable - no C# or project file is in the diff.
- [ ] `dotnet test`: **not run.** The suite raises a Windows elevation prompt on this
      machine (#1227) and is not run locally. Nothing in this diff is reachable from it -
      the diff is a workflow file and a markdown paragraph. CI is the judge.
- [x] Prettier for the `.md` change:

```
$ npx prettier --check "CONTRIBUTING.md"
[warn] CONTRIBUTING.md
$ git stash && npx prettier --check "CONTRIBUTING.md"     # same file at the base commit
[warn] CONTRIBUTING.md
$ diff <(tr -d '\r' < CONTRIBUTING.md) <(tr -d '\r' < <(npx prettier CONTRIBUTING.md))
                                                          # no output
```

The warning is present at the base commit too and survives stripping carriage returns from
both sides, so it is the checkout's CRLF endings (#1066), not this paragraph. CI checks out
with LF; the `prettier` required check is the reading that counts.

## Notes

The issue's inventory of the FAIL tier lists two checks; the file has three. The third
(build.yaml version bump without CHANGELOG) is exempted along with the other two, on the
tier-as-a-whole reasoning above rather than on a claim that an outside author might cut a
release.

Nothing in this change reaches the WARN tier, and nothing changes for a pull request
opened from inside the repository - which is every pull request the board has today.
