### PR TITLE
Evidence run for the commit-message character set gate

### DIFF
--- a/.charset-evidence.txt
+++ b/.charset-evidence.txt
@@ -1,0 +1,1 @@
+evidence run for the commit-message character set gate

--- a/.charset-evidence.txt
+++ b/.charset-evidence.txt
@@ -1,2 +1,3 @@
 evidence run for the commit-message character set gate
 second
+third

--- a/.charset-evidence.txt
+++ b/.charset-evidence.txt
@@ -1,1 +1,2 @@
 evidence run for the commit-message character set gate
+second


### PR DESCRIPTION
Evidence run for #1006, not for merging. It exists so the new check is observed failing in CI rather than asserted to fail.

Three commits, and only the OLDEST carries a token outside the permitted set, in the body, under a clean subject. That is both the shape that escaped before and the proof that the whole PR range is walked rather than only the tip.

This PR will be closed unmerged once the pr-hygiene job log is quoted on #1006's own pull request. It targets that pull request's branch rather than main, because the check being demonstrated does not exist on main yet.

Refs #1006

The job log is quoted on #1265, which is #1006's own pull request. This branch has served its purpose and is closed unmerged.