### PR TITLE
Replace the typographic dashes in this tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,14 +139,14 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 - **A provider response that names a JSON member twice is refused before it is
   parsed.** A repeated member is accepted silently by every reader these
   documents reach, and none of them raises an error, so which of the two values a
-  consumer acts on is decided by parser internals rather than by the document —
+  consumer acts on is decided by parser internals rather than by the document -
   RFC 8259 leaves it unspecified and calls such objects interoperability-unsafe.
   A **successfully served** OpenID discovery document, and the JWKS it names, are
   now screened on the transport, so such a body never reaches the reader that
   would resolve it: the refused document's `jwks_uri` is never requested at all,
   rather than requested and reported afterwards. A document that cannot be
-  inspected as JSON — malformed, truncated, nested too deeply, or carrying a
-  character set the runtime does not know — is refused the same way. There is no
+  inspected as JSON - malformed, truncated, nested too deeply, or carrying a
+  character set the runtime does not know - is refused the same way. There is no
   size limit here; bounding what the plugin reads from a provider is tracked
   separately. An error response (a 404, a 500) is deliberately not screened and
   keeps its own status, so the log still names what the provider actually
@@ -168,7 +168,7 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   without eliminating it.
 
   Two consequences worth knowing. The same refusal on the back-channel logout
-  path leaves the session untouched rather than ending it — the behaviour any
+  path leaves the session untouched rather than ending it - the behaviour any
   unreadable discovery document already had, unchanged here and tracked
   separately. And the admin **Test connection** button does not yet name this as
   a cause, so a refused document currently shows there under a check that does not
@@ -179,7 +179,7 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   names an extension it does not understand and process. The plugin implements
   no JWS extension, and the token library ignores `crit` entirely, so a
   genuinely signed `id_token` or back-channel `logout_token` carrying one was
-  accepted with the constraint it declared silently dropped — an extension is
+  accepted with the constraint it declared silently dropped - an extension is
   marked critical precisely because ignoring it changes what the token asserts,
   such as a narrowed audience or a proof-of-possession binding. Both token paths
   now refuse such a token from one shared rule, so they cannot drift apart.

--- a/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidBackChannelLogoutTests.cs
@@ -236,10 +236,10 @@ public sealed class SSOControllerOidBackChannelLogoutTests : IDisposable
         // screen (#1005) refuses a discovery document that names `issuer` twice, which on THIS path means the
         // logout token is never validated: the revocation the IdP ordered does not happen and the captured
         // session survives. That is fail-OPEN for a logout while being fail-closed for a login, it predates
-        // the screen (any unreadable discovery already does it), and the screen only adds a new cause — so it
+        // the screen (any unreadable discovery already does it), and the screen only adds a new cause - so it
         // is pinned here and decided there rather than changed inside this delivery.
         //
-        // Both halves are asserted. The revocation does not happen and the session survives — and the refusal
+        // Both halves are asserted. The revocation does not happen and the session survives - and the refusal
         // states its reason in the log, which on this path is the ONLY place it does: the endpoint answers a
         // deliberately uniform 400, indistinguishable from a legitimate rejection, so without the log entry a
         // suppressed revocation is silent to everyone.

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderErrorBoundTests.cs
@@ -86,8 +86,8 @@ public class OidcDiscoveryReaderErrorBoundTests
     [Fact]
     public async Task AnEightHundredKilobyteMemberName_ReachesNoLogEntryUnbounded()
     {
-        // The other value #1194 names. It was satisfied by exclusion when this row was written — the screen's
-        // refusal entry carried no provider-authored text at all — and #1195 has since put the member name
+        // The other value #1194 names. It was satisfied by exclusion when this row was written - the screen's
+        // refusal entry carried no provider-authored text at all - and #1195 has since put the member name
         // into that entry, with its own bound at that call. So the row now reads as what it always asserted:
         // 800 KB of provider-chosen name reaches no entry in this read, on either call, whole.
         var name = new string('m', 800 * 1024);

--- a/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcDiscoveryReaderTests.cs
@@ -177,7 +177,7 @@ public class OidcDiscoveryReaderTests
     public async Task TheSameDiscoveryDocumentWithoutTheDuplicate_IsStillRead()
     {
         // The positive control on the same subject. Without it, a screen that refused every document would
-        // satisfy the rejection above while taking every working provider offline — and it also proves the
+        // satisfy the rejection above while taking every working provider offline - and it also proves the
         // screen's body read leaves the response readable for the library that parses it afterwards.
         var http = new CountingFactory(Serve(FullDiscovery(Authority)));
 
@@ -197,7 +197,7 @@ public class OidcDiscoveryReaderTests
         //
         // Two properties of the fixture are load-bearing and neither is obvious. The planted URL is
         // SAME-AUTHORITY, because an off-authority one is refused by the discovery policy's endpoint
-        // validation before any fetch — the row would then pass with no screen at all, as evidence about
+        // validation before any fetch - the row would then pass with no screen at all, as evidence about
         // ValidateEndpoints. And it is LAST, because every reader resolves a repeat to its last occurrence,
         // so a URL planted first is the one nothing would ever request.
         var attackerJwks = Authority + "/jwks-attacker";
@@ -256,7 +256,7 @@ public class OidcDiscoveryReaderTests
         //
         // Asserting only that the read failed would NOT pin that: OidcDiscoveryReader catches every exception
         // and returns Unavailable, so a crashing screen and a refusing screen are indistinguishable from the
-        // result. The refusal REASON separates them — the screen can only log it by having walked the
+        // result. The refusal REASON separates them - the screen can only log it by having walked the
         // document and returned rather than thrown.
         var http = new CountingFactory(Serve("{\"a\\ud800\":1}"));
         var logger = new CapturingLogger();
@@ -289,7 +289,7 @@ public class OidcDiscoveryReaderTests
     public async Task AnUnknownCharset_IsRefusedRatherThanThrown_AndRecordedByExceptionTypeOnly()
     {
         // Content-Type is the provider's to choose, and an unknown charset makes the decode throw
-        // InvalidOperationException — on a body the ANONYMOUS challenge endpoint fetches. Unhandled, that
+        // InvalidOperationException - on a body the ANONYMOUS challenge endpoint fetches. Unhandled, that
         // escapes the screen: the read still fails closed via the caller's blanket catch, but the operator
         // loses the reason and this handler becomes the one fail path that reports nothing. This is the one
         // arm of the content-read catch a provider can reach; the other two are the row below.
@@ -385,7 +385,7 @@ public class OidcDiscoveryReaderTests
     [Fact]
     public async Task ANonSuccessResponse_KeepsItsOwnStatus_AndIsNotScreened()
     {
-        // A 404 or an HTML error page is not a document that means two things — it is a provider that served
+        // A 404 or an HTML error page is not a document that means two things - it is a provider that served
         // no document. Screening it would replace an honest status with "could not be inspected" and send the
         // operator hunting a duplicate that is not there. The HTML body is deliberately unwalkable, so a
         // screen that inspected non-success responses WOULD report it as uninspectable.
@@ -400,7 +400,7 @@ public class OidcDiscoveryReaderTests
         Assert.False(result.Available);
         Assert.DoesNotContain(logger.Entries, e => e.Message.Contains(RepeatedMemberScreen.UninspectableReason, StringComparison.Ordinal));
 
-        // The status the provider actually returned is what reaches the operator — the half this row was
+        // The status the provider actually returned is what reaches the operator - the half this row was
         // named for and did not assert. A screened non-success response would carry the screen's constant
         // reason here instead, which is exactly what must not happen.
         var failClosed = Assert.Single(logger.Entries, e => e.Message.StartsWith("Could not read the OpenID discovery document", StringComparison.Ordinal));
@@ -414,7 +414,7 @@ public class OidcDiscoveryReaderTests
         // The screen deliberately does not inspect a non-success body, and the library DOES parse one:
         // measured, a 404 body still populates the discovery response, and a repeated `issuer` in it resolves
         // to the attacker's last occurrence. Nothing is acted on today only because the caller returns on
-        // IsError before touching any value — so that check is load-bearing, and this row is what pins it.
+        // IsError before touching any value - so that check is load-bearing, and this row is what pins it.
         // Without it, a future read of a discovery value outside the IsError branch would reintroduce the
         // last-wins resolution this whole change exists to remove, with the suite still green.
         var hostile = FullDiscovery(Authority).TrimEnd('}')
@@ -438,7 +438,7 @@ public class OidcDiscoveryReaderTests
     // The discriminating assertion, in one place so no row can be written without it.
     //
     // A screen that INSPECTS, logs, and then hands the document on produces exactly the same log entry as
-    // one that refuses — the entry is written before the decision. And every hostile fixture here is one
+    // one that refuses - the entry is written before the decision. And every hostile fixture here is one
     // the library rejects unaided, so `Available == false` does not discriminate either. What only a real
     // refusal produces is the SUBSTITUTED response: the library then reports the screen's constant reason,
     // and the JWKS the refused document named is never fetched. That second fact is the one a
@@ -470,7 +470,7 @@ public class OidcDiscoveryReaderTests
         // The entry carries a constant reason, the operator's own provider name, a constant naming the
         // document, and ONE value the provider chose: the repeated member name, which is what identifies the
         // defect to report and is bounded and neutralised at that log call (#1195). Nothing else of the
-        // provider's joins it — the request URL in particular stays out, because an entry that echoed a
+        // provider's joins it - the request URL in particular stays out, because an entry that echoed a
         // provider-chosen URL would carry a second unbounded string beside the one that is bounded.
         const string plantedMember = "zzUnmistakableMemberNamezz";
         var duplicated = FullDiscovery(Authority).Insert(1, $"\"{plantedMember}\":1,\"{plantedMember}\":2,");
@@ -570,7 +570,7 @@ public class OidcDiscoveryReaderTests
             }
 
             // Counted so a test can assert the JWKS URL a refused discovery document named was never
-            // dereferenced — the property a post-parse screen structurally cannot hold.
+            // dereferenced - the property a post-parse screen structurally cannot hold.
             if (url.EndsWith("/jwks", StringComparison.Ordinal))
             {
                 JwksRequests++;

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -25,7 +25,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 public static class LoginButtonInjector
 {
     /// <summary>The opening fence of the plugin-managed region inside the login disclaimer.</summary>
-    internal const string BeginMarker = "<!-- SSO-LOGIN-BUTTONS:BEGIN (managed by jellyfin-plugin-sso — do not edit inside) -->";
+    internal const string BeginMarker = "<!-- SSO-LOGIN-BUTTONS:BEGIN (managed by jellyfin-plugin-sso - do not edit inside) -->";
 
     /// <summary>The closing fence of the plugin-managed region.</summary>
     internal const string EndMarker = "<!-- SSO-LOGIN-BUTTONS:END -->";

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -94,7 +94,7 @@ internal static class OidcDiscoveryReader
             using var client = SsoHttp.CreateClient(httpClientFactory, allowPrivateNetworkAddresses);
             client.Timeout = FetchTimeout;
 
-            // Screen both documents this read fetches — the well-known document and the JWKS it points at —
+            // Screen both documents this read fetches - the well-known document and the JWKS it points at -
             // on the transport, so a body that names a member twice never reaches the library that would
             // resolve the repeat to its last occurrence (#1005). The screen forwards through the client
             // above rather than replacing it, so the User-Agent, the timeout and the SSRF-hardened transport

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
 /// Validates an inbound OpenID Connect back-channel <c>logout_token</c> (OIDC Back-Channel Logout 1.0
-/// §2.4–§2.6, #962). The endpoint that calls this is ANONYMOUS - the token's signature is the only
+/// §2.4 - §2.6, #962). The endpoint that calls this is ANONYMOUS - the token's signature is the only
 /// authenticator - so every §2.6 rule is fail-closed and each maps to a fixed reason code (never
 /// request-derived text, so a rejection leaves an audit trail without a subject-identifier oracle,
 /// mirroring the SAML inbound-logout validator). Signature/JWKS/algorithm verification goes through the

--- a/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
+++ b/SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs
@@ -15,7 +15,7 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// <summary>
 /// Refuses a provider response whose body names a member twice, BEFORE the identity library parses it
 /// (#1005). It presents the plugin's SSRF-hardened outbound client as a transport handler, so both documents
-/// the discovery read fetches — the well-known document and the JWKS it points at — pass through one screen
+/// the discovery read fetches - the well-known document and the JWKS it points at - pass through one screen
 /// on their way to the library.
 ///
 /// Position is the whole point. An equivalent check applied to the parsed result would report the problem
@@ -102,7 +102,7 @@ internal sealed class RepeatedMemberScreen : HttpMessageHandler
 
         // A non-success response passes through unscreened so it keeps its own status: replacing a 404 with
         // "could not be inspected" would tell the operator the document was malformed when the real answer is
-        // that the provider served none. The library does parse such a body — measured — so what keeps its
+        // that the provider served none. The library does parse such a body - measured - so what keeps its
         // values from being acted on is the caller's `IsError` return in OidcDiscoveryReader. That check is
         // load-bearing rather than incidental, which is why ANonSuccessBodyThatRepeatsAMember_IsNeverActedOn
         // pins the outcome; the structural rule that would stop the read at compile time is #1062's.

--- a/SSO-Auth/Api/Provider/ProviderNameValidator.cs
+++ b/SSO-Auth/Api/Provider/ProviderNameValidator.cs
@@ -45,7 +45,7 @@ internal static class ProviderNameValidator
     {
         foreach (char c in name.AsSpan())
         {
-            // char.IsControl covers C0 (U+0000–U+001F), DEL (U+007F), and C1 (U+0080–U+009F) by name -
+            // char.IsControl covers C0 (U+0000 - U+001F), DEL (U+007F), and C1 (U+0080 - U+009F) by name -
             // chosen over spelling the two disjoint ranges out with ContainsAnyInRange because the BCL
             // property states the intent where hex bounds would need verifying. Control characters do
             // not round-trip through the callback URL, and a newline is also the ProviderScopedKey


### PR DESCRIPTION
Em and en dashes are the first item on the list of markers that public text here does not carry.

    git grep -o -e '—' -e '–' -- . | wc -l
    30     before
    0     after

10 files changed.

`LICENSE`, `COPYING`, `NOTICE` and vendored trees are untouched by construction: their wording is either foreign or compared byte for byte, and a changed licence file stops being the licence file. Anything binary is skipped, detected by a null byte rather than by extension alone.

Strings in source are changed with everything else, deliberately. A dash inside a string reaches the program's output, and the output is the public text this is about. Where a test asserts the old wording, the test run says so and the test moves in the same change.

The measurement behind this pass and the scope it produced are recorded elsewhere.