### PR TITLE
Correct the Dependabot cooldown rationale for action bumps [#1055]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,16 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # Wait 7 days before proposing a new version so a release compromised between
-    # publish and adoption is caught before it enters a PR (recent supply-chain
-    # attacks were live for hours-to-days). Security updates are exempt - they are
-    # still proposed immediately.
+    # Hold a newly published version for 7 days before it may enter a pull
+    # request, so a release compromised between publish and adoption has time to
+    # surface in the advisory feeds first. GitHub's own words on the carve-out:
+    # the cooldown "does not apply to security updates".
+    #
+    # No tier key here, deliberately. NuGet does support semver-*-days, but
+    # shortening the patch tier would speed up only the non-security bumps, and
+    # the patch tier is exactly where a registry compromise publishes. GitHub
+    # has also made 3 days the platform-wide default, so a 3-day patch tier
+    # would buy no margin over configuring nothing at all.
     cooldown:
       default-days: 7
 
@@ -17,7 +23,24 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    # Same cooldown for action bumps - the tj-actions / Trivy-action incidents were
-    # exactly compromised-tag adoptions a delay would have caught.
+    # What this hold reaches: a freshly published malicious version of an action,
+    # which then waits 7 days before it can be proposed here. Same carve-out as
+    # above, in GitHub's words - the cooldown "does not apply to security
+    # updates".
+    #
+    # What it does NOT reach, and no comment here should claim otherwise: a
+    # re-pointed tag, where an existing tag is moved onto a malicious commit. The
+    # release keeps its original publication date, so there is no new
+    # publication for a date-based hold to delay. What defends this repository
+    # against that class is SHA-pinning every `uses:` plus zizmor's unpinned-uses
+    # audit in .github/workflows/zizmor.yml: a SHA pin keeps resolving to the old
+    # commit after the tag moves, and the audit fails the build on a ref that is
+    # not a SHA.
+    #
+    # No tier keys here because GitHub's cooldown support table does not list
+    # github-actions for semver-major-days / semver-minor-days /
+    # semver-patch-days. That is the reason, and it is not a statement about how
+    # action tags are versioned: Helm and Terraform are semver and are absent
+    # from the same table, while Maven is not semver and is present.
     cooldown:
       default-days: 7


### PR DESCRIPTION
# What & why

The `github-actions` cooldown entry justified its 7-day hold by naming the
tj-actions and Trivy-action incidents as "compromised-tag adoptions a delay
would have caught". Both were tag re-points: an existing tag moved onto a
malicious commit, with the underlying release keeping its original publication
date. There is no new publication for a date-based hold to delay, so the
comment promised a protection the setting cannot give. That is the defect this
change removes: a false security comment is what the next author reads instead
of re-deriving the answer.

The replacement says what the hold reaches (a freshly published malicious
version of an action), what it does not reach (a re-pointed tag), and which
control does cover that class: SHA-pinning every `uses:` together with
zizmor's unpinned-uses audit. That control is real in this tree today, not
aspirational:

```
$ grep -rh "uses:" .github/workflows/ .github/actions/ | wc -l
80
$ grep -rhn "uses:" .github/workflows/ .github/actions/ \
    | grep -v "uses: \./" | grep -vE "@[0-9a-f]{40}"
11:# version moves. Keep the only `uses:` (checkout) SHA-pinned and
```

80 references, and the only line that is not a 40-hex pin is prose inside a
comment rather than a reference.

Both entries now record why they carry no semver tier key. For
`github-actions` the reason is that GitHub's cooldown support table does not
list it, stated without implying anything about how action tags are versioned:
Helm and Terraform are semver and absent from that table, Maven is not semver
and present. Verified against
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
on 2026-08-06. For `nuget`, where the tier keys are available, the file now
says the tier was declined deliberately rather than overlooked, matching the
acceptance criterion the issue withdrew on 2026-07-28. Neither value moves;
both stay at `default-days: 7`.

The security carve-out is kept visible on both entries in GitHub's own words,
"does not apply to security updates", so the hold is not misread as delaying
an advisory-driven bump.

Closes #1055

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: no behaviour changes. Both `cooldown` values are
      byte-identical before and after; the diff is comments only, plus the
      `default-days: 7` lines being re-emitted unchanged.
- [x] No secrets logged; secrets are redacted on config export. Not applicable,
      the file holds no secret and no logging path.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. NOT PERFORMED. This change
      touches none of those three surfaces: it edits comments in
      `.github/dependabot.yml`, which is neither the login path nor the publish
      pipeline.
- [ ] Review record. NO SECOND READER WAS AVAILABLE FOR THIS CHANGE, and no
      review lens was run. The evidence stands in its place: the pinning counts
      above, and the two independent reads of GitHub's support table cited
      under "What & why". Read the claims against those, not against a review
      that did not happen.
- [x] Log inputs from the IdP are sanitized inline at the log call. Not
      applicable, no log call is touched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. No logic is added.
- [x] The change adds no more code than the problem requires. The diff is
      confined to the one file the issue names.
- [x] The code is self-documenting; comments explain why, not what. This change
      is entirely that: each entry now carries the reason for its value and the
      bound on what the value achieves.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule. No structural property changes;
      no `.cs` file is touched.
- [x] Docs impact considered: none. The cooldown posture is not described in the
      README or the wiki, so the file's own comments are its only home.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green. NOT RUN. No compiled
      file is in the diff, so the build cannot observe this change. The
      repository's `build` check on this pull request runs it regardless and is
      the verdict to read.
- [ ] `dotnet test` is green. NOT RUN, for the same reason, and for a second
      one: #1227 records that the suite raises a Windows elevation prompt on this
      machine, and that prompt is not something to trigger for a comment edit.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such
      file changed. Prettier was still used as the YAML parse check the issue's
      last criterion asks for:

      ```
      $ npx prettier --check .github/dependabot.yml
      Checking formatting...
      All matched files use Prettier code style!
      ```

## Notes

The withdrawn `semver-patch-days: 3` criterion is honoured rather than
silently dropped: `nuget` keeps `default-days: 7`, and the file now records
why the tier was declined, so the next reader does not re-propose it.

Out of scope as the issue states: schedules, `open-pull-requests-limit`,
grouping, and the zizmor configuration itself. zizmor is named in the new
comment but not edited.
