### PR TITLE
Admit a case-variant member repeat, and pin the decision [#1191]

### DIFF
--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Xunit;
 
@@ -41,6 +43,11 @@ public class StrictJsonTests
     // would report Repeated for a document whose two members are not the same name. That is a false
     // accusation against a provider, which is the one direction a screen must never fail in.
     private const string TwoRawLoneSurrogateNames = "{\"a\uD800\":1,\"a\uDC00\":1}";
+
+    // Two member names differing only in case, carrying two DIFFERENT values. This is the document the
+    // recorded decision on #1191 is about, and it is a fixture rather than a literal inside one test
+    // because the same bytes are read three ways below.
+    private const string CaseVariantIssuers = "{\"issuer\":\"https://good.example\",\"ISSUER\":\"https://evil.example\"}";
 
     // A UTF-8 BOM, which a provider serving a BOM-prefixed file emits. Utf8JsonReader treats it as
     // content, so without stripping it every such document reads as malformed - and Unreadable is a
@@ -106,6 +113,12 @@ public class StrictJsonTests
         "{\"issuer\":\"https://one.example\",\"token_endpoint\":\"https://one.example/token\","
             + "\"mtls_endpoint_aliases\":{\"token_endpoint\":\"https://mtls.one.example/token\","
             + "\"userinfo_endpoint\":\"https://mtls.one.example/userinfo\"}}",
+
+        // The recorded decision of #1191: names differing only in case are two members, so this document is
+        // admitted. It sits in the corpus rather than only in its own test so that reversing the decision -
+        // one word, StringComparer.Ordinal to StringComparer.OrdinalIgnoreCase - fails the corpus theory
+        // as well as the row that argues the decision.
+        CaseVariantIssuers,
     };
 
     private static readonly string[] Unreadable =
@@ -203,10 +216,71 @@ public class StrictJsonTests
     [Fact]
     public void NamesDifferingOnlyInCase_AreClean()
     {
-        // JSON member names are case-sensitive and every consumer of these documents compares them ordinally,
-        // so folding case here would refuse a document none of them reads as ambiguous.
+        // The decision of #1191, and it is a decision rather than a fact about JSON consumers in general.
+        // JSON member names are case-sensitive, and every reader on the plugin's own path INDEXES a name it
+        // spells itself - PkceDiscovery and OidcResponseIssuer both JObject.Parse and index, JsonDocument
+        // indexes, and the identity library's typed mapping is case-sensitive - so a case-variant pair is
+        // unambiguous to all of them. Refusing it would take offline a provider whose document none of its
+        // consumers misreads, and the walk compares EVERY member at every scope, so the pair that took the
+        // provider down could be two unrelated vendor extensions rather than anything a login rests on.
         Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("{\"issuer\":1,\"Issuer\":2}", out _));
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(CaseVariantIssuers, out _));
     }
+
+    [Fact]
+    public void WhatAdmittingACaseVariantPairLeavesOpen_IsMeasuredRatherThanAssumed()
+    {
+        // The cost of that decision, measured on the exact bytes rather than asserted about consumers in
+        // general - the earlier comment here claimed every consumer compares ordinally, which is not
+        // established and is false for the case-folding shape below.
+        //
+        // One document, three readers, three answers. An indexing reader takes the lowercase value; a
+        // deserializer configured case-insensitively - which is what JsonSerializerDefaults.Web gives you,
+        // and what any PropertyNameCaseInsensitive = true option carries - resolves both spellings onto one
+        // property and keeps the LAST, so it takes the other one; a case-sensitive deserializer with no
+        // naming policy matches neither spelling and reads nothing at all.
+        //
+        // No reader on the plugin's current login path is the second kind, which is why the pair is
+        // admitted. This row is what makes that a bounded claim instead of a hope: if a future reader on
+        // this path folds case, the divergence it would inherit is already written down here.
+        using var document = JsonDocument.Parse(CaseVariantIssuers);
+        Assert.Equal("https://good.example", document.RootElement.GetProperty("issuer").GetString());
+
+        var caseFolding = JsonSerializer.Deserialize<IssuerCarrier>(CaseVariantIssuers, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        Assert.Equal("https://evil.example", caseFolding!.Issuer);
+
+        var caseSensitive = JsonSerializer.Deserialize<IssuerCarrier>(CaseVariantIssuers, new JsonSerializerOptions());
+        Assert.Null(caseSensitive!.Issuer);
+
+        // And the fourth reading, which is the one the decision rests on: a reader that spells both names
+        // gets both values, because they are two members. Nothing is lost by admitting the document.
+        var bothSpellings = JsonSerializer.Deserialize<CaseVariantCarrier>(CaseVariantIssuers, new JsonSerializerOptions());
+        Assert.Equal("https://good.example", bothSpellings!.Lower);
+        Assert.Equal("https://evil.example", bothSpellings.Upper);
+    }
+
+#if NET10_0_OR_GREATER
+    [Fact]
+    public void TheStrictPresetTakesTheSameDecisionOnCase()
+    {
+        // #1043 replaces this walk with JsonSerializerOptions.Strict once net9.0 is dropped, so the decision
+        // above may not contradict what that preset does with case without saying so. It does not, and this
+        // is the measurement rather than a reading of the documentation: Strict refuses a member named twice
+        // and does not treat a case-variant pair as one, which is this walk's posture in both directions.
+        //
+        // Compiled only on net10.0 because the preset does not exist in the .NET 9 System.Text.Json the
+        // Jellyfin 10.11 line binds - referencing it there fails the build with CS0117, which is the same
+        // reason StrictJson is a hand-rolled walk at all.
+        // One carrier for both rows, so the only difference between them is the repeat itself and not which
+        // members happened to bind.
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<CaseVariantCarrier>("{\"issuer\":\"a\",\"issuer\":\"b\"}", JsonSerializerOptions.Strict));
+
+        var admitted = JsonSerializer.Deserialize<CaseVariantCarrier>(CaseVariantIssuers, JsonSerializerOptions.Strict);
+        Assert.Equal("https://good.example", admitted!.Lower);
+        Assert.Equal("https://evil.example", admitted.Upper);
+    }
+#endif
 
     [Fact]
     public void EscapeSpelledName_CountsAsItsPlainSpelling()
@@ -278,5 +352,24 @@ public class StrictJsonTests
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(null, out _));
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(string.Empty, out _));
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("   ", out _));
+    }
+
+    // The shape a deserializer binds the discovery issuer onto. The property is spelled in the CLR casing a
+    // real binding target would carry, which is what makes the naming policy and the case-insensitivity
+    // setting decide the answer.
+    private sealed class IssuerCarrier
+    {
+        public string? Issuer { get; set; }
+    }
+
+    // Both spellings bound explicitly, so a reader can tell a refusal caused by the repeat from one caused
+    // by a member that simply did not map.
+    private sealed class CaseVariantCarrier
+    {
+        [JsonPropertyName("issuer")]
+        public string? Lower { get; set; }
+
+        [JsonPropertyName("ISSUER")]
+        public string? Upper { get; set; }
     }
 }

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -108,13 +108,25 @@ internal static class StrictJson
     /// readers rather than a fact about consumers, see below - and AFTER unescaping, so a name spelled with a
     /// <c>\u</c> escape counts as the same name as its plain spelling.
     ///
-    /// Ordinal is a decision about THIS plugin's readers, not a fact about JSON consumers in general, and the
-    /// difference matters: a deserializer configured case-insensitively - which is what
+    /// Ordinal is a DECISION about this plugin's readers (#1191), not a fact about JSON consumers in general,
+    /// and the difference matters: a deserializer configured case-insensitively - which is what
     /// <c>JsonSerializerDefaults.Web</c> gives you - resolves <c>ISSUER</c> onto <c>Issuer</c> and keeps the
-    /// last occurrence, while an indexing reader over the same bytes returns the first. The plugin's own
-    /// discovery readers index, so a case-variant pair is unambiguous to them and refusing it would take a
-    /// working provider offline; whether that holds for every consumer this walk may acquire is not settled
-    /// here and is tracked separately.
+    /// last occurrence, while an indexing reader over the same bytes returns the first. Both readings are
+    /// measured, on those bytes, in <c>WhatAdmittingACaseVariantPairLeavesOpen_IsMeasuredRatherThanAssumed</c>.
+    ///
+    /// A case-variant pair is therefore ADMITTED, and what each direction costs is this. Refusing one takes
+    /// offline a provider whose document no reader on this login path misreads - every one of them indexes a
+    /// name it spells itself - and because every member at every scope is compared, the pair that took the
+    /// provider down need not be a member a login rests on at all; two unrelated vendor extensions differing
+    /// in case would do it. Admitting one costs nothing to any reader present today and leaves one thing
+    /// open: a future consumer on this path that folds case would answer differently from the indexing
+    /// readers beside it, and the divergence it would inherit is written down in that same row rather than
+    /// left to be rediscovered. Not established, and so not claimed: that no consumer anywhere folds case.
+    ///
+    /// .NET 10's <c>JsonSerializerOptions.Strict</c>, which #1043 replaces this walk with once net9.0 is
+    /// dropped, takes the same decision in both directions - it refuses a member named twice and does not
+    /// treat a case-variant pair as one. Measured on net10.0 in <c>TheStrictPresetTakesTheSameDecisionOnCase</c>,
+    /// so the replacement inherits this posture rather than contradicting it.
     ///
     /// Never throws.
     /// </returns>


### PR DESCRIPTION
# What & why

`StrictJson` compares member names ordinally, so a document naming both `issuer`
and `ISSUER` with different values is `Clean`. That was a choice, and nothing
recorded it as one: the test comment beside it asserted that every consumer of
these documents compares ordinally, which is not established and is wrong for a
deserializer configured case-insensitively.

This records the decision, states what each direction costs, and pins the chosen
one so reversing it breaks the build.

**The decision: a case-variant pair is admitted.**

Refusing one would take offline a provider whose document no reader on this login
path misreads. Every reader here indexes a name it spells itself, and because the
walk compares every member at every scope, the pair that took the provider down
need not be a member a login rests on at all - two unrelated vendor extensions
differing only in case would do it. Admitting one costs no present reader
anything and leaves exactly one thing open: a future consumer on this path that
folds case would answer differently from the indexing readers beside it.

That residual is measured rather than asserted, on the exact bytes:

- an indexing reader (`JsonDocument.GetProperty`) answers the lowercase value
- a case-folding deserializer (`JsonSerializerDefaults.Web`) answers the uppercase one
- a case-sensitive deserializer with no naming policy answers nothing at all
- a reader spelling both names gets both values, which is why nothing is lost by admitting

What is not established, and so is not claimed anywhere in the change: that no
consumer anywhere folds case.

Closes #1191

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: this changes no verdict. The walk's behaviour is
      byte-identical before and after; what changes is a doc comment, a test
      comment that carried an unmeasured claim, and the fixtures that pin the
      posture.
- [x] No secrets logged; secrets are redacted on config export. No logging is
      touched.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **No second reader was
      available for this change.** The evidence below stands in place of one
      rather than the box being ticked.
- [ ] Review record: not applicable - no review was run, see above.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged;
      no log call is added or moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No structural property is established here.
- [x] Docs impact considered: no README or wiki surface describes the
      case-variant posture. The Hardening and Options Reference page is where the
      repeated-member refusal is documented, and #1063 already owns that page.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - both target frameworks,
      0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
      Der Buildvorgang wurde erfolgreich ausgefuehrt. 0 Warnung(en) 0 Fehler

      `git status --porcelain -- '*packages.lock.json'` is empty after both.

- [ ] `dotnet test` is green. **Not run on this machine.** The suite raises a
      Windows elevation prompt here (#1227), so it was not run locally at all,
      with or without a filter. The checks on this pull request are the judge of
      the suite, and this box stays unticked rather than being answered from a
      build.
- [x] Prettier is clean: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

**How the pin was shown to bite.** The corpus row is only worth its line if
reversing the decision fails the suite. One word - `StringComparer.Ordinal` to
`StringComparer.OrdinalIgnoreCase` in the walk's per-scope name set - is the
reversal, and it is carried on a separate evidence branch so this branch's
history stays honest. The failing run is linked from #1191 with its output.

The `JsonSerializerOptions.Strict` row compiles only on net10.0: the preset does
not exist in the .NET 9 System.Text.Json the Jellyfin 10.11 line binds, which is
the same reason `StrictJson` is a hand-rolled walk in the first place.

Out of scope, and the sibling issue: whether an invalid escape folds two member
names into one (#1197). The parent #1073 covers both.
