### PR TITLE
Raise both CodeQL action steps together, and keep them together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,23 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # init und analyze sind EINE Sache und muessen zusammen wandern.
+    #
+    # Dependabot fuehrt github/codeql-action/init und .../analyze als zwei
+    # Abhaengigkeiten und hat sie am 06.08. in zwei getrennten PRs auf 4.37.4
+    # gehoben. Jeder dieser PRs traegt nur eine der beiden Stufen, und die
+    # Action bricht dann ab:
+    #
+    #     Loaded a configuration file for version '4.37.3',
+    #     but running version '4.37.4'
+    #
+    # Beide PRs mussten also scheitern, jeder fuer sich, und keiner der beiden
+    # war reparierbar - ein gruener Lauf war nur mit beiden Aenderungen im
+    # selben Baum moeglich. Diese Gruppe sorgt dafuer, dass es einer bleibt.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     # What this hold reaches: a freshly published malicious version of an action,
     # which then waits 7 days before it can be proposed here. Same carve-out as
     # above, in GitHub's words - the cooldown "does not apply to security

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -95,7 +95,7 @@ jobs:
           dotnet-version: 9.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -103,6 +103,6 @@ jobs:
           queries: security-extended
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Closes #1283. Replaces the two Dependabot pull requests #1255 and #1256, each of which carried one half of a change that only works whole.