### PR TITLE
Say how far sign-in actually reaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > [!NOTE]
 >
 > **Part of [Flowfin](https://github.com/Flowfin).** It works with any Jellyfin
-> server, and with the Flowfin clients.
+> server, and sign-in reaches any client that supports Quick Connect, not only
+> the Flowfin ones.
 >
 > **Status: Release Candidate**, the fourth rung of the maturity ladder (In-Development, Alpha, Beta, Release Candidate, Full Release). Install it by adding this plugin's own repository to Jellyfin, see [Installing](#installing).
 


### PR DESCRIPTION
The note read: *It works with any Jellyfin server, and with the Flowfin clients.*

That understates the client side and, worse, reads as though sign-in were limited to clients that do not exist yet. Sign-in through this plugin reaches any client that supports Quick Connect, which is most of them. The README already states that further down, on the installation line; the note contradicted it.

Nothing else changes.