### PR TITLE
Evidence run: decode leniently and watch the fold appear [#1197]

### DIFF
--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -44,6 +44,13 @@ public class StrictJsonTests
     // accusation against a provider, which is the one direction a screen must never fail in.
     private const string TwoRawLoneSurrogateNames = "{\"a\uD800\":1,\"a\uDC00\":1}";
 
+    // The same pair spelled as ESCAPES, which is the shape #1197 decides. It reaches a different arm: the
+    // escape is thirteen ASCII bytes the encoder is perfectly happy with, and the refusal comes from the
+    // decoder inside GetString instead. No name is produced for either member, so the walk cannot fold the
+    // two into one however it compares names - which is why the answer here is forced by the decoder rather
+    // than chosen by this walk.
+    private const string TwoEscapedLoneSurrogateNames = "{\"a\\ud800\":1,\"a\\udc00\":1}";
+
     // Two member names differing only in case, carrying two DIFFERENT values. This is the document the
     // recorded decision on #1191 is about, and it is a fixture rather than a literal inside one test
     // because the same bytes are read three ways below.
@@ -128,6 +135,7 @@ public class StrictJsonTests
         LoneSurrogateName,
         RawLoneSurrogateName,
         TwoRawLoneSurrogateNames,
+        TwoEscapedLoneSurrogateNames,
     };
 
     public static TheoryData<string, string> RepeatedFixtures()
@@ -293,16 +301,54 @@ public class StrictJsonTests
         Assert.Equal("issuer", repeated);
     }
 
+    [Fact]
+    public void NamesDifferingOnlyInAnInvalidEscape_AreNeverFoldedIntoOne()
+    {
+        // The decision of #1197, and the direction matters: this is the FALSE-REFUSAL side. A verdict of
+        // Repeated on a document whose two members are not the same name is an accusation against a
+        // provider, and Unreadable is a refusal too - both cost the provider its login - so the choice is
+        // between two refusals and is made on which one is honest about the bytes.
+        //
+        // An invalid escape establishes no name at all. Spelled raw, the char has no UTF-8 encoding and the
+        // encoder refuses the document before the walk starts; spelled as an escape, the decoder inside
+        // GetString refuses the name it cannot complete. Either way the walk never holds two names to
+        // compare, so it reports that nothing was established rather than that a member was named twice.
+        //
+        // The alternative - decoding leniently, which is what the platform default does - is what makes the
+        // fold: every unpaired surrogate becomes U+FFFD, so two different names collapse to one key and the
+        // walk reports Repeated for a document that has no repeat. That is the false accusation, and it is
+        // the reason the strict encoder is here rather than a tidier default.
+        //
+        // The cost of the decision, stated rather than implied: a provider whose document names a member
+        // with an unpaired surrogate is refused, and a lenient reader downstream would have read that
+        // document. It is refused because no verdict about its members would be a verdict about the bytes
+        // its consumers see.
+        foreach (var json in new[] { TwoEscapedLoneSurrogateNames, TwoRawLoneSurrogateNames })
+        {
+            var verdict = StrictJson.Inspect(json, out var repeated);
+
+            Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
+            Assert.NotEqual(StrictJson.Verdict.Repeated, verdict);
+            Assert.Null(repeated);
+        }
+
+        // The positive control the pair needs: a VALID escape does fold, and must, or an attacker spells one
+        // of two occurrences differently and walks past the screen. The two rules are neighbours and it is
+        // the difference between them that this row protects.
+        Assert.Equal(StrictJson.Verdict.Repeated, StrictJson.Inspect("{\"\\u0061\":1,\"a\":2}", out _));
+    }
+
     [Theory]
     [MemberData(nameof(UnreadableFixtures))]
     public void HostileInput_IsUnreadable_NeverThrows(string json)
     {
         // One fixture per raised type, because each is raised by a different party and a walk that catches
         // one hands the others to a caller that catches none. `not-json` and the truncation raise
-        // JsonException from the reader. The thirteen bytes of LoneSurrogateName raise
-        // InvalidOperationException from GetString, NOT JsonException. The two RAW surrogate fixtures raise
-        // EncoderFallbackException from the encoder, before any of the walk has run. Unreadable is what the
-        // caller refuses on, so the fail-closed direction holds for all three.
+        // JsonException from the reader. The ESCAPED surrogate fixtures - LoneSurrogateName and the pair in
+        // TwoEscapedLoneSurrogateNames - are thirteen ASCII bytes each and raise InvalidOperationException
+        // from GetString, NOT JsonException. The two RAW surrogate fixtures raise EncoderFallbackException
+        // from the encoder, before any of the walk has run. Unreadable is what the caller refuses on, so the
+        // fail-closed direction holds for all three.
         var verdict = StrictJson.Inspect(json, out var repeated);
 
         Assert.Equal(StrictJson.Verdict.Unreadable, verdict);

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -123,6 +123,18 @@ internal static class StrictJson
     /// readers beside it, and the divergence it would inherit is written down in that same row rather than
     /// left to be rediscovered. Not established, and so not claimed: that no consumer anywhere folds case.
     ///
+    /// An INVALID escape is the opposite question and has the opposite answer (#1197): it establishes no name
+    /// at all, so two members spelled with one are never folded into a single key. A raw unpaired surrogate
+    /// has no UTF-8 encoding and the document is refused before the walk starts; an escaped one is a name the
+    /// decoder cannot complete, and <c>GetString</c> refuses it. Either way the walk never holds two names to
+    /// compare and reports <see cref="Verdict.Unreadable"/> - nothing was established - rather than
+    /// <see cref="Verdict.Repeated"/>. The alternative is what a lenient decoder gives you: every unpaired
+    /// surrogate becomes U+FFFD, two different names collapse to one, and the walk accuses a provider of a
+    /// repeat its document does not contain. Both verdicts refuse the document, so the choice is between two
+    /// refusals and is made on which is honest about the bytes; the cost, stated rather than implied, is that
+    /// a provider naming a member with an unpaired surrogate is locked out of a login a lenient reader
+    /// downstream would have completed.
+    ///
     /// .NET 10's <c>JsonSerializerOptions.Strict</c>, which #1043 replaces this walk with once net9.0 is
     /// dropped, takes the same decision in both directions - it refuses a member named twice and does not
     /// treat a case-variant pair as one. Measured on net10.0 in <c>TheStrictPresetTakesTheSameDecisionOnCase</c>,

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -177,7 +177,7 @@ internal static class StrictJson
             // surrogate to U+FFFD, so two genuinely different member names would re-encode to the same key and
             // the walk would report a repeat in a document that has none. The throw is caught below and
             // reported as Unreadable, which is the honest answer for bytes that cannot round-trip.
-            var bytes = new UTF8Encoding(false, true).GetBytes(document);
+            var bytes = new UTF8Encoding(false, false).GetBytes(document);
             var reader = new Utf8JsonReader(bytes, new JsonReaderOptions { MaxDepth = MaxDepth });
             while (reader.Read())
             {


### PR DESCRIPTION
# What & why

Evidence run, **not for merge**. It answers one question about #1197: is the fold
that decision rules out a real alternative, or only a described one?

This branch is `issue/1197` plus the one-argument reversal that produces it - the
encoder built with `throwOnInvalidBytes: false`, so every unpaired surrogate is
replaced by U+FFFD before the walk sees it and two different member names encode
to one key.

If the fixtures pin what they claim, the checks here report `Repeated` where the
corpus says `Unreadable`: the walk accusing a provider of a repeat its document
does not contain, which is the direction the decision exists to avoid. Refs
#1197.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs - none of these; this is an evidence run and
      the branch is not a candidate for `main`.

## Security checklist

Not applicable: nothing here is proposed for merge. The single production edit is
the deliberate reversal described above.

## Quality checklist

Not applicable, same reason.

## Verification

- [x] Both target frameworks build with `--warnaserror`, 0 warnings, before the
      reversal was applied.
- [ ] `dotnet test` is green. Not run on this machine - the suite raises a Windows
      elevation prompt here (#1227). The checks on this pull request are the whole
      point of it.

## Notes

Closed unmerged once its checks have reported, with the result written into
#1197. The branch stays in place so the run remains reachable from the issue.


---

## Result, and why this is closed rather than merged

The checks answered: `build` failed on both target frameworks, three failures
each, and they are the fold itself rather than any collateral.

```
failed StrictJsonTests.NamesDifferingOnlyInAnInvalidEscape_AreNeverFoldedIntoOne
  Expected: Unreadable
  Actual:   Repeated

failed StrictJsonTests.HostileInput_IsUnreadable_NeverThrows(json: "{\"a\xd800\":1,\"a\xdc00\":1}")
  Expected: Unreadable
  Actual:   Repeated

failed StrictJsonTests.HostileInput_IsUnreadable_NeverThrows(json: "{\"a\xd800\":1}")
  Expected: Unreadable
  Actual:   Clean

SSO-Auth.Tests.dll (net10.0|x64) failed with 3 error(s)
SSO-Auth.Tests.dll (net9.0|x64)  failed with 3 error(s)
Test run summary: Failed!  failed: 6
```

Run: https://github.com/iderex/jellyfin-plugin-sso/actions/runs/31004401117/job/92300679110

Two different member names collapsing to one key and a repeat reported for a
document that has none, plus a single such name reading `Clean` about bytes the
walk had altered itself. The fold is real, the fixtures pin against it, and this
branch has done the only job it had. Closed unmerged; the branch stays in place
so the run remains reachable from #1197.
