### PR TITLE
Name each logout_token refusal instead of collapsing eleven into one

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -91,19 +94,30 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     [Theory]
     [InlineData("not-a-jwt")]
     [InlineData("only.two")]
-    [InlineData("a.b.c")]
-    public async Task GarbageNonJwt_IsInvalid_FailClosed(string token)
+    public async Task GarbageNonJwt_IsMalformed_FailClosed(string token)
     {
-        // A non-empty non-JWT reaches the handler and fails signature/parse validation - still fail-closed,
-        // reported as Invalid (the handler catches it, it never throws a 500).
+        // A non-empty non-JWT reaches the handler and comes back malformed - still fail-closed, and now
+        // under the code whose own summary already claimed this case ("absent, unparseable, or not a JWT").
         var result = await _validator.ValidateAsync(token, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Malformed, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task ThreeGarbageSegments_FallThroughToTheUnclassifiedCode()
+    {
+        // The fail-closed default, exercised rather than described. Three segments of nonsense get far
+        // enough into the handler to fail somewhere this plugin has not classified, so the refusal keeps
+        // the old collapsed code instead of borrowing a name that would be a guess.
+        var result = await _validator.ValidateAsync("a.b.c", Options(), _now);
 
         Assert.False(result.IsValid);
         Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
     }
 
     [Fact]
-    public async Task WrongSigningKey_IsInvalid()
+    public async Task WrongSigningKey_UnderATrustedKid_IsSignatureInvalid()
     {
         using var attacker = RSA.Create(2048);
         var forged = new JsonWebTokenHandler().CreateToken(Descriptor(Claims(sub: "user-1"), signingKey: attacker));
@@ -111,42 +125,200 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         var result = await _validator.ValidateAsync(forged, Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.SignatureInvalid, result.ReasonCode);
     }
 
     [Fact]
-    public async Task WrongIssuer_IsInvalid()
+    public async Task WrongSigningKey_UnderAnUnknownKid_IsKeyNotFound()
+    {
+        // The neighbour of the test above, and the pair is the point: the same forgery separates into two
+        // codes purely on whether the kid names a key the provider published. An operator reading the trail
+        // sees "somebody signed with their own key" apart from "somebody named a key we do not have".
+        using var attacker = RSA.Create(2048);
+        var descriptor = Descriptor(Claims(sub: "user-1"));
+        descriptor.SigningCredentials = new SigningCredentials(
+            new RsaSecurityKey(attacker) { KeyId = "some-other-key" },
+            SecurityAlgorithms.RsaSha256);
+        var forged = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(forged, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.KeyNotFound, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task WrongIssuer_IsIssuerInvalid()
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), issuer: "https://evil.example.test");
 
         var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.IssuerInvalid, result.ReasonCode);
     }
 
     [Fact]
-    public async Task WrongAudience_IsInvalid()
+    public async Task WrongAudience_IsAudienceInvalid()
     {
         var token = CreateToken(claims: Claims(sub: "user-1"), audience: "another-client");
 
         var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AudienceInvalid, result.ReasonCode);
     }
 
     [Fact]
-    public async Task ExpiredToken_IsInvalid()
+    public async Task IncoherentLifetime_IsLifetimeInvalid()
     {
-        // 10 minutes past exp is beyond the default 5-minute clock skew.
+        // exp BEFORE nbf. This is the shape the previous "expired" test actually built, and it is a
+        // different refusal from an ordinary expiry: the handler reports the lifetime as incoherent before
+        // it ever compares exp to the clock.
         var token = CreateToken(claims: Claims(sub: "user-1"), lifetime: TimeSpan.FromMinutes(-10));
 
         var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.LifetimeInvalid, result.ReasonCode);
     }
+
+    [Fact]
+    public async Task GenuinelyExpiredToken_IsExpired()
+    {
+        // A coherent lifetime wholly in the past, beyond the 5-minute skew: the ordinary case an operator
+        // reads as a slow or retrying IdP rather than as an attack.
+        var descriptor = Descriptor(Claims(sub: "user-1"));
+        descriptor.IssuedAt = DateTime.UtcNow - TimeSpan.FromHours(3);
+        descriptor.NotBefore = DateTime.UtcNow - TimeSpan.FromHours(3);
+        descriptor.Expires = DateTime.UtcNow - TimeSpan.FromHours(1);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Expired, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task NotYetValidToken_IsNotYetValid()
+    {
+        var descriptor = Descriptor(Claims(sub: "user-1"));
+        descriptor.IssuedAt = DateTime.UtcNow;
+        descriptor.NotBefore = DateTime.UtcNow + TimeSpan.FromHours(2);
+        descriptor.Expires = DateTime.UtcNow + TimeSpan.FromHours(3);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotYetValid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task AlgNone_IsAlgorithmNotAllowed()
+    {
+        var result = await _validator.ValidateAsync(UnsignedAlgNoneToken(), Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AlgorithmNotAllowed, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task AlgCaseVariant_IsAlgorithmNotAllowed()
+    {
+        // "rs256" is not "RS256". The allowlist holds the exact RFC 7518 names and the comparison is
+        // Ordinal, so a case-folded spelling is refused rather than quietly accepted as its neighbour.
+        var reheadered = WithHeaderAlgorithm("rs256", CreateToken(Claims(sub: "user-1")));
+
+        var result = await _validator.ValidateAsync(reheadered, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AlgorithmNotAllowed, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task AlgorithmConfusion_HS256KeyedWithTheAdvertisedPublicKey_IsAlgorithmNotAllowed()
+    {
+        // The classic: sign with HMAC using the provider's PUBLIC key as the secret, which anybody can
+        // fetch. It is refused either way; what this pins is that the trail says so. Measured before the
+        // gate existed, the handler reported it as an ordinary invalid signature, because ValidAlgorithms
+        // is evaluated per key inside signature validation.
+        var publicKey = _rsa.ExportSubjectPublicKeyInfo();
+        var descriptor = Descriptor(Claims(sub: "user-1"));
+        descriptor.SigningCredentials = new SigningCredentials(
+            new SymmetricSecurityKey(publicKey) { KeyId = KeyId },
+            SecurityAlgorithms.HmacSha256);
+        var forged = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(forged, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AlgorithmNotAllowed, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task StrippedSignature_IsSignatureInvalid()
+    {
+        // alg stays RS256, so the algorithm gate passes it through and the handler owns the refusal. It is
+        // not separable from a wrong-key signature here, and the code says signature rather than pretending
+        // to a distinction the library does not make.
+        var token = CreateToken(Claims(sub: "user-1"));
+        var stripped = token[..(token.LastIndexOf('.') + 1)];
+
+        var result = await _validator.ValidateAsync(stripped, Options(), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.SignatureInvalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task EveryReasonCodeIsAFixedConstant_AndNoneCarriesTokenText()
+    {
+        // The constraint the whole split is bounded by: more codes must not mean more information about
+        // WHO the token named. Every code is compared against the declared constants, so a code
+        // interpolated from a claim would have to be added to this list to pass, which is the moment a
+        // reviewer sees it.
+        var declared = typeof(OidcLogoutTokenValidator.RejectReason)
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .Select(f => (string)f.GetRawConstantValue()!)
+            .ToList();
+
+        Assert.NotEmpty(declared);
+        Assert.Equal(declared.Count, declared.Distinct(StringComparer.Ordinal).Count());
+
+        using var attacker = RSA.Create(2048);
+        string[] subjects = ["user-secret-1", "user-secret-2"];
+        foreach (var subject in subjects)
+        {
+            var forged = new JsonWebTokenHandler().CreateToken(Descriptor(Claims(sub: subject), signingKey: attacker));
+            var result = await _validator.ValidateAsync(forged, Options(), _now);
+
+            Assert.Contains(result.ReasonCode, declared);
+            Assert.DoesNotContain(subject, result.ReasonCode, StringComparison.Ordinal);
+        }
+    }
+
+    private static string Base64Url(string json) => Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(json));
+
+    private static string UnsignedAlgNoneToken()
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var payload = "{\"iss\":\"" + Issuer + "\",\"aud\":\"" + ClientId + "\",\"sub\":\"user-1\",\"jti\":\""
+            + Guid.NewGuid() + "\",\"iat\":" + now + ",\"nbf\":" + (now - 60) + ",\"exp\":" + (now + 300)
+            + ",\"events\":{\"" + LogoutEvent + "\":{}}}";
+        return Header("none") + "." + Base64Url(payload) + ".";
+    }
+
+    private static string WithHeaderAlgorithm(string algorithm, string token)
+    {
+        var parts = token.Split('.');
+        return Header(algorithm) + "." + parts[1] + "." + parts[2];
+    }
+
+    private static string Header(string algorithm) =>
+        Base64Url("{\"alg\":\"" + algorithm + "\",\"typ\":\"JWT\",\"kid\":\"" + KeyId + "\"}");
 
     [Fact]
     public async Task NoEventsClaim_IsNotALogoutToken()
@@ -253,7 +425,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
     }
 
     [Fact]
-    public async Task AzpMismatch_IsInvalid()
+    public async Task AzpMismatch_IsAuthorizedPartyMismatch()
     {
         // Parity with the id_token validator (OIDC Core 3.1.3.7 rule 5): an azp naming a different party is
         // refused even though this client is the audience.
@@ -262,11 +434,11 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         var result = await _validator.ValidateAsync(CreateToken(claims: claims), Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AuthorizedPartyMismatch, result.ReasonCode);
     }
 
     [Fact]
-    public async Task MultipleAudiencesWithoutAzp_IsInvalid()
+    public async Task MultipleAudiencesWithoutAzp_IsItsOwnCode()
     {
         // Rules 3-4: a multi-audience token MUST carry azp; one minted for a co-listed different party is refused.
         var claims = Claims(sub: "user-1");
@@ -283,7 +455,7 @@ public sealed class OidcLogoutTokenValidatorTests : IDisposable
         var result = await _validator.ValidateAsync(token, Options(), _now);
 
         Assert.False(result.IsValid);
-        Assert.Equal(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.MultipleAudiencesWithoutAuthorizedParty, result.ReasonCode);
     }
 
     private static Dictionary<string, object> Claims(string? sub = null, string? sid = null, string? jti = null)

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -73,6 +73,18 @@ internal sealed class OidcLogoutTokenValidator
             return new Result(false, null, null, RejectReason.CriticalHeader);
         }
 
+        // The algorithm is judged before the handler runs, purely so the refusal can be named. The handler
+        // refuses a disallowed alg on its own - nothing new is rejected here - but it reports alg: none, a
+        // case-variant spelling and an HS256 token keyed with the advertised public key as
+        // SecurityTokenInvalidSignatureException, indistinguishable from an ordinary bad signature, because
+        // ValidAlgorithms is evaluated per key inside signature validation. An operator watching this
+        // endpoint needs those apart: a spread of algorithm refusals is somebody probing, a steady stream of
+        // signature failures is usually a rotated key nobody re-published (#1164).
+        if (!OidcSignatureKeys.TokenHasAllowedAlgorithm(logoutToken))
+        {
+            return new Result(false, null, null, RejectReason.AlgorithmNotAllowed);
+        }
+
         // ECDsa instances built from the JWKS are ours to dispose; RSA keys built from RSAParameters are
         // not disposable. Owned here rather than by the caller because the basis is now built here too -
         // the finally must not run until ValidateTokenAsync has returned (#1176).
@@ -93,7 +105,7 @@ internal sealed class OidcLogoutTokenValidator
                 OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys, requireExpiration: false)).ConfigureAwait(false);
             if (!result.IsValid)
             {
-                return new Result(false, null, null, RejectReason.Invalid);
+                return new Result(false, null, null, ReasonFor(result.Exception));
             }
 
             var token = (JsonWebToken)result.SecurityToken;
@@ -107,12 +119,12 @@ internal sealed class OidcLogoutTokenValidator
             var azp = result.ClaimsIdentity.FindFirst("azp")?.Value;
             if (azp != null && !string.Equals(azp, options.ClientId, StringComparison.Ordinal))
             {
-                return new Result(false, null, null, RejectReason.Invalid);
+                return new Result(false, null, null, RejectReason.AuthorizedPartyMismatch);
             }
 
             if (azp == null && token.Audiences.Count() > 1)
             {
-                return new Result(false, null, null, RejectReason.Invalid);
+                return new Result(false, null, null, RejectReason.MultipleAudiencesWithoutAuthorizedParty);
             }
 
             // §2.4: a logout_token MUST NOT contain a nonce. Rejecting it here is what refuses an id_token
@@ -160,6 +172,35 @@ internal sealed class OidcLogoutTokenValidator
         }
     }
 
+    // The fixed code for a handler refusal, chosen from the exception TYPE and never from its message: an
+    // IdentityModel message can embed claim values, and this trail must stay free of anything derived from
+    // the token's subject. Every arm is a const, so no request byte can reach the audit line.
+    //
+    // Which exception each shape actually produces was measured against this basis rather than inferred from
+    // the type names, and the measurement is why several shapes share one arm: alg: none, a case-variant
+    // alg, an HS256 token keyed with the advertised public key, a stripped signature and a foreign key
+    // signing under a trusted kid all arrive as SecurityTokenInvalidSignatureException. The first three are
+    // separated ahead of the handler by the algorithm gate above; the last two are not separable here, and
+    // calling both signature_invalid is the honest answer rather than a guess.
+    //
+    // Anything unmapped keeps the old collapsed code, which is the fail-closed default: a library version
+    // introducing a new exception type reports a refusal this plugin has not classified, rather than
+    // reporting one it has.
+    private static string ReasonFor(Exception? exception) => exception switch
+    {
+        SecurityTokenMalformedException => RejectReason.Malformed,
+        SecurityTokenSignatureKeyNotFoundException => RejectReason.KeyNotFound,
+        SecurityTokenInvalidSignatureException => RejectReason.SignatureInvalid,
+        SecurityTokenInvalidAlgorithmException => RejectReason.AlgorithmNotAllowed,
+        SecurityTokenInvalidIssuerException => RejectReason.IssuerInvalid,
+        SecurityTokenInvalidAudienceException => RejectReason.AudienceInvalid,
+        SecurityTokenExpiredException => RejectReason.Expired,
+        SecurityTokenNotYetValidException => RejectReason.NotYetValid,
+        SecurityTokenInvalidLifetimeException => RejectReason.LifetimeInvalid,
+        SecurityTokenNoExpirationException => RejectReason.LifetimeInvalid,
+        _ => RejectReason.Invalid,
+    };
+
     // The events claim is a JSON object; presence of the back-channel-logout member is what makes this a
     // logout_token. Read it as a JsonElement and require the member - a claim that is absent, not an object,
     // or an object without the member is rejected. Any parse failure is a fail-closed "not a logout_token".
@@ -194,8 +235,42 @@ internal sealed class OidcLogoutTokenValidator
         /// <summary>The header carries a crit parameter, naming a JWS extension this plugin does not process (RFC 7515 4.1.11, #1038).</summary>
         internal const string CriticalHeader = "unprocessed_critical_header";
 
-        /// <summary>Signature, issuer, audience, algorithm, or lifetime validation failed (unsigned, wrong key, weak alg, expired).</summary>
+        /// <summary>
+        /// A handler refusal this plugin has not classified. Every shape reaching it today has its own code
+        /// below; this is what a future library version's new exception type falls through to, so an
+        /// unrecognised refusal reads as unrecognised instead of borrowing a neighbour's name (#1164).
+        /// </summary>
         internal const string Invalid = "signature_or_time_invalid";
+
+        /// <summary>The header alg is outside the asymmetric-only allowlist: alg none, a case variant, or a symmetric algorithm keyed with the advertised public key (#1164).</summary>
+        internal const string AlgorithmNotAllowed = "algorithm_not_allowed";
+
+        /// <summary>The signature did not verify under any advertised key, or the token carries none. A stripped signature and a foreign key signing under a trusted kid are not separable here (#1164).</summary>
+        internal const string SignatureInvalid = "signature_invalid";
+
+        /// <summary>The header names a kid no key in the provider's JWKS carries, so nothing could verify it (#1164).</summary>
+        internal const string KeyNotFound = "key_not_found";
+
+        /// <summary>The iss claim is not this provider's issuer (#1164).</summary>
+        internal const string IssuerInvalid = "issuer_invalid";
+
+        /// <summary>The aud claim does not list this client (#1164).</summary>
+        internal const string AudienceInvalid = "audience_invalid";
+
+        /// <summary>The token's exp has passed, allowing for the configured clock skew (#1164).</summary>
+        internal const string Expired = "expired";
+
+        /// <summary>The token's nbf is still in the future, allowing for the configured clock skew (#1164).</summary>
+        internal const string NotYetValid = "not_yet_valid";
+
+        /// <summary>The token's lifetime is not coherent: nbf at or after exp, or a required expiry absent (#1164).</summary>
+        internal const string LifetimeInvalid = "lifetime_invalid";
+
+        /// <summary>The azp claim names a party other than this client (OIDC Core 3.1.3.7 rule 4, #1164).</summary>
+        internal const string AuthorizedPartyMismatch = "azp_mismatch";
+
+        /// <summary>The token lists several audiences and carries no azp, so it was not minted for this client alone (OIDC Core 3.1.3.7 rule 3, #1164).</summary>
+        internal const string MultipleAudiencesWithoutAuthorizedParty = "multiple_audiences_without_azp";
 
         /// <summary>The events claim is absent or does not contain the back-channel-logout event - this is not a logout_token.</summary>
         internal const string NotALogoutToken = "not_a_logout_token";

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security.Cryptography;
 using Duende.IdentityModel.OidcClient;
 using Jellyfin.Plugin.SSO_Auth.Api.Crypto;
@@ -136,6 +137,57 @@ internal static class OidcSignatureKeys
         }
 
         return IsAcceptableKeyId(keyId);
+    }
+
+    /// <summary>
+    /// Whether a compact-serialized JWT's header <c>alg</c> is one this plugin verifies, read from the same
+    /// <see cref="AllowedSignatureAlgorithms"/> the validation basis enforces. The handler refuses a
+    /// disallowed algorithm on its own, so this changes NOTHING about what is accepted; what it changes is
+    /// what the refusal can be called. Measured rather than assumed: <c>alg: none</c>, a case-variant
+    /// spelling and an HS256 token keyed with the advertised public key all surface from the handler as
+    /// <c>SecurityTokenInvalidSignatureException</c>, because <c>ValidAlgorithms</c> is evaluated per key
+    /// inside signature validation - so an operator reading the audit trail cannot tell an algorithm attack
+    /// from an ordinary bad signature unless the algorithm is judged before the handler runs (#1164).
+    /// <para>
+    /// Called by the back-channel <c>logout_token</c> path only. The id_token path keeps the handler's own
+    /// refusal because <c>OidcClient</c> depends on the <c>invalid_signature</c> contract it produces, which
+    /// is why #1164 excludes that path rather than sharing this call the way the <c>kid</c> and <c>crit</c>
+    /// gates are shared.
+    /// </para>
+    /// <para>
+    /// Comparison is Ordinal, so a case variant is refused rather than folded: the allowlist entries are the
+    /// exact RFC 7518 names, and a verifier that accepted <c>rs256</c> would be accepting a spelling the
+    /// basis does not list. A token this cannot read at all is reported as allowed rather than refused, the
+    /// same contract and the same reason as <see cref="TokenHasAcceptableKeyId"/>: this gate is not the
+    /// fail-closed floor.
+    /// </para>
+    /// </summary>
+    /// <param name="token">The raw compact-serialized JWT.</param>
+    /// <returns><c>false</c> only when an <c>alg</c> was positively read and is outside the allowlist.</returns>
+    internal static bool TokenHasAllowedAlgorithm(string? token)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return true;
+        }
+
+        string? algorithm;
+        try
+        {
+            algorithm = new JsonWebToken(token).Alg;
+        }
+        catch (ArgumentException)
+        {
+            // Not a readable JWT. The handler rejects it on its own terms; see the remark above.
+            return true;
+        }
+        catch (FormatException)
+        {
+            // A later segment that will not base64url-decode, the shape TokenHasAcceptableKeyId documents.
+            return true;
+        }
+
+        return string.IsNullOrEmpty(algorithm) || AllowedSignatureAlgorithms.Contains(algorithm, StringComparer.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

Closes #1164.

Every signature, algorithm, key, lifetime and audience-restriction failure on
the anonymous back-channel logout endpoint was audited as one code,
`signature_or_time_invalid`. That code is what an operator alerts on, and it
could not separate a misconfigured identity provider from somebody probing:
a rotated key nobody re-published and a spread of forged algorithms read
identically in the log.

The split is bounded by the constraint the issue sets. Token SHAPE carries no
subject identifier, so per-shape codes cost no confidentiality. Every code is a
`const string`; the mapping reads the handler's exception TYPE and never its
message, because an IdentityModel message can embed claim values. The HTTP
answer does not change: the caller still gets the one uniform 400 with nothing
that distinguishes a branch. The SAML side keeps its identically named constant
and is untouched, and the id_token path is unchanged.

## The measurement, which changed the design twice

The issue asks for the mapping to be confirmed empirically rather than inferred
from type names. It was, against this plugin's own validation basis, and the
result does not match what the type names suggest.

| shape | exception from the handler |
| --- | --- |
| non-JWT garbage | `SecurityTokenMalformedException` |
| `alg: none` | `SecurityTokenInvalidSignatureException` |
| `alg` case variant (`rs256`) | `SecurityTokenInvalidSignatureException` |
| HS256 keyed with the advertised public key | `SecurityTokenInvalidSignatureException` |
| stripped signature | `SecurityTokenInvalidSignatureException` |
| foreign key under a trusted `kid` | `SecurityTokenInvalidSignatureException` |
| foreign key under an unknown `kid` | `SecurityTokenSignatureKeyNotFoundException` |
| wrong `iss` | `SecurityTokenInvalidIssuerException` |
| wrong `aud` | `SecurityTokenInvalidAudienceException` |
| coherent lifetime wholly in the past | `SecurityTokenExpiredException` |
| `nbf` in the future | `SecurityTokenNotYetValidException` |

**Five shapes arrive as one exception**, because `ValidAlgorithms` is evaluated
per key inside signature validation. So exception mapping alone cannot produce
the per-shape codes this issue asks for. The first three are separated by
judging the header `alg` against the same allowlist the basis enforces, before
the handler runs. That gate refuses nothing the handler would have accepted; it
only lets the refusal be named, and it carries the same contract its two
neighbours (`TokenHasAcceptableKeyId`, `TokenHasNoCriticalHeader`) already
declare: a token it cannot read is passed through, because this gate is not the
fail-closed floor. The last two are not separable and both report
`signature_invalid`, which is the honest answer rather than a guess.

**An expired token and an incoherent one are different refusals.** The test that
claimed to cover expiry was building the second shape: `exp` ten minutes in the
past against `nbf` one minute in the past is `nbf` after `exp`, which the
handler reports as an invalid lifetime before it ever compares `exp` to the
clock. Both are now covered separately, by what each one actually is.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Nothing new is accepted: the algorithm gate only
      narrows, and `signature_or_time_invalid` survives as the default for an
      unmapped exception type, so a future library version's new refusal reads
      as unclassified instead of borrowing a neighbour's name.
- [x] No secrets logged. No message text reaches a code or a log line; every
      code is a compile-time constant.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. See the disclosure at the
      end: no second reader looked at this.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised. No lens review was run.
- [x] Log inputs from the IdP are sanitized inline at the log call. The audit
      sink is unchanged and still receives a fixed code.

## Quality checklist

- [x] No duplicated logic. The algorithm predicate reads the one existing
      allowlist and sits beside the two gates it mirrors; the mapping is one
      switch expression.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. No new structural property, so no
      rule was added.
- [x] Docs impact considered: the reason codes are internal audit strings and
      are documented at their declarations. Nothing in the wiki enumerates them
      (`git grep -l "signature_or_time_invalid" -- '*.md'` finds nothing), so
      no page drifts.

## Verification

    $ git rev-parse HEAD
    8e4da53

Both target frameworks, analyzer gate on:

    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    Build succeeded. 0 Warning(s) 0 Error(s)
    $ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
    Total: 2725, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

Measured before the rebase onto the two changes that landed while this was in
progress, on the same content:

    $ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
    Total: 2714, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

The four skips are `SsoHttpTests`' LAN-binding tests, which raise a Windows
firewall consent dialog and need an administrator (#1227). They were skipped
rather than worked around, and they touch nothing this change touches.

### Every guard was made to fail before it was trusted

Each falsifier was applied to a rebuilt tree and then reverted.

The algorithm gate returning `true` unconditionally:

    OidcLogoutTokenValidatorTests.AlgNone_IsAlgorithmNotAllowed [FAIL]
    OidcLogoutTokenValidatorTests.AlgCaseVariant_IsAlgorithmNotAllowed [FAIL]
    OidcLogoutTokenValidatorTests.AlgorithmConfusion_HS256KeyedWithTheAdvertisedPublicKey_IsAlgorithmNotAllowed [FAIL]
    Total: 30, Errors: 0, Failed: 3

The `key_not_found` arm deleted from the mapping, which reds exactly the
unknown-`kid` row and nothing else:

    OidcLogoutTokenValidatorTests.WrongSigningKey_UnderAnUnknownKid_IsKeyNotFound [FAIL]
    Total: 30, Errors: 0, Failed: 1

The token's `sub` appended to the returned code, which is the failure the whole
fixed-constant rule exists against. Twelve rows red, including the one that
asserts no code carries token text:

    OidcLogoutTokenValidatorTests.EveryReasonCodeIsAFixedConstant_AndNoneCarriesTokenText [FAIL]
    Total: 30, Errors: 0, Failed: 12

## Notes

The issue's suggested code list is not reproduced exactly, and the differences
are the measurement above rather than preference. `unsigned_token` is not a
separate code: a stripped signature is reported by the handler exactly as a
wrong-key signature is, and inventing a distinction the library does not make
would put a guess in the audit trail. `lifetime_invalid` gained two neighbours,
`expired` and `not_yet_valid`, because the handler does separate those.

The issue names `OidcTokenForgeryTests.LogoutToken_SameForgeries_AreRejected` as
the natural home for these assertions if #1004 had landed. It has not: PR #1030
closed unmerged and the battery went with it, so the assertions are in
`OidcLogoutTokenValidatorTests.cs` as the issue's fallback instructs, and the
forgery theory is left alone.

The audit sink named in the issue has moved. `SsoAudit.LogoutRejected` is now
the SAML-worded one; the OpenID path calls `SsoAudit.BackChannelLogoutRejected`,
split out by #1184, and it passes the code straight through. Confirmed rather
than assumed, and it needed no change.

No second reader looked at this change. The falsified guards, the measured
exception table and the commands above are what stands in place of one.
