### PR TITLE
Pin the canonical name to one ordinal comparison on every route it arrives on

### DIFF
--- a/SSO-Auth.Tests/Linking/LinkingIdentifierOneDecisionTests.cs
+++ b/SSO-Auth.Tests/Linking/LinkingIdentifierOneDecisionTests.cs
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The provider-side canonical name reaches one comparison decision wherever it arrives (#1165), so a
+/// name that can be linked is the same name that can be unlinked and neither route can be shadowed by a
+/// variant the other accepts.
+/// <para>
+/// In this tree that decision is not spread across the add path, the remove path and login-time
+/// resolution: the identifier is never normalised, and all three index ONE map - the per-provider
+/// <c>CanonicalLinks</c> dictionary - so the comparison is the dictionary's own comparer and there is
+/// exactly one of it. That makes the property a fact about the map rather than about three call sites,
+/// which is what the rules below assert: the comparer is the ordinal default on every provider kind and
+/// survives a persistence round trip, and the end-to-end behaviour that follows from it holds on the
+/// routes an administrator actually drives.
+/// </para>
+/// <para>
+/// The failure this exists against is a later edit giving one of these maps a case- or culture-folding
+/// comparer to be helpful. That would make <c>Alice</c> and <c>alice</c> one link for whichever paths
+/// read the folded map and two for whichever did not - and the half that folds is a login-time identity
+/// collapse, not a convenience.
+/// </para>
+/// </summary>
+[Collection("SSOController")]
+public class LinkingIdentifierOneDecisionTests
+{
+    private static readonly Guid Target = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    // Every map the canonical name is a KEY of, on a freshly constructed configuration. Derived from the
+    // config objects rather than named as literals, so a provider kind added later is covered.
+    private static IEnumerable<(string Where, IEqualityComparer<string> Comparer)> IdentifierKeyedMaps()
+    {
+        var oid = new OidConfig();
+        var saml = new SamlConfig();
+
+        yield return ("OidConfig.CanonicalLinks", oid.CanonicalLinks.Comparer);
+        yield return ("OidConfig.CanonicalLinkIssuers", oid.CanonicalLinkIssuers.Comparer);
+        yield return ("SamlConfig.CanonicalLinks", saml.CanonicalLinks.Comparer);
+    }
+
+    [Fact]
+    public void EveryIdentifierKeyedMap_ComparesOrdinally()
+    {
+        // The rule. One comparer, and it is the ordinal default: no case folding, no culture, nothing that
+        // could make two different subjects the same key on one path and different keys on another.
+        foreach (var (where, comparer) in IdentifierKeyedMaps())
+        {
+            Assert.True(
+                IsOrdinal(comparer),
+                $"{where} no longer compares its keys ordinally. The canonical name is an identity, so folding it here silently merges two provider subjects into one link on whichever paths read this map (#1165).");
+        }
+    }
+
+    [Fact]
+    public void TheRule_RefusesAFoldingComparer()
+    {
+        // Must-catch fixture. The comparers a helpful edit would reach for are refused by the same
+        // predicate the rule uses, so the rule above is a statement and not a tautology.
+        Assert.False(IsOrdinal(new Dictionary<string, Guid>(StringComparer.OrdinalIgnoreCase).Comparer));
+        Assert.False(IsOrdinal(new Dictionary<string, Guid>(StringComparer.InvariantCulture).Comparer));
+        Assert.False(IsOrdinal(new Dictionary<string, Guid>(StringComparer.InvariantCultureIgnoreCase).Comparer));
+
+        // And it accepts both spellings of the thing it is asserting, so a later refactor writing the
+        // comparer out explicitly does not read as a regression.
+        Assert.True(IsOrdinal(new Dictionary<string, Guid>().Comparer));
+        Assert.True(IsOrdinal(new Dictionary<string, Guid>(StringComparer.Ordinal).Comparer));
+    }
+
+    [Fact]
+    public void TheComparer_SurvivesThePersistenceRoundTrip()
+    {
+        // The map login-time resolution reads is the DESERIALIZED one, not the one a constructor made. A
+        // round trip that dropped the comparer would leave the rule above true of a map nothing reads.
+        var config = new PluginConfiguration();
+        config.OidConfigs["keycloak"] = new OidConfig { CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-Alice"] = Target } };
+
+        var restored = RoundTrip(config);
+
+        Assert.True(IsOrdinal(restored.OidConfigs["keycloak"].CanonicalLinks.Comparer));
+        Assert.True(restored.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-Alice"));
+        Assert.False(restored.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-alice"));
+    }
+
+    [Fact]
+    public async Task ACaseVariantOfALinkedName_IsRefusedByTheDeleteRouteAndTheExactNameStillRemovesIt()
+    {
+        // End to end on the routes an administrator drives. The shadow this closes is
+        // linkable-but-not-unlinkable: a variant the DELETE route accepted while the stored key stayed
+        // behind would leave a live link no operator could revoke.
+        var harness = ForCaller(c => c.OidConfigs["keycloak"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-Alice"] = Target },
+        });
+
+        Assert.IsType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-alice"));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-Alice")));
+
+        Assert.IsNotType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-Alice"));
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-Alice")));
+    }
+
+    [Fact]
+    public async Task AWhitespaceVariantOfALinkedName_IsRefusedRatherThanTrimmedIntoAMatch()
+    {
+        // The other half of "never normalised". Trimming on the way in would let " sub-1" unlink "sub-1",
+        // which is the same shadow read from the opposite side: a name nobody stored resolving to a link.
+        var harness = ForCaller(c => c.OidConfigs["keycloak"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = Target },
+        });
+
+        Assert.IsType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, " sub-1"));
+        Assert.IsType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("oid", "keycloak", Target, "sub-1 "));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.OidConfigs["keycloak"].CanonicalLinks.ContainsKey("sub-1")));
+    }
+
+    [Fact]
+    public async Task TheSamlLinkMap_HoldsTheSameDecision()
+    {
+        // The identifier is the SAML NameID on this side and the OpenID sub on the other, and both are
+        // keys of the same kind of map. Asserted on both so a divergence cannot land on one protocol.
+        var harness = ForCaller(c => c.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["Alice@example.test"] = Target },
+        });
+
+        Assert.IsType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("saml", "adfs", Target, "alice@example.test"));
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("Alice@example.test")));
+
+        Assert.IsNotType<NotFoundObjectResult>(await harness.Controller.DeleteCanonicalLink("saml", "adfs", Target, "Alice@example.test"));
+        Assert.False(SSOPlugin.Instance.ReadConfiguration(c => c.SamlConfigs["adfs"].CanonicalLinks.ContainsKey("Alice@example.test")));
+    }
+
+    [Fact]
+    public void TheIdentifierEntryPointSet_IsNonEmpty()
+    {
+        // Sentinel. The route segment is the one medium the identifier arrives on as a parameter - on the
+        // add route it travels inside the redeemed identity and on the login path it is a persisted key,
+        // neither of which a parameter walk can see. If this ever reads zero the behavioural proofs above
+        // are driving a method no URL reaches any more.
+        var carrying = EntryPointInventory.OfThePlugin()
+            .Where(e => e.Parameters.Any(p => string.Equals(p.Name, "canonicalName", StringComparison.Ordinal)))
+            .Select(e => e.Template)
+            .ToList();
+
+        Assert.NotEmpty(carrying);
+        Assert.All(carrying, t => Assert.Contains("Link", t, StringComparison.Ordinal));
+    }
+
+    // The identifier is an opaque identity, so the only comparer that is right for it is the ordinal one,
+    // and this is deliberately an identity check rather than a behavioural sniff. A culture comparer agrees
+    // with ordinal on ASCII and diverges on inputs no fixture would think to try, which is exactly the kind
+    // of near-miss a behavioural probe passes. The case leg stays as a second bar so a custom comparer
+    // handed back in place of one of these instances still has to behave.
+    private static bool IsOrdinal(IEqualityComparer<string> comparer) =>
+        (ReferenceEquals(comparer, EqualityComparer<string>.Default) || ReferenceEquals(comparer, StringComparer.Ordinal))
+        && !comparer.Equals("a", "A")
+        && comparer.Equals("sub-1", "sub-1");
+
+    // A persistence round trip through the same XML serializer the plugin stores its configuration with.
+    private static PluginConfiguration RoundTrip(PluginConfiguration configuration)
+    {
+        var serializer = new System.Xml.Serialization.XmlSerializer(typeof(PluginConfiguration));
+        using var buffer = new System.IO.MemoryStream();
+        serializer.Serialize(buffer, configuration);
+        buffer.Position = 0;
+
+        // Read back with DTD processing off and no resolver, the same posture the plugin's own XML reads
+        // take - a test fixture is not a reason to open one.
+        using var reader = System.Xml.XmlReader.Create(buffer, new System.Xml.XmlReaderSettings
+        {
+            DtdProcessing = System.Xml.DtdProcessing.Prohibit,
+            XmlResolver = null,
+        });
+        return (PluginConfiguration)serializer.Deserialize(reader)!;
+    }
+
+    // An administrator acting on their own account, which is what both link routes gate on before the
+    // identifier is compared at all.
+    private static SsoControllerHarness ForCaller(Action<PluginConfiguration> configure)
+    {
+        var harness = new SsoControllerHarness(configure);
+
+        var user = new User("caller", "SSO-Auth", "Default") { Id = Target, EnableUserPreferenceAccess = true };
+        user.SetPermission(PermissionKind.IsAdministrator, true);
+        harness.AuthContext.GetAuthorizationInfo(Arg.Any<HttpRequest>()).Returns(Task.FromResult(new AuthorizationInfo { User = user }));
+        return harness;
+    }
+}


### PR DESCRIPTION
# What & why

The provider-side canonical name arrives on three media - a DELETE route segment, the
redeemed identity inside the link write, and a key already persisted in the map
login-time resolution reads - and nothing asserted the three agree. The failure that
leaves open is a link that can be created and then not revoked: a variant one route
accepts and the other does not shadows the stored name, and an operator has no way to
reach the live link.

In this tree those three do not each carry a comparison of their own. The identifier is
never normalised and all three index one map per provider, so the decision is that map's
comparer and there is exactly one of it. The rule is written where the property actually
lives rather than as three call-site assertions that would be true by construction.

Closes #1165

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff is one new test file and no production source, so no behaviour changes here.
The boxes below are answered about what the change asserts rather than about what it
alters.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review gate was run on this change and no second reader saw it.** The
evidence below stands in place of one: each guard was deleted and the suite watched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The conformance box is left unticked for the same reason as in #1312: the suite passes,
but the rule lives in its own file rather than in `ArchitectureConformanceTests`, which
is where the checklist points and which is the open question #1189 holds. This change
does not settle it.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, at this commit:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q   # 0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2770, Errors: 0, Failed: 0, Skipped: 4
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q   # 0 warnings, 0 errors
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2771, Errors: 0, Failed: 0, Skipped: 4
```

No `.js` / `.html` / `.md` / `.css` file is touched.

### The guards, deleted and watched

The remove lookup made to trim its input, `links.TryGetValue(canonicalName.Trim(), ...)`
in `CanonicalLinkService`:

```
   LinkingIdentifierOneDecisionTests.AWhitespaceVariantOfALinkedName_IsRefusedRatherThanTrimmedIntoAMatch [FAIL]
   Total: 7, Failed: 1
```

The OpenID link map given a case-folding comparer, which needed a comparer-taking
constructor on `SerializableDictionary` to be expressible at all - which is itself the
shape of the change this rule exists against:

```
   LinkingIdentifierOneDecisionTests.EveryIdentifierKeyedMap_ComparesOrdinally [FAIL]
     OidConfig.CanonicalLinks no longer compares its keys ordinally. The canonical name
     is an identity, so folding it here silently merges two provider subjects into one
     link on whichever paths read this map (#1165).
   Total: 7, Failed: 1
```

Both edits were reverted before the commit; the tree here carries neither.

## Notes

The issue's Done asks for a rule that the add path, `TryRemoveLink` and login-time
resolution apply the same normalisation and the same `StringComparer`, with a
must-catch fixture where a call site using a different comparer fails. That rule cannot
be written against this tree as three call-site assertions, because there are no three
comparisons: `TryCreateLink` writes `links[providerUserId]`, `TryRemoveLink` reads
`links.TryGetValue(canonicalName, ...)`, and resolution indexes the same map, all
through the one private accessor that hands the map out. The comparer is the map's, so
"the same comparer" is a property of the map and the must-catch fixture is a map built
with a folding comparer, which is what landed here.

Also carried out of the issue's surface list: `SsoManagedProviderId` and
`AccountLinkResolver` contain no comparison of the identifier at all, so neither is a
site the rule needs to reach. That is reported on the issue with the commands.

The route-segment medium has one property this change does not assert: a name
containing a character the router treats specially cannot be spelled as a segment at
all, so it would be linkable and not unlinkable for a reason that is about URL shape
rather than about comparison. That is a separate claim and it is written into the issue
rather than made here.
