### PR TITLE
Decide and pin the JWKS-side kid posture: advertised keys are not screened [#1029]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
@@ -182,6 +182,81 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
         Assert.Equal("user-1", result.Subject);
     }
 
+    /// <summary>
+    /// The other half of the same question (#1029): a <c>kid</c> the PROVIDER advertises in its JWKS,
+    /// outside the same allowlist. These are the shapes that turn up in the field - a standard-base64
+    /// thumbprint rather than a base64url one is the common case, because the two alphabets differ in
+    /// exactly the characters the allowlist excludes.
+    /// </summary>
+    public static TheoryData<string> OutOfAllowlistAdvertisedKeyIds() => new()
+    {
+        "ab+cd/ef=",              // standard base64 rather than base64url: + / =
+        "signing key 2026",       // spaces
+        "kid:2026:rotate",        // colons, the shape of a namespaced identifier
+    };
+
+    [Theory]
+    [MemberData(nameof(OutOfAllowlistAdvertisedKeyIds))]
+    public void AdvertisedKeyOutsideTheAllowlist_IsKept(string keyId)
+    {
+        // THE DECISION, pinned: the allowlist screens the needle, never the haystack. An advertised key is
+        // skipped only when it is unusable AS A KEY - not a signing key, under the RSA floor, un-decodable
+        // material - and the spelling of its kid is none of those. Skipping it would refuse a
+        // well-behaved provider over an alphabet choice and take its signature verification down with it,
+        // which is a real outage traded for nothing: the header screen already stops a hostile kid from
+        // reaching the lookup, and this value is what the lookup is searched THROUGH.
+        Assert.False(OidcSignatureKeys.IsAcceptableKeyId(keyId), "row is not actually outside the allowlist");
+
+        var ephemeral = new List<IDisposable>();
+        try
+        {
+            var keys = OidcSignatureKeys.Convert(new Duende.IdentityModel.Jwk.JsonWebKeySet(Jwks(keyId)), ephemeral);
+
+            var key = Assert.Single(keys);
+            Assert.Equal(keyId, key.KeyId);
+        }
+        finally
+        {
+            foreach (var disposable in ephemeral)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfAllowlistAdvertisedKeyIds))]
+    public async Task TokenWithoutAKid_StillValidatesAgainstSuchAKey(string keyId)
+    {
+        // "Kept" is not the same as "usable", so the decision is pinned end to end as well: the provider
+        // advertises only this key, the token names no key, and the signature still verifies. Without this
+        // row, a change that kept the key but made it unreachable would leave the row above green.
+        var token = CreateTokenWithoutKid();
+        Assert.True(string.IsNullOrEmpty(new JsonWebToken(token).Kid), "the token was supposed to carry no kid");
+
+        var result = await _idTokenValidator.ValidateAsync(token, Options(keyId), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfAllowlistAdvertisedKeyIds))]
+    public async Task TokenNamingSuchAKeyByKid_IsStillRefused(string keyId)
+    {
+        // And the cost of the decision, stated rather than left to be discovered: such a key can be reached
+        // by trying every advertised key, but never BY NAME, because naming it means putting the same
+        // characters in the token header where the screen refuses them. A provider that advertises one of
+        // these AND mints tokens carrying it therefore does not log anyone in - which is a configuration
+        // this repository cannot verify against a live IdP, so it is recorded here rather than claimed to
+        // be impossible.
+        var result = await _idTokenValidator.ValidateAsync(
+            CreateToken(keyId: keyId), Options(keyId), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Contains("unacceptable kid", result.Error, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task ValidToken_OnBothPaths_StillSucceeds()
     {
@@ -222,6 +297,24 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
         var p = _rsa.ExportParameters(false);
         return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + keyId + "\","
             + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
+    }
+
+    // A token signed by the same RSA key but carrying no kid header, so key resolution has to fall back to
+    // trying every advertised key. The signing credentials get no KeyId, which is what leaves the header
+    // member out; the caller asserts the absence rather than trusting it.
+    private string CreateTokenWithoutKid()
+    {
+        var now = DateTime.UtcNow;
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa), SecurityAlgorithms.RsaSha256),
+        });
     }
 
     private string CreateToken(string keyId = KeyId, IDictionary<string, object>? claims = null)

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -168,6 +168,17 @@ internal static class OidcSignatureKeys
     /// Converts the advertised JWKS into usable signing keys, skipping any key that is null, not a signing
     /// key (<c>use != "sig"</c>), under the RSA size floor (#733), or of un-decodable/invalid material - so
     /// one broken key in the set cannot take down verification against a good one. Never throws.
+    /// <para>
+    /// The <c>kid</c> the PROVIDER advertises is deliberately NOT screened against
+    /// <see cref="IsAcceptableKeyId"/>, and that is a decision rather than an omission (#1029). Every
+    /// exclusion above is a key that cannot do the job; a spelling is not one of them. The two sides of a
+    /// lookup are not symmetric: the token header is the needle and arrives from outside, the advertised
+    /// <c>kid</c> is what the haystack is searched THROUGH, and refusing a key over its alphabet - a
+    /// standard-base64 thumbprint rather than a base64url one is the ordinary case - would take a
+    /// well-behaved provider's signature verification down for nothing the header screen does not already
+    /// stop. The cost that comes with it is that such a key is reachable by trying every advertised key
+    /// but never by name, and <c>OidcSignatureKeysKidTests</c> pins both halves.
+    /// </para>
     /// </summary>
     /// <param name="keySet">The advertised JSON Web Key Set (may be null/empty).</param>
     /// <param name="ephemeralKeys">Collects disposable ECDsa handles for the caller to release.</param>


### PR DESCRIPTION
# What & why

Closes #1029.

Three of this issue's four acceptance criteria were met by #1167 (PR #1221). The one left is
the mirror of the question that issue answered: a `kid` the PROVIDER advertises in its JWKS,
outside the same allowlist. This decides it, records the reason where the converter is read,
and pins both halves of the consequence.

**The decision: an advertised key is not screened on the spelling of its `kid`.**

The two sides of a key lookup are not symmetric. The token header is the needle and arrives
from outside, which is what #1167's screen is for. The advertised `kid` is what the haystack
is searched *through*. Every existing skip in `Convert` / `TryConvertSigningKey` is a key that
cannot do the job - a null entry, `use != "sig"`, under the RSA size floor (#733), un-decodable
or invalid material - and an alphabet choice is not one of those.

The realistic case decides it. A standard-base64 thumbprint rather than a base64url one differs
from the allowlist in exactly the characters the allowlist excludes (`+`, `/`, `=`). Skipping
such a key refuses a well-behaved provider over a spelling and takes its signature verification
down with it, and buys nothing the header screen does not already stop.

## The cost, written down rather than discovered

Such a key is reachable by trying every advertised key, and never **by name** - naming it means
putting the same characters in the token header, where the screen refuses them. A provider that
both advertises one of these shapes and mints tokens carrying it therefore does not log anyone
in.

That combination cannot be verified here against a live IdP, so it is recorded as the cost of
the decision rather than claimed to be impossible. `TokenNamingSuchAKeyByKid_IsStillRefused` is
the row that holds it, and it is deliberately an assertion about the *current* posture: if a
later change makes the header screen consult the advertised set, that row goes red and this
paragraph is what the reader will find.

## The three rows, and why none of them is redundant

- `AdvertisedKeyOutsideTheAllowlist_IsKept` - the key survives conversion with its `kid` intact.
  Also asserts the row is genuinely outside the allowlist, so the theory data cannot rot into a
  set of acceptable values and stay green.
- `TokenWithoutAKid_StillValidatesAgainstSuchAKey` - kept is not usable. The provider advertises
  only this key, the token names none, and the signature verifies end to end. Without this row a
  change that kept the key but made it unreachable would leave the first row green. The test
  asserts the token really carries no `kid` rather than trusting the helper to omit it.
- `TokenNamingSuchAKeyByKid_IsStillRefused` - the cost above.

## Type of change

- [x] Security hardening / vulnerability fix

(It ships no behaviour change. It is filed here rather than under docs because what it settles is
a login-path validation posture, and the record it adds is the thing a later change has to argue
with.)

## Security checklist

- [x] Fail-closed preserved. Nothing in the diff relaxes a check: the header screen from #1167 is
      untouched, and the converter's exclusions (null entry, `use != "sig"`, RSA size floor,
      un-decodable material) are untouched. The decision is to leave one thing unscreened that was
      never screened, and the third test row pins that the screen which does exist still bites.
- [x] No secrets logged; secrets redacted on config export. No logging is added.
- [ ] A security review was performed. **No adversarial review was run on this change.** This line
      is the disclosure, not a waiver.
- [ ] Review record. **None exists. Nothing here was read by a second person.**
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added. Worth
      noting for whoever adds one: the advertised `kid` is now explicitly documented as
      unconstrained, so a future log line carrying it needs its own inline sanitation - it does not
      inherit one from this decision.

## Quality checklist

- [x] No duplicated logic. No production logic is added at all; the tests reuse the existing
      `Jwks` / `Options` / `CreateToken` helpers in the file, and the one new helper exists only to
      omit the `kid`.
- [x] The change adds no more code than the problem requires.
- [x] Comments say why, not what.
- [x] Architecture-conformance: no new structural property, no new file, no new type. The rows go
      into the file that already owns the `kid` question so there is one home for it rather than
      two.
- [x] Docs impact: none. Nothing user-facing, no config, no admin surface, no wiki page describes
      JWKS conversion. The record belongs at the converter, and that is where it is.

## Verification

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.    0 Warnung(en)    0 Fehler
$ git status --short
 M SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
 M SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
```

- [x] `dotnet build --warnaserror` green on both target frameworks, 0 warnings. Both
      `packages.lock.json` files are unmodified after both builds, which is the `git status`
      above.
- [ ] `dotnet test`: **not run locally.** The suite raises a Windows elevation prompt on this
      machine, which is #1227, and running it is not something this change is worth interrupting
      somebody for. **So the three new rows have never been executed here.** CI is the judge of
      whether they pass, and if it reds this body is wrong about the posture rather than the tests
      being wrong about the code - `TokenWithoutAKid_StillValidatesAgainstSuchAKey` is the row that
      would say so, and a red there would be a finding about key resolution worth its own issue.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is in the diff.

## Notes

The other three criteria of #1029, for the record, all landed with #1167 and are read off `main`
rather than restated from memory:

```
$ git show origin/main:SSO-Auth/Api/Oidc/OidcSignatureKeys.cs | grep -n "IsAcceptableKeyId\|MaxKeyIdLength" | head -4
32:    private const int MaxKeyIdLength = 256;
54:    /// set only, up to <see cref="MaxKeyIdLength"/>.
70:    internal static bool IsAcceptableKeyId(string? keyId)
77:        if (keyId.Length > MaxKeyIdLength)
```

with the per-character-class negatives and the real-world compatibility rows in
`SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs`, on both the id_token and the `logout_token`
path.
