### PR TITLE
Add a roles fuzz target and seed its repeated-key grammar [#1158]

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,8 +5,8 @@
 # libFuzzer runtime work. The headline target is the SAML response parse/validate
 # path (`SamlResponseLoader.TryParse` -> `SamlResponse` ctor + `IsValid` + every
 # claim getter, seeded from the SamlTestFactory-shaped corpus), which is what
-# #174 asks for; the same harness also exposes the OIDC `discovery`, `idtoken`
-# and `jwks` parse readers, fuzzed in the same sweep at no extra maintenance.
+# #174 asks for; the same harness also exposes the OIDC `discovery`, `idtoken`,
+# `jwks` and `roles` readers, fuzzed in the same sweep at no extra maintenance.
 #
 # NON-GATING BY CONSTRUCTION: this workflow runs ONLY on a weekly schedule and on
 # manual dispatch - never on push or pull_request - so it is not a PR check and
@@ -61,11 +61,12 @@ jobs:
       # One target's crasher (a real finding) must not cancel the others' runs.
       fail-fast: false
       matrix:
-        # saml is the #174 target and is listed first; discovery/idtoken/jwks are
-        # the sibling parse readers the same harness (#402) exposes. jwks (#1156)
-        # is the only one whose surface touches key material rather than JSON
-        # alone, which is why it is worth its own leg.
-        target: [saml, discovery, idtoken, jwks]
+        # saml is the #174 target and is listed first; the rest are the sibling
+        # readers the same harness (#402) exposes. jwks (#1156) is the only one
+        # whose surface touches key material rather than JSON alone, and roles
+        # (#1158) the only one whose output decides a privilege rather than a
+        # diagnostic, which is why each is worth its own leg.
+        target: [saml, discovery, idtoken, jwks, roles]
     env:
       # The managed harness executable libFuzzer drives, and the plugin assembly
       # SharpFuzz instruments in place (loaded by the harness from the same dir).

--- a/SSO-Auth.Fuzz/Program.cs
+++ b/SSO-Auth.Fuzz/Program.cs
@@ -38,6 +38,11 @@ internal static class Program
     // code path's robustness, not a signature bypass (which coverage-guided fuzzing cannot reach).
     private static readonly string SamlCertificateBase64 = CreateSelfSignedCertificateBase64();
 
+    // The role-claim path the `roles` target drives, pinned beside the corpus it belongs to: segment[0] is
+    // the claim name the caller matched, the rest walk into the claim value. Changing it invalidates every
+    // seed in corpus/roles, which is why it lives here as one constant rather than at the call.
+    private static readonly string[] RoleClaimPath = { "resource_access", "jellyfin", "roles" };
+
     private static int Main(string[] args)
     {
         var target = Environment.GetEnvironmentVariable("SSO_FUZZ_TARGET") ?? "saml";
@@ -48,8 +53,9 @@ internal static class Program
             "discovery" => FuzzOidcDiscovery,
             "idtoken" => FuzzOidcIdToken,
             "jwks" => FuzzJwks,
+            "roles" => FuzzOidcRoles,
             _ => throw new ArgumentException(
-                $"Unknown SSO_FUZZ_TARGET '{target}'. Expected one of: saml, discovery, idtoken, jwks."),
+                $"Unknown SSO_FUZZ_TARGET '{target}'. Expected one of: saml, discovery, idtoken, jwks, roles."),
         };
 
         // Differential mode asks a different question from either mode below, and it is the only one that can
@@ -205,6 +211,28 @@ internal static class Program
                 ephemeralKey.Dispose();
             }
         }
+    }
+
+    // OpenID role claim: the value of the claim the role-claim path names, which reaches the plugin from
+    // the id_token or the UserInfo response and is provider-authored. OidcRoleExtractor.ExtractRoles parses
+    // it as JSON and walks it, so it is a byte-level parse surface like the readers above, and today no
+    // target feeds it.
+    //
+    // The path is FIXED so a seed and the driver cannot drift apart: every seed in corpus/roles is the value
+    // of a `resource_access` claim under the path resource_access.jellyfin.roles, which is Keycloak's shape.
+    // Both terminal shapes are driven from the one input span, because the shape is a per-provider setting
+    // (RoleClaimIsObjectMap, #934) rather than a property of the bytes: the same document is a valid input
+    // to either, and the mutator should reach both arms without needing two corpora.
+    //
+    // Only the harness's uniform property is asserted, by not catching: the call must terminate with a
+    // fail-closed result or an exception the extractor maps. WHICH roles come back from an unreadable or
+    // repeated-key claim is #1053's decision to make, and nothing here encodes an answer to it.
+    private static void FuzzOidcRoles(ReadOnlySpan<byte> data)
+    {
+        var claimValue = Encoding.UTF8.GetString(data);
+
+        _ = OidcRoleExtractor.ExtractRoles(RoleClaimPath, claimValue, terminalIsObjectMap: false);
+        _ = OidcRoleExtractor.ExtractRoles(RoleClaimPath, claimValue, terminalIsObjectMap: true);
     }
 
     private static string CreateSelfSignedCertificateBase64()

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -27,6 +27,7 @@ are what the harness drives (selected per run by the `SSO_FUZZ_TARGET` environme
 | `discovery`                | `StrictJson.Inspect`, `PkceDiscovery.SupportsS256` and `OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer` | The raw OpenID discovery JSON fetched at challenge                                                   |
 | `idtoken`                  | `OidcResponseIssuer.IdTokenIssuer` (`new JsonWebToken(token)`)                                                | The raw id_token JWT string                                                                          |
 | `jwks`                     | `OidcSignatureKeys.Convert` (after the library's `new JsonWebKeySet(json)`)                                   | The raw JWKS the challenge fetches from `jwks_uri`                                                   |
+| `roles`                    | `OidcRoleExtractor.ExtractRoles`, driven at both terminal shapes from one input                               | The role-claim value from the id_token or the UserInfo response                                      |
 
 The property under test is uniform: on **any** input the entry point must terminate with a fail-closed
 result (`false` / `null` / a rejection) **or** one of the exceptions it explicitly maps - it must never
@@ -102,7 +103,7 @@ dotnet tool install --global SharpFuzz.CommandLine
 sharpfuzz SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll
 
 # 3. Fuzz one target, seeded from its corpus (libFuzzer flags after --).
-export SSO_FUZZ_TARGET=saml   # or: discovery | idtoken | jwks
+export SSO_FUZZ_TARGET=saml   # or: discovery | idtoken | jwks | roles
 dotnet SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll \
     SSO-Auth.Fuzz/corpus/$SSO_FUZZ_TARGET -max_total_time=300
 ```
@@ -116,10 +117,12 @@ a plain 500/DoS), and fix the parser in a separate change - the harness only sur
 Because libFuzzer is Linux-only, set `SSO_FUZZ_SMOKE=1` to replay a corpus directory through the selected
 target **once** and exit - no instrumentation, no native runtime. It proves the dispatch + parse wiring
 runs and that every seed is handled fail-closed, so the harness can be validated on Windows and as a cheap
-CI sanity check. This is how the prototype was validated at delivery (all three targets, exit 0):
+CI sanity check. This is how the prototype was validated at delivery, and how a new target is validated
+before it lands: every target over its own corpus, exit 0. The count is not restated here because it
+moved once already and the loop above derives it from the corpus directories.
 
 ```sh
-export SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=saml   # or: discovery | idtoken | jwks
+export SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=saml   # or: discovery | idtoken | jwks | roles
 dotnet SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll SSO-Auth.Fuzz/corpus/$SSO_FUZZ_TARGET
 ```
 
@@ -176,6 +179,16 @@ without complaint, and the input on which `System.Text.Json`'s `GetString` raise
 `InvalidOperationException` rather than `JsonException` - so a walk catching only the latter takes the
 throw on the anonymous discovery read. It is committed as a seed so the arm stays replayed by the smoke
 gate rather than resting on a unit test alone.
+
+`corpus/roles/` (#1158) carries the repeated-name class on the role claim, which is the one surface here
+where a repeat could decide a privilege rather than a diagnostic. Every seed is the value of a
+`resource_access` claim read under the path `resource_access.jellyfin.roles`, pinned in `Program.cs`
+beside the driver so a seed and the path cannot drift apart: `array-terminal.json` and
+`object-map-terminal.json` are the two terminal shapes the extractor supports,
+`repeated-key-at-terminal.json` names `roles` twice in the object that holds it, and
+`repeated-key-below-terminal.json` repeats a role name inside the object map one level below. What the
+extractor should DO with a repeat is #1053's decision and is deliberately not encoded here; the target
+asserts only that the walk terminates fail-closed or with an exception it maps.
 
 ## Scorecard alert #36 and #174
 

--- a/SSO-Auth.Fuzz/corpus/roles/array-terminal.json
+++ b/SSO-Auth.Fuzz/corpus/roles/array-terminal.json
@@ -1,0 +1,1 @@
+{"jellyfin":{"roles":["jellyfin-access","jellyfin-admin"]}}

--- a/SSO-Auth.Fuzz/corpus/roles/object-map-terminal.json
+++ b/SSO-Auth.Fuzz/corpus/roles/object-map-terminal.json
@@ -1,0 +1,1 @@
+{"jellyfin":{"roles":{"jellyfin-access":{"7364":"example.com"},"jellyfin-admin":{"7364":"example.com"}}}}

--- a/SSO-Auth.Fuzz/corpus/roles/repeated-key-at-terminal.json
+++ b/SSO-Auth.Fuzz/corpus/roles/repeated-key-at-terminal.json
@@ -1,0 +1,1 @@
+{"jellyfin":{"roles":["jellyfin-access"],"roles":["jellyfin-admin"]}}

--- a/SSO-Auth.Fuzz/corpus/roles/repeated-key-below-terminal.json
+++ b/SSO-Auth.Fuzz/corpus/roles/repeated-key-below-terminal.json
@@ -1,0 +1,1 @@
+{"jellyfin":{"roles":{"jellyfin-access":{"7364":"example.com"},"jellyfin-access":{"7364":"other.example"}}}}


### PR DESCRIPTION
# What & why

`OidcRoleExtractor.ExtractRoles` reads a provider-authored claim value, and unlike every other reader the harness drives, its output decides a privilege rather than a diagnostic. No fuzz target fed it, so the roles seeds the parent issue asks for would have sat in a directory nothing runs. This adds the target, its corpus and its workflow leg.

The role-claim path is pinned as one constant beside the driver, `resource_access.jellyfin.roles`, so a seed and the driver cannot drift apart. Both terminal shapes are driven from the one input span, because `RoleClaimIsObjectMap` (#934) is a per-provider setting rather than a property of the bytes: the same document is a valid input to either arm, and the mutator reaches both without a second corpus.

Only the harness's uniform property is asserted, by not catching it: the call must terminate with a fail-closed result or an exception the extractor maps. Which roles come back from a repeated or unreadable key is #1053's decision, and nothing here encodes an answer to it, so the target stays valid whichever way that lands.

Closes #1158

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

No plugin code changes here. The diff is the out-of-band fuzz harness, its seed corpus, and the target list in the weekly workflow; `SSO-Auth/` is untouched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

No second reader looked at this change. Nothing here was read by anyone but its author, and the evidence below stands in place of a review rather than alongside one. The boxes above are unticked because none of them was done.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The harness README carries the target-table row and the seed-corpus paragraph, so the docs update is in this change. No wiki page describes the fuzz targets.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Commands and their output, run at `a8311a6`:

```
$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --warnaserror
    0 Warnung(en)
    0 Fehler

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
    0 Warnung(en)
    0 Fehler

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2653, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 24,595s
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2654, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 22,623s

$ npx prettier --check SSO-Auth.Fuzz/README.md
All matched files use Prettier code style!
```

Four tests are skipped on both frameworks. They bind a listener off loopback, which raises the Windows firewall consent dialog and needs an administrator (#1227). They were not run, and no attempt was made to work around the elevation. They are unrelated to this change and skip identically without it.

Smoke replay, every target over its own corpus, at `a8311a6`:

```
$ for t in saml discovery idtoken jwks roles; do SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=$t \
    dotnet SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.dll SSO-Auth.Fuzz/corpus/$t; echo "exit=$?"; done
Smoke OK: 15 seed(s) for target 'saml' handled fail-closed with no unmapped exception.
exit=0
Smoke OK: 5 seed(s) for target 'discovery' handled fail-closed with no unmapped exception.
exit=0
Smoke OK: 5 seed(s) for target 'idtoken' handled fail-closed with no unmapped exception.
exit=0
Smoke OK: 2 seed(s) for target 'jwks' handled fail-closed with no unmapped exception.
exit=0
Smoke OK: 4 seed(s) for target 'roles' handled fail-closed with no unmapped exception.
exit=0
```

Exit 0 there says the seeds survive, which is not the same as saying they are meaningful. Measured separately by printing both arms' results from the driver, a throwaway line reverted before the commit (the committed driver is byte-identical to the probed one apart from that line):

| Seed                               | array-terminal arm                            | object-map arm                                |
| ---------------------------------- | --------------------------------------------- | --------------------------------------------- |
| `array-terminal.json`              | `Resolved` [jellyfin-access, jellyfin-admin]  | `TerminalWrongShape` []                       |
| `object-map-terminal.json`         | `TerminalWrongShape` []                       | `Resolved` [jellyfin-access, jellyfin-admin]  |
| `repeated-key-at-terminal.json`    | `Resolved` [jellyfin-admin]                   | `TerminalWrongShape` []                       |
| `repeated-key-below-terminal.json` | `TerminalWrongShape` []                       | `Resolved` [jellyfin-access]                  |

Four seeds, four distinct outcomes, and both arms reached. Row three is the repeat's downstream effect, stated as measured behaviour rather than as a defect claim: a claim value naming `roles` twice resolves to the last occurrence, so the first copy's roles are dropped without a trace. What the extractor should do about that is #1053's to decide, which is why the seed is committed as grammar for the mutator and no assertion here depends on the outcome.

Three further hostile inputs went through the target in the same probe and are deliberately not committed, because none of them found anything: a lone high surrogate as a role value, a lone high surrogate as a member name, and a numeric literal with a six-digit exponent. All three terminated with a mapped fail-closed result and no unmapped exception.

## Notes

The corpus directory is what makes this run per pull request. The gating `build` job derives its smoke-replay target list from `SSO-Auth.Fuzz/corpus/*/`, so `roles` is replayed by the fact of having seeds, and an empty corpus directory fails that step rather than passing quietly.

The issue also asks to revisit `timeout-minutes` in `fuzz.yml` and its "three targets" comment. Both were already settled before this change: the ceiling is documented as per-leg and explicitly does not move with the target count, and the comment states no count. Only the matrix list and the header sentence needed the new target.

The `workflow_dispatch` leg named in the issue's done-when has not run yet. `fuzz.yml` triggers only on its weekly schedule and on manual dispatch, so it cannot run from this pull request. A dispatch against this branch is being run separately and its result will be recorded on the issue.

Carried forward from an earlier unmerged branch, `harden/roles-fuzz-target-1158` at `cdb4b5a`, which was pushed without a pull request. The commit here is that work cherry-picked onto current `main`, with the harness README conflict resolved in favour of both changes.

### Update: the dispatch has now run

`workflow_dispatch` on this branch with `max_total_time=60`, run https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/31258528951. All five legs green, `Fuzz roles` among them:

```
$ gh run view 31258528951 --json jobs --jq '.jobs[]|[.name,.conclusion]|@tsv'
Fuzz idtoken    success
Fuzz jwks       success
Fuzz roles      success
Fuzz discovery  success
Fuzz saml       success
```

The leg did work rather than merely starting. It picked up all four seeds, ran 739,139 executions in 61 seconds, grew the corpus by 312 units, and found nothing:

```
#5      INITED cov: 2 ft: 48 corp: 4/341b exec/s: 5 rss: 27Mb
Done 739139 runs in 61 second(s)
stat::number_of_executed_units: 739139
stat::new_units_added:          312
stat::slowest_unit_time_sec:    0
No crasher on the 'roles' parse surface this run.
```

`slowest_unit_time_sec: 0` is the hang half of the property, and no reproducer was written, so the crash half holds for this run too. A clean run bounds nothing beyond the inputs it reached, which is why the target lands as a standing leg rather than as a one-off result.
