### PR TITLE
Skip the LAN-binding tests on Windows so the suite runs unelevated [#1227]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,31 @@ you need both runtimes' SDKs installed - exactly what CI installs).
 
 CI restores in a separate step, so its build/test use `--no-restore`/`--no-build`; on a fresh local clone run `dotnet restore` once first (or drop `--no-restore` on the first build) or the build fails before any package is fetched.
 
+**The suite needs no administrator rights, on Windows included** (#1227), and a
+change that makes it need them is a defect rather than a step to document. What
+used to break that on Windows was a consent dialog: four tests in
+`SSO-Auth.Tests/Net/SsoHttpTests.cs` reproduce the "IdP on the admin's own LAN"
+case at the socket layer, so they bind a listener to this machine's own
+interface address instead of loopback, and that bind is what Windows Defender
+Firewall asks about. The dialog is answered by an administrator, and its subject
+is the executable's full path rather than the project, so answering it settles
+nothing beyond that one path - every new build directory is asked again. The
+four skip on Windows instead, each printing why, and the Linux legs carry the
+coverage with no opt-in. Run them on Windows deliberately, and expect the
+dialog, with:
+
+```sh
+SSO_TESTS_ALLOW_LAN_BIND=1 ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
+```
+
+Nothing else in the three test-side projects listens off loopback, writes a
+certificate into a store, or shells out to a tool that needs elevation. Before
+adding something that does, check what is there now:
+
+```sh
+git grep -rniE "\.Bind\(|HttpListener|netsh|sc\.exe|runas|X509Store|dev-certs" -- SSO-Auth.Tests SSO-Auth.Tests.Stryker SSO-Auth.Fuzz
+```
+
 **Developing the admin UI.** The settings page and the account-linking page are **embedded resources**, not files served from disk: `configPage.html`, `config.js`, and the `linking.*` assets are compiled into `SSO-Auth.dll` (see the `<EmbeddedResource>` entries in `SSO-Auth.csproj`). So the edit loop is **rebuild → redeploy the DLL → restart Jellyfin**: `dotnet publish -c Release`, copy the output into your Jellyfin `config/plugins/sso/`, and restart the server; there is no live reload. Jellyfin's logs (the plugin logs through them) live under the server's `config/log/` directory. One gotcha while iterating: the `/SSOViews` assets are served with an ETag derived from the assembly `FileVersion`, so a browser will `304`-serve the **previous** build of `linking.js`/`linking.css` until the version changes - disable the browser cache (DevTools → Network → "Disable cache") during a UI edit session, or you will be testing stale assets.
 
 **Branching and pull requests.** `main` is the released line and is PR-only. Branch every change - even a one-liner - off `main` for fixes and security work, or off the feature branch for features, using a short kebab-case name with a `fix/`, `harden/`, `feature/`, `chore/`, or `refactor/` prefix. Reference the issue your change addresses (`Closes #N`) and fill in the [pull request template](.github/pull_request_template.md).

--- a/SSO-Auth.Tests/Net/SsoHttpTests.cs
+++ b/SSO-Auth.Tests/Net/SsoHttpTests.cs
@@ -26,6 +26,36 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// </summary>
 public class SsoHttpTests
 {
+    // Opt in to binding a listener off loopback on Windows - see LanListenerAddress for why it is off by
+    // default and what answering the dialog it avoids actually costs.
+    private const string LanBindOptIn = "SSO_TESTS_ALLOW_LAN_BIND";
+
+    [Fact]
+    public void TheLanListenerGate_SkipsInsteadOfBindingOffLoopback_OnAWindowsRunThatDidNotOptIn()
+    {
+        // #1227. Four tests in this file bind a listener to this machine's own LAN interface address, and
+        // that bind is what raises the Windows firewall consent dialog - the administrator prompt that made
+        // the suite unrunnable without admin rights. The gate is the whole repair, so it is asserted here
+        // rather than assumed from a skip that nobody reads: remove its Windows arm and this goes red on a
+        // Windows run that has a LAN address, widen it to every platform and the branch below goes red on
+        // the Linux legs. The condition is re-derived from the environment rather than read back from the
+        // gate, so a gate that decided the opposite would not agree with it.
+        var (address, reason) = LanListenerAddress();
+        var optedIn = string.Equals(Environment.GetEnvironmentVariable(LanBindOptIn), "1", StringComparison.Ordinal);
+
+        if (OperatingSystem.IsWindows() && !optedIn)
+        {
+            Assert.Null(address);
+            Assert.Contains(LanBindOptIn, reason, StringComparison.Ordinal); // the way out is named in the skip
+        }
+        else
+        {
+            // Everywhere else the gate has to be transparent. A repair that skipped these tests on Linux
+            // too would take the #1058 coverage with it and still leave every run green.
+            Assert.Equal(FindLocalPrivateAddress(), address);
+        }
+    }
+
     [Fact]
     public void CreateClient_ResolvesTheNamedHardenedClient_AndAppliesTheUserAgent()
     {
@@ -164,8 +194,8 @@ public class SsoHttpTests
         // The reproduction from #1058, at the socket layer: an IdP on the admin's own LAN. Bind a real
         // listener to this machine's own private-range interface address and drive both handlers at it -
         // the strict one must refuse before connecting, the private-permitted one must get through.
-        var privateAddress = FindLocalPrivateAddress();
-        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+        var (privateAddress, skipReason) = LanListenerAddress();
+        Assert.SkipWhen(privateAddress is null, skipReason);
 
         using var listener = new PrivateListener(privateAddress!);
         var target = $"http://{privateAddress}:{listener.Port}/";
@@ -198,8 +228,8 @@ public class SsoHttpTests
         // build handlers directly - so registering the STRICT name with the relaxed policy would have
         // relaxed every caller that names no tier, including the SAML metadata importer, with the whole
         // suite still green. This drives the two registered names at a real socket instead.
-        var privateAddress = FindLocalPrivateAddress();
-        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+        var (privateAddress, skipReason) = LanListenerAddress();
+        Assert.SkipWhen(privateAddress is null, skipReason);
 
         var services = new ServiceCollection();
         services.AddLogging();
@@ -226,6 +256,26 @@ public class SsoHttpTests
 
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
         Assert.True(listener.Accepted, "the registered private-permitted client did not reach the private-address listener");
+    }
+
+    // The address the four LAN-facing tests bind their listener to, or null with the reason they skip.
+    //
+    // Two things make it null. The machine may have no RFC 1918 / CGNAT interface address at all - a
+    // container on a public address, or loopback-only. Or the run is on Windows without the opt-in: a
+    // process that begins listening on a socket bound to something other than loopback is what Windows
+    // Defender Firewall raises its consent dialog for, and that dialog is approved by an administrator.
+    // Its subject is the executable's full path, so answering it settles nothing beyond that one path -
+    // every new build directory is a program Windows holds no decision about, and is asked again. That is
+    // #1227: the suite must run unelevated by default. Set SSO_TESTS_ALLOW_LAN_BIND=1 to bind off loopback
+    // on Windows anyway; the Linux legs carry this coverage with no opt-in, so it is not lost.
+    private static (IPAddress? Address, string SkipReason) LanListenerAddress()
+    {
+        if (OperatingSystem.IsWindows() && !string.Equals(Environment.GetEnvironmentVariable(LanBindOptIn), "1", StringComparison.Ordinal))
+        {
+            return (null, $"Binding a listener off loopback raises the Windows firewall consent dialog, which needs an administrator (#1227) - set {LanBindOptIn}=1 to run this test on Windows.");
+        }
+
+        return (FindLocalPrivateAddress(), "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
     }
 
     // This machine's own RFC 1918 / CGNAT interface address, or null when it has none (a container on a
@@ -325,8 +375,8 @@ public class SsoHttpTests
         // The first hop must be an address the tier permits, and the only such address that can be bound
         // locally is this machine's own private one - so this test needs a private interface address and
         // skips without one. It runs where the feature matters; the skip is recorded rather than hidden.
-        var privateAddress = FindLocalPrivateAddress();
-        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+        var (privateAddress, skipReason) = LanListenerAddress();
+        Assert.SkipWhen(privateAddress is null, skipReason);
 
         using var blocked = new BlockedListener();
         using var redirector = new RedirectingListener(privateAddress!, _ => $"http://127.0.0.1:{blocked.Port}/");
@@ -350,8 +400,8 @@ public class SsoHttpTests
         // forever would otherwise spin the connect guard indefinitely. MaxAutomaticRedirections is 5, so a
         // listener that always redirects to itself must be asked exactly 6 times (the original request plus
         // five hops) and the client must hand back the last redirect rather than following it.
-        var privateAddress = FindLocalPrivateAddress();
-        Assert.SkipWhen(privateAddress is null, "This machine has no RFC 1918 / CGNAT interface address to bind a listener to.");
+        var (privateAddress, skipReason) = LanListenerAddress();
+        Assert.SkipWhen(privateAddress is null, skipReason);
 
         using var redirector = new RedirectingListener(privateAddress!, port => $"http://{privateAddress}:{port}/next");
         using var handler = SsoHttp.CreateHardenedHandler(AddressPolicy.PrivateNetworkPermitted);


### PR DESCRIPTION
# What & why

Running the test suite on Windows raised a Windows Defender Firewall consent dialog naming `SSO-Auth.Tests`. That dialog is answered by an administrator, so the suite could not be run without admin rights. Closes #1227.

The trigger is a process beginning to listen on a socket bound to something other than loopback. Four tests in `SSO-Auth.Tests/Net/SsoHttpTests.cs` do exactly that, because they reproduce the #1058 "IdP on the administrator's own LAN" case at the socket layer and need this machine's own interface address:

```
git grep -n "FindLocalPrivateAddress()" -- SSO-Auth.Tests
```

Binding loopback instead was considered and rejected on the issue: the strict handler refuses by address class, `127.0.0.1` is a different class from `192.168.x.x`, and the tests would keep running while testing nothing. Answering the dialog once was also not an option, because its subject is the executable's full path rather than the project, so every new build directory is asked again.

The four call sites now take their address from one gate, `LanListenerAddress`, which returns null with the reason when the run is on Windows without `SSO_TESTS_ALLOW_LAN_BIND=1`. The skip prints in every run rather than passing silently, the way to opt in is named in the message, and the Linux legs carry the coverage with no opt-in, so the #1058 reproduction is kept.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. The change touches no login path, no crypto, no config persistence and no release pipeline: the diff is one test file and `CONTRIBUTING.md`, and no file under `SSO-Auth/` is modified.

```
git diff --name-only origin/main...HEAD
CONTRIBUTING.md
SSO-Auth.Tests/Net/SsoHttpTests.cs
```

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a reproduction was produced). Every finding of either kind carries a disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change. The boxes above are unticked because nothing was done for them, and this line is the disclosure rather than a substitute for one.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

The four skip decisions were four copies of one literal reason string and one lookup; they are now one gate with one message. Nothing new is added to `ArchitectureConformanceTests`: this establishes no structural property over the shipped code, and the whole suite including that class is green below.

The third bullet of the issue asked for the property to be documented, and that is in this change rather than deferred: `CONTRIBUTING.md` states that the suite needs no administrator rights, names the opt-in, and carries the command that shows nothing else in the three test-side projects listens off loopback, writes to a certificate store or shells out to a tool needing elevation.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, built with `--warnaserror` on the test project so the analyzers are promoted, and the suite run from the built executable:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q     # 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q     # 0 warnings, 0 errors

./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2577, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 13,064s

./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2578, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 13,585s

npx prettier --check --end-of-line auto "CONTRIBUTING.md"
All matched files use Prettier code style!
```

All four skips are the gate and nothing else:

```
SsoHttpTests.CompositionRoot_GivesEachOutboundName_ItsOwnTier [SKIP]
SsoHttpTests.PrivatePermittedHandler_JudgesEveryRedirectHop_AndRefusesOneAimedAtLoopback [SKIP]
SsoHttpTests.PrivatePermittedHandler_StopsAtTheRedirectBoundTheHandlerSets [SKIP]
SsoHttpTests.PrivatePermittedHandler_ConnectsToAnRfc1918Address_WhereTheStrictOneRefuses [SKIP]
```

### The gate is proven, in both directions

`TheLanListenerGate_SkipsInsteadOfBindingOffLoopback_OnAWindowsRunThatDidNotOptIn` re-derives its expectation from the environment rather than reading it back off the gate, so it disagrees with a gate that decided the opposite. Both mutations were built and run:

```
# 1. the Windows arm removed, so the gate hands back a bindable address again
Assert.Null() Failure: Value is not null
Expected: null
Actual:   10.2.0.2

# 2. the gate widened to skip on every platform, run with the opt-in set so the
#    non-Windows branch is the one under test
Assert.Equal() Failure: Values differ
Expected: 10.2.0.2
Actual:   null
```

The first is the repair being removed. The second is the repair overshooting and taking the Linux coverage with it, which is the failure a plain skip-everywhere would have shipped green.

### That the prompt is gone is measured, not argued

The dialog writes its answer into the local firewall store, keyed by the executable's full path. This branch was built and the whole suite run on both frameworks, from a build directory Windows held no decision about. Afterwards:

```
powershell -NoProfile -Command "$f = Get-NetFirewallApplicationFilter | Where-Object { $_.Program -like '*sso-auth.tests.exe' }; $paths = $f.Program | Sort-Object -Unique; 'total paths with a decision: ' + $paths.Count; 'paths under this branch build dir: ' + (@($paths | Where-Object { $_ -like '*1227*' }).Count)"

total paths with a decision: 36
paths under this branch build dir: 0
```

36 is unchanged from the count recorded on the issue before this work, and the new path carries no decision, so no dialog was raised and none was answered. Only the counts are pasted; the paths describe how this machine is laid out and say nothing about the defect, and the command reconstructs them.

## Notes

The opt-in is a per-run environment variable and not a property of any build, so a Windows contributor who wants the LAN coverage sets it, answers the dialog for that one build directory, and gets it. Nothing is removed from CI: the Linux legs never see the gate's Windows arm.

Not covered here: whether the six Block rules in that store change any test outcome. The issue's second comment raised it and said it should not be assumed in either direction. It is untouched by this change, because with the four tests skipped on Windows no such connection is attempted at all.
