### PR TITLE
Derive the SPDX rule's root set from the project files [#1270]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2945,23 +2945,33 @@ public class ArchitectureConformanceTests
         // namespace, which SPDX/REUSE tooling expects).
         const string CopyrightLine = "// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors";
         const string LicenceLine = "// SPDX-License-Identifier: GPL-3.0-only";
-        var offenders = new List<string>();
-        foreach (var root in new[] { "SSO-Auth", "SSO-Auth.Tests", "SSO-Auth.Fuzz" })
-        {
-            foreach (var src in Directory.EnumerateFiles(Path.Combine(RepoRoot(), root), "*.cs", SearchOption.AllDirectories))
-            {
-                if (IsBuildOutput(src))
-                {
-                    continue;
-                }
+        var roots = ProjectRoots();
+        var sources = roots
+            .SelectMany(root => Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            .Where(src => !IsBuildOutput(src))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-                var firstLines = File.ReadLines(src).Take(2).ToList();
-                if (firstLines.Count < 2
-                    || firstLines[0].Trim() != CopyrightLine
-                    || firstLines[1].Trim() != LicenceLine)
-                {
-                    offenders.Add(Path.GetFileName(src));
-                }
+        // The liveness floor. A derived root set can silently become empty - a rename, a project moved, a
+        // repository root resolved one directory too high - and an empty scan reports no offenders, which
+        // reads exactly like a tree where every file carries its header. Both halves are floored, and both
+        // sit well under the real counts so an ordinary project or file being added or removed never moves
+        // them; this must fail when the DERIVATION breaks, not when the tree changes shape.
+        Assert.True(
+            roots.Count >= 3,
+            $"The SPDX root derivation found only {roots.Count} project directories; it has stopped seeing the tree, and this rule would now pass over the projects it no longer walks (#1270).");
+        Assert.True(
+            sources.Count >= 100,
+            $"The SPDX scan found only {sources.Count} C# files under the derived roots; the walk has broken and a missing header would no longer be seen (#1270).");
+
+        var offenders = new List<string>();
+        foreach (var src in sources)
+        {
+            var firstLines = File.ReadLines(src).Take(2).ToList();
+            if (firstLines.Count < 2
+                || firstLines[0].Trim() != CopyrightLine
+                || firstLines[1].Trim() != LicenceLine)
+            {
+                offenders.Add(Path.GetFileName(src));
             }
         }
 
@@ -2969,6 +2979,19 @@ public class ArchitectureConformanceTests
             offenders.Count == 0,
             "Every C# source file must open with the SPDX copyright + GPL-3.0-only header (#747). Missing or incorrect in: " + string.Join(", ", offenders));
     }
+
+    // Every directory in the tree that owns a C# project, derived from the project files themselves rather
+    // than listed (#1270). A literal list is the defect and not the fix: adding a root is a step somebody
+    // has to remember, and the project that lands while nobody remembers is the one carrying the unheaded
+    // file. Deriving it means a new project of the same shape - non-shipping, outside the solution, ordinary
+    // C# source - is covered on the day it lands, without this rule being edited.
+    private static IReadOnlyList<string> ProjectRoots() =>
+        Directory.EnumerateFiles(RepoRoot(), "*.csproj", SearchOption.AllDirectories)
+            .Where(project => !IsBuildOutput(project))
+            .Select(project => Path.GetDirectoryName(project)!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(root => root, StringComparer.Ordinal)
+            .ToList();
 
     [Fact]
     public void SamlSignaturePath_UsesOneXmlStackEndToEnd()

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2955,9 +2955,11 @@ public class ArchitectureConformanceTests
         // repository root resolved one directory too high - and an empty scan reports no offenders, which
         // reads exactly like a tree where every file carries its header. Both halves are floored, and both
         // sit well under the real counts so an ordinary project or file being added or removed never moves
-        // them; this must fail when the DERIVATION breaks, not when the tree changes shape.
+        // them; this must fail when the DERIVATION breaks, not when the tree changes shape. Two is the floor
+        // rather than today's count because the non-shipping projects are the ones that come and go, while
+        // the plugin and this test project cannot both leave without taking this rule with them.
         Assert.True(
-            roots.Count >= 3,
+            roots.Count >= 2,
             $"The SPDX root derivation found only {roots.Count} project directories; it has stopped seeing the tree, and this rule would now pass over the projects it no longer walks (#1270).");
         Assert.True(
             sources.Count >= 100,


### PR DESCRIPTION
# What & why

`EverySourceFile_CarriesTheSpdxHeader` walked a literal list of three roots, so a
fourth project of the same shape - non-shipping, outside the solution, ordinary C#
source - inherits the hole until somebody remembers to add it. Remembering is the
step that fails, and the project that lands while nobody remembers is the one
carrying the unheaded file.

The roots now come from the project files in the tree, so a new project directory is
covered on the day it lands without this rule being edited. Two liveness floors sit
under the derivation, because an empty scan reports no offenders and that reads
exactly like a tree where every file carries its header: one on the derived root
count, one on the scanned file count. Both are well under the real numbers, so an
ordinary project or file being added or removed never moves them.

Closes #1270

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: the diff is confined to a test-project conformance rule and changes
no production code, no login path, no crypto, no config persistence and no release
pipeline step.

- [ ] Review record: **no second reader ran on this change.** The evidence below
      stands in place of one. Raised as CONFIRMED 0 / PLAUSIBLE 0 because no lens
      was run, not because a lens ran and found nothing.

## Quality checklist

- [x] No duplicated logic; the derivation is one small helper next to the rule.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and the structural property is locked in.
- [x] Docs impact considered: no README/wiki update needed, no behaviour changes.

## Verification

Each half was falsified against a modified tree and then reverted:

    perl -ni -e 'print unless $. == 1' SSO-Auth/Api/Provider/ProviderNameValidator.cs \
                                       SSO-Auth.Tests/Http/EntryPointInventoryTests.cs \
                                       SSO-Auth.Fuzz/Program.cs
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*Spdx*"
    -> FAIL  "Missing or incorrect in: ProviderNameValidator.cs, Program.cs, EntryPointInventoryTests.cs"

all three roots named in one run, so each derived root is really walked. Then a
throwaway project directory holding one unheaded file, which is the property the
issue asks for:

    mkdir SSO-Auth.NewProject && <a bare .csproj and one unheaded .cs>
    -> FAIL  "Missing or incorrect in: Unheaded.cs"

caught with no edit to the rule. Then each floor, by pointing a glob at a pattern
that matches nothing:

    "*.csproj" -> "*.csprojBROKEN"   -> FAIL "The SPDX root derivation found only 0 project directories"
    "*.cs"     -> "*.csBROKEN"       -> FAIL "The SPDX scan found only 0 C# files under the derived roots"

Full gate at this branch:

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror -> 0 warnings, 0 errors
    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror -> 0 warnings, 0 errors
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe   -> Total: 2610, Failed: 0, Skipped: 4
    ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe  -> Total: 2611, Failed: 0, Skipped: 4

- [x] `dotnet build --warnaserror` is green on both target frameworks.
- [x] The full suite is green on both target frameworks.
- [x] Prettier: not applicable, no `.js` / `.html` / `.md` / `.css` file changed.

## Notes

A second commit lowers the root floor from three to two. Three sat level with the
four project directories the tree holds, which is the shape the neighbouring
inventory rule warns against in its own comment: a floor level with the real count
fails when the tree changes rather than when the walk breaks, and the non-shipping
projects are exactly the ones that come and go. Two is what cannot legitimately
leave. The break case is re-falsified above and still gives "found only 0 project
directories".

`SSO-Auth.Bench` is **not in the mainline tree**, so the issue's first Done clause -
that the rule covers it - follows from the derivation rather than from an
observation, and the throwaway project directory above is what stands in for it. It
is covered on the day that project lands, without a further edit here. That is the
one clause not demonstrated against the real subject, and it is stated rather than
ticked.

## Check status at the time of opening

The required checks had not run when this was opened, and they are not expected to
for some hours. The repository's Actions queue is backlogged rather than broken:

    gh api "repos/iderex/jellyfin-plugin-sso/actions/runs?status=queued&per_page=100" --jq '.total_count'
    34

    gh api "repos/iderex/jellyfin-plugin-sso/actions/runs?status=completed&per_page=3" \
      --jq '.workflow_runs[] | "\(.created_at) -> \(.updated_at) \(.name): \(.conclusion)"'
    2026-08-06T16:36:08Z -> 2026-08-06T22:26:02Z PR Hygiene: success
    2026-08-06T16:17:33Z -> 2026-08-06T22:23:26Z .NET: success

Runs created around 16:20 completed around 22:25, so the queue is draining at roughly
a six-hour lag and every open pull request on this repository shows the same picture.
This is stated because the local gate above passed and the remote one has not been
asked yet; the two are not the same evidence. **This must not be merged until the
required checks are green** - that verdict does not exist yet, and nothing here should
be read as it having passed.
