### PR TITLE
Assert the parse surface's post-conditions under the fuzzer

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3508,6 +3508,78 @@ public class ArchitectureConformanceTests
             .ToList();
 
     [Fact]
+    public void ParseSurfaceAssertions_NeverReachTheShippedBuild()
+    {
+        // #1082. The parse surface carries post-conditions so a silent mis-parse becomes a detectable fault
+        // under an assertion-enabled fuzzing build. They are Debug.Assert, which the compiler removes from a
+        // build without DEBUG, and that removal is the whole reason they are allowed on an authentication
+        // path at all: a post-condition that fired in a running server would take a login down over a
+        // condition the fail-closed paths already handle.
+        //
+        // WHAT THIS RULE DOES NOT DO, stated first because the name invites the wrong reading: it does not
+        // re-prove that [Conditional("DEBUG")] strips a call. That is the compiler's contract, and the
+        // evidence for it is the IL differential recorded on the issue, not a source scan. What this rule
+        // holds are the two ways the tree itself could defeat that contract.
+        var pluginSources = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            pluginSources.Count > 0,
+            "No plugin source file was found under SSO-Auth - the project moved, so this rule would pass vacuously (#1082).");
+
+        // The first way. Trace.Assert and Trace.Fail look like the same thing and are not: they are
+        // [Conditional("TRACE")], and TRACE is defined in a Release build by default, so one of these written
+        // by habit next to a Debug.Assert ships. It would then abort or dialog on whatever the fuzzer was
+        // meant to catch quietly, on the unauthenticated callback, in production.
+        var survivingAssertions = pluginSources
+            .SelectMany(path => CodeLines(path)
+                .Where(l => l.Text.Contains("Trace.Assert(", StringComparison.Ordinal)
+                    || l.Text.Contains("Trace.Fail(", StringComparison.Ordinal))
+                .Select(l => $"{Path.GetFileName(path)}:{l.Number}: {l.Text}"))
+            .ToList();
+
+        Assert.True(
+            survivingAssertions.Count == 0,
+            "Trace.Assert / Trace.Fail are [Conditional(\"TRACE\")] and TRACE is defined in Release, so they ship - use Debug.Assert for a parse-surface post-condition (#1082). Offending lines: " + string.Join(" | ", survivingAssertions));
+
+        // The second way. Defining DEBUG for the shipping build carries every Debug.Assert into the shipped
+        // assembly, and it is a one-word edit in a file nobody rereads. A DefineConstants that mentions DEBUG
+        // is therefore refused outright here rather than parsed for its condition: the plugin's build files
+        // define no constants at all today, so the honest rule is that they define none, and anyone who needs
+        // one comes here to say why.
+        var buildFiles = new[] { Path.Combine(RepoRoot(), "Directory.Build.props"), Path.Combine(RepoRoot(), "SSO-Auth", "SSO-Auth.csproj") }
+            .Where(File.Exists)
+            .ToList();
+
+        Assert.Equal(2, buildFiles.Count);
+
+        var debugDefiners = buildFiles
+            .Where(path => File.ReadAllText(path).Contains("DefineConstants", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.True(
+            debugDefiners.Count == 0,
+            "The plugin's build files must define no compilation constants: a DEBUG among them carries every parse-surface Debug.Assert into the shipped assembly (#1082). Offending files: " + string.Join(", ", debugDefiners));
+
+        // Sentinel against a vacuous pass. Both bans above guard something only while the post-conditions
+        // exist. If they were deleted, the rule would keep passing over a plugin that asserts nothing, and
+        // the fuzzing configuration that runs with assertions on would be running them against nothing.
+        var assertionSites = pluginSources
+            .SelectMany(path => CodeLines(path)
+                .Where(l => l.Text.Contains("Debug.Assert(", StringComparison.Ordinal))
+                .Select(l => $"{Path.GetFileName(path)}:{l.Number}"))
+            .ToList();
+
+        Assert.True(
+            assertionSites.Count > 0,
+            "No Debug.Assert remains in the plugin, so the assertion-enabled fuzzing configuration has nothing to check and the bans above guard nothing (#1082).");
+    }
+
+    [Fact]
     public void SamlSignaturePath_UsesOneXmlStackEndToEnd()
     {
         // #1003. XML signature wrapping against a SAML assertion is a full authentication bypass, and the way

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
@@ -68,9 +69,17 @@ internal static class OidcResponseIssuer
     /// </summary>
     /// <param name="discovery">The parsed discovery document, or <see langword="null"/> when it could not be parsed.</param>
     /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
-    internal static bool DiscoveryAdvertisesResponseIssuer(JObject? discovery) =>
-        discovery?["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
+    internal static bool DiscoveryAdvertisesResponseIssuer(JObject? discovery)
+    {
+        var advertised = discovery?["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
             && value.Value<bool>();
+
+        // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises
+        // nothing. Reading true off an unparsed document would make the callback REQUIRE an iss parameter the
+        // provider may never send, which is the tolerant direction this flag is deliberately not taking.
+        Debug.Assert(discovery is not null || !advertised, "DiscoveryAdvertisesResponseIssuer reported true for a document that did not parse.");
+        return advertised;
+    }
 
     /// <summary>
     /// The validated id_token's issuer (its <c>iss</c> claim), or null when the token is absent/degenerate.
@@ -81,7 +90,18 @@ internal static class OidcResponseIssuer
     /// </summary>
     /// <param name="identityToken">The redeemed, already-validated id_token.</param>
     /// <returns>The token's issuer; null when the token does not parse, and empty when it carries no <c>iss</c> (JsonWebToken.Issuer returns "" for an absent claim). Both are treated as "no issuer" by every consumer (IsNullOrWhiteSpace / ordinal Equals), so the link stays un-stamped.</returns>
-    internal static string? IdTokenIssuer(string? identityToken) => TokenIssuer(identityToken);
+    internal static string? IdTokenIssuer(string? identityToken)
+    {
+        var issuer = TokenIssuer(identityToken);
+
+        // Post-condition, compiled out of the shipped build (#1082): no token, no issuer. The canonical link
+        // is bound to (iss, sub), so an issuer invented where there was no token to read one from would stamp
+        // a link with an anchor nothing authenticated. Deliberately NOT asserted: that a non-null issuer is
+        // non-empty or trimmed. This method's contract says empty is what an absent iss claim returns, and
+        // JsonWebToken hands back the claim value as written, whitespace included.
+        Debug.Assert(!string.IsNullOrEmpty(identityToken) || issuer is null, "IdTokenIssuer produced an issuer without a token.");
+        return issuer;
+    }
 
     // The id_token was validated by OidcIdTokenValidator before this runs, so it parses; the guard and
     // catch are defensive so a degenerate token can never turn the mix-up check itself into a 500.

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 
@@ -39,9 +40,15 @@ internal static class PkceDiscovery
     internal static bool SupportsS256(JObject? discovery)
     {
         var methods = discovery?["code_challenge_methods_supported"] as JArray;
-        return methods is not null
+        var advertised = methods is not null
             && methods.Any(method =>
                 method.Type == JTokenType.String
                 && string.Equals(method.Value<string>(), "S256", StringComparison.Ordinal));
+
+        // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises
+        // nothing. This is the fail-closed half of RFC 9700 2.1.1 - the answer a caller acts on when the
+        // discovery read failed must come from the absence of evidence, never from a default.
+        Debug.Assert(discovery is not null || !advertised, "SupportsS256 reported S256 for a document that did not parse.");
+        return advertised;
     }
 }

--- a/SSO-Auth/Api/Saml/SamlResponse.cs
+++ b/SSO-Auth/Api/Saml/SamlResponse.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -413,7 +414,12 @@ internal sealed class SamlResponse : IDisposable
     {
         var assertion = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]", _xmlNameSpaceManager) as XmlElement;
         var id = assertion?.GetAttribute("ID");
-        return string.IsNullOrEmpty(id) ? null : id;
+        var assertionId = string.IsNullOrEmpty(id) ? null : id;
+
+        // Post-condition, compiled out of the shipped build (#1082): the replay store keys on this value, and
+        // an empty key would make every assertion without an ID collide into one already-consumed entry.
+        Debug.Assert(assertionId is null or { Length: > 0 }, "GetAssertionId returned an empty assertion ID.");
+        return assertionId;
     }
 
     /// <summary>
@@ -440,6 +446,10 @@ internal sealed class SamlResponse : IDisposable
             }
         }
 
+        // Post-condition, compiled out of the shipped build (#1082): callers retain a consumed assertion until
+        // this instant and compare it against a UTC clock, so a bound of any other kind would shift the
+        // retention window by the machine's offset without anything reading as wrong.
+        Debug.Assert(latest is null || latest.Value.Kind == DateTimeKind.Utc, "GetNotOnOrAfter returned a bound that is not UTC.");
         return latest;
     }
 
@@ -535,7 +545,14 @@ internal sealed class SamlResponse : IDisposable
     public string? GetNameID()
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:Subject/saml:NameID", _xmlNameSpaceManager);
-        return node?.InnerText;
+        var nameId = node?.InnerText;
+
+        // Post-condition, compiled out of the shipped build (#1082). This is the one getter here whose empty
+        // return is a real value rather than an absence, so the invariant is the ASYMMETRY: absent stays null.
+        // A refactor that started returning string.Empty for a missing NameID would hand the caller an empty
+        // subject to match a Jellyfin account against instead of a rejection.
+        Debug.Assert((node is null) == (nameId is null), "GetNameID collapsed an absent NameID into a value.");
+        return nameId;
     }
 
     /// <summary>
@@ -551,7 +568,12 @@ internal sealed class SamlResponse : IDisposable
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response/saml:Assertion[1]/saml:AuthnStatement", _xmlNameSpaceManager) as XmlElement;
         var sessionIndex = node?.GetAttribute("SessionIndex");
-        return string.IsNullOrEmpty(sessionIndex) ? null : sessionIndex;
+        var captured = string.IsNullOrEmpty(sessionIndex) ? null : sessionIndex;
+
+        // Post-condition, compiled out of the shipped build (#1082): a later Single Logout request names the
+        // session by this handle, and an empty handle would name every session that never carried one.
+        Debug.Assert(captured is null or { Length: > 0 }, "GetSessionIndex returned an empty session index.");
+        return captured;
     }
 
     /// <summary>
@@ -565,7 +587,13 @@ internal sealed class SamlResponse : IDisposable
     {
         var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var recipient = node?.GetAttribute("Recipient");
-        return string.IsNullOrEmpty(recipient) ? null : recipient;
+        var addressee = string.IsNullOrEmpty(recipient) ? null : recipient;
+
+        // Post-condition, compiled out of the shipped build (#1082): SamlRecipientValidator decides binding by
+        // ordinal set membership, so an empty recipient is a value that can match rather than an absence that
+        // is refused - the difference between a bound assertion and one minted for somebody else.
+        Debug.Assert(addressee is null or { Length: > 0 }, "GetRecipient returned an empty recipient.");
+        return addressee;
     }
 
     /// <summary>
@@ -579,7 +607,13 @@ internal sealed class SamlResponse : IDisposable
     {
         var node = _xmlDoc.SelectSingleNode(BearerSubjectConfirmationDataXPath, _xmlNameSpaceManager) as XmlElement;
         var inResponseTo = node?.GetAttribute("InResponseTo");
-        return string.IsNullOrEmpty(inResponseTo) ? null : inResponseTo;
+        var requestId = string.IsNullOrEmpty(inResponseTo) ? null : inResponseTo;
+
+        // Post-condition, compiled out of the shipped build (#1082): null here means an unsolicited response
+        // and is handled as such, so an empty string would be correlated against the issued-request cache as
+        // though it named a request rather than taking the IdP-initiated path.
+        Debug.Assert(requestId is null or { Length: > 0 }, "GetInResponseTo returned an empty request id.");
+        return requestId;
     }
 
     /// <summary>
@@ -593,7 +627,13 @@ internal sealed class SamlResponse : IDisposable
     {
         var node = _xmlDoc.SelectSingleNode("/samlp:Response", _xmlNameSpaceManager) as XmlElement;
         var destination = node?.GetAttribute("Destination");
-        return string.IsNullOrEmpty(destination) ? null : destination;
+        var sentTo = string.IsNullOrEmpty(destination) ? null : destination;
+
+        // Post-condition, compiled out of the shipped build (#1082): the same set-membership check as the
+        // recipient runs over this value, and it is the weaker of the two because it sits outside the
+        // assertion, so an empty value that could match is worth less here and costs the same to refuse.
+        Debug.Assert(sentTo is null or { Length: > 0 }, "GetDestination returned an empty destination.");
+        return sentTo;
     }
 
     /// <summary>
@@ -635,6 +675,10 @@ internal sealed class SamlResponse : IDisposable
             }
         }
 
+        // Post-condition, compiled out of the shipped build (#1082): the role mapper enumerates this list and
+        // compares each entry ordinally against the configured role names. A null entry would throw inside
+        // that comparison on the authenticated path rather than simply failing to match.
+        Debug.Assert(output.TrueForAll(value => value is not null), "GetCustomAttributes returned a null attribute value.");
         return output;
     }
 

--- a/SSO-Auth/Api/Saml/SamlResponseLoader.cs
+++ b/SSO-Auth/Api/Saml/SamlResponseLoader.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Xml;
@@ -72,6 +73,10 @@ internal static class SamlResponseLoader
         try
         {
             response = new SamlResponse(certificateStr, secondaryCertificateStr, responseString);
+
+            // Post-condition, compiled out of the shipped build (#1082): a true return promises the caller a
+            // response whose document is loaded, and every caller dereferences it without a second check.
+            Debug.Assert(response.Xml.Length > 0, "TryParse returned true with an unloaded document.");
             return true;
         }
         catch (Exception ex) when (ex is FormatException or XmlException or CryptographicException or ArgumentException)


### PR DESCRIPTION
# What & why

Closes #1082.

The fuzz harness drives the untrusted-input parse entry points and can only see
two outcomes: an unmapped exception, or nothing. A mis-parse that returns a
wrong-but-quiet object is indistinguishable from a correct one, so most of that
surface was invisible to it. There was not a single assertion in the plugin, so
the sibling piece that runs fuzzing with assertions enabled would have had
nothing to run.

Twelve post-conditions now sit on the entry points `SSO-Auth.Fuzz/Program.cs`
already drives, plus one conformance rule that keeps them out of the shipped
build. No production behaviour changes: every added call is `Debug.Assert`,
which the compiler removes from a build without `DEBUG`, and that is
demonstrated below rather than asserted.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Nothing in the diff changes a decision. Two of the
      assertions exist to state the fail-closed direction: a discovery document
      that did not parse advertises neither PKCE S256 nor the RFC 9207 `iss`
      parameter.
- [x] No secrets logged. No log call is added or moved. An assertion message
      names the method and the property, never a value, so a fired assertion in
      a Debug build cannot print an assertion, a token or an identifier.
- [ ] A security review was performed. **No.** No second reader looked at this
      change, and there is none available for it tonight. The evidence below
      stands in place of one; it is not a substitute and this line is the
      disclosure.
- [ ] Review record: none, for the reason above.
- [x] Log inputs from the IdP are sanitized inline at the log call: unchanged,
      no log call touched.

The reason `Debug.Assert` is acceptable on an authentication path at all is that
it does not reach it. A post-condition that fired in a running server would take
a login down over a condition the fail-closed paths already handle, which is
strictly worse than the silent mis-parse it was added to catch. Everything below
is about establishing that it cannot.

## Quality checklist

- [x] No duplicated logic. Each assertion is one line at the return it belongs
      to; no helper, no wrapper, no new type.
- [x] The change adds no more code than the problem requires.
- [x] Comments explain why. Each assertion's rationale names the consequence it
      exists for rather than restating the line above it.
- [x] Architecture-conformance tests pass, and the new structural property is
      locked in as `ParseSurfaceAssertions_NeverReachTheShippedBuild`.
- [x] Docs impact considered: no README or wiki surface describes the parse
      surface's post-conditions, and nothing user-facing changes.

## Verification

All commands run in a clean worktree off `origin/main` at `696385f`.

Build, both target frameworks, warnings as errors:

    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror
    Build succeeded. 0 warnings, 0 errors
    $ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
    Build succeeded. 0 warnings, 0 errors

Full suite, both frameworks:

    net9.0    Total: 2763, Failed: 0, Skipped: 4
    net10.0   Total: 2764, Failed: 0, Skipped: 4

The four skips are pre-existing and unrelated: `SsoHttpTests` cases that bind a
listener off loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). They are skipped, not worked around, and this diff
neither adds nor removes a skip.

Seed-corpus replay with the assertions live, which is the Done bullet asking for
it. Debug build, every target:

    $ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Debug --warnaserror
    $ SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=<t> ./SSO-Auth.Fuzz/bin/Debug/net9.0/SSO-Auth.Fuzz.exe SSO-Auth.Fuzz/corpus/<t>
    saml        15 seed(s) handled fail-closed
    discovery    5 seed(s) handled fail-closed
    idtoken      5 seed(s) handled fail-closed
    jwks         2 seed(s) handled fail-closed
    roles        4 seed(s) handled fail-closed

So the new invariants hold on every known-good and known-hostile seed, and are
not themselves the bug.

Prettier is clean: its scope is `**/*.{js,html,md,css,scss}` and this diff adds
none of those.

### The three falsifiers

A guard that has never been made to fail is not evidence. Each of these was run,
observed, and reverted.

**1. The assertions bite, and they bite through the harness.** `PkceDiscovery`
mutated to fail open (`methods is null || ...`), Debug build, one seed that is
not a discovery document:

    Process terminated.
    Assertion failed.
    SupportsS256 reported S256 for a document that did not parse.
       at ...PkceDiscovery.SupportsS256(JObject discovery) ... line 51
       at ...PkceDiscovery.SupportsS256(String discoveryJson) ... line 29
       at ...Fuzz.Program.FuzzOidcDiscovery ... line 155
    exit=35

That is a process termination reached from the fuzz driver, which is exactly the
shape libFuzzer records as a crasher.

**2. The same mutation is invisible in Release**, which is the other half of the
claim and the one that matters for shipping:

    $ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release
    $ SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=discovery ./SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.Fuzz.exe <seed>
    Smoke OK: 1 seed(s) for target 'discovery' handled fail-closed with no unmapped exception.
    exit=0

Read together, those two runs are the empirical form of "compiled out": the same
source, the same input, an abort in one configuration and silence in the other.
The assembly agrees. Searching each built `SSO-Auth.dll` for one assertion's
message literal, UTF-16 as the metadata string heap stores it:

    Debug    size 800768   utf16 hit: true
    Release  size 772096   utf16 hit: false

**3. The conformance rule bites, on both legs.** With the four production files
reverted to `main` and the rule kept, the sentinel fires:

    ParseSurfaceAssertions_NeverReachTheShippedBuild [FAIL]
      No Debug.Assert remains in the plugin, so the assertion-enabled fuzzing
      configuration has nothing to check and the bans above guard nothing (#1082).

With one `System.Diagnostics.Trace.Assert(true);` planted on the parse surface:

    ParseSurfaceAssertions_NeverReachTheShippedBuild [FAIL]
      Trace.Assert / Trace.Fail are [Conditional("TRACE")] and TRACE is defined in
      Release, so they ship - use Debug.Assert for a parse-surface post-condition
      (#1082). Offending lines: PkceDiscovery.cs:42: System.Diagnostics.Trace.Assert(true);

## Notes

**No second reader.** Nobody but the author has read this change. The falsifiers
above are what carries it instead.

**Means.** C# `Debug.Assert`, in the plugin's own sources. The issue offers a
`[Conditional("DEBUG")]` helper as the alternative; a helper would add a type
and an indirection to gain nothing, since `Debug.Assert` already carries the
attribute and the harness already runs the configuration that enables it.

**One invariant from the issue is deliberately not written**, and this is the
one thing here that departs from what was asked. The issue asks that a non-null
issuer imply a non-empty, trimmed string. That contradicts what
`OidcResponseIssuer.IdTokenIssuer` documents: empty is exactly what an absent
`iss` claim returns, and `JsonWebToken.Issuer` hands back the claim as written,
whitespace included. Asserting it would fire on a legitimate token rather than
on a defect. The weaker true property is asserted instead, no token means no
issuer, and the departure is stated at the call rather than left to be
rediscovered.

**A second one is not written either**, for a different reason. The issue asks
that a `false` return from `TryParse` imply no partially-built object escapes.
The `out` parameter is definitely assigned before every `false` return, so an
assertion there would restate the adjacent line and could not fail. The success
half is asserted; the failure half is a note in the commit message.

**`GetSessionIndex` is included** though the issue's list does not name it. It
is the same shape as its neighbours and reads a value a later Single Logout
request names a session by; leaving the one gap in a family invites the next
reader to wonder which reason applied.

**What this rule cannot do**, since the name invites the wrong reading: it does
not re-prove that `[Conditional("DEBUG")]` strips a call. That is the compiler's
contract and falsifiers 1 and 2 are its evidence. The rule holds the two ways
the tree itself could defeat it.
