### PR TITLE
Carry an OpenVEX document and refuse a malformed edit to it [#1092]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,6 +47,12 @@ jobs:
         cache-dependency-path: '**/packages.lock.json'
     - name: Jellyfin compatibility metadata check
       run: bash scripts/check-jellyfin-compat.sh
+    - name: VEX document check
+      # The published VEX statements are only useful if they parse and carry machine-readable
+      # dispositions, so a malformed edit fails here rather than at the release leg that ships the
+      # document (#1092). Structural only: the product-against-SBOM leg of the same checker takes the
+      # SBOM as a second argument, and no SBOM exists at this point in the job.
+      run: python3 scripts/check-vex.py security/vex/openvex.json
     - name: Restore dependencies
       # --locked-mode fails the restore if the committed packages.lock.json files would change,
       # so a drifted or tampered dependency graph cannot build in CI.

--- a/scripts/check-vex.py
+++ b/scripts/check-vex.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""OpenVEX document gate (#1092).
+
+Validates `security/vex/openvex.json` against the parts of the OpenVEX spec a
+consumer relies on, so a malformed edit fails a pull request instead of
+shipping with a release and being discovered by whoever tries to join it to the
+SBOM.
+
+What it refuses, and why each one matters to a consumer:
+
+* a missing or unparsable document, or one whose `@context` is not an OpenVEX
+  namespace - a consumer keys its parser off that field;
+* a missing or wrongly typed top-level field (`@id`, `author`, `timestamp`,
+  `version`, `statements`);
+* a statement without a vulnerability, without products, or without a status;
+* a status outside the OpenVEX enum, a `not_affected` statement whose
+  justification is free text rather than an enum member, and a `not_affected`
+  statement with no `impact_statement` for a human to read;
+* a product identifier that is absent from the SBOM, when an SBOM is given.
+
+Fail-closed: anything it cannot read is an error, not a pass. A document with
+zero statements is valid and is the correct state while nothing is triaged as
+not-exploitable - the file has to exist from day one for the release legs and
+the consumers that join it to the SBOM.
+
+Usage: check-vex.py <openvex.json> [<cyclonedx-sbom.json>]
+"""
+
+import json
+import sys
+from pathlib import Path
+
+STATUSES = {"not_affected", "affected", "fixed", "under_investigation"}
+
+# OpenVEX v0.2.0 justification enum. A justification outside it is not
+# machine-readable, which is the whole point of carrying one.
+JUSTIFICATIONS = {
+    "component_not_present",
+    "vulnerable_code_not_present",
+    "vulnerable_code_not_in_execute_path",
+    "vulnerable_code_cannot_be_controlled_by_adversary",
+    "inline_mitigations_already_exist",
+}
+
+REQUIRED_TOP_LEVEL = {
+    "@context": str,
+    "@id": str,
+    "author": str,
+    "timestamp": str,
+    "version": int,
+    "statements": list,
+}
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def sbom_identifiers(path):
+    """Every purl and bom-ref a CycloneDX document offers as a product identifier."""
+    try:
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        fail(f"SBOM {path} could not be read: {error}")
+
+    identifiers = set()
+    for component in document.get("components", []):
+        for key in ("purl", "bom-ref"):
+            value = component.get(key)
+            if isinstance(value, str) and value:
+                identifiers.add(value)
+
+    metadata_component = document.get("metadata", {}).get("component", {})
+    for key in ("purl", "bom-ref"):
+        value = metadata_component.get(key)
+        if isinstance(value, str) and value:
+            identifiers.add(value)
+
+    if not identifiers:
+        fail(f"SBOM {path} lists no purl or bom-ref, so no product could be checked against it")
+
+    return identifiers
+
+
+def product_ids(statement):
+    """The identifiers a statement claims, across the 0.2.0 and legacy shapes."""
+    identifiers = []
+    for product in statement.get("products", []):
+        if isinstance(product, str):
+            identifiers.append(product)
+        elif isinstance(product, dict):
+            if isinstance(product.get("@id"), str):
+                identifiers.append(product["@id"])
+            for name, value in product.get("identifiers", {}).items():
+                del name
+                if isinstance(value, str):
+                    identifiers.append(value)
+
+    return identifiers
+
+
+def check_statement(index, statement, known_identifiers):
+    where = f"statement {index}"
+    if not isinstance(statement, dict):
+        fail(f"{where} is not an object")
+
+    if not statement.get("vulnerability"):
+        fail(f"{where} names no vulnerability")
+
+    identifiers = product_ids(statement)
+    if not identifiers:
+        fail(f"{where} names no product")
+
+    status = statement.get("status")
+    if status not in STATUSES:
+        fail(f"{where} has status {status!r}, which is outside the OpenVEX enum {sorted(STATUSES)}")
+
+    if status == "not_affected":
+        justification = statement.get("justification")
+        if justification not in JUSTIFICATIONS:
+            fail(
+                f"{where} is not_affected with justification {justification!r}, which is not an OpenVEX "
+                f"enum member: {sorted(JUSTIFICATIONS)}"
+            )
+
+        if not statement.get("impact_statement"):
+            fail(f"{where} is not_affected but carries no impact_statement for a reader")
+
+    if known_identifiers is not None:
+        for identifier in identifiers:
+            if identifier not in known_identifiers:
+                fail(f"{where} names product {identifier!r}, which is in no component of the SBOM")
+
+
+def main(argv):
+    if not 2 <= len(argv) <= 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    path = argv[1]
+    try:
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        fail(f"VEX document {path} could not be read: {error}")
+
+    if not isinstance(document, dict):
+        fail(f"VEX document {path} is not an object")
+
+    for field, expected in REQUIRED_TOP_LEVEL.items():
+        if field not in document:
+            fail(f"VEX document {path} has no {field}")
+
+        # bool is an int in Python, and a boolean version is not a version.
+        if not isinstance(document[field], expected) or isinstance(document[field], bool):
+            fail(f"VEX document {path}: {field} is {type(document[field]).__name__}, expected {expected.__name__}")
+
+    if not document["@context"].startswith("https://openvex.dev/ns"):
+        fail(f"VEX document {path}: @context {document['@context']!r} is not an OpenVEX namespace")
+
+    known_identifiers = sbom_identifiers(argv[2]) if len(argv) == 3 else None
+
+    for index, statement in enumerate(document["statements"]):
+        check_statement(index, statement, known_identifiers)
+
+    scope = "against the SBOM" if known_identifiers else "structurally (no SBOM given)"
+    print(f"ok: {path} is a valid OpenVEX document with {len(document['statements'])} statement(s), checked {scope}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/security/vex/openvex.json
+++ b/security/vex/openvex.json
@@ -1,0 +1,9 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/iderex/jellyfin-plugin-sso/security/vex/openvex.json",
+  "author": "iderex",
+  "role": "Maintainer",
+  "timestamp": "2026-08-05T00:00:00Z",
+  "version": 1,
+  "statements": []
+}


### PR DESCRIPTION
# What & why

The repository now carries the disposition of triaged advisories in a machine-readable document at a fixed path, `security/vex/openvex.json`, so a release leg can reference it without globbing and an SBOM consumer can join the two on the same identifiers.

It carries zero statements, which is the correct content today rather than a placeholder. No advisory is currently triaged as not-exploitable against this plugin:

```
gh api "repos/iderex/jellyfin-plugin-sso/dependabot/alerts?state=all&per_page=100" --jq '[.[] | {number,state,dismissed_reason}]'
[]
```

The file exists from day one because the release legs and the consumers need it to, and because an empty document makes the first real statement a one-line change rather than a new artifact.

`scripts/check-vex.py` is the gate, wired into the `build` job in `.github/workflows/dotnet.yml` next to the other pre-build metadata check.

Means: Python 3, matching `scripts/check-coverage.py`, which the same job already runs as `python3`. It adds no runtime the tree does not carry, and it runs on a development machine as well as in the job, so its refusals could be observed rather than assumed. `vexctl` was the alternative the issue names: it would add a Go binary download to a job in a repository that pins its actions by SHA, for a document whose shape this refuses in 130 lines of a language already in `scripts/`.

Closes #1092

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This is supply-chain documentation and a CI gate over it. It touches no login path, no SAML or OIDC validation, no config persistence, and no publish or release workflow: the only workflow edit is one step in the pull-request `build` job.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

The checker itself is fail-closed by construction: an unreadable document, an unparsable one, a missing field, and an unreadable SBOM are all errors rather than passes, and that is shown below.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The conformance box stays unticked because that suite was not run for this change; the CI run on this pull request is what executes it. It polices the C# module structure and this change adds no C#.

The written procedure that keeps the document current is #1094, and shipping the document with releases is #1093. Both were already open before this change; neither is folded in.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No C# is touched, so neither .NET box is ticked; both are the CI run's to answer. `dotnet test` is additionally blocked on this machine by #1227. Prettier is vacuously clean: the change adds a `.json`, a `.py` and a workflow edit, none of which are in the checked glob.

The document passes its own gate:

```
python3 scripts/check-vex.py security/vex/openvex.json
ok: security/vex/openvex.json is a valid OpenVEX document with 0 statement(s), checked structurally (no SBOM given)   (exit 0)
```

Every refusal was observed rather than reasoned about. Each fixture below is the committed document with one thing wrong:

```
no author                       ::error::VEX document ... has no author                                        (exit 1)
version as a string             ::error::... version is str, expected int                                      (exit 1)
@context not OpenVEX            ::error::... @context 'https://example.com/ns' is not an OpenVEX namespace     (exit 1)
status 'not-affected'           ::error::statement 0 has status 'not-affected', which is outside the OpenVEX enum   (exit 1)
free-text justification         ::error::statement 0 is not_affected with justification 'we looked and it is fine',
                                         which is not an OpenVEX enum member                                   (exit 1)
not_affected, no impact         ::error::statement 0 is not_affected but carries no impact_statement for a reader   (exit 1)
document absent                 ::error::VEX document ... could not be read: [Errno 2] No such file or directory    (exit 1)
```

The hyphen in `not-affected` is the near-miss the status check is shaped around: it reads as a status to a person and is not one.

The product-against-SBOM leg was observed in both directions, so it is a check rather than a formality. One statement naming `pkg:nuget/Foo@1.0.0`:

```
# against a CycloneDX document that lists that purl
python3 scripts/check-vex.py good-statement.json sbom-with-foo.json
ok: ... 1 statement(s), checked against the SBOM                                                    (exit 0)

# against one that lists a different component
python3 scripts/check-vex.py good-statement.json sbom-without-foo.json
::error::statement 0 names product 'pkg:nuget/Foo@1.0.0', which is in no component of the SBOM      (exit 1)
```

## Notes

What is enforced in CI is the structural half. The step in `build` runs the checker with no SBOM, because no SBOM exists at that point in the job: `.github/actions/cyclonedx-sbom` generates one inside the packaging leg and nothing is committed. So the acceptance criterion about product identifiers matching a `bom-ref`/purl holds today because there are no statements, and it is enforced by the same checker whenever it is handed an SBOM, as shown above. Wiring that second argument into the packaging leg becomes worth doing when the first statement lands, and is the natural follow-up rather than something claimed here.

The statements are empty, so nothing in this pull request asserts that any advisory is not exploitable. The first statement will come with the triage that produced it, which is what #1094 writes down.

This change had no second reader. The refusal transcript above stands in place of one: every arm of the gate was made to fire, and the SBOM leg was checked in both directions rather than only the failing one.
