### PR TITLE
Prove the non-parallel-collection rule can go red [#1173]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3062,22 +3062,13 @@ public class ArchitectureConformanceTests
 
             var source = File.ReadAllText(src);
 
-            // Support types (no [Fact]/[Theory]) are not scheduled by the runner, so they cannot race
-            // anything; the harness itself opens six doors and would otherwise be a permanent offender.
-            if (!SourceCallsInCode(source, "[Fact]") && !SourceCallsInCode(source, "[Theory]"))
-            {
-                continue;
-            }
-
-            var serialized = SourceCallsInCode(source, "[Collection(\"SSOController\")]");
-            foreach (var door in doors.Where(door => SourceCallsInCode(source, door)))
+            foreach (var door in DoorsNamedByTestBearingSource(source, doors))
             {
                 users[door].Add(Path.GetFileName(src));
-                if (!serialized)
-                {
-                    offenders.Add(Path.GetFileName(src) + " opens " + door);
-                }
             }
+
+            offenders.AddRange(DoorsOpenedUnserialized(source, doors)
+                .Select(door => Path.GetFileName(src) + " opens " + door));
         }
 
         Assert.True(
@@ -3107,6 +3098,74 @@ public class ArchitectureConformanceTests
                 $"'{opener}' no longer calls '{door}', so the declared indirection is gone; the door needs a test user of its own or the hook needs removing.");
         }
     }
+
+    /// <summary>
+    /// The per-file decision of the rule above, fed synthetic source: one must-catch fixture and three
+    /// must-not-catch twins, each a single edit away from it and each falsifying a DIFFERENT conjunct of
+    /// the decision. Without the pair the rule is only ever observed passing on a clean tree, which is
+    /// indistinguishable from a scan that has gone blind (#1173).
+    /// <para>
+    /// Which twin moves under which mutation is not symmetric, and it follows from what the decision does.
+    /// It reports a file that is test-bearing, names a door, and is NOT serialized, so deleting the
+    /// collection check can only make it report MORE files: the offender was reported before that deletion
+    /// and still is, while the SERIALIZED twin goes from silent to reported. A mutation aimed at the
+    /// offender row would therefore change nothing observable and read as if the check had been proved.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void NonParallelRule_PerFileDecision_ReportsTheOffenderAndSparesEachTwin()
+    {
+        var doors = ProcessWideDoors();
+        const string Door = "OidcLoginService.ResetOidStateForTests";
+
+        // Sentinel: these fixtures say nothing if that name is no longer a derived door. The pair would go
+        // quiet for a reason unrelated to the conjuncts it exists to falsify, which is the failure a
+        // fixture-fed rule is most able to hide.
+        Assert.Contains(Door, doors, StringComparer.Ordinal);
+
+        static string Fixture(string attributes, string body) => string.Join(
+            "\n",
+            attributes,
+            "public sealed class DoorProbe",
+            "{",
+            "    public void Reset()",
+            "    {",
+            body,
+            "    }",
+            "}");
+
+        var call = "        " + Door + "();";
+
+        // Must-catch: test-bearing, names the door in code, no serializing attribute.
+        Assert.Equal(new[] { Door }, DoorsOpenedUnserialized(Fixture("[Fact]", call), doors));
+
+        // Twin 1, falsifying the code-line reader: the door named only in a comment. A whole-file text
+        // search reports this file, and removing a call while documenting the removal in a comment that
+        // names it is the edit that reads as diligence.
+        Assert.Empty(DoorsOpenedUnserialized(Fixture("[Fact]", "        // " + Door + "();"), doors));
+
+        // Twin 2, falsifying the collection check: the serializing attribute present, nothing else changed.
+        Assert.Empty(DoorsOpenedUnserialized(Fixture("[Collection(\"SSOController\")]\n[Fact]", call), doors));
+
+        // Twin 3, falsifying the test-bearing check: no [Fact]/[Theory] at all. This is what keeps the
+        // harness support type off the offender list although it opens six doors.
+        Assert.Empty(DoorsOpenedUnserialized(Fixture(string.Empty, call), doors));
+    }
+
+    // Every derived door a source names in CODE, or nothing at all when the source declares no test. A
+    // support type is never scheduled by the runner, so it cannot race anything; the harness itself opens
+    // six doors and would otherwise be a permanent offender.
+    private static IReadOnlyList<string> DoorsNamedByTestBearingSource(string source, IEnumerable<string> doors) =>
+        SourceCallsInCode(source, "[Fact]") || SourceCallsInCode(source, "[Theory]")
+            ? doors.Where(door => SourceCallsInCode(source, door)).ToList()
+            : Array.Empty<string>();
+
+    // The rule's whole per-file decision: the doors a source opens without carrying the serializing
+    // collection attribute. Takes source rather than a path so the pair above can be a string (#1173).
+    private static IReadOnlyList<string> DoorsOpenedUnserialized(string source, IEnumerable<string> doors) =>
+        SourceCallsInCode(source, "[Collection(\"SSOController\")]")
+            ? Array.Empty<string>()
+            : DoorsNamedByTestBearingSource(source, doors);
 
     // Every process-wide door a test can reach: the test-only hooks the production tree declares, keyed
     // Type.Method exactly as a call site spells them, plus the harness construction. Derived rather than


### PR DESCRIPTION
# What & why

`EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection` has only ever been observed passing on a clean tree, and a scan that has gone blind passes identically. This gives it a fixture pair that makes it fail on demand.

The rule's per-file decision moves out of the directory walk into two predicates over source TEXT, so a fixture can be a string instead of a file on disk: the doors a test-bearing source names in code, and the doors it opens without carrying `[Collection("SSOController")]`. The walk calls them and is otherwise unchanged - same offender list, same per-door floor, same derived door set.

The pair is one must-catch fixture with three must-not-catch twins, each a single edit away and each answering a different conjunct:

- the door named only in a comment answers the code-line reader
- the `[Collection("SSOController")]` attribute present answers the collection check
- a source with no `[Fact]`/`[Theory]` answers the test-bearing check, which is what keeps the harness support type off the offender list although it opens six doors

Closes #1173

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test-only. No file under `SSO-Auth/` is touched.

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review ran on this change and no second person read it.** Those two boxes stay unticked and this sentence is the disclosure rather than a softening of it. What stands in its place is the falsification section below and the diff surface:

    git diff --name-only origin/main...HEAD
    SSO-Auth.Tests/ArchitectureConformanceTests.cs

The two ticked security boxes are ticked as unchanged, not as re-verified: no production line moved, so neither posture could move.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The extraction removes a duplicated decision rather than adding one: the walk previously spelled the three conjuncts inline and nothing else could ask them. No user-visible behaviour changes, so there is no CHANGELOG entry and no README or wiki impact.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror`, 0 warnings, then the suite through the built runner:

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2696, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
    ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2697, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

The four skips are the loopback-bind tests that need an administrator on Windows (#1227). They were skipped, not worked around, and are unrelated to this change.

The Prettier box is ticked vacuously: the change touches no `.js`, `.html`, `.md`, `.css` or `.scss` file.

## Falsification

Which twin moves under which mutation is not symmetric, and it follows from what the decision does rather than from how it is spelled. The decision reports a file that is test-bearing, names a door, and is NOT serialized, so deleting the collection check can only ever make it report MORE files: the must-catch fixture was reported before that deletion and still is, while the serialized twin goes from silent to reported. A mutation aimed at the must-catch row would therefore have changed nothing observable and read as if the check had been proved.

Each row was made to fail by the mutation it answers, one at a time, then reverted.

Collection check replaced by `false`:

    NonParallelRule_PerFileDecision_ReportsTheOffenderAndSparesEachTwin [FAIL]
      Assert.Empty() Failure: Collection was not empty
      Collection: ["OidcLoginService.ResetOidStateForTests"]
      ArchitectureConformanceTests.cs(3148,0)      <- the serialized twin

Test-bearing check replaced by `true`:

    Assert.Empty() Failure: Collection was not empty
      Collection: ["OidcLoginService.ResetOidStateForTests"]
      ArchitectureConformanceTests.cs(3152,0)      <- the no-[Fact] twin

`SourceCallsInCode` reading raw text instead of code lines:

    Assert.Empty() Failure: Collection was not empty
      Collection: ["OidcLoginService.ResetOidStateForTests"]
      ArchitectureConformanceTests.cs(3145,0)      <- the comment-only twin

The door scan blinded (`doors.Where(door => false)`):

    Expected: string[]     ["OidcLoginService.ResetOidStateForTests"]
    Actual:   List<string> []
      ArchitectureConformanceTests.cs(3140,0)      <- the must-catch row

Four rows, four distinct line numbers, one per conjunct plus the offender itself. Every mutation was reverted and the full suite re-run green before the commit.

A sentinel guards the pair against a quieter failure than any of those: the fixtures name a derived door by its qualified name, and the test asserts that name is still in the derived set. Without it a rename would leave four fixtures agreeing about nothing and reporting green.

## Notes

The stated mutation in the issue - deleting the collection check to redden the must-catch fixture - is the one that changes nothing observable, for the reason set out above. The pair implements the mutation that does move an assertion instead.
