### PR TITLE
Add the intended-use notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,8 @@
+# Notice
+
+This software is developed for lawful use. Operators and users are
+responsible for making sure that their deployment and use comply with the
+laws that apply to them, including copyright and data protection law. The
+project does not endorse or support unlawful use of any kind, and nothing
+in it is designed to enable such use. The license contains the full
+warranty and liability disclaimer.

--- a/README.md
+++ b/README.md
@@ -104,3 +104,5 @@ Built on the [Jellyfin LDAP plugin](https://github.com/jellyfin/jellyfin-plugin-
 ## License
 
 Licensed under the [GNU GPL v3.0](https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt).
+
+See NOTICE.md for the intended-use notice.


### PR DESCRIPTION
# What & why

Adds a root `NOTICE.md` and one link line at the end of the README. The notice
states lawful use as the purpose, puts responsibility for legal compliance on
operators and users with copyright and data protection named, says the project
does not endorse or support unlawful use, and points at the license for the
warranty and liability disclaimer.

`LICENSE.txt` is untouched. That is deliberate and not an oversight: this
plugin is GPL-3.0, and the GPL forbids adding restrictions on top of it, so a
lawful-use clause written into the license would itself breach the license the
code is under. A notice beside the license says the intent without changing the
terms.

Closes #1245

## Type of change

- [x] Refactor / code quality / docs

`git diff --name-only origin/main...HEAD` on this branch prints `NOTICE.md` and
`README.md`, and nothing else.

## Security checklist

Nothing in this change touches the login path, SAML or OIDC validation, config
persistence or the release pipeline, so every line here has no subject and no
box is ticked. No security review was run, for the same reason. Stated rather
than ticked so the record does not claim a review that did not happen.

## Quality checklist

- [x] No duplicated logic; the change adds no logic at all.
- [x] The change adds no more code than the problem requires: one new file and
      one line.
- [x] Self-documenting: the notice is the whole content.
- [x] Architecture-conformance tests unchanged; this change establishes no
      structural property for one to lock in.
- [x] Docs impact: the update is included here. The README is the one place
      that needed to learn about the new file.

## Verification

- [x] Prettier is clean for the two `.md` files, run locally on this branch
      before the commit, against the file content as it is stored (LF):

      npx --yes prettier@3 --check "README.md" "NOTICE.md"
      Checking formatting...
      All matched files use Prettier code style!

- `dotnet build` and `dotnet test` were NOT run locally for this change, and
  that is written out rather than ticked. The diff adds a markdown file and one
  line of markdown, so no compiled artifact can differ. CI builds and tests the
  branch and that is the run this rests on.

## Notes

Nothing out of scope. No license file was modified. Whether the wording holds
up in law is not asserted here: it is written from the engineering side and has
not been reviewed by a lawyer.
