### PR TITLE
Close the base-class route around the file-local test scans

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2627,7 +2627,9 @@ public class ArchitectureConformanceTests
         // other (the exact intermittent 429→400 failure that motivated this rule, #928 U4). The
         // "SSOController" collection (DisableParallelization) is the existing convention; this makes it
         // self-enforcing: a NEW test class that constructs the harness without joining the collection is
-        // a red build naming the file, not a flaky suite three weeks later.
+        // a red build naming the file, not a flaky suite three weeks later. The scan reads each file's own
+        // code lines, which is sound only because a test class cannot inherit its setup from elsewhere -
+        // <see cref="NoTestClass_DeclaresABaseClass"/> is what holds that (#1172).
         var testsRoot = Path.Combine(RepoRoot(), "SSO-Auth.Tests");
         var offenders = new List<string>();
         foreach (var src in Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories))
@@ -2656,6 +2658,56 @@ public class ArchitectureConformanceTests
             Directory.EnumerateFiles(testsRoot, "*.cs", SearchOption.AllDirectories)
                 .Count(f => !IsBuildOutput(f) && File.ReadAllText(f).Contains("new SsoControllerHarness", StringComparison.Ordinal)) >= 10,
             "The harness-usage scan matched fewer than 10 files - SsoControllerHarness was renamed; update this rule.");
+    }
+
+    [Fact]
+    public void NoTestClass_DeclaresABaseClass()
+    {
+        // #1172: the harness rule above reads each file's own code lines. That is sound only while a test
+        // class cannot inherit its setup: `sealed class FooTests : SomeTestBase` where the base constructs
+        // the harness or clears a static matches no literal in FooTests.cs, so the file would be scanned
+        // clean and run in parallel with a class clearing the same statics. This rule closes that route by
+        // construction rather than by scanning for spellings of it - a test-bearing type inherits nothing
+        // but object, so whatever a test class does is in the file that declares it. Interfaces are not
+        // base types in the CLR, so IDisposable, IClassFixture<T> and IAsyncLifetime are unaffected. It
+        // also puts the Coding-Standards wiki rule "there are no test base classes" behind a build gate.
+        var testBearing = typeof(ArchitectureConformanceTests).Assembly.GetTypes()
+            .Where(t => !IsCompilerGenerated(t))
+            .Where(t => t
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Any(m => m.GetCustomAttributes(typeof(FactAttribute), inherit: true).Length > 0))
+            .ToList();
+
+        var offenders = testBearing
+            .Where(t => t.BaseType is not null && t.BaseType != typeof(object))
+            .Select(t => $"{TestSourceFileDeclaring(t)}: {SimpleName(t)} : {SimpleName(t.BaseType!)}")
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            "A test class must not derive from a base class - the file-local test scans (harness collection, statics) would not see what the base does. Implement an interface, or put the shared code in a fixture the class holds. Offenders: " + string.Join(", ", offenders));
+
+        // Liveness floor: the scan must actually reach the test classes. A reflection that stopped finding
+        // [Fact]/[Theory] carriers would report zero offenders forever.
+        Assert.True(
+            testBearing.Count >= 120,
+            $"The test-class reflection found only {testBearing.Count} types carrying [Fact]/[Theory] - the scan has been blinded (attribute renamed, tests moved out of this assembly); update this rule.");
+    }
+
+    // The test source file declaring a type, so an offender is reported as a file a reader can open rather
+    // than as a type name they then have to find. Test-side counterpart of SourceFilesDeclaring, which
+    // scans the plugin project.
+    private static string TestSourceFileDeclaring(Type type)
+    {
+        var declaration = new Regex(
+            $@"\b(?:{string.Join("|", TypeDeclarationKeywords)})\s+{Regex.Escape(SimpleName(type))}\b");
+
+        return Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth.Tests"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path => declaration.IsMatch(File.ReadAllText(path)))
+            .Select(Path.GetFileName)
+            .FirstOrDefault() ?? SimpleName(type) + " (declaring file not found)";
     }
 
     [Fact]


### PR DESCRIPTION
# What & why

`EveryHarnessUsingTestClass_IsInTheNonParallelControllerCollection` reads each test file's own code lines. A class that reaches `SsoControllerHarness` through a base type matches no literal in its own file, so it is scanned clean and runs in parallel with a class clearing the same process-wide statics. That is the intermittent race the rule exists to prevent, arriving through a door the rule cannot see. The wiki Coding-Standards page already says there are no test base classes, but nothing enforced it.

`NoTestClass_DeclaresABaseClass` closes the route by construction rather than by scanning for spellings of it. Reflection over the test assembly finds every type declaring a `[Fact]`/`[Theory]` method and requires its base type to be `object`, so whatever a test class does is in the file that declares it and the file-local scans are sound. Interfaces are not base types in the CLR, so `IDisposable`, `IClassFixture<T>` and `IAsyncLifetime` are untouched.

Closes #1172

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: test-only, no login path, crypto, config persistence or release pipeline is touched. No production file changed (`git diff --name-only origin/main...HEAD` returns one path, `SSO-Auth.Tests/ArchitectureConformanceTests.cs`).

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki update is needed. The wiki already states the standard this rule enforces; the change puts a gate behind an existing sentence rather than adding one.

## Verification

Both legs built `--warnaserror`, both suites run through the built MTP executables.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2584, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 15,625s

dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2585, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 15,876s
```

The rule is shown biting, for the reason it names. A probe file adding `public abstract class ZzProbeTestBase` and `public sealed class ZzProbeDerivedTests : ZzProbeTestBase` with one `[Fact]`:

```
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*NoTestClass_DeclaresABaseClass*"
    ArchitectureConformanceTests.NoTestClass_DeclaresABaseClass [FAIL]
      A test class must not derive from a base class ... Offenders: ZzProbeBaseClass.cs: ZzProbeDerivedTests : ZzProbeTestBase
   Total: 1, Errors: 0, Failed: 1
```

The probe file was deleted before the commit; `git diff --name-only origin/main...HEAD` shows it is not in the branch.

The liveness floor is measured, not guessed. Raising it to `999999` on a scratch build printed the real population, which is what the floor of 120 is set against:

```
      The test-class reflection found only 147 types carrying [Fact]/[Theory] - the scan has been blinded ...
```

Must-not-catch is the existing suite: `SSOControllerAuthorizationTests : IClassFixture<SsoAuthorizationServerFixture>`, six classes on `IDisposable`, and `SsoAuthorizationServerFixture : IAsyncDisposable` are all in the assembly and all green above.

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No file of those kinds is in the diff.

## Notes

`StubHttpMessageHandler : HttpMessageHandler` and the other `_Support` types keep their base types deliberately. The rule is scoped to types that carry `[Fact]`/`[Theory]`, which is where the file-local scans read, so a helper deriving from a framework type is not in its subject.

The rule reports the declaring file rather than only the type name, through a small `TestSourceFileDeclaring` helper that is the test-side counterpart of the existing `SourceFilesDeclaring`. It falls back to the type name and says so when no file matches, so a lookup miss is visible rather than silently blank.

This pull request had no second reader. The evidence above stands in place of one.
