### PR TITLE
Add the JWE and nested-JWT rows to the id_token forgery battery

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs
@@ -407,6 +407,57 @@ public sealed class OidcIdTokenValidatorTests : IDisposable
         Assert.False(result.IsError, result.Error);
     }
 
+    [Fact]
+    public async Task EncryptedIdToken_IsRejected_AndYieldsNoPrincipal()
+    {
+        // #1174. A JWE is five segments where a JWS is three, and the battery already refuses five
+        // segments of garbage - what it never established is what happens to a WELL-FORMED one, signed by
+        // the trusted key and then encrypted to a key this plugin does not hold. That is the shape a
+        // provider actually emits when an operator turns response encryption on at the IdP, and the
+        // handler's behaviour against it is the library's rather than this plugin's, so a library change
+        // to it would otherwise pass unseen.
+        //
+        // Non-vacuous by construction, and measured rather than asserted: remove the two encryption lines
+        // below and the same descriptor validates - it is Descriptor(), which
+        // ValidRs256Token_Succeeds_WithRawClaimsAndAlgorithm proves is accepted. So the rejection is
+        // bought by the encryption and by nothing else in the fixture.
+        using var contentKey = RSA.Create(2048);
+        var descriptor = Descriptor();
+        descriptor.EncryptingCredentials = new EncryptingCredentials(
+            new RsaSecurityKey(contentKey) { KeyId = KeyId }, SecurityAlgorithms.RsaOAEP, SecurityAlgorithms.Aes256CbcHmacSha512);
+        var token = new JsonWebTokenHandler().CreateToken(descriptor);
+
+        var result = await _validator.ValidateAsync(token, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Null(result.User);
+    }
+
+    [Fact]
+    public async Task NestedJwtPayload_UnderATrustedSignature_IsRejected_AndYieldsNoPrincipal()
+    {
+        // #1174, the other half of the shape: a JWS whose payload is itself a JWT rather than a claims
+        // object. Built by hand because no minting API produces it - and that is the point of the row.
+        // The signature is genuine, made with the SAME key and kid the JWKS advertises, so every check
+        // this battery already has passes: the kid is in the allowlist, no critical header, the signature
+        // verifies. What must refuse it is the payload not being a claims set, and nothing else was
+        // standing between an attacker and a principal built from whatever a reader made of it.
+        //
+        // Non-vacuous, measured the same way: swap the nested token for the plain claims JSON on the line
+        // below and this row goes green as an ACCEPTED token, because everything else about it is valid.
+        var inner = CreateToken();
+        var header = Base64UrlEncoder.Encode($$"""{"alg":"RS256","typ":"JWT","kid":"{{KeyId}}"}""");
+        var payload = Base64UrlEncoder.Encode(inner);
+        var signature = Base64UrlEncoder.Encode(_rsa.SignData(
+            System.Text.Encoding.ASCII.GetBytes($"{header}.{payload}"), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1));
+
+        var result = await _validator.ValidateAsync(
+            $"{header}.{payload}.{signature}", Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Null(result.User);
+    }
+
     // --- helpers ---
 
     private OidcClientOptions Options(string? jwks = null)


### PR DESCRIPTION
# What & why

Closes #1174, the JWE / nested-JWT shape on the id_token path.

Two rows, both named tests in `SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs`.

**Encrypted id_token.** A JWE is five segments where a JWS is three, and
`MalformedToken_IsRejected_WithoutThrowing` already refuses five segments of
garbage. What was unasserted is the well-formed case: a token signed by the
trusted key and then encrypted to a key this plugin does not hold, which is what
a provider emits once an operator turns response encryption on at the IdP. The
handling is the identity library's rather than this plugin's, so a library change
to it would have passed unseen.

**Nested JWT.** A JWS whose payload is itself a JWT rather than a claims object,
built by hand because no minting API produces it. Its signature is genuine, made
with the same key and `kid` the JWKS advertises, so every check the battery
already carries passes: the `kid` is in the allowlist, there is no critical
header, and the signature verifies. What has to refuse it is the payload not
being a claims set.

Both shapes are rejected on the shipped tree, so both are pinned here rather than
filed as a behaviour change.

### Scope note

The issue asks for a `ForgeryKind` value. There is none on this branch - the
battery is not parametrized and the id_token cases are named tests in that file - 
so the rows are named tests beside them, which is what the issue's "in whatever
the battery's file is at implementation time" allows for.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test-only: no production file is touched.

## Security checklist

The diff adds two negative tests on the id_token validation path and changes no
production code. No security review was run for it, and this line is the
disclosure rather than a tick.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: none, no reader-facing surface changes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change, the
      diff carries none of those file types.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   0 warnings, 0 errors

./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
Total: 2788, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
Total: 2789, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

### The weakening that reddens each row

Applied one at a time to the built tree and reverted afterwards. Each reddened
only its own row, and both were green again on the restored tree.

| weakening | result |
| --- | --- |
| drop the two `EncryptingCredentials` lines, leaving the plain `Descriptor()` | `EncryptedIdToken_IsRejected_AndYieldsNoPrincipal` red (1 of 2 failed) |
| swap the nested payload for a plain claims object under the same genuine signature | `NestedJwtPayload_UnderATrustedSignature_IsRejected_AndYieldsNoPrincipal` red (1 of 2 failed) |
| neither | both green |

The first weakening turns the fixture into the exact descriptor
`ValidRs256Token_Succeeds_WithRawClaimsAndAlgorithm` proves is accepted, so the
rejection is bought by the encryption and by nothing else in the fixture. The
second leaves the signature, `kid`, issuer, audience and lifetime untouched, so
what the row measures is the payload shape alone.

## Notes

No second person read this change. The evidence above stands in place of one.

`crit` stays out of scope, per the issue and #1038. The `typ`-confusion half of
the parent (#1047) is #1175 and is not in this diff.
