### PR TITLE
Refuse commit-message characters outside an explicit set [#1006]

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -24,10 +24,15 @@
 #   - FAIL  (high confidence, near-zero false-positive):
 #       * PR body carries an issue reference (Closes/Refs #N).
 #       * every commit subject carries a bracketed issue reference.
+#       * every commit message, subject and body, stays inside an explicit
+#         character set - printable ASCII plus a short table of code points
+#         derived from the messages already on main (#1006).
 #       * a build.yaml version bump also touches CHANGELOG.md.
 #     The whole FAIL tier is skipped for bots and for authors from outside this
 #     repository; the two skips have different reasons and both are written at
-#     the check, not only here (#1207).
+#     the check, not only here (#1207). The character check takes that skip too,
+#     but drops to the WARN tier rather than going silent, so a skipped run is
+#     never mistaken for a clean one.
 #   - WARN  (soft convention, annotation only - never fails):
 #       * the diff is large (>=400 changed lines) - advisory; a feature, doc
 #         migration, or bulk rename legitimately exceeds any cap, so size never reds.
@@ -177,6 +182,121 @@ jobs:
                   "Every commit subject must end with its issue reference(s) in " +
                   "the form `[#N]` (multiple issues: `[#N][#M]`).",
               );
+            }
+
+            // --- Check 1c: the commit message character set (#1006) -------------
+            // Subject AND body, every commit in the PR range. The repertoire is an
+            // explicit allowlist rather than a blocklist of known-bad code points:
+            // that is the recommendation of Unicode Technical Standard #55 and the
+            // Trojan-Source work (CVE-2021-42574), and it is the only form that
+            // holds against a script nobody has thought of yet. Bidi controls,
+            // zero-width joiners and homoglyphs are outside it without being named.
+            //
+            // Why the trailer needs its own check when `.cs` and workflow files
+            // already have one: the Unicode-guard job scans files in the tree, this
+            // scans git metadata, and no input is shared. A commit message is also
+            // immutable once it is on main - the repair for a bad one is a history
+            // rewrite - so the gate has to sit before the merge or not at all.
+            //
+            // The set is DERIVED, not remembered. Over all 1707 commits reachable
+            // from main at the time of writing, nine code points outside printable
+            // ASCII occur:
+            //
+            //   U+2014 EM DASH                       694    permitted
+            //   U+2192 RIGHTWARDS ARROW               13    permitted
+            //   U+2026 HORIZONTAL ELLIPSIS            10    permitted
+            //   U+00A7 SECTION SIGN                    8    permitted
+            //   U+0009 TAB                             4    permitted
+            //   U+00DC LATIN CAPITAL U WITH DIAERESIS  2    permitted
+            //   U+2265 GREATER-THAN OR EQUAL TO        1    permitted
+            //   U+2013 EN DASH                         1    permitted
+            //   U+2024 ONE DOT LEADER                  1    REFUSED
+            //
+            //   git log --format=%H%x1f%B%x1e origin/main   (counted per code point)
+            //
+            // U+2024 is the reason this check exists rather than an illustration of
+            // it: in 6fc801f it sits inside "(…․0)" where a full stop belongs, in a
+            // merged commit body, and nothing saw it. It is left out of the set on
+            // purpose - a period homoglyph has no legitimate use here.
+            //
+            // The German letters are the one addition not individually measured.
+            // U+00DC is measured, and the rest of that class arrives the same way:
+            // this repo quotes its own toolchain output as evidence, and on the
+            // machine that produces it that output is German. Refusing "ausgeführt"
+            // would make this gate fight the rule that a claim carries the command
+            // that produced it. Widening further is a deliberate edit of this table,
+            // which is the point of an allowlist; nothing here widens by pattern.
+            const ALLOWED_CODE_POINTS = new Map([
+              [0x0009, "TAB"],
+              [0x000a, "LINE FEED"],
+              [0x000d, "CARRIAGE RETURN"],
+              [0x00a7, "SECTION SIGN"],
+              [0x00c4, "LATIN CAPITAL LETTER A WITH DIAERESIS"],
+              [0x00d6, "LATIN CAPITAL LETTER O WITH DIAERESIS"],
+              [0x00dc, "LATIN CAPITAL LETTER U WITH DIAERESIS"],
+              [0x00df, "LATIN SMALL LETTER SHARP S"],
+              [0x00e4, "LATIN SMALL LETTER A WITH DIAERESIS"],
+              [0x00f6, "LATIN SMALL LETTER O WITH DIAERESIS"],
+              [0x00fc, "LATIN SMALL LETTER U WITH DIAERESIS"],
+              [0x2013, "EN DASH"],
+              [0x2014, "EM DASH"],
+              [0x2026, "HORIZONTAL ELLIPSIS"],
+              [0x2192, "RIGHTWARDS ARROW"],
+              [0x2265, "GREATER-THAN OR EQUAL TO"],
+            ]);
+            const isPermitted = (cp) =>
+              (cp >= 0x20 && cp <= 0x7e) || ALLOWED_CODE_POINTS.has(cp);
+            const asEscape = (cp) =>
+              `U+${cp.toString(16).toUpperCase().padStart(4, "0")}`;
+
+            // The offending line is echoed with every refused code point replaced by
+            // its escape. Echoing the raw character would reproduce the rendering
+            // attack inside the log that reports it, which is the one place it must
+            // not happen.
+            const neutralise = (line) =>
+              [...line]
+                .map((ch) =>
+                  isPermitted(ch.codePointAt(0)) ? ch : `<${asEscape(ch.codePointAt(0))}>`,
+                )
+                .join("");
+
+            const charFindings = [];
+            for (const c of commits) {
+              const lines = (c.commit.message || "").split("\n");
+              lines.forEach((line, index) => {
+                for (const ch of line) {
+                  const cp = ch.codePointAt(0);
+                  if (!isPermitted(cp)) {
+                    charFindings.push(
+                      `${c.sha.slice(0, 7)} line ${index + 1}: ${asEscape(cp)} - ` +
+                        `"${neutralise(line)}"`,
+                    );
+                    break;
+                  }
+                }
+              });
+            }
+            if (charFindings.length > 0) {
+              const REPORTED = 20;
+              const shown = charFindings.slice(0, REPORTED);
+              const tail =
+                charFindings.length > REPORTED
+                  ? ` (${charFindings.length - REPORTED} further line(s) not listed)`
+                  : "";
+              const report =
+                "Commit message character(s) outside the permitted set:\n" +
+                shown.map((f) => `  ${f}`).join("\n") +
+                tail +
+                "\nThe permitted set is printable ASCII plus the named code points " +
+                "listed at check 1c in .github/workflows/pr-hygiene.yml. Repair the " +
+                "message before it reaches main, where it can only be repaired by " +
+                "rewriting history.";
+              // Outside the FAIL tier this is reported and not failed, for the same
+              // audience reason as checks 1, 1b and 2 (#1207) - the tier is skipped
+              // whole. Reporting rather than staying silent keeps the skip from
+              // reading as "nothing was found here", which is the shape a hostile
+              // message would arrive in.
+              (failTierApplies ? failures : warnings).push(report);
             }
 
             // --- Check 2: a build.yaml version bump must touch CHANGELOG.md -----

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,11 @@ We are always open to better docs! The main place documentation could be improve
 
 Short, imperative subject line (`Add SAML replay cache`, not `feat: add ...`); explain the _why_ in the body. **Every commit subject ends with its issue reference(s) in brackets** - `Add SAML replay cache [#123]`, multiple issues as `[#123][#456]` - so the link survives `git blame`/`bisect`/`log`, which show only the subject. GitHub's auto-close keywords (`Closes #N`) additionally go in the body when the commit resolves the issue. The PR-hygiene gate enforces the bracketed subject reference per commit (bots and merge commits exempt).
 
-If you are contributing from outside this repository, the gate's failing checks do not apply to you: the issue convention is ours, and you have no way to know a number before the issue exists. Send the change; the linkage is not dropped, it moves to me - I add the issue reference, and file the issue where none exists yet, as part of handling the contribution.
+A commit message may only use printable ASCII plus a short, named set of extra characters: tab, the em and en dash, the ellipsis, the section sign, the rightwards arrow, the greater-than-or-equal sign, and the German letters `ÄÖÜäöüß`. Anything else fails the gate, naming the commit, the code point and the line. The set is an allowlist rather than a list of forbidden characters, because that is the only shape that also refuses a script nobody has thought of yet - the reasoning is Unicode Technical Standard #55 and the Trojan Source work (CVE-2021-42574). Widening it is a deliberate edit of the table in `.github/workflows/pr-hygiene.yml`, where the table also records which characters were measured in the existing history and which one was refused.
+
+The reason this is worth a gate of its own: the Unicode check on source files does not read git metadata, and a commit message cannot be corrected after it lands, only rewritten out of history.
+
+If you are contributing from outside this repository, the gate's failing checks do not apply to you: the issue convention is ours, and you have no way to know a number before the issue exists. Send the change; the linkage is not dropped, it moves to me - I add the issue reference, and file the issue where none exists yet, as part of handling the contribution. The character check still reports what it finds on your PR, as a note rather than a failure, because a message nobody can read is a problem whoever wrote it.
 
 ### Sign Your Work (DCO)
 


### PR DESCRIPTION
# What & why

`pr-hygiene` read commit subjects for their issue reference and nothing else, and the Trojan-Source job reads files in the tree. Neither reads the character repertoire of a commit message body, which is the one text channel in this repository that cannot be corrected after it lands: repairing a merged message means rewriting history.

Check 1c walks every commit in the PR range, subject and body, against an explicit allowlist of code points. Allowlist rather than a blocklist, because only that shape also refuses a script nobody has thought of yet; the reasoning is Unicode Technical Standard #55 and the Trojan Source work (CVE-2021-42574). Bidi controls, zero-width joiners and homoglyphs fall outside it without being named individually.

The set is derived from this repository's own history rather than remembered. Re-run at this branch head:

```
git log --format=%H%x1f%B%x1e origin/main   (counted per code point)
commits: 1765
U+2014 694   U+2192 13   U+2026 10   U+00A7 8   U+0009 4
U+00DC 2     U+2265 1    U+2024 1    U+2013 1
```

Nine code points outside printable ASCII occur. Eight are permitted. U+2024 ONE DOT LEADER is refused on purpose: it sits in the body of merged commit 6fc801f where a full stop belongs, nothing saw it, and a period homoglyph has no legitimate use in a commit message. That commit is the reason the check exists rather than an illustration of it.

The German letters beyond the measured U+00DC are the one addition not individually counted, and the table says so. This repository quotes its own toolchain output as evidence and that output is German on the machine that produces it, so refusing it would put this gate against the rule that a claim carries the command that produced it.

Outside the FAIL tier (bots, authors from outside this repository) the check drops to WARN rather than going silent, so a skipped run cannot be read as a clean one.

Closes #1006

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable to the plugin's own surfaces: the change adds a check to a CI workflow and a paragraph to CONTRIBUTING.md. It touches no login path, no crypto, no config persistence and no publish or release step.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change. The evidence run below stands in place of one and is reproducible from the branch it ran on.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The rule and the allowlist are written down in CONTRIBUTING.md next to the other pr-hygiene rules, so the contract is read rather than inferred from the script.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No C# file is touched, so the build and suite are unchanged by this diff and CI's `build` job is what covers them here. Prettier over the one changed Markdown file:

```
npx prettier --check "CONTRIBUTING.md"
Checking formatting...
All matched files use Prettier code style!
```

### The gate was observed refusing, not asserted to refuse

Evidence branch `probe/1006-charset-evidence`, opened as #1233 against this branch so the new check would run on it. Three commits, all with clean subjects carrying their issue reference, and only the OLDEST carrying a token outside the set, in the body:

```
git log --format='%h | %s' origin/issue/1006..origin/probe/1006-charset-evidence
dca4e08 | Extend the evidence marker again [#1006]
573fac5 | Extend the evidence marker [#1006]
b0b255a | Add the evidence marker [#1006]
```

The pr-hygiene job on that PR, run 31002310462, job 92293856844, ended:

```
##[error]Commit message character(s) outside the permitted set:
  b0b255a line 3: U+4E2D - "This body carries a token outside the permitted set on purpose: <U+4E2D><U+6587>"
The permitted set is printable ASCII plus the named code points listed at check 1c
in .github/workflows/pr-hygiene.yml. Repair the message before it reaches main,
where it can only be repaired by rewriting history.
```

That covers four of the acceptance criteria at once. A body-only offence under a clean subject is refused, which is the exact shape that escaped before. The message names the commit, the code point and the line. The offending line is echoed with every refused character replaced by its escape, so the log reporting a rendering attack does not reproduce it. And the refusal is on the oldest of three commits, which is only reachable if the whole range is walked rather than the tip.

### The permitted characters still pass

The same allowlist, applied to the last 100 commits on `main` at this head:

```
git log -100 --format=%H%x1f%B%x1e origin/main | node -e '<the check 1c predicate>'
commits examined: 100 findings: 0
```

Those 100 commits include U+2014, U+2026 and U+00A7 in their bodies, so the run is not vacuous.

## Notes

#1233 is an evidence branch and is not for merging. It is closed unmerged once this lands, and its own body says so.

The census figure in the workflow comment reads 1707 and was true when it was written; the re-run above gives 1765 commits with an identical distribution over the nine code points. The comment dates its own number rather than claiming a current one, and the count moves with every merge, so it is left as written.

Out of scope, as the issue says: cleaning up already-merged commit bodies, including 6fc801f, and any check over PR titles or issue text.
