### PR TITLE
Pin that a forwarded header never moves the rate-limit bucket [#1035]

### DIFF
--- a/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -19,6 +20,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// EveryMustThrottleEndpoint_CallsTheRateLimitGate</c>; these prove the wiring produces the right wire
 /// response at each route. The already-pinned endpoints (SamlChallenge, OidCallback, Link, Unregister)
 /// keep their own tests; this fills the remainder.
+///
+/// It also carries the forwarded-header attribution battery (#1035). Those rows are about a different
+/// property on the same gate: not what a throttled response looks like, but WHICH bucket an attempt is
+/// counted against when the request carries an <c>X-Forwarded-For</c> the plugin never asked for. They
+/// live here rather than in a file of their own because the subject is the same endpoint and the same
+/// single-attempt budget, and a second home for one property is how the next reader loses it.
 /// </summary>
 [Collection("SSOController")]
 public class SSOControllerRateLimitTests
@@ -117,5 +124,90 @@ public class SSOControllerRateLimitTests
         await harness.Controller.SamlAuth("does-not-exist", new AuthResponse());
 
         AssertThrottled(harness, await harness.Controller.SamlAuth("does-not-exist", new AuthResponse()));
+    }
+
+    [Fact]
+    public async Task ARotatingSpoofedForwardedFor_NeverBuysAFreshBucket()
+    {
+        // #1035, the attacker-chooses-your-bucket case. A forwarded header arriving at this plugin is
+        // client-supplied: Jellyfin's own middleware resolves and STRIPS the entries it was told to trust
+        // ("Known proxies"), so whatever survives to here came from a hop nobody trusted. If any of it
+        // reached the rate-limit key, an attacker would rotate the header to get a fresh budget on every
+        // attempt - unlimited attempts - and could equally pin a victim's address to spend the victim's
+        // budget for them.
+        //
+        // A different spoofed value on each attempt, one unchanging socket address. The second attempt
+        // must still be throttled: the budget belongs to the connection, not to anything the client wrote.
+        var harness = Throttling(IPAddress.Parse("8.8.9.1"));
+        harness.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] = "203.0.113.1";
+        await harness.Controller.OidChallenge("does-not-exist");
+
+        harness.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] = "203.0.113.2";
+
+        AssertThrottled(harness, await harness.Controller.OidChallenge("does-not-exist"));
+    }
+
+    [Theory]
+    [InlineData("", "8.8.9.10")]
+    [InlineData("not-an-ip", "8.8.9.11")]
+    [InlineData("203.0.113.9, 198.51.100.4, 192.0.2.7", "8.8.9.12")]
+    [InlineData("::1", "8.8.9.13")]
+    public async Task AMalformedEmptyOrChainedForwardedFor_FallsBackToNothing_ItWasNeverRead(string forwarded, string socket)
+    {
+        // The fail-closed direction of the same rule, and the reason it is four rows rather than one: an
+        // empty header, a value that is not an address at all, a chain longer than any configured depth,
+        // and a loopback claim that would land in the never-throttled class if it were believed. Every one
+        // of them has to leave attribution exactly where it was, because "the parse failed" and "trust this"
+        // are the two answers a header parser can give and only one of them is safe to default to.
+        //
+        // A distinct socket address per row so the process-static counter is this row's alone.
+        var harness = Throttling(IPAddress.Parse(socket));
+        harness.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] = forwarded;
+
+        await harness.Controller.OidChallenge("does-not-exist");
+
+        AssertThrottled(harness, await harness.Controller.OidChallenge("does-not-exist"));
+    }
+
+    [Fact]
+    public async Task RepeatedForwardedForHeaders_DoNotMoveTheBucketEither()
+    {
+        // The multiply-supplied case, which is a different input from a comma chain inside one header: two
+        // header lines, which some proxies emit and which a parser reading only the first or only the last
+        // would disagree about.
+        var harness = Throttling(IPAddress.Parse("8.8.9.2"));
+        harness.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] =
+            new StringValues(new[] { "203.0.113.5", "198.51.100.6" });
+
+        await harness.Controller.OidChallenge("does-not-exist");
+
+        AssertThrottled(harness, await harness.Controller.OidChallenge("does-not-exist"));
+    }
+
+    [Fact]
+    public async Task TheSameForwardedHeaderFromTwoConnections_GetsTwoBuckets()
+    {
+        // The positive control the three rows above need. Each of them passes trivially if the endpoint
+        // throttles everything - which would be a mass-lockout, not a guard - so this asserts the other
+        // direction on the same subject: one identical, unchanging forwarded header and two DIFFERENT
+        // socket addresses, and the second connection's first attempt goes through.
+        //
+        // Together the pair says what the plugin's attribution actually is: the connection decides the
+        // bucket and the header decides nothing, in both directions.
+        const string SameClaim = "203.0.113.77";
+
+        var first = Throttling(IPAddress.Parse("8.8.9.3"));
+        first.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] = SameClaim;
+        await first.Controller.OidChallenge("does-not-exist");
+        AssertThrottled(first, await first.Controller.OidChallenge("does-not-exist"));
+
+        var second = Throttling(IPAddress.Parse("8.8.9.4"));
+        second.Controller.ControllerContext.HttpContext.Request.Headers["X-Forwarded-For"] = SameClaim;
+
+        var result = await second.Controller.OidChallenge("does-not-exist");
+
+        Assert.False(
+            result is ContentResult { StatusCode: 429 },
+            "a second connection claiming the same forwarded address was throttled, so the header - not the connection - is deciding the bucket");
     }
 }


### PR DESCRIPTION
# What & why

The client IP a login is attributed to decides two things: which bucket the rate
limiter counts an attempt against, and which address the activity trail records.
The plugin's answer is that both come from the connection and from nothing else -
`HttpContext.Connection.RemoteIpAddress` is the sole input at every call site:

    git grep -n "RemoteIpAddress" -- SSO-Auth
    SSO-Auth/Api/Flows/OidcLoginService.cs:246
    SSO-Auth/Api/Flows/SamlLoginService.cs:299
    SSO-Auth/Api/Flows/SamlLoginService.cs:421
    SSO-Auth/Api/Http/SSOController.cs:1785

and no forwarded header is parsed anywhere:

    git grep -rln "X-Forwarded-For|XForwardedFor|TrustedProxies|KnownProxies"
    SSO-Auth/Api/RateLimit/SsoRateLimiter.cs      # a doc comment, not a parse

Jellyfin's own middleware resolves the real client into that address and strips
the entries it was told to trust, so anything surviving to this plugin arrived
from a hop nobody trusted. That was the whole design, and it was a sentence in a
doc comment with nothing under it. This is the battery.

**What each row prevents.**

- A **rotating spoofed header** must not buy a fresh budget per attempt. If it
  did, the budget would be unlimited, and the same lever pins a victim's address
  to spend the victim's budget for them.
- An **empty** header, a value that **is not an address**, a **chain longer than
  any configured depth**, and a **loopback claim** (which would land in the
  never-throttled class if it were believed) must each leave attribution exactly
  where it was. "The parse failed" and "trust this" are the two answers a header
  parser can give, and only one of them is safe to default to.
- **Two header lines** are a separate input from one comma chain: a parser
  reading only the first and one reading only the last disagree about them.

**The positive control is on the same subject, not beside it.** One identical
forwarded header from two different connections gets two buckets. Without it,
every row above would be satisfied by an endpoint that throttled everything -
which is a mass lockout rather than a guard.

Closes #1035

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no production code changes. The rows assert the
      existing attribution, including that an unattributable or non-public client
      is never throttled, which is the deliberate availability direction of this
      limiter.
- [x] No secrets logged; secrets are redacted on config export. No logging is
      touched.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **No second reader was
      available for this change.** The evidence here stands in place of one
      rather than the box being ticked.
- [ ] Review record: not applicable - no review was run, see above.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; no
      log call is added or moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The rows reuse the file's existing `Throttling` and `AssertThrottled`
      helpers rather than introducing a second way to drive the same gate.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      The structural half already exists there as
      `EveryMustThrottleEndpoint_CallsTheRateLimitGate`; what this adds is
      behavioural and belongs at the endpoint.
- [x] Docs impact considered: the posture is already documented in
      `SsoRateLimiter.NormalizeClientKey`'s comment, which this change puts tests
      under rather than rewrites. No README or wiki surface describes it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green - both target
      frameworks, 0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
      Der Buildvorgang wurde erfolgreich ausgefuehrt. 0 Warnung(en) 0 Fehler

- [ ] `dotnet test` is green. **Not run on this machine.** The suite raises a
      Windows elevation prompt here (#1227), so it was not run locally at all,
      with or without a filter. The checks on this pull request are the judge of
      the suite, and this box stays unticked rather than being answered from a
      build.
- [x] Prettier is clean: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

Every row uses a distinct public socket address, because the limiter is a
process-static keyed on the client: a shared address would make one row's counter
another row's starting state.

What this does NOT cover, and why it is not silently folded in: the trusted-proxy
list itself belongs to the host. Jellyfin's "Known proxies" setting decides which
hops are resolved and stripped before the plugin sees anything, and no test here
can drive that middleware. Depth and hop-trust behaviour therefore stay a
host-level property, exercised in the live harness by #986 rather than here.
