### PR TITLE
Pin that the code flow sends no nonce, and bind the code with PKCE [#1157]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -360,6 +360,40 @@ public class OidcRoundTripTests
     }
 
     [Fact]
+    public async Task Challenge_SendsNoNonce_AndBindsTheCodeWithPkceS256()
+    {
+        // The recorded answer to #1157, held by a test rather than by a sentence, because the two halves
+        // only mean something together.
+        //
+        // This plugin's code flow sends NO authentication-request nonce. Every nonce in the source is a
+        // different thing - the CSP nonce on the interstitial page, the AES-GCM nonce in the secret
+        // envelope, and the logout_token's PROHIBITION under OIDC Back-Channel Logout 2.4 - and none of
+        // them is this one. The authorize request is built by the pinned Duende.IdentityModel.OidcClient,
+        // so what it emits is a property of that package rather than of this repository, and this row
+        // measures it on the real challenge leg instead of quoting a plan comment about the version.
+        //
+        // OIDC Core 1.0 3.1.3.7 rule 11 requires nonce validation only when a nonce was sent, so with none
+        // sent, "missing nonce", "echoed-but-unbound nonce" and "nonce from another request" are assertions
+        // with no subject. What binds the code to this browser instead is PKCE S256 (RFC 9700 2.1.1), which
+        // is the second half asserted here: the pair is the guard, and a row asserting only the absence
+        // would be satisfied by a challenge that bound the code with nothing at all.
+        //
+        // WHAT MAKES THIS WORTH ITS LINE is the day it fails. A nonce appearing on the authorize request
+        // with no validator on the callback is the roadiz shape (CVE-2026-42206): generated, never checked,
+        // and worse than absent because it reads as a control. This row goes red on that day, and its
+        // failure is the signal to build the negatives rather than to relax the assertion.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+
+        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+
+        Assert.StartsWith(Authority + "/authorize", challenge.Url, StringComparison.Ordinal);
+        Assert.DoesNotContain("nonce", challenge.Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("code_challenge=", challenge.Url, StringComparison.Ordinal);
+        Assert.Contains("code_challenge_method=S256", challenge.Url, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ParEnabledButNotAdvertised_ChallengeUsesThePlainRedirect()
     {
         // The compatibility half of the production default: a provider that advertises no PAR endpoint

--- a/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcStateStoreTests.cs
@@ -738,8 +738,8 @@ public class OidcStateStoreTests
     public void Summaries_ProjectExactlyTheNonSecretFields_AndMapTheVariantToValid()
     {
         // Structural redaction: the Summary record carries Provider/Created/Valid/IsLinking and
-        // nothing else - the authorize-state token and PKCE code_verifier / nonce cannot leak through it,
-        // even to an admin. "Valid" is now which variant the entry is: a promoted Ready is valid.
+        // nothing else - the authorize-state token and PKCE code_verifier cannot leak through it,
+        // even to an admin. No nonce is named here any more: the store never held one (#1157). "Valid" is now which variant the entry is: a promoted Ready is valid.
         var store = Store();
         store.Seed("secret-ready", Ready("p", "secret-ready", Now, isLinking: true));
         store.Seed("secret-pending", Pending("q", "secret-pending", Now));

--- a/SSO-Auth/Api/Oidc/OidcStateStore.cs
+++ b/SSO-Auth/Api/Oidc/OidcStateStore.cs
@@ -237,8 +237,10 @@ internal sealed class OidcStateStore
 
     /// <summary>
     /// Projects the store to non-secret summaries for the admin debug endpoint. The raw store holds
-    /// the authorize-state token and the PKCE code_verifier / nonce; those must never be serialized
-    /// out, even to an admin. "Valid" is now which variant the entry is: a promoted
+    /// the authorize-state token and the PKCE code_verifier; those must never be serialized
+    /// out, even to an admin. It holds no nonce, and said so here until #1157 measured it: the code flow
+    /// this plugin drives sends none, and a sentence claiming a stored secret that does not exist is the
+    /// kind a later reader builds a validation rule on top of. "Valid" is now which variant the entry is: a promoted
     /// <see cref="AuthorizeSession.Ready"/> is valid, a <see cref="AuthorizeSession.Pending"/> is not.
     /// </summary>
     /// <returns>One summary per in-flight state.</returns>


### PR DESCRIPTION
# What & why

A nonce criterion was inherited from the JWT validation-posture work and nothing
on the board owned it. This settles it from the source, and the settlement is a
test rather than a sentence.

**The plugin sends no authentication-request nonce.** Every nonce in the source
is a different thing, and the search that says so is
`grep -rni nonce SSO-Auth/ --include=*.cs`:

- the CSP nonce on the interstitial page - `Api/Flows/WebResponse.cs`,
  `Api/Flows/OidcLoginService.cs`, `Api/Flows/SamlLoginService.cs`
- the AES-GCM nonce in the secret envelope - `Api/Secrets/SecretEnvelope.cs`
- the logout_token **prohibition** under OIDC Back-Channel Logout 2.4 -
  `Api/Oidc/OidcLogoutTokenValidator.cs`, which is a rejection rule and stays
  exactly as it is
- one doc comment claiming the state store holds a nonce, which it never has

The authorize request itself is built by the pinned
`Duende.IdentityModel.OidcClient`, so what it emits is a property of that package
and not of this repository. That is measured on the real challenge leg here
rather than quoted from a plan comment about the version.

OIDC Core 1.0 3.1.3.7 rule 11 requires nonce validation only when a nonce was
sent. With none sent, "missing nonce", "echoed-but-unbound nonce" and "nonce from
a different authorization request" are assertions with no subject, so the
negatives are retired rather than left quietly unmet. What binds the code to this
browser instead is PKCE S256 (RFC 9700 2.1.1), and both halves are asserted
together: a row asserting only the absence would be satisfied by a challenge that
bound the code with nothing at all.

**What makes the pin worth its line is the day it fails.** A nonce appearing on
the authorize request with no validator on the callback is the roadiz shape
(CVE-2026-42206): generated, never checked, and worse than absent because it
reads as a control. `Challenge_SendsNoNonce_AndBindsTheCodeWithPkceS256` goes red
on that day, and its failure is the signal to build the negatives - not to relax
the assertion.

Closes #1157

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no production behaviour changes. The one production
      edit is a doc comment that described a stored secret the store does not
      hold.
- [x] No secrets logged; secrets are redacted on config export. The corrected
      comment is on the admin summary projection, which still emits
      Provider/Created/Valid/IsLinking and nothing else.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **No second reader was
      available for this change.** The evidence here stands in place of one
      rather than the box being ticked.
- [ ] Review record: not applicable - no review was run, see above.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; no
      log call is added or moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. No production logic is added.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      No structural property is established here - the property asserted is
      behavioural and belongs on the challenge leg.
- [x] Docs impact considered: no README or wiki surface claims a nonce is sent or
      stored, so nothing outside the source describes the posture this pins.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - both target
      frameworks, 0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
      Der Buildvorgang wurde erfolgreich ausgefuehrt. 0 Warnung(en) 0 Fehler

- [ ] `dotnet test` is green. **Not run on this machine.** The suite raises a
      Windows elevation prompt here (#1227), so it was not run locally at all,
      with or without a filter. The checks on this pull request are the judge of
      the suite, and this box stays unticked rather than being answered from a
      build.
- [x] Prettier is clean: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

The row asserts the ABSENCE of a nonce, which is the shape that can pass for the
wrong reason if the challenge leg is not really running. It is not vacuous here:
the same assertion block requires `code_challenge=` and
`code_challenge_method=S256` on the same URL, and the URL is the one the real
`OidChallenge` produced against the in-test provider - so a challenge that
produced nothing at all fails the row rather than satisfying it.

The logout_token side is untouched: its 2.4 prohibition test still refuses an
id_token replayed at the back-channel endpoint.
