### PR TITLE
Rewrite the em dash out of the admin page and the translation surface

### DIFF
--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -45,7 +45,7 @@
   "config.provider_enabled_label": "Enabled",
   "config.provider_hide_login_button_label": "Hide from managed login-page buttons",
   "config.provider_hide_login_button_help": "Excludes this provider from the managed \"Sign in with …\" block on the login page while keeping it usable through its direct start URL. Only takes effect while the global \"Manage login buttons on the login page\" option is on; it never hides anything you added to the branding yourself.",
-  "config.provider_login_button_text_help": "Custom label for this provider's managed login-page button. Leave blank to use the provider name. Only takes effect while the global \"Manage login buttons on the login page\" option is on and the button is not hidden; any text is safe — it is always rendered inert, never as markup.",
+  "config.provider_login_button_text_help": "Custom label for this provider's managed login-page button. Leave blank to use the provider name. Only takes effect while the global \"Manage login buttons on the login page\" option is on and the button is not hidden; any text is safe: it is always rendered inert, never as markup.",
   "config.provider_enable_authorization_label": "Enable Authorization by Plugin",
   "config.provider_library_access_group": "Library access",
   "config.provider_enable_all_folders_label": "Enable All Folders",

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -1,5 +1,5 @@
 // The shared localization module (#913), set once its dynamic import resolves in localize() below.
-// Until then — and permanently if the load fails — tr() returns the caller's built-in English, so the
+// Until then, and permanently if the load fails, tr() returns the caller's built-in English, so the
 // page never renders a bare catalog key.
 let i18n = null;
 
@@ -9,18 +9,18 @@ function tr(key, englishDefault, params) {
   return i18n ? i18n.t(key, params, englishDefault) : englishDefault;
 }
 
-// Provider templates (#726) — the single source of truth for the "Start from a template" pickers.
+// Provider templates (#726): the single source of truth for the "Start from a template" pickers.
 // Applying a preset writes ONLY into existing marker-classed fields by their id (OpenID: the property
 // name; SAML: "saml-" + the property name) and pre-checks ONLY the compatibility toggles a given IdP
 // genuinely needs. Presets are plain data so they are trivial to extend and to lock in with a fitness
 // test (ProviderPresets_* in ArchitectureConformanceTests): every `fields` key / `toggles` entry must be
 // a real config property, no preset may fill a secret, and toggles may only pre-check a known
-// compatibility toggle. `fields` values are non-secret placeholders — endpoints use an example host and
+// compatibility toggle. `fields` values are non-secret placeholders: endpoints use an example host and
 // UPPERCASE tokens the admin replaces (realm/tenant/domain), never a hard-coded production host, so they
-// never go stale. OidScopes holds the ADDITIONAL scopes only (one per line) — the server always prepends
+// never go stale. OidScopes holds the ADDITIONAL scopes only (one per line); the server always prepends
 // "openid profile", so a preset lists just what a provider needs on top (e.g. "email", or "email\ngroups"
 // where roles ride a groups scope), never "openid"/"profile" again. Every OpenID preset sets the SAME four
-// fields (blank where a provider has none), so switching templates is idempotent — no stale value survives;
+// fields (blank where a provider has none), so switching templates is idempotent, and no stale value survives;
 // ProviderPresets_OidcPresetsShareTheSameFieldKeySet locks that shared-key-set invariant in.
 const OIDC_PRESETS = {
   keycloak: {
@@ -60,7 +60,7 @@ const OIDC_PRESETS = {
   },
   zitadel: {
     label: "Zitadel",
-    note: "Zitadel project application. Its roles arrive as an OBJECT whose keys are the role names, so 'Role claim is an object map' is pre-checked — without it no role can ever match. The project must have 'Assert Roles on Authentication' on, and the application 'User roles inside ID Token', or the role claim is absent entirely. Replace YOUR_INSTANCE in the endpoint.",
+    note: "Zitadel project application. Its roles arrive as an OBJECT whose keys are the role names, so 'Role claim is an object map' is pre-checked; without it no role can ever match. The project must have 'Assert Roles on Authentication' on, and the application 'User roles inside ID Token', or the role claim is absent entirely. Replace YOUR_INSTANCE in the endpoint.",
     fields: {
       OidEndpoint:
         "https://YOUR_INSTANCE.zitadel.cloud/.well-known/openid-configuration",
@@ -84,7 +84,7 @@ const OIDC_PRESETS = {
   },
   google: {
     label: "Google",
-    note: "Google issues no group or role claim, so Roles is left blank — grant access with folder/role mapping or leave it open. Endpoint validation is relaxed because Google's discovery document does not list every endpoint the strict check expects.",
+    note: "Google issues no group or role claim, so Roles is left blank: grant access with folder/role mapping or leave it open. Endpoint validation is relaxed because Google's discovery document does not list every endpoint the strict check expects.",
     fields: {
       OidEndpoint:
         "https://accounts.google.com/.well-known/openid-configuration",
@@ -96,7 +96,7 @@ const OIDC_PRESETS = {
   },
   auth0: {
     label: "Auth0",
-    note: "Auth0 application. Roles require a custom claim added by an Auth0 Action/Rule under a namespace you choose — set RoleClaim to that namespaced claim (e.g. https://your-app/roles). Replace YOUR_TENANT in the endpoint.",
+    note: "Auth0 application. Roles require a custom claim added by an Auth0 Action/Rule under a namespace you choose. Set RoleClaim to that namespaced claim (e.g. https://your-app/roles). Replace YOUR_TENANT in the endpoint.",
     fields: {
       OidEndpoint:
         "https://YOUR_TENANT.us.auth0.com/.well-known/openid-configuration",
@@ -155,7 +155,7 @@ const SAML_PRESETS = {
 
 // The compatibility/insecure toggles a preset is ALLOWED to pre-check. A preset never pre-checks a
 // fail-closed HARDENING toggle (RequirePkce, RequireVerifiedEmail*, RequireAcr, SAML ValidateRecipient/
-// ValidateInResponseTo/SignAuthnRequests) — enabling those is a deliberate admin decision, and silently
+// ValidateInResponseTo/SignAuthnRequests), because enabling those is a deliberate admin decision, and silently
 // turning them on could lock out a not-yet-ready IdP. This set is also what applyOidcPreset/applySamlPreset
 // clear before applying, so switching templates never leaves a previous preset's toggle checked.
 const OIDC_PRESET_MANAGED_TOGGLES = [
@@ -165,11 +165,11 @@ const OIDC_PRESET_MANAGED_TOGGLES = [
   "DoNotValidateResponseIssuer",
   "DisableHttps",
   "DoNotLoadProfile",
-  // Not an insecure toggle — it names the SHAPE of the RoleClaim path's terminal (#934). It is here because
+  // Not an insecure toggle: it names the SHAPE of the RoleClaim path's terminal (#934). It is here because
   // every preset sets RoleClaim, so leaving a previous provider's shape flag ticked while the claim path is
   // replaced by an array-shaped one (Keycloak's realm_access.roles) would extract ZERO roles and lock the
   // whole userbase out on the next login. Clearing is correct for every shipped preset; a future
-  // object-map preset can pre-check it from its own `toggles` — the Zitadel preset above does exactly that.
+  // object-map preset can pre-check it from its own `toggles`; the Zitadel preset above does exactly that.
   "RoleClaimIsObjectMap",
 ];
 const SAML_PRESET_MANAGED_TOGGLES = ["DoNotValidateAudience"];
@@ -194,7 +194,7 @@ const ssoConfigurationPage = {
   // (RequireVerifiedEmailForAdoption, RequireVerifiedEmailForLogin, RequirePkce): those are OFF by default
   // and enabling them makes the provider MORE secure, so flagging or force-surfacing them would be
   // backwards and would cause alert fatigue on well-configured providers. Do not add an OFF-direction
-  // surfacing for them either — it would be noisy on the default.
+  // surfacing for them either: it would be noisy on the default.
   sensitiveFieldIds: ["AllowExistingAccountLink"],
   loadConfiguration: (page) => {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
@@ -245,7 +245,7 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.renderProviderCards(page, providers);
   },
   // Render the provider LIST as cards (#365). Built with createElement/textContent (never innerHTML) so a
-  // provider name is inert on the page — a name like `<img onerror=...>` cannot inject markup — mirroring
+  // provider name is inert on the page (a name like `<img onerror=...>` cannot inject markup), mirroring
   // _populateFolders and the linking view (#221). Clicking a card loads that provider into the editor.
   renderProviderCards: (page, providers) => {
     const list = page.querySelector("#sso-provider-list");
@@ -284,7 +284,7 @@ const ssoConfigurationPage = {
 
       // Flag a provider that carries an active insecure / sensitive setting, so an admin sees the downgrade
       // in the list without opening the editor (the setting itself lives behind the collapsed
-      // "Security & hardening" accordion). Presentation only — the flag reads from the saved config and
+      // "Security & hardening" accordion). Presentation only: the flag reads from the saved config and
       // changes nothing.
       const flagged = ssoConfigurationPage.insecureFieldIds
         .concat(ssoConfigurationPage.sensitiveFieldIds)
@@ -313,7 +313,7 @@ const ssoConfigurationPage = {
   },
   // Load a card into the editor and reveal it. resetEditor gives a CLEAN SLATE first (the same way
   // addProvider does) so no field, toggle, or collapse state from the previously loaded provider can bleed
-  // into this one — a text/array field the target provider does not set must not keep the previous
+  // into this one: a text/array field the target provider does not set must not keep the previous
   // provider's value, or a later save would silently persist it (e.g. repoint OidEndpoint with no edit).
   // loadProvider then fills the target provider's actual values on top and re-syncs visibility at its tail.
   openProvider: (page, provider_name) => {
@@ -326,7 +326,7 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.loadProvider(page, provider_name);
     page.querySelector("#sso-editor").scrollIntoView({ block: "start" });
   },
-  // Open a blank editor for a NEW provider. Every toggle is reset OFF (fail closed) — the same security
+  // Open a blank editor for a NEW provider. Every toggle is reset OFF (fail closed), the same security
   // posture loadProvider enforces when switching providers, so a stale insecure toggle from a previous
   // edit can never be carried into a new provider and silently saved.
   addProvider: (page) => {
@@ -388,7 +388,7 @@ const ssoConfigurationPage = {
     ssoConfigurationPage.renderPresetNote(page, "OidPreset-note", "");
   },
   // Return every accordion section INSIDE the editor to its authored default collapse state (the sections
-  // with data-expanded="true" open, the rest — including "Security & hardening" — collapsed). Scoped to
+  // with data-expanded="true" open, the rest, including "Security & hardening", collapsed). Scoped to
   // #sso-editor so the page-level About / Export collapses are untouched.
   resetEditorSections: (page) => {
     const editor = page.querySelector("#sso-editor");
@@ -405,7 +405,7 @@ const ssoConfigurationPage = {
   // Drive an emby-collapse to a definite expanded/collapsed state. The host component tracks its open state
   // as the boolean `expanded` PROPERTY on its `.collapseContent` element and flips it by a click of the
   // generated `.emby-collapsible-button` (its own click handler runs the slide + hide-class toggle). We read
-  // that property and click only when it differs from the target, so this is idempotent — clicking an
+  // that property and click only when it differs from the target, so this is idempotent: clicking an
   // already-open section would wrongly collapse it. Null-guarded so it degrades to a no-op (rather than
   // throwing) if the section has not been upgraded yet or the host markup changes.
   setCollapseExpanded: (section, expanded) => {
@@ -464,7 +464,7 @@ const ssoConfigurationPage = {
     // disabled or an account-adoption path is widened. The "Security & hardening" accordion is collapsed by
     // default, and the insecure toggles are additionally behind a "Show insecure options" list, so a
     // downgrade on a loaded provider would otherwise be invisible behind two collapsed layers. Expand BOTH
-    // the enclosing accordion section AND, for the insecure subset, the inner list. Expand-only — it never
+    // the enclosing accordion section AND, for the insecure subset, the inner list. Expand-only: it never
     // AUTO-HIDES a set option; resetEditor returns the section to its default when switching to a provider
     // that has none.
     const isChecked = (id) => {
@@ -559,7 +559,7 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "OidEndpoint",
-        "Uses http:// — discovery would be unencrypted. Prefer an https:// endpoint.",
+        "Uses http://, so discovery would be unencrypted. Prefer an https:// endpoint.",
       );
       return;
     }
@@ -599,12 +599,12 @@ const ssoConfigurationPage = {
       );
       return;
     }
-    // Full origin only — no path, query or fragment (this is the base URL, not the redirect URI).
+    // Full origin only: no path, query or fragment (this is the base URL, not the redirect URI).
     if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
       ssoConfigurationPage.setFieldError(
         page,
         "BaseUrlOverride",
-        "Enter the base URL only (no path) — e.g. https://jellyfin.example.com, not the /sso/... redirect URI.",
+        "Enter the base URL only (no path), e.g. https://jellyfin.example.com, not the /sso/... redirect URI.",
       );
       return;
     }
@@ -694,7 +694,7 @@ const ssoConfigurationPage = {
       const out = document.createElement("label");
       // Tag the row with the class the re-render cleanup (querySelectorAll above) removes, so a
       // second populate deterministically clears the old rows instead of relying on the
-      // emby-checkbox upgrade to add it — otherwise folder IDs could be duplicated on re-populate.
+      // emby-checkbox upgrade to add it; otherwise folder IDs could be duplicated on re-populate.
       out.classList.add("emby-checkbox-label");
 
       // createElement's `is` option upgrades the customized built-in; the attribute is set as well
@@ -799,7 +799,7 @@ const ssoConfigurationPage = {
   // The provider form's save contract, made explicit (#365): every input in #sso-new-oidc-provider
   // that should persist carries an sso-* class AND an id spelled EXACTLY like the OidConfig property it
   // writes to (saveProvider does current_config[element.id] = value). A field with the wrong id, a
-  // missing sso-* class, or placed outside this form renders fine but silently never saves — and the
+  // missing sso-* class, or placed outside this form renders fine but silently never saves, and the
   // server drops unknown JSON members too. The ArchitectureConformanceTests
   // ProviderFormFieldIds_MatchOidConfigProperties test locks this in: it fails the build if any
   // sso-*-classed field id is not a real OidConfig property.
@@ -883,7 +883,7 @@ const ssoConfigurationPage = {
           // Always set the checkbox from the loaded provider so switching providers
           // resets stale toggles. Setting it only when truthy left a previous
           // provider's checked box in place, which a later save could silently
-          // persist as true — a security downgrade for toggles like
+          // persist as true, a security downgrade for toggles like
           // DoNotValidateEndpoints / DisableHttps.
           page.querySelector("#" + id).checked = Boolean(provider[id]);
         });
@@ -904,8 +904,8 @@ const ssoConfigurationPage = {
     );
   },
   // Computes the exact redirect_uri the login uses, so the admin can register it verbatim at the IdP (#724).
-  // Mirrors the server-side build (OidcRedirectUriBuilder): the canonical base — the Base URL Override when
-  // set, else this server's address — plus the fixed /sso/OID/redirect/<provider> path. The provider name is
+  // Mirrors the server-side build (OidcRedirectUriBuilder): the canonical base (the Base URL Override when
+  // set, else this server's address) plus the fixed /sso/OID/redirect/<provider> path. The provider name is
   // appended raw (names are validated to exclude URI-reserved characters, #336), matching the server, which
   // appends the route-decoded name without re-encoding so the string equals the login's byte-for-byte.
   computeRedirectUri: (page, providerName) => {
@@ -915,7 +915,7 @@ const ssoConfigurationPage = {
     try {
       // Mirror the server's CanonicalBaseUrl (System.Uri.GetLeftPart(UriPartial.Path)) so the shown value
       // equals what the login sends: `origin` lowercases scheme + host AND elides the default port
-      // (443/80) — exactly as System.Uri does — while pathname keeps any sub-path; query/fragment are
+      // (443/80), exactly as System.Uri does, while pathname keeps any sub-path; query/fragment are
       // dropped and the trailing slash trimmed. A raw string strip alone would show a non-canonical override
       // (e.g. `https://X.COM:443`) that the login then normalizes away, causing a redirect_uri mismatch.
       const u = new URL(raw);
@@ -962,7 +962,7 @@ const ssoConfigurationPage = {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(value).then(
         () => announce("Redirect URI copied to the clipboard."),
-        () => announce("Copy failed — select the field and copy it manually."),
+        () => announce("Copy failed. Select the field and copy it manually."),
       );
       return;
     }
@@ -979,7 +979,7 @@ const ssoConfigurationPage = {
     announce(
       ok
         ? "Redirect URI copied to the clipboard."
-        : "Copy failed — select the field and copy it manually.",
+        : "Copy failed. Select the field and copy it manually.",
     );
   },
   deleteProvider: (page, provider_name) => {
@@ -1011,7 +1011,7 @@ const ssoConfigurationPage = {
           },
           // Report a genuine save failure rather than swallowing it. The delete
           // re-posts the whole configuration, so the server can now reject it for
-          // a reason unrelated to this delete — e.g. a different provider whose
+          // a reason unrelated to this delete, e.g. a different provider whose
           // reserved-character name became "new" because it was removed from the
           // live config in the meantime (#336). Without this the PUT would reject
           // silently and the provider would appear undeleted with no explanation.
@@ -1028,11 +1028,11 @@ const ssoConfigurationPage = {
   },
   // Save the GLOBAL login-page buttons opt-in (#722). ManageLoginPageButtons is a root
   // PluginConfiguration flag, so this fetches the live configuration, changes ONLY this flag, and
-  // re-posts the whole document — the provider dictionaries and every other root setting ride along
+  // re-posts the whole document: the provider dictionaries and every other root setting ride along
   // unchanged, exactly as the provider save/delete paths do. The server reacts to the saved
   // configuration itself (LoginButtonManager listens for the configuration change), so no extra
-  // endpoint call is needed: on save the managed block is injected/refreshed, or — with the flag
-  // off — only the managed region is removed and the admin's own branding is preserved.
+  // endpoint call is needed: on save the managed block is injected/refreshed, or, with the flag
+  // off, only the managed region is removed and the admin's own branding is preserved.
   saveLoginButtons: (page) => {
     ApiClient.getPluginConfiguration(ssoConfigurationPage.pluginUniqueId).then(
       (config) => {
@@ -1063,7 +1063,7 @@ const ssoConfigurationPage = {
     );
   },
   // Save the GLOBAL Single Logout opt-in (#727). EnableSingleLogout is a root PluginConfiguration flag, so
-  // — exactly like saveLoginButtons — this fetches the live configuration, changes ONLY this flag, and
+  // this fetches the live configuration exactly like saveLoginButtons, changes ONLY this flag, and
   // re-posts the whole document, so the provider dictionaries and every other root setting ride along
   // unchanged. The per-provider post-logout redirect URL is saved with its provider, not here.
   saveSingleLogout: (page) => {
@@ -1166,7 +1166,7 @@ const ssoConfigurationPage = {
   },
   // Test-connection (#163). Calls the elevation-gated OID/Test endpoint for the SAVED provider and renders
   // the result. The endpoint reads the stored config server-side, fetches the discovery document over the
-  // login's hardened path, and returns only non-secret facts (issuer, endpoints, JWKS reachability) — the
+  // login's hardened path, and returns only non-secret facts (issuer, endpoints, JWKS reachability); the
   // client secret is never sent back. Everything is rendered with createElement/textContent (never
   // innerHTML) so a reflected issuer/endpoint string cannot inject markup, matching linking.js and
   // _populateFolders (#221).
@@ -1187,7 +1187,7 @@ const ssoConfigurationPage = {
     ).then(
       (result) => ssoConfigurationPage.renderTestResult(container, result),
       // A rejection is a transport/authorization failure or an unconfigured provider (404). Keep the
-      // message generic and actionable — it never reflects a server-side secret.
+      // message generic and actionable: it never reflects a server-side secret.
       () =>
         ssoConfigurationPage.renderTestMessage(
           container,
@@ -1229,7 +1229,7 @@ const ssoConfigurationPage = {
     container.appendChild(list);
   },
   // Config export (#161). Fetches the redacted export document from the elevation-gated endpoint (the
-  // server withholds every secret and account-link map) and saves it as a JSON file via a Blob download —
+  // server withholds every secret and account-link map) and saves it as a JSON file via a Blob download,
   // never navigation, so the admin's auth header is sent and no secret is placed in a URL. The filename is
   // fixed text; nothing from the document reaches the DOM as markup.
   exportConfig: (page) => {
@@ -1264,7 +1264,7 @@ const ssoConfigurationPage = {
   // Config import (#161). Reads the chosen file as text, parses it locally (a parse error is reported, never
   // applied), and POSTs it to the elevation-gated import endpoint. The server validates and merges it
   // fail-closed, keeping each unchanged provider's stored secret and links (an OpenID provider whose
-  // endpoint/client id the import changes has its links/secret cleared — the #186 repoint safety measure).
+  // endpoint/client id the import changes has its links/secret cleared, the #186 repoint safety measure).
   // On success the provider list is reloaded so the merged providers appear; the admin re-enters secrets.
   importConfig: (page, file) => {
     const container = page.querySelector("#ConfigTransferResult");
@@ -1294,7 +1294,7 @@ const ssoConfigurationPage = {
         ssoConfigurationPage.loadConfiguration(page);
         ssoConfigurationPage.renderTransferMessage(
           container,
-          "Imported. Re-enter each provider's secret and save it — secrets are never included in an export.",
+          "Imported. Re-enter each provider's secret and save it; secrets are never included in an export.",
         );
       })
       .catch((e) => {
@@ -1324,12 +1324,12 @@ const ssoConfigurationPage = {
 
   // Localize the page's own labels (#913). Jellyfin core serves this configuration page from its own
   // URL base, so a relative import would not resolve to the plugin's assets; load the shared applier
-  // from its absolute SSOViews URL — the same module the linking page uses — rather than duplicating
+  // from its absolute SSOViews URL, the same module the linking page uses, rather than duplicating
   // it here.
   //
   // Localization is strictly best-effort and must never take the page down with it: init calls this
   // BEFORE it wires the Save/Delete/Test handlers, so an escaping error would leave a fully rendered
-  // but inert admin page. The try/catch is load-bearing and NOT redundant with the .catch below —
+  // but inert admin page. The try/catch is load-bearing and NOT redundant with the .catch below:
   // ApiClient.getUrl throws SYNCHRONOUSLY on a missing server address, while the argument is evaluated,
   // so no promise exists yet for .catch to see. Either way the markup keeps its built-in English.
   localize: (view) => {
@@ -1348,7 +1348,7 @@ const ssoConfigurationPage = {
   },
 
   // ---- Provider templates (#726) ----
-  // Fill a preset picker's options from its catalog (createElement/textContent — the labels are our own
+  // Fill a preset picker's options from its catalog (createElement/textContent; the labels are our own
   // fixed strings, but building them inertly keeps the one-DOM-construction idiom). The leading blank
   // "Choose a template" option authored in the HTML is preserved.
   populatePresetPicker: (page, selectId, presets) => {
@@ -1452,7 +1452,7 @@ const ssoConfigurationPage = {
   // SAML provider workspace (#725)
   // ----------------------------------------------------------------------------
   // A lifecycle parallel to the OpenID one above, kept entirely separate so the OpenID workspace and its
-  // JS are untouched (there is no JS runtime test harness — the adversarial review is the primary
+  // JS are untouched (there is no JS runtime test harness; the adversarial review is the primary
   // verification, so isolation is the cheapest correctness guarantee). Every SAML persisting field id is
   // its SamlConfig property spelled with a "saml-" PREFIX (ids must be unique across the whole document,
   // and the OpenID fields already own the unprefixed spellings); the property is the id minus that prefix,
@@ -1468,7 +1468,7 @@ const ssoConfigurationPage = {
   // insecureFieldIds/sensitiveFieldIds for OpenID). DoNotValidateAudience disables the AudienceRestriction
   // check; AllowExistingAccountLink widens account adoption. Property names (no prefix): the flag is read
   // from the saved config (provider[prop]) and, when checking the live checkbox, queried as "#saml-"+prop.
-  // ProvisionNewUsersDisabled is deliberately NOT flagged — it is a fail-closed hardening toggle (ON is
+  // ProvisionNewUsersDisabled is deliberately NOT flagged: it is a fail-closed hardening toggle (ON is
   // MORE secure), so surfacing it would be backwards and cause alert fatigue, exactly as for OpenID.
   samlInsecureFieldIds: ["DoNotValidateAudience"],
   samlSensitiveFieldIds: ["AllowExistingAccountLink"],
@@ -1481,7 +1481,7 @@ const ssoConfigurationPage = {
     });
     ssoConfigurationPage.renderSamlProviderCards(page, providers);
   },
-  // SAML provider cards — same inert createElement/textContent construction as renderProviderCards (#221):
+  // SAML provider cards, same inert createElement/textContent construction as renderProviderCards (#221):
   // a provider name is never interpolated as markup, so a hostile name stays inert on the page.
   renderSamlProviderCards: (page, providers) => {
     const list = page.querySelector("#saml-provider-list");
@@ -1643,7 +1643,7 @@ const ssoConfigurationPage = {
     );
 
     // Surface active insecure / sensitive settings behind the collapsed "Security & hardening" accordion
-    // (and, for the insecure subset, its inner list) — expand-only, exactly like syncDependentFields.
+    // (and, for the insecure subset, its inner list): expand-only, exactly like syncDependentFields.
     const isChecked = (id) => {
       const el = page.querySelector("#saml-" + id);
       return Boolean(el && el.checked);
@@ -1717,7 +1717,7 @@ const ssoConfigurationPage = {
           const prop = ssoConfigurationPage.samlPropOf(id);
           // The write-only signing keys (SamlSigningKeyPfx / SamlRolloverSigningKeyPfx) are serialized back
           // as null by the server (WriteOnlySecretConverter), so provider[prop] is falsy and the field stays
-          // blank — its "leave blank to keep" placeholder governs, exactly like the OpenID OidSecret.
+          // blank, and its "leave blank to keep" placeholder governs, exactly like the OpenID OidSecret.
           if (provider[prop]) {
             page.querySelector("#" + id).value = provider[prop];
           }
@@ -1745,7 +1745,7 @@ const ssoConfigurationPage = {
 
         form_elements.check_fields.forEach((id) => {
           // Always set from the loaded provider (not only when truthy) so a stale insecure toggle from a
-          // previously loaded provider is never left checked to be silently re-saved — the exact reason the
+          // previously loaded provider is never left checked to be silently re-saved, the exact reason the
           // OpenID loadProvider sets Boolean(provider[id]) unconditionally.
           const prop = ssoConfigurationPage.samlPropOf(id);
           page.querySelector("#" + id).checked = Boolean(provider[prop]);
@@ -1766,7 +1766,7 @@ const ssoConfigurationPage = {
   },
   // Canonical external base for the computed SAML URLs (mirrors the inline logic in computeRedirectUri,
   // #724): the Base URL Override when set, else this server's address, normalized the way the server's
-  // CanonicalBaseUrl (System.Uri.GetLeftPart) is — origin lowercases scheme+host and elides the default
+  // CanonicalBaseUrl (System.Uri.GetLeftPart) is: origin lowercases scheme+host and elides the default
   // port, pathname keeps any sub-path, and the trailing slash is trimmed. When the override is blank the
   // shown URL reflects the browser's server address; the scheme/port overrides are a legacy mechanism the
   // Base URL Override supersedes (its callout steers the admin there).
@@ -1824,7 +1824,7 @@ const ssoConfigurationPage = {
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(value).then(
         () => announce(label + " copied to the clipboard."),
-        () => announce("Copy failed — select the field and copy it manually."),
+        () => announce("Copy failed. Select the field and copy it manually."),
       );
       return;
     }
@@ -1840,13 +1840,13 @@ const ssoConfigurationPage = {
     announce(
       ok
         ? label + " copied to the clipboard."
-        : "Copy failed — select the field and copy it manually.",
+        : "Copy failed. Select the field and copy it manually.",
     );
   },
   // Import IdP metadata (#735) from a URL (fetched server-side through the SSRF-hardened outbound client) or
   // pasted XML, and pre-fill the endpoint + signing certificate(s) for the admin to review and save. The
   // server returns the parsed values; NOTHING is applied server-side by this call. The IdP EntityId is
-  // shown for reference only — it is NOT the SP SamlClientId, which the admin chooses.
+  // shown for reference only: it is NOT the SP SamlClientId, which the admin chooses.
   importSamlMetadata: (page, source) => {
     const status = page.querySelector("#saml-metadata-status");
     const url =
@@ -1902,7 +1902,7 @@ const ssoConfigurationPage = {
           entity
             ? "Imported the endpoint and certificate. The provider's entity id is " +
                 entity +
-                " (reference only — set the SAML Client ID yourself). Review the fields and Save."
+                " (reference only; set the SAML Client ID yourself). Review the fields and Save."
             : "Imported the endpoint and certificate. Review the fields and Save.",
         );
       },
@@ -2002,7 +2002,7 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "saml-SamlEndpoint",
-        "Uses http:// — the redirect would be unencrypted. Prefer an https:// endpoint.",
+        "Uses http://, so the redirect would be unencrypted. Prefer an https:// endpoint.",
       );
       return;
     }
@@ -2045,20 +2045,20 @@ const ssoConfigurationPage = {
       ssoConfigurationPage.setFieldError(
         page,
         "saml-BaseUrlOverride",
-        "Enter the base URL only (no path) — e.g. https://jellyfin.example.com, not the /sso/... ACS URL.",
+        "Enter the base URL only (no path), e.g. https://jellyfin.example.com, not the /sso/... ACS URL.",
       );
       return;
     }
     ssoConfigurationPage.setFieldError(page, "saml-BaseUrlOverride", "");
   },
-  // Pre-emptive certificate shape check (WARNING only, never blocks the save — the server stays the
+  // Pre-emptive certificate shape check (WARNING only, never blocks the save; the server stays the
   // authority, so a false positive cannot lock an admin out). Accepts an empty optional field, a PEM block,
   // or a bare Base64 body; only an obviously malformed value (non-Base64 characters once PEM armor and
   // whitespace are stripped) is flagged. label/id let it serve both the primary and secondary certificate.
   validateSamlCertificate: (page, id, label) => {
     const raw = page.querySelector("#" + id).value.trim();
     if (!raw) {
-      // Optional (the secondary) or required-checked elsewhere (the primary) — an empty value is not a
+      // Optional (the secondary) or required-checked elsewhere (the primary): an empty value is not a
       // SHAPE error here; requiredness for the primary is enforced by the server on save.
       ssoConfigurationPage.setFieldError(page, id, "");
       return;
@@ -2072,7 +2072,7 @@ const ssoConfigurationPage = {
         page,
         id,
         label +
-          " is not valid Base64 — paste the certificate body (the text between the PEM BEGIN/END lines) or the whole PEM block.",
+          " is not valid Base64. Paste the certificate body (the text between the PEM BEGIN/END lines) or the whole PEM block.",
       );
       return;
     }
@@ -2237,7 +2237,7 @@ export default function initSsoConfigurationPage(view) {
       () =>
         ssoConfigurationPage.renderSaveStatus(
           view,
-          "Save failed — see the details in the alert.",
+          "Save failed. See the details in the alert.",
           false,
         ),
     );
@@ -2362,7 +2362,7 @@ export default function initSsoConfigurationPage(view) {
 
   // Live-update the computed redirect URI (#724) as the provider name or the base-URL override changes, so
   // the value shown always matches what the login will send. `input` (per-keystroke) not `blur`, since the
-  // field is purely informational — reflecting immediately is the point.
+  // field is purely informational: reflecting immediately is the point.
   ["OidProviderName", "BaseUrlOverride"].forEach((id) => {
     view
       .querySelector("#" + id)
@@ -2415,7 +2415,7 @@ export default function initSsoConfigurationPage(view) {
   view.querySelector("#sso-self-service-link").href =
     ApiClient.getUrl("/SSOViews/linking");
 
-  // ---- SAML workspace bindings (#725) — the exact parallel of the OpenID bindings above ----
+  // ---- SAML workspace bindings (#725): the exact parallel of the OpenID bindings above ----
   view.querySelector("#saml-SaveProvider").addEventListener("click", (e) => {
     const target_provider = view.querySelector("#saml-provider-name").value;
 
@@ -2431,7 +2431,7 @@ export default function initSsoConfigurationPage(view) {
       () =>
         ssoConfigurationPage.renderSamlSaveStatus(
           view,
-          "Save failed — see the details in the alert.",
+          "Save failed. See the details in the alert.",
           false,
         ),
     );

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -26,7 +26,7 @@
           </div>
 
           <!--
-            About / notes — compact and collapsible so it does not push the provider workspace below the
+            About / notes, compact and collapsible so it does not push the provider workspace below the
             fold. Presentation-only: the same guidance the page always carried, moved into a native
             emby-collapse (collapsed by default) so the workspace is the first thing an admin sees.
           -->
@@ -159,11 +159,11 @@
           </details>
 
           <!--
-            Config export / import (#161). Export downloads a REDACTED, importable document — the provider
+            Config export / import (#161). Export downloads a REDACTED, importable document: the provider
             secrets and the server-managed canonical-link maps are withheld by the server, so the file carries
             no secret, encrypted envelope, or key. Import merges the document into THIS instance, keeping the
             stored secret and account links of each unchanged provider (an OpenID provider whose endpoint or
-            client id the import changes has its links/secret cleared — the #186 repoint safety measure);
+            client id the import changes has its links/secret cleared, the #186 repoint safety measure);
             because secrets are redacted, they are re-entered on the target after an import. Both endpoints
             require administrator privileges. The download is built from a Blob and the status is rendered with
             textContent (never innerHTML), so no document value reaches the DOM as markup (#221).
@@ -180,12 +180,12 @@
                   configuration (provider secrets and account links are never
                   included). Import merges an exported file into this instance,
                   keeping the stored secret and account links of each unchanged
-                  provider — but if the import gives an OpenID provider a
-                  different discovery endpoint or client id, that provider's
-                  links and secret are cleared (a repoint safety measure), so
-                  review a file before importing it over a live provider.
-                  Re-enter each provider's secret here after importing. Requires
-                  administrator privileges.
+                  provider. If the import gives an OpenID provider a different
+                  discovery endpoint or client id, that provider's links and
+                  secret are cleared (a repoint safety measure), so review a
+                  file before importing it over a live provider. Re-enter each
+                  provider's secret here after importing. Requires administrator
+                  privileges.
                 </div>
 
                 <button
@@ -218,7 +218,7 @@
           </form>
 
           <!--
-            Login-page buttons (#722) — GLOBAL setting. ManageLoginPageButtons lives on the root
+            Login-page buttons (#722): GLOBAL setting. ManageLoginPageButtons lives on the root
             PluginConfiguration, not on a provider, so it deliberately sits OUTSIDE both provider forms
             and carries NO sso-* marker class: it is saved by its own handler (config.js
             saveLoginButtons), which re-posts the whole configuration with only this flag changed, and
@@ -247,7 +247,7 @@
                   <div class="fieldDescription checkboxFieldDescription">
                     Off by default: the plugin never touches the server's login
                     branding unless you opt in here. When on, a managed "Sign in
-                    with …" block — one button per enabled provider — is spliced
+                    with …" block, one button per enabled provider, is spliced
                     into the login page's branding disclaimer and refreshed
                     whenever this plugin's configuration is saved (and at server
                     start). When off, only that managed block is removed; any
@@ -270,8 +270,8 @@
           </form>
 
           <!--
-            Single Logout (#727) — GLOBAL setting. EnableSingleLogout lives on the root PluginConfiguration,
-            not on a provider, so — like ManageLoginPageButtons above — it sits OUTSIDE both provider forms and
+            Single Logout (#727): GLOBAL setting. EnableSingleLogout lives on the root PluginConfiguration,
+            not on a provider, so, like ManageLoginPageButtons above, it sits OUTSIDE both provider forms and
             carries NO sso-* marker class: it is saved by its own handler (config.js saveSingleLogout), which
             re-posts the whole configuration with only this flag changed, and loaded by loadConfiguration. The
             per-provider return URL (PostLogoutRedirectUri) is an ordinary persisting provider-form field in
@@ -328,7 +328,7 @@
             each saved OpenID provider is a card (name + type badge + enabled/disabled pill); clicking a card
             loads it into the editor below. The hidden <select id="selectProvider"> is retained as the state
             holder the save path already reads (config.js saveProvider sets its value after a save), so the
-            serializer contract is unchanged — only the visible affordance moved from a dropdown to cards.
+            serializer contract is unchanged; only the visible affordance moved from a dropdown to cards.
           -->
           <form id="sso-load-config" class="esqConfigurationForm">
             <div class="verticalSection">
@@ -410,13 +410,13 @@
           </form>
 
           <!--
-            Provider settings form — the save contract (#365). Each input here that must persist carries a
+            Provider settings form: the save contract (#365). Each input here that must persist carries a
             behavior-marker class (sso-text / sso-line-list / sso-toggle / sso-folder-list / sso-role-map)
             AND an id spelled EXACTLY like the OidConfig property it writes to: config.js saveProvider does
             current_config[element.id] = value, and the server drops JSON members that are not OidConfig
             properties. A field with a mismatched id, a missing marker class, or placed outside this form
             renders but silently never saves. The provider-name input is the one deliberate non-persisting
-            field — it supplies the OidConfigs dictionary key, not a property — so it carries no marker
+            field (it supplies the OidConfigs dictionary key, not a property), so it carries no marker
             class. Locked in by ArchitectureConformanceTests.ProviderFormFieldIds_MatchOidConfigProperties.
 
             The editor is chunked into native emby-collapse accordion sections (Connection, User provisioning,
@@ -430,8 +430,8 @@
             <div class="sso-editor" id="sso-editor" hidden>
               <div class="sso-editor-header">
                 <!--
-                  Deliberately carries NO data-i18n marker (#913): config.js OWNS this heading — it writes
-                  the loaded provider's name here (setEditorTitle) — and the catalog is applied
+                  Deliberately carries NO data-i18n marker (#913): config.js OWNS this heading, since it writes
+                  the loaded provider's name here (setEditorTitle), and the catalog is applied
                   asynchronously. A marker would let a late applyTo() overwrite "keycloak-prod" with
                   "New provider" over an editor that actually has a provider loaded, and the Save path
                   targets the loaded provider without a name-bearing confirmation. The blank-editor
@@ -512,7 +512,7 @@
               >
                 <div class="collapseContent">
                   <!--
-                    Why this label — and every field label that wraps a required/optional hint — carries no
+                    Why this label, and every field label that wraps a required/optional hint, carries no
                     data-i18n marker (#913): the marker REPLACES an element's textContent, so a marker here
                     would delete the nested <span class="sso-required">*</span> the moment the catalog
                     resolves, silently dropping the required indicator from a rendered page (it would still
@@ -600,7 +600,7 @@
                       aria-live="polite"
                     ></div>
                     <div class="fieldDescription" id="OidRedirectUri-help">
-                      The exact redirect URI the login uses — register it
+                      The exact redirect URI the login uses. Register it
                       verbatim at your identity provider. It updates as you type
                       the provider name above. Derived from the
                       <strong>Base URL Override</strong> (in the Advanced
@@ -815,7 +815,7 @@
                       button. Leave blank to use the provider name. Only takes
                       effect while the global "Manage login buttons on the login
                       page" option is on and the button is not hidden; any text
-                      is safe — it is always rendered inert, never as markup.
+                      is safe: it is always rendered inert, never as markup.
                     </div>
                   </div>
 
@@ -1051,7 +1051,7 @@
                         "&lt;domain&gt;"}}</code
                       >
                       under <code>urn:zitadel:iam:org:project:roles</code>. Only
-                      the names are read — never the values, never nested
+                      the names are read, never the values, never nested
                       objects. Off by default; leave it off for a provider that
                       returns a list (Keycloak, Authelia, authentik).
                     </div>
@@ -1089,8 +1089,8 @@
                       If a user has any of these roles, then the user is
                       authenticated. This validates the OpenID response against
                       the claim set in <strong>"RoleClaim"</strong>. (If your
-                      provider — Zitadel does this — carries the roles as object
-                      keys, also tick "Role claim is an object map" beside the
+                      provider carries the roles as object keys, as Zitadel
+                      does, also tick "Role claim is an object map" beside the
                       Role Claim field.)
                       <br />
                       Leave blank to disable role checking.
@@ -1499,8 +1499,8 @@
                       from the request Host header; behind a reverse proxy that
                       is only safe if Jellyfin's Known Proxies is set and the
                       proxy sends a trusted X-Forwarded-Host (not a
-                      client-supplied one) — setting this override is the robust
-                      fix. This is the base URL, not the redirect URI — register
+                      client-supplied one). Setting this override is the robust
+                      fix. This is the base URL, not the redirect URI; register
                       <code
                         >&lt;this
                         URL&gt;/sso/OID/redirect/&lt;ProviderName&gt;</code
@@ -1562,7 +1562,7 @@
                       />
                       <div class="fieldDescription">
                         Space-separated acr_values sent on the authorization
-                        request (OIDC Core §3.1.2.1), most-preferred first — the
+                        request (OIDC Core §3.1.2.1), most-preferred first: the
                         requested authentication-context references (e.g. an MFA
                         reference your IdP advertises). Leave blank to send
                         nothing (unchanged request). Also the allow-list Require
@@ -1597,7 +1597,7 @@
                         class="sso-text"
                       />
                       <div class="fieldDescription">
-                        OIDC max_age — the maximum time (seconds) since the
+                        OIDC max_age: the maximum time (seconds) since the
                         user's last active authentication; <code>0</code> forces
                         re-authentication. Leave blank to omit it.
                       </div>
@@ -1617,7 +1617,7 @@
                       </label>
                       <div class="fieldDescription checkboxFieldDescription">
                         Refuse any login whose verified id_token does not return
-                        an acr within Acr Values above — a fail-closed step-up /
+                        an acr within Acr Values above: a fail-closed step-up /
                         forced-MFA gate. Off by default. Requires Acr Values to
                         be set (the save is rejected otherwise, so a mis-set
                         cannot lock out a userbase). The break-glass password
@@ -1688,8 +1688,8 @@
                         account by enabling it in the Jellyfin dashboard
                         (Administration → Users). Off by default (new accounts
                         are created enabled). This never disables an existing or
-                        adopted account — only a brand-new one — and each
-                        deferred provisioning is recorded as an audit event.
+                        adopted account, only a brand-new one, and each deferred
+                        provisioning is recorded as an audit event.
                       </div>
                     </div>
 
@@ -1740,8 +1740,8 @@
                       <div class="fieldDescription checkboxFieldDescription">
                         ⚠ Sensitive: requires every OpenID login for this
                         provider to carry a provider-verified email
-                        (email_verified == true) — whether it adopts, creates,
-                        or signs in to an already-linked account — not only the
+                        (email_verified == true), whether it adopts, creates, or
+                        signs in to an already-linked account, not only the
                         adoption moment above. A login whose email_verified is
                         not exactly true (absent, false, or unparseable) is
                         refused. Needs the email scope so the provider actually
@@ -1927,7 +1927,7 @@
                 Test-connection (#163). No sso-* marker class: this button and the result container are
                 not persisting provider fields, so listArgumentsByType/saveProvider must not pick them up
                 and the ProviderFormFieldIds_MatchOidConfigProperties contract does not apply to them. The
-                test validates the SAVED provider — it reads the stored config server-side — so save first.
+                test validates the SAVED provider, reading the stored config server-side, so save first.
               -->
               <div class="sso-test-block">
                 <button
@@ -1967,7 +1967,7 @@
           </form>
 
           <!--
-            SAML provider workspace (#725) — a second, independent workspace parallel to the OpenID one above.
+            SAML provider workspace (#725): a second, independent workspace parallel to the OpenID one above.
             To keep every element id unique in the document (an HTML requirement) while still driving the save
             contract off the id, every SAML persisting field carries a "saml-" PREFIXED id AND the marker class:
             config.js's SAML save path writes current_config[id.slice("saml-".length)] = value, so the property
@@ -2072,7 +2072,7 @@
               </p>
 
               <!--
-                Start from a template (#726) — the SAML counterpart of the OpenID picker above.
+                Start from a template (#726): the SAML counterpart of the OpenID picker above.
                 Non-persisting (no marker class); options populated from SAML_PRESETS in config.js.
                 Pre-fills only the non-secret endpoint placeholder; never a signing key, never auto-saves.
               -->
@@ -2224,7 +2224,7 @@
                       hidden
                     ></div>
                     <div class="fieldDescription">
-                      The identity provider's Single Sign-On URL — where the
+                      The identity provider's Single Sign-On URL, where the
                       browser is redirected to authenticate.
                     </div>
                   </div>
@@ -2249,7 +2249,7 @@
                       hidden
                     ></div>
                     <div class="fieldDescription">
-                      The identity provider's Single-Logout (SLO) URL — a
+                      The identity provider's Single-Logout (SLO) URL, a
                       distinct endpoint from the SSO endpoint above, where the
                       browser is redirected with a signed SP-initiated
                       LogoutRequest. Must be an absolute https URL. Leave blank
@@ -2283,7 +2283,7 @@
                       hidden
                     ></div>
                     <div class="fieldDescription">
-                      This service provider's entity id — the value the plugin
+                      This service provider's entity id: the value the plugin
                       sends as the AuthnRequest issuer and expects as the
                       audience. You choose it and register it at the IdP; it is
                       also the SP entityID shown below.
@@ -2313,7 +2313,7 @@
                     ></div>
                     <div class="fieldDescription">
                       The identity provider's PUBLIC signing certificate as
-                      Base64 (DER) — the value between the PEM
+                      Base64 (DER): the value between the PEM
                       <code>BEGIN/END CERTIFICATE</code> lines, or the whole
                       PEM. Used to verify the SAML response signature.
                     </div>
@@ -2385,7 +2385,7 @@
                       aria-live="polite"
                     ></div>
                     <div class="fieldDescription">
-                      This service provider's metadata document — many IdPs can
+                      This service provider's metadata document. Many IdPs can
                       import it by URL instead of hand-configuring the ACS and
                       entityID. The SP entityID it advertises is the SAML Client
                       ID above.
@@ -2447,7 +2447,7 @@
                       button. Leave blank to use the provider name. Only takes
                       effect while the global "Manage login buttons on the login
                       page" option is on and the button is not hidden; any text
-                      is safe — it is always rendered inert, never as markup.
+                      is safe: it is always rendered inert, never as markup.
                     </div>
                   </div>
                 </div>

--- a/SSO-Auth/Web/i18n.js
+++ b/SSO-Auth/Web/i18n.js
@@ -21,8 +21,8 @@ function format(text, params) {
   );
 }
 
-// Look up a key. When it is not in the loaded catalog — most importantly when the fetch failed and the
-// catalog is empty — fall back to the caller's built-in English default (the same role the hard-coded text
+// Look up a key. When it is not in the loaded catalog, most importantly when the fetch failed and the
+// catalog is empty, fall back to the caller's built-in English default (the same role the hard-coded text
 // on data-i18n markup plays), and only to the key itself if no default was given, so a missing string is
 // never blank. Placeholders are substituted in either case.
 export function t(key, params, fallback) {

--- a/SSO-Auth/Web/linking.js
+++ b/SSO-Auth/Web/linking.js
@@ -41,8 +41,8 @@ const ssoConfigLinking = {
         .catch(() => ssoConfigLinking.showError());
     });
   },
-  // When a protocol section ends up with no rows — no enabled providers to offer and no existing
-  // link the user still holds — show a placeholder instead of a bare heading over blank space
+  // When a protocol section ends up with no rows (no enabled providers to offer and no existing
+  // link the user still holds), show a placeholder instead of a bare heading over blank space
   // (#669), so a single-protocol or fresh install does not look broken. Called only after both the
   // enabled-provider list and the existing-links feed have resolved, since a disabled provider the
   // user still holds a link to is rendered from the links feed and keeps the section non-empty.
@@ -92,7 +92,7 @@ const ssoConfigLinking = {
             // No container means the provider is not offered for new links because it is disabled
             // (it is absent from the enabled-only GetNames list, #344). The server still returns
             // such links and still lets the user delete them (LinksByUser / TryRemoveLink pass
-            // requireEnabled:false — disabling then cleaning up is the intended workflow), so render
+            // requireEnabled:false; disabling then cleaning up is the intended workflow), so render
             // a container without an add button, marked disabled, rather than dropping it and
             // throwing on a null container. A disabled provider the user holds no link to (empty
             // list, nothing to remove) is skipped.

--- a/SSO-Auth/Web/style.css
+++ b/SSO-Auth/Web/style.css
@@ -67,7 +67,7 @@
 /*
   Provider workspace redesign (#365). Purely additive presentation classes. Colours reuse the AA-safe
   #b71c1c red from emby-restyle.css (destructive/danger) as a solid background or accent border paired with
-  light text — never as body text on the dark dashboard, where a dark red fails the 4.5:1 contrast floor.
+  light text, never as body text on the dark dashboard, where a dark red fails the 4.5:1 contrast floor.
   Error and status TEXT stays in the theme's own high-contrast foreground so it clears WCAG AA in both the
   dark and light dashboards; the red is carried by the accent border, the tinted panel and the ⚠ glyph, so
   meaning is never signalled by colour alone.
@@ -237,7 +237,7 @@
 }
 
 .sso-required {
-  color: #ff8a80; /* Light red: an accent glyph, not body text — decorative emphasis only. */
+  color: #ff8a80; /* Light red: an accent glyph, not body text; decorative emphasis only. */
   font-weight: 700;
 }
 
@@ -362,7 +362,7 @@
 }
 
 .sso-danger-title {
-  color: #ff8a80; /* Accent heading, paired with the descriptive text below it — not colour-only. */
+  color: #ff8a80; /* Accent heading, paired with the descriptive text below it, not colour-only. */
 }
 
 .sso-insecure-toggle {


### PR DESCRIPTION
# What & why

Closes #1292.

The admin configuration page and the translation surface carried 120 em dashes.
#1202 swept the source and the infrastructure and deliberately left this half
out, because it is text a Jellyfin administrator reads on screen: a change to
the product rather than a mechanical sweep, and it needs a reviewer who is
reading the words.

**This changes user-facing strings.** Every string on the config page, in
`linking.js`, in `i18n.js` and in the English catalog that contained an em dash
now reads differently. Nothing else about the page changed: no key moved, no
control was added or removed, and no behaviour depends on the wording.

Each occurrence was replaced with the punctuation its own sentence wants rather
than with one substitute applied everywhere. Where the dash held an aside it
became a parenthesis, where it introduced an explanation a colon, where it
joined two independent clauses a semicolon or a new sentence. "Copy failed -
select the field" is now two sentences, because the second half is an
instruction and not a continuation.

`configPage.html` is reflowed by Prettier after the edit, because the text
lengths changed and the pinned Prettier gate reads the wrapping. That is why
its diff is larger than the number of edited sentences.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: no file on the login path, in the SAML or OIDC crypto, in
config persistence or in the release pipeline is touched. The changed set is
five browser assets and one English catalog value.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition, FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. No logic changed at all.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. No new structural property is
      established, so no rule was added.
- [x] Docs impact considered: the wiki documents options and behaviour, neither
      of which moved, so no README or wiki update is owed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for the changed `.js` / `.html` / `.css` files.

Commands and their output, run at this head commit:

    $ git rev-parse HEAD
    e02f63aea4a5f93ba5909f0e8e710ec7c72c8f4f

The done-when's first clause. The grep finds nothing and exits 1:

    $ git grep -c -P '\x{2014}' HEAD -- 'SSO-Auth/Web/' 'SSO-Auth/Localization/' ; echo "exit=$?"
    exit=1

The done-when's second clause, the catalog key set, compared against `main`
rather than asserted:

    $ git show origin/main:SSO-Auth/Localization/en.json > /tmp/en_main.json
    $ git show HEAD:SSO-Auth/Localization/en.json      > /tmp/en_head.json
    $ node -e "const fs=require('fs');const k=p=>Object.keys(JSON.parse(fs.readFileSync(p,'utf8')));
               const a=k('/tmp/en_main.json'),b=k('/tmp/en_head.json');
               console.log(a.length,b.length,JSON.stringify(a)===JSON.stringify(b));"
    69 69 true

Build and suite, on `net9.0`, with the analyzer gate on:

    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    Build succeeded. 0 Warning(s) 0 Error(s)
    $ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
    Total: 2653, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

The four skips are `SsoHttpTests`' LAN-binding tests. They print their own
reason: binding a listener off loopback raises the Windows firewall consent
dialog, which needs an administrator (#1227), and they run only with
`SSO_TESTS_ALLOW_LAN_BIND=1`. They were skipped rather than worked around, and
they touch nothing this change touches.

Prettier passes on the committed bytes. Checked against the blobs rather than
the working tree, because this clone has `core.autocrlf=true` and reports
every one of these files as needing a rewrite purely for its line endings:

    $ for f in config.js configPage.html i18n.js linking.js style.css; do
        git cat-file blob HEAD:SSO-Auth/Web/$f > lfcheck/SSO-Auth/Web/$f; done
    $ (cd lfcheck && npx prettier --check "SSO-Auth/Web/*")
    Checking formatting...
    All matched files use Prettier code style!

The guard that keeps the two halves together was made to fail on purpose,
because a guard nobody has seen bite proves nothing. Reverting the one edited
catalog value to its em-dash form while leaving the markup rewritten reds the
suite, naming the key:

    $ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe \
        -class "Jellyfin.Plugin.SSO_Auth.Tests.LocalizationCatalogTests"
    LocalizationCatalogTests.MarkupBuiltInEnglish_MatchesTheCatalog [FAIL]
      These built-in English strings have drifted from the catalog:
      configPage.html: 'config.provider_login_button_text_help' markup ... != catalog ...
    Total: 11, Errors: 0, Failed: 1
    $ git checkout -- SSO-Auth/Localization/en.json   # falsifier removed

## Notes

Whether the new wording is better is a judgement no command makes. It wants a
reader who opens the rendered configuration page, and this pull request does
not claim that reading has happened.

No second reader looked at this change. The evidence above is what stands in
place of one.

The rest of the repository still carries em dashes, and that residue is
deliberately out of scope here. #1292 lists it: 24 occurrences that arrived in
source after #1203 merged, plus the `BeginMarker` literal in
`LoginButtonInjector.cs`, which #1202 classifies as a migration rather than a
punctuation edit and which is correctly still there. Neither is this change's.
