### PR TITLE
Pin the OIDC redirect_uri to one builder over one canonical base

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -17,6 +17,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Identity;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 using Jellyfin.Plugin.SSO_Auth.Api.Saml;
 using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Net;
 using Jellyfin.Plugin.SSO_Auth.Api.Provider;
 using Jellyfin.Plugin.SSO_Auth.Api.RateLimit;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
@@ -2994,6 +2995,176 @@ public class ArchitectureConformanceTests
         Assert.False((bool)method.Invoke(null, ["keycloak"])!, "the pinned predicate now rejects an ordinary name, which would strand every registration (#336).");
 
         return $"{nameof(ProviderNameValidator)}.{method.Name}(";
+    }
+
+    // The path fragment that turns a base URL into an OpenID callback URL. RFC 6749 section 4.1.3 compares
+    // redirect_uri byte-for-byte, so the authorization request and the token exchange have to hand out the
+    // same string; a second place that composes this fragment is where the two would drift apart, and the
+    // symptom lands at the identity provider as a refused login rather than anywhere a unit test looks.
+    private const string OidcCallbackPathFragment = "/sso/OID/";
+
+    // The one file allowed to compose it. Repo-relative and exact rather than a file name, for the reason
+    // ParseSites() gives: two files can share a name and an allowlist keyed on the short one admits the
+    // wrong file.
+    private const string OidcRedirectUriCompositionSite = "SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs";
+
+    // Where a source text composes the OpenID callback path: the fragment inside a STRING LITERAL on a code
+    // line. Reading literals rather than raw text is what keeps the five doc comments that quote the route
+    // (LoginButton, OidcCallbackPath, ChallengePath, RouteSuffix) out of it, and the fixtures below pin both
+    // directions. Its limit is the literal boundary - a site splitting the fragment across two literals is
+    // not seen - and that residual is pinned rather than left to be discovered.
+    private static IEnumerable<(int Number, string Text)> OidcCallbackPathCompositions(string source) =>
+        CodeLinesOf(source)
+            .Where(l => StringLiterals(l.Text).Any(literal => literal.Contains(OidcCallbackPathFragment, StringComparison.Ordinal)));
+
+    [Fact]
+    public void TheOidcCallbackPath_IsComposedInExactlyOnePlace()
+    {
+        // #1162. Two call sites hand out a redirect_uri, the challenge and the token exchange, and they must
+        // produce identical bytes. Today both go through OidcRedirectUriBuilder; nothing refuses a third site
+        // that concatenates the path itself, which is the edit that makes them differ.
+        var root = RepoRoot();
+        var offenders = Directory
+            .EnumerateFiles(Path.Combine(root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Select(path => (Relative: Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/'), Path: path))
+            .Where(file => !string.Equals(file.Relative, OidcRedirectUriCompositionSite, StringComparison.Ordinal))
+            .SelectMany(file => OidcCallbackPathCompositions(File.ReadAllText(file.Path))
+                .Select(l => $"{file.Relative}:{l.Number}: {l.Text}"))
+            .ToList();
+
+        Assert.True(
+            offenders.Count == 0,
+            $"Only {OidcRedirectUriCompositionSite} may compose the OpenID callback path; a second site is how the challenge's redirect_uri and the token exchange's stop being the same bytes (#1162): " + string.Join(" | ", offenders));
+
+        // Sentinel against a vacuous pass: the allowlisted file must still be the thing the scan is about. If
+        // the composition moved out of it the loop above would find nothing and report a clean surface, which
+        // is the shape this rule exists to refuse.
+        Assert.True(
+            OidcCallbackPathCompositions(File.ReadAllText(Path.Combine(root, OidcRedirectUriCompositionSite))).Any(),
+            $"{OidcRedirectUriCompositionSite} no longer composes '{OidcCallbackPathFragment}', so this rule is now scanning for a fragment nothing in the tree holds and would pass over any hand-rolled site (#1162).");
+    }
+
+    [Fact]
+    public void EveryOidcRedirectUriCallSite_FeedsTheOneBuilderACanonicalBase()
+    {
+        // The other half: the single builder is only single while every caller reaches it, and only correct
+        // while every caller hands it the SAME base. A call site passing the raw request host instead of the
+        // resolved canonical base produces a well-formed redirect_uri that the other leg does not match.
+        var challenge = OidcRedirectUriBuilderMethod(nameof(OidcRedirectUriBuilder.ChallengeRedirectUri));
+        var callback = OidcRedirectUriBuilderMethod(nameof(OidcRedirectUriBuilder.CallbackRedirectUri));
+
+        var callSite = new Regex(
+            $@"{nameof(OidcRedirectUriBuilder)}\.(?<method>\w+)\(\s*(?<base>[A-Za-z_][\w.]*)\(");
+
+        var calls = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .SelectMany(path => CodeLines(path).Select(l => (File: Path.GetFileName(path), l.Number, l.Text)))
+            .Where(l => l.Text.Contains($"{nameof(OidcRedirectUriBuilder)}.", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(
+            calls.Count >= 2,
+            $"The redirect_uri call-site walk found {calls.Count} call(s) of {nameof(OidcRedirectUriBuilder)}; both the challenge and the token exchange must reach it, so a smaller number means the walk has stopped seeing the flow and this rule would pass over nothing (#1162).");
+
+        var strays = calls
+            .Select(l => (l.File, l.Number, l.Text, Match: callSite.Match(l.Text)))
+            .Where(c => !c.Match.Success
+                || !string.Equals(c.Match.Groups["base"].Value, OidcCanonicalBaseReader, StringComparison.Ordinal)
+                || (c.Match.Groups["method"].Value != challenge.Name && c.Match.Groups["method"].Value != callback.Name))
+            .Select(c => $"{c.File}:{c.Number}: {c.Text}")
+            .ToList();
+
+        Assert.True(
+            strays.Count == 0,
+            $"Every {nameof(OidcRedirectUriBuilder)} call must name one of its two methods and take {OidcCanonicalBaseReader}(...) as its base, so both legs are built over one canonical base (#1162, #242): " + string.Join(" | ", strays));
+
+        Assert.Contains(challenge.Name, calls.Select(c => c.Text).Aggregate(string.Concat), StringComparison.Ordinal);
+        Assert.Contains(callback.Name, calls.Select(c => c.Text).Aggregate(string.Concat), StringComparison.Ordinal);
+
+        // And the base reader is the shared canonical decision rather than a local re-derivation of it, which
+        // is the hop the two assertions above would otherwise take on trust.
+        var flow = Assert.Single(SourceFilesDeclaring(new[] { typeof(OidcLoginService) }));
+        var flowSource = File.ReadAllText(flow);
+        Assert.Contains($"string {OidcCanonicalBaseReader}(HttpRequest request, OidConfig config) =>", flowSource, StringComparison.Ordinal);
+        Assert.True(
+            SourceCallsInCode(flowSource, $"{nameof(CanonicalBaseUrl)}.{nameof(CanonicalBaseUrl.Resolve)}("),
+            $"{OidcCanonicalBaseReader} must resolve through {nameof(CanonicalBaseUrl)}.{nameof(CanonicalBaseUrl.Resolve)}; a local base derivation is how the redirect_uri stops matching the one the SAML side and the admin page compute (#242, #1162).");
+
+        // One assignment reaches the library, so there is no route that sets a redirect_uri the builder did
+        // not produce. Both call sites feed this one parameter.
+        var assignments = CodeLines(flow).Where(l => l.Text.Contains("options.RedirectUri", StringComparison.Ordinal)).ToList();
+        var assignment = Assert.Single(assignments);
+        Assert.Equal("options.RedirectUri = redirectUri;", assignment.Text);
+    }
+
+    [Fact]
+    public void TheAdminPagesRedirectUriPreview_StillMirrorsTheServersPath()
+    {
+        // The admin config page computes the same string in JavaScript so an administrator can register it
+        // verbatim at the identity provider (#724). It is a second producer of these bytes in a language no
+        // C# rule reaches, and it hard-codes the new-path spelling. Nothing made the two move together, so a
+        // server-side path change would leave the page telling admins to register a URL the login never
+        // sends, and the failure appears at the identity provider rather than in this suite. Pinned here
+        // rather than deduplicated: the duplication itself is #1303.
+        var preview = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Web", "config.js"));
+        Assert.Contains(
+            $"return base + \"{OidcCallbackPathFragment}redirect/\" + providerName;",
+            preview,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheOidcCallbackPathScan_LeavesTheSamlBuilderAlone()
+    {
+        // Must-not-catch, named by #1162: the SAML AssertionConsumerServiceURL is the sibling issue's subject
+        // (#1163) and its builder must read as clean here, or the two rules would fight over one file.
+        var saml = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Saml", "SamlAcsUrlBuilder.cs"));
+
+        Assert.Empty(OidcCallbackPathCompositions(saml));
+        Assert.Contains("/sso/SAML/", saml, StringComparison.Ordinal);
+    }
+
+    // The composition scan, fed synthetic source. The near-miss worth spending the fixtures on is a new
+    // OpenID entry point whose author concatenates the path instead of calling the builder: it compiles, it
+    // looks right, and it is wrong only in bytes. The last row is the scan's residual rather than an
+    // oversight waved through - a fragment split across two literals is invisible to it, and pinning that
+    // makes closing it later a deliberate edit with a failing test in front of it.
+    [Theory]
+    [InlineData("        var uri = baseUrl + \"/sso/OID/r/\" + provider;", true)]
+    [InlineData("        return baseUrl + \"/sso/OID/\" + segment + \"/\" + provider;", true)]
+    [InlineData("        var uri = $\"{baseUrl}/sso/OID/redirect/{provider}\";", true)]
+    [InlineData("/// <param name=\"path\">The callback request path, e.g. <c>/sso/OID/redirect/{provider}</c>.</param>", false)]
+    [InlineData("        // the hand-rolled \"/sso/OID/r/\" + provider was removed here", false)]
+    [InlineData("     * see \"/sso/OID/redirect/\" for the spelling", false)]
+    [InlineData("        return baseUrl + \"/sso/SAML/\" + segment + \"/\" + provider;", false)]
+    [InlineData("        var uri = baseUrl + \"/sso/OID\" + \"/r/\" + provider;", false)]
+    public void TheOidcCallbackPathScan_ReadsStringLiteralsOnCodeLines(string line, bool expected)
+    {
+        Assert.Equal(expected, OidcCallbackPathCompositions(line).Any());
+    }
+
+    // The local reader every redirect_uri call site takes its base from. Named once so the rule and its
+    // message cannot disagree about which hop is being required.
+    private const string OidcCanonicalBaseReader = "RequestBaseUrl";
+
+    // A builder method, pinned by reflection so a rename fails here instead of turning the source scans into
+    // a search for a token nothing contains - the shape #1162 asks for a sentinel against. The signature is
+    // asserted too: a method renamed back into place with a different shape would satisfy a name-only check.
+    private static MethodInfo OidcRedirectUriBuilderMethod(string name)
+    {
+        var method = typeof(OidcRedirectUriBuilder).GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+        Assert.True(method is not null, $"{nameof(OidcRedirectUriBuilder)}.{name} was renamed or removed; the redirect_uri rules scan for it by name (#1162).");
+        Assert.Equal(typeof(string), method!.ReturnType);
+
+        var parameters = method.GetParameters();
+        Assert.Equal(3, parameters.Length);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);
+        Assert.Equal(typeof(string), parameters[2].ParameterType);
+
+        return method;
     }
 
     // The harness door, spelled as a construction rather than as a call: building the harness is what swaps


### PR DESCRIPTION
# What & why

Closes #1162.

RFC 6749 section 4.1.3 compares `redirect_uri` byte-for-byte, so the string the
authorization request advertises and the string the token exchange repeats have
to be the same bytes. Both come from `OidcRedirectUriBuilder` today. Nothing
refused a third site that composed the path itself, and the symptom of that edit
is a refused login at the identity provider rather than anything this suite
watches.

Four rules, all source scans over `SSO-Auth/`, added to
`ArchitectureConformanceTests`. No production code changes.

- `TheOidcCallbackPath_IsComposedInExactlyOnePlace`. Only
  `SSO-Auth/Api/Oidc/OidcRedirectUriBuilder.cs` may put `/sso/OID/` in a string
  literal on a code line. Reading string literals rather than raw file text is
  what keeps the four doc comments that quote the route (`LoginButton`,
  `OidcCallbackPath`, `ChallengePath`, `RouteSuffix`) out of it.
- `EveryOidcRedirectUriCallSite_FeedsTheOneBuilderACanonicalBase`. Every
  `OidcRedirectUriBuilder` call names one of its two methods and takes
  `RequestBaseUrl(...)` as its base, and `RequestBaseUrl` resolves through
  `CanonicalBaseUrl.Resolve`. It also pins the single `options.RedirectUri =
  redirectUri;` assignment, so no route can hand the library a redirect_uri the
  builder did not produce. A call site passing the raw request host would build
  a well-formed URI that the other leg does not match.
- `TheOidcCallbackPathScan_LeavesTheSamlBuilderAlone`. The must-not-catch the
  issue names: `SamlAcsUrlBuilder` reads as clean, because the ACS URL is
  #1163's subject and the two rules must not fight over one file.
- `TheAdminPagesRedirectUriPreview_StillMirrorsTheServersPath`. See the finding
  below.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff is one test file and changes no product behaviour, so the boxes below
that ask about runtime posture have nothing to answer for. The change is on this
list because what it pins is a login-path property.

- [x] Fail-closed preserved: nothing in the login path moved.
- [x] No secrets logged; no logging changed.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. See the disclosure at the
      end: no second reader looked at this.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. No lens review was run.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is touched.

## Quality checklist

- [x] No duplicated logic; the composition predicate is one function used by
      both the tree scan and the fixtures, and it is built on the file's
      existing `CodeLinesOf` and `StringLiterals` helpers rather than a second
      comment stripper.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and the new structural property is
      what this change is.
- [x] Docs impact considered: the wiki documents behaviour and options, neither
      of which moved. Nothing is owed.

## Verification

    $ git rev-parse HEAD
    946ef8cd5e1f38dd5a7d27b334efc2ecb0ba88d0

Both target frameworks, analyzer gate on:

    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    Build succeeded. 0 Warning(s) 0 Error(s)
    $ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
    Total: 2717, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    Build succeeded. 0 Warning(s) 0 Error(s)
    $ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
    Total: 2718, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

The four skips are `SsoHttpTests`' LAN-binding tests. They print their own
reason: binding a listener off loopback raises the Windows firewall consent
dialog, which needs an administrator (#1227), and they run only under
`SSO_TESTS_ALLOW_LAN_BIND=1`. They were skipped rather than worked around, and
they touch nothing this change touches.

### Every guard was made to fail before it was trusted

A rule nobody has watched go red proves nothing, so each was falsified against
the tree and the falsifier reverted.

A hand-rolled second composition site, added to `OidcCallbackPath.cs` as
`baseUrl + "/sso/OID/r/" + provider`:

    ArchitectureConformanceTests.TheOidcCallbackPath_IsComposedInExactlyOnePlace [FAIL]
    Total: 160, Errors: 0, Failed: 1

One call site's base swapped from `RequestBaseUrl(request, config)` to
`RawBase(request)`:

    ArchitectureConformanceTests.EveryOidcRedirectUriCallSite_FeedsTheOneBuilderACanonicalBase [FAIL]
      Every OidcRedirectUriBuilder call must name one of its two methods and take
      RequestBaseUrl(...) as its base, so both legs are built over one canonical
      base (#1162, #242): OidcLoginService.cs:809: var redirectUri =
      OidcRedirectUriBuilder.CallbackRedirectUri(RawBase(request), request.Path.Value, provider);
    Total: 160, Errors: 0, Failed: 1

The admin page's path changed from `redirect` to `r`:

    ArchitectureConformanceTests.TheAdminPagesRedirectUriPreview_StillMirrorsTheServersPath [FAIL]
    Total: 160, Errors: 0, Failed: 1

### Sentinels, because a scan that matches nothing passes

Both are asserted rather than assumed. The allowlisted file must still hold the
fragment, so a composition that moved out of it cannot leave the rule reporting
a clean surface. The call-site walk must still find at least two calls, so a
walk that stopped seeing the flow fails instead of passing over nothing. The two
builder methods are pinned by reflection with their return type and their
parameter shape, so a rename fails at the pin.

### What the scan cannot do

Its limit is the string-literal boundary: a site splitting the fragment across
two literals, `"/sso/OID" + "/r/"`, is invisible to it. That residual is pinned
as a fixture row rather than left to be discovered, so closing it later has to be
a deliberate edit with a failing test in front of it. The rule also reads C#
only, which is what the next section is about.

## Notes

**A second producer the issue does not list.** The admin configuration page
computes the same bytes in JavaScript so an administrator can copy the value into
the identity provider (#724):

    $ git grep -n 'sso/OID/redirect' origin/main -- SSO-Auth/Web/config.js
    928:    return base + "/sso/OID/redirect/" + providerName;

Its own comment says it mirrors `OidcRedirectUriBuilder`. It hard-codes the
`redirect` spelling where the server picks between `redirect` and `r` from the
route, and it reimplements the canonical base in the browser. No C# rule reaches
it, and a mismatch surfaces as an administrator registering a URL the login never
sends. This pull request pins the JavaScript literal against the server-side
fragment so a server-side path change cannot land silently. That is a tripwire,
not a fix: it holds the path fragment only and says nothing about the base
resolution or the spelling choice. The duplication itself is filed as #1303.

**Not swept in here.** `SamlAcsUrlBuilder` is #1163's subject, and the rule above
proves it is left alone rather than leaving that to inspection.

No second reader looked at this change. The falsified guards and the commands
above are what stands in place of one.
