### PR TITLE
Name the organisation as the plugin owner

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -8,7 +8,7 @@ version: "4.3.0"
 # login on an older 10.11 server (#142). Raise this only to a floor that job still builds clean on.
 targetAbi: "10.11.0.0"
 framework: "net9.0"
-owner: "iderex"
+owner: "Flowfin"
 overview: "Sign in to Jellyfin through OpenID Connect or SAML 2.0 identity providers."
 description: |
   Single sign-on for Jellyfin via OpenID Connect and SAML 2.0 - works with self-hosted and


### PR DESCRIPTION
`build.yaml` named an individual account as the plugin owner while every
plugin repository now lives in the Flowfin organisation.

The owner field is not internal bookkeeping. It is rendered next to the plugin
in the Jellyfin catalogue, so it should name the same party the repository and
the manifest domain belong to. A catalogue entry that names one party while the
source names another gives a reader no way to tell which is right.

Nothing else changes. The plugin identity, version and target ABI are
untouched.
