### PR TITLE
Follow the organisation default for the sponsor button (#1318)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# Sponsor button shown on the repository. Only the platforms actually in use are listed;
-# see https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
-buy_me_a_coffee: iderex


### PR DESCRIPTION
Closes #1318.

The organization keeps the default in the `.github` repository, and it applies to every repository without a file of its own. This one had its own with the same content.

They have already drifted apart: the default has pointed at GitHub Sponsors since 09.08., this copy still at Buy Me a Coffee. After the merge this repository shows the same as the others, and there is only one place left where it stands.
