### PR TITLE
Build the fuzz harness in the gating PR job

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,6 +61,26 @@ jobs:
         fi
     - name: Build
       run: dotnet build --no-restore --warnaserror
+    # The fuzz harness is deliberately absent from SSO-Auth.sln, so the restore and
+    # build above never see it and a module rename in the plugin could break it
+    # unnoticed until the weekly fuzzing run days later (#1132, #1008). Compiling it
+    # inside the job the "Protect main" ruleset gates on makes that break red on the
+    # PR that causes it.
+    #
+    # It stays OUT of the solution and is built by path on purpose: joining the
+    # solution would also pull it into `dotnet test`, the coverage gate and the
+    # vulnerable-dependency scan above, all of which are meant to see the shipping
+    # project set and nothing else.
+    #
+    # This compiles the harness; it does not fuzz. No clang, no `sharpfuzz` CLI and
+    # no libFuzzer runtime is needed for that, and the libFuzzer run itself stays
+    # non-gating in fuzz.yml, which gains no push or pull_request trigger.
+    - name: Restore the fuzz harness (locked)
+      # Same --locked-mode reasoning as the solution restore above: the harness has
+      # its own committed packages.lock.json and a drifted graph must not build.
+      run: dotnet restore SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --locked-mode
+    - name: Build the fuzz harness (Release)
+      run: dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror
     - name: Test
       run: dotnet test --no-build --verbosity normal
     # Line coverage for the RC coverage gate (#718). A second, instrumented run

--- a/SSO-Auth.Fuzz/Program.cs
+++ b/SSO-Auth.Fuzz/Program.cs
@@ -7,7 +7,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Jellyfin.Plugin.SSO_Auth;
-using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using SharpFuzz;
 

--- a/SSO-Auth.Fuzz/Program.cs
+++ b/SSO-Auth.Fuzz/Program.cs
@@ -7,7 +7,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Jellyfin.Plugin.SSO_Auth;
-using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using SharpFuzz;
 

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -4,9 +4,10 @@ This project is the coverage-guided fuzz harness prototype for the plugin's logi
 written evaluation behind [Scorecard alert #36 (Fuzzing)](https://github.com/iderex/jellyfin-plugin-sso/issues/402).
 It is the concrete harness the weekly scheduled job (#174) runs.
 
-It is **out of band**: not part of `SSO-Auth.sln`, so a normal `dotnet build` / `dotnet test` and every
-per-PR CI job never restore SharpFuzz or build it. It is compiled and driven only by the scheduled Linux
-fuzzing job, exactly as the acceptance criteria require ("scheduled, non-blocking").
+It is **out of band**: not part of `SSO-Auth.sln`, so a normal `dotnet build` / `dotnet test` never
+restores SharpFuzz or builds it. The _fuzzing_ is driven only by the scheduled Linux job, exactly as the
+acceptance criteria require ("scheduled, non-blocking"). Since #1132 the gating `build` job does compile
+the harness by path, so a module rename that breaks it reds the PR rather than the weekly run.
 
 ## The attack surface we target
 
@@ -66,8 +67,9 @@ value is the fuzzing itself, which the scheduled job delivers regardless of whet
 - **Actual fuzzing is Linux-only.** The `sharpfuzz` instrumentation CLI and the libFuzzer runtime are
   Linux-oriented; a coverage-guided run on Windows is impractical. So the _run_ lives in CI, never on the
   maintainer's machine. This is expected and is why #174 is a scheduled Linux job.
-- Because the project is not in the solution, the per-PR CI never builds it. The weekly job is what keeps
-  it compiling and running; that is an accepted trade-off for a non-shipping prototype.
+- The project is not in the solution, so nothing that works from the solution builds it. Since #1132 the
+  gating `build` job compiles it by path on every PR, which is what keeps it from bitrotting; the weekly
+  job is what keeps it _running_.
 
 ## Value assessment vs. the existing gate
 

--- a/SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj
+++ b/SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj
@@ -3,8 +3,12 @@
   <!--
     Out-of-band, coverage-guided fuzz harness for the untrusted-input parse surface (#402), the
     prototype the weekly SharpFuzz job (#174) runs. It is DELIBERATELY NOT part of SSO-Auth.sln, so a
-    normal `dotnet build`/`dotnet test` (and every PR CI job) never restores SharpFuzz or builds this
-    project - it is compiled and run only by the scheduled Linux fuzzing job. See README.md for the
+    normal `dotnet build`/`dotnet test` never restores SharpFuzz or builds this project, and neither
+    does any CI step that works from the solution. Since #1132 the gating `build` job compiles it BY
+    PATH, so a module rename that breaks the harness reds the PR instead of surfacing days later in
+    the weekly run; the fuzzing itself is still run only by the scheduled Linux job. Staying out of
+    the solution is what keeps `dotnet test`, the coverage gate and the vulnerable-dependency scan
+    operating on the shipping project set alone. See README.md for the
     ClusterFuzzLite-vs-SharpFuzz evaluation, the feasibility finding, and how to run it.
   -->
   <PropertyGroup>


### PR DESCRIPTION
# What & why

`SSO-Auth.Fuzz` is deliberately absent from `SSO-Auth.sln`, so the restore and build in the gating `build` job never saw it. A module rename in the plugin could break the harness and stay silent until the weekly libFuzzer run days later. That is not hypothetical: the #777 module migration dissolved the flat `Jellyfin.Plugin.SSO_Auth.Api` namespace `Program.cs` imported, and the harness stopped compiling with nothing on a PR to notice.

The `build` job now restores the harness in `--locked-mode` and builds it in Release with `--warnaserror`, by path. Compiling needs no clang, no `sharpfuzz` CLI and no libFuzzer runtime.

The project stays out of the solution, recorded as a decision rather than left as an omission: joining the solution would also pull it into `dotnet test`, the coverage gate and the vulnerable-dependency scan, which are meant to see the shipping project set alone. Building by path buys the compile check without moving any of those boundaries.

The fuzzing itself stays non-gating. `fuzz.yml` gains no `push` or `pull_request` trigger, and the `build` job keeps its job id with no `name:`, so the check-run name the "Protect main" ruleset matches is unchanged.

Three places claimed the harness is never built on a PR, and all three are corrected here so the stale claim does not survive in a second home: the csproj header comment, and two passages in `SSO-Auth.Fuzz/README.md`.

Closes #1132
Closes #1008

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

Not applicable and left unticked on purpose. No login-path, crypto or config-persistence code changes here. The release pipeline is untouched: `build.yml`, `publish-*` and `fuzz.yml` are byte-identical, and the only workflow edit is two added steps in the PR-time `build` job.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the first box: the two steps are the ones `fuzz.yml` already runs, quoted rather than re-invented. They are duplicated across two workflows in the literal sense, and that is the smaller evil: a shared composite action for two `run:` lines would add a maintained file to save nothing, and the two jobs need the harness built for different reasons.

On the fourth box: no new structural property. The rule this establishes lives in the workflow, and CI refusing the break is the proof, below.

On the last box: the affected documentation is the harness README and the csproj header, both included here. No README or wiki page states the PR-time build scope.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The test suite was not run on this machine, see #1227. The judge of this change is this PR's own CI, which runs `dotnet test` in the same job the change edits. That box stays unticked rather than being ticked on an assumption.

Local runs, at the harness commands the job now uses:

```
dotnet restore SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --locked-mode
dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgeführt.  0 Warnung(en)  0 Fehler
git status --porcelain
(no output, so --locked-mode moved no lockfile)

npx prettier --check "SSO-Auth.Fuzz/README.md"
All matched files use Prettier code style!
```

## The guard is shown failing, in CI

`SSO-Auth.Fuzz/Program.cs` is broken on purpose in the second commit, importing the flat `Api` namespace #777 dissolved instead of `Api.Oidc`. That is the exact shape that rotted unnoticed, not an invented one. Locally it already refuses:

```
error CS0103: PkceDiscovery does not exist in the current context
error CS0103: OidcResponseIssuer does not exist in the current context
```

The push carrying that break is what the first CI run on this PR judges, so the red `build` check is the measurement rather than a prediction. The break is reverted in a following commit and the job is green again before this merges. Both runs are quoted here once they exist.

## Notes

Reviewers: this change had no second reader. Nobody but its author has read it, so the evidence above stands in place of one, and the red-then-green CI record is the part that is not a claim.

CHANGELOG.md is untouched on purpose. It records changes to the plugin, and this changes no shipped behaviour.

Out of scope: the seed-corpus replay `SSO_FUZZ_SMOKE=1` that #1008 raises as worth considering alongside the compile. It is its own change with its own failure mode, and #1134 already holds it.

<details>
<summary>Verification notes</summary>

The break is deliberately the #777 one rather than an invented shape, so the near-miss is the one somebody actually makes. Locally only `dotnet restore` and `dotnet build` were run; the suite was left alone, see #1227, and this text claims nothing otherwise.

</details>
