### PR TITLE
Read both discovery facts out of one parse [#1170]

### DIFF
--- a/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="DiscoveryJson"/> - the single parse a discovery response gets, out of which both
+/// challenge-time facts are read (#1170). Before this the two readers each walked the same body for one
+/// boolean apiece. They pin: the parse answers null for every body that is not a JSON object rather than
+/// throwing; one parsed root serves both facts; the fail-closed / fail-tolerant asymmetry between the two
+/// readers survives the move, on the raw entry point and on the root one alike; and the plugin holds no
+/// second parse site.
+/// </summary>
+public class DiscoveryJsonTests
+{
+    // Advertises both facts, so a reader that stopped reading its member would show up as a flipped answer
+    // rather than as an answer that was already false.
+    private const string BothFacts =
+        "{\"code_challenge_methods_supported\":[\"S256\"],\"authorization_response_iss_parameter_supported\":true}";
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData(BothFacts)]
+    [InlineData("{\"issuer\":\"https://idp.example.com\"}")]
+    public void AJsonObject_Parses(string discoveryJson)
+    {
+        Assert.NotNull(DiscoveryJson.TryParse(discoveryJson));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-json")]
+    [InlineData("[1,2]")] // a JSON array is well-formed JSON and still not a discovery document
+    [InlineData("42")]
+    [InlineData("{\"a\":1} trailing")]
+    [InlineData("{\"a\":1")]
+    public void AnythingThatIsNotAJsonObject_IsNullRatherThanAThrow(string? discoveryJson)
+    {
+        // The readers below turn a null root into their own answer, and the two answers differ. Throwing
+        // here instead would take that decision away from them and hand the whole read to
+        // OidcDiscoveryReader's catch-all, which fails the login closed - including for the tolerant fact.
+        Assert.Null(DiscoveryJson.TryParse(discoveryJson));
+    }
+
+    [Fact]
+    public void OneParsedRoot_ServesBothFacts()
+    {
+        // What "parsed once" is observable as: both readers answer off the instance they were handed, so a
+        // change made to that one instance moves both answers. A reader holding its own parse of the same
+        // bytes could not see either removal.
+        var root = DiscoveryJson.TryParse(BothFacts);
+
+        Assert.NotNull(root);
+        Assert.True(PkceDiscovery.SupportsS256(root));
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
+
+        root.Remove("code_challenge_methods_supported");
+        root.Remove("authorization_response_iss_parameter_supported");
+
+        Assert.False(PkceDiscovery.SupportsS256(root));
+        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
+    }
+
+    [Fact]
+    public void ANullRoot_KeepsTheAsymmetryBetweenTheTwoFacts()
+    {
+        // The one thing the shared parse must not quietly level out. PKCE support fails CLOSED on a
+        // document that could not be read (#141); the RFC 9207 response-iss flag stays TOLERANT, because a
+        // flag nobody could read must never lock out a provider that omits iss (#210). Both are false here,
+        // and they are false for opposite reasons - the rows below are what keeps the pair from drifting
+        // into one answer.
+        Assert.False(PkceDiscovery.SupportsS256((JObject?)null));
+        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer((JObject?)null));
+
+        // Tolerant means: an advertised flag on an otherwise empty document still reads true, and a
+        // document that omits it reads false without the read having failed.
+        var advertised = DiscoveryJson.TryParse("{\"authorization_response_iss_parameter_supported\":true}");
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(advertised));
+        Assert.False(PkceDiscovery.SupportsS256(advertised));
+    }
+
+    [Theory]
+    [InlineData(BothFacts, true, true)]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"]}", true, false)]
+    [InlineData("{\"authorization_response_iss_parameter_supported\":true}", false, true)]
+    [InlineData("{\"code_challenge_methods_supported\":[\"plain\"],\"authorization_response_iss_parameter_supported\":false}", false, false)]
+    [InlineData("{\"code_challenge_methods_supported\":\"S256\",\"authorization_response_iss_parameter_supported\":\"true\"}", false, false)]
+    [InlineData("{}", false, false)]
+    [InlineData("not-json", false, false)]
+    [InlineData("", false, false)]
+    [InlineData(null, false, false)]
+    public void TheSeamAgreesWithBothRawEntryPoints(string? discoveryJson, bool expectedPkce, bool expectedResponseIssuer)
+    {
+        // The behaviour bound on the refactor: what the challenge reads out of one parse is what the two
+        // raw-JSON readers answered separately before it. The expectations are written out rather than
+        // computed from the readers, so a change that moved BOTH sides at once would still be caught.
+        var facts = OidcDiscoveryReader.FactsFrom(discoveryJson);
+
+        Assert.Equal(expectedPkce, facts.PkceS256);
+        Assert.Equal(expectedResponseIssuer, facts.ResponseIssuerAdvertised);
+        Assert.Equal(PkceDiscovery.SupportsS256(discoveryJson), facts.PkceS256);
+        Assert.Equal(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(discoveryJson), facts.ResponseIssuerAdvertised);
+    }
+
+    [Fact]
+    public void TheShippedPluginHoldsOneParseSite()
+    {
+        // The rule the refactor is: one document, one parse. Nothing stops a later reader from adding its
+        // own JObject.Parse next to the shared one, and nothing about that would fail a behaviour test -
+        // both parses would agree. So the count is asserted directly.
+        //
+        // The scan is over raw file text, so a mention inside a comment counts as a site. That is
+        // deliberate: it needs no agreement with anyone else's idea of what a comment is, and prose can say
+        // "the shared parse" at no cost.
+        var pluginRoot = Path.Combine(RepoRoot(), "SSO-Auth");
+        var owner = Path.Combine("Api", "Oidc", "DiscoveryJson.cs");
+
+        var sites = Directory.EnumerateFiles(pluginRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => File.ReadAllText(path).Contains("JObject.Parse(", StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(pluginRoot, path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(new List<string> { owner }, sites);
+    }
+
+    // The repository root, derived from this test file's compile-time path
+    // (<root>/SSO-Auth.Tests/Oidc/<file>).
+    private static string RepoRoot([CallerFilePath] string thisFilePath = "") =>
+        Directory.GetParent(Directory.GetParent(Path.GetDirectoryName(thisFilePath)!)!.FullName)!.FullName;
+}

--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -226,7 +226,7 @@ public class StrictJsonTests
     {
         // The decision of #1191, and it is a decision rather than a fact about JSON consumers in general.
         // JSON member names are case-sensitive, and every reader on the plugin's own path INDEXES a name it
-        // spells itself - PkceDiscovery and OidcResponseIssuer both JObject.Parse and index, JsonDocument
+        // spells itself - PkceDiscovery and OidcResponseIssuer both index the shared discovery parse, JsonDocument
         // indexes, and the identity library's typed mapping is case-sensitive - so a case-variant pair is
         // unambiguous to all of them. Refusing it would take offline a provider whose document none of its
         // consumers misreads, and the walk compares EVERY member at every scope, so the pair that took the

--- a/SSO-Auth/Api/Oidc/DiscoveryJson.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryJson.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// The one place a provider's OpenID discovery document is turned into a Newtonsoft object graph. Both
+/// security facts the challenge reads - PKCE-S256 (#141) and the RFC 9207 response-<c>iss</c> parameter
+/// (#210) - are read out of the root this returns, so one discovery response is walked once for both
+/// instead of once per fact (#1170).
+///
+/// Returns <see langword="null"/> rather than throwing for every input that is not a JSON object: a null,
+/// empty or blank body, and any document Newtonsoft refuses. Each reader decides for itself what a null
+/// root means, and the two answers differ on purpose - PKCE support fails CLOSED, the response-<c>iss</c>
+/// flag fails TOLERANT so an unreadable flag never locks out a provider that omits <c>iss</c>.
+/// </summary>
+internal static class DiscoveryJson
+{
+    /// <summary>
+    /// Parses a discovery document into its root object.
+    /// </summary>
+    /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
+    /// <returns>The parsed root, or <see langword="null"/> when the document is absent, blank or malformed.</returns>
+    internal static JObject? TryParse(string? discoveryJson)
+    {
+        if (string.IsNullOrWhiteSpace(discoveryJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JObject.Parse(discoveryJson);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -98,9 +98,7 @@ internal static class OidcDiscoveryReader
             // parsed from), read through the two fail-closed/tolerant pure parsers: PKCE-S256 fails closed
             // (#141, caller rejects only under RequirePkce), response-iss stays tolerant (#210, absence
             // never locks out a provider that omits `iss`).
-            var facts = new DiscoveryFacts(
-                PkceDiscovery.SupportsS256(discovery.Raw),
-                OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(discovery.Raw));
+            var facts = FactsFrom(discovery.Raw);
 
             // The exact discovery -> ProviderInformation mapping OidcClient performs internally, so feeding
             // this back into PrepareLoginAsync reproduces the library's own login setup from the very
@@ -128,5 +126,23 @@ internal static class OidcDiscoveryReader
                 provider?.ReplaceLineEndings(string.Empty));
             return OidcDiscoveryResult.Unavailable;
         }
+    }
+
+    /// <summary>
+    /// Reads both discovery facts out of ONE parse of the document (#1170). The two readers used to take
+    /// the raw body and each walk it themselves, so one response was parsed twice for two booleans; the
+    /// parse now happens here, once, and both readers index the root it produced. The asymmetry between
+    /// them is unchanged and deliberate: PKCE-S256 fails closed on a document that cannot be parsed,
+    /// the RFC 9207 response-<c>iss</c> flag stays tolerant so an unreadable flag never locks out a
+    /// provider that omits <c>iss</c> (#210).
+    /// </summary>
+    /// <param name="discoveryJson">The raw discovery body of the response the facts are read from.</param>
+    /// <returns>The two facts this document advertises.</returns>
+    internal static DiscoveryFacts FactsFrom(string? discoveryJson)
+    {
+        var document = DiscoveryJson.TryParse(discoveryJson);
+        return new DiscoveryFacts(
+            PkceDiscovery.SupportsS256(document),
+            OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(document));
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -59,23 +58,19 @@ internal static class OidcResponseIssuer
     /// </summary>
     /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
     /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
-    internal static bool DiscoveryAdvertisesResponseIssuer(string? discoveryJson)
-    {
-        if (string.IsNullOrWhiteSpace(discoveryJson))
-        {
-            return false;
-        }
+    internal static bool DiscoveryAdvertisesResponseIssuer(string? discoveryJson) =>
+        DiscoveryAdvertisesResponseIssuer(DiscoveryJson.TryParse(discoveryJson));
 
-        try
-        {
-            return JObject.Parse(discoveryJson)["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
-                && value.Value<bool>();
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
-    }
+    /// <summary>
+    /// The same flag read off an already-parsed document, so the challenge reads both of its discovery facts
+    /// out of one parse (#1170). Stays tolerant (<c>false</c>) on a null root, exactly as the raw-JSON entry
+    /// point is on absent, blank or malformed input.
+    /// </summary>
+    /// <param name="discovery">The parsed discovery document, or <see langword="null"/> when it could not be parsed.</param>
+    /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
+    internal static bool DiscoveryAdvertisesResponseIssuer(JObject? discovery) =>
+        discovery?["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
+            && value.Value<bool>();
 
     /// <summary>
     /// The validated id_token's issuer (its <c>iss</c> claim), or null when the token is absent/degenerate.

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -26,24 +25,23 @@ internal static class PkceDiscovery
     /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
     /// a non-array value, non-string elements, or malformed/blank JSON.
     /// </returns>
-    internal static bool SupportsS256(string? discoveryJson)
-    {
-        if (string.IsNullOrWhiteSpace(discoveryJson))
-        {
-            return false;
-        }
+    internal static bool SupportsS256(string? discoveryJson) => SupportsS256(DiscoveryJson.TryParse(discoveryJson));
 
-        try
-        {
-            var methods = JObject.Parse(discoveryJson)["code_challenge_methods_supported"] as JArray;
-            return methods is not null
-                && methods.Any(method =>
-                    method.Type == JTokenType.String
-                    && string.Equals(method.Value<string>(), "S256", StringComparison.Ordinal));
-        }
-        catch (JsonException)
-        {
-            return false;
-        }
+    /// <summary>
+    /// The same decision taken on an already-parsed document, so the challenge reads both of its discovery
+    /// facts out of one parse (#1170).
+    /// </summary>
+    /// <param name="discovery">The parsed discovery document, or <see langword="null"/> when it could not be parsed.</param>
+    /// <returns>
+    /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
+    /// a non-array value, non-string elements, or a null root.
+    /// </returns>
+    internal static bool SupportsS256(JObject? discovery)
+    {
+        var methods = discovery?["code_challenge_methods_supported"] as JArray;
+        return methods is not null
+            && methods.Any(method =>
+                method.Type == JTokenType.String
+                && string.Equals(method.Value<string>(), "S256", StringComparison.Ordinal));
     }
 }


### PR DESCRIPTION
# What & why

The OpenID challenge reads two booleans out of a provider's discovery document,
PKCE-S256 support (#141) and the RFC 9207 response-`iss` parameter (#210), and
each reader ran its own full `JObject.Parse` over the same body. One response,
two parses, two members.

`DiscoveryJson.TryParse` is now the one place a discovery body becomes an object
graph. Both readers gained an overload that indexes a root the caller already
holds, and `OidcDiscoveryReader.FactsFrom` parses once and hands that one root to
both. The raw-JSON entry points stay and delegate, so each reader is still
exercisable on its own and the fuzz target in `SSO-Auth.Fuzz/Program.cs` keeps
the string surface it drives.

Closes #1170

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the asymmetry between the two facts is the thing
      this could quietly have levelled, and it is unchanged. PKCE support fails
      CLOSED on a document that cannot be read; the response-`iss` flag stays
      TOLERANT, because a flag nobody could read must never lock out a provider
      that omits `iss`. `TryParse` answers null rather than throwing for every
      body that is not a JSON object, so each reader keeps deciding what an
      unreadable document means, instead of the whole read failing closed
      through `ReadAsync`'s catch-all and taking the tolerant fact with it.
      `ANullRoot_KeepsTheAsymmetryBetweenTheTwoFacts` is the row that holds it.
- [x] No secrets logged; secrets are redacted on config export. No logging
      changed here.
- [ ] A security review was performed. **It was not.** There is no second
      reader on this change, and this line stays as it is rather than being
      ticked from the evidence below. What stands in its place is the falsifier
      set: three deliberately broken builds, each observed red, quoted with the
      command and the output under Verification. That is proof the guards bite;
      it is not a second pair of eyes, and the two are different things.
- [ ] Review record: no lenses ran. CONFIRMED 0 / PLAUSIBLE 0 is what an
      unrun review reports, so no counts are claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. The two
      existing `ReplaceLineEndings` call sites in `OidcDiscoveryReader` are
      untouched.

## Quality checklist

- [x] No duplicated logic; the parse now lives in one small, single-purpose,
      testable unit and the duplicate walk is gone.
- [x] The change adds no more code than the problem requires. #1041 bounds this
      work explicitly: it is worth doing only if it stays small. It did not pull
      in the reader contracts or the discovery result type.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. `DiscoveryJson` sits in
      `Api/Oidc/` under the matching namespace with `DiscoveryJsonTests.cs`
      under `SSO-Auth.Tests/Oidc/`, which is what `ModuleTests_MirrorTheSourceModuleFolders`
      and `SourceModuleNamespaces_MirrorTheirFolder` require. The new structural
      property, one parse site in the plugin, is locked in as
      `TheShippedPluginHoldsOneParseSite` in the new file rather than in
      `ArchitectureConformanceTests.cs`, because that file is being edited by
      other open work and a rule that needs no shared comment predicate does not
      need to land there to bite. If the reviewer wants it in the conformance
      file instead, say so and it moves.
- [x] Docs impact: none. No user-visible behaviour, no option, no log line and
      no error text changes, so there is nothing for the README, `providers.md`
      or the wiki to say. No CHANGELOG entry for the same reason.

## Verification

- [x] `dotnet build --warnaserror` green on both target frameworks:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
      0 Warnung(en) / 0 Fehler
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
      0 Warnung(en) / 0 Fehler
      dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --warnaserror --nologo -v q
      0 Warnung(en) / 0 Fehler

- [x] Full suite green on both:

      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
      Total: 2528, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
      ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
      Total: 2529, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

### The three guards, each watched going red

Every new assertion was run against a build broken on purpose, so none of them
is a row that passes for the wrong reason.

1. A second parse site in the plugin. `PkceDiscovery`'s string entry point was
   put back to parsing for itself:

       ./SSO-Auth.Tests.exe -method "*TheShippedPluginHoldsOneParseSite*"
       Expected: ["Api\Oidc\DiscoveryJson.cs"]
       Actual:   ["Api\Oidc\DiscoveryJson.cs", "Api\Oidc\PkceDiscovery.cs"]
       Total: 1, Failed: 1

2. PKCE failing OPEN on an unreadable document, the one direction the shared
   parse could have introduced. `SupportsS256(JObject?)` was made to return true
   on a null root:

       Failed: ANullRoot_KeepsTheAsymmetryBetweenTheTwoFacts
       Failed: TheSeamAgreesWithBothRawEntryPoints("not-json" / "" / null)
       Total: 23, Failed: 4

3. The two facts wired to the wrong slots inside `FactsFrom`:

       Failed: TheSeamAgreesWithBothRawEntryPoints({"code_challenge_methods_supported":["S256"]})
       Failed: TheSeamAgreesWithBothRawEntryPoints({"authorization_response_iss_parameter_supported":true})
       Total: 23, Failed: 2

`OneParsedRoot_ServesBothFacts` carries no such row and is weaker for it: it
shows both readers answering off the instance they were handed, by removing the
members from that one root and watching both answers move, and it would not
catch a caller that went back to parsing twice. Guard 1 is what owns that
property.

## Notes

`SSO-Auth.Tests/Oidc/StrictJsonTests.cs` gets a one-clause correction: a comment
there said both readers `JObject.Parse` and index, which this change makes false.
It is the only file outside the issue's stated scope, and it is touched because
the change created the false sentence, not to carry unrelated work.

Out of scope, from the issue itself: the identity library's own typed
`System.Text.Json` read of the same document is a third pass and is not the
plugin's to remove.
