### PR TITLE
Refuse the roles when two copies of the role claim disagree [#1040]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,17 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   filter for OpenID logout failures finds them. The HTTP response is unchanged:
   every rejection is still the one uniform 400 with nothing that distinguishes
   the branches to the caller.
+- **A document that says two things about a user's roles now grants none of
+  them.** When a provider's UserInfo response names the role claim twice, the
+  two copies reach the plugin as two separate claims, each one clean on its own,
+  so the screen that refuses a repeated member inside a claim value never saw
+  them. The roles of both copies were merged, which means a second copy naming
+  an extra role granted that role. Copies that disagree are now refused
+  outright: the login proceeds with no roles rather than with the union.
+  Providers that emit the same role claim in both the id_token and the UserInfo
+  response are unaffected, because copies that agree still grant, and so is the
+  common shape of one claim per group, which is a list written as repeated
+  claims rather than two statements about one object.
 - **A provider response that names a JSON member twice is refused before it is
   parsed.** A repeated member is accepted silently by every reader these
   documents reach, and none of them raises an error, so which of the two values a

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -295,6 +295,101 @@ public class OidcAuthorizeStateBuilderTests
     }
 
     [Fact]
+    public void ARepeatedObjectValuedRoleClaim_WhoseCopiesDisagree_GrantsNeitherCopysRoles()
+    {
+        // With LoadProfile on (the default) OidcClient merges the UNSIGNED UserInfo response into the
+        // principal, so a UserInfo body naming the role claim twice arrives here as two claims of one type.
+        // Each copy is individually clean, so the value-level screen (#1005) never fires on it, and
+        // appending them granted the UNION - the second copy's "admins" among them.
+        //
+        // The fixture is the exact document from #1040: {"realm_access": {...}, "realm_access": {...}}.
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.RoleClaim = "realm_access.roles";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "alice"),
+                ("realm_access", "{\"roles\":[\"users\"]}"),
+                ("realm_access", "{\"roles\":[\"admins\"]}")),
+            config);
+
+        // Neither copy's roles are granted, not merely the second one's: a document that says two things
+        // about the roles says nothing this login can act on.
+        Assert.False(result.Admin);
+        Assert.Empty(result.Folders);
+    }
+
+    [Fact]
+    public void ARepeatedObjectValuedRoleClaim_WhoseCopiesAgree_StillGrants()
+    {
+        // The positive control for the row above, and the reason it compares rather than counts. A provider
+        // that emits the role claim in BOTH the id_token and the UserInfo response produces two claims of
+        // one type saying the same thing. Refusing on the count alone would take every role from that
+        // ordinary deployment.
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.RoleClaim = "realm_access.roles";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "alice"),
+                ("realm_access", "{\"roles\":[\"admins\"]}"),
+                ("realm_access", "{\"roles\":[\"admins\"]}")),
+            config);
+
+        Assert.True(result.Admin);
+    }
+
+    [Fact]
+    public void ARepeatedObjectMapRoleClaim_WhoseCopiesDisagree_GrantsNothing()
+    {
+        // The object-map opt-in (#934) reads the roles from the property NAMES, and a one-segment path there
+        // is still object-valued: the claim value IS the terminal object. So the same comparison applies,
+        // and the row exists because the shape reaches a different branch of the extractor.
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.RoleClaim = "urn:zitadel:iam:org:project:roles";
+            c.RoleClaimIsObjectMap = true;
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(
+                ("preferred_username", "alice"),
+                ("urn:zitadel:iam:org:project:roles", "{\"users\":{\"7364\":\"example.com\"}}"),
+                ("urn:zitadel:iam:org:project:roles", "{\"admins\":{\"7364\":\"example.com\"}}")),
+            config);
+
+        Assert.False(result.Admin);
+    }
+
+    [Fact]
+    public void AProviderEmittingOneClaimPerGroup_KeepsBeingUnioned()
+    {
+        // The shape the comparison must NOT catch: a one-segment path over plain string values, where a
+        // provider emits the claim once per group. Those copies are meant to be unioned - they are a list
+        // written as repeated claims, not two statements about one object - so a rule that refused every
+        // repeated role-claim type would silently strip the roles of every provider that emits groups this
+        // way. Deliberately disagreeing values, which is exactly what makes the shape legitimate.
+        var config = Config(c =>
+        {
+            c.AdminRoles = new[] { "admins" };
+            c.RoleClaim = "groups";
+        });
+
+        var result = OidcAuthorizeStateBuilder.Build(
+            Claims(("preferred_username", "alice"), ("groups", "users"), ("groups", "admins")),
+            config);
+
+        Assert.True(result.Admin);
+    }
+
+    [Fact]
     public void SubFallback_WhenNotValidAndRolesEmpty_UsesSubAndIsValid()
     {
         // No preferred-username claim, an empty (non-null) allow-list → the sub claim is the username

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -203,7 +203,7 @@ internal static class OidcAuthorizeStateBuilder
 
         string? username = null;
         var valid = false;
-        var roles = new List<string>();
+        var copies = new List<List<string>>();
         foreach (var claim in claims)
         {
             if (string.Equals(claim.Type, usernameClaimType, StringComparison.Ordinal))
@@ -220,11 +220,57 @@ internal static class OidcAuthorizeStateBuilder
                 // The walk now says WHY it produced what it produced (#1147). This step reads only the roles
                 // and discards the reason deliberately: reporting it is #1149's step, and folding the two
                 // together would put a behaviour change behind a pure classification.
-                roles.AddRange(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value, config.RoleClaimIsObjectMap).Roles);
+                //
+                // Each copy is kept SEPARATE rather than appended to one list, because how several copies
+                // combine is a decision, and appending made it silently (#1040).
+                copies.Add(OidcRoleExtractor.ExtractRoles(roleClaimSegments, claim.Value, config.RoleClaimIsObjectMap).Roles);
             }
         }
 
-        return (username, valid, roles);
+        return (username, valid, RolesFromCopies(copies, roleClaimSegments, config));
+    }
+
+    /// <summary>
+    /// Reduces the copies of the role claim a document carried to the role set the login is granted.
+    /// </summary>
+    /// <remarks>
+    /// One copy is the ordinary case and stands as it is. SEVERAL copies of an OBJECT-VALUED role claim are
+    /// two statements about the same thing, and the plugin never sees the bytes behind them: with
+    /// <c>LoadProfile</c> on (the default) OidcClient merges the UNSIGNED UserInfo response into the
+    /// principal, so a UserInfo body naming the claim twice arrives here as two claims of one type, each
+    /// individually clean, which is why the value-level screen (#1005) never fires on it. Appending them
+    /// granted the UNION, so a second copy naming an extra role was granted that role (#1040).
+    /// <para>
+    /// Copies that AGREE still grant. A provider that emits the claim in both the id_token and the UserInfo
+    /// response says one thing twice, and refusing that would take every role from a normal deployment.
+    /// Copies that DISAGREE grant nothing: a document that says two things about the roles says nothing
+    /// this login can act on, and the fail-closed reading is the one that cannot be talked into a
+    /// privilege. The refusal is silent for now; the operator trail for a refused role claim is #1042.
+    /// </para>
+    /// <para>
+    /// Scoped to the object-valued shapes on purpose. A provider emitting one claim per group - a
+    /// one-segment path over plain string values - is a normal, documented shape whose copies are MEANT to
+    /// be unioned, so it keeps the append.
+    /// </para>
+    /// </remarks>
+    /// <param name="copies">The roles each copy of the role claim produced, in document order.</param>
+    /// <param name="roleClaimSegments">The split role-claim path; more than one segment means the claim value is JSON.</param>
+    /// <param name="config">The provider configuration, for the object-map opt-in.</param>
+    /// <returns>The roles the login is granted.</returns>
+    private static List<string> RolesFromCopies(List<List<string>> copies, string[] roleClaimSegments, OidConfig config)
+    {
+        if (copies.Count <= 1)
+        {
+            return copies.Count == 1 ? copies[0] : new List<string>();
+        }
+
+        if (roleClaimSegments.Length == 1 && !config.RoleClaimIsObjectMap)
+        {
+            return copies.SelectMany(copy => copy).ToList();
+        }
+
+        var first = new HashSet<string>(copies[0], StringComparer.Ordinal);
+        return copies.TrueForAll(first.SetEquals) ? copies[0] : new List<string>();
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

Closes #1040.

`OidcAuthorizeStateBuilder.ScanClaims` appended the roles of every claim whose
type matched the configured role claim, so a claim list carrying that type twice
granted the union of both copies. With `LoadProfile` on, which is the default,
OidcClient merges the unsigned UserInfo response into the principal, so a
UserInfo body naming the role claim twice arrives here as two claims of one type.
Each copy is individually clean, which is exactly why the value-level screen
(#1005) never fires on it.

Measured on the builder, with the allow-list satisfied by the first copy and the
admin role in the second:

```
both copies:      valid=True  admin=True
first copy alone: valid=True  admin=False
```

So the difference the repeat makes is not a longer role list. It is
administrator.

## Which of the issue's two candidate directions this takes

The issue offers refusing when the role-claim type appears more than once, or
unioning only when every copy agrees and refusing otherwise. This is the second,
and the first is deliberately not taken.

Counting is wrong for a measurable reason rather than an aesthetic one. A
provider emitting the role claim in both the id_token and the UserInfo response
produces two claims of one type saying the same thing, and a count-based rule
takes every role from that deployment. Weakening 2 below is that rule, and it
reddens an existing parental-rating row written for something else, which says
the count would break a documented feature and not only an invented fixture.

The comparison is scoped to the object-valued shapes, so the ordinary
one-claim-per-group shape - a one-segment path over plain strings - keeps its
union. Its copies are a list written as repeated claims and are meant to
disagree.

Copies that do disagree grant nothing at all, rather than the intersection. Both
readings satisfy the acceptance criterion, and refusal is the one that cannot be
talked into a privilege by a provider that is half-trusted.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a claim list that says two things about the roles
      grants none of them, and the login then survives only if something else
      validated it.
- [x] No secrets logged. Nothing is logged by this change at all, which is the
      cost named under Notes.
- [ ] A security review was performed. **It was not.** No second reader looked at
      this change. The measurements below stand in place of one and are not a
      substitute for one.
- [ ] Review record. **There is none**: no lens was run, so there are no
      CONFIRMED or PLAUSIBLE counts and no findings to dispose of.
- [x] Log inputs from the IdP are sanitized inline at the log call - not
      applicable, no log call is added.

## Quality checklist

- [x] No duplicated logic. The reduction is one private method with the decision
      in it, and the loop above it now records rather than decides.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why, not what. The method's remarks say why agreement
      rather than count, and why the object-valued scope.
- [x] Architecture-conformance tests pass. No new structural property.
- [x] Docs impact considered. No option and no configuration surface is added,
      and the behaviour change is operator-visible only as a refusal, which the
      CHANGELOG carries.

## Verification

- [x] Both target frameworks built with `--warnaserror`, 0 warnings, 0 errors.
- [x] Full suite green on both: 2663 passing on `net9.0`, 2664 on `net10.0`, 0
      failed, 4 skipped.
- [x] Prettier clean on `CHANGELOG.md`, the one covered file touched.

Both weakenings were run on this branch, full suite each time so a row breaking
something else would show. The file was restored and compared against its backup
after each.

| Weakening                                                     | Result                                                                                                                                          |
| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| The union restored                                             | 2 failed: `ARepeatedObjectValuedRoleClaim_WhoseCopiesDisagree_GrantsNeitherCopysRoles`, `ARepeatedObjectMapRoleClaim_WhoseCopiesDisagree_GrantsNothing`. Nothing else moved. |
| Refusal on the count alone, ignoring agreement and shape scope | 3 failed: `ARepeatedObjectValuedRoleClaim_WhoseCopiesAgree_StillGrants`, `AProviderEmittingOneClaimPerGroup_KeepsBeingUnioned`, and the existing `ParentalRating_MatchedRole_CarriesTheMinimumCeilingOnTheState` |

## Notes

**The refusal is silent, and that is a real gap.** Threading a logger through the
builder's call chain is #1042's subject and belongs there. Until it lands, a
refused role claim looks to an operator exactly like a provider that sent no
roles.

**One link in the original chain is still read rather than executed.** The step
from a UserInfo document naming the claim twice to two `Claim` instances happens
inside `Duende.IdentityModel.OidcClient`, and the library's own profile load was
not driven here. What is measured is that the reader preserves both members and
that this builder unions whatever claim list it is handed. If the library folds
the duplicate itself, the reported route disappears and the guard costs nothing;
the id_token route to two claims of one type does not depend on it either way.
The acceptance criteria are met by the property the builder now holds rather
than by that unmeasured step, and stating this is not a claim that the step was
checked.

The change was written on 2026-08-06 and could not be pushed from the machine it
was made on. It is cherry-picked onto current `main` unchanged apart from the
`CHANGELOG.md` merge, whose entry and the back-channel logout entry both wanted
the top of one section; keeping both is the whole resolution. The commit message
is amended: the original dropped half a sentence about the missing operator
trail, which is the one gap it most needed to state.

Four tests are skipped, unchanged by this branch. One binds a listener off
loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). It was not run and no workaround was attempted.
