### PR TITLE
Have the logout validator derive its own validation basis [#1176]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -47,7 +47,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1", sid: "sess-9"));
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.True(result.IsValid);
         Assert.Equal("user-1", result.Subject);
@@ -58,7 +58,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task SubOnly_Succeeds_SidNull()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sub: "user-1")), Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sub: "user-1")), Options(), _now);
 
         Assert.True(result.IsValid);
         Assert.Equal("user-1", result.Subject);
@@ -68,7 +68,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task SidOnly_Succeeds_SubNull()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sid: "sess-9")), Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims(sid: "sess-9")), Options(), _now);
 
         Assert.True(result.IsValid);
         Assert.Null(result.Subject);
@@ -81,7 +81,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     public async Task AbsentToken_IsMalformed(string? token)
     {
         // Nothing was sent - a distinct fail-closed code from a bad token that reached the JWT handler.
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Malformed, result.ReasonCode);
@@ -95,7 +95,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         // A non-empty non-JWT reaches the handler and fails signature/parse validation - still fail-closed,
         // reported as Invalid (the handler catches it, it never throws a 500).
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -107,7 +107,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         using var attacker = RSA.Create(2048);
         var forged = new JsonWebTokenHandler().CreateToken(Descriptor(Claims(sub: "user-1"), signingKey: attacker));
 
-        var result = await _validator.ValidateAsync(forged, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(forged, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -118,7 +118,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), issuer: "https://evil.example.test");
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -129,7 +129,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), audience: "another-client");
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -141,7 +141,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // 10 minutes past exp is beyond the default 5-minute clock skew.
         var token = CreateToken(claims: Claims(sub: "user-1"), lifetime: TimeSpan.FromMinutes(-10));
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -152,7 +152,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: new Dictionary<string, object> { ["sub"] = "user-1", ["jti"] = Guid.NewGuid().ToString() });
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
@@ -166,7 +166,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         claims["events"] = new Dictionary<string, object> { ["http://schemas.openid.net/event/some-other"] = new Dictionary<string, object>() };
         var token = CreateToken(claims: claims);
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
@@ -180,7 +180,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         claims["nonce"] = "abc123";
         var token = CreateToken(claims: claims);
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.ProhibitedNonce, result.ReasonCode);
@@ -189,7 +189,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Fact]
     public async Task NeitherSubNorSid_IsRejected()
     {
-        var result = await _validator.ValidateAsync(CreateToken(claims: Claims()), Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: Claims()), Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.NoSubjectOrSid, result.ReasonCode);
@@ -200,8 +200,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     {
         var token = CreateToken(claims: Claims(sub: "user-1", jti: "fixed-jti"));
 
-        var first = await _validator.ValidateAsync(token, Params(), Skew, _now);
-        var second = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var first = await _validator.ValidateAsync(token, Options(), _now);
+        var second = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.True(first.IsValid);
         Assert.False(second.IsValid);
@@ -214,8 +214,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // A token with no jti still gets one-time-use via its signature - a byte-identical resend collides.
         var token = CreateToken(claims: Claims(sub: "user-1"));
 
-        Assert.True((await _validator.ValidateAsync(token, Params(), Skew, _now)).IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, (await _validator.ValidateAsync(token, Params(), Skew, _now)).ReasonCode);
+        Assert.True((await _validator.ValidateAsync(token, Options(), _now)).IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Replay, (await _validator.ValidateAsync(token, Options(), _now)).ReasonCode);
     }
 
     [Fact]
@@ -224,8 +224,8 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // Fixed codes only - a rejection is never a subject oracle (T-I1).
         var token = CreateToken(claims: Claims(sub: "secret-subject", sid: "secret-session"));
         // Force a replay rejection carrying no subject text.
-        await _validator.ValidateAsync(token, Params(), Skew, _now);
-        var replay = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        await _validator.ValidateAsync(token, Options(), _now);
+        var replay = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.DoesNotContain("secret-subject", replay.ReasonCode, StringComparison.Ordinal);
         Assert.DoesNotContain("secret-session", replay.ReasonCode, StringComparison.Ordinal);
@@ -245,7 +245,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
             SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
         });
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.True(result.IsValid);
         Assert.Equal("user-1", result.Subject);
@@ -258,7 +258,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         // refused even though this client is the audience.
         var claims = Claims(sub: "user-1");
         claims["azp"] = "another-client";
-        var result = await _validator.ValidateAsync(CreateToken(claims: claims), Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(CreateToken(claims: claims), Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -279,7 +279,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
             SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
         });
 
-        var result = await _validator.ValidateAsync(token, Params(), Skew, _now);
+        var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
@@ -305,25 +305,27 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         return claims;
     }
 
-    private TokenValidationParameters Params()
+    // What the endpoint hands the validator: the provider's options, from which the validator derives its
+    // own basis (#1176). The requireExpiration:false posture (OIDC Back-Channel Logout §2.4 does not mandate
+    // exp) is the validator's own and no longer something a caller - or a test - can choose, which is the
+    // point of the change: these tests cannot validate under a posture the endpoint does not use.
+    private OidcClientOptions Options()
     {
         var p = _rsa.ExportParameters(false);
         var jwks = $$"""
             {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
               "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
             """;
-        var options = new OidcClientOptions
+        return new OidcClientOptions
         {
             ClientId = ClientId,
+            ClockSkew = Skew,
             ProviderInformation = new ProviderInformation
             {
                 IssuerName = Issuer,
                 KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
             },
         };
-        // The back-channel path builds with requireExpiration:false (OIDC Back-Channel Logout §2.4 does not
-        // mandate exp), so the tests validate under the same posture the endpoint uses.
-        return OidcSignatureKeys.BuildValidationParameters(options, new List<IDisposable>(), requireExpiration: false);
     }
 
     private string CreateToken(IDictionary<string, object> claims, string issuer = Issuer, string audience = ClientId, TimeSpan? lifetime = null)

--- a/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcSignatureKeysKidTests.cs
@@ -153,7 +153,7 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
     {
         var token = CreateToken(keyId: keyId, claims: LogoutClaims());
 
-        var result = await _logoutValidator.ValidateAsync(token, Parameters(), Skew, _now);
+        var result = await _logoutValidator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.UnacceptableKeyId, result.ReasonCode);
@@ -180,7 +180,7 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
     {
         var token = CreateToken(keyId: keyId, claims: LogoutClaims());
 
-        var result = await _logoutValidator.ValidateAsync(token, Parameters(keyId), Skew, _now);
+        var result = await _logoutValidator.ValidateAsync(token, Options(keyId), _now);
 
         Assert.True(result.IsValid, result.ReasonCode);
         Assert.Equal("user-1", result.Subject);
@@ -324,7 +324,7 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
         Assert.False(idResult.IsError, idResult.Error);
 
         var logoutResult = await _logoutValidator.ValidateAsync(
-            CreateToken(claims: LogoutClaims()), Parameters(), Skew, _now);
+            CreateToken(claims: LogoutClaims()), Options(), _now);
         Assert.True(logoutResult.IsValid, logoutResult.ReasonCode);
     }
 
@@ -342,15 +342,13 @@ public sealed class OidcSignatureKeysKidTests : IDisposable
     private OidcClientOptions OptionsFor(string jwks) => new()
     {
         ClientId = ClientId,
+        ClockSkew = Skew,
         ProviderInformation = new ProviderInformation
         {
             IssuerName = Issuer,
             KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
         },
     };
-
-    private TokenValidationParameters Parameters(string keyId = KeyId) =>
-        OidcSignatureKeys.BuildValidationParameters(Options(keyId), new List<IDisposable>(), requireExpiration: false);
 
     private string Jwks(string keyId) => "{\"keys\":[" + KeyEntry(keyId, _rsa) + "]}";
 

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -701,22 +701,10 @@ internal sealed class OidcLoginService
 
         options.ProviderInformation = discovery.ProviderInformation;
 
-        var ephemeralKeys = new List<IDisposable>();
-        try
-        {
-            // requireExpiration:false - OIDC Back-Channel Logout 1.0 §2.4 does not mandate exp on a
-            // logout_token; replay is bounded by the jti one-time-use, not by exp. Requiring it would
-            // silently reject (and thus no-op the logout for) a spec-compliant exp-less IdP (#962).
-            var parameters = OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys, requireExpiration: false);
-            return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, parameters, options.ClockSkew, DateTime.UtcNow).ConfigureAwait(false);
-        }
-        finally
-        {
-            foreach (var key in ephemeralKeys)
-            {
-                key.Dispose();
-            }
-        }
+        // The validator derives its own validation basis from these options and owns the ephemeral signing
+        // keys that come with it, so nothing here holds a TokenValidationParameters that could be weakened
+        // between building it and verifying against it (#1176).
+        return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, options, DateTime.UtcNow).ConfigureAwait(false);
     }
 
     private OidcClientOptions BuildOidcOptions(OidConfig config, string redirectUri, string scope)

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
@@ -19,8 +20,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// request-derived text, so a rejection leaves an audit trail without a subject-identifier oracle,
 /// mirroring the SAML inbound-logout validator). Signature/JWKS/algorithm verification goes through the
 /// SAME <see cref="OidcSignatureKeys"/> basis the id_token validator uses - there is no second, laxer
-/// verification path. On success it yields the (sub, sid) pair the revocation lookup keys on; the
-/// validator itself revokes nothing.
+/// verification path, and this class derives that basis from the provider's options itself rather than
+/// accepting one, so no caller holds the object between its construction and the verification (#1176). On
+/// success it yields the (sub, sid) pair the revocation lookup keys on; the validator itself revokes
+/// nothing.
 /// </summary>
 internal sealed class OidcLogoutTokenValidator
 {
@@ -40,16 +43,16 @@ internal sealed class OidcLogoutTokenValidator
     /// Parses and fully validates a <c>logout_token</c> for a provider.
     /// </summary>
     /// <param name="logoutToken">The raw compact-serialized logout_token.</param>
-    /// <param name="validationParameters">The signature/issuer/audience/lifetime parameters - the SAME basis the id_token uses.</param>
-    /// <param name="clockSkew">The validation clock skew (used for the jti-retention window; matches the parameters' ClockSkew).</param>
+    /// <param name="options">The provider's client options - the issuer, client id, discovery JWKS and clock skew this method derives its own validation basis from.</param>
     /// <param name="nowUtc">The current time (injected for determinism).</param>
     /// <returns>The validation outcome.</returns>
     internal async Task<Result> ValidateAsync(
         string? logoutToken,
-        TokenValidationParameters validationParameters,
-        TimeSpan clockSkew,
+        OidcClientOptions options,
         DateTime nowUtc)
     {
+        ArgumentNullException.ThrowIfNull(options);
+
         if (string.IsNullOrEmpty(logoutToken))
         {
             return new Result(false, null, null, RejectReason.Malformed);
@@ -62,68 +65,91 @@ internal sealed class OidcLogoutTokenValidator
             return new Result(false, null, null, RejectReason.UnacceptableKeyId);
         }
 
-        // Signature / issuer / audience / lifetime - the SAME hardened basis as the id_token (the caller
-        // builds validationParameters via OidcSignatureKeys); any failure is fail-closed.
-        var handler = new JsonWebTokenHandler { MapInboundClaims = false };
-        var result = await handler.ValidateTokenAsync(logoutToken, validationParameters).ConfigureAwait(false);
-        if (!result.IsValid)
+        // ECDsa instances built from the JWKS are ours to dispose; RSA keys built from RSAParameters are
+        // not disposable. Owned here rather than by the caller because the basis is now built here too -
+        // the finally must not run until ValidateTokenAsync has returned (#1176).
+        var ephemeralKeys = new List<IDisposable>();
+        try
         {
-            return new Result(false, null, null, RejectReason.Invalid);
+            // Signature / issuer / audience / lifetime, from the SAME hardened basis as the id_token; any
+            // failure is fail-closed. The basis is built into the call rather than into a local, exactly as
+            // OidcIdTokenValidator does it: no reference to it exists for anything to write through
+            // between construction and verification (#1176).
+            //
+            // requireExpiration:false - OIDC Back-Channel Logout 1.0 §2.4 does not mandate exp on a
+            // logout_token; replay is bounded by the jti one-time-use below, not by exp. Requiring it would
+            // silently reject (and so no-op the logout for) a spec-compliant exp-less IdP (#962).
+            var handler = new JsonWebTokenHandler { MapInboundClaims = false };
+            var result = await handler.ValidateTokenAsync(
+                logoutToken,
+                OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys, requireExpiration: false)).ConfigureAwait(false);
+            if (!result.IsValid)
+            {
+                return new Result(false, null, null, RejectReason.Invalid);
+            }
+
+            var token = (JsonWebToken)result.SecurityToken;
+
+            // azp / additional-audience restriction (OIDC Core 3.1.3.7 rules 3-5), the SAME check the
+            // id_token validator applies - §2.4 says the logout_token aud follows OpenID.Core, so the two
+            // token types must not drift on it: when azp is present it MUST equal this client's id, and a
+            // multi-audience token MUST carry azp (a token minted for a different party that merely
+            // co-lists this client is refused). ValidateAudience already confirmed this client is AMONG the
+            // audiences, from the same options.ClientId compared here.
+            var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
+            if (azp != null && !string.Equals(azp, options.ClientId, StringComparison.Ordinal))
+            {
+                return new Result(false, null, null, RejectReason.Invalid);
+            }
+
+            if (azp == null && token.Audiences.Count() > 1)
+            {
+                return new Result(false, null, null, RejectReason.Invalid);
+            }
+
+            // §2.4: a logout_token MUST NOT contain a nonce. Rejecting it here is what refuses an id_token
+            // (which carries nonce) replayed at the back-channel endpoint.
+            if (token.TryGetPayloadValue<string>("nonce", out var nonce) && !string.IsNullOrEmpty(nonce))
+            {
+                return new Result(false, null, null, RejectReason.ProhibitedNonce);
+            }
+
+            // §2.4/§2.6: the events claim MUST be a JSON object containing the back-channel-logout member.
+            if (!HasBackChannelLogoutEvent(token))
+            {
+                return new Result(false, null, null, RejectReason.NotALogoutToken);
+            }
+
+            var sub = token.TryGetPayloadValue<string>("sub", out var s) && !string.IsNullOrEmpty(s) ? s : null;
+            var sid = token.TryGetPayloadValue<string>("sid", out var i) && !string.IsNullOrEmpty(i) ? i : null;
+
+            // §2.4: at least one of sub / sid MUST be present.
+            if (sub is null && sid is null)
+            {
+                return new Result(false, null, null, RejectReason.NoSubjectOrSid);
+            }
+
+            // One-time-use on jti so a captured valid token cannot be replayed to churn revocations. A token
+            // without a jti is treated as non-replayable-once (fail-closed): give it a synthetic key derived
+            // from its signature so an identical token still collides, while distinct tokens do not.
+            var jti = token.TryGetPayloadValue<string>("jti", out var j) && !string.IsNullOrEmpty(j)
+                ? j
+                : token.EncodedSignature;
+            var retention = ReplayCache.ComputeRetention(nowUtc, token.ValidTo == DateTime.MinValue ? null : token.ValidTo, options.ClockSkew);
+            if (!LogoutTokenReplays.TryConsume(jti, retention, nowUtc, out _))
+            {
+                return new Result(false, null, null, RejectReason.Replay);
+            }
+
+            return new Result(true, sub, sid, string.Empty);
         }
-
-        var token = (JsonWebToken)result.SecurityToken;
-
-        // azp / additional-audience restriction (OIDC Core 3.1.3.7 rules 3-5), the SAME check the id_token
-        // validator applies - §2.4 says the logout_token aud follows OpenID.Core, so the two token types
-        // must not drift on it: when azp is present it MUST equal this client's id, and a multi-audience
-        // token MUST carry azp (a token minted for a different party that merely co-lists this client is
-        // refused). ValidateAudience already confirmed this client is AMONG the audiences.
-        var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
-        if (azp != null && !string.Equals(azp, validationParameters.ValidAudience, StringComparison.Ordinal))
+        finally
         {
-            return new Result(false, null, null, RejectReason.Invalid);
+            foreach (var key in ephemeralKeys)
+            {
+                key.Dispose();
+            }
         }
-
-        if (azp == null && token.Audiences.Count() > 1)
-        {
-            return new Result(false, null, null, RejectReason.Invalid);
-        }
-
-        // §2.4: a logout_token MUST NOT contain a nonce. Rejecting it here is what refuses an id_token
-        // (which carries nonce) replayed at the back-channel endpoint.
-        if (token.TryGetPayloadValue<string>("nonce", out var nonce) && !string.IsNullOrEmpty(nonce))
-        {
-            return new Result(false, null, null, RejectReason.ProhibitedNonce);
-        }
-
-        // §2.4/§2.6: the events claim MUST be a JSON object containing the back-channel-logout member.
-        if (!HasBackChannelLogoutEvent(token))
-        {
-            return new Result(false, null, null, RejectReason.NotALogoutToken);
-        }
-
-        var sub = token.TryGetPayloadValue<string>("sub", out var s) && !string.IsNullOrEmpty(s) ? s : null;
-        var sid = token.TryGetPayloadValue<string>("sid", out var i) && !string.IsNullOrEmpty(i) ? i : null;
-
-        // §2.4: at least one of sub / sid MUST be present.
-        if (sub is null && sid is null)
-        {
-            return new Result(false, null, null, RejectReason.NoSubjectOrSid);
-        }
-
-        // One-time-use on jti so a captured valid token cannot be replayed to churn revocations. A token
-        // without a jti is treated as non-replayable-once (fail-closed): give it a synthetic key derived
-        // from its signature so an identical token still collides, while distinct tokens do not.
-        var jti = token.TryGetPayloadValue<string>("jti", out var j) && !string.IsNullOrEmpty(j)
-            ? j
-            : token.EncodedSignature;
-        var retention = ReplayCache.ComputeRetention(nowUtc, token.ValidTo == DateTime.MinValue ? null : token.ValidTo, clockSkew);
-        if (!LogoutTokenReplays.TryConsume(jti, retention, nowUtc, out _))
-        {
-            return new Result(false, null, null, RejectReason.Replay);
-        }
-
-        return new Result(true, sub, sid, string.Empty);
     }
 
     // The events claim is a JSON object; presence of the back-channel-logout member is what makes this a


### PR DESCRIPTION
# What & why

The back-channel logout endpoint is anonymous, so the `logout_token`'s signature is the only authenticator. Until now its caller built the hardened validation basis, held it in a local, and handed it to the validator, which left a window in which that object could be weakened. Closes #1176.

```csharp
// SSO-Auth/Api/Flows/OidcLoginService.cs, before
var parameters = OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys, requireExpiration: false);
return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, parameters, options.ClockSkew, DateTime.UtcNow).ConfigureAwait(false);
```

`OidcLogoutTokenValidator.ValidateAsync` now takes the provider's `OidcClientOptions` and builds the basis into the `ValidateTokenAsync` call rather than into a local. That is the shape `OidcIdTokenValidator` already had, which is why the id_token path never carried this window, and the issue asked for the logout path to match it rather than for that call site to be restructured.

The options were chosen over a dedicated basis type because they are already what the caller has and what the id_token validator takes, so the two token types keep one entry shape; a new type would have added a third thing to keep in step for the same door.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a reproduction was produced). Every finding of either kind carries a disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change and no review lens was run. The two boxes above are unticked because nothing was done for them; this sentence is the disclosure, not a substitute for one. What stands in its place is the compile-time proof and the test evidence below, and the fact that the change is a parameter move: every validation rule and its order are unchanged.

The posture has to be identical before and after, so here is each thing the parameters used to carry and where it comes from now:

| what | before | after |
| --- | --- | --- |
| signature / issuer / audience / lifetime | `BuildValidationParameters(options, keys, requireExpiration: false)` in the caller | the same call, inside the validator |
| `requireExpiration: false` (#962) | chosen by the caller | stated in the validator, not choosable from outside |
| azp comparison value | `validationParameters.ValidAudience` | `options.ClientId`, which is what `ValidAudience` was assigned from (`OidcSignatureKeys.cs:157`) |
| jti retention skew | `options.ClockSkew`, passed as `clockSkew` | `options.ClockSkew`, read directly |
| ephemeral ECDsa handles | caller's `List<IDisposable>`, disposed in the caller's `finally` | the validator's list, disposed in its own `finally` after `ValidateTokenAsync` has returned |

The two early returns for an absent token and an unacceptable `kid` still run before any key material is built, so a token rejected on either costs no JWKS conversion.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

No conformance rule is added, and that is deliberate: the property this establishes is enforced by the compiler rather than by a scan, which is stronger than the source-scanning rule that could not see the window in the first place. The doc comment says what the class now checks and does not enumerate what it misses, per the #1050 decision.

Net line count is roughly flat: the caller loses its `try`/`finally` and the two test helpers lose their `BuildValidationParameters` call, while the validator gains the block the caller gave up.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q    # 0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q    # 0 warnings, 0 errors

./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2576, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 15,651s
```

No `.js` / `.html` / `.md` / `.css` file is touched, so the Prettier box is ticked on an empty set rather than on a run.

The three classes that own this surface, named rather than left inside a total:

```
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe \
  -class "...OidcLogoutTokenValidatorTests" \
  -class "...OidcSignatureKeysKidTests" \
  -class "...SSOControllerOidBackChannelLogoutTests"
   Total: 102, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 4,248s
```

That includes `SSOControllerOidBackChannelLogoutTests.ForgedToken_Rejects_MintsNoRevoke`, the endpoint-driven row the issue required to stay green.

### The weakening no longer compiles

The mutation the issue names was written back into the call site on this branch and built:

```
// inserted at SSO-Auth/Api/Flows/OidcLoginService.cs:707
parameters.RequireSignedTokens = false;

dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0
SSO-Auth/Api/Flows/OidcLoginService.cs(707,9): error CS0103: the name "parameters" does not exist in the current context
```

The message is quoted from a German-locale build and translated; the code `CS0103` is verbatim. It fails at compile rather than at a test, which is what the issue asked for: before this change the same insertion built clean at zero warnings and only one test noticed.

### On the net10.0 leg

The net10.0 suite was run as:

```
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe -method- "*SsoHttpTests.PrivatePermittedHandler_ConnectsToAnRfc1918Address*" -method- "*SsoHttpTests.CompositionRoot_GivesEachOutboundName_ItsOwnTier*" -method- "*SsoHttpTests.PrivatePermittedHandler_JudgesEveryRedirectHop*" -method- "*SsoHttpTests.PrivatePermittedHandler_StopsAtTheRedirectBound*"
   Total: 2573, Errors: 0, Failed: 0, Skipped: 0, Not Run: 0, Time: 15,020s
```

2573 rather than 2577: four tests were excluded, and they are named above rather than silently dropped. They bind a listener off loopback, which on Windows raises the firewall consent dialog (#1227, now fixed on `main` but not in this branch's base). None of the four touches OIDC, and the CI Linux legs run all four with no exclusion.

## Notes

`OidcSignatureKeys.BuildValidationParameters` keeps its `requireExpiration` parameter and its `internal` visibility. It now has two production callers, both of which build inline, and one test caller in `OidcSignatureKeysTests`. Making the whole builder unreachable from outside the two validators would be a wider change than this issue's scope and would take the direct builder tests with it.

Not done here: the issue's last bullet asks for a record on #1050 that its gap 2 is closed. That record is not written, because #1050 is outside what this change may write to tonight. The evidence it needs is this section and the CS0103 above.

The parent #1049 has two children. #1190 closed on 2026-08-05 and this is the other one, so the parent becomes closable once this lands.
