### PR TITLE
Retry the logout discovery read inside a stated budget [#1183]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **A single dropped discovery response no longer cancels a sign-out the
+  identity provider ordered (#1183).** On an inbound back-channel logout the
+  plugin reads the provider's discovery document to obtain the keys the logout
+  token is verified against. That read used to be attempted once, and any
+  failure left the sessions the provider had just ended still running, with only
+  a log entry to say so. A transient failure is now retried once, within a
+  worst case of 21 seconds for the whole request, and only on this path: the
+  login redirect and the admin Test-connection button still make exactly one
+  attempt, because a failure there creates no session in the first place.
+  Nothing is accepted that was not accepted before - when both attempts fail the
+  request is still refused, still with the same answer and the same recorded
+  reason, and a logout token whose signing keys were never obtained is still
+  never acted on. A provider endpoint that is not a usable URL is a
+  configuration mistake rather than a transient fault and is not retried.
+
 - **An identity provider can no longer write unbounded log through a failed
   discovery read (#1194).** When a discovery or JWKS fetch failed, the
   fail-closed warning quoted the identity library's error text whole, and that

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.AspNetCore.Mvc;
@@ -298,11 +299,129 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
         await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task ADiscoveryReadThatFailsOnceIsRetried_AndTheRevocationStillHappens()
+    {
+        // #1183. The IdP has ordered this revocation, so a single dropped or slow discovery response must
+        // not turn it into a no-op. The provider is reachable on the second attempt and the sessions the
+        // IdP ended are ended here too - which is the whole difference between this path and the login
+        // challenge, where the same refusal creates no session and is the safe direction.
+        var discoveryAttempts = 0;
+        var harness = new SsoControllerHarness(
+            ConfiguredWithSession,
+            httpResponder: request =>
+            {
+                if (request.RequestUri!.AbsoluteUri == _fixture.DiscoveryUrl && ++discoveryAttempts == 1)
+                {
+                    return new HttpResponseMessage(HttpStatusCode.GatewayTimeout);
+                }
+
+                return Responder(request);
+            });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        Assert.IsType<OkResult>(result);
+        Assert.Equal(2, discoveryAttempts);
+        await harness.SessionManager.Received(1).RevokeUserTokens(UserA, null);
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    [Fact]
+    public async Task EveryDiscoveryAttemptFailing_StillRefuses_AndStopsAtTheBudgetedCount()
+    {
+        // The other half of the same change, and the one that keeps it from being a relaxation: when the
+        // budget is exhausted nothing is granted. Still the uniform 400, still no revoke, still the
+        // ProviderUnreachable reason - acting on a logout_token whose signing keys were never obtained
+        // would be a forgery oracle for mass session termination.
+        //
+        // The count is asserted too. A retry with no ceiling is a way to hold an anonymous endpoint open,
+        // and "attempts times timeout" left implicit is how that ceiling goes missing.
+        var discoveryAttempts = 0;
+        var harness = new SsoControllerHarness(
+            ConfiguredWithSession,
+            httpResponder: request =>
+            {
+                if (request.RequestUri!.AbsoluteUri == _fixture.DiscoveryUrl)
+                {
+                    discoveryAttempts++;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.GatewayTimeout);
+            });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(result);
+        Assert.Equal(OidcLoginService.LogoutDiscoveryAttempts, discoveryAttempts);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+        Assert.Contains(
+            harness.ControllerLog.Entries,
+            e => e.Message.Contains(OidcLogoutTokenValidator.RejectReason.ProviderUnreachable.ToString(), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AMalformedEndpoint_IsNotRetried()
+    {
+        // A configured endpoint that is not a usable URL is a CONFIGURATION fault, not a transient one:
+        // repeating it produces the same answer and spends the budget for nothing. It fails before any
+        // request leaves the process, so the assertion is that NOTHING was fetched - a retry wrapped one
+        // level too high would show here as two attempts at a URL that can never work.
+        var requests = 0;
+        var harness = new SsoControllerHarness(
+            c =>
+            {
+                c.EnableSingleLogout = true;
+                c.OidConfigs["kc"] = new OidConfig
+                {
+                    Enabled = true,
+                    OidEndpoint = "not-a-usable-url",
+                    OidClientId = "jf",
+                    EnableBackChannelLogout = true,
+                };
+                c.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
+            },
+            httpResponder: _ =>
+            {
+                requests++;
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            });
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", _fixture.LogoutToken("sub-1", "sess-9"));
+
+        AssertUniform400(result);
+        Assert.Equal(0, requests);
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public void TheLogoutDiscoveryBudgetIsWhatItsPartsAddUpTo()
+    {
+        // The stated worst case has to keep matching what the parts actually produce. Each attempt is
+        // bounded by the reader's own fetch timeout and the pauses sit between them, so raising the attempt
+        // count, the delay or that timeout without re-choosing the budget fails here rather than quietly
+        // widening how long one anonymous, rate-limited request can hold the endpoint.
+        var parts = (OidcDiscoveryReader.FetchTimeout * OidcLoginService.LogoutDiscoveryAttempts)
+            + (OidcLoginService.LogoutDiscoveryRetryDelay * (OidcLoginService.LogoutDiscoveryAttempts - 1));
+
+        Assert.Equal(OidcLoginService.LogoutDiscoveryBudget, parts);
+    }
+
     private static void AssertUniform400(ActionResult result)
     {
         var content = Assert.IsType<ContentResult>(result);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Logout token could not be processed", content.Content);
+    }
+
+    // The single-logout feature on, this provider opted in, and one matching session to revoke - the state
+    // the retry rows differ from each other only by their responder against.
+    private void ConfiguredWithSession(PluginConfiguration config)
+    {
+        config.EnableSingleLogout = true;
+        config.OidConfigs["kc"] = Provider(backChannel: true);
+        config.LogoutSessions["a"] = Session("sub-1", "sess-9", UserA);
     }
 
     private OidConfig Provider(bool backChannel) => new OidConfig

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -132,6 +132,15 @@ public class OidcDiscoveryReaderTests
 
         Assert.False(result.Available);
         Assert.Null(result.ProviderInformation);
+
+        // ONE attempt, and no more. #1183 gives the back-channel logout path a retry because a refusal
+        // there leaves alive the sessions the IdP has already ended; the login challenge and the admin
+        // Test-connection probe get no such thing, because refusing THERE creates no session and a second
+        // attempt would only widen what one anonymous challenge costs. Both callers are single-attempt by
+        // virtue of this method being single-attempt, so it is asserted here rather than twice downstream:
+        // a retry moved inside ReadAsync would satisfy the logout tests and silently double the anonymous
+        // challenge endpoint's worst case.
+        Assert.Equal(1, http.DiscoveryRequests);
     }
 
     [Fact]

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -52,6 +52,32 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Flows;
 /// </remarks>
 internal sealed class OidcLoginService
 {
+    /// <summary>
+    /// How many discovery reads one inbound back-channel logout may make (#1183). Two, not more: the
+    /// transient this exists for is a single dropped or slow response, and every further attempt is spent
+    /// on an ANONYMOUS endpoint the IdP drives, so the cost of a provider that is simply down is what
+    /// bounds the count rather than the chance of eventually succeeding.
+    /// </summary>
+    internal const int LogoutDiscoveryAttempts = 2;
+
+    /// <summary>
+    /// The pause between those attempts. Long enough that a retry is not simply the same failing packet
+    /// resent, short enough to stay inside the budget below.
+    /// </summary>
+    internal static readonly TimeSpan LogoutDiscoveryRetryDelay = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The worst-case wall clock one inbound back-channel logout may spend reading discovery. Stated as a
+    /// constant rather than left as "attempts times timeout" so the ceiling on an anonymous, rate-limited
+    /// endpoint (<c>SsoRateLimitClass.Logout</c>) is a number somebody chose and a test can hold, instead
+    /// of a number that moves whenever one of its factors does.
+    /// <para>
+    /// <c>TheLogoutDiscoveryBudgetIsWhatItsPartsAddUpTo</c> is what keeps this honest: it fails if the
+    /// attempt count, the delay or the per-attempt fetch timeout moves without this being re-chosen.
+    /// </para>
+    /// </summary>
+    internal static readonly TimeSpan LogoutDiscoveryBudget = TimeSpan.FromSeconds(21);
+
     // The in-flight OpenID authorize-state store (cap, lifetime, throttled sweep and capacity signal all
     // live inside; see OidcStateStore). One process-wide instance, like the SAML caches the controller keeps.
     private static readonly OidcStateStore StateStore = new();
@@ -693,7 +719,7 @@ internal sealed class OidcLoginService
         // exactly as before.
         options.HttpClientFactory = _ => SsoHttp.CreateClient(_httpClientFactory, config.AllowPrivateNetworkAddresses);
 
-        var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
+        var discovery = await ReadDiscoveryForLogoutAsync(options, provider, config).ConfigureAwait(false);
         if (!discovery.Available)
         {
             return new OidcLogoutTokenValidator.Result(false, null, null, OidcLogoutTokenValidator.RejectReason.ProviderUnreachable);
@@ -705,6 +731,39 @@ internal sealed class OidcLoginService
         // keys that come with it, so nothing here holds a TokenValidationParameters that could be weakened
         // between building it and verifying against it (#1176).
         return await new OidcLogoutTokenValidator().ValidateAsync(logoutToken, options, DateTime.UtcNow).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads discovery for an inbound back-channel logout, retrying a failed read inside
+    /// <see cref="LogoutDiscoveryBudget"/> before giving up (#1183).
+    /// <para>
+    /// The same refusal means opposite things on the two paths that reach
+    /// <see cref="OidcDiscoveryReader.ReadAsync"/>. On the login challenge, an unreadable discovery
+    /// document means no session is created, which is the safe direction and is why that path keeps its
+    /// single attempt. Here the provider has already ORDERED a revocation, so refusing leaves alive the
+    /// sessions the IdP has ended - one dropped response turns a termination into a no-op, and an attacker
+    /// who can disrupt the server-to-IdP path can produce that on purpose.
+    /// </para>
+    /// <para>
+    /// The retry relaxes no validation. When the budget is exhausted the read is still unavailable, the
+    /// caller still refuses, and the reason code is unchanged; acting on a <c>logout_token</c> whose
+    /// signing keys were never obtained would be a forgery oracle for mass session termination. What the
+    /// retry buys is that a transient failure stops being indistinguishable from a provider that cannot be
+    /// verified at all.
+    /// </para>
+    /// </summary>
+    private async Task<OidcDiscoveryResult> ReadDiscoveryForLogoutAsync(OidcClientOptions options, string provider, OidConfig config)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            var discovery = await OidcDiscoveryReader.ReadAsync(options, provider, _httpClientFactory, _logger, config.AllowPrivateNetworkAddresses).ConfigureAwait(false);
+            if (discovery.Available || attempt >= LogoutDiscoveryAttempts)
+            {
+                return discovery;
+            }
+
+            await Task.Delay(LogoutDiscoveryRetryDelay).ConfigureAwait(false);
+        }
     }
 
     private OidcClientOptions BuildOidcOptions(OidConfig config, string redirectUri, string scope)

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -53,13 +53,22 @@ internal static class OidcDiscoveryReader
     /// <summary>Marks an error text this reader cut, so a truncated entry is not read as the whole error.</summary>
     private const string ErrorTruncationMarker = "[truncated]";
 
-    // The discovery/JWKS fetch is bounded so a slow or hanging authorization server cannot stall the
-    // anonymous challenge endpoint. This is now the login-critical discovery (its result is fed to
-    // PrepareLoginAsync), so the bound is tighter than the platform-default ~100s the library's own
-    // in-PrepareLoginAsync discovery ran under before #450 - a deliberate anonymous-endpoint DoS-hardening
-    // trade-off: a pathologically slow IdP (a 10s+ cold start) is refused fail-closed and self-heals on the
-    // next challenge, rather than tying up the endpoint. It keeps the 10s the pre-#450 probe already applied.
-    private static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(10);
+    /// <summary>
+    /// The bound on ONE discovery/JWKS fetch, so a slow or hanging authorization server cannot stall the
+    /// anonymous challenge endpoint. This is the login-critical discovery (its result is fed to
+    /// PrepareLoginAsync), so the bound is tighter than the platform-default ~100s the library's own
+    /// in-PrepareLoginAsync discovery ran under before #450 - a deliberate anonymous-endpoint DoS-hardening
+    /// trade-off: a pathologically slow IdP (a 10s+ cold start) is refused fail-closed and self-heals on the
+    /// next challenge, rather than tying up the endpoint. It keeps the 10s the pre-#450 probe already
+    /// applied.
+    /// <para>
+    /// Per ATTEMPT rather than per caller. A caller that reads more than once - the back-channel logout
+    /// path, which retries a transient failure rather than leaving an IdP-ordered revocation undone
+    /// (#1183) - multiplies this, and its own total budget is stated as a constant derived from it rather
+    /// than left implicit.
+    /// </para>
+    /// </summary>
+    internal static readonly TimeSpan FetchTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Reads the discovery document named by <paramref name="options"/> (its <c>Authority</c> and


### PR DESCRIPTION
# What & why

A back-channel logout is a revocation the identity provider has already ordered. When the discovery read that obtains the signing keys failed, the plugin refused and left alive the sessions the provider had just ended. One dropped or slow response turned a termination into a no-op, and an attacker who can disrupt the server-to-IdP path could produce that on purpose.

The read is now retried on that path, and only on that path. `OidcDiscoveryReader.ReadAsync` stays single-attempt and the retry sits at the logout call site, so the login challenge and the admin Test-connection probe are untouched: a refusal there creates no session, which is the safe direction, and a second attempt would only widen what one anonymous challenge costs.

Nothing is relaxed. When the budget is exhausted the read is still unavailable, the caller still refuses, the answer is still the uniform 400 and the reason is still `ProviderUnreachable`. Acting on a `logout_token` whose signing keys were never obtained would be a forgery oracle for mass session termination, so exhausting the retry has to mean exactly what one failure used to mean. The malformed-endpoint branch is a configuration fault rather than a transient one, fails before any request leaves the process, and is not retried.

Two attempts with a one-second pause. The worst case is a named constant rather than "attempts times timeout" left implicit, because the endpoint is anonymous and rate-limited (`SsoRateLimitClass.Logout`) and its ceiling has to be a number somebody chose. `OidcDiscoveryReader.FetchTimeout` becomes `internal` so the budget can be checked against the parts it is made of.

Closes #1183

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review ran on this change and no second person read it.** Those two boxes stay unticked and this paragraph is the disclosure, not a softening of it. This is the change in this set that most deserved one - it is production code on a privilege path - and it did not get one. What stands in place of a reader is the falsification section below, which was written to answer the three questions a reviewer would ask first, and this statement of what the change deliberately does not touch:

- validation is untouched. The retry produces a discovery result or it does not; `OidcLogoutTokenValidator` is called with exactly the same options it was called with before, and only when a read succeeded.
- the refusal is untouched. `EveryDiscoveryAttemptFailing_StillRefuses_AndStopsAtTheBudgetedCount` asserts the uniform 400, no revoke, the surviving session, and the `ProviderUnreachable` reason in the log. The pre-existing `DiscoveryUnavailable_RejectsFailClosed_MintsNoRevoke` passes unchanged, as the issue requires.
- the two other callers of `ReadAsync` are untouched, and that is asserted rather than argued: see the third mutation below.

The fail-closed box is ticked because exhausting the budget lands on the same refusal it landed on before; the sanitizer box is ticked as unchanged, since no log call moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The retry is one private method on the flow service that already owns the call site. It establishes no new structural property, so no conformance rule is added; the existing suite runs and is green. A CHANGELOG entry is included - this changes what an operator observes when a sign-out does not happen, which is read at upgrade time.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, `--warnaserror`, 0 warnings, then the suite through the built runner:

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2701, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
    ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
       SSO-Auth.Tests  Total: 2702, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

Four new rows against the 2697 / 2698 `main` produced before this branch.

The four skips are the loopback-bind tests that need an administrator on Windows (#1227). They were skipped, not worked around, and are unrelated to this change.

`CHANGELOG.md` was run through `prettier --write` and re-checked. The repository-wide `prettier --check` reports pre-existing warnings on files this branch does not touch, on this Windows checkout only; the CI job is the authority there and it is the one to read.

## Falsification

Every new assertion was made to fail before it was kept, one mutation at a time, each reverted afterwards.

Attempts cut to 1, which is the change removed:

    ADiscoveryReadThatFailsOnceIsRetried_AndTheRevocationStillHappens [FAIL]
      Assert.IsType() Failure: Value is not the exact type

    TheLogoutDiscoveryBudgetIsWhatItsPartsAddUpTo [FAIL]
      Assert.Equal() Failure: Values differ

The first is the whole point of the issue: with one attempt the provider that answers on the second try gets the 400 again and the sessions survive.

Attempts raised to 3 without re-choosing the budget:

    TheLogoutDiscoveryBudgetIsWhatItsPartsAddUpTo [FAIL]
      Expected: 00:00:21
      Actual:   00:00:32

The attempt-count test stays GREEN under that mutation, deliberately and worth stating plainly: it reads the constant, so what it proves is that the loop honours its stated count, not that the count is small. The budget arithmetic is what refuses a silently widened ceiling on an anonymous endpoint. Two rows, two different questions; neither covers for the other. The mutated run also took 2.4s against 1.4s, which is the third attempt's pause showing up in wall clock.

A second discovery read moved INSIDE `ReadAsync`, which is where a retry would land if it were written for everyone:

    ReadAsync_FetchFailure_ReturnsUnavailable [FAIL]
      Expected: 1
      Actual:   2

That row is what holds the "only this path" half of the issue. Without it the logout tests would pass just as well with the retry in the shared reader, and the anonymous login challenge would quietly have doubled its worst case.

The malformed-endpoint row is falsified by construction rather than by a mutation: it asserts that zero requests left the process, so a retry wrapped one level higher - around the options build instead of around the read - shows up as two attempts at a URL that can never work.

All mutations reverted, full suite re-run green on both frameworks before the commits.

## Notes

Out of scope, as the issue puts it: caching the discovery keys to avoid the fetch entirely. That is a lifetime decision against the #247 bound and is not attempted here.

The retry pause is a plain `Task.Delay`, not injected. That costs the suite about one second on each of the two rows that exercise a failing read, which is visible in the timings above and is the price of not adding a clock seam to a flow service for one constant.
