### PR TITLE
Derive the beta repository URL instead of writing the old owner into it

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -216,7 +216,7 @@ jobs:
           body: |
             Jellyfin 10.11 beta ${{ steps.version.outputs.base }}-beta (plugin version ${{ steps.version.outputs.beta }}).
             Install via the beta repository URL:
-            https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+            https://raw.githubusercontent.com/${{ github.repository }}/manifest-beta/manifest.json
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish the draft release as the repo's Latest release

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -193,7 +193,7 @@ jobs:
           body: |
             Jellyfin 12.0 (.NET 10) beta ${{ steps.version.outputs.base }}-JF12-beta (plugin version ${{ steps.version.outputs.beta }}).
             Install via the beta repository URL (a Jellyfin 12.0 server picks this build automatically by targetAbi):
-            https://raw.githubusercontent.com/iderex/jellyfin-plugin-sso/manifest-beta/manifest.json
+            https://raw.githubusercontent.com/${{ github.repository }}/manifest-beta/manifest.json
 
             Scope note (#743): the JF12/5.0 line is **not validated against a live Jellyfin 12.0 server yet** - no 12.0 GA server exists to run the E2E checklist against. It is CI-built and unit/conformance-tested only, and it is NOT part of the 4.x (Jellyfin 10.11) release-candidate gate; the 5.0 line clears its own live-validation gate when a Jellyfin 12.0 RC/GA build is available. Use these betas for testing, not production.
       env:


### PR DESCRIPTION
Every beta release note printed `raw.githubusercontent.com/iderex/...` as the repository URL to add in Jellyfin. That address lives on the transfer redirect, which the old owner can end by creating a repository of that name again.

A plugin repository URL is not an ordinary link. A server that has it keeps fetching it forever, so when it stops resolving, the plugin simply never updates again and nothing reports an error.

The README already used the current path; these two workflows did not. They now derive it from `github.repository`, so it cannot drift a second time.

The same class as #1285, which was the icon rather than the repository URL.