### PR TITLE
State how a triaged advisory becomes a published VEX statement [#1094]

### DIFF
--- a/docs/SECURITY-REMEDIATION-POLICY.md
+++ b/docs/SECURITY-REMEDIATION-POLICY.md
@@ -23,6 +23,37 @@ ever drift, the policy is corrected or the gate is fixed, never papered over.
 - **Dependabot** watches both ecosystems (NuGet and GitHub Actions); its
   security PRs run the full gate like any other change.
 
+### Publishing a not-exploitable disposition (VEX)
+
+- **What may be dispositioned at all:** only a finding this plugin does not
+  reach - a transitive component whose vulnerable code no plugin path executes.
+  A vulnerability in code the login path runs is **fixed**, never dispositioned;
+  the existence of VEX does not soften the merge gate above or the
+  security-before-features ordering. "Upgrading is inconvenient" is not a
+  disposition.
+- **Who decides, and on what evidence:** I do, and the evidence is a
+  reachability argument written down with the statement: which entry point would
+  have to be reached for the advisory to bite, and what stops it. The statement
+  carries a `justification` from the **OpenVEX enum** (so a consumer can act on
+  it) plus an `impact_statement` a person can read.
+  `scripts/check-vex.py` refuses free text in the justification field, so a
+  statement that skips the enum fails the build rather than shipping.
+- **When it is written:** in the **same change** that dispositions the finding,
+  never batched afterwards - the reasoning is only cheap while the triage is in
+  hand, and an undocumented disposition is indistinguishable from an overlooked
+  one.
+- **Where it lives:** `security/vex/openvex.json`, at that fixed path. Product
+  identifiers use the same purls the CycloneDX SBOM emits, so a consumer joins
+  the two without a mapping table; the checker compares products against an SBOM
+  when it is handed one, and validates the document's structure on every pull
+  request. A document with **zero statements is the correct state** while
+  nothing is triaged as not-exploitable.
+- **When a statement is revisited or withdrawn:** when the dependency is
+  upgraded past the advisory, or when the reachability judgement stops holding -
+  a new call site into the component is the ordinary trigger. The statement is
+  corrected or removed in the change that broke it, not left to be discovered by
+  whoever next reads the document.
+
 ## SAST - static analysis
 
 - **Merge gate:** CodeQL (with the `security-extended` query pack) and the
@@ -37,6 +68,9 @@ ever drift, the policy is corrected or the gate is fixed, never papered over.
 - **Accepted residuals** are documented where they live: the
   [Review Gate](https://github.com/iderex/jellyfin-plugin-sso/wiki/Review-Gate)
   wiki page records the known accepted residual(s) of the overall gate stack.
+  A dependency advisory triaged as not-exploitable is not a residual of this
+  kind - it is a published statement in `security/vex/openvex.json`, under
+  _Publishing a not-exploitable disposition (VEX)_ above.
 
 ## Secrets management
 


### PR DESCRIPTION
# What & why

`docs/SECURITY-REMEDIATION-POLICY.md` described the SCA gates and said nothing about the document those gates now validate, so `security/vex/openvex.json` would have decayed after its first commit with no written rule for keeping it current.

The new subsection under **SCA - dependency vulnerabilities** says which findings may be dispositioned at all (only ones this plugin does not reach; a vulnerability in code the login path executes is fixed), who decides and on what evidence, that the justification comes from the OpenVEX enum and that `scripts/check-vex.py` refuses free text there, that the statement is committed in the same change as the triage rather than batched, where the document lives and how its identifiers join the SBOM, and when a statement is revisited or withdrawn. The existing _Accepted residuals_ paragraph and the new subsection now point at each other.

Closes #1094

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Documentation only. One file, no code:

```
git diff --stat origin/main...HEAD
 docs/SECURITY-REMEDIATION-POLICY.md | 34 ++++++++++++++++++++++++++++++++++
```

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The conformance box stays unticked because that suite was not run for this change; the CI run on this pull request is what executes it. This change is the documentation half, so nothing further is filed.

The subsection is written in the voice and bullet shape the rest of that file already uses, so it reads as one document rather than an appended note.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No C# is touched, so neither .NET box is ticked; both are the CI run's to answer, and `dotnet test` is additionally blocked on this machine by #1227.

```
npx prettier --check --end-of-line auto "docs/SECURITY-REMEDIATION-POLICY.md"
Checking formatting...
All matched files use Prettier code style!
```

Each claim the new text makes about the tooling was checked against the tree rather than written from the issue:

```
# the document the section points at exists at that path
ls security/vex/openvex.json
security/vex/openvex.json

# the checker refuses a free-text justification, which is what the section promises
python3 scripts/check-vex.py <a statement with justification "we looked and it is fine">
::error::statement 0 is not_affected with justification 'we looked and it is fine', which is not an
         OpenVEX enum member                                                                    (exit 1)

# the validation the section describes runs on a pull request
grep -n "check-vex" .github/workflows/dotnet.yml
55:      run: python3 scripts/check-vex.py security/vex/openvex.json
```

Line 55 sits in the `build` job, which `.github/workflows/dotnet.yml` triggers on `pull_request`.

## Notes

The section describes only what exists today. Shipping the document with a release is #1093 and is not done, so nothing here says a release carries it. That is deliberate: the file's own opening rule is that it describes what the tooling actually does, and an aspirational step nobody performs is exactly what this issue asked to avoid.

The issue's own framing is worth keeping: it notes that `docs/SECURE-SDLC.md` does not exist and that this file is the one that already covers SCA disposition. That is still true.

This change had no second reader. The evidence above stands in place of one: every mechanism the new text claims is quoted from the tree or shown refusing.
