### PR TITLE
Pin that a repeated scalar aud collapses to the last occurrence [#1193]

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
@@ -200,6 +200,49 @@ public sealed class OidcIdTokenValidatorTests : IDisposable
     }
 
     [Fact]
+    public async Task RepeatedAudience_CollapsesToTheLastOccurrence()
+    {
+        // #1193: a payload naming "aud" twice as a scalar does not present two audiences to the token
+        // library - the last occurrence wins and Audiences carries exactly one value. Because
+        // CheckAudienceRestriction fires on Audiences.Count() > 1, the OIDC Core 3.1.3.7 rules 3-4
+        // rejection never engages on a token minted for two parties in that form. This pin records the
+        // behaviour rather than guarding it (whether a guard is warranted is decided elsewhere), so a
+        // change in the library surfaces here instead of at a login.
+        using var raw = new OidcTokenFixture(Issuer, ClientId);
+        var options = Options(jwks: raw.Jwks());
+        var now = DateTimeOffset.UtcNow;
+        var times = $"\"iat\":{now.AddMinutes(-15).ToUnixTimeSeconds()},"
+            + $"\"nbf\":{now.AddMinutes(-15).ToUnixTimeSeconds()},"
+            + $"\"exp\":{now.AddMinutes(5).ToUnixTimeSeconds()}";
+
+        var repeated = raw.RawPayloadIdToken(
+            $"{{\"iss\":\"{Issuer}\",\"aud\":\"other-api\",\"aud\":\"{ClientId}\",\"sub\":\"user-1\",{times}}}");
+
+        // The observable, with the surviving value named: asserting only the count would stay green if a
+        // future reader kept "other-api" instead, and first-versus-last is the difference between a token
+        // this client accepts and one it rejects outright.
+        Assert.Equal(ClientId, Assert.Single(new JsonWebToken(repeated).Audiences));
+
+        // The consequence: two audiences in the bytes, no azp, and the token is accepted.
+        var result = await _validator.ValidateAsync(repeated, options, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+
+        // The contrast beside it, one edit away: the same two audiences expressed as a JSON array still
+        // reach the rule as two, and are rejected. The pair is what shows the rule is live and that only
+        // the repeated-member form evades it.
+        var array = raw.RawPayloadIdToken(
+            $"{{\"iss\":\"{Issuer}\",\"aud\":[\"other-api\",\"{ClientId}\"],\"sub\":\"user-1\",{times}}}");
+
+        Assert.Equal(2, new JsonWebToken(array).Audiences.Count());
+
+        var arrayResult = await _validator.ValidateAsync(array, options, TestContext.Current.CancellationToken);
+
+        Assert.True(arrayResult.IsError);
+        Assert.Equal("Identity token validation failed: multiple audiences without azp", arrayResult.Error);
+    }
+
+    [Fact]
     public async Task NullEntryInJwks_IsSkipped_GoodKeyStillValidates()
     {
         // A JWKS carrying a literal null entry must not 500 the login (skip-on-malformed contract).


### PR DESCRIPTION
# What & why

An id_token payload naming `aud` twice as a scalar does not reach the audience rule as two audiences. The token library keeps the last occurrence, so `JsonWebToken.Audiences` carries one value and `CheckAudienceRestriction` - which fires on `azp == null && token.Audiences.Count() > 1` - never engages. A token minted for two parties in that form is accepted, where the same two audiences written as a JSON array are rejected.

This adds the pin that records it. No production code changes.

The test asserts the observable with the surviving value named rather than only the count: a reader that kept the first occurrence instead would leave a count-only assertion green while turning a token this client accepts into one it refuses. Beside it, one edit away, the array form is asserted rejected with the exact error string, which is what shows the rule is live and that only the repeated-member form evades it.

The payload is signed through `OidcTokenFixture.RawPayloadIdToken`. A payload built from a claim dictionary cannot emit a repeated member at all, so the ordinary builder cannot ask this question.

Whether the collapse warrants refusing a repeated `aud`, or reading the audiences off the raw payload, stays out of scope exactly where the issue puts it. That decision is taken from what this records.

Closes #1193

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test-only. The behaviour under test is on the login path; the change to it is not.

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review ran on this change and no second person read it.** Those two boxes stay unticked and this sentence is the disclosure, not a softening of it. What stands in place of a reader is the falsification below and the fact that `git diff --name-only origin/main...HEAD` names one file, a test file:

    git diff --name-only origin/main...HEAD
    SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs

The fail-closed and inline-sanitizer boxes are ticked as unchanged rather than as re-verified: no production line moved, so neither posture could move either.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The pin establishes no structural property; the conformance suite runs as part of the full suite below and is green. No user-visible behaviour changes, so there is no CHANGELOG entry and no README or wiki impact.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, built with `--warnaserror`, 0 warnings, then the suite run through the built runner:

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2696, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
    ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2697, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

The four skips are the loopback-bind tests that need an administrator on Windows (#1227). They were skipped, not worked around, and they are unrelated to this change.

The Prettier box is ticked vacuously: the change touches no `.js`, `.html`, `.md`, `.css` or `.scss` file.

The .NET 10 leg matters here rather than being ceremony. That is the framework where duplicate-property strictness arrived, so the collapse could plausibly have differed there. It does not: the same test passes on both legs, and the reader in play is the identity library's own rather than a `JsonSerializerOptions` this project configures.

## Falsification

Both assertions were made to fail before the pin was kept, each by a mutation aimed at one of them.

Widening the rule to `azp == null && token.Audiences.Count() > 2` in `OidcIdTokenValidator.CheckAudienceRestriction`:

    Jellyfin.Plugin.SSO_Auth.Tests.OidcIdTokenValidatorTests.RepeatedAudience_CollapsesToTheLastOccurrence [FAIL]
      Assert.True() Failure
      Expected: True
      Actual:   False

That is the array half: the contrast case stops being rejected, so the pin is reading the live rule and not restating a tautology.

Expecting the first occurrence as the survivor instead of the last:

    Jellyfin.Plugin.SSO_Auth.Tests.OidcIdTokenValidatorTests.RepeatedAudience_CollapsesToTheLastOccurrence [FAIL]
      Assert.Equal() Failure: Strings differ
      Expected: "other-api"
      Actual:   "jellyfin-client"

That is the collapse half: the assertion reads the surviving value rather than passing on whatever one value it finds. Both mutations were reverted and the suite re-run green before the commit.

## Notes

Out of scope, and named so it is not read as covered: whether a repeated `aud` should be refused outright. That is a guard, this is a measurement, and the issue puts the decision after this record exists.
