### PR TITLE
Say that this plugin belongs to Flowfin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,34 @@
 
 > [!NOTE]
 >
-> **Status: Release Candidate** - the fourth rung of the maturity ladder (In-Development → Alpha → Beta → Release Candidate → Full Release). Install it by adding this plugin's own repository to Jellyfin - see [Installing](#installing).
+> **Part of [Flowfin](https://github.com/Flowfin).** It works with any Jellyfin
+> server, and with the Flowfin clients.
+>
+> **Status: Release Candidate**, the fourth rung of the maturity ladder (In-Development, Alpha, Beta, Release Candidate, Full Release). Install it by adding this plugin's own repository to Jellyfin, see [Installing](#installing).
 
 <h1 align="center">Community SSO for Jellyfin</h1>
 
 <p align="center">
-<img alt="Community SSO for Jellyfin" src="https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
+<img alt="Community SSO for Jellyfin" src="https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/main/img/banner.png" width="820"/>
 <br/>
 <br/>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt">
-<img alt="GPL 3.0 License" src="https://img.shields.io/github/license/iderex/jellyfin-plugin-sso.svg"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/LICENSE.txt">
+<img alt="GPL 3.0 License" src="https://img.shields.io/github/license/Flowfin/jellyfin-plugin-sso.svg"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/releases">
-<img alt="Latest release" src="https://img.shields.io/github/v/release/iderex/jellyfin-plugin-sso?display_name=tag&label=release"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/releases">
+<img alt="Latest release" src="https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&label=release"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
-<img alt="Build Status" src="https://github.com/iderex/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
+<img alt="Build Status" src="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>
 </a>
-<a href="https://github.com/iderex/jellyfin-plugin-sso/wiki">
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/wiki">
 <img alt="Documentation" src="https://img.shields.io/badge/docs-wiki-blue"/>
 </a>
 <a href="https://www.bestpractices.dev/projects/13660">
 <img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/13660/badge"/>
 </a>
-<a href="https://securityscorecards.dev/viewer/?uri=github.com/iderex/jellyfin-plugin-sso">
-<img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/iderex/jellyfin-plugin-sso/badge"/>
+<a href="https://securityscorecards.dev/viewer/?uri=github.com/Flowfin/jellyfin-plugin-sso">
+<img alt="OpenSSF Scorecard" src="https://api.securityscorecards.dev/projects/github.com/Flowfin/jellyfin-plugin-sso/badge"/>
 </a>
 </p>
 
@@ -51,11 +54,11 @@ Sign in to Jellyfin with your existing identity provider - Keycloak, Authelia, a
 - **Avatar sync, Quick Connect, and self-service account linking.**
 - **Tested** - a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
 
-How this plugin compares to Jellyfin's built-in auth, the official LDAP plugin, and the archived 9p4 plugin: see the [Comparison](https://github.com/iderex/jellyfin-plugin-sso/wiki/Comparison) wiki page.
+How this plugin compares to Jellyfin's built-in auth, the official LDAP plugin, and the archived 9p4 plugin: see the [Comparison](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Comparison) wiki page.
 
 ## Supported providers
 
-Any OIDC-conformant or SAML 2.0 identity provider should work. Keycloak, Authelia, authentik, Dex, Pocket ID, Kanidm, Zitadel, and Google have verified, step-by-step guides - with the per-provider caveats - on the [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) wiki page.
+Any OIDC-conformant or SAML 2.0 identity provider should work. Keycloak, Authelia, authentik, Dex, Pocket ID, Kanidm, Zitadel, and Google have verified, step-by-step guides - with the per-provider caveats - on the [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) wiki page.
 
 The self-hostable providers run in an automated end-to-end login test in CI ([`e2e-login.yml`](.github/workflows/e2e-login.yml)); cloud providers (Google, Entra ID) can't run in ephemeral CI and are verified manually. A verified guide (or a test) for a provider you use is a welcome contribution.
 
@@ -66,32 +69,32 @@ The self-hostable providers run in an automated end-to-end login test in CI ([`e
 1. In Jellyfin, go to **Dashboard → Plugins → Repositories** and add this repository URL (one URL serves both Jellyfin 10.11 and 12.0 - your server installs the matching build automatically):
 
    ```
-   https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+   https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/manifest-beta/manifest.json
    ```
 
 2. Go to **Dashboard → Plugins → Catalog**, find **Community SSO for Jellyfin**, and install it.
 3. **Restart Jellyfin.**
 
-This project publishes only to the **beta channel** for now - a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, client (Quick Connect) support, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) wiki page.
+This project publishes only to the **beta channel** for now - a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, client (Quick Connect) support, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) wiki page.
 
 ## Configuration
 
-Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/iderex/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details.
+Configure your providers on the plugin's settings page (**Dashboard → Plugins → SSO-Auth**) and via the admin API. The [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) walkthrough and the [Hardening & Options Reference](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Hardening-and-Options-Reference) cover every option, the provider-name rules, and the admin-API details.
 
 ## Documentation
 
-Full documentation lives in the **[Wiki](https://github.com/iderex/jellyfin-plugin-sso/wiki)**:
+Full documentation lives in the **[Wiki](https://github.com/Flowfin/jellyfin-plugin-sso/wiki)**:
 
-- [Installation](https://github.com/iderex/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/iderex/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/iderex/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/iderex/jellyfin-plugin-sso/wiki/Troubleshooting)
+- [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Project policies: [Governance](GOVERNANCE.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
 
 The plugin's own served pages are translatable from JSON catalogs, no C# involved. [Translating the UI](CONTRIBUTING.md#translating-the-ui) lists the supported languages, the catalog format, and how to add one.
 
 ## Security
 
-This plugin is built to **fail closed by default**: a missing signature, a weak signature or under-strength key, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Secrets are stored write-only and AES-256-GCM-encrypted at rest. The controls and their tuning - encryption at rest, optional rate limiting, new-user approval, step-up/MFA passthrough - are on the [Security Model](https://github.com/iderex/jellyfin-plugin-sso/wiki/Security-Model) wiki page, and security-relevant behavior is covered by the test suite.
+This plugin is built to **fail closed by default**: a missing signature, a weak signature or under-strength key, an out-of-bounds time window, a wrong audience, a replayed assertion, or an unrecognized identity is rejected rather than waved through. Secrets are stored write-only and AES-256-GCM-encrypted at rest. The controls and their tuning - encryption at rest, optional rate limiting, new-user approval, step-up/MFA passthrough - are on the [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) wiki page, and security-relevant behavior is covered by the test suite.
 
-Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/iderex/jellyfin-plugin-sso/security/advisories/new) - not the public issue tracker. See [SECURITY.md](SECURITY.md).
+Found a vulnerability? Please report it **privately** via GitHub's ["Report a vulnerability"](https://github.com/Flowfin/jellyfin-plugin-sso/security/advisories/new) - not the public issue tracker. See [SECURITY.md](SECURITY.md).
 
 ## Contributing
 
@@ -103,6 +106,6 @@ Built on the [Jellyfin LDAP plugin](https://github.com/jellyfin/jellyfin-plugin-
 
 ## License
 
-Licensed under the [GNU GPL v3.0](https://github.com/iderex/jellyfin-plugin-sso/blob/main/LICENSE.txt).
+Licensed under the [GNU GPL v3.0](https://github.com/Flowfin/jellyfin-plugin-sso/blob/main/LICENSE.txt).
 
 See NOTICE.md for the intended-use notice.


### PR DESCRIPTION
The repository moved to the Flowfin organisation. The readme now says so, and its own links point at the new location instead of relying on a redirect.