### PR TITLE
Read a redirect parameter through one helper in the test project [#1046]

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerChallengeTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerChallengeTests.cs
@@ -196,26 +196,12 @@ public class SSOControllerChallengeTests
 
     private static bool RedirectSignatureVerifies(string url, RSA publicKey)
     {
-        var samlRequest = QueryValue(url, "SAMLRequest");
-        var sigAlg = QueryValue(url, "SigAlg");
-        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
+        var signature = Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-    }
-
-    private static string QueryValue(string url, string name)
-    {
-        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == name)
-            {
-                return Uri.UnescapeDataString(pair[(eq + 1)..]);
-            }
-        }
-
-        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
@@ -405,7 +405,8 @@ public class SSOControllerOidPostTests
         harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
 
-        var state = QueryValue(challenge.Url, "state");
+        // An absent state reads back as empty here, so the assertion below reports it rather than a throw.
+        var state = UrlEncodedQuery.Find(challenge.Url, "state") ?? string.Empty;
         Assert.False(string.IsNullOrEmpty(state));
         var binding = BindingCookie(harness.Controller.Response);
         Assert.False(string.IsNullOrEmpty(binding));
@@ -415,21 +416,6 @@ public class SSOControllerOidPostTests
         harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
         harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={binding}";
         return (harness, state);
-    }
-
-    // Reads a single query-parameter value out of the challenge's authorization redirect URL.
-    private static string QueryValue(string url, string key)
-    {
-        foreach (var pair in new Uri(url).Query.TrimStart('?').Split('&'))
-        {
-            var kv = pair.Split('=', 2);
-            if (kv.Length == 2 && kv[0] == key)
-            {
-                return Uri.UnescapeDataString(kv[1]);
-            }
-        }
-
-        return string.Empty;
     }
 
     // Extracts the browser-binding cookie value the challenge wrote to the response's Set-Cookie header.

--- a/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
@@ -454,17 +454,7 @@ public class SSOControllerSamlLogoutTests
     // Extracts and inflates the SAMLResponse query parameter of the redirect URL back into its XML document.
     private static XmlDocument DecodeSamlResponse(string url)
     {
-        var query = url[(url.IndexOf('?') + 1)..];
-        string? encoded = null;
-        foreach (var pair in query.Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == "SAMLResponse")
-            {
-                encoded = Uri.UnescapeDataString(pair[(eq + 1)..]);
-                break;
-            }
-        }
+        var encoded = UrlEncodedQuery.Find(url, "SAMLResponse");
 
         Assert.NotNull(encoded);
         var compressed = Convert.FromBase64String(encoded!);

--- a/SSO-Auth.Tests/Http/SSOControllerSamlSpLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSamlSpLogoutTests.cs
@@ -233,17 +233,7 @@ public class SSOControllerSamlSpLogoutTests
     // Extracts and inflates the SAMLRequest query parameter of the redirect URL back into its XML document.
     private static XmlDocument DecodeSamlRequest(string url)
     {
-        var query = url[(url.IndexOf('?') + 1)..];
-        string? encoded = null;
-        foreach (var pair in query.Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == "SAMLRequest")
-            {
-                encoded = Uri.UnescapeDataString(pair[(eq + 1)..]);
-                break;
-            }
-        }
+        var encoded = UrlEncodedQuery.Find(url, "SAMLRequest");
 
         Assert.NotNull(encoded);
         var compressed = Convert.FromBase64String(encoded!);

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -126,9 +126,9 @@ public class OidcRoundTripTests
         harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
 
-        Assert.Equal("phr mfa", QueryValue(challenge.Url, "acr_values"));
-        Assert.Equal("login", QueryValue(challenge.Url, "prompt"));
-        Assert.Equal("0", QueryValue(challenge.Url, "max_age"));
+        Assert.Equal("phr mfa", UrlEncodedQuery.Require(challenge.Url, "acr_values"));
+        Assert.Equal("login", UrlEncodedQuery.Require(challenge.Url, "prompt"));
+        Assert.Equal("0", UrlEncodedQuery.Require(challenge.Url, "max_age"));
     }
 
     [Fact]
@@ -141,9 +141,12 @@ public class OidcRoundTripTests
         harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
 
-        Assert.Equal(string.Empty, QueryValue(challenge.Url, "acr_values"));
-        Assert.Equal(string.Empty, QueryValue(challenge.Url, "prompt"));
-        Assert.Equal(string.Empty, QueryValue(challenge.Url, "max_age"));
+        // Omitted means the name is absent from the query, not present with an empty value: the builder adds
+        // each pair only when its setting is set (OidcFrontChannelParameters), and the copy this file used to
+        // carry could not tell those two apart.
+        Assert.Null(UrlEncodedQuery.Find(challenge.Url, "acr_values"));
+        Assert.Null(UrlEncodedQuery.Find(challenge.Url, "prompt"));
+        Assert.Null(UrlEncodedQuery.Find(challenge.Url, "max_age"));
     }
 
     [Fact]
@@ -430,7 +433,8 @@ public class OidcRoundTripTests
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
         Assert.StartsWith(Authority + "/authorize", challenge.Url);
 
-        var state = QueryValue(challenge.Url, "state");
+        // An absent state reads back as empty here, so the assertion below reports it rather than a throw.
+        var state = UrlEncodedQuery.Find(challenge.Url, "state") ?? string.Empty;
         Assert.False(string.IsNullOrEmpty(state));
         var binding = BindingCookie(harness.Controller.Response);
         Assert.False(string.IsNullOrEmpty(binding));
@@ -455,21 +459,6 @@ public class OidcRoundTripTests
         AppName = "Jellyfin Web",
         AppVersion = "1.0",
     };
-
-    // Reads a single query-parameter value out of the challenge's authorization redirect URL.
-    private static string QueryValue(string url, string key)
-    {
-        foreach (var pair in new Uri(url).Query.TrimStart('?').Split('&'))
-        {
-            var kv = pair.Split('=', 2);
-            if (kv.Length == 2 && kv[0] == key)
-            {
-                return Uri.UnescapeDataString(kv[1]);
-            }
-        }
-
-        return string.Empty;
-    }
 
     // Extracts the browser-binding cookie value the challenge wrote to the response's Set-Cookie header.
     private static string BindingCookie(HttpResponse response)

--- a/SSO-Auth.Tests/Saml/SamlAuthnRequestTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAuthnRequestTests.cs
@@ -76,9 +76,9 @@ public class SamlAuthnRequestTests
 
     private static bool SignatureVerifies(string url, RSA publicKey)
     {
-        var samlRequest = QueryValue(url, "SAMLRequest");
-        var sigAlg = QueryValue(url, "SigAlg");
-        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
+        var signature = Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
@@ -86,25 +86,11 @@ public class SamlAuthnRequestTests
 
     private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey)
     {
-        var samlRequest = QueryValue(url, "SAMLRequest");
-        var sigAlg = QueryValue(url, "SigAlg");
-        var signature = Convert.FromBase64String(QueryValue(url, "Signature"));
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
+        var signature = Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
-    }
-
-    private static string QueryValue(string url, string name)
-    {
-        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == name)
-            {
-                return Uri.UnescapeDataString(pair[(eq + 1)..]);
-            }
-        }
-
-        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
     }
 }

--- a/SSO-Auth.Tests/Saml/SamlLogoutRequestBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutRequestBuilderTests.cs
@@ -149,24 +149,10 @@ public class SamlLogoutRequestBuilderTests
     // Reconstructs the signed octet string (SAMLRequest, then SigAlg - no RelayState here) from the URL.
     private static string SignedQuery(string url)
     {
-        var samlRequest = QueryValue(url, "SAMLRequest");
-        var sigAlg = QueryValue(url, "SigAlg");
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
         return "SAMLRequest=" + Uri.EscapeDataString(samlRequest) + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
     }
 
-    private static byte[] Signature(string url) => Convert.FromBase64String(QueryValue(url, "Signature"));
-
-    private static string QueryValue(string url, string name)
-    {
-        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == name)
-            {
-                return Uri.UnescapeDataString(pair[(eq + 1)..]);
-            }
-        }
-
-        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
-    }
+    private static byte[] Signature(string url) => Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 }

--- a/SSO-Auth.Tests/Saml/SamlLogoutResponseBuilderTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlLogoutResponseBuilderTests.cs
@@ -153,8 +153,8 @@ public class SamlLogoutResponseBuilderTests
     // Reconstructs the signed octet string (SAMLResponse, then RelayState when present, then SigAlg) from the URL.
     private static string SignedQuery(string url, string? relayState)
     {
-        var samlResponse = QueryValue(url, "SAMLResponse");
-        var sigAlg = QueryValue(url, "SigAlg");
+        var samlResponse = UrlEncodedQuery.Require(url, "SAMLResponse");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
         var query = "SAMLResponse=" + Uri.EscapeDataString(samlResponse);
         if (!string.IsNullOrEmpty(relayState))
         {
@@ -164,19 +164,5 @@ public class SamlLogoutResponseBuilderTests
         return query + "&SigAlg=" + Uri.EscapeDataString(sigAlg);
     }
 
-    private static byte[] Signature(string url) => Convert.FromBase64String(QueryValue(url, "Signature"));
-
-    private static string QueryValue(string url, string name)
-    {
-        foreach (var pair in url[(url.IndexOf('?') + 1)..].Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == name)
-            {
-                return Uri.UnescapeDataString(pair[(eq + 1)..]);
-            }
-        }
-
-        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
-    }
+    private static byte[] Signature(string url) => Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 }

--- a/SSO-Auth.Tests/Saml/SamlRedirectSignerTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlRedirectSignerTests.cs
@@ -181,7 +181,7 @@ public class SamlRedirectSignerTests
         using var rsa = RSA.Create(2048);
         var url = SamlRedirectSigner.BuildSignedRedirectUrl(Endpoint, "SAMLRequest", Message, relayState: null, rsa);
 
-        var sigAlg = ExtractQueryValue(url, "SigAlg");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
 
         // The outgoing signer must reuse the inbound response-validator's allowlist, and never SHA-1.
         Assert.True(SamlSignatureAlgorithms.IsSignatureMethodAllowed(sigAlg));
@@ -197,9 +197,9 @@ public class SamlRedirectSignerTests
 
     private static bool SignatureVerifies(string url, RSA publicKey, string? expectedRelayState)
     {
-        var samlRequest = ExtractQueryValue(url, "SAMLRequest");
-        var sigAlg = ExtractQueryValue(url, "SigAlg");
-        var signature = Convert.FromBase64String(ExtractQueryValue(url, "Signature"));
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
+        var signature = Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest);
         if (!string.IsNullOrEmpty(expectedRelayState))
@@ -216,9 +216,9 @@ public class SamlRedirectSignerTests
     // IEEE P1363 r||s concatenation the signer emits, so verification must use the same format.
     private static bool EcdsaSignatureVerifies(string url, ECDsa publicKey, string? expectedRelayState)
     {
-        var samlRequest = ExtractQueryValue(url, "SAMLRequest");
-        var sigAlg = ExtractQueryValue(url, "SigAlg");
-        var signature = Convert.FromBase64String(ExtractQueryValue(url, "Signature"));
+        var samlRequest = UrlEncodedQuery.Require(url, "SAMLRequest");
+        var sigAlg = UrlEncodedQuery.Require(url, "SigAlg");
+        var signature = Convert.FromBase64String(UrlEncodedQuery.Require(url, "Signature"));
 
         var signedQuery = "SAMLRequest=" + Uri.EscapeDataString(samlRequest);
         if (!string.IsNullOrEmpty(expectedRelayState))
@@ -229,20 +229,5 @@ public class SamlRedirectSignerTests
         signedQuery += "&SigAlg=" + Uri.EscapeDataString(sigAlg);
 
         return publicKey.VerifyData(Encoding.UTF8.GetBytes(signedQuery), signature, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
-    }
-
-    private static string ExtractQueryValue(string url, string name)
-    {
-        var query = url[(url.IndexOf('?') + 1)..];
-        foreach (var pair in query.Split('&'))
-        {
-            var eq = pair.IndexOf('=');
-            if (eq > 0 && pair[..eq] == name)
-            {
-                return Uri.UnescapeDataString(pair[(eq + 1)..]);
-            }
-        }
-
-        throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
     }
 }

--- a/SSO-Auth.Tests/_Support/UrlEncodedQuery.cs
+++ b/SSO-Auth.Tests/_Support/UrlEncodedQuery.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Reads one value out of an <c>application/x-www-form-urlencoded</c> sequence, for tests asserting on a
+/// redirect URL the plugin built. It exists once so that two tests asserting on the same parameter cannot
+/// be asserting under different decoding rules, which is what the nine hand-written copies of this loop
+/// allowed (#1046): they disagreed about how the sequence was reached out of the URL, and about what an
+/// absent name means.
+///
+/// The sequence is sliced by hand rather than through <see cref="Uri"/>, so a relative or otherwise
+/// malformed redirect fails the assertion the test was written for instead of throwing inside the parse.
+/// Nothing here folds <c>+</c> to a space: no call site parses a form body today, and a decoding rule that
+/// no caller asks for is one a later caller can inherit by accident.
+/// </summary>
+internal static class UrlEncodedQuery
+{
+    /// <summary>
+    /// Returns the value for <paramref name="name"/>, or <c>null</c> when the sequence carries no such name.
+    /// </summary>
+    internal static string? Find(string url, string name)
+    {
+        foreach (var pair in SequenceOf(url).Split('&'))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq > 0 && pair[..eq] == name)
+            {
+                return Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the value for <paramref name="name"/>, and throws when the sequence carries no such name.
+    /// </summary>
+    internal static string Require(string url, string name) =>
+        Find(url, name) ?? throw new InvalidOperationException($"Query parameter '{name}' not found in {url}.");
+
+    // Everything after the first '?' and before any fragment. A string without a '?' is read as a bare
+    // sequence, which is what a caller holding one already passes.
+    private static string SequenceOf(string url)
+    {
+        var start = url.IndexOf('?') + 1;
+        var fragment = url.IndexOf('#', start);
+        return fragment < 0 ? url[start..] : url[start..fragment];
+    }
+}


### PR DESCRIPTION
# What & why

The same "split on `&`, split on `=`, unescape, return the value for this name" loop was written nine times across the test project, and the copies disagreed about two things: how the sequence was reached out of the URL (two through `new Uri(url).Query`, seven by slicing at the first `?`), and what an absent name means (five threw, two returned an empty string, two returned null). So a test asserting on a parameter could be asserting under different decoding rules from its neighbour, and which rule applied was a property of which copy its author reached for.

`SSO-Auth.Tests/_Support/UrlEncodedQuery.cs` is now the only parse in the project. `Find` returns `null` for an absent name, `Require` throws with the message the five throwing copies used, and each call site says which of the two it wants. The sequence is sliced by hand rather than through `Uri`, so a relative or otherwise malformed redirect fails the assertion the test was written for instead of throwing inside the parse.

Closes #1046

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. Test-only, and no production file is touched:

```
git diff --name-only origin/main...HEAD
SSO-Auth.Tests/Http/SSOControllerChallengeTests.cs
SSO-Auth.Tests/Http/SSOControllerOidPostTests.cs
SSO-Auth.Tests/Http/SSOControllerSamlLogoutTests.cs
SSO-Auth.Tests/Http/SSOControllerSamlSpLogoutTests.cs
SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
SSO-Auth.Tests/Saml/SamlAuthnRequestTests.cs
SSO-Auth.Tests/Saml/SamlLogoutRequestBuilderTests.cs
SSO-Auth.Tests/Saml/SamlLogoutResponseBuilderTests.cs
SSO-Auth.Tests/Saml/SamlRedirectSignerTests.cs
SSO-Auth.Tests/_Support/UrlEncodedQuery.cs
```

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The conformance box stays unticked because that suite was not run for this change; the CI run on this pull request is what executes it. No new structural property is established here, so nothing is added to it. `ModuleTests_MirrorTheSourceModuleFolders` is the rule nearest this change and the new file is out of its scope by its own comment: it is not a `*Tests.cs` and there is no `Api/<Module>/UrlEncodedQuery.cs` for it to mirror.

The count went from nine copies to one, and the whole diff is 37 added against 153 removed lines.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, warnings promoted:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror     0 warnings, 0 errors (exit 0)
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror     0 warnings, 0 errors (exit 0)
```

`dotnet test` was not run locally and the box stays unticked rather than being ticked on an assumption. Running the suite on this machine is blocked by #1227, so the CI run on this pull request is what exercises it. Prettier is vacuously clean here: the change touches no `.js`, `.html`, `.md`, `.css` or `.scss` file, per the file list above.

Acceptance criteria from the issue:

```
# exactly one implementation of the parse remains
grep -rn "Split('&')" --include=*.cs SSO-Auth.Tests
SSO-Auth.Tests/_Support/UrlEncodedQuery.cs:27:        foreach (var pair in SequenceOf(url).Split('&'))

# no caller is left on a private copy
grep -rn "QueryValue(\|ExtractQueryValue(" --include=*.cs SSO-Auth.Tests
(no matches)

# the test total cannot have moved: no test attribute line is added or removed
git diff origin/main...HEAD -- '*.cs' | grep -c "^[-+].*\[\(Fact\|Theory\|InlineData\|MemberData\)"
0
```

The third criterion also asks for the full suite green on both frameworks, and that half is the CI run rather than a local claim.

## Notes

Two things the issue's text no longer matches, both checked against the tree rather than assumed:

The `+`-folding argument the issue asks for is not added. It was to preserve the one form-body copy, and that copy no longer exists: `grep -rn "FormValue" --include=*.cs SSO-Auth.Tests` returns nothing, and the file the issue points at for it now holds only a query reader. A decoding rule no caller asks for is one a later caller can inherit by accident, which is the defect this change exists to remove, so the helper does not carry it. Adding it back is a one-line change on the day a form-body caller appears.

The issue counts eight copies at listed line numbers; the tree has nine and the lines have moved. The list above is what `grep` returns today.

One assertion is stronger than the one it replaces. `Challenge_NoStepUpConfigured_OmitsTheStepUpParameters` compared each step-up parameter to the empty string, which the old copy returned both for an absent name and for a name present with an empty value. It now asserts absence, which is what the test is named for and what `OidcFrontChannelParameters.FromConfig` does: each pair is added only when its setting is set, so an unconfigured provider emits no such name at all. If that ever changes, this test is where it surfaces.

This change had no second reader. The evidence above stands in place of one, and the behaviour-preserving claim is checkable from the diff: every call site keeps the decoding its copy had, except the one named in the paragraph above.
