### PR TITLE
Cap provider response bodies at the shared outbound HTTP seam [#1169]

### DIFF
--- a/SSO-Auth.Tests/Net/ProviderResponseSizeLimitDiscoveryTests.cs
+++ b/SSO-Auth.Tests/Net/ProviderResponseSizeLimitDiscoveryTests.cs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The outbound size bound seen from the anonymous challenge path it exists to protect (#1169). The unit rows
+/// in <see cref="ProviderResponseSizeLimitTests"/> pin the handler; these pin what an operator and an
+/// unauthenticated caller actually get, which is the only place the bound's value can be judged.
+/// <para>
+/// The client here is built the way the composition root builds it - the limiter in front of the transport -
+/// rather than the way the other discovery tests build theirs, which is a bare stub. That difference is the
+/// test: a bound registered only in production and never exercised through the reader would be a bound
+/// nobody has seen work.
+/// </para>
+/// </summary>
+public sealed class ProviderResponseSizeLimitDiscoveryTests
+{
+    private const string Authority = "https://idp-size.example.test";
+
+    [Fact]
+    public async Task AnOversizeDiscoveryDocument_FailsTheLoginClosed_AndTheWarningNamesTheProviderAndTheLimit()
+    {
+        // The refusal has to read AS a refusal. Before this bound existed, an over-large body could only
+        // surface through the generic "could not read the discovery document" path, which is the same thing
+        // an operator sees for malformed JSON - and the two ask different things of them. A malformed
+        // document is the provider's bug; an over-large one is a limit this plugin chose and may have set
+        // too low for an unusual provider.
+        var logger = new CapturingLogger();
+        var factory = FactoryServing(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new OversizeJson((int)ProviderResponseSizeLimit.MaxProviderResponseBytes + 4096),
+        });
+
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger);
+
+        Assert.Equal(OidcDiscoveryResult.Unavailable, result);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(Microsoft.Extensions.Logging.LogLevel.Warning, entry.Level);
+        Assert.Contains("kc", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(
+            ProviderResponseSizeLimit.MaxProviderResponseBytes.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            entry.Message,
+            StringComparison.Ordinal);
+
+        // Where the limit comes from, measured rather than designed. The refusal is raised inside the
+        // outbound pipeline, and the identity library converts a transport failure into its own IsError
+        // result before the reader ever sees an exception - so the reader cannot catch this refusal apart,
+        // and a catch clause added there would never fire. What carries the reason instead is the refusal's
+        // MESSAGE, which the library passes through into discovery.Error and the reader logs. That is why
+        // ProviderResponseTooLargeException words its message to name the bound, and this row is what stops
+        // that wording being "tidied" into something that no longer says it.
+        Assert.Contains("exceeds the", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("-byte limit", entry.Message, StringComparison.Ordinal);
+
+        // And it is distinguishable from the malformed-document case, which is the whole point of naming it:
+        // a parse failure carries no limit, so an operator can tell "your provider sent nonsense" from "this
+        // plugin refused a body for its size".
+        Assert.DoesNotContain("could not be inspected", entry.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AnOrdinaryDiscoveryDocument_IsUnaffectedByTheBound()
+    {
+        // The positive control for the row above, through the same reader and the same limiter: the bound
+        // must be invisible to every provider that is not attacking anyone.
+        var logger = new CapturingLogger();
+        var factory = FactoryServing(request =>
+            request.RequestUri!.AbsoluteUri.EndsWith("/jwks", StringComparison.Ordinal)
+                ? Json("{\"keys\":[]}")
+                : Json(FullDiscovery));
+
+        var result = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", factory, logger);
+
+        Assert.NotEqual(OidcDiscoveryResult.Unavailable, result);
+        Assert.Empty(logger.Entries);
+    }
+
+    private static readonly string FullDiscovery = "{"
+        + $"\"issuer\":\"{Authority}\","
+        + $"\"authorization_endpoint\":\"{Authority}/authorize\","
+        + $"\"token_endpoint\":\"{Authority}/token\","
+        + $"\"userinfo_endpoint\":\"{Authority}/userinfo\","
+        + $"\"jwks_uri\":\"{Authority}/jwks\","
+        + "\"response_types_supported\":[\"code\"],"
+        + "\"subject_types_supported\":[\"public\"],"
+        + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
+        + "\"code_challenge_methods_supported\":[\"S256\"],"
+        + "\"authorization_response_iss_parameter_supported\":true}";
+
+    private static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    // A factory whose clients carry the limiter in front of the stub, exactly as the composition root
+    // registers it for both named outbound tiers.
+    private static IHttpClientFactory FactoryServing(Func<HttpRequestMessage, HttpResponseMessage> respond)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ =>
+            new HttpClient(new ProviderResponseSizeLimit { InnerHandler = new StubHttpMessageHandler(respond) }));
+        return factory;
+    }
+
+    private static OidcClientOptions OptionsFor(string authority)
+    {
+        var options = new OidcClientOptions { Authority = authority };
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(authority).GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.RequireHttps = true;
+        options.Policy.Discovery.ValidateIssuerName = true;
+        options.Policy.Discovery.ValidateEndpoints = true;
+        return options;
+    }
+
+    // A well-formed JSON object padded past the bound, so the body is refused for its SIZE and not because it
+    // failed to parse - otherwise the test could pass for the wrong reason.
+    private sealed class OversizeJson : HttpContent
+    {
+        private readonly int _size;
+
+        internal OversizeJson(int size)
+        {
+            _size = size;
+            Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+        }
+
+        protected override async Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context)
+        {
+            var head = Encoding.UTF8.GetBytes("{\"issuer\":\"" + Authority + "\",\"padding\":\"");
+            await stream.WriteAsync(head).ConfigureAwait(false);
+
+            var chunk = new byte[8192];
+            Array.Fill(chunk, (byte)'p');
+            for (var written = 0; written < _size;)
+            {
+                var next = Math.Min(chunk.Length, _size - written);
+                await stream.WriteAsync(chunk.AsMemory(0, next)).ConfigureAwait(false);
+                written += next;
+            }
+
+            await stream.WriteAsync(Encoding.UTF8.GetBytes("\"}")).ConfigureAwait(false);
+        }
+
+        // No advertised length: the interesting path, because the cheap header check cannot see it.
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/SSO-Auth.Tests/Net/ProviderResponseSizeLimitTests.cs
+++ b/SSO-Auth.Tests/Net/ProviderResponseSizeLimitTests.cs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The outbound response-size bound (#1169, part of #1041). One named limit, enforced once at the seam every
+/// server-to-provider call passes through, so an anonymous challenge cannot be made to allocate without bound
+/// by a hostile or compromised authorization server.
+/// <para>
+/// Timeouts already bound how LONG a slow server can hold the endpoint. Nothing bounded how MUCH a fast one
+/// could make it allocate, and the discovery body is parsed several times over, so a large body cost a
+/// multiple of its own size on a route that needs no credential to reach.
+/// </para>
+/// </summary>
+public sealed class ProviderResponseSizeLimitTests
+{
+    private const long Max = ProviderResponseSizeLimit.MaxProviderResponseBytes;
+
+    [Fact]
+    public async Task AnAdvertisedLengthOverTheBound_IsRefusedWithoutReadingTheBody()
+    {
+        // The cheap path: Content-Length alone is enough to refuse, and the body is never touched. The
+        // counter below proves "never touched" rather than assuming it - a bound that still reads the
+        // megabytes it is refusing would not be a bound on allocation at all.
+        var bodyReads = 0;
+        using var client = Client(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new CountingContent(new string('a', 32), () => bodyReads++, declaredLength: Max + 1),
+        });
+
+        var ex = await Assert.ThrowsAsync<ProviderResponseTooLargeException>(
+            () => client.GetStringAsync("https://idp.example.test/.well-known/openid-configuration", TestContext.Current.CancellationToken));
+
+        Assert.Equal(Max, ex.MaxBytes);
+        Assert.Equal(0, bodyReads);
+    }
+
+    [Fact]
+    public async Task ABodyOverTheBound_WithNoAdvertisedLength_IsStillRefused()
+    {
+        // A server that sends no Content-Length (chunked) or lies about it walks straight past the header
+        // check. The bound has to be on bytes actually delivered, so this is the row that makes it a bound
+        // rather than a courtesy - and it is the shape a hostile server would pick precisely because the
+        // cheap check cannot see it.
+        using var client = Client(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new UndeclaredLengthContent((int)Max + 4096),
+        });
+
+        var ex = await Record.ExceptionAsync(
+            () => client.GetStringAsync("https://idp.example.test/.well-known/openid-configuration", TestContext.Current.CancellationToken));
+
+        // Asserted on the whole exception chain rather than on the outermost type: HttpClient buffers the
+        // body itself and may re-wrap what the stream threw, so pinning only the top type would pin a
+        // runtime detail. What must hold is that the refusal reaches the caller as a fail-closed transport
+        // failure and that this bound is identifiably the reason.
+        Assert.NotNull(ex);
+        Assert.IsAssignableFrom<HttpRequestException>(ex);
+        Assert.Contains(Unwrap(ex), e => e is ProviderResponseTooLargeException);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1024)]
+    [InlineData(64 * 1024)]
+    public async Task ADocumentUnderTheBound_IsDeliveredByteForByte(int size)
+    {
+        // The positive control, and the one that matters most. A bound nobody surveyed against real documents
+        // buys a hypothetical attack for a real provider lockout, so the sizes here bracket what a discovery
+        // document, a JWKS and a UserInfo response actually are: single- to low-double-digit KB.
+        var body = new string('x', size);
+        using var client = Client(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") });
+
+        var received = await client.GetStringAsync("https://idp.example.test/jwks", TestContext.Current.CancellationToken);
+
+        Assert.Equal(body, received);
+    }
+
+    [Fact]
+    public async Task ABodyExactlyAtTheBound_IsDelivered()
+    {
+        // The boundary is pinned from the permitted side too, so a future off-by-one that starts refusing at
+        // exactly the limit is a red test rather than a provider that mysteriously stops working.
+        using var client = Client(_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new UndeclaredLengthContent((int)Max) });
+
+        var received = await client.GetByteArrayAsync("https://idp.example.test/jwks", TestContext.Current.CancellationToken);
+
+        Assert.Equal(Max, received.LongLength);
+    }
+
+    [Fact]
+    public async Task TheContentTypeSurvivesTheSubstitution()
+    {
+        // The limiter replaces the response content in order to count what comes out of it. The charset the
+        // identity library and the repeated-member screen both decode by travels on Content-Type, so losing
+        // it here would silently change how every provider body is read.
+        using var client = Client(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        });
+
+        using var response = await client.GetAsync("https://idp.example.test/jwks", TestContext.Current.CancellationToken);
+
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal("utf-8", response.Content.Headers.ContentType?.CharSet);
+    }
+
+    private static System.Collections.Generic.IEnumerable<Exception> Unwrap(Exception? ex)
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            yield return e;
+        }
+    }
+
+    private static HttpClient Client(Func<HttpRequestMessage, HttpResponseMessage> respond) =>
+        new(new ProviderResponseSizeLimit { InnerHandler = new StubHttpMessageHandler(respond) });
+
+    // Content that reports a length of the caller's choosing while holding a short body, so a test can prove
+    // the header check refuses before the body is read.
+    private sealed class CountingContent : HttpContent
+    {
+        private readonly byte[] _body;
+        private readonly Action _onRead;
+
+        internal CountingContent(string body, Action onRead, long declaredLength)
+        {
+            _body = Encoding.UTF8.GetBytes(body);
+            _onRead = onRead;
+            Headers.ContentLength = declaredLength;
+        }
+
+        protected override Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context)
+        {
+            _onRead();
+            return stream.WriteAsync(_body, 0, _body.Length);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = Headers.ContentLength ?? 0;
+            return true;
+        }
+    }
+
+    // Content that refuses to state its length, which is what a chunked response looks like to the handler.
+    private sealed class UndeclaredLengthContent : HttpContent
+    {
+        private readonly int _size;
+
+        internal UndeclaredLengthContent(int size) => _size = size;
+
+        protected override async Task SerializeToStreamAsync(System.IO.Stream stream, System.Net.TransportContext? context)
+        {
+            var chunk = new byte[8192];
+            Array.Fill(chunk, (byte)'y');
+            for (var written = 0; written < _size;)
+            {
+                var next = Math.Min(chunk.Length, _size - written);
+                await stream.WriteAsync(chunk.AsMemory(0, next), CancellationToken.None).ConfigureAwait(false);
+                written += next;
+            }
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
+        }
+    }
+}

--- a/SSO-Auth/Api/Net/ProviderResponseSizeLimit.cs
+++ b/SSO-Auth/Api/Net/ProviderResponseSizeLimit.cs
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
+
+/// <summary>
+/// Refuses an over-large provider response at the plugin's outbound seam, before any parser sees the body
+/// (#1169, part of #1041). Registered on both named outbound clients, so every server-to-provider call on the
+/// login path is bounded from ONE place rather than per call site.
+///
+/// Position is the point. Three of the four fetches this bounds - JWKS, token and UserInfo - happen INSIDE
+/// <c>Duende.IdentityModel.OidcClient</c>, over the client the plugin hands it, so there is no plugin call
+/// site to guard for them. The fourth, the discovery read, is buffered whole by
+/// <see cref="Oidc.RepeatedMemberScreen"/> before it is inspected, so a bound applied any later than here
+/// would arrive after the allocation it exists to prevent.
+///
+/// What it bounds is allocation, not time. <c>OidcDiscoveryReader.FetchTimeout</c> already bounds how LONG a
+/// slow server can hold the anonymous challenge endpoint open; nothing bounded how MUCH a fast one could make
+/// it allocate, and the discovery body is parsed several times over, so a large body cost a multiple of its
+/// own size on a route that needs no credential to reach.
+/// </summary>
+internal sealed class ProviderResponseSizeLimit : DelegatingHandler
+{
+    /// <summary>
+    /// The most a provider response may carry before it is refused unread.
+    ///
+    /// Chosen against the largest document any consumer of this seam legitimately parses, which is SAML
+    /// federation metadata: <see cref="Saml.SamlMetadataParser.MaxCharactersInDocument"/> caps that reader at
+    /// 256 KiB, and <c>SamlMetadataImporter</c> enforces the same 256 KiB on its own read. An OpenID
+    /// discovery document, a JWKS, a token response and a UserInfo document are single- to low-double-digit
+    /// KB. So this bound sits four times above the largest legitimate document and roughly two orders of
+    /// magnitude above the routine ones.
+    ///
+    /// Deliberately loose rather than tight, for the same reason the <c>kid</c> length cap is: the value
+    /// being bounded at all is what closes the unbounded-allocation hole, while a tight bound would trade a
+    /// hypothetical attack for a real lockout of a provider nobody surveyed. It is also deliberately ABOVE
+    /// the SAML importer's own 256 KiB, so that importer keeps reporting its own clearer message and this
+    /// seam never pre-empts it.
+    ///
+    /// The avatar fetch does not pass here - it builds its client directly on
+    /// <see cref="SsoHttp.CreateHardenedHandler"/> and carries its own, much larger
+    /// <c>AvatarService.MaxAvatarBytes</c>, because an image is legitimately megabytes where a metadata
+    /// document is not. That separation is intended, not an oversight.
+    /// </summary>
+    internal const long MaxProviderResponseBytes = 1024 * 1024;
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        // The advertised length, when there is one: refusing here costs nothing and never reads the body at
+        // all. A server that lies about it, or sends none (chunked), is caught by the counting stream below,
+        // so this check is the cheap path rather than the guarantee.
+        if (response.Content.Headers.ContentLength > MaxProviderResponseBytes)
+        {
+            response.Dispose();
+            throw new ProviderResponseTooLargeException(MaxProviderResponseBytes);
+        }
+
+        var body = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var bounded = new StreamContent(new BoundedStream(body, MaxProviderResponseBytes));
+
+        // Carry the original headers across, so Content-Type (and the charset the library and the
+        // repeated-member screen both decode by) survives the substitution unchanged.
+        foreach (var header in response.Content.Headers)
+        {
+            bounded.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        response.Content = bounded;
+        return response;
+    }
+
+    /// <summary>
+    /// A read-only pass-through that refuses once more than <c>maxBytes</c> have come out of it. This is what
+    /// makes the bound hold for a chunked response and for one whose Content-Length understates the body: the
+    /// count is of bytes actually delivered, never of what the server claimed.
+    /// </summary>
+    private sealed class BoundedStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly long _maxBytes;
+        private long _read;
+
+        internal BoundedStream(Stream inner, long maxBytes)
+        {
+            _inner = inner;
+            _maxBytes = maxBytes;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return Count(read);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Count(_inner.Read(buffer, offset, count));
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private int Count(int read)
+        {
+            _read += read;
+            return _read > _maxBytes
+                ? throw new ProviderResponseTooLargeException(_maxBytes)
+                : read;
+        }
+    }
+}

--- a/SSO-Auth/Api/Net/ProviderResponseTooLargeException.cs
+++ b/SSO-Auth/Api/Net/ProviderResponseTooLargeException.cs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Globalization;
+using System.Net.Http;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Net;
+
+/// <summary>
+/// The refusal <see cref="ProviderResponseSizeLimit"/> raises when a provider response exceeds the seam's
+/// byte bound.
+///
+/// It derives from <see cref="HttpRequestException"/> on purpose. Every existing caller on the login path
+/// already treats an <see cref="HttpRequestException"/> as a fail-closed transport failure - the discovery
+/// read, the SAML metadata importer and the avatar fetch each catch it and refuse - so the bound inherits
+/// their fail-closed handling without one of them needing to learn a new exception type.
+///
+/// The MESSAGE is load-bearing, and that is measured rather than assumed. On the discovery path the identity
+/// library converts a transport failure into its own error result before the plugin sees an exception, so no
+/// caller there can catch this type apart; what reaches the operator's warning is this message, passed
+/// through as the library's error text. So the message names the bound, and
+/// <c>ProviderResponseSizeLimitDiscoveryTests</c> pins that it still does.
+/// </summary>
+internal sealed class ProviderResponseTooLargeException : HttpRequestException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProviderResponseTooLargeException"/> class.
+    /// </summary>
+    /// <param name="maxBytes">The bound that was exceeded, so a caller can name the limit without importing the constant.</param>
+    internal ProviderResponseTooLargeException(long maxBytes)
+        : base(string.Create(CultureInfo.InvariantCulture, $"The provider response exceeds the {maxBytes}-byte limit."))
+    {
+        MaxBytes = maxBytes;
+    }
+
+    /// <summary>Gets the bound that was exceeded, in bytes.</summary>
+    internal long MaxBytes { get; }
+}

--- a/SSO-Auth/SsoOnlyServiceRegistrator.cs
+++ b/SSO-Auth/SsoOnlyServiceRegistrator.cs
@@ -42,6 +42,10 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // This is the tier every caller gets by default, including the SAML metadata importer.
         serviceCollection.AddHttpClient(SsoHttp.OutboundClientName)
             .ConfigurePrimaryHttpMessageHandler(() => SsoHttp.CreateHardenedHandler())
+            // One byte bound for every server-to-provider response, applied here rather than per call site
+            // because three of the four fetches it covers happen inside the identity library, over this very
+            // client, with no plugin call site to guard (#1169).
+            .AddHttpMessageHandler(() => new ProviderResponseSizeLimit())
             // The hardened handler manages its own connection freshness via PooledConnectionLifetime, so the
             // factory need not also rotate (and rebuild) the handler on its default 2-minute cadence - the
             // documented pattern when you own PooledConnectionLifetime. Keeps one long-lived hardened handler
@@ -57,6 +61,9 @@ public sealed class SsoOnlyServiceRegistrator : IPluginServiceRegistrator
         // logins, so a relaxation that was not part of the client's identity could leak to another provider.
         serviceCollection.AddHttpClient(SsoHttp.PrivateOutboundClientName)
             .ConfigurePrimaryHttpMessageHandler(() => SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted))
+            // The same bound as the strict tier. Opting a provider in to the administrator's own network says
+            // where it may live, never how much it may send.
+            .AddHttpMessageHandler(() => new ProviderResponseSizeLimit())
             .SetHandlerLifetime(Timeout.InfiniteTimeSpan);
     }
 }


### PR DESCRIPTION
# What & why

The anonymous OpenID challenge endpoint had no bound on how large a provider
response could be. `OidcDiscoveryReader.FetchTimeout` bounds how LONG a slow
authorization server can hold the endpoint open; nothing bounded how MUCH a fast
one could make it allocate, and the discovery body is read whole and then parsed
several times over, so a large body cost a multiple of its own size on a route
that needs no credential to reach.

This adds one named bound, enforced once at the seam every server-to-provider
call passes through.

Closes #1169

## Why the seam and not the call sites

Three of the four fetches this covers, JWKS, token and UserInfo, happen inside
`Duende.IdentityModel.OidcClient` over the client the plugin hands it, so there
is no plugin call site to guard for them. The fourth, the discovery read, is
buffered whole by `RepeatedMemberScreen` before it is inspected, so a bound
applied any later than the seam would arrive after the allocation it exists to
prevent.

## The bound is enforced twice, on purpose

The advertised `Content-Length` is the cheap path: it refuses without reading a
byte, and a test asserts the body was never touched rather than assuming it. A
server that sends no length (chunked) or lies about it walks straight past that
check, so a counting stream bounds what is actually delivered. That second one
is the shape a hostile server would pick, precisely because the cheap check
cannot see it.

## Choosing 1 MiB

Measured against the largest document any consumer of this seam legitimately
parses.

| document | size |
| --- | --- |
| SAML federation metadata | capped by its own reader at `SamlMetadataParser.MaxCharactersInDocument` = 256 KiB |
| OpenID discovery, JWKS, token, UserInfo | single- to low-double-digit KB |

So the bound sits four times above the largest legitimate document and roughly
two orders of magnitude above the routine ones. It is deliberately loose rather
than tight, for the same reason the `kid` length cap is loose: bounding the value
at all is what closes the unbounded-allocation hole, while a tight bound trades a
hypothetical attack for a real lockout of a provider nobody surveyed.

The issue asked for the SAML interaction to be stated either way. It is chosen,
not inherited: the bound is deliberately ABOVE `SamlMetadataImporter`'s own
256 KiB read cap, so that importer keeps reporting its own clearer message and
this seam never pre-empts it. The reasoning is in the constant's comment.

The avatar fetch deliberately does not pass here. It builds its client directly
on `SsoHttp.CreateHardenedHandler()` and carries its own, much larger
`AvatarService.MaxAvatarBytes`, because an image is legitimately megabytes where
a metadata document is not. That separation is intended and is written down.

## How the refusal reaches an operator, measured rather than designed

A `catch (ProviderResponseTooLargeException)` was written into
`OidcDiscoveryReader` first. It was then measured to be unreachable: the identity
library converts a transport failure into its own `IsError` result before the
reader ever sees an exception. It was removed rather than shipped, because a
guard that cannot bite is worse than no guard.

What carries the reason instead is the refusal's message, passed through as the
library's error text. The warning an operator actually gets, captured in the
test:

```
Could not read the OpenID discovery document for provider kc: Error connecting
to https://idp-size.example.test/.well-known/openid-configuration. The provider
response exceeds the 1048576-byte limit... The login fails closed rather than
proceeding on unverified discovery facts.
```

That names the provider and the limit, and is distinguishable from the
malformed-document case, which is what the issue asked for. It also means the
exception's MESSAGE is load-bearing, so a test pins that it still names the
bound and does not get tidied into something that no longer does.

## Every new assertion shown failing on a deliberately weakened build

Each enforcement point was neutralised on its own, so the rows are attributed to
the guard they actually exercise rather than to the pair.

| weakening | rows that go red |
| --- | --- |
| `Content-Length` check neutralised | `AnAdvertisedLengthOverTheBound_IsRefusedWithoutReadingTheBody` (1) |
| counting stream neutralised | `ABodyOverTheBound_WithNoAdvertisedLength_IsStillRefused` and `AnOversizeDiscoveryDocument_FailsTheLoginClosed_AndTheWarningNamesTheProviderAndTheLimit` (2) |

The positive controls stayed green through both mutations, so the pair is not a
tautology. The build was confirmed to have SUCCEEDED before each of those runs;
a failed build would have re-run the previous binary and printed a green suite.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. An over-large response is refused and the login
      fails closed; nothing is accepted on a truncated body, because the
      refusal throws rather than returning what it read so far. The new
      exception derives from `HttpRequestException`, which every caller on this
      path already treats as a fail-closed transport failure, so the bound
      inherits their existing refusal handling rather than needing new branches.
- [x] No secrets logged; secrets are redacted on config export. The limit named
      in the log is this plugin's own constant, never provider-authored, and no
      body content reaches any log entry.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. NOT PERFORMED.
- [ ] Review record. NO SECOND READER READ THIS CHANGE, and no review lens was
      run against it. That is a real gap on a login-path diff and it is not
      softened here. Standing in its place: the two independent mutation runs
      above with their exact red sets, the positive controls held across both,
      the end-to-end assertion through `OidcDiscoveryReader` with the limiter
      wired as the composition root wires it, and the full suite on both target
      frameworks. The judgement that most wants a second reader is the 1 MiB
      value itself, and the table above is the evidence it was chosen against
      rather than picked.
- [x] Log inputs from the IdP are sanitized inline at the log call. The existing
      discovery warning already strips line endings from both the provider name
      and the library error text inline, and that call is unchanged by this diff.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. One handler, one constant, one exception type.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting; comments explain why, not what.
- [x] Architecture-conformance tests pass. They are in the suite runs below.
      The new types live in `SSO-Auth/Api/Net/` under the module's own
      namespace, so the module DAG is unchanged.
- [x] Docs impact considered: no README or wiki page documents the outbound
      response limits, so the constant's comment is its only home. Nothing to
      update and no `documentation` issue is owed.

## Verification

- [x] `dotnet build --warnaserror` is green, plugin and tests, both frameworks:

```
$ dotnet build SSO-Auth/SSO-Auth.csproj            -f net9.0  --warnaserror   0 Warnung(en) 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   0 Warnung(en) 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   0 Warnung(en) 0 Fehler
```

- [x] The suite is green on both target frameworks:

```
net9.0    Total: 2572, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
net10.0   Total: 2573, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0
```

FOUR TESTS WERE EXCLUDED FROM BOTH LOCAL RUNS AND WERE NOT EXECUTED AT ALL:
`PrivatePermittedHandler_ConnectsToAnRfc1918Address_WhereTheStrictOneRefuses`,
`CompositionRoot_GivesEachOutboundName_ItsOwnTier`,
`PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback`
and `PrivatePermittedHandler_StopsAtTheRedirectBoundTheHandlerSets`. Those are
the four that bind a listener to a non-loopback interface address, which is the
trigger behind #1227. They were removed by `-method-` filters rather than run.
Two of them are in this change's blast radius, since they exercise the outbound
handlers this diff registers a new stage in front of, so their local absence
matters more here than it would elsewhere. The `build` check on this pull
request runs the whole suite with nothing excluded, and that is the verdict to
read for those four.

- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such
      file changed.

## Notes

CHANGELOG.md is deliberately not touched here.

#1041 is the parent and stays open: its "also worth folding in" half, reducing
the discovery document's parse count, is a refactor rather than a bound and is
explicitly not mixed in here. #1170 already took one of those parses out.

The limiter is registered on both named outbound tiers. Opting a provider in to
the administrator's own network says where it may live, never how much it may
send, so the private-permitted tier carries the same bound.

Not covered, stated rather than left implicit: the bound is on a single
response. Nothing here bounds the NUMBER of provider responses one challenge can
cause, which is a different exhaustion shape and is not in this issue's scope.
