### PR TITLE
Report a lockfile a local build rewrote, at the moment it happens [#1150]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,8 +151,20 @@ Any code editor or IDE with .NET support will work out of the box with this prog
 dotnet restore                               # once on a fresh clone; the --no-restore flags below assume it
 dotnet build --no-restore --warnaserror      # warnings are errors, exactly as in CI
 dotnet test --no-build --verbosity normal    # the xUnit project SSO-Auth.Tests must stay green
+bash scripts/check-lockfiles.sh              # after building: no pinned lockfile may be left modified
 npx prettier --check --end-of-line auto "**/*.{js,html,md,css,scss}"   # for any .js/.html/.md/.css change
 ```
+
+`scripts/check-lockfiles.sh` is the last step because a restore rewrites a
+`packages.lock.json` whenever it resolves a version other than the pinned one,
+and nothing local says so. The usual cause is passing an explicit
+`-p:JellyfinVersion` to an ordinary build: the defaults in
+`SSO-Auth/SSO-Auth.csproj` are conditioned on that property being empty, so any
+value defeats them and the pins are rewritten under you. Left uncommitted it
+resurfaces later as an NU1004 restore failure in CI, which restores in
+`--locked-mode`. The script reports the drifted files and the command that
+restores them; it never reverts or commits anything itself, because the rewritten
+pins are the evidence for what caused the drift.
 
 `--end-of-line auto` is not optional on Windows. Prettier's default is `lf`,
 CI checks out on Linux, and a Windows checkout under `core.autocrlf=true` is

--- a/scripts/check-lockfiles.sh
+++ b/scripts/check-lockfiles.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# Lockfile drift gate (issue #1150): report every tracked packages.lock.json that a local build
+# modified, at the moment it happens.
+#
+# NuGet rewrites a lockfile whenever a restore resolves a package version other than the pinned one.
+# The usual cause on this repository is an explicit -p:JellyfinVersion on an ordinary local build:
+# both defaults in SSO-Auth/SSO-Auth.csproj are conditioned on that property being EMPTY, so any
+# value defeats them and restore re-pins every lockfile. Nothing local notices today - the drift is
+# found later in git status, or in CI where the --locked-mode restore fails with NU1004 after the
+# commit is already pushed.
+#
+# The set of lockfiles is derived from the index rather than listed here, so a project added later
+# is covered without editing this file, and an empty set fails instead of passing vacuously.
+#
+# This gate REPORTS. It never reverts and never commits: the drift is evidence about the build that
+# produced it, and discarding it would hide the cause along with the symptom.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+lockfiles=()
+while IFS= read -r path; do lockfiles+=("$path"); done < <(git ls-files -- '*packages.lock.json')
+
+if [[ ${#lockfiles[@]} -eq 0 ]]; then
+  echo "::error::no tracked packages.lock.json found - this gate would pass without checking anything" >&2
+  exit 1
+fi
+
+dirty=$(git status --porcelain -- "${lockfiles[@]}")
+
+if [[ -z "$dirty" ]]; then
+  echo "ok: ${#lockfiles[@]} tracked lockfile(s) unchanged"
+  exit 0
+fi
+
+drifted=()
+echo "::error::a local build modified pinned lockfile(s):" >&2
+while IFS= read -r line; do
+  echo "  ${line}" >&2
+  drifted+=("${line:3}")
+done <<<"$dirty"
+echo "Do not commit the rewritten pins. Inspect what re-pinned them, then restore with:" >&2
+echo "  git checkout -- ${drifted[*]}" >&2
+echo "Set no JellyfinVersion property on an ordinary local build: the csproj defaults are conditioned" >&2
+echo "on it being empty, so any explicit value re-pins both target frameworks." >&2
+exit 1


### PR DESCRIPTION
# What & why

A restore rewrites a `packages.lock.json` whenever it resolves a package version other than the pinned one, and nothing local says so. The usual cause is an explicit `-p:JellyfinVersion` on an ordinary build: both defaults in `SSO-Auth/SSO-Auth.csproj` are conditioned on that property being empty, so any value defeats them and the pins are rewritten. The drift is then found later in `git status`, or in CI, whose `--locked-mode` restore fails with NU1004 after the commit is already pushed.

`scripts/check-lockfiles.sh` reports it at the moment it happens, and `CONTRIBUTING.md` puts it in the local build sequence so it is run by anyone building locally rather than by one private copy of a command.

The file set is derived from the index (`git ls-files -- '*packages.lock.json'`) rather than listed in the script, so a project added later is covered without editing it, and an empty set fails rather than passing vacuously. The gate reports and never reverts or commits: the rewritten pins are the evidence for what caused the drift, and discarding them would hide the cause with the symptom.

Means: bash, because the two existing gate scripts in `scripts/` are bash, the whole check is one `git status` invocation, and it adds no runtime the tree does not already carry.

Closes #1150

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This change touches no login path, no SAML or OIDC validation, no config persistence and no release pipeline. It adds a shell script that reads `git status` and a paragraph in `CONTRIBUTING.md`.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The conformance box stays unticked because that suite was not run for this change. It polices the C# module structure, this change adds no C# and establishes no structural property, so there is nothing here for it to lock in, but "considered" is not "passes" and the box is not ticked on that basis. The CI run on this pull request is what executes it.

The docs half is included here rather than deferred: `CONTRIBUTING.md` carries the new step and the reason for it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

`dotnet test` was not run locally for this change, and the box stays unticked rather than being ticked on an assumption. Running the suite on this machine is blocked by #1227. The CI run on this pull request is what exercises it.

The build:

```
dotnet restore
dotnet build --no-restore --warnaserror
0 warnings, 0 errors                     (exit 0)
bash scripts/check-lockfiles.sh
ok: 4 tracked lockfile(s) unchanged      (the restore above left every pin intact)
```

Prettier:

```
npx prettier --check --end-of-line auto "CONTRIBUTING.md"
Checking formatting...
All matched files use Prettier code style!
```

The guard is proven by making it fire, on this branch:

```
# clean tree, one line of output
bash scripts/check-lockfiles.sh
ok: 4 tracked lockfile(s) unchanged            (exit 0)

# the deliberate cause from the issue, with obj cleared so the restore actually runs
rm -rf SSO-Auth/obj
dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0 -p:JellyfinVersion=10.11.11
bash scripts/check-lockfiles.sh
::error::a local build modified pinned lockfile(s):
   M SSO-Auth/packages.lock.json
Do not commit the rewritten pins. Inspect what re-pinned them, then restore with:
  git checkout -- SSO-Auth/packages.lock.json
Set no JellyfinVersion property on an ordinary local build: the csproj defaults are conditioned
on it being empty, so any explicit value re-pins both target frameworks.   (exit 1)

# the same drift staged, which is the one-character variant of the mistake
git add SSO-Auth/packages.lock.json
bash scripts/check-lockfiles.sh
::error::a local build modified pinned lockfile(s):
  M  SSO-Auth/packages.lock.json                                           (exit 1)

# the file is still modified after both failing runs, which is the no-revert half

# empty set, in a scratch repository with no lockfiles
bash <path>/check-lockfiles.sh
::error::no tracked packages.lock.json found - this gate would pass without checking anything  (exit 1)
```

The drift the third command produced was real, not simulated: `git diff --stat` reported 52 insertions and 52 deletions in `SSO-Auth/packages.lock.json`, with `Jellyfin.Controller` re-pinned from `12.0.0-rc2` to `10.11.11`. It was restored with `git checkout --` afterwards, and the branch carries no lockfile change.

## Notes

Two surfaces the issue names cannot be carried by a pull request, because the repository does not track them:

```
git check-ignore -v CLAUDE.md .claude
.gitignore:459:CLAUDE.md	CLAUDE.md
.gitignore:458:.claude/	.claude
```

So the shared checker lands here, and `CONTRIBUTING.md` is the tracked consumer that makes the step visible to anyone building locally. Wiring the same script into an untracked local command file is a local edit that no reviewer of this repository could see or verify, and it is not claimed here.

This change had no second reader. The evidence above stands in place of one: the guard is shown firing on the cause the issue names, on its staged variant, and on the vacuous-pass case, with the exit codes.
