### PR TITLE
Document the translation flow and what ships today [#1155]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
   - [Improving The Documentation](#improving-the-documentation)
+  - [Translating the UI](#translating-the-ui)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
   - [Sign Your Work (DCO)](#sign-your-work-dco)
@@ -189,6 +190,22 @@ This is a security-sensitive login path: before opening a pull request, understa
 ### Improving The Documentation
 
 We are always open to better docs! The main place documentation could be improved is the [provider setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) documentation. This file keeps track of configurations that are known to work with common SSO providers.
+
+### Translating the UI
+
+The plugin serves two pages of its own, the interstitial login page and the browser error page, and their text comes from per-language JSON catalogs rather than from the C# source. Translating one needs no build and no C# at all.
+
+Supported languages today are English alone, shipped as `SSO-Auth/Localization/en.json`. English is also the invariant fallback: every key exists there, and a lookup walks the requested culture, then its base language, then English, then the key itself, so a string that is missing from a catalog falls back rather than rendering blank.
+
+**To add a language**, copy `en.json` to `SSO-Auth/Localization/<bcp47>.json` (`de.json`, `pt-BR.json`), translate the values, and keep the key set exactly as English has it. Nothing else needs editing: the project file globs `Localization\*.json` into the assembly as embedded resources.
+
+**To fix a translation**, change the value and never the key. Keys are internal identifiers that the served pages reference by name, and no user-supplied or provider-supplied value is ever used as one.
+
+**Keep every `{name}` placeholder** in the value you translate. `SSO-Auth/Web/i18n.js` substitutes them from the parameters the page passes, so a placeholder dropped from a translated string takes its substituted text with it. The reverse is safe: a parameter that is absent at runtime leaves the placeholder standing verbatim rather than blanking the line.
+
+**Some text is deliberately not translated.** Server logs and the audit trail are operator-facing and stay in English; the catalogs are read only by the served pages, so nothing on those paths reaches a translator. Error text that an identity provider interpolated into a message is passed through as it arrived rather than translated, HTML-encoded on the way out.
+
+The standing guard is `SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs`, and it runs in CI on every pull request. A catalog that is not a flat string-to-string map, that carries a blank value, or whose key set diverges from English in either direction (a missing key or an orphan one) fails the build. So an incomplete catalog is caught before it ships rather than discovered by whoever speaks that language.
 
 ## Styleguides
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Full documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-plug
 - [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Project policies: [Governance](GOVERNANCE.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
 
+The plugin's own served pages are translatable from JSON catalogs, no C# involved. [Translating the UI](CONTRIBUTING.md#translating-the-ui) lists the supported languages, the catalog format, and how to add one.
+
 ## Security
 
 This plugin is built to **fail closed by default**: a missing signature, a weak signature or under-strength key, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Secrets are stored write-only and AES-256-GCM-encrypted at rest. The controls and their tuning - encryption at rest, optional rate limiting, new-user approval, step-up/MFA passthrough - are on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) wiki page, and security-relevant behavior is covered by the test suite.


### PR DESCRIPTION
# What & why

The localization mechanism is on `main` and nothing described it to a human, so a
translator had to read C# to learn that catalogs are flat JSON, that English is
the invariant fallback, and that the project file already globs the folder. This
is that description, in `CONTRIBUTING.md` with a pointer from `README.md`. Prose
only, no behaviour change.

What it says, each verified against the tree rather than the parent issue's
intent:

- **Supported languages today are English alone.** `ls SSO-Auth/Localization/`
  returns `en.json` and nothing else, so that is what the doc claims. The list is
  what ships, not what #913 aims at.
- **English is the invariant fallback**, and the lookup chain is requested
  culture, base language, English, then the key itself, so a missing string falls
  back rather than rendering blank (`SsoLocalizer`).
- **Adding a language needs no project edit**: `SSO-Auth/SSO-Auth.csproj:56`
  globs `Localization\*.json` as embedded resources.
- **Keys are identifiers and are never translated**, and no user- or
  provider-supplied value is ever used as one.
- **A `{name}` placeholder dropped from a translated value takes its substituted
  text with it**, while a parameter absent at runtime leaves the placeholder
  standing verbatim (`SSO-Auth/Web/i18n.js:12-22`). Both directions are stated
  because only one of them is safe.
- **What is deliberately not translated**: server logs and the audit trail. The
  catalogs are read only by the two served pages -
  `git grep -n "SsoLocalizer.GetString|Localize("` outside the localization
  folder returns `Api/Flows/WebResponse.cs` and `Api/Shared/BrowserErrorPage.cs`
  and nothing else - and error text an identity provider interpolated is passed
  through as it arrived, HTML-encoded (`BrowserErrorPage.cs:104-110`).
- **The standing guard is named**: `LocalizationCatalogTests` fails CI on a
  missing key, an orphan key, a blank value, or a shape that is not a flat map.

Closes #1155

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: no code is touched. The change is two Markdown files, and the one
security-relevant sentence it adds ("no user- or provider-supplied value is ever
used as a key") describes the existing behaviour rather than proposing it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. No logic at all.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
      None is established.
- [x] Docs impact considered: this change IS the doc. The single home is the
      `CONTRIBUTING.md` section; the README carries a pointer rather than a second
      copy of the list, so the two cannot drift apart.

## Verification

- [x] Prettier is clean:

      npx prettier@3 --check --end-of-line auto "README.md" "CONTRIBUTING.md"
      Checking formatting...
      All matched files use Prettier code style!

- [x] The issue's own acceptance grep finds the list:

      grep -ri "supported languages" CONTRIBUTING.md README.md docs/
      CONTRIBUTING.md:Supported languages today are English alone, ...
      README.md:... lists the supported languages, the catalog format, and how to add one.

- [x] The list matches the tree exactly: `ls SSO-Auth/Localization/` -> `en.json`.
- [ ] `dotnet test` is green. **Not run on this machine.** The suite raises a
      Windows elevation prompt here (#1227). No C# is touched by this change, and
      the checks on this pull request are the judge either way.
- [x] `dotnet build --no-restore --warnaserror`: not run, and not applicable - no
      compiled file is touched. The unticked test box above is the honest one.

## Notes

The section lives under "I Want To Contribute" rather than under "Styleguides",
because it is a contribution route rather than a formatting rule, and a
translator arriving from the README should not have to pass the C# and DCO
sections to reach it.

Deliberately not included: an invitation to add languages that do not exist yet
as empty stubs. An empty catalog would fail the drift test, which is the correct
outcome and a confusing first experience, so the doc says to copy the English key
set rather than to start from nothing.
