### PR TITLE
Build every OpenID client with its discovery metadata already set [#1067]

### DIFF
--- a/SSO-Auth.Tests/Oidc/CallbackClientMetadataTests.cs
+++ b/SSO-Auth.Tests/Oidc/CallbackClientMetadataTests.cs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Binds the repeated-member screen to the transport rather than to a call site (#1067).
+///
+/// Assigning <c>ProviderInformation</c> before <c>new OidcClient(options)</c> is what sets the library's
+/// internal use-discovery flag to false. A client built without it keeps discovery ENABLED and fetches the
+/// discovery document and the JWKS itself, through <c>options.HttpClientFactory</c> - which the screen is not
+/// on, because the screen lives inside <c>OidcDiscoveryReader.ReadAsync</c>. So the pre-assignment is not a
+/// performance detail: it is the only thing keeping the callback leg off an unscreened fetch. The same flag
+/// disables the library's <c>invalid_signature</c> JWKS-refresh-and-retry, so a second unscreened key fetch
+/// sits behind it.
+///
+/// The shape decided for this was to keep the screen where it is and require every construction site to
+/// pre-assign, rather than to move the screen onto <c>options.HttpClientFactory</c>. That factory also
+/// carries the token and UserInfo legs, and whether the screen belongs on those is an open scope question
+/// (#1069); moving it there would answer that question as a side effect of a bug fix.
+///
+/// What makes the decision hold is this rule and not the line it protects. One unconditional assignment is
+/// true of the code that exists; a rule is true of the code that arrives next. The behavioural half - that
+/// the callback leg performs no discovery of its own - is
+/// <c>OidcRoundTripTests.TheCallbackLegFetchesNoDiscoveryOfItsOwn</c>, on the real round trip.
+/// </summary>
+public class CallbackClientMetadataTests
+{
+    [Fact]
+    public void EveryOidcClientInTheFlowTierIsBuiltWithItsMetadataAlready()
+    {
+        var flowTier = Path.Combine(RepoRoot(), "SSO-Auth", "Api", "Flows");
+
+        // Sentinel first. A scan over a folder that is not there reports the same all-clear as a scan that
+        // found two correct sites, and a moved repository root is how that happens.
+        Assert.True(Directory.Exists(flowTier), "the flow tier is not where this rule looks for it");
+
+        var sites = 0;
+        foreach (var file in Directory.EnumerateFiles(flowTier, "*.cs", SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!IsConstructionSite(lines[i]))
+                {
+                    continue;
+                }
+
+                sites++;
+                Assert.True(
+                    PreAssignsAt(lines, i),
+                    $"{Path.GetFileName(file)}:{i + 1} builds an OidcClient with no unconditional ProviderInformation assignment before it, so the library keeps discovery enabled and fetches the discovery document and the JWKS off the screened path");
+            }
+        }
+
+        Assert.True(sites >= 2, $"the scan found {sites} OidcClient construction sites; it expects the challenge leg and the callback leg at least");
+    }
+
+    [Fact]
+    public void TheRuleRefusesAConditionalAssignment()
+    {
+        // The must-catch / adjacent-must-not-catch pair for the rule's own predicate, in the shape the
+        // callback leg actually had. A rule with no red fixture is decorative, and a text scan is the kind
+        // most easily written so that nothing can fail it.
+        var conditional = new[]
+        {
+            "    private OidcClient Build()",
+            "    {",
+            "        var options = new OidcClientOptions();",
+            "        if (providerInformation is not null)",
+            "        {",
+            "            options.ProviderInformation = providerInformation;",
+            "        }",
+            "",
+            "        return new OidcClient(options);",
+            "    }",
+        };
+
+        var unconditional = new[]
+        {
+            "    private OidcClient Build()",
+            "    {",
+            "        var options = new OidcClientOptions();",
+            "        options.ProviderInformation = providerInformation;",
+            "",
+            "        return new OidcClient(options);",
+            "    }",
+        };
+
+        // A neighbour's assignment must not be borrowed across a method boundary, which is the other way a
+        // scan like this passes on code it should refuse.
+        var borrowed = new[]
+        {
+            "    private void Other()",
+            "    {",
+            "        options.ProviderInformation = providerInformation;",
+            "    }",
+            "",
+            "    private OidcClient Build()",
+            "    {",
+            "        return new OidcClient(new OidcClientOptions());",
+            "    }",
+        };
+
+        Assert.False(PreAssignsAt(conditional, IndexOfSite(conditional)), "the rule accepts the conditional shape it was written to refuse");
+        Assert.True(PreAssignsAt(unconditional, IndexOfSite(unconditional)), "the rule refuses the shape the flow tier ships, so it would fail on correct code");
+        Assert.False(PreAssignsAt(borrowed, IndexOfSite(borrowed)), "the rule borrows an assignment from the method next door");
+    }
+
+    // The rule's predicate. The assignment must stand at method-body indentation: eight spaces is the only
+    // depth at which it is unconditional, because a statement inside a braced `if` sits at twelve and
+    // StyleCop requires the braces. The indentation IS the conditionality test.
+    private static bool PreAssignsAt(IReadOnlyList<string> lines, int siteIndex)
+    {
+        for (var back = siteIndex - 1; back >= 0 && back > siteIndex - 40; back--)
+        {
+            if (lines[back].StartsWith("        options.ProviderInformation = ", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // A method boundary ends the search before it can borrow a neighbour's assignment.
+            if (lines[back].StartsWith("    }", StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    // A construction, not a sentence about one. The comment above CreateCallbackOidcClient explains why the
+    // assignment has to precede `new OidcClient(options)`, and the first version of this rule read that
+    // sentence as a site and failed on it. Prose is where a text scan goes wrong first.
+    private static bool IsConstructionSite(string line) =>
+        line.Contains("new OidcClient(", StringComparison.Ordinal)
+        && !line.TrimStart().StartsWith("//", StringComparison.Ordinal);
+
+    private static int IndexOfSite(IReadOnlyList<string> lines)
+    {
+        for (var i = 0; i < lines.Count; i++)
+        {
+            if (IsConstructionSite(lines[i]))
+            {
+                return i;
+            }
+        }
+
+        Assert.Fail("the fixture carries no OidcClient construction site, so it tests nothing");
+        return -1;
+    }
+
+    private static string RepoRoot([CallerFilePath] string thisFilePath = "") =>
+        Directory.GetParent(Directory.GetParent(Path.GetDirectoryName(thisFilePath)!)!.FullName)!.FullName;
+}

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -415,6 +415,47 @@ public class OidcRoundTripTests
         Assert.DoesNotContain("request_uri=", challenge.Url, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task TheCallbackLegFetchesNoDiscoveryOfItsOwn()
+    {
+        // #1067, the behavioural half. The callback client is constructed with the metadata the challenge
+        // captured, which sets the library's internal use-discovery flag to false. Built WITHOUT it, the
+        // library performs its own discovery and JWKS fetch inside ProcessResponseAsync, through
+        // options.HttpClientFactory - a transport the repeated-member screen (#1061) is not on, because that
+        // screen lives inside OidcDiscoveryReader.ReadAsync. So the property is not "one fetch fewer": it is
+        // that no fetch on this leg leaves the screened path.
+        //
+        // Asserted on the wire rather than on the option, because the option is the predicate and the fetch
+        // is the property. A row reading oidcClient.Options.ProviderInformation would stay green against a
+        // library version that consulted something else.
+        using var fixture = new OidcTokenFixture(Authority, "jf");
+        var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
+        var requested = new System.Collections.Generic.List<string>();
+        var harness = BuildHarness(fixture, request =>
+        {
+            requested.Add(request.RequestUri!.AbsoluteUri);
+            return ServeIdp(fixture, request, idToken);
+        });
+
+        var (state, binding) = await DriveChallenge(harness);
+
+        // The challenge leg legitimately reads both documents, through the screened reader. Only what the
+        // CALLBACK asks for is the subject here.
+        Assert.Contains(fixture.DiscoveryUrl, requested);
+        requested.Clear();
+
+        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
+
+        // The leg really ran to completion, so the absences below are absences and not a callback that
+        // failed before it could fetch anything.
+        Assert.Equal("text/html", callback.ContentType);
+        Assert.Contains(fixture.TokenUrl, requested);
+
+        Assert.DoesNotContain(fixture.DiscoveryUrl, requested);
+        Assert.DoesNotContain(fixture.JwksUrl, requested);
+    }
+
     // Builds a harness with a single enabled provider "kc" pointed at the fixture's authority, served by the
     // supplied responder. DisablePushedAuthorization keeps the challenge to a plain redirect; DoNotLoadProfile
     // makes the id_token claims the whole identity (no userinfo fetch); EnableAuthorization/AllowExistingAccountLink

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -819,12 +819,18 @@ internal sealed class OidcLoginService
         // OUT / revoked during the window stays accepted until the state expires, since the callback validates
         // against the captured set - a far tighter exposure than the platform-default 24-hour JWKS cache, and
         // never wider than the state lifetime. Populated only from a validated fetch (never hand-filled), so
-        // the DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed. The
-        // conditional is kept as-is (behaviour-preserving) though the sole caller always supplies non-null.
-        if (providerInformation is not null)
-        {
-            options.ProviderInformation = providerInformation;
-        }
+        // the DiscoveryPolicy (RequireHttps / ValidateIssuerName / ValidateEndpoints) is not bypassed.
+        //
+        // UNCONDITIONAL, and that is the security property rather than a tidy-up (#1067). This assignment is
+        // what sets _useDiscovery = false. A client constructed without it keeps discovery ENABLED, and
+        // ProcessResponseAsync then fetches the discovery document and the JWKS itself, through
+        // options.HttpClientFactory - a transport the repeated-member screen is not on, because that screen
+        // lives inside OidcDiscoveryReader.ReadAsync and not on the client the library keeps. Before that
+        // screen existed a skipped assignment cost a redundant fetch; after it, it costs a fetch that routes
+        // around a control. The guard against that is not this line, which the next construction site would
+        // not inherit: it is EveryOidcClientInTheFlowTierIsBuiltWithItsMetadataAlready, which reads the
+        // source and fails on a construction site that does not pre-assign.
+        options.ProviderInformation = providerInformation;
 
         return new OidcClient(options);
     }


### PR DESCRIPTION
# What & why

Closes #1067.

`CreateCallbackOidcClient` assigned the captured discovery metadata under a null
check. That assignment is what sets the library's internal use-discovery flag to
false. Without it the client keeps discovery **enabled**, and
`ProcessResponseAsync` fetches the discovery document and the JWKS itself
through `options.HttpClientFactory`, a transport the repeated-member screen is
not on, because the screen lives inside `OidcDiscoveryReader.ReadAsync`. The
same flag disables the library's `invalid_signature` JWKS-refresh-and-retry, so
a second unscreened key fetch sits behind it.

Unreachable today: `AuthorizeSession.Pending.ProviderInformation` is
non-nullable and is only ever populated from a successful, policy-validated
read. So this closes a latent route around a control, not a live one. Before
#1061 a false predicate cost a redundant fetch; after it, it costs a fetch off
the screened path, which is what makes it worth closing rather than tidying.

## The decision between the two shapes, and its reason

The issue set out two. This takes **shape 1**: keep the screen where it is and
require every construction site to pre-assign.

Shape 2, moving the screen onto `options.HttpClientFactory`, puts it on the
**token and UserInfo legs** as well, because that one factory serves all of
them. Whether the screen belongs on those responses is an open scope question
with its own issue (#1069). Answering it as a side effect of a bug fix is the
wrong way round, and it would also be a materially larger behaviour change: a
duplicated member anywhere in a token response would start refusing logins.

The issue's own objection to shape 1 is that it "leaves the property 'the screen
is on one call site' true", so the next construction site reintroduces the
latency. That objection is answered by the rule below rather than by the line.
One unconditional assignment is true of the code that exists; a rule is true of
the code that arrives next.

## What is asserted, and how

- `CallbackClientMetadataTests.EveryOidcClientInTheFlowTierIsBuiltWithItsMetadataAlready`
  scans `SSO-Auth/Api/Flows/` and refuses any `new OidcClient(` that is not
  preceded, inside its own method, by an `options.ProviderInformation =`
  assignment at method-body indentation. Eight spaces is the conditionality
  test: a statement inside a braced `if` sits at twelve, and StyleCop requires
  the braces.
- `CallbackClientMetadataTests.TheRuleRefusesAConditionalAssignment` is the
  must-catch / adjacent-must-not-catch pair for that predicate, plus a third
  fixture proving the search does not borrow an assignment from the method next
  door.
- `OidcRoundTripTests.TheCallbackLegFetchesNoDiscoveryOfItsOwn` is the
  behavioural half, on the real challenge-to-callback round trip: the callback
  requests the token endpoint and requests neither the well-known document nor
  the JWKS. Asserted **on the wire** rather than on `Options.ProviderInformation`
 , the option is the predicate, the fetch is the property, and a row reading
  the option would stay green against a library version that consulted
  something else.

### Shown to bite

| mutation | rows run | result |
| --- | --- | --- |
| restore the `if (providerInformation is not null)` conditional | `CallbackClientMetadataTests` (2) | Total: 2, Failed: 1 |
| drop the assignment entirely | `TheCallbackLegFetchesNoDiscoveryOfItsOwn` | Total: 1, Failed: 1 |
| point the scan at a folder that is not there | `EveryOidcClientInTheFlowTier...` | Total: 1, Failed: 1, the sentinel fires rather than passing empty |

Worth recording: the first version of the scan failed on the repository's own
prose. The comment above `CreateCallbackOidcClient` contains the words
`new OidcClient(options)`, and a raw text match read that sentence as a
construction site. The predicate now skips comment lines, and the reason is in
the code rather than only here, because prose is where a text scan goes wrong
first.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Nothing about the refusal path changes; the change
      removes a branch that could have left discovery enabled.
- [x] No secrets logged. No logging is touched.
- [ ] **A security review was NOT performed for this change.** No second reader
      ran on it. The box stays unticked and the mutation table above stands in
      its place rather than a review record.
- [ ] **No review record exists**, so there are no per-lens verdicts and no
      CONFIRMED / PLAUSIBLE counts to report. Stated as an absence rather than
      left blank.
- [x] Log inputs from the IdP are sanitized inline at the log call - unchanged
      here; no log call is touched.

## Quality checklist

- [x] No duplicated logic. The scan and its fixtures share one predicate,
      `PreAssignsAt`, so the rule and its own proof cannot drift.
- [x] The change adds no more code than the problem requires: one statement in
      production, and the rule that keeps it true.
- [x] Comments explain why. The production comment now says what the assignment
      is for and names the rule that guards it, instead of calling the
      conditional behaviour-preserving — which the third acceptance bullet asked
      for, because it is no longer true.
- [x] Architecture-conformance tests pass. The new structural property is locked
      in as a rule; it sits in its own file rather than in
      `ArchitectureConformanceTests`, matching where the neighbouring OIDC screen
      rules already sit. Folding those in is #1189's.
- [x] Docs impact: none. Nothing observable to an operator changes - the branch
      removed was unreachable — so there is no README, wiki or CHANGELOG line to
      write. Claiming a user-visible improvement here would be claiming a live
      bug that was not live.

## Verification

- [x] Both target frameworks built with `--warnaserror`: 0 warnings, 0 errors.
- [x] Full suite through the built MTP executables: `net9.0` Total 2762,
      Failed 0, Skipped 4; `net10.0` Total 2763, Failed 0, Skipped 4.
- [x] Prettier: no `.js` / `.html` / `.md` / `.css` file is touched.

The 4 skips are not this change's: they are the `SsoHttp` rows that bind a
listener off loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). They were left skipped rather than worked around, and
nothing here was run elevated.

## Notes

Out of scope and deliberately untouched: the third options object, on the
back-channel logout leg, which is assigned the same unscreened factory and
constructs no `OidcClient`. Shape 2 would have covered it; shape 1 leaves it as
it is, and the flow-tier rule has nothing to say about a site that builds no
client. It is named here so the next reader does not have to re-derive that it
was considered.
