### PR TITLE
Say that this plugin belongs to Flowfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,94 +2,99 @@
 
 > [!NOTE]
 >
-> **Status: Release Candidate** — the fourth rung of the maturity ladder (In-Development → Alpha → Beta → Release Candidate → Full Release). Install it by adding this plugin's own repository to Jellyfin — see [Installing](#installing).
+> **Part of [Flowfin](https://github.com/Flowfin).** It works with any Jellyfin
+> server, and with the Flowfin clients.
+>
+> **Status: Release Candidate**, the fourth rung of the maturity ladder (In-Development, Alpha, Beta, Release Candidate, Full Release). Install it by adding this plugin's own repository to Jellyfin, see [Installing](#installing).
 
 <h1 align="center">Community SSO for Jellyfin</h1>
 
 <p align="center">
-<img alt="Community SSO for Jellyfin" src="https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
+<img alt="Community SSO for Jellyfin" src="https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
 <br/>
 <br/>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt">
-<img alt="GPL 3.0 License" src="https://img.shields.io/github/license/iderex/jellyfin-plugin-sso.svg"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/LICENSE.txt">
+<img alt="GPL 3.0 License" src="https://img.shields.io/github/license/Flowfin/jellyfin-plugin-sso.svg"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/releases">
-<img alt="Latest release" src="https://img.shields.io/github/v/release/iderex/jellyfin-plugin-sso?display_name=tag&label=release"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/releases">
+<img alt="Latest release" src="https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&label=release"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
-<img alt="Build Status" src="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
+<img alt="Build Status" src="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/wiki">
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki">
 <img alt="Documentation" src="https://img.shields.io/badge/docs-wiki-blue"/>
 </a>
 <a href="https://www.bestpractices.dev/projects/13660">
 <img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13660/badge"/>
 </a>
-<a href="https://securityscorecards.dev/viewer/?uri=github.com/iderex/jellyfin-plugin-sso">
-<img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/iderex/jellyfin-plugin-sso/badge"/>
+<a href="https://securityscorecards.dev/viewer/?uri=github.com/Flowfin/jellyfin-plugin-sso">
+<img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/Flowfin/jellyfin-plugin-sso/badge"/>
 </a>
 </p>
 
 <p align="center">
-Sign in to Jellyfin with your existing identity provider — Keycloak, Authelia, authentik, Entra ID, Google, and more — over <b>OpenID&nbsp;Connect</b> or <b>SAML&nbsp;2.0</b>, instead of a separate Jellyfin password.
+Sign in to Jellyfin with your existing identity provider - Keycloak, Authelia, authentik, Entra ID, Google, and more - over <b>OpenID&nbsp;Connect</b> or <b>SAML&nbsp;2.0</b>, instead of a separate Jellyfin password.
 </p>
 
 > ### 🔁 Revival
 >
-> This is a security-first revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continues from the last upstream release (**4.0.0.x**) and now supports **both Jellyfin 10.11 (.NET 9) and Jellyfin 12.0 (.NET 10)** — one repository URL serves the matching build to each. Huge thanks to the original author and contributors for the foundation.
+> This is a security-first revival of [**9p4/jellyfin-plugin-sso**](https://github.com/9p4/jellyfin-plugin-sso), which its original author has since archived. It continues from the last upstream release (**4.0.0.x**) and now supports **both Jellyfin 10.11 (.NET 9) and Jellyfin 12.0 (.NET 10)** - one repository URL serves the matching build to each. Huge thanks to the original author and contributors for the foundation.
 >
 > ### 🤝 AI-assisted, human-owned
 >
-> Development here is **AI-assisted — the AI only _supports_ the work, it never takes it over.** Claude (Anthropic) assists with individual **process steps**: it helps me generate and analyse code, helps me run the adversarial security reviews, and translates documentation and comments into English. **The coding work stays mine — for every one of those parts the AI only assists, and each step it produces is a proposal, never finished, unreviewed work.** I review, understand, edit where needed, and sign off on every one — the AI proposes, I decide, and **a human stays responsible for every line that ships, at all times.** Nothing lands because a tool suggested it; it lands because I wrote or verified it.
+> Development here is **AI-assisted - the AI only _supports_ the work, it never takes it over.** Claude (Anthropic) assists with individual **process steps**: it helps me generate and analyse code, helps me run the adversarial security reviews, and translates documentation and comments into English. **The coding work stays mine - for every one of those parts the AI only assists, and each step it produces is a proposal, never finished, unreviewed work.** I review, understand, edit where needed, and sign off on every one - the AI proposes, I decide, and **a human stays responsible for every line that ships, at all times.** Nothing lands because a tool suggested it; it lands because I wrote or verified it.
 
 ## Features
 
-- **OpenID Connect and SAML 2.0** — either or both, multiple providers side by side.
-- **Role-based access control** — map identity-provider groups/roles to login, administrator, library folders, Live TV, generic permissions, and a per-group parental-rating ceiling.
-- **Hardened, fail-closed login path** — identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches.
-- **Optional SSO-only login** — disable password login for every account except a designated break-glass admin, behind a fail-closed last-admin guard.
+- **OpenID Connect and SAML 2.0** - either or both, multiple providers side by side.
+- **Role-based access control** - map identity-provider groups/roles to login, administrator, library folders, Live TV, generic permissions, and a per-group parental-rating ceiling.
+- **Hardened, fail-closed login path** - identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches.
+- **Optional SSO-only login** - disable password login for every account except a designated break-glass admin, behind a fail-closed last-admin guard.
 - **Avatar sync, Quick Connect, and self-service account linking.**
-- **Tested** — a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
+- **Tested** - a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
 
-How this plugin compares to Jellyfin's built-in auth, the official LDAP plugin, and the archived 9p4 plugin: see the [Comparison](https://github.com/iderex/jellyfin-plugin-sso/wiki/Comparison) wiki page.
+How this plugin compares to Jellyfin's built-in auth, the official LDAP plugin, and the archived 9p4 plugin: see the [Comparison](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Comparison) wiki page.
 
 ## Supported providers
 
-Any OIDC-conformant or SAML 2.0 identity provider should work. Keycloak, Authelia, authentik, Dex, Pocket ID, Kanidm, Zitadel, and Google have verified, step-by-step guides — with the per-provider caveats — on the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) wiki page.
+Any OIDC-conformant or SAML 2.0 identity provider should work. Keycloak, Authelia, authentik, Dex, Pocket ID, Kanidm, Zitadel, and Google have verified, step-by-step guides - with the per-provider caveats - on the [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) wiki page.
 
 The self-hostable providers run in an automated end-to-end login test in CI ([`e2e-login.yml`](.github/workflows/e2e-login.yml)); cloud providers (Google, Entra ID) can't run in ephemeral CI and are verified manually. A verified guide (or a test) for a provider you use is a welcome contribution.
 
 ## Installing
 
-> **This is an independent plugin repository** — it is not in Jellyfin's built-in catalog. You install it by adding **its** repository under **Plugins → Repositories**.
+> **This is an independent plugin repository** - it is not in Jellyfin's built-in catalog. You install it by adding **its** repository under **Plugins → Repositories**.
 
-1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add this repository URL (one URL serves both Jellyfin 10.11 and 12.0 — your server installs the matching build automatically):
+1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add this repository URL (one URL serves both Jellyfin 10.11 and 12.0 - your server installs the matching build automatically):
 
    ```
-   https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+   https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/manifest-beta/manifest.json
    ```
 
 2. Go to **Dashboard → Plugins → Catalog**, find **Community SSO for Jellyfin**, and install it.
 3. **Restart Jellyfin.**
 
-This project publishes only to the **beta channel** for now — a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, client (Quick Connect) support, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) wiki page.
+This project publishes only to the **beta channel** for now - a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, client (Quick Connect) support, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) wiki page.
 
 ## Configuration
 
-Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/iderex/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details.
+Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details.
 
 ## Documentation
 
-Full documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-plugin-sso/wiki)**:
+Full documentation lives in the **[Wiki](https://github.com/Flowfin/jellyfin-plugin-sso/wiki)**:
 
-- [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
+- [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Project policies: [Governance](GOVERNANCE.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
+
+The plugin's own served pages are translatable from JSON catalogs, no C# involved. [Translating the UI](CONTRIBUTING.md#translating-the-ui) lists the supported languages, the catalog format, and how to add one.
 
 ## Security
 
-This plugin is built to **fail closed by default**: a missing signature, a weak signature or under-strength key, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Secrets are stored write-only and AES-256-GCM-encrypted at rest. The controls and their tuning — encryption at rest, optional rate limiting, new-user approval, step-up/MFA passthrough — are on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) wiki page, and security-relevant behavior is covered by the test suite.
+This plugin is built to **fail closed by default**: a missing signature, a weak signature or under-strength key, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Secrets are stored write-only and AES-256-GCM-encrypted at rest. The controls and their tuning - encryption at rest, optional rate limiting, new-user approval, step-up/MFA passthrough - are on the [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) wiki page, and security-relevant behavior is covered by the test suite.
 
-Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new) — not the public issue tracker. See [SECURITY.md](SECURITY.md).
+Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/Flowfin/jellyfin-plugin-sso/security/advisories/new) - not the public issue tracker. See [SECURITY.md](SECURITY.md).
 
 ## Contributing
 
@@ -97,8 +102,10 @@ Issues and pull requests are welcome. The plugin targets **.NET 9 / Jellyfin 10.
 
 ## Credits
 
-Built on the [Jellyfin LDAP plugin](https://github.com/jellyfin/jellyfin-plugin-ldapauth), [AspNetSaml](https://github.com/jitbit/AspNetSaml/) (SAML), and the [Duende IdentityModel OIDC Client](https://github.com/DuendeSoftware/foss) (OpenID Connect) — and on the original [9p4/jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso) and its contributors.
+Built on the [Jellyfin LDAP plugin](https://github.com/jellyfin/jellyfin-plugin-ldapauth), [AspNetSaml](https://github.com/jitbit/AspNetSaml/) (SAML), and the [Duende IdentityModel OIDC Client](https://github.com/DuendeSoftware/foss) (OpenID Connect) - and on the original [9p4/jellyfin-plugin-sso](https://github.com/9p4/jellyfin-plugin-sso) and its contributors.
 
 ## License
 
-Licensed under the [GNU GPL v3.0](https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt).
+Licensed under the [GNU GPL v3.0](https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/LICENSE.txt).
+
+See NOTICE.md for the intended-use notice.

--- a/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/StrictJsonTests.cs
@@ -28,6 +28,25 @@ public class StrictJsonTests
 
     private const string LoneSurrogateName = "{\"a\\ud800\":1}";
 
+    // The same lone surrogate as a RAW char rather than an escape, which is a different input reaching a
+    // different arm. The escape above is thirteen ASCII bytes the reader decodes. This is a char with no
+    // UTF-8 encoding at all, so it is refused while the document is being encoded and the reader never sees
+    // it. Without that refusal the default replacement fallback would rewrite it to U+FFFD in silence, and
+    // the walk would report Clean about bytes it had altered itself.
+    private const string RawLoneSurrogateName = "{\"a\uD800\":1}";
+
+    // Two DIFFERENT member names, each ending in a different unpaired surrogate. This is what makes the
+    // throwing fallback a rule rather than a sentence about one. Under the default replacement fallback both
+    // names encode to the same bytes, because every unpaired surrogate maps to the same U+FFFD, so the walk
+    // would report Repeated for a document whose two members are not the same name. That is a false
+    // accusation against a provider, which is the one direction a screen must never fail in.
+    private const string TwoRawLoneSurrogateNames = "{\"a\uD800\":1,\"a\uDC00\":1}";
+
+    // A UTF-8 BOM, which a provider serving a BOM-prefixed file emits. Utf8JsonReader treats it as
+    // content, so without stripping it every such document reads as malformed — and Unreadable is a
+    // refusal at the seam, so that would lock the provider out.
+    private const string Bom = "\uFEFF";
+
     // The corpora live as plain arrays so the both-TFM row below can walk exactly what the theories run,
     // rather than a second copy that could drift from them.
     private static readonly (string Json, string Member)[] Repeated =
@@ -48,6 +67,16 @@ public class StrictJsonTests
         // attacker appending to a document puts other members between the two.
         ("{\"issuer\":\"https://one.example\",\"o\":{\"issuer\":\"nested\"},\"issuer\":\"https://two.example\"}", "issuer"),
         ("{\"a\":1,\"k\":[{\"x\":1},{\"y\":2}],\"a\":2}", "a"),
+
+        // A BOM-prefixed document still has its repeat found: stripping the BOM must not cost detection.
+        (Bom + "{\"issuer\":1,\"issuer\":2}", "issuer"),
+
+        // A non-object root. The walk handles it and no fixture covered it, which is how a corpus gap
+        // and a behaviour gap become indistinguishable in a review.
+        ("[{\"a\":1,\"a\":2}]", "a"),
+
+        // The empty name is a legal member and a provider can repeat it; it must not fold with "no name".
+        ("{\"\":1,\"\":2}", ""),
     };
 
     private static readonly string[] Clean =
@@ -59,11 +88,15 @@ public class StrictJsonTests
         "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"a1\"}]}",
         RealisticJwks,
 
-        // Nested deeper than a hand-picked small cap but far inside the reader's own default, so the cap is
-        // pinned from BOTH directions: raising it fails the over-deep row below, and tightening it fails this
-        // one. Only the first was pinned before, and a cap tightened to a handful of levels would refuse every
-        // real JWKS carrying an `x5c` certificate chain while the suite stayed green.
+        // Nested well inside the cap. This row alone pins nothing about the cap — any value from 11 upward
+        // satisfies it — and an earlier comment here claimed it pinned the tightening direction, which it did
+        // not. The cap is pinned by its two neighbours in TheDepthCapIsPinnedAtItsBoundary; this fixture is
+        // here because a realistically-nested clean document belongs in the corpus regardless.
         "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":{\"f\":{\"g\":{\"h\":{\"i\":{\"j\":1}}}}}}}}}}",
+
+        // A BOM-prefixed document that is otherwise perfect. Without the strip this is Unreadable, which
+        // at the seam refuses a provider that did nothing wrong.
+        Bom + "{\"issuer\":\"https://one.example\"}",
 
         // A DESCENDANT scope reusing an ancestor's member name, which is the scope relation real discovery
         // documents actually contain: RFC 8705 puts a second `token_endpoint` and `userinfo_endpoint` inside
@@ -80,6 +113,8 @@ public class StrictJsonTests
         "not-json",
         "{\"a\":1,",
         LoneSurrogateName,
+        RawLoneSurrogateName,
+        TwoRawLoneSurrogateNames,
     };
 
     public static TheoryData<string, string> RepeatedFixtures()
@@ -138,6 +173,25 @@ public class StrictJsonTests
     }
 
     [Fact]
+    public void TheDefaultVerdictIsTheRefusal()
+    {
+        // default(Verdict) is what an uninitialised field or a skipped assignment yields. On a fail-closed
+        // component that value must be the refusal, or the failure mode of forgetting to assign is approval.
+        Assert.Equal(StrictJson.Verdict.Unreadable, default(StrictJson.Verdict));
+    }
+
+    [Fact]
+    public void RepeatedBomPrefixes_AreNotStrippedAway()
+    {
+        // Exactly one leading BOM is stripped. A document prefixed with several is one no consumer can
+        // parse, so admitting it would be this walk disagreeing with its readers in the permissive direction.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(Bom + Bom + "{\"a\":1}", out _));
+
+        // And a BOM that is not first is not a BOM prefix at all.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(" " + Bom + "{\"a\":1}", out _));
+    }
+
+    [Fact]
     public void SiblingScopesReusingAName_AreClean()
     {
         // The scope rule: one name set per OPEN object. A walk pooling names document-wide would refuse this
@@ -169,62 +223,60 @@ public class StrictJsonTests
     [MemberData(nameof(UnreadableFixtures))]
     public void HostileInput_IsUnreadable_NeverThrows(string json)
     {
-        // One fixture per raised type. `not-json` and the truncation raise JsonException; the thirteen bytes
-        // of LoneSurrogateName raise InvalidOperationException from GetString — NOT JsonException, so a walk
-        // catching only the latter hands the crash to a caller that catches neither. Unreadable is what the
-        // caller refuses on, so the fail-closed direction holds.
+        // One fixture per raised type, because each is raised by a different party and a walk that catches
+        // one hands the others to a caller that catches none. `not-json` and the truncation raise
+        // JsonException from the reader. The thirteen bytes of LoneSurrogateName raise
+        // InvalidOperationException from GetString, NOT JsonException. The two RAW surrogate fixtures raise
+        // EncoderFallbackException from the encoder, before any of the walk has run. Unreadable is what the
+        // caller refuses on, so the fail-closed direction holds for all three.
         var verdict = StrictJson.Inspect(json, out var repeated);
 
         Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
         Assert.Null(repeated);
     }
 
+    private static string NestedTo(int depth) =>
+        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string('}', depth);
+
     [Fact]
     public void NestingPastTheDepthCap_IsUnreadable()
     {
+        // The behaviour at the boundary, and only that. An earlier row claimed to pin the cap CONSTANT from
+        // both directions; it could not, because the value equals the reader's own default and deleting the
+        // constant leaves every verdict identical. The claim is withdrawn rather than restated.
+        //
         // 65 opens against the reader's own default of 64: a document this walk cannot reach the bottom of is
         // one its consumers could not read either, so it is refused rather than passed on half-inspected.
-        var tooDeep = string.Concat(Enumerable.Repeat("{\"a\":", 65)) + "1" + new string('}', 65);
-
-        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(tooDeep, out _));
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(NestedTo(64), out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(NestedTo(65), out _));
     }
 
     [Fact]
-    public void NoInputAtAll_IsClean()
+    public void ADocumentCarryingNoObject_IsUnreadable()
     {
-        // A body that carries no member cannot repeat one. Clean rather than Unreadable, so an empty response
-        // is refused (or not) by whatever rule owns emptiness, not silently by this walk.
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(null, out _));
-        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("   ", out _));
+        // Widened from "no input" to its actual rule. A bare scalar and an array of scalars are well-formed
+        // and carry no scope in which a member could repeat, so the walk established nothing about them —
+        // the same reason an empty body is not Clean. Reporting Clean here would hand a caller an
+        // affirmative answer about a document nothing read.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("17", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("true", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("\"a string\"", out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("[1,2,3]", out _));
+
+        // An EMPTY object is the boundary of that rule and stays Clean: it has a scope, and that scope
+        // repeats nothing.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect("{}", out _));
     }
 
     [Fact]
-    public void TheDecisionIsPinnedForTheFrameworkThisRunIsOn()
+    public void NoInputAtAll_IsUnreadable()
     {
-        // The acceptance list asks for the corpus decision to be pinned per target framework, because the
-        // plugin binds the HOST's System.Text.Json — .NET 9's under Jellyfin 10.11, .NET 10's under 12.0 —
-        // and only the latter has the Strict preset whose duplicate policy this walk deliberately does not
-        // use. A walk that had picked up a framework-dependent policy would answer differently on the two
-        // legs, and this row is what makes that a failure rather than a divergence nobody looks at.
-        //
-        // It records WHICH framework it ran on in its failure message, so a red leg names itself rather than
-        // leaving a reader to work out which of the two matrix runs disagreed.
-        var leg = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-
-        foreach (var (json, member) in Repeated)
-        {
-            Assert.True(StrictJson.Inspect(json, out var actual) == StrictJson.Verdict.Repeated, $"{leg}: expected Repeated for {json}");
-            Assert.True(actual == member, $"{leg}: expected member '{member}' for {json}, got '{actual}'");
-        }
-
-        foreach (var json in Clean)
-        {
-            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Clean, $"{leg}: expected Clean for {json}");
-        }
-
-        foreach (var json in Unreadable)
-        {
-            Assert.True(StrictJson.Inspect(json, out _) == StrictJson.Verdict.Unreadable, $"{leg}: expected Unreadable for {json}");
-        }
+        // Not Clean. Clean is an affirmative "no scope names a member twice", which a caller written the
+        // obvious way consumes as approval — and every reader these documents reach rejects an empty body
+        // outright, so Clean would make this walk disagree with its own consumers about one document. Nothing
+        // was established, which is exactly what Unreadable means.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(null, out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(string.Empty, out _));
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect("   ", out _));
     }
 }

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -27,8 +27,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// the agreement measured above is a property of the current dependency set and not a guarantee any of them
 /// documents. A repeat in <c>issuer</c>, <c>jwks_uri</c>, or a JWKS entry is where that would decide a login
 /// anchor or a validation key. Deliberately out of scope: an operator who edits the plugin's own
-/// configuration, and any document that does not reach a consumer through <see cref="RepeatedMemberScreen"/>
-/// — this walk defends against a hostile provider, not against the person who administers the server, and
+/// configuration, and any document nothing routes through this walk before parsing it — a decision function
+/// stops nothing on its own, and placing it on a path is the caller's job (#1061). This walk defends against
+/// a hostile provider, not against the person who administers the server, and
 /// review and branch protection are what cover the latter. Also out of scope, and worth stating because the
 /// two are easily conflated: this is not the control that stops a hostile <c>issuer</c> VALUE, which is
 /// <c>ValidateIssuerName</c>'s job whether that value is repeated or not.
@@ -48,8 +49,19 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// </summary>
 internal static class StrictJson
 {
+    // What this cannot do, stated because a decision function invites the assumption that it protects the
+    // path it decides for: it bounds nothing. It is handed a string that is already in memory and allocates
+    // a UTF-8 copy of it, so a document large enough to hurt has already hurt before this runs. Bounding
+    // belongs at the position that reads the bytes, which is the caller's, and #1041 owns it there.
+
     // Matches the System.Text.Json reader default rather than raising it, so a document this walk cannot
     // reach the bottom of is one its consumers could not read either.
+    //
+    // Because it EQUALS that default, no behavioural test can tell this constant from its absence: deleting
+    // it and the reader options leaves every verdict identical. It is kept for what it pins against — a
+    // future runtime moving its default — and that is a property no test in this repository can observe, so
+    // none claims to. An earlier test asserted it was pinned "from both directions"; it was not, and the
+    // claim is gone rather than reworded.
     private const int MaxDepth = 64;
 
     /// <summary>
@@ -60,14 +72,19 @@ internal static class StrictJson
     /// </summary>
     internal enum Verdict
     {
+        /// <summary>
+        /// Nothing was established about the document — it could not be walked to the end, or it carries no
+        /// object to walk. Deliberately the ZERO value: <c>default(Verdict)</c> is what an uninitialised
+        /// field or a silently skipped assignment produces, and on a fail-closed component that default must
+        /// be the refusal rather than the approval.
+        /// </summary>
+        Unreadable,
+
         /// <summary>No object scope names a member twice.</summary>
         Clean,
 
         /// <summary>An object scope names a member twice, so the document means two things.</summary>
         Repeated,
-
-        /// <summary>The document could not be walked to the end, so nothing was established about it.</summary>
-        Unreadable,
     }
 
     /// <summary>
@@ -81,11 +98,24 @@ internal static class StrictJson
     /// <returns>
     /// <see cref="Verdict.Repeated"/> when one object scope names a member twice;
     /// <see cref="Verdict.Unreadable"/> when the walk could not complete — malformed, truncated, nested past
-    /// the depth cap, or carrying a member name the decoder refuses (an unpaired surrogate escape is the
-    /// measured instance); <see cref="Verdict.Clean"/> otherwise, including for a null, empty or whitespace
-    /// input, which carries no member to repeat. Names are compared ordinally, because JSON member names are
-    /// case-sensitive and every consumer of these documents compares them ordinally too, and AFTER
-    /// unescaping, so a name spelled with a <c>\u</c> escape counts as the same name as its plain spelling.
+    /// the depth cap, carrying a member name the decoder refuses (an unpaired surrogate escape is the
+    /// measured instance), carrying a char with no UTF-8 encoding at all (a RAW unpaired surrogate, refused
+    /// before the walk starts), or carrying no object at all — a null, empty or whitespace body, and equally a
+    /// bare scalar or a document whose root is not and contains no object. None of those establishes
+    /// anything, which is what <see cref="Verdict.Unreadable"/> means, and reporting <c>Clean</c> for them
+    /// would hand a caller an affirmative answer about a document nothing read.
+    /// <see cref="Verdict.Clean"/> otherwise. Names are compared ordinally — a decision about this plugin's
+    /// readers rather than a fact about consumers, see below — and AFTER unescaping, so a name spelled with a
+    /// <c>\u</c> escape counts as the same name as its plain spelling.
+    ///
+    /// Ordinal is a decision about THIS plugin's readers, not a fact about JSON consumers in general, and the
+    /// difference matters: a deserializer configured case-insensitively — which is what
+    /// <c>JsonSerializerDefaults.Web</c> gives you — resolves <c>ISSUER</c> onto <c>Issuer</c> and keeps the
+    /// last occurrence, while an indexing reader over the same bytes returns the first. The plugin's own
+    /// discovery readers index, so a case-variant pair is unambiguous to them and refusing it would take a
+    /// working provider offline; whether that holds for every consumer this walk may acquire is not settled
+    /// here and is tracked separately.
+    ///
     /// Never throws.
     /// </returns>
     internal static Verdict Inspect(string? json, out string? repeatedMember)
@@ -93,21 +123,44 @@ internal static class StrictJson
         repeatedMember = null;
         if (string.IsNullOrWhiteSpace(json))
         {
-            return Verdict.Clean;
+            // Nothing was established about a body carrying no members, so this is Unreadable and not Clean.
+            // Clean is an affirmative "no scope names a member twice", which a caller reads as approval —
+            // and every reader these documents reach rejects an empty body outright, so reporting Clean would
+            // make this walk disagree with its own consumers about one document, which is what it exists to
+            // prevent.
+            return Verdict.Unreadable;
         }
+
+        // A UTF-8 BOM is a provider's to emit and Utf8JsonReader treats it as content, so a document that is
+        // otherwise perfect reads as malformed and — since Unreadable is a refusal at every seam that
+        // consumes this — locks that provider out. Stripped here rather than left to the caller: the one
+        // caller that exists today happens to strip it while decoding, but that is an undocumented property
+        // of a consumer this function does not have and cannot require.
+        // ONE leading BOM, not a run of them: TrimStart would strip any number, and a document prefixed
+        // with several is one no consumer can parse, so admitting it would be this walk disagreeing with its
+        // readers in the permissive direction. A BOM that is not first — after whitespace, say — is left
+        // alone and the document reads as malformed, which is the honest answer for it.
+        var document = json!.StartsWith('\uFEFF') ? json.Substring(1) : json;
 
         // One name set per open object, so sibling scopes may reuse a name — every JWKS entry repeats `kty`
         // and `kid`, so a walk pooling names document-wide would refuse real documents while reporting an
         // attack. Only a repeat within the SAME object is a document that means two things.
         var scopes = new Stack<HashSet<string>>();
+        var sawObject = false;
         try
         {
-            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json), new JsonReaderOptions { MaxDepth = MaxDepth });
+            // Throw-on-invalid rather than the default replacement fallback: replacement maps every unpaired
+            // surrogate to U+FFFD, so two genuinely different member names would re-encode to the same key and
+            // the walk would report a repeat in a document that has none. The throw is caught below and
+            // reported as Unreadable, which is the honest answer for bytes that cannot round-trip.
+            var bytes = new UTF8Encoding(false, true).GetBytes(document);
+            var reader = new Utf8JsonReader(bytes, new JsonReaderOptions { MaxDepth = MaxDepth });
             while (reader.Read())
             {
                 switch (reader.TokenType)
                 {
                     case JsonTokenType.StartObject:
+                        sawObject = true;
                         scopes.Push(new HashSet<string>(StringComparer.Ordinal));
                         break;
 
@@ -116,6 +169,9 @@ internal static class StrictJson
                         break;
 
                     case JsonTokenType.PropertyName:
+                        // GetString returns null only for a JSON null, which cannot be a member name, so the fallback is
+                        // unreachable — but folding it to "" would make the empty name and "no name" the same
+                        // key, and the empty name is a legal member a provider can repeat.
                         var name = reader.GetString() ?? string.Empty;
                         if (!scopes.Peek().Add(name))
                         {
@@ -134,8 +190,20 @@ internal static class StrictJson
         {
             return Verdict.Unreadable;
         }
+        catch (EncoderFallbackException)
+        {
+            // The document cannot be re-encoded without loss, so no verdict about its members would be about
+            // the document the consumer sees.
+            return Verdict.Unreadable;
+        }
         catch (InvalidOperationException)
         {
+            // This arm is broader than its main cause, and the breadth is deliberate rather than
+            // overlooked: it also covers a stack operation on an empty stack, which would be a defect in
+            // this walk rather than anything the provider did. A walk bug therefore reports as an
+            // uninspectable document — the fail-closed direction, which is why the breadth is acceptable,
+            // but it does mean a verdict of Unreadable is not by itself evidence about the document.
+            //
             // GetString raises this — NOT JsonException — on a member name the decoder cannot complete: an
             // unpaired surrogate escape is thirteen bytes both parser families read without complaint. A
             // caller catching only JsonException would therefore take the crash, so this arm is what keeps a
@@ -143,6 +211,9 @@ internal static class StrictJson
             return Verdict.Unreadable;
         }
 
-        return Verdict.Clean;
+        // A well-formed document that contains no object at all — a bare scalar, an array of scalars — has
+        // no scope in which a member could repeat, so the walk established nothing about it and says so. An
+        // EMPTY object is different and stays Clean: it has a scope, and that scope genuinely repeats nothing.
+        return sawObject ? Verdict.Clean : Verdict.Unreadable;
     }
 }


### PR DESCRIPTION
The repository moved to the Flowfin organisation. The readme now says so, and its own links point at the new location instead of relying on a redirect.