### PR TITLE
Give the file-writing tests a directory the suite owns [#1218]

### DIFF
--- a/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
@@ -238,7 +238,7 @@ public class ConfigXmlLifecycleTests
         // encrypted config is written back to XML and read again, and the original plaintext is recovered via
         // SecretStore.Reveal. NOTE: this exercises secret-at-rest migration - a security-surface change of
         // this shape belongs to the /security-review gate.
-        var keyPath = Path.Combine(Path.GetTempPath(), "sso-cfgxml-" + Guid.NewGuid().ToString("N") + ".key");
+        var keyPath = SuiteTempFiles.Path("sso-cfgxml");
         try
         {
             var legacy = new PluginConfiguration();

--- a/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
+++ b/SSO-Auth.Tests/Secrets/ConfigSecretProtectionTests.cs
@@ -18,7 +18,7 @@ public class ConfigSecretProtectionTests
 {
     private static void WithStore(Action<SecretStore> test)
     {
-        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        var path = SuiteTempFiles.Path("sso-cfgsec");
         try
         {
             test(new SecretStore(path));
@@ -139,7 +139,7 @@ public class ConfigSecretProtectionTests
     [Fact]
     public void HasAnyEnvelope_ALogoutIdTokenEnvelopeAlone_IsDetected_SoAMissingKeyFailsClosed()
     {
-        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        var path = SuiteTempFiles.Path("sso-cfgsec");
         try
         {
             // An envelope living ONLY in a captured logout id_token must still be seen as "config holds an
@@ -166,7 +166,7 @@ public class ConfigSecretProtectionTests
     [Fact]
     public void HasAnyEnvelope_ARolloverEnvelopeAlone_IsDetected_SoAMissingKeyFailsClosed()
     {
-        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        var path = SuiteTempFiles.Path("sso-cfgsec");
         try
         {
             // Encrypt a value so a real envelope exists, place it ONLY in the rollover field, then lose the
@@ -210,7 +210,7 @@ public class ConfigSecretProtectionTests
     [Fact]
     public void ProtectAll_ExistingEnvelopeButMissingKey_FailsClosedWithoutMinting()
     {
-        var path = Path.Combine(Path.GetTempPath(), "sso-cfgsec-" + Guid.NewGuid().ToString("N") + ".key");
+        var path = SuiteTempFiles.Path("sso-cfgsec");
         try
         {
             // Encrypt one secret so a real envelope exists, then lose the key file (restored config, lost key).

--- a/SSO-Auth.Tests/Secrets/SecretStoreTests.cs
+++ b/SSO-Auth.Tests/Secrets/SecretStoreTests.cs
@@ -18,7 +18,7 @@ public class SecretStoreTests
 {
     private static void WithTempKeyPath(Action<string> test)
     {
-        var path = Path.Combine(Path.GetTempPath(), "sso-key-test-" + Guid.NewGuid().ToString("N") + ".key");
+        var path = SuiteTempFiles.Path("sso-key-test");
         try
         {
             test(path);

--- a/SSO-Auth.Tests/_Support/SuiteTempFiles.cs
+++ b/SSO-Auth.Tests/_Support/SuiteTempFiles.cs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// One directory per test run, owned by the suite, for the tests that write real files - today the
+/// secret-store key blobs (#1218). They used to be written straight into <c>Path.GetTempPath()</c>, which
+/// every process on the machine shares and several things sweep; a key file removed between the write and
+/// the read that follows it produced eighteen red tests in two of five consecutive runs of one unchanged
+/// binary, all of them in the classes whose purpose is to prove secrets fail closed.
+/// <para>
+/// A suite-owned subdirectory does not make the files un-deletable, and nothing here claims it does: what
+/// it removes is the exposure to a sweep aimed at the SHARED directory, and it makes the lifetime the
+/// suite's own - the directory is created once per process and removed when the process ends, rather than
+/// leaving a key blob per test behind for something else to tidy up.
+/// </para>
+/// </summary>
+internal static class SuiteTempFiles
+{
+    // Created on first use rather than in a static constructor, so a run that touches none of these tests
+    // creates no directory at all. Lazy is thread-safe by default, which matters because the suite runs
+    // its collections in parallel.
+    private static readonly Lazy<string> RootDirectory = new(CreateRoot);
+
+    /// <summary>
+    /// A path inside this run's own directory, with a name unique per call. The file is NOT created; the
+    /// caller writes it, exactly as it did when the path pointed at the shared temp directory.
+    /// </summary>
+    /// <param name="prefix">A short prefix naming the test family, kept so a leftover file still says where it came from.</param>
+    /// <param name="extension">The file extension, including the dot.</param>
+    /// <returns>The full path.</returns>
+    internal static string Path(string prefix, string extension = ".key") =>
+        System.IO.Path.Combine(RootDirectory.Value, prefix + "-" + Guid.NewGuid().ToString("N") + extension);
+
+    private static string CreateRoot()
+    {
+        var root = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "sso-suite-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        // Best-effort removal at the end of the run. It is deliberately swallowed: a directory that could
+        // not be deleted (a file still held open by a crashed run, a scanner holding a handle) must not
+        // turn a green suite red on the way out, and the next run is unaffected because it creates its own.
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+        };
+
+        return root;
+    }
+}


### PR DESCRIPTION
# What & why

The secret-store key blobs were written straight into `Path.GetTempPath()`, the
directory every process on the machine writes to and several things sweep. A key
file removed between the write and the read that follows it produced eighteen red
tests in two of five consecutive runs of one unchanged binary, all of them in the
classes whose whole purpose is to prove secrets fail closed.

`SuiteTempFiles` hands out paths inside one directory created per run and removed
when the process ends. The three classes that write real files take their paths
from it.

Closes #1218

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix (test infrastructure)
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. No production code is touched; the tests that assert
      the fail-closed posture are unchanged in what they assert, only in where
      they put their file.
- [x] No secrets logged. The key material stays what it was: throwaway bytes
      written by tests, now in a directory the run deletes.
- [ ] A security review was performed. **It was not.** No second reader on this
      change tonight. The evidence in its place is the twenty-run measurement
      below, which is what the issue asks for.
- [ ] Review record: no lenses ran, so no counts are claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. Not touched.

## Quality checklist

- [x] No duplicated logic: six call sites that each built their own path now share
      one helper.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why, including what the change does **not** claim.
- [x] Architecture-conformance tests pass, unchanged. The helper sits in
      `_Support/`, where the shared test infrastructure lives.
- [x] Docs impact: none. Nothing user-facing, no option, no message.

## Verification

- [x] The issue's own acceptance run, twenty consecutive times:

      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe \
        -class "...SecretStoreTests" -class "...ConfigSecretProtectionTests" -class "...ConfigXmlLifecycleTests"

      runs 1-20: Total: 28, Errors: 0, Failed: 0 each
      PASSRUNS=20 FAILRUNS=0

- [x] The shared directory is clean afterwards: `sso-suite-*` count 0, and
      `sso-key-test-*` / `sso-cfgsec-*` count 0. So the per-run directory is
      really removed at process exit under the MTP runner, measured rather than
      assumed, and the old shape's leftovers are gone with it.

- [x] Full suite, `--warnaserror`, both frameworks:

      net9.0   Total: 2528, Failed: 0
      net10.0  Total: 2529, Failed: 0

- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

**What this does not prove.** The sweeper was never identified, and this change
does not identify it either. A subdirectory is not un-deletable; twenty green runs
are twenty green runs, not an impossibility proof. What the change actually
removes is the exposure to a sweep aimed at the shared directory, and it makes the
lifetime the suite's own rather than leaving a key blob per test behind for
something else to tidy up. If the failure returns inside the owned directory, that
is new information and a different issue, and the failure text will at least name
a path this suite created.

The remaining `Path.GetTempPath()` call sites in the suite hand a path to a mocked
`IApplicationPaths` and create nothing on disk, so they are left alone rather than
swept into this change.

The cleanup swallows `IOException` and `UnauthorizedAccessException` on purpose: a
directory still held open, by a scanner or a crashed run, must not turn a green
suite red on the way out, and the next run is unaffected because it creates its
own.
