### PR TITLE
Bound the provider-authored text in the discovery read's warning [#1194]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **An identity provider can no longer write unbounded log through a failed
+  discovery read (#1194).** When a discovery or JWKS fetch failed, the
+  fail-closed warning quoted the identity library's error text whole, and that
+  text names the URL the fetch was connecting to. On the JWKS leg the provider
+  chooses that URL, because its own discovery document named it in `jwks_uri`,
+  so a hostile server could put as much text in the log as it liked, once per
+  anonymous login challenge, with only the 1 MB response cap in the way.
+  Measured before the fix: a document advertising a 200 KB `jwks_uri` produced a
+  205,042-character entry from a single read. The quoted text is now cut at 512
+  characters with a `[truncated]` marker, so a cut entry cannot be mistaken for
+  a whole one, and the endpoint an operator reads the entry to find still
+  survives in every ordinary failure.
+
 - **A back-channel logout that did not happen is now its own audit entry.** When
   an identity provider orders a session termination and the plugin cannot reach
   that provider to verify the request, the termination does not happen and the

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins the bound on the provider-authored text in <see cref="OidcDiscoveryReader"/>'s fail-closed warning
+/// (#1194).
+///
+/// The value under test is NOT the plugin's. The library's error text quotes the URL it was connecting to,
+/// and on the JWKS leg the provider chose that URL: the discovery document named it in <c>jwks_uri</c>. So a
+/// hostile authorization server writes as much log as it likes, once per anonymous challenge, with nothing
+/// but the 1 MB response cap in the way. Measured before the bound existed: a document advertising a 200 KB
+/// <c>jwks_uri</c> produced a 205,042-character entry.
+///
+/// The screen's own refusal entry is a different call and needs no bound - it carries no provider-authored
+/// text at all, which the same measurement showed (211 characters against an 800 KB repeated member name).
+/// That is why the bound lives here and not there.
+///
+/// Both directions are pinned, because a ceiling-only test passes against a bound tightened to a stub, and a
+/// stub would throw away the endpoint an operator reads the entry to find. The mutation each test kills is
+/// named on the test.
+/// </summary>
+public class OidcDiscoveryReaderErrorBoundTests
+{
+    private const string Authority = "https://idp-bound.example.com";
+
+    // Comfortably past the 512-character bound, and past any URL a working deployment produces, so the
+    // fixture actually reaches the truncation rather than sitting under it - which is how the first attempt
+    // at this bound shipped something no test could kill.
+    private const int LongSegmentChars = 8192;
+
+    [Fact]
+    public async Task AProviderAuthoredJwksUrl_DoesNotReachTheWarningUnbounded()
+    {
+        // Kills: deleting the truncation and logging discovery.Error whole.
+        var segment = new string('u', LongSegmentChars);
+        var logger = new CapturingLogger();
+
+        var result = await ReadAsync(logger, JwksUri(Authority + "/" + segment));
+
+        Assert.False(result.Available);
+        var warning = FailClosedWarning(logger);
+
+        // The entry is bounded, and bounded well below what the provider sent rather than merely "shorter".
+        Assert.True(
+            warning.Length < LongSegmentChars,
+            $"the fail-closed warning carries {warning.Length} characters against an {LongSegmentChars}-character provider-authored URL");
+        Assert.Contains("[truncated]", warning, StringComparison.Ordinal);
+
+        // And the provider cannot get a long run of its own bytes in even below the total length: a bound
+        // applied to the wrong operand, or applied after concatenation, would still let a long run through.
+        Assert.DoesNotContain(new string('u', 1024), warning, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AnOrdinaryErrorText_ReachesTheWarningWhole()
+    {
+        // Kills: tightening the bound to a stub. A two-character ceiling passes the test above and destroys
+        // the entry an operator reads to find WHICH endpoint failed, so the floor is pinned separately.
+        var logger = new CapturingLogger();
+
+        var result = await ReadAsync(logger, JwksUri(Authority + "/jwks"));
+
+        Assert.False(result.Available);
+        var warning = FailClosedWarning(logger);
+
+        // The endpoint the read failed on survives intact, and so does the marker's absence: an untruncated
+        // entry must not claim to have been cut.
+        Assert.Contains(Authority + "/jwks", warning, StringComparison.Ordinal);
+        Assert.DoesNotContain("[truncated]", warning, StringComparison.Ordinal);
+    }
+
+    // A discovery document naming the given jwks_uri. Everything else is the smallest set of members the
+    // library maps, so the only thing that varies between the two tests is the provider-authored URL.
+    private static string JwksUri(string jwks) =>
+        "{"
+        + $"\"issuer\":\"{Authority}\","
+        + $"\"authorization_endpoint\":\"{Authority}/authorize\","
+        + $"\"token_endpoint\":\"{Authority}/token\","
+        + $"\"jwks_uri\":\"{jwks}\","
+        + "\"response_types_supported\":[\"code\"],"
+        + "\"subject_types_supported\":[\"public\"],"
+        + "\"id_token_signing_alg_values_supported\":[\"RS256\"]}";
+
+    private static async Task<OidcDiscoveryResult> ReadAsync(ILogger logger, string discovery)
+    {
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new Router(discovery)));
+
+        var options = new OidcClientOptions { Authority = Authority };
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(Authority).GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.ValidateEndpoints = false;
+
+        return await OidcDiscoveryReader.ReadAsync(options, "bound", factory, logger);
+    }
+
+    private static string FailClosedWarning(CapturingLogger logger)
+    {
+        var entry = Assert.Single(
+            logger.Entries,
+            e => e.Message.StartsWith("Could not read the OpenID discovery document", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        return entry.Message;
+    }
+
+    // Serves the discovery document and refuses the JWKS leg with a repeated member, so the read fails at
+    // the JWKS fetch and the library's error names the provider-chosen URL it was connecting to.
+    private sealed class Router : HttpMessageHandler
+    {
+        private readonly string _discovery;
+
+        internal Router(string discovery) => _discovery = discovery;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.AbsoluteUri;
+            var body = url.EndsWith("/.well-known/openid-configuration", StringComparison.Ordinal)
+                ? _discovery
+                : "{\"keys\":[],\"keys\":[]}";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
@@ -83,6 +83,44 @@ public class OidcDiscoveryReaderErrorBoundTests
         Assert.DoesNotContain("[truncated]", warning, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll()
+    {
+        // The other value #1194 names, and the reason the bound above is not also applied to the screen's
+        // refusal entry: that entry carries no provider-authored text, so there is nothing there to bound.
+        // Asserted rather than assumed, because "satisfied by exclusion" stops being true the moment
+        // something starts logging the member name, and #1068 is the issue that may decide to. This row goes
+        // red on that day and makes the bound owed at that call too.
+        var name = new string('m', 800 * 1024);
+        var logger = new CapturingLogger();
+
+        var result = await ReadAsync(logger, RepeatedMember(name));
+
+        Assert.False(result.Available);
+
+        var refusal = Assert.Single(
+            logger.Entries,
+            e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));
+        Assert.True(
+            refusal.Message.Length < 1024,
+            $"the refusal entry carries {refusal.Message.Length} characters against an {name.Length}-character provider-authored member name");
+        Assert.DoesNotContain(new string('m', 1024), refusal.Message, StringComparison.Ordinal);
+
+        // And no other entry carries it either, so the name is not merely absent from the entry this row
+        // reads while travelling on the one beside it.
+        Assert.DoesNotContain(
+            logger.Entries,
+            e => e.Message.Contains(new string('m', 1024), StringComparison.Ordinal));
+    }
+
+    // A discovery document naming one member twice, so the screen refuses it on the FIRST leg and the name
+    // is the only thing in it a provider chose to make large.
+    private static string RepeatedMember(string name) =>
+        "{"
+        + $"\"{name}\":\"a\","
+        + $"\"{name}\":\"b\","
+        + $"\"issuer\":\"{Authority}\"}}";
+
     // A discovery document naming the given jwks_uri. Everything else is the smallest set of members the
     // library maps, so the only thing that varies between the two tests is the provider-authored URL.
     private static string JwksUri(string jwks) =>

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -35,6 +35,24 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// </summary>
 internal static class OidcDiscoveryReader
 {
+    /// <summary>
+    /// How much of the library's error text the fail-closed warning may carry (#1194). The text quotes the
+    /// URL the fetch was connecting to, and on the JWKS leg that URL is PROVIDER-AUTHORED - the discovery
+    /// document named it in <c>jwks_uri</c>. Measured: a document advertising a 200 KB <c>jwks_uri</c> put a
+    /// 205,042-character entry in the log, driven by one anonymous challenge, and the response cap
+    /// (<see cref="Net.ProviderResponseSizeLimit.MaxProviderResponseBytes"/>, 1 MB) is the only thing that
+    /// bounded it at all.
+    ///
+    /// 512 is chosen to sit well above every error text a working deployment produces - the longest is
+    /// "Error connecting to " plus an endpoint URL plus the transport's reason - and far below the point
+    /// where repeating the request fills a disk. An operator who needs the whole string has the exception
+    /// itself on the catch-all arm below.
+    /// </summary>
+    private const int MaxLoggedProviderErrorChars = 512;
+
+    /// <summary>Marks an error text this reader cut, so a truncated entry is not read as the whole error.</summary>
+    private const string ErrorTruncationMarker = "[truncated]";
+
     // The discovery/JWKS fetch is bounded so a slow or hanging authorization server cannot stall the
     // anonymous challenge endpoint. This is now the login-critical discovery (its result is fed to
     // PrepareLoginAsync), so the bound is tighter than the platform-default ~100s the library's own
@@ -87,17 +105,27 @@ internal static class OidcDiscoveryReader
                 // The provider name and the library error are stripped of line endings inline at the log
                 // call so an admin-supplied value or a reflected server string cannot forge or split the
                 // entry (the log-forging sanitizer never crosses a helper boundary).
+                //
+                // The error is BOUNDED here too, for the same reason it is stripped here: it is not the
+                // plugin's string. It quotes the URL the library was connecting to, which on the JWKS leg
+                // the provider chose, so an unbounded entry lets one anonymous challenge write as much log
+                // as the response cap allows. The truncation is inline for the same reason the strip is -
+                // moving either into a helper takes the sanitizer out of the call the analyzer reads.
+                var error = discovery.Error ?? string.Empty;
                 logger.LogWarning(
                     "Could not read the OpenID discovery document for provider {Provider}: {Error}. The login fails closed rather than proceeding on unverified discovery facts.",
                     provider?.ReplaceLineEndings(string.Empty),
-                    discovery.Error?.ReplaceLineEndings(string.Empty));
+                    (error.Length > MaxLoggedProviderErrorChars
+                        ? string.Concat(error.AsSpan(0, MaxLoggedProviderErrorChars), ErrorTruncationMarker)
+                        : error).ReplaceLineEndings(string.Empty));
 
                 // The screen's own record of what it refused, never a re-reading of the library's error
                 // text, so the reason the admin probe reports (#1064) cannot drift from the reason logged
                 // above. It is Unnamed when the read failed for any reason the screen did not raise - an
                 // unreachable endpoint, a policy rejection, the outbound size bound - and the caller then
                 // reports the generic cause rather than a specific wrong one. Nothing on the login path
-                // branches on it: that path fails closed on `Available` alone.
+                // branches on it: that path fails closed on `Available` alone. The bound above is on the
+                // TEXT this entry carries, and none of it travels on that record: the reason is an enum.
                 return OidcDiscoveryResult.Refused(screen.Refusal);
             }
 

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -26,7 +26,10 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// rejects CR/LF/NUL with a <see cref="FormatException"/>, so a member name spelled with an escaped line feed
 /// would make this handler throw while building its own refusal; and sanitising the name to fit would place a
 /// sanitiser one helper boundary away from the log call, which is exactly what the log-forging invariant
-/// forbids. So the reason phrase is a constant and the member name is logged here, stripped inline.
+/// forbids. So the reason phrase is a constant, and the member name reaches neither the response nor this
+/// handler's own entry: the walk reports it and the call site discards it (#1068 is where logging it is
+/// decided, and what bounding and filtering it would owe). AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll
+/// is what holds that, so this paragraph stays a checkable claim rather than a description that drifted.
 /// </summary>
 internal sealed class RepeatedMemberScreen : HttpMessageHandler
 {


### PR DESCRIPTION
# What & why

Closes #1194.

An identity provider could write as much log as it liked through a failed
discovery read, once per anonymous login challenge. `OidcDiscoveryReader`'s
fail-closed warning quotes the identity library's error text, that text names the
URL the fetch was connecting to, and on the JWKS leg the provider chose that URL,
because its own discovery document named it in `jwks_uri`. Nothing bounded it but
the 1 MB response cap. Measured through the real reader over a stub transport: a
document advertising a 200 KB `jwks_uri` produced a 205,042-character entry from
one read.

The quoted text is now cut at 512 characters with a `[truncated]` marker, inline
at the log call for the same reason the line-ending strip is inline there:
moving either into a helper takes the sanitizer out of the call the analyzer
reads.

**The bound is not where the issue said it would be, and that is on purpose.**
The issue names the screen's own refusal entry. That entry carries no
provider-authored text at all: the walk reports which member repeated and the
call site discards it, and the document kind is a constant chosen from a fixed
pair of two. So an 800 KB member name produces a 211-character entry there, the
400 KB entry the issue describes does not reproduce, and the value that is
genuinely unbounded sits one frame up at the caller. The first commit bounds the
value that is real.

The second commit turns the issue's first Done-when from a measurement somebody
wrote down into a check somebody re-runs. "Satisfied by exclusion" stops being
true the moment something starts logging the member name, and #1068 is the issue
that may decide to, so a row now drives an 800 KB repeated name through the real
reader and requires that no entry anywhere carries a long run of it. The same
commit corrects the class comment on `RepeatedMemberScreen`, which said the
member name is logged there, stripped inline. It is not, and has not been since
that unit narrowed.

The first commit was written on 2026-08-07 and could not be pushed from the
machine it was made on; it is cherry-picked here unchanged apart from one
conflict against #1064, which merged into the same `if (discovery.IsError)`
block earlier today. The resolution keeps both: the bound on the text, and the
refusal record the probe reads.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Nothing about the refusal changes: the read still
      returns an unavailable result and every caller still fails the login
      closed. Only what the warning prints is different.
- [x] No secrets logged. The bound removes text from a log entry and adds none.
- [ ] A security review was performed. **It was not.** No second reader looked at
      this change. The evidence below stands in place of one and is not a
      substitute for one.
- [ ] Review record. **There is none**, for the same reason: no lens was run, so
      there are no CONFIRMED or PLAUSIBLE counts and no findings to dispose of.
- [x] Log inputs from the IdP are sanitized inline at the log call. The
      truncation joins the line-ending strip in the same call rather than in a
      helper, which is what keeps the CodeQL sanitizer on the path it reads.

## Quality checklist

- [x] No duplicated logic; the bound is one expression at the one call that
      carries the value.
- [x] The change adds no more code than the problem requires: two constants and
      one conditional.
- [x] Comments explain why, not what. The constant's own comment says where 512
      comes from and what an operator who needs the whole string still has.
- [x] Architecture-conformance tests pass. No new structural property.
- [x] Docs impact considered. Nothing user-configurable changes and no option is
      added, so no README or wiki page goes stale; the CHANGELOG carries the
      operator-visible half.

## Verification

- [x] Both target frameworks built with `--warnaserror`, 0 warnings, 0 errors.
- [x] Full suite green on both: 2659 passing on `net9.0`, 2660 on `net10.0`, 0
      failed, 4 skipped.
- [x] Prettier clean on `CHANGELOG.md`, the one covered file touched.

Every guard was proven by running its mutation on this branch, not by citing the
earlier run. Restored after each and the file compared against its backup.

| Mutation                                            | Result                                                                                                          |
| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| The truncation deleted, the error logged whole       | `AProviderAuthoredJwksUrl_DoesNotReachTheWarningUnbounded` failed: "the fail-closed warning carries 8434 characters against an 8192-character provider-authored URL" |
| The bound tightened to two characters                | `AnOrdinaryErrorText_ReachesTheWarningWhole` failed: the endpoint an operator reads the entry to find no longer survives |
| The screen made to log the repeated member name      | `AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll` failed                                                 |

One mutation attempt earlier in this session did not compile, and the runner
executed the previous binary and reported green. That run is not counted above;
each result in the table is from a build that succeeded.

## Notes

Not covered, and unchanged by this branch: the catch-all arm below the bounded
call logs the exception object rather than a string. Whether a provider can drive
its message long is not measured, and bounding a value handed to `LogWarning` as
an exception is the sink's decision rather than this call's.

Four tests are skipped, unchanged by this branch. One binds a listener off
loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). It was not run and no workaround was attempted.
