### PR TITLE
Pin what every id_token read route does with a repeated member [#1192]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcIdTokenDuplicateClaimTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenDuplicateClaimTests.cs
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins what every id_token read route does with a payload that names one claim TWICE (#1192). The plugin
+/// reads four claims out of the raw, signature-verified id_token through their own readers -
+/// <see cref="OidcResponseIssuer.IdTokenIssuer"/> for <c>iss</c>, <see cref="OidcIdTokenSid"/>,
+/// <see cref="OidcIdTokenAcr"/> and <see cref="OidcIdTokenAuthTime"/> - while the validated principal is
+/// built from the same bytes by the JWT library. Each reader takes the LAST match out of a claim
+/// collection it did not build, so whether the routes can be made to disagree is a property of that
+/// library and not of any code here. It is read rather than assumed.
+///
+/// Nothing in this file guards anything. It records the posture, so that a dependency bump that changes
+/// how a repeated member is folded fails here, at a row that says what the old behaviour was, rather than
+/// showing up as a step-up gate and a logout key that disagree about which session was authenticated.
+/// </summary>
+public sealed class OidcIdTokenDuplicateClaimTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+
+    private const string FirstIssuer = Issuer;
+    private const string SecondIssuer = "https://idp.example.test/second";
+    private const string FirstSid = "sess-first";
+    private const string SecondSid = "sess-second";
+    private const string FirstAcr = "acr-first";
+    private const string SecondAcr = "acr-second";
+
+    private readonly OidcTokenFixture _fixture = new(Issuer, ClientId);
+    private readonly OidcIdTokenValidator _validator = new();
+
+    private readonly long _firstAuthTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 600;
+    private readonly long _secondAuthTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 60;
+
+    public void Dispose() => _fixture.Dispose();
+
+    [Fact]
+    public void RepeatedMembersAreReallyInThePayload()
+    {
+        // The liveness control for every row below. All of them asserting "one value" would pass just as
+        // well against a payload that named each claim once, so the bytes are checked to carry two
+        // occurrences of all four names before anything is concluded from what came back out.
+        var payload = Encoding.UTF8.GetString(Base64UrlEncoder.DecodeBytes(DuplicatingToken().Split('.')[1]));
+
+        foreach (var member in new[] { "iss", "sid", "acr", "auth_time" })
+        {
+            Assert.Equal(2, Regex.Matches(payload, "\"" + member + "\":").Count);
+        }
+    }
+
+    [Fact]
+    public async Task ADuplicatingTokenStillValidates()
+    {
+        // The second control: a token the validator refused would make every agreement below vacuous,
+        // because the routes would be agreeing about a document the login path never accepts. The library
+        // does accept it, so the four readers below run on a token that would have reached them in a real
+        // callback.
+        var result = await _validator.ValidateAsync(DuplicatingToken(), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Fact]
+    public void EveryRepeatedMemberFoldsToExactlyOneClaim()
+    {
+        // The mechanism the four agreements below rest on: the payload is folded into a claim collection
+        // BEFORE any reader sees it, and the fold keeps one entry per name. That is why LastOrDefault and
+        // JsonWebToken.Issuer cannot pick different occurrences - there is only one left to pick. If a
+        // dependency bump ever surfaced both, this row fails first and names the change.
+        var claims = new JsonWebToken(DuplicatingToken()).Claims.ToList();
+
+        Assert.Equal(1, claims.Count(c => c.Type == "iss"));
+        Assert.Equal(1, claims.Count(c => c.Type == "sid"));
+        Assert.Equal(1, claims.Count(c => c.Type == "acr"));
+        Assert.Equal(1, claims.Count(c => c.Type == "auth_time"));
+    }
+
+    [Fact]
+    public void IssuerRoutesAgreeOnTheLastOccurrence()
+    {
+        // Which occurrence survives is named rather than merely asserted equal, because "the routes agree"
+        // stays true if a bump flips both of them to the first value, and the canonical account link is
+        // stamped with this issuer (#186).
+        var token = DuplicatingToken();
+
+        Assert.Equal(SecondIssuer, new JsonWebToken(token).Issuer);
+        Assert.Equal(SecondIssuer, OidcResponseIssuer.IdTokenIssuer(token));
+        Assert.NotEqual(FirstIssuer, OidcResponseIssuer.IdTokenIssuer(token));
+    }
+
+    [Fact]
+    public async Task TheValidatorItselfReadsTheLastIssuerOccurrence()
+    {
+        // The issuer check is the one place a route's disagreement would be silent rather than visible in
+        // a claim: the validator compares the token's iss against the configured anchor and says only
+        // accepted or refused. Driving it against BOTH occurrences turns that into two observations, and
+        // they are opposite, which is what proves the validator folds the same way the readers do rather
+        // than being indifferent to the anchor.
+        var token = DuplicatingToken();
+
+        var onTheLast = await _validator.ValidateAsync(token, Options(SecondIssuer), TestContext.Current.CancellationToken);
+        var onTheFirst = await _validator.ValidateAsync(token, Options(FirstIssuer), TestContext.Current.CancellationToken);
+
+        Assert.False(onTheLast.IsError, onTheLast.Error);
+        Assert.True(onTheFirst.IsError);
+    }
+
+    [Fact]
+    public void SidRoutesAgreeOnTheLastOccurrence()
+    {
+        // The persisted back-channel logout key (#727). A split here would revoke a session the provider
+        // never named.
+        var token = DuplicatingToken();
+
+        Assert.Equal(SecondSid, new JsonWebToken(token).Claims.Single(c => c.Type == "sid").Value);
+        Assert.Equal(SecondSid, OidcIdTokenSid.Read(token));
+    }
+
+    [Fact]
+    public void AcrRoutesAgreeOnTheLastOccurrence()
+    {
+        // The step-up gate (#757), where the two occurrences are a satisfied and an unsatisfied assurance
+        // level and the gate's answer is whichever one it reads.
+        var token = DuplicatingToken();
+
+        Assert.Equal(SecondAcr, new JsonWebToken(token).Claims.Single(c => c.Type == "acr").Value);
+        Assert.Equal(SecondAcr, OidcIdTokenAcr.Read(token));
+    }
+
+    [Fact]
+    public void AuthTimeRoutesAgreeOnTheLastOccurrence()
+    {
+        // The max_age freshness gate (#961). This is the route that can disagree by REJECTING where the
+        // others accept, because it parses the surviving value as Unix seconds after picking it, so its
+        // agreement is asserted on the parsed long rather than on the string the others compare.
+        var token = DuplicatingToken();
+
+        Assert.Equal(
+            _secondAuthTime.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            new JsonWebToken(token).Claims.Single(c => c.Type == "auth_time").Value);
+        Assert.Equal(_secondAuthTime, OidcIdTokenAuthTime.Read(token));
+        Assert.NotEqual(_firstAuthTime, OidcIdTokenAuthTime.Read(token));
+    }
+
+    [Fact]
+    public async Task TheValidatedPrincipalAgreesWithTheRawReaders()
+    {
+        // The last route, and the one the other four are compared against in the issue: the principal the
+        // login path actually carries. iss is absent here by design - OidcClient filters the protocol
+        // claims out of the principal, which is the whole reason the readers above re-read the raw token.
+        var token = DuplicatingToken();
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal(SecondSid, result.User.Claims.Single(c => c.Type == "sid").Value);
+        Assert.Equal(SecondAcr, result.User.Claims.Single(c => c.Type == "acr").Value);
+        Assert.Equal(
+            _secondAuthTime.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            result.User.Claims.Single(c => c.Type == "auth_time").Value);
+    }
+
+    [Fact]
+    public void TheSurvivingValueFollowsDocumentOrder()
+    {
+        // What separates "the last occurrence wins" from "this particular string wins": the same two
+        // values, written the other way round, come back the other way round. Without this row every
+        // agreement above would also hold for a library that folded to the alphabetically later value, to
+        // the longer one, or to a cached constant, and the rows would read as a pin on behaviour while
+        // pinning a coincidence of the fixture.
+        var reversed = _fixture.RawPayloadIdToken(
+            "{\"iss\":\"" + SecondIssuer + "\",\"iss\":\"" + FirstIssuer + "\","
+            + "\"sub\":\"user-1\",\"aud\":\"" + ClientId + "\","
+            + "\"sid\":\"" + SecondSid + "\",\"sid\":\"" + FirstSid + "\","
+            + "\"acr\":\"" + SecondAcr + "\",\"acr\":\"" + FirstAcr + "\","
+            + "\"auth_time\":" + _secondAuthTime + ",\"auth_time\":" + _firstAuthTime + "}");
+
+        Assert.Equal(FirstIssuer, OidcResponseIssuer.IdTokenIssuer(reversed));
+        Assert.Equal(FirstSid, OidcIdTokenSid.Read(reversed));
+        Assert.Equal(FirstAcr, OidcIdTokenAcr.Read(reversed));
+        Assert.Equal(_firstAuthTime, OidcIdTokenAuthTime.Read(reversed));
+    }
+
+    // One token, used by every row, repeating each of the four claims with two DISTINCT values so a route
+    // reading the first occurrence and a route reading the second are visibly different answers rather
+    // than the same string twice. exp/nbf/iat are single so the token validates on its lifetime.
+    private string DuplicatingToken()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var payload =
+            "{\"iss\":\"" + FirstIssuer + "\",\"iss\":\"" + SecondIssuer + "\","
+            + "\"sub\":\"user-1\",\"aud\":\"" + ClientId + "\","
+            + "\"sid\":\"" + FirstSid + "\",\"sid\":\"" + SecondSid + "\","
+            + "\"acr\":\"" + FirstAcr + "\",\"acr\":\"" + SecondAcr + "\","
+            + "\"auth_time\":" + _firstAuthTime + ",\"auth_time\":" + _secondAuthTime + ","
+            + "\"exp\":" + (now + 300) + ",\"nbf\":" + (now - 60) + ",\"iat\":" + (now - 60) + "}";
+
+        return _fixture.RawPayloadIdToken(payload);
+    }
+
+    // Anchored on the SECOND issuer, because that is the occurrence the readers report surviving. The row
+    // above proves the validator agrees by refusing the other anchor.
+    private OidcClientOptions Options(string? issuerName = null) => new()
+    {
+        ClientId = ClientId,
+        ProviderInformation = new ProviderInformation
+        {
+            IssuerName = issuerName ?? SecondIssuer,
+            KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(_fixture.Jwks()),
+        },
+    };
+}

--- a/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenFixture.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
+using System.Text;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 
@@ -80,6 +81,28 @@ internal sealed class OidcTokenFixture : IDisposable
             SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
         };
         return new JsonWebTokenHandler().CreateToken(descriptor);
+    }
+
+    /// <summary>
+    /// Signs a payload supplied VERBATIM, with this fixture's key and <c>kid</c>, so the token validates
+    /// through the real path while carrying bytes no claim dictionary could express. <see cref="IdToken"/>
+    /// builds its payload from a <c>Dictionary&lt;string, object&gt;</c> and therefore cannot emit a
+    /// repeated member at all, which is the posture #1192 has to read: what every id_token route does with
+    /// a payload that names one claim twice is a property of the JWT library, and a fixture that cannot
+    /// produce the bytes cannot ask the question.
+    /// </summary>
+    /// <param name="payloadJson">The id_token payload, used exactly as written.</param>
+    /// <returns>The signed token: this fixture's RS256 header, the given payload, and a matching signature.</returns>
+    internal string RawPayloadIdToken(string payloadJson)
+    {
+        var header = "{\"alg\":\"RS256\",\"kid\":\"" + KeyId + "\",\"typ\":\"JWT\"}";
+        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(header))
+            + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payloadJson));
+
+        var signature = _rsa.SignData(
+            Encoding.UTF8.GetBytes(signingInput), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        return signingInput + "." + Base64UrlEncoder.Encode(signature);
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

Four claims are read out of the raw, signature-verified id_token by their own readers: `iss` through `OidcResponseIssuer.IdTokenIssuer`, and `sid`, `acr` and `auth_time` through `OidcIdTokenSid`, `OidcIdTokenAcr` and `OidcIdTokenAuthTime`. Each takes the last match from a claim collection it did not build, while the validated principal is built from the same bytes by the JWT library. What any of them does with a payload naming one claim twice was therefore a property of the dependency, and nothing had read it.

The fixture could not even ask the question: `IdToken` builds its payload from a `Dictionary<string, object>` and cannot emit a repeated member. It gains `RawPayloadIdToken`, which signs a payload verbatim with the same key and `kid`, so the bytes are arbitrary and the token still validates through the real path.

What the new file measures, on one signed token that repeats all four claims with distinct values:

- the payload folds to exactly one claim per name before any reader sees it
- the surviving occurrence is the last one in document order
- the principal, `JsonWebToken`, and all four readers report that same value
- the validator folds the same way: it accepts the token against the second issuer and refuses it against the first

No guard, rejection or normalisation is added. The issue puts that decision after this, to be made from what this records.

Closes #1192

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

The diff is test-only: one new test file and a signing helper on the test fixture. No production file is touched, so no login-path, crypto, config-persistence or release-pipeline behaviour changes. It is listed under `area: oidc` because what it pins is an OIDC posture.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change. The measurements and the falsification below stand in place of one, and every one of them is reproducible from this branch.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror`, full suite:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2611, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 17,474s

dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2612, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 23,324s
```

Ten of those rows are new. `git status --porcelain` over the two lockfiles is empty after both builds. No `.js` / `.html` / `.md` / `.css` file is touched, so Prettier has nothing to say about this diff.

### What was measured, before anything was asserted

A throwaway row printed what each route returned for the repeated payload, and the assertions were written from its output rather than from an expectation:

```
jwt.Issuer          = [https://idp.example/second]
OidcResponseIssuer  = [https://idp.example/second]
claims iss          = [https://idp.example/second]
claims sid          = [sess-second]
OidcIdTokenSid      = [sess-second]
claims acr          = [acr-second]
OidcIdTokenAcr      = [acr-second]
claims auth_time    = [1786025983]     (first = 1786025443, second = 1786025983)
OidcIdTokenAuthTime = [1786025983]
all claim types     = [iss,sub,aud,sid,acr,auth_time,exp,nbf,iat]
```

The last line is the mechanism: one entry per name survives the fold, which is why no reader can pick a different occurrence than another. That row is now `EveryRepeatedMemberFoldsToExactlyOneClaim`, so the fold is pinned rather than left as the reason a comment gives.

### Three controls against a vacuous agreement

`RepeatedMembersAreReallyInThePayload` decodes the payload segment and requires two occurrences of each of the four names. Delete one occurrence from the fixture and it goes red while every agreement row stays green, which is the shape it exists to stop.

`ADuplicatingTokenStillValidates` puts the token through the real `OidcIdTokenValidator`. A token the validator refused would make the agreements true about a document the login path never accepts.

`TheSurvivingValueFollowsDocumentOrder` writes the same two values the other way round and requires the other one back. Without it the rows would hold equally for a library folding to the alphabetically later value, the longer one, or a constant.

## Notes

One finding came out of the falsification, and it is not in this diff. All three readers were switched from `LastOrDefault` to `FirstOrDefault` and the whole suite stayed green:

```
    SSO-Auth.Tests  Total: 2611, Errors: 0, Failed: 0, Skipped: 4
```

The repeated-member shape cannot see that difference, because the fold has already collapsed the claim to one entry. An array-valued claim can: a payload carrying `"sid":["sess-a","sess-b"]` surfaces two `sid` claims, and the reader returns `sess-b` today. So the last-match choice in three production readers is real, reachable, and currently unfalsifiable by the suite.

It is reported on #1192 with both measurements and carried to its own issue rather than fixed here. Which element of a multi-valued `sid` or `acr` a reader should take is the guard-shaped decision the issue puts after this one, and an array value is a different shape from the repeated member this issue names.
