### PR TITLE
Name the screened discovery refusal in Test connection [#1064]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Changed
 
+- **Test connection now says when a provider's document was refused for its
+  shape (#1064).** An OpenID document that a provider serves perfectly well can
+  still be rejected before it is parsed, because it names the same JSON member
+  twice or because its body cannot be inspected as JSON at all. Test connection
+  reported both of those under the one message it had, which asks the
+  administrator to check that the endpoint is reachable, serves
+  `/.well-known/openid-configuration` and is served over HTTPS - all of which
+  were already true, so the diagnostic answered confidently and pointed
+  somewhere else. The two refusals now have their own messages, worded exactly
+  as the matching server-log entry, so an administrator reading the panel and
+  the log sees one wording rather than two. Every other read failure keeps the
+  message it had. Which member repeated stays in the server log and is not
+  echoed into the admin panel.
+
 - **Renamed to "Community SSO for Jellyfin".** The plugin's display name (the
   catalog entry, the dashboard plugin name, and the documentation) is now
   **Community SSO for Jellyfin**. The plugin GUID, the assembly, and the

--- a/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
+++ b/SSO-Auth.Tests/Http/ProviderConnectionTesterTests.cs
@@ -6,11 +6,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Http;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
@@ -75,6 +77,80 @@ public class ProviderConnectionTesterTests
         Assert.False(result.Ok);
         Assert.Contains("discovery document", result.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(result.Details);
+    }
+
+    [Fact]
+    public async Task TestOidcAsync_ADocumentTheScreenRefused_IsReportedUnderItsOwnCause()
+    {
+        // The probe is the one in-product diagnostic on the recovery path (#1064). A document the provider
+        // served fine and the screen refused used to arrive under the reachability/well-known/HTTPS message,
+        // which answers confidently and sends the admin to look at connectivity for a provider defect.
+        //
+        // The generic sentence's own marker is asserted ABSENT rather than the cause merely being asserted
+        // present: a probe that appended the new cause to the old one would satisfy a presence-only check
+        // while still telling the admin to go and check their TLS.
+        var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
+        var repeated = FullDiscovery(Authority).Insert(1, "\"issuer\":\"https://attacker.example\",");
+        var logger = new CapturingLogger();
+
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", FactoryFor(Serve(repeated)), logger);
+
+        Assert.False(result.Ok);
+        Assert.Contains(RepeatedMemberScreen.RefusalReason, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("/.well-known/openid-configuration", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(RepeatedMemberScreen.UninspectableReason, result.Message, StringComparison.Ordinal);
+
+        // The wording the admin reads on screen is the wording the server log carries, byte for byte, because
+        // both render one constant. Reword either side alone and this goes red, which is what keeps an admin
+        // matching the UI against the log from having to translate between two paraphrases.
+        Assert.Contains(
+            logger.Entries,
+            e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal)
+                && e.Message.Contains(RepeatedMemberScreen.RefusalReason, StringComparison.Ordinal));
+
+        // The member name is a provider-authored string, and every bound and filter it needs sits on the log
+        // entry rather than here. This surface is elevation-gated, so the reason it stays out is not the login
+        // path's disclosure question - it is that one place stays responsible for bounding it.
+        Assert.DoesNotContain("attacker.example", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TestOidcAsync_AnUninspectableBody_IsReportedApartFromTheRepeatedMember()
+    {
+        // The two screened refusals have different remedies - one is a provider defect to report, the other is
+        // a truncation or a charset problem - so collapsing them into one message loses the thing the admin
+        // came to the probe for. An unknown charset is the provider-reachable instance of the second.
+        var config = new OidConfig { OidEndpoint = Authority, OidClientId = "jf" };
+        var factory = FactoryFor(_ => JsonWithCharset(FullDiscovery(Authority), "zzMarkerCharsetzz"));
+
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+
+        Assert.False(result.Ok);
+        Assert.Contains(RepeatedMemberScreen.UninspectableReason, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(RepeatedMemberScreen.RefusalReason, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("/.well-known/openid-configuration", result.Message, StringComparison.Ordinal);
+
+        // The charset is the provider's to choose, so it is one more untrusted string and never reaches an
+        // admin-facing field, exactly as it never reaches the log entry.
+        Assert.DoesNotContain("zzMarkerCharsetzz", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TestOidcAsync_AFailureNoScreenRaised_KeepsTheReachabilityCause()
+    {
+        // The other direction, and the one that stops the new causes being reported for every failure. An
+        // unreachable endpoint is refused before any body exists to screen, so the reason stays Unnamed and
+        // the message that names what to CHECK is still the right one. Without this row, a probe that reported
+        // a screen refusal unconditionally would pass every assertion above.
+        var config = new OidConfig { OidEndpoint = "https://idp-unreachable.example.com", OidClientId = "jf" };
+        var factory = FactoryFor(_ => throw new HttpRequestException("unreachable"));
+
+        var result = await ProviderConnectionTester.TestOidcAsync(config, "kc", factory, Logger());
+
+        Assert.False(result.Ok);
+        Assert.Contains("/.well-known/openid-configuration", result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(RepeatedMemberScreen.RefusalReason, result.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(RepeatedMemberScreen.UninspectableReason, result.Message, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -239,6 +315,15 @@ public class ProviderConnectionTesterTests
 
         return new HttpResponseMessage(HttpStatusCode.NotFound);
     };
+
+    // A body the runtime cannot decode, because the Content-Type names a character set it does not know. The
+    // charset is provider-chosen, so this is the reachable instance of the screen's uninspectable refusal.
+    private static HttpResponseMessage JsonWithCharset(string body, string charset)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body) };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = charset };
+        return response;
+    }
 
     private static HttpResponseMessage Json(string body) =>
         new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };

--- a/SSO-Auth/Api/Http/ProviderConnectionTester.cs
+++ b/SSO-Auth/Api/Http/ProviderConnectionTester.cs
@@ -69,8 +69,7 @@ internal static class ProviderConnectionTester
         {
             // The reader already logged the fail-closed warning (with the library error, never a secret).
             // The admin-facing message stays generic: it names what to check, not any sensitive value.
-            return ProviderTestResult.Failure(
-                "Could not read the OpenID discovery document. Check that the endpoint is reachable, serves /.well-known/openid-configuration, and - unless HTTPS discovery is disabled - is served over HTTPS.");
+            return ProviderTestResult.Failure(CauseOf(discovery.Refusal));
         }
 
         var info = discovery.ProviderInformation;
@@ -143,6 +142,28 @@ internal static class ProviderConnectionTester
             return ProviderTestResult.Success("The SAML signing certificate parsed successfully.", details);
         }
     }
+
+    // Why the discovery read came back unavailable, in words that describe THIS failure (#1064). The probe is
+    // the one in-product diagnostic on the recovery path, so a message that answers confidently and points
+    // somewhere else is worse than a vague one: an admin whose provider serves a document the screen refuses
+    // would otherwise be sent to look at reachability, the well-known path and TLS, none of which is wrong.
+    //
+    // Each screened cause opens with the SAME constant the server log carries, so an admin matching the two
+    // sees one wording rather than two paraphrases of it. Neither names the repeated member. The surface is
+    // elevation-gated, so that is not the login path's disclosure question, but the member name is a
+    // provider-authored string and every bound and filter it needs sits on the log entry (#1068, #1194) and
+    // nowhere else; pointing at the log spends nothing and keeps one place responsible for it.
+    private static string CauseOf(OidcDiscoveryRefusal refusal) => refusal switch
+    {
+        OidcDiscoveryRefusal.RepeatedMember =>
+            RepeatedMemberScreen.RefusalReason
+            + ", so the OpenID discovery read was refused. The document was served and rejected before it was parsed, which is a defect to report to the identity provider - a document whose meaning depends on which reader parses it. The Jellyfin server log records which document and which member.",
+        OidcDiscoveryRefusal.Uninspectable =>
+            RepeatedMemberScreen.UninspectableReason
+            + ", so the OpenID discovery read was refused. That is usually a truncated body or a Content-Type naming a character set this server cannot decode, rather than a connectivity problem. The Jellyfin server log records which document and the failure it hit.",
+        _ =>
+            "Could not read the OpenID discovery document. Check that the endpoint is reachable, serves /.well-known/openid-configuration, and - unless HTTPS discovery is disabled - is served over HTTPS.",
+    };
 
     // A discovery value the admin can eyeball, or an explicit marker when the document did not advertise it,
     // so a blank field reads as "not advertised" rather than an empty line.

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -91,7 +91,14 @@ internal static class OidcDiscoveryReader
                     "Could not read the OpenID discovery document for provider {Provider}: {Error}. The login fails closed rather than proceeding on unverified discovery facts.",
                     provider?.ReplaceLineEndings(string.Empty),
                     discovery.Error?.ReplaceLineEndings(string.Empty));
-                return OidcDiscoveryResult.Unavailable;
+
+                // The screen's own record of what it refused, never a re-reading of the library's error
+                // text, so the reason the admin probe reports (#1064) cannot drift from the reason logged
+                // above. It is Unnamed when the read failed for any reason the screen did not raise - an
+                // unreachable endpoint, a policy rejection, the outbound size bound - and the caller then
+                // reports the generic cause rather than a specific wrong one. Nothing on the login path
+                // branches on it: that path fails closed on `Available` alone.
+                return OidcDiscoveryResult.Refused(screen.Refusal);
             }
 
             // Both facts come from the raw body of THIS response (the same bytes the metadata below is

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryRefusal.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryRefusal.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// Why a discovery read came back unavailable, for the surfaces that have to tell an operator what to do
+/// about it (#1064). The login path does not branch on this - it fails closed on any value - so the reason
+/// exists for the admin Test-connection probe, whose one job is to answer "why did this break".
+/// <para>
+/// It carries no provider-authored text. Each value maps to a constant the operator also sees in the server
+/// log, so the two read the same; WHICH member repeated stays in the log entry alone.
+/// </para>
+/// </summary>
+internal enum OidcDiscoveryRefusal
+{
+    /// <summary>
+    /// The read failed for a reason no screen named: unreachable, refused by the discovery policy, over the
+    /// outbound size bound, or a document the identity library itself would not accept. This is the default,
+    /// so a result that was never given a reason reports the generic cause rather than a specific wrong one.
+    /// </summary>
+    Unnamed = 0,
+
+    /// <summary>The response was refused by <see cref="RepeatedMemberScreen"/> for naming a JSON member twice.</summary>
+    RepeatedMember = 1,
+
+    /// <summary>The response was refused by <see cref="RepeatedMemberScreen"/> because its body could not be inspected as JSON.</summary>
+    Uninspectable = 2,
+}

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryResult.cs
@@ -15,18 +15,28 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// </summary>
 /// <param name="Facts">The PKCE-S256 (#141) and RFC 9207 response-<c>iss</c> (#210) facts read from the document.</param>
 /// <param name="ProviderInformation">The provider metadata built from the same document, or null when the read failed.</param>
-internal readonly record struct OidcDiscoveryResult(DiscoveryFacts Facts, ProviderInformation ProviderInformation)
+/// <param name="Refusal">
+/// Why an unavailable result is unavailable (#1064), for the admin Test-connection probe. The login path
+/// never branches on it: <see cref="Available"/> alone decides, so no value of this can open a door.
+/// </param>
+internal readonly record struct OidcDiscoveryResult(DiscoveryFacts Facts, ProviderInformation ProviderInformation, OidcDiscoveryRefusal Refusal)
 {
     /// <summary>Gets a value indicating whether the discovery document was read (the facts and metadata are usable).</summary>
     internal bool Available => ProviderInformation is not null;
 
-    /// <summary>Gets the failed-read result - no facts, no metadata - on which the caller fails the login closed.</summary>
+    /// <summary>Gets the failed-read result - no facts, no metadata, no named reason - on which the caller fails the login closed.</summary>
     internal static OidcDiscoveryResult Unavailable => default;
+
+    /// <summary>The same failed read, carrying the reason a caller may report to an administrator.</summary>
+    /// <param name="refusal">Why the read came back unavailable.</param>
+    /// <returns>An unavailable result naming its reason.</returns>
+    internal static OidcDiscoveryResult Refused(OidcDiscoveryRefusal refusal) =>
+        Unavailable with { Refusal = refusal };
 
     /// <summary>A successful read: the facts and the provider metadata, both from the one discovery response.</summary>
     /// <param name="facts">The facts parsed from the discovery document.</param>
     /// <param name="providerInformation">The provider metadata built from the same document (never null on success).</param>
     /// <returns>An available result carrying both.</returns>
     internal static OidcDiscoveryResult From(DiscoveryFacts facts, ProviderInformation providerInformation) =>
-        new(facts, providerInformation);
+        new(facts, providerInformation, OidcDiscoveryRefusal.Unnamed);
 }

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -43,6 +43,7 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
     private readonly HttpClient _client;
     private readonly string? _provider;
     private readonly ILogger _logger;
+    private OidcDiscoveryRefusal _refusal;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RepeatedMemberScreen"/> class.
@@ -56,6 +57,18 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
         _provider = provider;
         _logger = logger;
     }
+
+    /// <summary>
+    /// Gets the refusal this screen made, or <see cref="OidcDiscoveryRefusal.Unnamed"/> if it refused nothing
+    /// (#1064). The reader hands this to its caller so the admin probe can say WHY a read failed instead of
+    /// naming reachability at a document that arrived fine and was rejected. It is the screen's own record
+    /// rather than a re-reading of the library's error text, so the two cannot drift apart.
+    /// <para>
+    /// A read fetches two documents through one screen, so a refusal on either leg is reported; the last one
+    /// wins, and there is no second leg after a refusal because the first one ends the read.
+    /// </para>
+    /// </summary>
+    internal OidcDiscoveryRefusal Refusal => _refusal;
 
     /// <summary>
     /// Forwards the request and screens a successful response's body before it reaches the library.
@@ -100,7 +113,7 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
             // the day the read is no longer pre-buffered, and
             // ABodyThatCannotBeCopied_ReachesNeitherTheHttpRequestExceptionNorTheIOExceptionArm goes red on
             // exactly that day, so keeping them stays a checkable claim rather than a decorative one.
-            return Refuse(request, response, UninspectableReason, cause: e);
+            return Refuse(request, response, OidcDiscoveryRefusal.Uninspectable, cause: e);
         }
 
         // The walk still reports WHICH member repeated; this unit deliberately does not log it (#1068).
@@ -110,7 +123,11 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
             return response;
         }
 
-        return Refuse(request, response, verdict == StrictJson.Verdict.Repeated ? RefusalReason : UninspectableReason, cause: null);
+        return Refuse(
+            request,
+            response,
+            verdict == StrictJson.Verdict.Repeated ? OidcDiscoveryRefusal.RepeatedMember : OidcDiscoveryRefusal.Uninspectable,
+            cause: null);
     }
 
     // Records why the response is being withheld and returns the constant-reason refusal in its place.
@@ -126,8 +143,13 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
     // Only the exception TYPE is logged, never its message: the message quotes the provider's own
     // Content-Type, so it is one more untrusted string, while the type name is runtime-authored and
     // distinguishes the decode failures an operator has to tell apart.
-    private HttpResponseMessage Refuse(HttpRequestMessage request, HttpResponseMessage response, string reason, Exception? cause)
+    private HttpResponseMessage Refuse(HttpRequestMessage request, HttpResponseMessage response, OidcDiscoveryRefusal refusal, Exception? cause)
     {
+        // One mapping from the refusal to the words an operator reads, so the log entry and the admin probe
+        // that reports the same refusal (#1064) cannot be reworded apart.
+        var reason = refusal == OidcDiscoveryRefusal.RepeatedMember ? RefusalReason : UninspectableReason;
+        _refusal = refusal;
+
         _logger.LogWarning(
             "Refused the OpenID {Document} for provider {Provider}: {Reason}{Cause}. The read fails closed rather than handing on a document whose meaning depends on which reader parses it.",
             DocumentKind(request),


### PR DESCRIPTION
# What & why

Closes #1064.

`ProviderConnectionTester.TestOidcAsync` is the one in-product diagnostic on the
recovery path: an administrator whose login broke opens **Test connection** to
find out why. It runs the same `OidcDiscoveryReader.ReadAsync` the login runs, so
it reaches the repeated-member refusal and the uninspectable refusal that
`RepeatedMemberScreen` added, but the causes it named were written before either
existed. A document the provider served correctly and this plugin rejected
before parsing came back as _"Check that the endpoint is reachable, serves
`/.well-known/openid-configuration`, and is served over HTTPS"_ - three things
that were already true. That is the worst shape a diagnostic can take: it
answers confidently and points somewhere else.

What changed, at the seam rather than at the message:

- `RepeatedMemberScreen` records which refusal it made, as its own field set in
  the one place that builds a refusal.
- `OidcDiscoveryReader` hands that record to its caller on the `IsError` return.
  It reads the screen, never the identity library's error text, so the reason on
  screen and the reason in the log cannot drift apart.
- `OidcDiscoveryResult` carries the reason; `ProviderConnectionTester` renders
  one message per refusal, each opening with the same compile-time constant the
  server log entry carries.

The three decisions #1064 asked the implementer to take, and where they landed:

1. **Does the probe surface the member name?** No. The surface is
   elevation-gated, so this is not the login path's disclosure question - the
   reason is ownership. The member name is a provider-authored string, and every
   bound and character filter it needs sits on the log entry (#1068, #1194) and
   nowhere else. The probe points at the server log, which costs nothing and
   keeps one place responsible for bounding it. Asserted absent, along with the
   provider-offered charset.
2. **Does it distinguish "repeated member" from "could not be inspected"?** Yes,
   two messages. The remedies differ: one is a provider defect to report, the
   other is usually a truncation or a charset problem. Each message asserts the
   other's constant absent, so collapsing them reddens the suite.
3. **Shared vocabulary.** Both messages render
   `RepeatedMemberScreen.RefusalReason` / `.UninspectableReason` verbatim, and a
   test drives the probe and reads the captured log for the same fixture,
   asserting the same constant in both. Reword either side alone and it goes
   red.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: nothing on the login path branches on the new
      reason. `OidcDiscoveryReader` still returns an unavailable result, and
      every caller still decides on `Available` alone, so no value of the enum
      opens a door. The default is `Unnamed`, so a read that failed for a reason
      no screen raised - unreachable, refused by the discovery policy, over the
      outbound size bound - still reports the generic cause rather than a
      specific wrong one, and a row pins that direction.
- [x] No secrets logged; secrets are redacted on config export. No secret is
      touched by this change, and `TestOidcAsync_NeverLeaksTheStoredClientSecret`
      still passes.
- [ ] A security review was performed. **It was not.** No second reader looked
      at this change, and nothing here should be read as reviewed. The evidence
      below stands in place of one rather than claiming to be one.
- [ ] Review record. **There is none**, for the same reason. No lens was run, so
      there are no CONFIRMED or PLAUSIBLE counts to report and no findings to
      dispose of.
- [x] Log inputs from the IdP are sanitized inline at the log call. The log call
      is untouched by this change; what is new is a reason value carried out of
      the screen, and it is an enum rather than a string, so no provider-authored
      text can travel on it.

## Quality checklist

- [x] No duplicated logic. One place maps a refusal to the words an operator
      reads, inside `RepeatedMemberScreen.Refuse`, and the probe renders the same
      two constants rather than paraphrasing them.
- [x] The change adds no more code than the problem requires: one enum, one
      factory on the existing result, one field on the screen, one switch in the
      probe.
- [x] Comments explain why, not what.
- [x] Architecture-conformance tests pass. No new structural property is
      established here: no conformance rule names `RepeatedMemberScreen` or the
      probe today, and this change adds no rule of its own.
- [x] Docs impact considered. The two new admin-facing messages are the wording
      #1063 exists to document, and #1063 is open and carries it; this adds no
      option and no configuration surface, so no README or wiki page is stale
      because of it.

## Verification

- [x] Both target frameworks built with `--warnaserror`, 0 warnings, 0 errors.
- [x] Full suite green on both: 2656 passing on `net9.0` and 2657 on `net10.0`,
      0 failed, 4 skipped.
- [x] Prettier clean for the one file it covers here, `CHANGELOG.md`; no `.js`,
      `.html`, `.css` or `.scss` file is touched.

Each guard was proven by running the mutation, not by describing it. Restored
after each run and the file compared byte-for-byte against its backup.

| Mutation                                                       | Result                                                                                                                       |
| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
| The probe's cause switch collapses back to the single message   | 2 failed: `ADocumentTheScreenRefused_IsReportedUnderItsOwnCause`, `AnUninspectableBody_IsReportedApartFromTheRepeatedMember`  |
| The reader stops carrying the screen's record                    | the same 2 failed                                                                                                            |
| Every failure reported as the repeated-member cause              | 2 failed: `AFailureNoScreenRaised_KeepsTheReachabilityCause` and the pre-existing `UnreadableDiscovery_FailsClosedWithActionableMessage` |

## Notes

Four tests are skipped, unchanged by this branch. One of them binds a listener
off loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). It was not run and no workaround was attempted.

The repository-wide Prettier check reports warnings on files this branch does
not touch. They are present on a clean checkout of `main` in this environment
too and look like a line-ending artefact of the Windows working tree rather than
tracked content; #1066 is where that belongs. Nothing here is claimed about how
that check resolves on the server.
