### PR TITLE
Refuse an invalid escape rather than folding two names into one [#1197]

### DIFF
--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -44,6 +44,13 @@ public class StrictJsonTests
     // accusation against a provider, which is the one direction a screen must never fail in.
     private const string TwoRawLoneSurrogateNames = "{\"a\uD800\":1,\"a\uDC00\":1}";
 
+    // The same pair spelled as ESCAPES, which is the shape #1197 decides. It reaches a different arm: the
+    // escape is thirteen ASCII bytes the encoder is perfectly happy with, and the refusal comes from the
+    // decoder inside GetString instead. No name is produced for either member, so the walk cannot fold the
+    // two into one however it compares names - which is why the answer here is forced by the decoder rather
+    // than chosen by this walk.
+    private const string TwoEscapedLoneSurrogateNames = "{\"a\\ud800\":1,\"a\\udc00\":1}";
+
     // Two member names differing only in case, carrying two DIFFERENT values. This is the document the
     // recorded decision on #1191 is about, and it is a fixture rather than a literal inside one test
     // because the same bytes are read three ways below.
@@ -128,6 +135,7 @@ public class StrictJsonTests
         LoneSurrogateName,
         RawLoneSurrogateName,
         TwoRawLoneSurrogateNames,
+        TwoEscapedLoneSurrogateNames,
     };
 
     public static TheoryData<string, string> RepeatedFixtures()
@@ -293,16 +301,54 @@ public class StrictJsonTests
         Assert.Equal("issuer", repeated);
     }
 
+    [Fact]
+    public void NamesDifferingOnlyInAnInvalidEscape_AreNeverFoldedIntoOne()
+    {
+        // The decision of #1197, and the direction matters: this is the FALSE-REFUSAL side. A verdict of
+        // Repeated on a document whose two members are not the same name is an accusation against a
+        // provider, and Unreadable is a refusal too - both cost the provider its login - so the choice is
+        // between two refusals and is made on which one is honest about the bytes.
+        //
+        // An invalid escape establishes no name at all. Spelled raw, the char has no UTF-8 encoding and the
+        // encoder refuses the document before the walk starts; spelled as an escape, the decoder inside
+        // GetString refuses the name it cannot complete. Either way the walk never holds two names to
+        // compare, so it reports that nothing was established rather than that a member was named twice.
+        //
+        // The alternative - decoding leniently, which is what the platform default does - is what makes the
+        // fold: every unpaired surrogate becomes U+FFFD, so two different names collapse to one key and the
+        // walk reports Repeated for a document that has no repeat. That is the false accusation, and it is
+        // the reason the strict encoder is here rather than a tidier default.
+        //
+        // The cost of the decision, stated rather than implied: a provider whose document names a member
+        // with an unpaired surrogate is refused, and a lenient reader downstream would have read that
+        // document. It is refused because no verdict about its members would be a verdict about the bytes
+        // its consumers see.
+        foreach (var json in new[] { TwoEscapedLoneSurrogateNames, TwoRawLoneSurrogateNames })
+        {
+            var verdict = StrictJson.Inspect(json, out var repeated);
+
+            Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
+            Assert.NotEqual(StrictJson.Verdict.Repeated, verdict);
+            Assert.Null(repeated);
+        }
+
+        // The positive control the pair needs: a VALID escape does fold, and must, or an attacker spells one
+        // of two occurrences differently and walks past the screen. The two rules are neighbours and it is
+        // the difference between them that this row protects.
+        Assert.Equal(StrictJson.Verdict.Repeated, StrictJson.Inspect("{\"\\u0061\":1,\"a\":2}", out _));
+    }
+
     [Theory]
     [MemberData(nameof(UnreadableFixtures))]
     public void HostileInput_IsUnreadable_NeverThrows(string json)
     {
         // One fixture per raised type, because each is raised by a different party and a walk that catches
         // one hands the others to a caller that catches none. `not-json` and the truncation raise
-        // JsonException from the reader. The thirteen bytes of LoneSurrogateName raise
-        // InvalidOperationException from GetString, NOT JsonException. The two RAW surrogate fixtures raise
-        // EncoderFallbackException from the encoder, before any of the walk has run. Unreadable is what the
-        // caller refuses on, so the fail-closed direction holds for all three.
+        // JsonException from the reader. The ESCAPED surrogate fixtures - LoneSurrogateName and the pair in
+        // TwoEscapedLoneSurrogateNames - are thirteen ASCII bytes each and raise InvalidOperationException
+        // from GetString, NOT JsonException. The two RAW surrogate fixtures raise EncoderFallbackException
+        // from the encoder, before any of the walk has run. Unreadable is what the caller refuses on, so the
+        // fail-closed direction holds for all three.
         var verdict = StrictJson.Inspect(json, out var repeated);
 
         Assert.Equal(StrictJson.Verdict.Unreadable, verdict);

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -123,6 +123,18 @@ internal static class StrictJson
     /// readers beside it, and the divergence it would inherit is written down in that same row rather than
     /// left to be rediscovered. Not established, and so not claimed: that no consumer anywhere folds case.
     ///
+    /// An INVALID escape is the opposite question and has the opposite answer (#1197): it establishes no name
+    /// at all, so two members spelled with one are never folded into a single key. A raw unpaired surrogate
+    /// has no UTF-8 encoding and the document is refused before the walk starts; an escaped one is a name the
+    /// decoder cannot complete, and <c>GetString</c> refuses it. Either way the walk never holds two names to
+    /// compare and reports <see cref="Verdict.Unreadable"/> - nothing was established - rather than
+    /// <see cref="Verdict.Repeated"/>. The alternative is what a lenient decoder gives you: every unpaired
+    /// surrogate becomes U+FFFD, two different names collapse to one, and the walk accuses a provider of a
+    /// repeat its document does not contain. Both verdicts refuse the document, so the choice is between two
+    /// refusals and is made on which is honest about the bytes; the cost, stated rather than implied, is that
+    /// a provider naming a member with an unpaired surrogate is locked out of a login a lenient reader
+    /// downstream would have completed.
+    ///
     /// .NET 10's <c>JsonSerializerOptions.Strict</c>, which #1043 replaces this walk with once net9.0 is
     /// dropped, takes the same decision in both directions - it refuses a member named twice and does not
     /// treat a case-variant pair as one. Measured on net10.0 in <c>TheStrictPresetTakesTheSameDecisionOnCase</c>,


### PR DESCRIPTION
# What & why

#1073 asked which spellings count as one member name. #1191 answered the case
half; this is the other one, and it runs in the opposite direction: not a repeat
the walk lets through, but a repeat it might report where the document has none.

**The decision: an invalid escape establishes no name, so two members spelled
with one are never folded into a single key.** Spelled raw, the char has no UTF-8
encoding and the document is refused before the walk starts. Spelled as an
escape, it is a name the decoder inside `GetString` cannot complete and refuses.
Either way the walk never holds two names to compare, so the verdict is
`Unreadable` - nothing was established - and never `Repeated`.

The alternative is what a lenient decoder gives you, and it is worth naming
because it is the tidier-looking code: every unpaired surrogate becomes U+FFFD,
two genuinely different names collapse to one key, and the walk accuses a
provider of a repeat its document does not contain. Both verdicts refuse the
document at the seam, so this is a choice between two refusals, decided on which
one is honest about the bytes.

The cost, stated rather than implied: a provider naming a member with an unpaired
surrogate is locked out of a login that a lenient reader downstream would have
completed. It is refused because no verdict about that document's members would
be a verdict about the bytes its consumers see.

**What the issue described has already moved.** #1073 recorded the walk folding
such names and reporting `Repeated`. That was true of the replacement-fallback
decoding it had then; the throwing encoder replaced it, and the corpus carries
the raw pair as `Unreadable` today. The escaped pair - the same two names spelled
as escapes, which reaches a different arm entirely - was covered by no fixture at
all, so nothing stopped that half from regressing back. It is a corpus row now.

Closes #1197

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no verdict changes. Both spellings were refused
      before this change and are refused after it; what is added is the fixture
      that keeps the escaped one refused, and the reason in the source.
- [x] No secrets logged; secrets are redacted on config export. No logging is
      touched.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **No second reader was
      available for this change.** The evidence below stands in place of one
      rather than the box being ticked.
- [ ] Review record: not applicable - no review was run, see above.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; no
      log call is added or moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. No production logic is added at all - the change is a fixture, a row
      and the reasons.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No structural property is established here.
- [x] Docs impact considered: no README or wiki surface describes name identity
      inside the walk. #1063 owns the Hardening and Options Reference page where
      the repeated-member refusal is documented.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - both target
      frameworks, 0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
      Der Buildvorgang wurde erfolgreich ausgefuehrt. 0 Warnung(en) 0 Fehler

      `git status --porcelain -- '*packages.lock.json'` is empty after both.

- [ ] `dotnet test` is green. **Not run on this machine.** The suite raises a
      Windows elevation prompt here (#1227), so it was not run locally at all,
      with or without a filter. The checks on this pull request are the judge of
      the suite, and this box stays unticked rather than being answered from a
      build.
- [x] Prettier is clean: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

The positive control sits beside the new row on purpose: a VALID escape still
folds, and must, or an attacker spells one of two occurrences `\u0069ssuer` and
walks past the screen. The two rules are neighbours, and what the row protects is
the difference between them.

How the fold was shown to be a real alternative rather than a hypothetical one is
carried on a separate evidence branch and written into #1197 with its output.
