### PR TITLE
Pin the SAML ACS URL to one composition site [#1163]

### DIFF
--- a/SSO-Auth.Tests/Saml/SamlAcsUrlConformanceTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAcsUrlConformanceTests.cs
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins that the AssertionConsumerServiceURL this service provider PUBLISHES in its metadata, the one it
+/// SENDS in the AuthnRequest, and the set it ACCEPTS a signed Recipient against are all composed in one
+/// place (#1163).
+///
+/// <para>
+/// Why a structural rule and not a unit test. <see cref="SamlRecipientValidator.IsBound"/> compares the
+/// signed Recipient and Destination against the expected set with <c>StringComparer.Ordinal</c>, and it
+/// only ever sees the set it was handed. A site that published one URL and accepted another would be an
+/// endpoint-binding bypass that every test of the validator passes, because the disagreement is between two
+/// CALLERS and the validator is not one of them. The property has to be asserted over the composition
+/// sites, which is what this does.
+/// </para>
+/// </summary>
+public class SamlAcsUrlConformanceTests
+{
+    // The path this SP's ACS URL is composed from. It is the ordinal bytes the identity provider echoes
+    // back in the signed Recipient, so a second site spelling the same path a different way is the defect,
+    // not a style question.
+    private const string AcsPath = "/sso/SAML/";
+
+    private const string Builder = "SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs";
+    private const string FlowService = "SSO-Auth/Api/Flows/SamlLoginService.cs";
+    private const string AssertionValidator = "SSO-Auth/Api/Saml/SamlAssertionValidator.cs";
+
+    // The surface the must-not-catch clause names: the endpoints that arrive through SAML/ImportMetadata
+    // are the IDENTITY PROVIDER's SSO and SLO addresses, read out of its metadata document at runtime. They
+    // are not this SP's ACS URLs and a rule that swept them in would be demanding they come from a builder
+    // that composes this server's own routes.
+    private const string MetadataImporter = "SSO-Auth/Api/Http/SamlMetadataImporter.cs";
+
+    [Fact]
+    public void TheAcsPathIsComposedInExactlyOnePlace()
+    {
+        // The whole property in one assertion. As long as the path appears on a code line in one file, no
+        // second site can be publishing or accepting a differently-composed string, because there is
+        // nowhere else the string is made.
+        Assert.Equal(new List<string> { Builder }, FilesWhoseCodeHolds(AcsPath));
+    }
+
+    [Fact]
+    public void ThePublishSendAndAcceptSitesAllTakeTheUrlFromTheBuilder()
+    {
+        // Two files call the builder, and between them they are the three sites. The flow service holds
+        // both the metadata leg and the AuthnRequest leg; the assertion validator holds the accepted set.
+        var callers = FilesWhoseCodeHolds("SamlAcsUrlBuilder.");
+        Assert.Equal(new List<string> { FlowService, AssertionValidator }.OrderBy(p => p, StringComparer.Ordinal).ToList(), callers);
+
+        // And the publishing site is one of them rather than a third file that composes its own. Metadata
+        // is the document an administrator hands the identity provider, so a published URL the SP does not
+        // accept is the mismatch this rule exists to prevent, arriving by configuration rather than attack.
+        var publishers = FilesWhoseCodeHolds("SamlSpMetadataBuilder.Build(");
+        Assert.Equal(new List<string> { FlowService }, publishers);
+        Assert.Subset(callers.ToHashSet(StringComparer.Ordinal), publishers.ToHashSet(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void TheIdentityProvidersOwnEndpointsAreNotSweptIn()
+    {
+        // The must-not-catch surface, asserted where a reader will look for it rather than left implied by
+        // the two set equalities above. The importer reads the IdP's SSO and SLO Locations out of its
+        // metadata; it composes no URL of this server's and calls no builder, and the rule says nothing
+        // about it.
+        Assert.True(
+            File.Exists(Path.Combine(RepoRoot(), MetadataImporter.Replace('/', Path.DirectorySeparatorChar))),
+            $"The must-not-catch surface no longer exists at {MetadataImporter}; re-point this rule before trusting it.");
+        Assert.DoesNotContain(MetadataImporter, FilesWhoseCodeHolds(AcsPath));
+        Assert.DoesNotContain(MetadataImporter, FilesWhoseCodeHolds("SamlAcsUrlBuilder."));
+    }
+
+    [Fact]
+    public void ASecondIndependentlyComposedAcsUrl_IsRejectedByTheScan()
+    {
+        // The must-catch fixture, over the predicate rather than over the tree: the natural way somebody
+        // adds a second composition, reached for because the builder was not to hand.
+        const string Source = @"
+internal static class Elsewhere
+{
+    internal static string Acs(string baseUrl, string provider) =>
+        baseUrl + ""/sso/SAML/post/"" + provider;
+}";
+
+        Assert.True(HoldsOnACodeLine(Source, AcsPath));
+    }
+
+    [Fact]
+    public void ReadingAnIdentityProvidersEndpoint_IsNotFlaggedByTheScan()
+    {
+        // The adjacent must-not-catch twin, one edit from the fixture above: it handles a SAML endpoint URL
+        // and composes none. Every URL here is a value read at runtime out of somebody else's document.
+        //
+        // The bound this states plainly: the predicate matches a LITERAL in source, so it cannot mistake a
+        // runtime value for a composition, but it would flag source that quoted an ACS-shaped URL inside a
+        // string. No production file does, and the set equality above is what would catch one that started.
+        const string Source = @"
+internal static class Importer
+{
+    private const string PostBinding = ""urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"";
+
+    internal static string? SsoEndpoint(XmlElement descriptor) =>
+        descriptor.GetElementsByTagName(""SingleSignOnService"")
+            .OfType<XmlElement>()
+            .FirstOrDefault(e => e.GetAttribute(""Binding"") == PostBinding)
+            ?.GetAttribute(""Location"");
+}";
+
+        Assert.False(HoldsOnACodeLine(Source, AcsPath));
+    }
+
+    [Theory]
+    [InlineData(@"baseUrl + ""/sso/SAML/post/"" + provider;", true)]
+    [InlineData(@"// baseUrl + ""/sso/SAML/post/"" + provider;", false)]
+    [InlineData(@"/// The ACS is <c>/sso/SAML/post/{provider}</c>.", false)]
+    [InlineData(@"* links to /sso/SAML/start/{name}", false)]
+    public void TheCodeReaderKeepsCompositionsAndDropsProse(string line, bool expected)
+    {
+        // Prose may name the path at no cost, and it does: a login-button summary documents the SAML start
+        // route in an XML-doc line. A whole-file text search would call that a second composition site and
+        // the rule would have to be widened or waived to survive it.
+        Assert.Equal(expected, HoldsOnACodeLine(line, AcsPath));
+    }
+
+    [Fact]
+    public void TheBuilderAndTheBindingCheckArePinnedByReflection()
+    {
+        // The sentinel. Every assertion above is a string search over source, so a rename that emptied the
+        // scans would leave them green on a tree where nothing composes an ACS URL at all. These four
+        // members are what the rule is about; if one is gone the rule is stale rather than satisfied.
+        Assert.NotNull(typeof(SamlAcsUrlBuilder).GetMethod("AcsUrl", BindingFlags.NonPublic | BindingFlags.Static));
+        Assert.NotNull(typeof(SamlAcsUrlBuilder).GetMethod("ExpectedAcsUrls", BindingFlags.NonPublic | BindingFlags.Static));
+        Assert.NotNull(typeof(SamlRecipientValidator).GetMethod("IsBound", BindingFlags.NonPublic | BindingFlags.Static));
+        Assert.NotEmpty(FilesWhoseCodeHolds(AcsPath));
+    }
+
+    // Every repo-relative path under SSO-Auth/ whose CODE holds the token, forward slashes so the constants
+    // above read the same on either platform.
+    private static IReadOnlyList<string> FilesWhoseCodeHolds(string token)
+    {
+        var root = RepoRoot();
+
+        return Directory.EnumerateFiles(Path.Combine(root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Where(path => HoldsOnACodeLine(File.ReadAllText(path), token))
+            .Select(path => Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // Whether a source text holds the token on a line that is not a comment. Comment lines are dropped
+    // because prose can name the ACS path without any site composing one, and one XML-doc line already
+    // does.
+    private static bool HoldsOnACodeLine(string source, string token) =>
+        source.Split('\n')
+            .Select(line => line.Trim())
+            .Where(text => !text.StartsWith("//", StringComparison.Ordinal)
+                && !text.StartsWith("/*", StringComparison.Ordinal)
+                && !text.StartsWith("*", StringComparison.Ordinal))
+            .Any(text => text.Contains(token, StringComparison.Ordinal));
+
+    // obj/bin hold generated and compiled output; this scan reads hand-written source only.
+    private static bool IsBuildOutput(string path) =>
+        path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+        || path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal);
+
+    // The repository root, derived from this test file's compile-time path
+    // (<root>/SSO-Auth.Tests/Saml/<file>).
+    private static string RepoRoot([CallerFilePath] string thisFilePath = "") =>
+        Directory.GetParent(Directory.GetParent(Path.GetDirectoryName(thisFilePath)!)!.FullName)!.FullName;
+}


### PR DESCRIPTION
# What & why

The AssertionConsumerServiceURL this service provider publishes in its metadata, the one it sends in the AuthnRequest, and the set it accepts a signed Recipient against are now pinned to one composition site.

`SamlRecipientValidator.IsBound` compares the signed `Recipient` and `Destination` against the expected set with `StringComparer.Ordinal`, and it only ever sees the set its caller handed it. A site that published one URL and accepted a differently-composed one would be an endpoint-binding bypass that every test of the validator passes, because the disagreement is between two callers and the validator is not one of them. That is why this is a rule over the composition sites rather than another unit test.

What the rule asserts, measured against `2ba500a`:

```
git show 2ba500a:SSO-Auth/Api/Saml/SamlAcsUrlBuilder.cs | grep -n 'baseUrl + '
38:        baseUrl + "/sso/SAML/" + segment + "/" + provider;
```

That path appears on a code line in exactly one file. Two files call the builder: `SSO-Auth/Api/Flows/SamlLoginService.cs`, which holds both the metadata leg (`SamlAcsUrlBuilder.AcsUrl` at 527 and 528, handed to `SamlSpMetadataBuilder.Build` at 543) and the AuthnRequest leg (395), and `SSO-Auth/Api/Saml/SamlAssertionValidator.cs`, which holds the accepted set (303). The only file calling `SamlSpMetadataBuilder.Build` is the first of those, so the published URL cannot come from a third place.

The must-not-catch is the metadata importer. The SSO and SLO endpoints arriving through `SAML/ImportMetadata` are the identity provider's own addresses, read out of its document at runtime, and a rule that swept them in would be demanding they come from a builder that composes this server's routes.

Closes #1163

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Test-only. It adds no production code and changes no SAML behaviour.

- [x] Fail-closed preserved: nothing changed. The rule records where the ACS URL is composed.
- [x] No secrets logged; secrets are redacted on config export. Nothing here logs.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **No second reader ran on this change.** The mutation table below stands in place of one.
- [x] Review record: no lens was run, so there are no lens verdicts to report. CONFIRMED 0 / PLAUSIBLE 0, from zero lenses rather than from a clean pass.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; this touches no log call.

### The mutations, each run and each red

| Mutation | Rule that went red |
| --- | --- |
| an ACS string composed in a second file | `TheAcsPathIsComposedInExactlyOnePlace` names the new file |
| the assertion validator composing its expected set inline instead of calling the builder | `ThePublishSendAndAcceptSitesAllTakeTheUrlFromTheBuilder`, caller set drops to one |
| a second file calling `SamlSpMetadataBuilder.Build` | same rule, publisher set grows to two |
| `ExpectedAcsUrls` renamed across production and its existing direct callers, build kept green | `TheBuilderAndTheBindingCheckArePinnedByReflection` |
| the comment exclusion removed from the code-line reader | 5 of the 10 assertions, including the tree scans |

The rename probe is worth a note. Renaming the builder method without updating its callers does not reach the sentinel at all, because the existing direct-call tests stop compiling first. The sentinel is for the other case, a refactor that renames the method and its callers together, where every compile-time reference moves and a string-keyed reflection pin is what is left to notice.

The comment-exclusion probe is what shows the code-line reader is load-bearing rather than decorative here. `SSO-Auth/Api/LoginButtons/LoginButton.cs` names the SAML start path in an XML-doc line and `SSO-Auth/Api/Saml/SamlSpMetadataBuilder.cs` names the builder in three prose lines. A whole-file text search would call both of them composition sites, and the rule would have to be widened or waived to survive its own tree.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. The rule is in its own file because `SSO-Auth.Tests/ArchitectureConformanceTests.cs` is carried by three other open pull requests; the scan and its sentinel are written so a later fold moves them unchanged.
- [x] Docs impact considered: no README or wiki surface changes; this is an internal test rule.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Test project built on both TFMs with `--warnaserror`: 0 warnings, 0 errors.
- [x] `dotnet test` is green. Full suite through the built MTP executables: `net9.0` 2631 total, 0 failed, 4 skipped; `net10.0` 2632 total, 0 failed, 4 skipped.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. This branch changes one `.cs` file, outside Prettier's scope.

## Notes

The bound the rule states in its own comment: the predicate matches a literal in source, so it cannot mistake a runtime value read out of an identity provider's metadata for a composition, but it would flag source that quoted an ACS-shaped URL inside a string. No production file does one, and a file that started would be caught by the same set equality.

One shape it does not cover: an ACS URL assembled from fragments that never spell the path in one literal. The set equality on the builder's callers is the second half that would notice such a site appearing in a file that publishes or accepts.
