### PR TITLE
Derive the HTTP entry-point surface by reflection [#1159]

### DIFF
--- a/SSO-Auth.Tests/Http/EntryPointInventoryTests.cs
+++ b/SSO-Auth.Tests/Http/EntryPointInventoryTests.cs
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins <see cref="EntryPointInventory"/>, the substrate the per-field route rules consume (#1159). It is
+/// built and proved first for one reason: every rule built on it asserts something about EVERY route a field
+/// arrives on, so an inventory that quietly stops seeing a route does not make those rules fail. It makes
+/// them pass, over a smaller surface, in silence. That is the failure this file exists to make loud.
+/// <para>
+/// Three kinds of assertion, and they are not interchangeable. The fixture pair pins what the walk must and
+/// must not report, over test-local controllers whose whole content is visible here. The sentinel pins the
+/// walk against the REAL assembly, so a walk that matches fixtures and nothing else fails. The pinned
+/// examples name actions and parameters that exist today, so a rename is caught rather than absorbed.
+/// </para>
+/// </summary>
+public class EntryPointInventoryTests
+{
+    // The must-catch fixture. Both parameters of Get are shapes an attribute-only reader gets wrong: one is
+    // explicit, the other carries nothing at all and binds from the route by name - the shape OidChallenge
+    // and SamlChallenge use for `provider`, which is the most route-multiplied field in the plugin.
+    [Route("[controller]")]
+    private sealed class FixtureController : ControllerBase
+    {
+        [HttpGet("thing/{id}")]
+        public ActionResult Get(string id, [FromQuery] string filter) => Ok($"{id}{filter}");
+
+        [HttpPost("thing/{id}")]
+        [HttpPost("thing/alt/{id}")]
+        public ActionResult Post(string id, [FromBody] FixturePayload payload) => Ok($"{id}{payload.Value}");
+
+        // A public method on a controller that is not reachable over HTTP. It carries no verb attribute, so
+        // it is not an action, and it must not appear in the inventory.
+        public string HelperThatIsNotAnAction(string anything) => anything;
+
+        // A method that carries a verb attribute and is still excluded from routing.
+        [HttpGet("never")]
+        [NonAction]
+        public ActionResult NotRouted() => Ok();
+    }
+
+    private sealed class FixturePayload
+    {
+        public string Value { get; init; } = string.Empty;
+    }
+
+    // The adjacent must-not-catch fixture: same attribute, same method name, one difference - it is not a
+    // controller.
+    private sealed class NotAControllerAtAll
+    {
+        [HttpGet("thing/{id}")]
+        public string Get(string id) => id;
+    }
+
+    [Fact]
+    public void TheWalk_ReportsAnExplicitAndAnImplicitlyBoundParameter()
+    {
+        var entry = Assert.Single(EntryPointInventory.Of([typeof(FixtureController)]), e => e.Action == "Get");
+
+        Assert.Equal("GET", entry.Method);
+        Assert.Equal("thing/{id}", entry.Template);
+
+        var id = Assert.Single(entry.Parameters, p => p.Name == "id");
+        Assert.Equal(EntryPointSource.Route, id.Source);
+        Assert.False(id.IsExplicit, "the route bind must be derived from the template, not from an attribute that is not there");
+
+        var filter = Assert.Single(entry.Parameters, p => p.Name == "filter");
+        Assert.Equal(EntryPointSource.Query, filter.Source);
+        Assert.True(filter.IsExplicit);
+    }
+
+    [Fact]
+    public void TheWalk_YieldsOneEntryPointPerRouteAttribute_NotOnePerAction()
+    {
+        // Two URLs a caller can arrive on is two entry points. Collapsing them to one would let a rule pass
+        // by checking whichever of the two the walk happened to keep, and the plugin has four such pairs on
+        // the login path alone (OID/r + OID/redirect, OID/p + OID/start, SAML/p + SAML/post, SAML/p + SAML/start).
+        var posts = EntryPointInventory.Of([typeof(FixtureController)]).Where(e => e.Action == "Post").ToList();
+
+        Assert.Equal(2, posts.Count);
+        Assert.Equal(["thing/alt/{id}", "thing/{id}"], posts.Select(p => p.Template).Order(StringComparer.Ordinal));
+        Assert.All(posts, p => Assert.Equal("POST", p.Method));
+        Assert.All(posts, p => Assert.Equal(EntryPointSource.Body, Assert.Single(p.Parameters, x => x.Name == "payload").Source));
+    }
+
+    [Fact]
+    public void TheWalk_ReportsNeitherANonActionMethodNorANonControllerType()
+    {
+        var fromController = EntryPointInventory.Of([typeof(FixtureController)]);
+        var fromNonController = EntryPointInventory.Of([typeof(NotAControllerAtAll)]);
+
+        Assert.DoesNotContain(fromController, e => e.Action == "HelperThatIsNotAnAction");
+        Assert.DoesNotContain(fromController, e => e.Action == "NotRouted");
+        Assert.Empty(fromNonController);
+
+        // And the must-catch half of the same walk is still reported, so the two exclusions above are a real
+        // decision rather than a walk that reports nothing at all.
+        Assert.NotEmpty(fromController);
+    }
+
+    [Fact]
+    public void TheWalk_OverTheRealAssembly_IsNonEmpty_AndMeetsItsFloor()
+    {
+        // The sentinel. A walk that stops matching - a changed base type, a controller moved out of the
+        // assembly, an attribute namespace that no longer resolves - would otherwise turn every rule built
+        // on this into a vacuous pass over an empty set.
+        //
+        // The floor is deliberately well under the real count rather than equal to it: this must fail when
+        // the walk BREAKS, and never merely because an endpoint was legitimately added or removed. A test
+        // that has to be edited on every ordinary change gets edited without being read.
+        var entries = EntryPointInventory.OfThePlugin();
+
+        Assert.NotEmpty(EntryPointInventory.ControllerTypes());
+        Assert.True(
+            entries.Count >= 30,
+            $"The entry-point walk found only {entries.Count} entry points on the plugin assembly; it has stopped matching the real controllers, and every rule built on it would now pass over a surface that is too small (#1159).");
+    }
+
+    [Fact]
+    public void TheWalk_OverTheRealAssembly_PinsANamedActionAndItsImplicitlyBoundParameter()
+    {
+        // The floor above proves the walk found SOMETHING. This proves it found the right thing, and it is
+        // pinned on the shape a floor cannot see: OidChallenge's `provider` carries no binding attribute, so
+        // an inventory that read attributes only would report this action with one parameter instead of two
+        // and still clear any count-based sentinel.
+        var challenges = EntryPointInventory.OfThePlugin().Where(e => e.Action == "OidChallenge").ToList();
+
+        Assert.Equal(2, challenges.Count); // OID/p/{provider} and OID/start/{provider}
+        Assert.All(challenges, e =>
+        {
+            var provider = Assert.Single(e.Parameters, p => p.Name == "provider");
+            Assert.Equal(EntryPointSource.Route, provider.Source);
+            Assert.False(provider.IsExplicit);
+            Assert.Equal(typeof(string), provider.ParameterType);
+        });
+    }
+
+    [Fact]
+    public void TheWalk_OverTheRealAssembly_SeesEveryBindingSourceTheControllersActuallyUse()
+    {
+        // Each of these is a distinct way an attacker-influenced value enters the plugin, and a rule that
+        // asks "every route this field arrives on" is wrong if the walk is blind to one of them. Asserted as
+        // presence rather than as a count, so adding an endpoint does not move it.
+        var sources = EntryPointInventory.OfThePlugin()
+            .SelectMany(e => e.Parameters)
+            .Select(p => p.Source)
+            .Distinct()
+            .ToList();
+
+        Assert.Contains(EntryPointSource.Route, sources);
+        Assert.Contains(EntryPointSource.Query, sources);
+        Assert.Contains(EntryPointSource.Body, sources);
+    }
+}

--- a/SSO-Auth.Tests/_Support/EntryPointInventory.cs
+++ b/SSO-Auth.Tests/_Support/EntryPointInventory.cs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Where one action parameter's value comes from.
+/// </summary>
+public enum EntryPointSource
+{
+    /// <summary>A route segment, whether declared with <c>[FromRoute]</c> or bound by name from the template.</summary>
+    Route,
+
+    /// <summary>The query string.</summary>
+    Query,
+
+    /// <summary>A form field.</summary>
+    Form,
+
+    /// <summary>The request body, deserialized by the host's input formatter.</summary>
+    Body,
+
+    /// <summary>A request header.</summary>
+    Header,
+
+    /// <summary>The DI container, not the request - never an attacker-influenced value.</summary>
+    Services,
+
+    /// <summary>Supplied by the framework rather than by the request (a cancellation token).</summary>
+    Framework,
+}
+
+/// <summary>
+/// One parameter of one HTTP entry point, with the source its value arrives from.
+/// </summary>
+/// <param name="Name">The parameter name as declared.</param>
+/// <param name="ParameterType">The declared parameter type.</param>
+/// <param name="Source">Where the value comes from.</param>
+/// <param name="IsExplicit">Whether an attribute named the source, as opposed to it being ASP.NET's default for this parameter.</param>
+public sealed record EntryPointParameter(string Name, Type ParameterType, EntryPointSource Source, bool IsExplicit)
+{
+    /// <inheritdoc />
+    public override string ToString() => $"{Source}{(IsExplicit ? string.Empty : " (implicit)")} {ParameterType.Name} {Name}";
+}
+
+/// <summary>
+/// One reachable HTTP entry point: a method, a route template, the action behind it, and its parameters.
+/// An action carrying two route attributes is two entry points, because that is two URLs a caller can arrive on.
+/// </summary>
+/// <param name="Method">The HTTP method, upper-case.</param>
+/// <param name="Template">The action-level route template as declared, empty when the attribute carries none.</param>
+/// <param name="Controller">The declaring controller's simple type name.</param>
+/// <param name="Action">The action method name.</param>
+/// <param name="Parameters">The action's parameters, in declaration order.</param>
+public sealed record HttpEntryPoint(
+    string Method,
+    string Template,
+    string Controller,
+    string Action,
+    IReadOnlyList<EntryPointParameter> Parameters)
+{
+    /// <inheritdoc />
+    public override string ToString() =>
+        $"{Method} {Template} -> {Controller}.{Action}({string.Join(", ", Parameters)})";
+}
+
+/// <summary>
+/// The plugin's HTTP entry-point surface, derived by reflection from the controller types rather than from a
+/// hand-written list (#1159), so an endpoint added later is seen without editing any rule built on this.
+/// <para>
+/// Every rule that asks "does every route a given field arrives on run the same validator" needs the set of
+/// routes first. Getting that set from a literal list is the failure mode those rules exist to prevent: the
+/// route somebody forgot to add to the list is exactly the route that skipped the validator. So the set is
+/// walked, and the walk is sentinel-guarded by <see cref="EntryPointInventoryTests"/> against passing empty.
+/// </para>
+/// <para>
+/// Implicit binding is the part a naive inventory gets wrong. <c>string provider</c> on <c>OidChallenge</c>
+/// and <c>SamlChallenge</c> carries no attribute at all and binds from the route, so an inventory that reads
+/// only <c>[From*]</c> attributes would miss a large share of the provider-id surface - the single most
+/// route-multiplied field in this plugin. <see cref="ImplicitSourceOf"/> reproduces ASP.NET's default rule
+/// instead of ignoring it.
+/// </para>
+/// </summary>
+public static class EntryPointInventory
+{
+    /// <summary>
+    /// Gets every entry point on the shipped plugin assembly's controllers.
+    /// </summary>
+    /// <returns>The entry points, in no guaranteed order.</returns>
+    public static IReadOnlyList<HttpEntryPoint> OfThePlugin() => Of(ControllerTypes());
+
+    /// <summary>
+    /// Gets the controller types the shipped plugin assembly declares, discovered by base type rather than by
+    /// name so a controller that is renamed or split still counts.
+    /// </summary>
+    /// <returns>The controller types.</returns>
+    public static IReadOnlyList<Type> ControllerTypes() =>
+        typeof(SSOPlugin).Assembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(ControllerBase).IsAssignableFrom(t))
+            .ToList();
+
+    /// <summary>
+    /// Gets every entry point on the given types. Types that are not controllers contribute nothing, so a
+    /// caller may hand in a mixed set.
+    /// </summary>
+    /// <param name="types">The candidate types.</param>
+    /// <returns>The entry points, in no guaranteed order.</returns>
+    public static IReadOnlyList<HttpEntryPoint> Of(IEnumerable<Type> types)
+    {
+        ArgumentNullException.ThrowIfNull(types);
+
+        return types
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(ControllerBase).IsAssignableFrom(t))
+            .SelectMany(EntryPointsOn)
+            .ToList();
+    }
+
+    // A public instance method is an action only when it carries an HTTP-method attribute. This plugin routes
+    // by attribute throughout, so a public method without one - a helper the class happens to expose - is not
+    // reachable over HTTP and must not appear. [NonAction] is honoured as well, for a method that carries a
+    // verb attribute and is still excluded from routing.
+    private static IEnumerable<HttpEntryPoint> EntryPointsOn(Type controller) =>
+        controller.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName && m.GetCustomAttribute<NonActionAttribute>() is null)
+            .SelectMany(method => method.GetCustomAttributes<HttpMethodAttribute>(inherit: true)
+                .SelectMany(attribute => attribute.HttpMethods.Select(verb => new
+                {
+                    Verb = verb,
+                    Template = attribute.Template ?? string.Empty,
+                    Method = method,
+                }))
+                .Select(e => new HttpEntryPoint(
+                    e.Verb.ToUpperInvariant(),
+                    e.Template,
+                    controller.Name,
+                    e.Method.Name,
+                    ParametersOf(e.Method, e.Template))));
+
+    private static IReadOnlyList<EntryPointParameter> ParametersOf(MethodInfo action, string template) =>
+        action.GetParameters()
+            .Select(p => ExplicitSourceOf(p) is { } source
+                ? new EntryPointParameter(p.Name ?? string.Empty, p.ParameterType, source, IsExplicit: true)
+                : new EntryPointParameter(p.Name ?? string.Empty, p.ParameterType, ImplicitSourceOf(p, template), IsExplicit: false))
+            .ToList();
+
+    private static EntryPointSource? ExplicitSourceOf(ParameterInfo parameter) => parameter switch
+    {
+        _ when parameter.GetCustomAttribute<FromRouteAttribute>() is not null => EntryPointSource.Route,
+        _ when parameter.GetCustomAttribute<FromQueryAttribute>() is not null => EntryPointSource.Query,
+        _ when parameter.GetCustomAttribute<FromFormAttribute>() is not null => EntryPointSource.Form,
+        _ when parameter.GetCustomAttribute<FromBodyAttribute>() is not null => EntryPointSource.Body,
+        _ when parameter.GetCustomAttribute<FromHeaderAttribute>() is not null => EntryPointSource.Header,
+        _ when parameter.GetCustomAttribute<FromServicesAttribute>() is not null => EntryPointSource.Services,
+        _ => null,
+    };
+
+    // ASP.NET's default when no attribute names a source: a name that appears in the route template binds
+    // from the route; otherwise a simple type binds from the query string and a complex one from the body.
+    // Route-parameter names are matched case-insensitively, as routing matches them.
+    private static EntryPointSource ImplicitSourceOf(ParameterInfo parameter, string template)
+    {
+        if (parameter.ParameterType == typeof(CancellationToken))
+        {
+            return EntryPointSource.Framework;
+        }
+
+        if (TemplateNames(template).Contains(parameter.Name ?? string.Empty, StringComparer.OrdinalIgnoreCase))
+        {
+            return EntryPointSource.Route;
+        }
+
+        return IsSimple(parameter.ParameterType) ? EntryPointSource.Query : EntryPointSource.Body;
+    }
+
+    // The names inside a template's {...} segments, with any inline constraint or default (":int", "?", "=x")
+    // stripped, and catch-all "*"/"**" prefixes removed.
+    private static IEnumerable<string> TemplateNames(string template)
+    {
+        var rest = template;
+        while (rest.IndexOf('{', StringComparison.Ordinal) is var open && open >= 0)
+        {
+            var close = rest.IndexOf('}', open);
+            if (close < 0)
+            {
+                yield break;
+            }
+
+            var name = rest[(open + 1)..close].TrimStart('*');
+            var cut = name.IndexOfAny([':', '=', '?']);
+            yield return cut >= 0 ? name[..cut] : name;
+
+            rest = rest[(close + 1)..];
+        }
+    }
+
+    // "Simple" in the model-binding sense: something a single string can be converted into. Anything else is
+    // a complex type, which is what makes the difference between an implicit query bind and an implicit body
+    // bind.
+    private static bool IsSimple(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        return underlying.IsPrimitive
+            || underlying.IsEnum
+            || underlying == typeof(string)
+            || underlying == typeof(decimal)
+            || underlying == typeof(DateTime)
+            || underlying == typeof(DateTimeOffset)
+            || underlying == typeof(TimeSpan)
+            || underlying == typeof(Guid)
+            || underlying == typeof(Uri);
+    }
+}


### PR DESCRIPTION
# What & why

The per-field route rules on #1160 through #1165 each assert that every route a security-relevant field arrives on runs the same validator. That claim needs the set of routes before it needs anything else, and a set written as a literal list fails in exactly the direction those rules exist to catch: the route nobody remembered to add to the list is the route that skipped the validator, and the rule passes over what is left. Closes #1159.

`EntryPointInventory` walks the controller types instead. Two files, both test-side, no production change.

- `SSO-Auth.Tests/_Support/EntryPointInventory.cs`, the walk, plus `HttpEntryPoint` and `EntryPointParameter`.
- `SSO-Auth.Tests/Http/EntryPointInventoryTests.cs`, the fixture pair, the sentinel, and the named pins.

Controllers are found by base type, the way `ArchitectureConformanceTests.ControllerSourceFiles` already finds their source files, so a rename or the planned controller split still counts them. An action carrying two route attributes yields two entry points, because that is two URLs a caller can arrive on, and the plugin has four such pairs on the login path alone.

Implicit binding is the part an attribute-only reader gets wrong, and it is not a corner case here. `string provider` on `OidChallenge` and `SamlChallenge` carries no attribute and binds from the route by name, and the provider id is the most route-multiplied field in the plugin. So the walk reproduces ASP.NET's default rule rather than skipping it: a name that appears in the template binds from the route, otherwise a simple type binds from the query string and a complex one from the body.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test substrate. It asserts nothing about the login path itself yet; the rules that will are the sibling issues.

## Security checklist

Not applicable. No file under `SSO-Auth/` is touched.

```
git diff --name-only origin/main...HEAD
SSO-Auth.Tests/Http/EntryPointInventoryTests.cs
SSO-Auth.Tests/_Support/EntryPointInventory.cs
```

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a reproduction was produced). Every finding of either kind carries a disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change and no review lens was run. The boxes are unticked because nothing was done for them, and this sentence is the disclosure rather than a replacement for one. What stands in its place is the mutation table below.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the update is included here, OR it is filed as a `documentation` issue on the current-release milestone (link it in Notes).

Nothing is added to `ArchitectureConformanceTests`: this establishes no structural property over the shipped code. It is substrate that later rules consume, and the whole suite including that class is green below.

`_Support/EndpointCatalog.cs` was read before writing this and deliberately not extended. It reads the LIVE routing table from a running host and classifies endpoints by authorization only; it needs an `IServiceProvider` and reports no parameters. This walk is reflection over types, needs no host, and reports parameters and their binding sources. Different inputs, different outputs, no overlap to merge.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q   # 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2583, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 13,902s

dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q   # 0 warnings, 0 errors
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2584, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 14,811s
```

The four skips are the LAN-binding rows in `SsoHttpTests`, which skip on Windows since #1227 and run on the Linux legs. Nothing here touches them.

No `.js` / `.html` / `.md` / `.css` file is touched, so that box is ticked on an empty set rather than on a run.

### What the walk actually finds

40 entry points on the shipped assembly. The number is read out of the sentinel's own failure message rather than asserted, which is why the floor is 30: this test must go red when the walk BREAKS, never because an endpoint was legitimately added or removed. A test that has to be edited on every ordinary change gets edited without being read.

### Each property, removed one at a time

Five mutations, each applied to a clean copy of both files, built, and run. The restore between them is from a snapshot rather than from git, because these files are new and `git checkout --` on an untracked path silently does nothing; an earlier attempt at this table stacked the mutations on top of each other and had to be thrown away.

| removed | red | green |
| --- | --- | --- |
| the floor raised past the real count (control) | the sentinel, reporting `found only 40 entry points` | 5 |
| the implicit route-bind branch, leaving an attribute-only reader | `TheWalk_ReportsAnExplicitAndAnImplicitlyBoundParameter`, `TheWalk_OverTheRealAssembly_PinsANamedActionAndItsImplicitlyBoundParameter` | 4 |
| all but the first route attribute per action | `TheWalk_YieldsOneEntryPointPerRouteAttribute_NotOnePerAction`, `TheWalk_OverTheRealAssembly_PinsANamedActionAndItsImplicitlyBoundParameter` | 4 |
| the `[NonAction]` exclusion | `TheWalk_ReportsNeitherANonActionMethodNorANonControllerType` | 5 |
| the real-assembly discovery, matched against a name no type has | the three real-assembly rows | the three fixture rows |

The last row is the one that shows the two halves are separate: breaking the walk over the shipped assembly leaves every fixture assertion green, so the fixtures cannot stand in for the sentinel and the sentinel cannot stand in for the fixtures. The first row is a control on the sentinel's own message, not a property being removed.

## Notes

`Header`, `Form`, `Services` and `Framework` are in the source enum and are not asserted as present on the real assembly, because the controllers do not currently use them. Asserting them would fail today; asserting their absence would break the moment one is legitimately used. The presence assertion covers `Route`, `Query` and `Body`, which are what the controllers actually carry.

The walk reports the action-level template as declared and does not compose it with the controller's `[Route("[controller]")]` prefix. The sibling rules compare which routes a field arrives on rather than resolving a URL, so the prefix would be constant across every comparison. Composing it is a small addition if one of them turns out to need the full path.
