### PR TITLE
Name the repeated member in the refusal entry, neutralised at the log call [#1195]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,13 +155,17 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   Note for operators. A provider whose discovery or JWKS document repeats **any**
   member name inside one object will now fail to sign users in, where previously
   the repeat was resolved silently, and no configuration overrides that. The
-  server log records which of the two documents was refused and why. It does not
-  yet name the repeated member: that value is the provider's to choose, and it
-  arrives together with the bounding and filtering that make it safe to record
-  rather than ahead of it. Twenty discovery and JWKS documents from ten widely
-  used hosted providers were checked and none repeats a member; that sample is
-  hosted providers rather than the self-hosted identity servers many
-  installations run, so it bounds the risk without eliminating it.
+  server log records which of the two documents was refused, why, and which
+  member name was repeated, so the entry says what to report to the provider.
+  That name is the provider's to choose, so at most 128 characters of it are
+  recorded, marked `[truncated]` when it is cut, and control characters, Unicode
+  format characters and the line and paragraph separators are removed from it
+  first. A line-ending strip alone removes none of the first two, and each of
+  those classes can split, truncate, reorder or corrupt the entry it lands in.
+  Twenty discovery and JWKS documents from ten widely used hosted providers were
+  checked and none repeats a member; that sample is hosted providers rather than
+  the self-hosted identity servers many installations run, so it bounds the risk
+  without eliminating it.
 
   Two consequences worth knowing. The same refusal on the back-channel logout
   path leaves the session untouched rather than ending it — the behaviour any

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
@@ -25,9 +25,9 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// but the 1 MB response cap in the way. Measured before the bound existed: a document advertising a 200 KB
 /// <c>jwks_uri</c> produced a 205,042-character entry.
 ///
-/// The screen's own refusal entry is a different call and needs no bound - it carries no provider-authored
-/// text at all, which the same measurement showed (211 characters against an 800 KB repeated member name).
-/// That is why the bound lives here and not there.
+/// The screen's own refusal entry is a different call with its own bound, which is why the one here is not
+/// also applied there: it carries the repeated member name, cut at that call and neutralised there (#1195).
+/// The row below is this file's check that the two do not leave a gap between them.
 ///
 /// Both directions are pinned, because a ceiling-only test passes against a bound tightened to a stub, and a
 /// stub would throw away the endpoint an operator reads the entry to find. The mutation each test kills is
@@ -84,13 +84,12 @@ public class OidcDiscoveryReaderErrorBoundTests
     }
 
     [Fact]
-    public async Task AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll()
+    public async Task AnEightHundredKilobyteMemberName_ReachesNoLogEntryUnbounded()
     {
-        // The other value #1194 names, and the reason the bound above is not also applied to the screen's
-        // refusal entry: that entry carries no provider-authored text, so there is nothing there to bound.
-        // Asserted rather than assumed, because "satisfied by exclusion" stops being true the moment
-        // something starts logging the member name, and #1068 is the issue that may decide to. This row goes
-        // red on that day and makes the bound owed at that call too.
+        // The other value #1194 names. It was satisfied by exclusion when this row was written — the screen's
+        // refusal entry carried no provider-authored text at all — and #1195 has since put the member name
+        // into that entry, with its own bound at that call. So the row now reads as what it always asserted:
+        // 800 KB of provider-chosen name reaches no entry in this read, on either call, whole.
         var name = new string('m', 800 * 1024);
         var logger = new CapturingLogger();
 

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -465,12 +465,13 @@ public class OidcDiscoveryReaderTests
     }
 
     [Fact]
-    public async Task NoProviderAuthoredValueReachesTheRefusalEntry()
+    public async Task TheRepeatedMemberNameIsTheOnlyProviderAuthoredValueInTheRefusalEntry()
     {
-        // The entry carries a constant reason, the operator's own provider name, and a constant naming the
-        // document — nothing the provider chose. That is what lets it be safe without a sanitiser, so it is
-        // asserted rather than left to the next edit: the member name and the request URL arrive in #1068
-        // together with the bounds and filters that make them safe.
+        // The entry carries a constant reason, the operator's own provider name, a constant naming the
+        // document, and ONE value the provider chose: the repeated member name, which is what identifies the
+        // defect to report and is bounded and neutralised at that log call (#1195). Nothing else of the
+        // provider's joins it — the request URL in particular stays out, because an entry that echoed a
+        // provider-chosen URL would carry a second unbounded string beside the one that is bounded.
         const string plantedMember = "zzUnmistakableMemberNamezz";
         var duplicated = FullDiscovery(Authority).Insert(1, $"\"{plantedMember}\":1,\"{plantedMember}\":2,");
         var http = new CountingFactory(Serve(duplicated));
@@ -480,7 +481,7 @@ public class OidcDiscoveryReaderTests
 
         Assert.False(result.Available);
         var entry = Assert.Single(logger.Entries, e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));
-        Assert.DoesNotContain(plantedMember, entry.Message, StringComparison.Ordinal);
+        Assert.Contains(plantedMember, entry.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(DiscoveryUrl, entry.Message, StringComparison.Ordinal);
     }
     // Serves the given discovery JSON for the well-known document and the given JWKS for the keyset fetch;

--- a/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
+++ b/SSO-Auth.Tests/Oidc/RefusalEntryMemberNameTests.cs
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Pins what a provider-authored member name may do to the refusal entry <see cref="RepeatedMemberScreen"/>
+/// writes (#1195).
+///
+/// The name is the one value in that entry the provider chooses, and it is put there deliberately: it is what
+/// identifies the defect to report, and nothing relaxes the refusal, so an entry without it leaves an operator
+/// with a broken login and no lead. Putting it there is what creates the exposure these rows bound.
+///
+/// <c>ReplaceLineEndings</c>, which is all the entry beside it gets, is not enough for this value. It passes a
+/// raw vertical tab and a raw NUL straight through - a console sink advances a line on the first, a C-string
+/// consumer truncates its record on the second - and it does not touch a right-to-left override, which
+/// reorders the rest of the entry as it is displayed rather than inserting anything into it. So three
+/// character classes come off the name, and each row below names the mutation it kills.
+///
+/// The fourth class #1195 names, the unpaired surrogate, is answered by measurement rather than by an arm:
+/// <see cref="AnUnpairedSurrogate_NeverBecomesARepeatedMemberName"/> shows a provider cannot get one into this
+/// value at all, and <see cref="TheBoundNeverCutsThroughAnAstralPair"/> covers the one thing that could
+/// manufacture one, which is the plugin's own truncation.
+///
+/// Every row asserts the REFUSAL and not merely the entry. A screen that logged the name and then handed the
+/// document on would write an identical entry, so each read also checks that the library was given the
+/// screen's constant reason instead of the document, and that the JWKS the refused document named was never
+/// fetched.
+/// </summary>
+public class RefusalEntryMemberNameTests
+{
+    private const string Authority = "https://idp-name.example.com";
+
+    // An ordinary member name, long enough to be unmistakable in an entry and made only of characters no
+    // class below removes, so a row that finds it intact has found the filter passing what it must pass.
+    private const string Marker = "zzMemberNamezz";
+
+    // The segment the entry uses to introduce the name. Quoted from the production template so a row cannot
+    // pass against an entry that stopped carrying the name at all.
+    private const string NameLeadIn = "the repeated member is named";
+
+    [Fact]
+    public async Task AnOrdinaryMemberName_ReachesTheEntryWhole()
+    {
+        // Kills: tightening the bound to a stub, and any filter that drops more than the three classes. A
+        // ceiling-only proof passes against a two-character bound, which would throw away the one thing the
+        // operator reads this entry to find.
+        //
+        // The fixture is the longest name the OpenID discovery metadata registry actually defines, so the
+        // floor is derived from what a real document carries rather than from the constant that bounds it.
+        const string Longest = "authorization_response_iss_parameter_supported";
+
+        var entry = await RefusalEntryFor(Longest);
+
+        Assert.Contains(NameLeadIn + " \"" + Longest + "\"", entry, StringComparison.Ordinal);
+        Assert.DoesNotContain("[truncated]", entry, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    // The two ReplaceLineEndings passes through, which is why this class exists at all.
+    [InlineData("\\u0000")]
+    [InlineData("\\u000b")]
+    // The ones it does remove, so the class is a superset of the strip rather than a neighbour of it.
+    [InlineData("\\r")]
+    [InlineData("\\n")]
+    [InlineData("\\u000c")]
+    [InlineData("\\u0085")]
+    // Both control blocks, so the row is not written against the C0 range alone.
+    [InlineData("\\u007f")]
+    [InlineData("\\u009f")]
+    public async Task AControlCharacterInTheName_NeverReachesTheEntry(string escape)
+        => await AssertNeutralisedAtEveryPosition(escape);
+
+    [Theory]
+    // A right-to-left override forges by rearranging what is displayed. It is the reason this class is here.
+    [InlineData("\\u202e")]
+    [InlineData("\\u202d")]
+    // A left-to-right isolate does the same through the newer mechanism, and a zero-width space and a soft
+    // hyphen hide a difference between two names that read alike.
+    [InlineData("\\u2066")]
+    [InlineData("\\u200b")]
+    [InlineData("\\u00ad")]
+    public async Task AFormatCharacterInTheName_NeverReachesTheEntry(string escape)
+        => await AssertNeutralisedAtEveryPosition(escape);
+
+    [Theory]
+    [InlineData("\\u2028")]
+    [InlineData("\\u2029")]
+    public async Task ALineOrParagraphSeparatorInTheName_NeverReachesTheEntry(string escape)
+        => await AssertNeutralisedAtEveryPosition(escape);
+
+    [Fact]
+    public async Task AnOverlongMemberName_IsBoundedInTheEntry()
+    {
+        // Kills: deleting the bound. Measured before it existed: an 800 KB name is what one anonymous
+        // challenge can put in front of this call. The fixture is smaller than that and still far past any
+        // name a working provider emits, so it reaches the truncation instead of sitting under it.
+        var name = new string('m', 8192);
+
+        var entry = await RefusalEntryFor(name);
+
+        Assert.True(
+            entry.Length < 1024,
+            $"the refusal entry carries {entry.Length} characters against an {name.Length}-character provider-authored member name");
+        Assert.Contains("[truncated]", entry, StringComparison.Ordinal);
+
+        // And not merely shorter overall: a bound applied to the wrong operand still lets a long run through.
+        Assert.DoesNotContain(new string('m', 1024), entry, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AValidAstralMemberName_ReachesTheEntryIntact()
+    {
+        // Kills: filtering surrogates as a class. That would answer #1195's fourth class by mangling every
+        // legitimate name outside the basic plane, which is a filter doing damage rather than preventing it.
+        const string Astral = "zz\U0001F600zz";
+
+        var entry = await RefusalEntryFor("zz\\ud83d\\ude00zz");
+
+        Assert.Contains(NameLeadIn + " \"" + Astral + "\"", entry, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheBoundNeverCutsThroughAnAstralPair()
+    {
+        // Kills: cutting at the bound without stepping back off a high surrogate.
+        //
+        // The bound is the only thing on this path that can manufacture an unpaired surrogate, and a half
+        // pair corrupts the entry it lands in - which is one of the four things #1195 says the name must not
+        // be able to do. The offsets are swept rather than aimed at the constant, so the row is derived from
+        // the input space and stays true if the bound moves.
+        for (var lead = 1; lead <= 300; lead++)
+        {
+            var entry = await RefusalEntryFor(new string('m', lead) + "\\ud83d\\ude00" + "zz");
+            AssertNoHalfSurrogatePair(entry, lead);
+        }
+    }
+
+    [Fact]
+    public async Task AnUnpairedSurrogate_NeverBecomesARepeatedMemberName()
+    {
+        // The measurement behind the missing fourth arm. A provider cannot put an unpaired surrogate into
+        // this value: a RAW one has no UTF-8 encoding, so the walk refuses the document before it starts, and
+        // an ESCAPED one is a name GetString will not complete, so the walk reports Unreadable. Either way it
+        // never holds a name to report.
+        //
+        // This row is what turns "no arm is needed" from a belief into a fact, and it goes red the day the
+        // walk starts decoding leniently - which is the day the arm becomes owed.
+        var spellings = new[]
+        {
+            "\\ud800",          // lone high surrogate
+            "\\udc00",          // lone low surrogate
+            "\\udc00\\ud800",   // a reversed pair, which is two unpaired surrogates rather than one pair
+        };
+
+        foreach (var spelling in spellings)
+        {
+            var json = "{\"a" + spelling + "\":1,\"a" + spelling + "\":2}";
+            var verdict = StrictJson.Inspect(json, out var reported);
+
+            Assert.Equal(StrictJson.Verdict.Unreadable, verdict);
+            Assert.Null(reported);
+        }
+
+        // The raw spelling, which does not even reach the reader.
+        var rawVerdict = StrictJson.Inspect("{\"a\ud800\":1,\"a\ud800\":2}", out var rawReported);
+        Assert.Equal(StrictJson.Verdict.Unreadable, rawVerdict);
+        Assert.Null(rawReported);
+
+        // And at the seam the entry carries no name at all rather than an empty or corrupted one, so nothing
+        // downstream reads a name that was never established.
+        var (entry, failClosed) = await RefusalEntryAndFailClosedFor("{\"a\\ud800\":1,\"a\\ud800\":2}");
+        Assert.DoesNotContain(NameLeadIn, entry, StringComparison.Ordinal);
+        Assert.Contains(RepeatedMemberScreen.UninspectableReason, entry, StringComparison.Ordinal);
+        Assert.Contains(RepeatedMemberScreen.UninspectableReason, failClosed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheNeutralisationLivesInTheMethodThatLogs()
+    {
+        // Kills: lifting the bound or the filter out of the method that writes the entry. The log-forging
+        // sanitizer this repository relies on does not propagate across a method boundary, so a helper that
+        // returns a clean string leaves the analyzer reading an unsanitised value at the call - and no
+        // behavioural test can tell the two apart, because both produce the same entry.
+        var source = File.ReadAllText(Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Oidc", "RepeatedMemberScreen.cs"));
+
+        var start = source.IndexOf("private HttpResponseMessage Refuse(", StringComparison.Ordinal);
+        Assert.True(start >= 0, "the refusing method was renamed; this rule points at a method that no longer exists");
+
+        // The next member declaration at class indentation ends the body. The sentinel below is what keeps a
+        // mis-parse from producing a span that trivially contains everything.
+        var end = source.IndexOf("\n    private static ", start, StringComparison.Ordinal);
+        Assert.True(end > start, "the method after Refuse moved; the span this rule reads no longer terminates");
+        Assert.True(
+            end - start < source.Length / 2,
+            "the span read as one method covers half the file, so it is not one method");
+
+        var body = source.Substring(start, end - start);
+        foreach (var token in new[] { "MaxLoggedMemberNameChars", "char.IsHighSurrogate(", "char.IsControl(", "UnicodeCategory.Format", "Array.FindAll(", "_logger.LogWarning(" })
+        {
+            Assert.Contains(token, body, StringComparison.Ordinal);
+            Assert.Equal(
+                CountOf(source, token),
+                CountOf(body, token) + CountOf(source[..start], token));
+        }
+
+        // The count identity above passes vacuously if a token appears nowhere, so the presence assertion is
+        // paired with a check that the tokens the constant declaration legitimately puts above the method are
+        // the only ones there.
+        Assert.Equal(1, CountOf(source[..start], "MaxLoggedMemberNameChars = "));
+    }
+
+    // Drives one repeated member name through the real seam and returns the refusal entry, having first
+    // established that the read actually REFUSED: the library was handed the screen's constant reason in
+    // place of the document, and the JWKS that document named was never fetched. A screen that logged and
+    // passed the document on satisfies neither.
+    private static async Task<string> RefusalEntryFor(string jsonMemberName)
+    {
+        var (entry, failClosed) = await RefusalEntryAndFailClosedFor(
+            "{\"" + jsonMemberName + "\":\"a\",\"" + jsonMemberName + "\":\"b\",\"issuer\":\"" + Authority + "\"}");
+
+        Assert.Contains(RepeatedMemberScreen.RefusalReason, entry, StringComparison.Ordinal);
+        Assert.Contains(RepeatedMemberScreen.RefusalReason, failClosed, StringComparison.Ordinal);
+        return entry;
+    }
+
+    private static async Task<(string Entry, string FailClosed)> RefusalEntryAndFailClosedFor(string discovery)
+    {
+        var logger = new CapturingLogger();
+        var router = new Router(discovery);
+
+        var factory = Substitute.For<IHttpClientFactory>();
+        factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(router));
+
+        var options = new OidcClientOptions { Authority = Authority };
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(Authority).GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.ValidateEndpoints = false;
+
+        var result = await OidcDiscoveryReader.ReadAsync(options, "name", factory, logger);
+
+        Assert.False(result.Available);
+
+        // Nothing beyond the refused document was fetched, which is the fact a report-and-pass-through screen
+        // cannot produce.
+        Assert.Equal(1, router.Requests);
+
+        var entry = Assert.Single(logger.Entries, e => e.Message.StartsWith("Refused the OpenID", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        var failClosed = Assert.Single(logger.Entries, e => e.Message.StartsWith("Could not read the OpenID discovery document", StringComparison.Ordinal));
+        return (entry.Message, failClosed.Message);
+    }
+
+    // Runs one hostile character at each position it can occupy in a member name and asserts two things at
+    // once: the character is gone, and everything around it survived. Without the second half a filter that
+    // dropped the whole name would pass every row here.
+    private static async Task AssertNeutralisedAtEveryPosition(string escape)
+    {
+        // Decoded with the same reader the walk uses, so the row cannot be about a character the fixture
+        // never actually carried.
+        var hostile = JsonSerializer.Deserialize<string>("\"" + escape + "\"")!;
+        Assert.Equal(1, hostile.Length);
+
+        var placements = new (string Label, string JsonName)[]
+        {
+            ("leading", escape + Marker),
+            ("interior", Marker[..6] + escape + Marker[6..]),
+            ("trailing", Marker + escape),
+        };
+
+        foreach (var (label, jsonName) in placements)
+        {
+            var entry = await RefusalEntryFor(jsonName);
+
+            Assert.DoesNotContain(hostile, entry, StringComparison.Ordinal);
+            Assert.True(
+                entry.Contains(NameLeadIn + " \"" + Marker + "\"", StringComparison.Ordinal),
+                label + ": the entry does not carry the name the filter should have left behind: " + entry);
+        }
+    }
+
+    private static void AssertNoHalfSurrogatePair(string entry, int lead)
+    {
+        for (var i = 0; i < entry.Length; i++)
+        {
+            if (char.IsHighSurrogate(entry[i]))
+            {
+                Assert.True(
+                    i + 1 < entry.Length && char.IsLowSurrogate(entry[i + 1]),
+                    $"a high surrogate stands alone in the entry at lead {lead}");
+                i++;
+                continue;
+            }
+
+            Assert.False(char.IsLowSurrogate(entry[i]), $"a low surrogate stands alone in the entry at lead {lead}");
+        }
+    }
+
+    private static int CountOf(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0; i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFilePath = "") =>
+        Directory.GetParent(Directory.GetParent(Path.GetDirectoryName(thisFilePath)!)!.FullName)!.FullName;
+
+    // Serves the fixture for the well-known document and counts every outbound request, so a row can assert
+    // the JWKS leg was never reached.
+    private sealed class Router : HttpMessageHandler
+    {
+        private readonly string _discovery;
+
+        internal Router(string discovery) => _discovery = discovery;
+
+        internal int Requests { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests++;
+            var url = request.RequestUri!.AbsoluteUri;
+            var body = url.EndsWith("/.well-known/openid-configuration", StringComparison.Ordinal)
+                ? _discovery
+                : "{\"keys\":[]}";
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+                RequestMessage = request,
+            });
+        }
+    }
+}

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -22,14 +23,12 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// it, so by the time a post-hoc check could speak, the fetch the repeat aimed at has already happened. Here
 /// the discovery response never reaches the library, so the JWKS URL it named is never requested at all.
 ///
-/// The refusal deliberately carries no provider-authored text. <see cref="HttpResponseMessage.ReasonPhrase"/>
-/// rejects CR/LF/NUL with a <see cref="FormatException"/>, so a member name spelled with an escaped line feed
-/// would make this handler throw while building its own refusal; and sanitising the name to fit would place a
-/// sanitiser one helper boundary away from the log call, which is exactly what the log-forging invariant
-/// forbids. So the reason phrase is a constant, and the member name reaches neither the response nor this
-/// handler's own entry: the walk reports it and the call site discards it (#1068 is where logging it is
-/// decided, and what bounding and filtering it would owe). AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll
-/// is what holds that, so this paragraph stays a checkable claim rather than a description that drifted.
+/// The RESPONSE carries no provider-authored text. <see cref="HttpResponseMessage.ReasonPhrase"/> rejects
+/// CR/LF/NUL with a <see cref="FormatException"/>, so a member name spelled with an escaped line feed would
+/// make this handler throw while building its own refusal. The reason phrase is therefore a constant, and the
+/// member name travels only on this handler's own log entry, where it is bounded and neutralised inline at the
+/// log call (#1195). An operator needs it: the name is what identifies the defect to report to the provider,
+/// and no configuration relaxes the refusal, so an entry that withheld it would leave nothing to act on.
 /// </summary>
 internal sealed class RepeatedMemberScreen : HttpMessageHandler
 {
@@ -42,6 +41,24 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
 
     /// <summary>The constant reason a response that could not be inspected as JSON travels under.</summary>
     internal const string UninspectableReason = "The provider response could not be inspected as JSON";
+
+    /// <summary>
+    /// How much of a provider-authored member name may reach the refusal entry. The name arrives with no
+    /// natural bound: measured before this bound existed, one anonymous challenge put an 800 KB name in front
+    /// of this call, and the only thing limiting it was the 1 MB response cap
+    /// (<see cref="Net.ProviderResponseSizeLimit.MaxProviderResponseBytes"/>).
+    /// <para>
+    /// 128 sits well above every member name these two documents carry - the longest name in the OpenID
+    /// discovery metadata registry is the 46-character <c>authorization_response_iss_parameter_supported</c>,
+    /// and a JWKS entry's are shorter still - and far below the point where repeating the request fills a
+    /// disk. Both directions are pinned by tests, because a ceiling-only proof passes against a bound
+    /// tightened to a stub, and a stub throws away the one thing the entry exists to carry.
+    /// </para>
+    /// </summary>
+    private const int MaxLoggedMemberNameChars = 128;
+
+    /// <summary>Marks a member name this screen cut, so a truncated name is not read as the whole name.</summary>
+    private const string NameTruncationMarker = "[truncated]";
 
     private readonly HttpClient _client;
     private readonly string? _provider;
@@ -116,11 +133,10 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
             // the day the read is no longer pre-buffered, and
             // ABodyThatCannotBeCopied_ReachesNeitherTheHttpRequestExceptionNorTheIOExceptionArm goes red on
             // exactly that day, so keeping them stays a checkable claim rather than a decorative one.
-            return Refuse(request, response, OidcDiscoveryRefusal.Uninspectable, cause: e);
+            return Refuse(request, response, OidcDiscoveryRefusal.Uninspectable, repeatedMember: null, cause: e);
         }
 
-        // The walk still reports WHICH member repeated; this unit deliberately does not log it (#1068).
-        var verdict = StrictJson.Inspect(body, out _);
+        var verdict = StrictJson.Inspect(body, out var repeatedMember);
         if (verdict == StrictJson.Verdict.Clean)
         {
             return response;
@@ -130,34 +146,72 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
             request,
             response,
             verdict == StrictJson.Verdict.Repeated ? OidcDiscoveryRefusal.RepeatedMember : OidcDiscoveryRefusal.Uninspectable,
+            repeatedMember,
             cause: null);
     }
 
     // Records why the response is being withheld and returns the constant-reason refusal in its place.
     //
-    // NOTHING PROVIDER-AUTHORED reaches this entry. The reason is a compile-time constant, the provider
-    // name is the operator's own configuration value, and the document is named by a constant chosen from
-    // the request rather than echoed out of it. That is what makes the entry safe without a sanitiser: an
-    // arbitrary provider-chosen string needs bounding and filtering that ReplaceLineEndings alone does not
-    // give it — a raw vertical tab forges a line on a console sink, a NUL truncates the record for a
-    // C-string consumer, a right-to-left override reorders what is displayed — and the value that needs all
-    // that arrives with it in #1068 rather than ahead of it.
+    // ONE value here is provider-authored: the repeated member name. Everything beside it is not - the reason
+    // is a compile-time constant, the provider name is the operator's own configuration value, the document
+    // is named by a constant chosen from the request rather than echoed out of it, and only the exception
+    // TYPE is logged because its message quotes the provider's own Content-Type back.
     //
-    // Only the exception TYPE is logged, never its message: the message quotes the provider's own
-    // Content-Type, so it is one more untrusted string, while the type name is runtime-authored and
-    // distinguishes the decode failures an operator has to tell apart.
-    private HttpResponseMessage Refuse(HttpRequestMessage request, HttpResponseMessage response, OidcDiscoveryRefusal refusal, Exception? cause)
+    // The name is bounded and neutralised in THIS method, and that is not a style choice: the log-forging
+    // sanitizer this repository relies on does not propagate across a method boundary, so a filter lifted
+    // into a helper stops being one as far as the analyzer is concerned.
+    //
+    // Four classes come off it, each because ReplaceLineEndings - the strip applied to the operator's own
+    // provider name beside it - does not remove them:
+    //
+    //   * CONTROL characters. A raw vertical tab advances a line on a console sink and a raw NUL truncates
+    //     the record for a C-string consumer, and ReplaceLineEndings passes both through. The class also
+    //     covers CR, LF, FF and NEL, so it subsumes that strip rather than sitting beside it, which is why
+    //     the strip is not also applied here: it would make two of these four classes unkillable by their
+    //     own mutation and prove nothing the class arms do not already prove.
+    //   * FORMAT characters. A right-to-left override is neither a control nor a separator, and it reorders
+    //     the rest of the entry as it is displayed - forging by rearranging rather than by inserting.
+    //   * The LINE and PARAGRAPH separators, which a line-ending replacement treats as line endings but a
+    //     control-character test does not reach.
+    //
+    // The fourth class named on #1195, the unpaired surrogate, has no arm, because a provider cannot put one
+    // here: a raw one has no UTF-8 encoding and StrictJson refuses the document before the walk starts, and
+    // an escaped one is a name GetString will not complete, so the walk reports Unreadable and never a name.
+    // AnUnpairedSurrogate_NeverBecomesARepeatedMemberName is what keeps that a measurement rather than a
+    // belief; a surrogate filter would instead mangle the legitimate astral names that arrive in pairs.
+    //
+    // What CAN manufacture one is the bound, by cutting between the halves of a pair, so the cut steps back
+    // off a high surrogate rather than through it.
+    private HttpResponseMessage Refuse(HttpRequestMessage request, HttpResponseMessage response, OidcDiscoveryRefusal refusal, string? repeatedMember, Exception? cause)
     {
         // One mapping from the refusal to the words an operator reads, so the log entry and the admin probe
         // that reports the same refusal (#1064) cannot be reworded apart.
         var reason = refusal == OidcDiscoveryRefusal.RepeatedMember ? RefusalReason : UninspectableReason;
         _refusal = refusal;
 
+        // Bounded before it is filtered, so the walk over the characters is over what the entry can carry
+        // rather than over everything the provider sent. The cut steps BACK off a high surrogate instead of
+        // through it: the bound is the one thing here that can manufacture an unpaired surrogate, by
+        // separating the halves of a legitimate astral pair, and a half pair corrupts the entry it lands in.
+        var cut = repeatedMember is null || repeatedMember.Length <= MaxLoggedMemberNameChars
+            ? repeatedMember
+            : string.Concat(
+                repeatedMember.AsSpan(0, char.IsHighSurrogate(repeatedMember[MaxLoggedMemberNameChars - 1]) ? MaxLoggedMemberNameChars - 1 : MaxLoggedMemberNameChars),
+                NameTruncationMarker);
+
+        // The filter, in the method that logs rather than behind a call from it. SA1118 forbids the
+        // expression inside the argument list, so it is a local here; what the log-forging invariant rules
+        // out is a HELPER, and TheNeutralisationLivesInTheMethodThatLogs is the scan that keeps it out.
+        var named = cut is null
+            ? string.Empty
+            : ", the repeated member is named \"" + new string(Array.FindAll(cut.ToCharArray(), c => !char.IsControl(c) && char.GetUnicodeCategory(c) is not (UnicodeCategory.Format or UnicodeCategory.LineSeparator or UnicodeCategory.ParagraphSeparator))) + "\"";
+
         _logger.LogWarning(
-            "Refused the OpenID {Document} for provider {Provider}: {Reason}{Cause}. The read fails closed rather than handing on a document whose meaning depends on which reader parses it.",
+            "Refused the OpenID {Document} for provider {Provider}: {Reason}{Member}{Cause}. The read fails closed rather than handing on a document whose meaning depends on which reader parses it.",
             DocumentKind(request),
             _provider?.ReplaceLineEndings(string.Empty),
             reason,
+            named,
             cause is null ? string.Empty : $" [{cause.GetType().Name}]");
 
         response.Dispose();


### PR DESCRIPTION
# What & why

Closes #1195.

The repeated-member screen refuses a discovery or JWKS document that names a
member twice, and records which document and why. It did not record **which**
member. An operator who hits it has a broken login, no configuration that
relaxes the refusal, and nothing in the entry that says what to report to the
provider. This puts the name there.

The name is the one provider-authored value in that entry, so it lands with its
protection in the same change rather than ahead of it. Both the bound and the
filter sit in the method that writes the entry, not behind a call from it: the
log-forging sanitizer does not propagate across a method boundary, so a filter
lifted into a helper stops being one as far as the analyzer is concerned.
SA1118 forbids the expression inside the argument list, so it is two locals in
`Refuse` rather than one expression at the call, and a source scan keeps it
there.

**Bound.** 128 characters, with a `[truncated]` marker. The longest name the
OpenID discovery metadata registry defines is the 46-character
`authorization_response_iss_parameter_supported`; before any bound existed one
anonymous challenge could put 800 KB in front of this call.

**Filter.** Three classes, each because `ReplaceLineEndings` (all the entry
beside it gets) does not remove them:

- control characters, since a raw vertical tab advances a line on a console sink
  and a raw NUL truncates the record for a C-string consumer;
- Unicode format characters, since a right-to-left override reorders the rest of
  the entry as it is displayed, forging by rearranging rather than by inserting;
- the line and paragraph separators.

The control class is a superset of that strip (CR, LF, FF and NEL are all Cc),
so the strip is not also applied to this value. Applying it would leave two of
the three classes unkillable by their own mutation while proving nothing the
class arms do not already prove, and that trade is stated in the code.

**The fourth class, and why it has no arm.** #1195 names unpaired surrogates.
Measured rather than assumed: a raw one has no UTF-8 encoding, so `StrictJson`
refuses the document before the walk starts, and an escaped one is a name
`GetString` will not complete, so the walk reports `Unreadable` and never
reports a name at all. A provider cannot get one into this value.
`AnUnpairedSurrogate_NeverBecomesARepeatedMemberName` pins that in both
spellings plus the reversed pair, and goes red the day the walk starts decoding
leniently, which is the day the arm becomes owed. Filtering surrogates as a
class instead would mangle every legitimate astral name, which arrives as a
pair.

What **can** manufacture a half pair is the plugin's own bound, by cutting
between the halves. The cut therefore steps back off a high surrogate rather
than through it, and `TheBoundNeverCutsThroughAnAstralPair` sweeps the astral
character across 300 offsets instead of aiming at the constant, so the row is
derived from the input space and survives the bound moving.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: the refusal path is untouched. Every new row
      asserts the refusal itself and not just the entry, because a screen that
      logged the name and then handed the document on would write an identical
      entry. Each read checks that the library was given the screen's constant
      reason in place of the document, and that the JWKS the refused document
      named was never fetched.
- [x] No secrets logged. The value added is a JSON member name from a public
      metadata document; no secret reaches this call.
- [ ] **A security review was NOT performed for this change.** No second reader
      ran on it. This box stays unticked and the evidence below stands in its
      place rather than a review record.
- [ ] **No review record exists**, so there are no per-lens verdicts and no
      CONFIRMED / PLAUSIBLE counts to report. Stated as an absence rather than
      left blank.
- [x] Log inputs from the IdP are sanitized in the method that logs them, and
      `TheNeutralisationLivesInTheMethodThatLogs` is the scan that keeps them
      there.

### Every arm shown dying, with the mutation that killed it

Each mutation was applied to `RepeatedMemberScreen.cs` alone, built, run against
the named rows, then restored from a pre-edit copy. `git status --porcelain` was
compared before and after each and was unchanged every time.

| mutation | rows run | result |
| --- | --- | --- |
| drop `!char.IsControl(c)` | `AControlCharacterInTheName_NeverReachesTheEntry` | Total: 8, Failed: 8 |
| drop `UnicodeCategory.Format` | `AFormatCharacterInTheName_NeverReachesTheEntry` | Total: 5, Failed: 5 |
| drop `LineSeparator or ParagraphSeparator` | `ALineOrParagraphSeparatorInTheName_NeverReachesTheEntry` | Total: 2, Failed: 2 |
| never truncate | `AnOverlongMemberName_IsBoundedInTheEntry` | Total: 1, Failed: 1 |
| tighten the bound to 2 | `AnOrdinaryMemberName_ReachesTheEntryWhole` | Total: 1, Failed: 1 |
| cut at the bound without stepping off a high surrogate | `TheBoundNeverCutsThroughAnAstralPair` | Total: 1, Failed: 1 |
| add `!char.IsSurrogate(c)` to the filter | `AValidAstralMemberName_ReachesTheEntryIntact` | Total: 1, Failed: 1 |
| lift bound and filter into a `Neutralise` helper | whole class (21) | Total: 21, Failed: 1, and the one is the scan row |
| withhold the name from the entry again | whole class (21) | Total: 21, Failed: 18 |

The helper row is the one worth reading twice: 20 of 21 rows stay green under
it, which is exactly why the scan exists. No behavioural test can tell a filter
in the method from a filter behind a call.

## Quality checklist

- [x] No duplicated logic. The bound and the filter are two locals in the method
      that already builds the entry; nothing new was extracted, deliberately.
- [x] No more code than the problem requires: two locals, two constants, one
      extra `{Member}` placeholder in the template.
- [x] Comments explain why. The three classes carry the reason each is present
      and the fourth carries the reason it is absent.
- [x] Architecture-conformance tests pass. This change establishes one new
      structural property, and it is locked in as
      `TheNeutralisationLivesInTheMethodThatLogs`. It sits in the new test file
      rather than in `ArchitectureConformanceTests`, matching where the
      neighbouring screen rules already sit; folding those in is #1189's.
- [x] Docs impact: the CHANGELOG paragraph that said the entry "does not yet
      name the repeated member" is corrected here. The wiki half is #1063, which
      is already open on this milestone and is written against exactly this
      behaviour.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj --warnaserror` green on
      both target frameworks, 0 warnings, 0 errors.
- [x] Full suite through the built MTP executables: `net9.0` Total 2759,
      Failed 0, Skipped 4; `net10.0` Total 2760, Failed 0, Skipped 4.
- [x] Prettier clean for `CHANGELOG.md`, the only non-`.cs` file touched.

The 4 skips are not this change's and are not silent: they are the `SsoHttp`
rows that bind a listener off loopback, which raises a Windows firewall consent
dialog needing an administrator (#1227). They were left skipped rather than
worked around, and nothing here was run elevated.

## Notes

Two rows elsewhere asserted the opposite of what now holds and are corrected
rather than left drifting:

- `OidcDiscoveryReaderTests.NoProviderAuthoredValueReachesTheRefusalEntry`
  becomes `TheRepeatedMemberNameIsTheOnlyProviderAuthoredValueInTheRefusalEntry`.
  It still asserts the request URL stays out, so the entry gains one bounded
  provider-authored value and not two.
- `OidcDiscoveryReaderErrorBoundTests.AnEightHundredKilobyteMemberName_ReachesNoLogEntryAtAll`
  becomes `..._ReachesNoLogEntryUnbounded`. Its assertions are unchanged; they
  were written to fire only on an unbounded entry, and #1194's own comment said
  this row would need re-reading on the day the name was logged.

Out of scope: the back-channel-logout consequence of the same refusal (#1060),
and the fetch-position size bound (#1041, closed).
