### PR TITLE
Replay the committed fuzz seeds in the gating build [#1134]

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -87,6 +87,48 @@ jobs:
       run: dotnet restore SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --locked-mode
     - name: Build the fuzz harness (Release)
       run: dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror
+    # Replaying the committed seeds is a BEHAVIOURAL gate, and it is a different
+    # question from the compilation above: a plugin change can leave the harness
+    # building perfectly while making a known-hostile input throw an exception the
+    # fail-closed filters do not name, which on the real callback is an
+    # unauthenticated 500. Smoke mode needs no clang, no `sharpfuzz` CLI and no
+    # libFuzzer runtime, so this costs seconds; the coverage-guided run stays
+    # non-gating in fuzz.yml, which still has no push or pull_request trigger.
+    #
+    # The target list is DERIVED from the corpus directories rather than written
+    # here, so a target added to the harness is replayed by the fact of having a
+    # corpus and cannot be silently uncovered by a list nobody updated.
+    #
+    # Both empty answers are failures. RunSmoke exits 2 for a missing directory but
+    # 0 for a directory that happens to hold nothing, so a corpus that stopped
+    # being checked out, or a glob that stopped matching, would otherwise read as a
+    # clean pass. The seed count is counted here and required to be non-zero, and
+    # the whole loop is required to have found at least one target.
+    - name: Replay the fuzz seed corpus
+      run: |
+        set -o pipefail
+        # nullglob so a corpus that vanished leaves the loop with nothing to do and
+        # is caught by the counter below, rather than by `find` failing on a literal
+        # unexpanded glob - both fail the step, but only one of them says why.
+        shopt -s nullglob
+        targets=0
+        for dir in SSO-Auth.Fuzz/corpus/*/; do
+          target="$(basename "$dir")"
+          seeds="$(find "$dir" -type f | wc -l)"
+          if [ "$seeds" -eq 0 ]; then
+            echo "::error::The fuzz corpus for target '${target}' is empty, so replaying it proves nothing."
+            exit 1
+          fi
+          echo "Replaying ${seeds} seed(s) through target '${target}'."
+          SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET="${target}" \
+            dotnet SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll "${dir}"
+          targets=$((targets + 1))
+        done
+        if [ "$targets" -eq 0 ]; then
+          echo "::error::No fuzz corpus directories were found under SSO-Auth.Fuzz/corpus/."
+          exit 1
+        fi
+        echo "Replayed ${targets} target(s) with no unmapped exception."
     - name: Test
       run: dotnet test --no-build --verbosity normal
     # Line coverage for the RC coverage gate (#718). A second, instrumented run

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -9,6 +9,12 @@ restores SharpFuzz or builds it. The _fuzzing_ is driven only by the scheduled L
 acceptance criteria require ("scheduled, non-blocking"). Since #1132 the gating `build` job does compile
 the harness by path, so a module rename that breaks it reds the PR rather than the weekly run.
 
+Since #1134 that job also **replays every committed seed** through its target in smoke mode, which asks a
+different question from compiling: a plugin change can leave the harness building perfectly while making a
+known-hostile input throw an exception the fail-closed filters do not name. The target list comes from the
+corpus directories, so a new target is replayed by the fact of having a corpus. An empty corpus directory,
+or no corpus at all, fails the step rather than passing quietly. The coverage-guided run stays non-gating.
+
 ## The attack surface we target
 
 The login endpoints are anonymous and hand attacker-controlled bytes straight into parsers before any

--- a/SSO-Auth.Fuzz/corpus/idtoken/tmp-1249-reproducer
+++ b/SSO-Auth.Fuzz/corpus/idtoken/tmp-1249-reproducer
@@ -1,0 +1,2 @@
+eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZWb25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZW50In0.
+50In0.

--- a/SSO-Auth.Fuzz/corpus/idtoken/tmp-1249-reproducer
+++ b/SSO-Auth.Fuzz/corpus/idtoken/tmp-1249-reproducer
@@ -1,2 +1,0 @@
-eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZWb25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZW50In0.
-50In0.


### PR DESCRIPTION
# What & why

Compiling the fuzz harness in the gating job (#1132) catches a rename. It cannot
catch the thing the harness exists for: a plugin change that leaves a
known-hostile seed throwing an exception the fail-closed filters do not name,
which on the real callback is an unauthenticated 500. Until now nothing asked
that question until the weekly run, days later.

The gating `build` job now replays every committed seed through its target in
smoke mode, right after the harness build. No clang, no `sharpfuzz` CLI, no
libFuzzer runtime; seconds for the whole corpus. `fuzz.yml` is untouched and
still has no push or pull_request trigger.

Closes #1134

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs (CI gate)

## Security checklist

- [x] Fail-closed preserved. The step is fail-closed in both directions a
      decorative gate would not be: an empty corpus directory and an absent
      corpus both fail it, because `RunSmoke` exits 2 for a missing directory but
      **0** for a directory holding nothing.
- [x] No secrets logged. The step prints seed counts and target names.
- [ ] A security review was performed. **It was not.** No second reader tonight.
      What stands in its place is the falsifier set below, three of them local
      and one run on this pull request's own checks.
- [ ] Review record: no lenses ran, so no counts are claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. Not touched.

## Quality checklist

- [x] No duplicated logic. The target list is **derived** from the corpus
      directories rather than written into the workflow, so it cannot drift from
      the harness the way a hand-maintained list does.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why: why replaying is a different question from
      compiling, why both empty answers are failures, and why `nullglob` is
      there.
- [x] Architecture-conformance tests pass, unchanged.
- [x] Docs impact: the harness README says what the gating job now does, in this
      change. Nothing user-facing moves.

## Verification

- [x] The step, run verbatim on this machine against the committed corpus:

      Replaying 4 seed(s) through target 'discovery'.   Smoke OK: 4 seed(s) ...
      Replaying 4 seed(s) through target 'idtoken'.     Smoke OK: 4 seed(s) ...
      Replaying 2 seed(s) through target 'jwks'.        Smoke OK: 2 seed(s) ...
      Replaying 15 seed(s) through target 'saml'.       Smoke OK: 15 seed(s) ...
      Replayed 4 target(s) with no unmapped exception.   EXIT=0

- [x] Prettier clean on the changed README.
- [x] Plugin build and suite untouched by this change; the step runs after them
      in the same job and CI is the reader of that.

### Watched failing, three ways locally

1. An empty corpus directory:

       ::error::The fuzz corpus for target 'emptytarget' is empty, so replaying it proves nothing.
       EXIT=1

2. No corpus directories at all:

       ::error::No fuzz corpus directories were found under SSO-Auth.Fuzz/corpus/.
       EXIT=1

3. A seed that throws an unmapped exception, which is the case the gate exists
   for. The seed used is the real reproducer from **#1249**, a live crasher on
   the `idtoken` surface, rather than a synthetic one:

       System.FormatException: IDX10400: Unable to decode ... as Base64url encoded string.
          at ... OidcResponseIssuer.TokenIssuer(String identityToken)
       EXIT=127

   That seed is deliberately **not** committed. Committing it would red this gate
   for every unrelated change until #1249 is fixed, which is a different decision
   from the one this pull request makes.

### And once on the real check

The issue asks for the gate to be watched going red in CI rather than only on a
workstation. That was done on this branch, as a temporary commit adding the
#1249 reproducer to `corpus/idtoken/`, reverted in the commit after it. The two
commits and the check results either side of them are in this branch's history;
the merged state carries no crasher seed.

## Notes

The step is placed before `Test` rather than after, so a parse-surface regression
is reported ahead of the longer suite.
