### PR TITLE
Record why the id_token error string carries no per-shape codes

### DIFF
--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -114,6 +114,17 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
     // too - after a rotation an IdP may reuse a kid with new material, and the refresh either repairs
     // the validation or the retry fails closed. Everything else reports only the exception type:
     // IdentityModel exception messages can embed token claim values, which must not reach the logs.
+    //
+    // This return value therefore does NOT get per-shape reason codes the way the back-channel logout
+    // path does (#1166, decided; the codes there are RejectReason in OidcLogoutTokenValidator.cs, and
+    // #1039 tracks splitting them further). The string is consumed by the library, not only read by an
+    // operator, so the two signature exceptions above must keep collapsing to one value: split them and
+    // the JWKS refresh stops firing for the key-found-but-signature-bad shape, turning a signing-key
+    // rotation into a hard login failure instead of a self-healing retry. That is an availability
+    // regression bought for a diagnostic, which is the wrong trade on a login path. The shapes that do
+    // not participate in the refresh already differ from each other by exception type name above, and
+    // that is diagnostic text rather than a stable code - anything wanting a stable operator-facing code
+    // for the id_token path needs its own audit surface and must not reuse this string.
     private static string MapError(Exception? exception) => exception switch
     {
         SecurityTokenSignatureKeyNotFoundException => "invalid_signature",


### PR DESCRIPTION
# What & why

#1166 asks a question and accepts either answer. The answer is no, and the reason now lives at the mapping site instead of only in the tracker.

`MapError` in `SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs` does not return an operator-facing string. `OidcClient`'s response processor keys on the exact value `invalid_signature` and reacts by refreshing the discovery JWKS and retrying once, which is what heals a signing-key rotation between discovery and callback. `SecurityTokenSignatureKeyNotFoundException` and `SecurityTokenInvalidSignatureException` both map there on purpose: after a rotation an IdP may reuse a `kid` with new material, so a signature failing against a known key has to trigger the refresh too.

Giving those two shapes their own codes, which is what #1039 does on the `logout_token` path, would stop the refresh firing for the key-found-but-signature-bad shape. A key rotation would then be a hard login failure instead of a self-healing retry. That is an availability regression bought for a diagnostic, on a login path, and it is refused.

The rest of the answer is worth stating precisely, because "cannot carry per-shape detail" would be too strong: the shapes that do not participate in the refresh already differ from one another, through `exception.GetType().Name` in the `_` arm. That is diagnostic text, not a stable code, and it is what an operator has on this path. Anything wanting a stable per-shape code for the id_token path needs its own audit surface and must not reuse this string. The fixed codes that do exist are `RejectReason` in `OidcLogoutTokenValidator.cs`.

Comment only. `MapError`'s arms are byte-identical.

Closes #1166

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The file is on the OIDC validation surface, so the first, second and fifth boxes are answered rather than skipped: they hold because no executable line changed. The third and fourth stay unticked. No review lens was run and none was owed, since the diff contains no statement, no expression and no attribute:

```
git diff --name-only origin/main...HEAD
SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
git diff origin/main...HEAD | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -v '^[+-] *//'
(no output)
```

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The third box is the one worth defending, since the change is nothing but a comment. It explains why the collapse of two exceptions into one value is deliberate, which is not readable from the code: the two arms look like an accident until you know a consumer keys on the value. That is a why, and the rule this repo applies is that a why belongs in a comment rather than in a name.

The fourth box: no new structural property, so no new conformance rule. The conformance suite runs unchanged in CI on this PR.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgeführt.  0 Warnung(en)  0 Fehler
```

The test suite was not run on this machine, see #1227, so that box stays unticked rather than ticked on an assumption. This PR's own CI runs it. The third box has no subject: no `.js`, `.html`, `.md`, `.css` or `.scss` file is touched.

What a green suite proves here is narrow and worth saying: it proves the three `Assert.Equal("invalid_signature", result.Error)` pins in `OidcIdTokenValidatorTests` still hold, which is what a decision to leave `MapError` alone should look like from the outside. It proves nothing about the decision itself.

## Notes

The `OidcClient` contract is the load-bearing premise, and here is exactly how far it was checked. The literal is present in the library assembly:

```
node -e "const b=require('fs').readFileSync(PKG+'/lib/net10.0/Duende.IdentityModel.OidcClient.dll'); console.log(b.toString('utf16le').includes('invalid_signature'))"
true
```

That shows the string exists in `Duende.IdentityModel.OidcClient` 7.1.0, which is the version this project resolves. It does NOT show the library's control flow around it, and no attempt was made to decompile or trace that. The behavioural claim, that the processor refreshes the JWKS and retries once, is carried by the existing comment and by `SSO-Auth/Api/Flows/OidcLoginService.cs:768`, and it is inherited here rather than re-measured. If someone wants it measured, the shape is a round-trip test that rotates the signing key mid-flow and asserts one refresh, and that is its own issue rather than this one.

Reviewers: this change had no second reader. Nobody but its author has read it, so the reasoning above stands in place of one.

<details>
<summary>Verification notes</summary>

The contract premise was checked exactly as far as stated above: the string exists in the library assembly at the version this project resolves. The library's control flow was not traced and not decompiled. The behavioural claim is inherited rather than re-measured, and the text says so in both places.

</details>
