### PR TITLE
Refuse a degenerate multi-segment token instead of raising out of the reader [#1249]

### DIFF
--- a/SSO-Auth.Fuzz/corpus/idtoken/five-segment-undecodable.jwt
+++ b/SSO-Auth.Fuzz/corpus/idtoken/five-segment-undecodable.jwt
@@ -1,0 +1,2 @@
+eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZWb25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJoY2xpZW50In0.
+50In0.

--- a/SSO-Auth.Tests/Oidc/OidcDegenerateTokenSegmentsTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDegenerateTokenSegmentsTests.cs
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A compact token carrying MORE than three segments is unreadable in a way the readers did not name (#1249).
+/// Such a token gets far enough for the token library to base64url-decode a LATER segment, and that decode
+/// raises <see cref="FormatException"/> - which is not an <see cref="ArgumentException"/>, so it escaped every
+/// defensive catch on the id_token and <c>logout_token</c> paths.
+/// <para>
+/// Why it is a security test and not a tidiness one: <see cref="OidcSignatureKeys.TokenHasAcceptableKeyId"/> is
+/// the <c>kid</c> screen both token paths run BEFORE any signing key is looked up, and the back-channel logout
+/// endpoint takes its token straight from an anonymous POST body. The escape therefore replaced the endpoint's
+/// deliberately uniform 400 with a 500, which is an availability cost and an oracle: a 500 tells an
+/// unauthenticated caller that single-logout is switched on for that provider, which the uniform rejection
+/// exists to hide. Nothing is accepted and no session is revoked, so this is fail-stop rather than fail-open.
+/// </para>
+/// </summary>
+public sealed class OidcDegenerateTokenSegmentsTests
+{
+    /// <summary>
+    /// The libFuzzer reproducer from #1249, base64 of the exact bytes. Held encoded on purpose: it carries
+    /// literal newlines, and a raw literal would be normalised by this repository's .gitattributes on the way
+    /// into git - deleting the very bytes the fixture exists to preserve.
+    /// </summary>
+    private const string CrasherBase64 =
+        "ZXlKaGJHY2lPaUp1YjI1bElpd2lkSGx3SWpvaVNsZFVJbjAuZXlKcGMzTWlPaUpvWTJ4cFpXYjI1bElpd2lkSGx3SWpvaVNsZFVJbjAuZXlKcGMzTWlPaUpvWTJ4cFpXNTBJbjAuCjUwSW4wLgo=";
+
+    /// <summary>The reproducer minimised to the shape that matters: a readable header, then five segments.</summary>
+    private const string Minimised = "eyJhbGciOiJub25lIn0.a.b.c.!";
+
+    public static TheoryData<string> DegenerateTokens => new(Crasher(), Minimised);
+
+    /// <summary>
+    /// Five-segment tokens whose later segments DO decode, and three-segment tokens with an undecodable
+    /// header, take the ordinary unreadable path. They are here so a green suite cannot be read as "any odd
+    /// token is now swallowed": the widened catch is aimed at one shape, and these prove the others were
+    /// already handled and still are.
+    /// </summary>
+    public static TheoryData<string> AlreadyHandledTokens => new("a.b.c.d.e", "!!!.eyJpc3MiOiJoIn0.sig", "not-a-jwt", "only.two");
+
+    private static string Crasher() => Encoding.UTF8.GetString(Convert.FromBase64String(CrasherBase64));
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    [MemberData(nameof(AlreadyHandledTokens))]
+    public void KidGate_ReportsAcceptable_RatherThanThrowing(string token)
+    {
+        // The gate is deliberately not the fail-closed floor: a token it cannot read is the handler's to
+        // refuse, on the handler's own terms. "Cannot read" has to mean that whichever exception says so,
+        // otherwise the gate leaks the failure to the endpoint as a 500.
+        Assert.True(OidcSignatureKeys.TokenHasAcceptableKeyId(token));
+    }
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    [MemberData(nameof(AlreadyHandledTokens))]
+    public void IdTokenIssuer_ReadsAsAbsent_RatherThanThrowing(string token)
+    {
+        // The mix-up check reads the issuer off the token; a degenerate token must leave it absent so the
+        // check refuses on a missing issuer instead of the reader raising into the callback.
+        Assert.Null(OidcResponseIssuer.IdTokenIssuer(token));
+    }
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    [MemberData(nameof(AlreadyHandledTokens))]
+    public void Acr_ReadsAsAbsent_RatherThanThrowing(string token)
+        => Assert.Null(OidcIdTokenAcr.Read(token));
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    [MemberData(nameof(AlreadyHandledTokens))]
+    public void Sid_ReadsAsAbsent_RatherThanThrowing(string token)
+        => Assert.Null(OidcIdTokenSid.Read(token));
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    [MemberData(nameof(AlreadyHandledTokens))]
+    public void AuthTime_ReadsAsAbsent_RatherThanThrowing(string token)
+    {
+        // auth_time absent is the fail-closed reading: the caller's max_age check refuses rather than
+        // trusting a value it could not parse.
+        Assert.Null(OidcIdTokenAuthTime.Read(token));
+    }
+}
+
+/// <summary>
+/// The endpoint half of #1249. The unit rows above pin the readers; this pins the thing an anonymous caller
+/// can actually observe, because the oracle lives at the endpoint and not at the helper.
+/// </summary>
+[Collection("SSOController")]
+public sealed class OidcDegenerateTokenSegmentsEndpointTests : IDisposable
+{
+    private const string Authority = "https://idp-degenerate.example.test";
+
+    private readonly OidcTokenFixture _fixture = new(Authority, "jf");
+
+    public OidcDegenerateTokenSegmentsEndpointTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    public void Dispose()
+    {
+        _fixture.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    public static TheoryData<string> DegenerateTokens => OidcDegenerateTokenSegmentsTests.DegenerateTokens;
+
+    [Theory]
+    [MemberData(nameof(DegenerateTokens))]
+    public async Task BackChannelLogout_AnswersTheUniform400_AndMintsNoRevoke(string logoutToken)
+    {
+        // The feature and the per-provider opt-in are both ON, so the endpoint reads the untrusted token
+        // rather than collapsing to the rejection without looking at it - which is what makes this the 500
+        // path rather than a repeat of the gate tests.
+        var harness = new SsoControllerHarness(
+            c =>
+            {
+                c.EnableSingleLogout = true;
+                c.OidConfigs["kc"] = new OidConfig
+                {
+                    Enabled = true,
+                    OidEndpoint = Authority,
+                    OidClientId = "jf",
+                    EnableBackChannelLogout = true,
+                };
+            },
+            httpResponder: Responder);
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", logoutToken);
+
+        // The uniform rejection, byte for byte - a distinguishable answer here is the oracle the uniform
+        // 400 exists to close, and a 500 was one.
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Logout token could not be processed", content.Content);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    // Serves this fixture's discovery document and JWKS so the refusal is the token's shape and not a
+    // failure to reach the provider; any other URL 404s so an unexpected call is visible.
+    private HttpResponseMessage Responder(HttpRequestMessage request)
+    {
+        var url = request.RequestUri!.AbsoluteUri;
+        if (url == _fixture.DiscoveryUrl)
+        {
+            return Json(_fixture.Discovery());
+        }
+
+        return url == _fixture.JwksUrl ? Json(_fixture.Jwks()) : new HttpResponseMessage(HttpStatusCode.NotFound);
+    }
+
+    private static HttpResponseMessage Json(string body) => new HttpResponseMessage(HttpStatusCode.OK)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+}

--- a/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenAcr.cs
@@ -47,5 +47,12 @@ internal static class OidcIdTokenAcr
         {
             return null;
         }
+        catch (FormatException)
+        {
+            // A token with more than three segments gets far enough for the library to base64url-decode a
+            // LATER segment, and that decode raises FormatException rather than the malformed-token
+            // ArgumentException above. Unreadable by another name, so it reads as absent like the rest.
+            return null;
+        }
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcIdTokenAuthTime.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenAuthTime.cs
@@ -66,5 +66,12 @@ internal static class OidcIdTokenAuthTime
         {
             return null;
         }
+        catch (FormatException)
+        {
+            // A token with more than three segments gets far enough for the library to base64url-decode a
+            // LATER segment, and that decode raises FormatException rather than the malformed-token
+            // ArgumentException above. Unreadable by another name, so it reads as absent like the rest.
+            return null;
+        }
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenSid.cs
@@ -47,5 +47,12 @@ internal static class OidcIdTokenSid
         {
             return null;
         }
+        catch (FormatException)
+        {
+            // A token with more than three segments gets far enough for the library to base64url-decode a
+            // LATER segment, and that decode raises FormatException rather than the malformed-token
+            // ArgumentException above. Unreadable by another name, so it reads as absent like the rest.
+            return null;
+        }
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -104,5 +104,12 @@ internal static class OidcResponseIssuer
         {
             return null;
         }
+        catch (FormatException)
+        {
+            // A token with more than three segments gets far enough for the library to base64url-decode a
+            // LATER segment, and that decode raises FormatException rather than the malformed-token
+            // ArgumentException above. Unreadable by another name, so it reads as absent like the rest.
+            return null;
+        }
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -125,6 +125,15 @@ internal static class OidcSignatureKeys
             // Not a readable JWT. The handler rejects it on its own terms; see the remark above.
             return true;
         }
+        catch (FormatException)
+        {
+            // The same case arriving under another name. A token with more than three segments gets far
+            // enough for the library to base64url-decode a LATER segment, and that decode raises
+            // FormatException rather than the malformed-token ArgumentException the line above catches -
+            // so an anonymous caller could turn this gate into a 500. Unreadable is unreadable whichever
+            // exception says so; the handler still owns the refusal.
+            return true;
+        }
 
         return IsAcceptableKeyId(keyId);
     }


### PR DESCRIPTION
# What & why

A compact token carrying more than three segments gets far enough for the token
library to base64url-decode a LATER segment, and that decode raises
`System.FormatException`. `FormatException` is not an `ArgumentException`, so it
escaped every defensive catch on the OpenID token readers.

`OidcSignatureKeys.TokenHasAcceptableKeyId` is the `kid` screen both token paths
run before any signing key is looked up, and the back-channel logout endpoint
takes its token straight from an anonymous POST body. The exception therefore
propagated to the endpoint and replaced the deliberately uniform 400 with a 500.
Nothing was accepted and no session was revoked, so this is fail-stop and not
fail-open. The cost is availability plus an oracle: a 500 tells an
unauthenticated caller that single logout is switched on for that provider,
which the uniform rejection exists to hide.

Closes #1249

## Which exception each shape actually raises

Measured with a throwaway probe over both call sites rather than reasoned from
the stack trace, because the fix depends on which types the existing catches
already cover:

| input | `new JsonWebToken(...)` raises | is it an `ArgumentException`? |
| --- | --- | --- |
| the issue's reproducer | `System.FormatException` | no |
| `eyJhbGciOiJub25lIn0.a.b.c.!` | `System.FormatException` | no |
| `a.b.c.d.e` | `System.ArgumentException` | yes |
| `!!!.eyJpc3MiOiJoIn0.sig` | `System.ArgumentException` | yes |
| `not-a-jwt`, `only.two` | `SecurityTokenMalformedException` | yes |

The last row is the one worth stating: the malformed-token exception already
derives from `ArgumentException`, so the existing catch covered it and needed no
widening. Only `FormatException` escaped. The probe was deleted before the
commit; the same inputs survive as the `AlreadyHandledTokens` rows in the test,
so a green suite cannot be read as "any odd token is now swallowed".

## Scope, stated because it is wider than the issue asks

The issue names two untrusted-string `JsonWebToken` constructions. There are
five. The other three read `acr`, `sid` and `auth_time` off an already-validated
token, so a degenerate token cannot reach them today, but each carries a comment
promising that a degenerate token can never turn the gate into a 500, and that
promise was false for this shape. All five are widened, so one property is
stated the same way everywhere rather than three copies drifting behind the two
that were fixed.

## The guard is proven by removing it

With the five catches reverted and the tests kept:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*DegenerateTokenSegments*"
   Total: 32, Errors: 0, Failed: 12, Skipped: 0, Not Run: 0

System.FormatException : IDX10400: Unable to decode: ... as Base64url encoded string.
   at Microsoft.IdentityModel.JsonWebTokens.JsonWebToken..ctor(String jwtEncodedString)
   SSO-Auth\Api\Oidc\OidcSignatureKeys.cs(121,0): at OidcSignatureKeys.TokenHasAcceptableKeyId(String token)
   SSO-Auth\Api\Oidc\OidcLogoutTokenValidator.cs(60,0): at OidcLogoutTokenValidator.ValidateAsync(...)
   SSO-Auth\Api\Flows\OidcLoginService.cs(711,0): at OidcLoginService.ValidateBackChannelLogoutAsync(...)
   SSO-Auth\Api\Http\SSOController.cs(304,0): at SSOController.OidBackChannelLogout(String provider, String logoutToken)
```

That is the issue's own reported path, reproduced through the endpoint rather
than through the helper, which is where the oracle would be. With the catches
restored the same 32 rows pass.

The corpus seed is proven the same way:

```
$ SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=idtoken dotnet SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll SSO-Auth.Fuzz/corpus/idtoken
Smoke OK: 5 seed(s) for target 'idtoken' handled fail-closed with no unmapped exception.

EXIT WITH GUARD = 0
EXIT WITHOUT GUARD = 127
```

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. The change only converts an escaping exception into
      the "unreadable" reading each site already had. No token becomes
      acceptable that was not acceptable before: `TokenHasAcceptableKeyId`
      returning true is not an accept, it hands the token to the handler which
      owns signature, issuer, audience and lifetime, and the endpoint test
      asserts the token is still refused with the uniform 400 and mints no
      revoke.
- [x] No secrets logged; secrets are redacted on config export. No logging path
      is touched, and no token bytes are written anywhere by this change.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. NOT PERFORMED.
- [ ] Review record. NO SECOND READER READ THIS CHANGE, and no review lens was
      run against it. That is a real gap on an OIDC validation diff and it is
      not softened here. What stands in its place is executed evidence rather
      than an opinion: the exception-type table above, the guard shown failing
      12 rows when deleted and passing 32 when restored, the endpoint asserted
      rather than the helper, the corpus replay red without the guard and green
      with it, and the full suite on both target frameworks. Read the change
      against those.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is added or changed.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. No logic is added at all; five existing catch lists each gain one
      clause.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why, not what. Each new
      catch states why a `FormatException` is the same case under another name,
      which is what the issue asked for.
- [x] Architecture-conformance tests pass. They are in the suite runs below and
      this change establishes no new structural property.
- [x] Docs impact considered: none. This restores the documented behaviour of
      these readers rather than changing it, and no README or wiki page
      describes the exception types.

## Verification

- [x] `dotnet build --warnaserror` is green, on both target frameworks:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   0 Warnung(en) 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   0 Warnung(en) 0 Fehler
```

- [x] The suite is green on both target frameworks:

```
net9.0    Total: 2563, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
net10.0   Total: 2564, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

FOUR TESTS WERE EXCLUDED FROM BOTH LOCAL RUNS AND WERE NOT EXECUTED AT ALL:
`PrivatePermittedHandler_ConnectsToAnRfc1918Address_WhereTheStrictOneRefuses`,
`CompositionRoot_GivesEachOutboundName_ItsOwnTier`,
`PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback`
and `PrivatePermittedHandler_StopsAtTheRedirectBoundTheHandlerSets`. Those are
the four that bind a listener to a non-loopback interface address, which is the
trigger behind #1227. They were removed by `-method-` filters rather than run,
and they touch none of the code in this diff. The `build` check on this pull
request runs the whole suite with nothing excluded, and that is the verdict to
read for those four.

- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such
      file changed.

## Notes

CHANGELOG.md is deliberately not touched here.

Two things this change does not do, recorded rather than left to be
rediscovered. The five catch lists are now identical copies of one another,
which is a duplication a single shared reader would remove; that is a refactor
with its own scope and is not folded into a security fix. And the widened catch
is keyed on an exception type the token library chooses, so a library version
that renames or re-parents it would move the behaviour silently. The corpus seed
is the guard against that, since the replay gate runs the exact bytes on every
change.
