### PR TITLE
Refuse a token whose JWS header marks an extension critical [#1038]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,25 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   a cause, so a refused document currently shows there under a check that does not
   describe it.
 
+- **A token whose JWS header marks an extension critical is refused (#1038).**
+  RFC 7515 §4.1.11 requires a recipient to reject a token whose `crit` header
+  names an extension it does not understand and process. The plugin implements
+  no JWS extension, and the token library ignores `crit` entirely, so a
+  genuinely signed `id_token` or back-channel `logout_token` carrying one was
+  accepted with the constraint it declared silently dropped — an extension is
+  marked critical precisely because ignoring it changes what the token asserts,
+  such as a narrowed audience or a proof-of-possession binding. Both token paths
+  now refuse such a token from one shared rule, so they cannot drift apart.
+
+  This was not exploitable on its own: the token still had to carry a signature
+  from a key the provider's own JWKS advertises, so nobody could mint one. What
+  changes is that a provider using a JWS extension the plugin cannot honour now
+  gets a refusal rather than a login granted on terms the plugin never applied.
+  The back-channel refusal carries its own reason code
+  (`unprocessed_critical_header`) rather than the generic signature failure, so
+  an operator can tell a provider that needs a feature apart from an attempted
+  forgery.
+
 ## 4.3.0
 
 A feature release. This line advances the plugin's maturity to **Beta** on the

--- a/SSO-Auth.Tests/Oidc/OidcCriticalHeaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcCriticalHeaderTests.cs
@@ -29,6 +29,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// logout endpoint does not is the drift <see cref="OidcSignatureKeys"/> exists to prevent.
 /// </para>
 /// </summary>
+[Collection("SSOController")]
 public sealed class OidcCriticalHeaderTests : IDisposable
 {
     private const string Issuer = "https://idp.example.test";

--- a/SSO-Auth.Tests/Oidc/OidcCriticalHeaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcCriticalHeaderTests.cs
@@ -1,0 +1,222 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// RFC 7515 §4.1.11 on both token paths (#1038): a JWS whose header carries <c>crit</c> is refused,
+/// because this plugin implements no JWS extension and therefore understands and processes none of them.
+/// <para>
+/// Every token below is GENUINELY SIGNED by the key the JWKS advertises and is otherwise valid, and each
+/// rejection test is paired with the same token minus the header. Without that pairing a rejection proves
+/// nothing about <c>crit</c> - a fixture the code cannot parse is refused by the signature check and the
+/// test passes for a reason it does not name.
+/// </para>
+/// <para>
+/// The two paths are asserted against ONE predicate on purpose. The handler ignores <c>crit</c> outright,
+/// so this is the plugin's own rule, and a rule the id_token path holds while the anonymous back-channel
+/// logout endpoint does not is the drift <see cref="OidcSignatureKeys"/> exists to prevent.
+/// </para>
+/// </summary>
+public sealed class OidcCriticalHeaderTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+    private const string UnknownExtension = "http://example.test/unknown";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcIdTokenValidator _idTokenValidator = new();
+    private readonly OidcLogoutTokenValidator _logoutValidator = new();
+
+    public OidcCriticalHeaderTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    /// <summary>
+    /// The shapes a <c>crit</c> member can arrive in. All are refused, and the refusal is one rule rather
+    /// than six: the plugin processes no extension, so no value could make the header acceptable and the
+    /// malformed shapes §4.1.11 forbids need no branch of their own.
+    /// <para>
+    /// The <c>json-string</c>, <c>number</c> and <c>bool</c> rows are the near-miss this file is built
+    /// around. They are what a <c>crit</c> written by hand rather than by a library looks like, and they
+    /// are the rows that die if the guard reads the member as a TYPE instead of asking whether it is
+    /// there: <c>JsonWebToken.TryGetHeaderValue&lt;JsonElement&gt;("crit", out _)</c> returns FALSE for
+    /// each of them - measured, not assumed - so a typed read reports the member absent and admits the
+    /// token. Every other row here survives that mistake, which is why it needs its own rows.
+    /// </para>
+    /// </summary>
+    public static TheoryData<string, object> CriticalHeaderShapes => new()
+    {
+        { "named-extension", new[] { UnknownExtension } },
+        { "json-string", UnknownExtension },
+        { "number", 5 },
+        { "bool", true },
+        { "empty-array", Array.Empty<string>() },
+        { "null-member", new string?[] { null } },
+        { "empty-string-member", new[] { string.Empty } },
+        { "registered-header-name", new[] { "alg" } },
+        { "duplicate-member", new[] { UnknownExtension, UnknownExtension } },
+        { "object", new Dictionary<string, object>() },
+    };
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public async Task IdToken_WithoutCriticalHeader_IsAccepted()
+    {
+        // The positive control the rejections below are read against: this fixture differs from them by
+        // the header member and nothing else, so a rejection there is attributable to crit.
+        var result = await _idTokenValidator.ValidateAsync(IdToken(), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Theory]
+    [MemberData(nameof(CriticalHeaderShapes))]
+    public async Task IdToken_WithCriticalHeader_IsRejected(string shape, object crit)
+    {
+        var token = IdToken(new Dictionary<string, object> { ["crit"] = crit });
+
+        var result = await _idTokenValidator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError, shape);
+        Assert.Contains("critical header", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task IdToken_CriticalHeaderNamingAProcessedExtension_IsStillRejected()
+    {
+        // A provider that marks a member critical AND supplies it gets no better treatment. The plugin
+        // reads no JWS extension, so "understood and processed" is false for every name that can appear.
+        var token = IdToken(new Dictionary<string, object>
+        {
+            ["crit"] = new[] { UnknownExtension },
+            [UnknownExtension] = true,
+        });
+
+        var result = await _idTokenValidator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+    }
+
+    [Fact]
+    public async Task LogoutToken_WithoutCriticalHeader_IsAccepted()
+    {
+        var result = await _logoutValidator.ValidateAsync(LogoutToken(), Options(), DateTime.UtcNow);
+
+        Assert.True(result.IsValid, result.ReasonCode);
+        Assert.Equal("user-1", result.Subject);
+    }
+
+    [Theory]
+    [MemberData(nameof(CriticalHeaderShapes))]
+    public async Task LogoutToken_WithCriticalHeader_IsRejected(string shape, object crit)
+    {
+        var token = LogoutToken(new Dictionary<string, object> { ["crit"] = crit });
+
+        var result = await _logoutValidator.ValidateAsync(token, Options(), DateTime.UtcNow);
+
+        Assert.False(result.IsValid, shape);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.CriticalHeader, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task LogoutToken_CriticalHeaderRefusal_IsNotTheGenericInvalidCode()
+    {
+        // The code is what an operator alerts on. Collapsing this into signature_or_time_invalid would
+        // report a provider defect as a forgery attempt, and the two want different responses.
+        var result = await _logoutValidator.ValidateAsync(
+            LogoutToken(new Dictionary<string, object> { ["crit"] = new[] { UnknownExtension } }), Options(), DateTime.UtcNow);
+
+        Assert.NotEqual(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("!!!.eyJpc3MiOiJoIn0.sig")]
+    [InlineData(".eyJhbGciOiJSUzI1NiJ9.sig")]
+    [InlineData("eyJub3QtanNvbg.payload.sig")]
+    public void UnreadableHeader_IsNotRefusedHere(string? token)
+    {
+        // The gate is not the fail-closed floor and must not pretend to be one: a header it cannot read is
+        // passed on to the handler, which refuses the token on its own terms and with an accurate reason.
+        // These inputs also reach the two catch arms from outside - the back-channel endpoint is anonymous,
+        // so an unhandled decode or parse failure here would be a 500 an unauthenticated caller can drive.
+        Assert.True(OidcSignatureKeys.TokenHasNoCriticalHeader(token));
+    }
+
+    [Fact]
+    public void HeaderWithoutCrit_IsAcceptedByThePredicate()
+    {
+        // The predicate's own positive control: it must not refuse every token it can read.
+        Assert.True(OidcSignatureKeys.TokenHasNoCriticalHeader(IdToken()));
+    }
+
+    // --- helpers ---
+
+    private OidcClientOptions Options()
+    {
+        var p = _rsa.ExportParameters(false);
+        var jwks = $$"""
+            {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """;
+        return new OidcClientOptions
+        {
+            ClientId = ClientId,
+            ClockSkew = TimeSpan.FromMinutes(5),
+            ProviderInformation = new ProviderInformation
+            {
+                IssuerName = Issuer,
+                KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
+            },
+        };
+    }
+
+    private string IdToken(IDictionary<string, object>? header = null) =>
+        Sign(new Dictionary<string, object> { ["sub"] = "user-1", ["preferred_username"] = "alice" }, header);
+
+    private string LogoutToken(IDictionary<string, object>? header = null) =>
+        Sign(
+            new Dictionary<string, object>
+            {
+                ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
+                ["jti"] = Guid.NewGuid().ToString(),
+                ["sub"] = "user-1",
+            },
+            header);
+
+    private string Sign(IDictionary<string, object> claims, IDictionary<string, object>? header)
+    {
+        var now = DateTime.UtcNow;
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = claims,
+            AdditionalHeaderClaims = header,
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        });
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -51,6 +51,14 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
                 return Reject("Identity token validation failed: unacceptable kid");
             }
 
+            // RFC 7515 4.1.11: a header naming a critical extension this plugin does not process is
+            // refused (#1038). Screened here rather than by the handler because the handler ignores crit
+            // entirely, and from the same shared predicate the logout_token path calls.
+            if (!OidcSignatureKeys.TokenHasNoCriticalHeader(identityToken))
+            {
+                return Reject("Identity token validation failed: unprocessed critical header");
+            }
+
             var handler = new JsonWebTokenHandler { MapInboundClaims = false };
             var result = await handler.ValidateTokenAsync(identityToken, OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
             if (!result.IsValid)

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -65,6 +65,14 @@ internal sealed class OidcLogoutTokenValidator
             return new Result(false, null, null, RejectReason.UnacceptableKeyId);
         }
 
+        // RFC 7515 4.1.11, from the same shared predicate the id_token path calls (#1038). The handler
+        // below ignores crit, so without this a genuinely signed token could assert a constraint this
+        // plugin never applied - and this endpoint is anonymous, which is where that matters most.
+        if (!OidcSignatureKeys.TokenHasNoCriticalHeader(logoutToken))
+        {
+            return new Result(false, null, null, RejectReason.CriticalHeader);
+        }
+
         // ECDsa instances built from the JWKS are ours to dispose; RSA keys built from RSAParameters are
         // not disposable. Owned here rather than by the caller because the basis is now built here too -
         // the finally must not run until ValidateTokenAsync has returned (#1176).
@@ -182,6 +190,9 @@ internal sealed class OidcLogoutTokenValidator
     {
         /// <summary>The token was absent, unparseable, or not a JWT.</summary>
         internal const string Malformed = "malformed";
+
+        /// <summary>The header carries a crit parameter, naming a JWS extension this plugin does not process (RFC 7515 4.1.11, #1038).</summary>
+        internal const string CriticalHeader = "unprocessed_critical_header";
 
         /// <summary>Signature, issuer, audience, algorithm, or lifetime validation failed (unsigned, wrong key, weak alg, expired).</summary>
         internal const string Invalid = "signature_or_time_invalid";

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -139,6 +139,65 @@ internal static class OidcSignatureKeys
     }
 
     /// <summary>
+    /// Whether a compact-serialized JWT's header is free of the <c>crit</c> parameter (RFC 7515 §4.1.11,
+    /// #1038). A recipient MUST reject a token whose <c>crit</c> names an extension it does not understand
+    /// AND process; this plugin implements no JWS extension at all, so the rule collapses to a presence
+    /// test: <c>crit</c> in the header means refuse. Both token paths call this, so the id_token and the
+    /// <c>logout_token</c> cannot drift on it, exactly as they share the algorithm allowlist.
+    /// <para>
+    /// Not exploitable on its own - the token must still carry a signature from a key in the discovery
+    /// JWKS. What it prevents is semantic: an IdP marks a header extension critical precisely because
+    /// ignoring it changes what the token asserts (a narrowed audience, a scope restriction, a
+    /// proof-of-possession binding), so accepting one means acting on an assertion whose stated
+    /// constraints were silently dropped.
+    /// </para>
+    /// <para>
+    /// The member is looked up by PRESENCE - <c>object</c>, the one type every JSON value converts to -
+    /// and not by reading it as the string array §4.1.11 says a well-formed <c>crit</c> is. Reading it as
+    /// a typed value is the mistake this spelling exists to avoid, and the difference is measured rather
+    /// than supposed: <c>TryGetHeaderValue&lt;JsonElement&gt;</c> reports a STRING-valued <c>crit</c> as
+    /// ABSENT, so a typed read admits <c>"crit":"urn:example:ext"</c> - a malformed <c>crit</c>, which the
+    /// RFC forbids too, walking through the guard meant to stop it. Presence subsumes every malformed
+    /// shape the RFC lists (non-array, empty array, empty or duplicate member, registered header name, a
+    /// bare null): no extension is processed here, so nothing about the value could make it acceptable.
+    /// </para>
+    /// <para>
+    /// A token this cannot read at all is reported as free of it rather than refused, the same contract
+    /// (and the same reason) as <see cref="TokenHasAcceptableKeyId"/>: this gate is not the fail-closed
+    /// floor. The handler that follows owns signature, issuer, audience and lifetime and refuses an
+    /// unreadable token on its own terms, and refusing from here would replace an accurate rejection
+    /// reason with a misleading one. It reads the header through the token library for the same reason
+    /// that predicate does - so the plugin gains no second, unscreened JSON parse over provider bytes.
+    /// </para>
+    /// </summary>
+    /// <param name="token">The raw compact-serialized JWT.</param>
+    /// <returns><c>false</c> only when a header member named <c>crit</c> was positively read.</returns>
+    internal static bool TokenHasNoCriticalHeader(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return true;
+        }
+
+        try
+        {
+            return !new JsonWebToken(token).TryGetHeaderValue<object>("crit", out _);
+        }
+        catch (ArgumentException)
+        {
+            // Not a readable JWT. The handler rejects it on its own terms; see the remark above.
+            return true;
+        }
+        catch (FormatException)
+        {
+            // A later segment that will not base64url-decode, the same shape TokenHasAcceptableKeyId
+            // documents. This endpoint is anonymous, so an escaping decode failure would be a 500 an
+            // unauthenticated caller can drive.
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Builds the signature/issuer/audience/lifetime validation parameters every JWT the plugin verifies
     /// against a provider uses - the id_token and the back-channel logout_token share this ONE builder, so
     /// their signature posture cannot drift apart. Signed + expiring tokens are required (fail closed); the


### PR DESCRIPTION
# What & why

Closes #1038.

RFC 7515 §4.1.11 says a recipient that does not understand an extension named in
`crit` must reject the JWS. This plugin processes no JWS extension at all, and
until now it ignored the header on both token paths. Measured through
`OidcIdTokenValidator.ValidateAsync` rather than against the library handler, so
what it reports is this plugin's posture:

```
crit:["http://example.test/unknown"] and the member itself  ->  IsError=False
crit:[]                                                     ->  IsError=False
crit:"http://example.test/unknown"                          ->  IsError=False
crit:[null]                                                 ->  IsError=False
```

Every fixture is signed by the key its JWKS advertises and is otherwise valid, so
acceptance was attributable to the header being ignored and not to anything else
in the token. A `crit` an implementation ignores changes what the token asserts:
a narrowed audience, a scope restriction, a proof-of-possession binding.
Accepting one means acting on an assertion whose stated constraints were silently
dropped.

The rule lands once, as a predicate in `OidcSignatureKeys` beside the `kid`
screen, and both validators call it. They already share one basis, so this is one
enforcement point rather than two, and the back-channel path carries its own
reason code instead of a generic signature failure.

Two implementation notes that are not visible from the issue text and both
changed the code:

**The obvious reading of the header is a new JSON parse, and the tree refuses
one.** `UntrustedJson_IsParsedOnlyThroughTheScreenedSeam` went red on a
`JsonDocument.Parse` of the decoded header segment, correctly: that is
provider-authored input parsed with no screen in front of it. Reading the header
through the token library, which has already parsed it, adds no parse site.

**The typed accessor is a fail-open.**
`TryGetHeaderValue<JsonElement>("crit", out _)` returns **false** when `crit` is
a JSON string, a number or a boolean, so a guard written that way reports the
member absent and admits exactly the malformed shapes §4.1.11 also forbids. The
lookup is therefore by presence, `object` being the one type every JSON value
converts to. Measured over nine shapes: `TryGetHeaderValue<object>` is true for
all nine and false only when the member is absent.

An unreadable token is reported as free of `crit` rather than refused, the same
contract and the same reason as the neighbouring `kid` predicate: this gate is
not the fail-closed floor, and refusing from here would replace an accurate
rejection reason with a misleading one.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. The guard only ever adds a rejection; the handler
      behind it still owns signature, issuer, audience and lifetime, and the
      unreadable-token arm defers to it rather than short-circuiting.
- [x] No secrets logged. Nothing is logged by this change.
- [ ] A security review was performed. **It was not.** No second reader looked at
      this change. The measurements below stand in place of one and are not a
      substitute for one.
- [ ] Review record. **There is none**: no lens was run, so there are no
      CONFIRMED or PLAUSIBLE counts and no findings to dispose of.
- [x] Log inputs from the IdP are sanitized inline at the log call - not
      applicable, no log call is added.

## Quality checklist

- [x] No duplicated logic. One predicate, called from both validators, beside the
      `kid` screen that holds the same shape of contract.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why, not what. The predicate's remarks record why presence
      and not the typed read, with the measurement behind it.
- [x] Architecture-conformance tests pass, including the untrusted-JSON parse-site
      rule that shaped the implementation and the non-parallel-collection rule the
      second commit answers. No new structural property is established here.
- [x] Docs impact considered. No option and no configuration surface is added; a
      provider using `crit` was already outside what this plugin supports, and the
      CHANGELOG carries the operator-visible half.

## Verification

- [x] Both target frameworks built with `--warnaserror`, 0 warnings, 0 errors.
- [x] Full suite green on both: 2695 passing on `net9.0`, 2696 on `net10.0`, 0
      failed, 4 skipped.
- [x] Prettier clean on `CHANGELOG.md`, the one covered file touched.

Both mutations were run on this branch, full suite each time, and the file was
restored and compared against its backup after each.

| Mutation                                              | Result                                                                                                                                 |
| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
| The guard deleted, so the predicate always reports no `crit` | 21 rows red. The 11 that stay green are the positive controls and the unreadable-header contract, which must not depend on it.       |
| The typed accessor in place of presence                | 6 rows red, and exactly the expected 6: `json-string`, `number` and `bool` on both the id_token and the logout_token path. Nothing else moved. |

## Notes

The change was written on 2026-08-07 and could not be pushed from the machine it
was made on; it is cherry-picked onto current `main` unchanged. It arrived red
rather than wrong: `EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection`
landed after it was written, and the new test class opens a process-wide door by
calling `OidcLogoutTokenValidator.ResetReplaysForTests`. The second commit adds
`[Collection("SSOController")]` and changes nothing else about the rows.

One correction to that second commit's message, made here because the branch is
pushed and a force-push is not on the table. It says it also reflows the
CHANGELOG entry to Prettier. Prettier was run and reported the file clean, and
the commit carries one file and one line: the only difference was line endings,
which `.gitattributes` normalises, so no CHANGELOG change is in that commit. The
CHANGELOG entry itself is in the first commit and is unchanged.

Four tests are skipped, unchanged by this branch. One binds a listener off
loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). It was not run and no workaround was attempted.
