### PR TITLE
Pin the JWKS side of the kid allowlist as a set-level contract [#1168]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
@@ -35,6 +35,9 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
     private static readonly TimeSpan Skew = TimeSpan.FromMinutes(5);
 
     private readonly RSA _rsa = RSA.Create(2048);
+    // A SECOND key, so a set can carry an entry whose material is not the one that signed the token. Without
+    // it, every mixed-set row would verify through whichever entry survived and prove nothing about which.
+    private readonly RSA _other = RSA.Create(2048);
     private readonly OidcIdTokenValidator _idTokenValidator = new();
     private readonly OidcLogoutTokenValidator _logoutValidator = new();
     private readonly DateTime _now = DateTime.UtcNow;
@@ -75,6 +78,7 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
     public void Dispose()
     {
         _rsa.Dispose();
+        _other.Dispose();
         OidcLogoutTokenValidator.ResetReplaysForTests();
     }
 
@@ -257,6 +261,60 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
         Assert.Contains("unacceptable kid", result.Error, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [MemberData(nameof(OutOfAllowlistAdvertisedKeyIds))]
+    public async Task OneOddKeyInTheSet_DoesNotTakeDownTheGoodOne(string oddKeyId)
+    {
+        // The availability half of the decision, and the reason the answer is skip-nothing rather than
+        // refuse-the-set (#1168). The provider advertises two keys: one whose kid is outside the allowlist,
+        // one ordinary. The token is signed by the ordinary key and names it. If the odd entry were refused
+        // AS A SET, this login would be gone; if it were skipped, this login would survive - and the rows
+        // above cannot tell those two apart, because they use a set of one.
+        //
+        // The two entries carry DIFFERENT key material, so the signature can only verify through the good
+        // entry. A mixed set built from one modulus would pass even if the good entry had been dropped.
+        var result = await _idTokenValidator.ValidateAsync(
+            CreateToken(), OptionsFor(MixedJwks(oddKeyId)), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+    }
+
+    [Theory]
+    [MemberData(nameof(OutOfAllowlistAdvertisedKeyIds))]
+    public async Task ASetWhoseEveryKeyIsOdd_AndNoneIsTheSigner_FailsClosedWithoutThrowing(string oddKeyId)
+    {
+        // The other end of the same contract: keeping an odd-kid key is not a way into anything. Every
+        // advertised key here is outside the allowlist AND none of them is the key that signed the token,
+        // so verification has nothing to succeed with. The requirement is that it FAILS - fail-closed,
+        // through the ordinary no-usable-key path - rather than throwing, which on the callback becomes a
+        // 500 on an anonymous endpoint instead of a rejection.
+        var jwks = "{\"keys\":[" + KeyEntry(oddKeyId, _other) + "," + KeyEntry(oddKeyId + "-2", _other) + "]}";
+
+        var result = await _idTokenValidator.ValidateAsync(
+            CreateToken(), OptionsFor(jwks), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.False(string.IsNullOrEmpty(result.Error));
+    }
+
+    [Fact]
+    public async Task AnAdvertisedKeyWithNoKidAtAll_KeepsWorking()
+    {
+        // A single-key set that names no kid is the ordinary small-provider shape, and it must be untouched
+        // by anything the allowlist does. Both directions: the token names no key, and the token names one
+        // the set does not carry - in each case the only usable key is the one advertised without a name.
+        var jwks = "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\"," + Material(_rsa) + "}]}";
+
+        var withoutKid = await _idTokenValidator.ValidateAsync(
+            CreateTokenWithoutKid(), OptionsFor(jwks), TestContext.Current.CancellationToken);
+        Assert.False(withoutKid.IsError, withoutKid.Error);
+
+        var withKid = await _idTokenValidator.ValidateAsync(
+            CreateToken(), OptionsFor(jwks), TestContext.Current.CancellationToken);
+        Assert.False(withKid.IsError, withKid.Error);
+    }
+
     [Fact]
     public async Task ValidToken_OnBothPaths_StillSucceeds()
     {
@@ -279,24 +337,35 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
         ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
     };
 
-    private OidcClientOptions Options(string keyId = KeyId) => new()
+    private OidcClientOptions Options(string keyId = KeyId) => OptionsFor(Jwks(keyId));
+
+    private OidcClientOptions OptionsFor(string jwks) => new()
     {
         ClientId = ClientId,
         ProviderInformation = new ProviderInformation
         {
             IssuerName = Issuer,
-            KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(Jwks(keyId)),
+            KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
         },
     };
 
     private TokenValidationParameters Parameters(string keyId = KeyId) =>
         OidcSignatureKeys.BuildValidationParameters(Options(keyId), new List<IDisposable>(), requireExpiration: false);
 
-    private string Jwks(string keyId)
+    private string Jwks(string keyId) => "{\"keys\":[" + KeyEntry(keyId, _rsa) + "]}";
+
+    // Two advertised keys: the odd-kid one FIRST, so a walk that aborted on it would never reach the good
+    // one, and the good one second carrying the material that actually signed the token.
+    private string MixedJwks(string oddKeyId) =>
+        "{\"keys\":[" + KeyEntry(oddKeyId, _other) + "," + KeyEntry(KeyId, _rsa) + "]}";
+
+    private static string KeyEntry(string keyId, RSA rsa) =>
+        "{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + keyId + "\"," + Material(rsa) + "}";
+
+    private static string Material(RSA rsa)
     {
-        var p = _rsa.ExportParameters(false);
-        return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + keyId + "\","
-            + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
+        var p = rsa.ExportParameters(false);
+        return "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"";
     }
 
     // A token signed by the same RSA key but carrying no kid header, so key resolution has to fall back to

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -209,6 +209,13 @@ internal static class OidcSignatureKeys
     // use!="sig" is not a signing key, and un-decodable/invalid key material is caught and skipped so one
     // broken key in the set cannot take down verification signed by a good one. Returns false - never
     // throws - on every reject path so the caller drops the key without aborting the scan.
+    //
+    // The advertised kid is NOT one of the exclusions, and that is the decided contract rather than a
+    // gap (#1029, #1168): every exclusion above is a key that cannot do the job, and a spelling is not
+    // one of those. The set is also never refused whole over one entry - the odd key is kept, the good
+    // ones beside it keep working, and the token header's own kid is screened separately by
+    // IsAcceptableKeyId before any lookup. OidcSignatureKeysKidTests holds both directions of this,
+    // including what it costs: such a key is reachable by trying every advertised key, never by name.
     private static bool TryConvertSigningKey(Duende.IdentityModel.Jwk.JsonWebKey? webKey, List<IDisposable> ephemeralKeys, [NotNullWhen(true)] out SecurityKey? key)
     {
         key = null;


### PR DESCRIPTION
# What & why

The decision about a provider-advertised `kid` outside the allowlist was taken
and pinned in #1029: keep the key, never refuse the set, screen the token header
instead. What #1168 asks for is the part that decision's rows cannot carry,
because every one of them uses a key set of **one**.

A single-key set cannot distinguish the two candidate contracts. "Skip the odd
key" and "refuse the whole set" produce the same observable answer there, and the
difference between them is exactly the failure this issue is about: whether one
provider's spelling of one `kid` takes a working login down.

So this adds the set-level rows and states the contract where the code takes it.

Closes #1168

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs (tests and one source comment; no behaviour
      change)

## Security checklist

- [x] Fail-closed preserved. One of the three new rows exists to assert it: a set
      whose every advertised `kid` is out of the allowlist and none of whose keys
      signed the token must fail closed through the ordinary no-usable-key path,
      **without throwing**. A throw out of the conversion becomes a 500 on an
      anonymous endpoint where a rejection belongs.
- [x] No secrets logged. Nothing logged at all; the test keys are generated per
      run and disposed.
- [ ] A security review was performed. **It was not.** There is no second reader
      on this change tonight. In its place the three new rows were each watched
      going red on a build broken on purpose, quoted below; that is proof the
      rows bite, and it is not a second pair of eyes.
- [ ] Review record: no lenses ran, so no CONFIRMED / PLAUSIBLE counts are
      claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. Not touched.

## Quality checklist

- [x] No duplicated logic. The `Jwks` helper was one string builder; it is now
      `KeyEntry` + `Material` so a set can hold two entries, and the existing
      helper is expressed through them.
- [x] The change adds no more code than the problem requires: three rows, one
      second RSA key, two small helpers, one comment.
- [x] Comments explain why. The new comment on `TryConvertSigningKey` states
      what the conversion does and does not exclude, and names the cost the
      existing tests hold; it enumerates no evasions (#1050).
- [x] Architecture-conformance tests pass, unchanged. The change establishes no
      new structural property, so no rule is added.
- [x] Docs impact: none. The contract was already documented in the source and
      in #1029; no user-facing behaviour, option or message moves.

## Verification

- [x] Both frameworks, `--warnaserror`, full suite:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q   -> 0 Fehler
      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    Total: 2535, Failed: 0
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q   -> 0 Fehler
      ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   Total: 2536, Failed: 0

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

### Each new row watched going red

Run as `SSO-Auth.Tests.exe -method "*OidcSignatureKeysKidTests*"`, 70 rows in the
file.

1. **The set refused whole** over one odd entry, which is the alternative
   contract the issue names. `OneOddKeyInTheSet_DoesNotTakeDownTheGoodOne` goes
   red on all three odd shapes; the pre-existing single-key rows go red with it,
   which is the point about what a set of one can and cannot see.

       Failed: 9 (OneOddKeyInTheSet... x3, AdvertisedKeyOutsideTheAllowlist_IsKept x3,
                  TokenWithoutAKid_StillValidatesAgainstSuchAKey x3)

2. **Keys advertised without a `kid` dropped** from the walk.
   `AnAdvertisedKeyWithNoKidAtAll_KeepsWorking` goes red **alone**, so that row
   covers something no other row in the file did:

       Failed: 1

3. **The walk made to throw** on an out-of-allowlist advertised `kid`, breaking
   the never-throws contract.
   `ASetWhoseEveryKeyIsOdd_AndNoneIsTheSigner_FailsClosedWithoutThrowing` goes
   red, together with the rows that depend on the key surviving:

       Failed: 12

## Notes

The two entries in the mixed set carry **different** key material on purpose. A
mixed set built from one modulus would verify through whichever entry survived
and would prove nothing about which one did, which is the way this row could
have passed for the wrong reason.

The issue asks for the reasoning to sit on `TryConvertSigningKey` alongside the
other exclusions rather than only in a commit message; it now does. The wider
argument for the decision stays in `Convert`'s summary where #1029 put it, and
neither place enumerates what the screen misses.
