### PR TITLE
Report a Jellyfin account's SSO posture in one elevation-gated read

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2810,6 +2810,7 @@ public class ArchitectureConformanceTests
         "Config/Export", "Config/Import", // elevated config transfer
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
         "saml/links/{jellyfinUserId}", "oid/links/{jellyfinUserId}", // authenticated link listings
+        "SSO-Managed/Status/{jellyfinUserId}", // elevated read-only account report (#1136), in-memory, no outbound fetch
         "{viewName}", // SSOViewsController: read-only embedded static asset (ETag/304), no I/O, no login path
         "i18n", // SSOViewsController: anonymous read-only UI-string catalog (#913), in-memory, no I/O, no login path
     };

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -43,6 +43,9 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         "ExportConfig", "ImportConfig", "Unregister",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",
+        // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for
+        // an account other than the caller's.
+        "SsoManagedStatus",
     };
 
     // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) - the canonical

--- a/SSO-Auth.Tests/Http/SSOControllerSsoManagedStatusTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerSsoManagedStatusTests.cs
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the per-account SSO-managed report (#1136) via <see cref="SsoControllerHarness"/>.
+/// The endpoint exists because "holds a link" and "cannot log in with a password" are different facts that
+/// a caller previously had to infer from two link maps, so the tests are built around the four combinations
+/// where that inference goes wrong, rather than around a happy path.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerSsoManagedStatusTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Bob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+
+    private const string PasswordProviderId = "Jellyfin.Server.Implementations.Users.DefaultAuthenticationProvider";
+
+    [Fact]
+    public void SsoStampedAccountHoldingALink_ReportsBothFacts()
+    {
+        var harness = Harness(oidLinks: new Dictionary<string, Guid> { ["sub-alice"] = Alice });
+        StampedUser(harness, Alice, SsoManagedProviderId.Value);
+
+        var report = Report(harness, Alice);
+
+        Assert.True(report.GetProperty("PasswordLoginDisabled").GetBoolean());
+        Assert.True(report.GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void SsoStampedAccountWithNoLinkLeft_StillReportsPasswordLoginDisabled()
+    {
+        // The state an account is left in after every link is removed without the provider id being put
+        // back. Reading "has links" as "password login is off" gets this one wrong in the safe direction;
+        // reading it the other way round gets the next test wrong in the unsafe one.
+        var harness = Harness();
+        StampedUser(harness, Alice, SsoManagedProviderId.Value);
+
+        var report = Report(harness, Alice);
+
+        Assert.True(report.GetProperty("PasswordLoginDisabled").GetBoolean());
+        Assert.False(report.GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void PasswordAccountHoldingALink_ReportsPasswordLoginStillEnabled()
+    {
+        // The combination this endpoint exists for: the account can sign in through the identity provider
+        // AND with its Jellyfin password. A caller that offered no password field here would be hiding a
+        // credential that still works.
+        var harness = Harness(oidLinks: new Dictionary<string, Guid> { ["sub-alice"] = Alice });
+        StampedUser(harness, Alice, PasswordProviderId);
+
+        var report = Report(harness, Alice);
+
+        Assert.False(report.GetProperty("PasswordLoginDisabled").GetBoolean());
+        Assert.True(report.GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void PlainPasswordAccount_ReportsNeitherFact()
+    {
+        var harness = Harness();
+        StampedUser(harness, Alice, PasswordProviderId);
+
+        var report = Report(harness, Alice);
+
+        Assert.False(report.GetProperty("PasswordLoginDisabled").GetBoolean());
+        Assert.False(report.GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void ALinkOnASamlProviderAlone_IsReported()
+    {
+        // The link test is an OR over both protocols. With the SAML arm removed this is the case that goes
+        // red, so the arm is proven rather than merely present.
+        var harness = Harness(samlLinks: new Dictionary<string, Guid> { ["nameid-alice"] = Alice });
+        StampedUser(harness, Alice, PasswordProviderId);
+
+        Assert.True(Report(harness, Alice).GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void ALinkBelongingToAnotherAccount_IsNotReportedAsThisOnes()
+    {
+        // A provider carrying links is not the same as this user carrying one. Without the per-user filter
+        // every account on a server with any link at all would report as linked.
+        var harness = Harness(oidLinks: new Dictionary<string, Guid> { ["sub-bob"] = Bob });
+        StampedUser(harness, Alice, PasswordProviderId);
+
+        Assert.False(Report(harness, Alice).GetProperty("HasCanonicalLink").GetBoolean());
+    }
+
+    [Fact]
+    public void AnUnknownUserId_IsNotFound_RatherThanAnAccountWithNothingSet()
+    {
+        // "This account uses a password" and "there is no such account" are different answers and a caller
+        // that cannot tell them apart offers a password field for an account it will fail to find.
+        var harness = Harness();
+
+        var result = harness.Controller.SsoManagedStatus(Alice);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+    }
+
+    [Fact]
+    public void TheReport_CarriesTheTwoFactsAndNothingElse()
+    {
+        // The response is what leaves the server, so the bound on it is a bound on the whole payload rather
+        // than on the members somebody remembered to check. A provider secret sits in the configuration this
+        // action reads through, which is what makes the absence assertion meaningful.
+        const string Secret = "provider-secret-that-must-never-leave";
+        var harness = Harness(
+            oidLinks: new Dictionary<string, Guid> { ["sub-alice"] = Alice },
+            configure: configuration => configuration.OidConfigs["idp"].OidSecret = Secret);
+        StampedUser(harness, Alice, SsoManagedProviderId.Value);
+
+        var body = JsonSerializer.Serialize(Assert.IsType<OkObjectResult>(harness.Controller.SsoManagedStatus(Alice)).Value);
+
+        Assert.Equal(
+            new[] { "HasCanonicalLink", "PasswordLoginDisabled" },
+            JsonDocument.Parse(body).RootElement.EnumerateObject().Select(p => p.Name).OrderBy(n => n, StringComparer.Ordinal));
+        Assert.DoesNotContain(Secret, body, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-alice", body, StringComparison.Ordinal);
+    }
+
+    // --- helpers ---
+
+    private static SsoControllerHarness Harness(
+        IDictionary<string, Guid>? oidLinks = null,
+        IDictionary<string, Guid>? samlLinks = null,
+        Action<PluginConfiguration>? configure = null)
+    {
+        return new SsoControllerHarness(configuration =>
+        {
+            configuration.OidConfigs["idp"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = Map(oidLinks),
+            };
+            configuration.SamlConfigs["saml"] = new SamlConfig
+            {
+                Enabled = true,
+                CanonicalLinks = Map(samlLinks),
+            };
+            configure?.Invoke(configuration);
+        });
+    }
+
+    private static SerializableDictionary<string, Guid> Map(IDictionary<string, Guid>? links)
+    {
+        var map = new SerializableDictionary<string, Guid>();
+        foreach (var link in links ?? new Dictionary<string, Guid>())
+        {
+            map[link.Key] = link.Value;
+        }
+
+        return map;
+    }
+
+    private static void StampedUser(SsoControllerHarness harness, Guid id, string authenticationProviderId)
+    {
+        var user = TestUsers.Named("alice", id);
+        user.AuthenticationProviderId = authenticationProviderId;
+        harness.UserManager.GetUserById(id).Returns(user);
+    }
+
+    private static JsonElement Report(SsoControllerHarness harness, Guid id)
+    {
+        var value = Assert.IsType<OkObjectResult>(harness.Controller.SsoManagedStatus(id)).Value;
+        return JsonDocument.Parse(JsonSerializer.Serialize(value)).RootElement;
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1516,6 +1516,54 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Reports whether one Jellyfin account is SSO-managed (#1136), so a provisioning tool can decide in a
+    /// single call whether to offer a password field, a reset link, or neither. Requires administrator
+    /// privileges. Read-only - it changes nothing.
+    /// </summary>
+    /// <remarks>
+    /// The two facts are reported SEPARATELY because they genuinely differ, and collapsing them is the
+    /// inference this endpoint exists to remove. An account can hold a canonical link while its
+    /// <c>AuthenticationProviderId</c> still routes password attempts to core's default provider, and an
+    /// account can carry the SSO stamp with no link left on it (unregistered, or provisioned and never
+    /// linked). Only the first of the two decides whether a password can be used.
+    /// </remarks>
+    /// <param name="jellyfinUserId">The Jellyfin user to report on.</param>
+    /// <returns>The account's SSO posture, or 404 when no such user exists.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("SSO-Managed/Status/{jellyfinUserId}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult SsoManagedStatus(Guid jellyfinUserId)
+    {
+        // A user id nobody holds is a 404 rather than a report of two falses: "this account uses passwords"
+        // and "this account does not exist" are different answers, and a caller that cannot tell them apart
+        // would offer a password field for an account it is about to fail to find.
+        if (_userManager.GetUserById(jellyfinUserId) is not { } user)
+        {
+            return NotFound("No such Jellyfin user.");
+        }
+
+        return Ok(new
+        {
+            // The same detector the SSO-only feature and the login-path re-assertion use, so this report and
+            // the enforcement can never disagree about what the stamp means.
+            PasswordLoginDisabled = SsoAuthenticationProviders.IsSsoProvider(user.AuthenticationProviderId),
+            HasCanonicalLink = HoldsAnyCanonicalLink(jellyfinUserId),
+        });
+    }
+
+    /// <summary>
+    /// Whether the user holds at least one canonical link on any provider of either protocol. Reuses the
+    /// same per-mode read the link endpoints answer with, so this cannot report a link set the link
+    /// endpoints would not list. A provider present with no link for this user yields an empty list, which
+    /// is why the test is on the values rather than on the map being non-empty.
+    /// </summary>
+    /// <param name="jellyfinUserId">The Jellyfin user to look for.</param>
+    /// <returns>True when any provider of either protocol holds a link for that user.</returns>
+    private bool HoldsAnyCanonicalLink(Guid jellyfinUserId) =>
+        _canonicalLinks.LinksByUser(ProviderMode.Oid, jellyfinUserId).Any(entry => entry.Value.Any())
+        || _canonicalLinks.LinksByUser(ProviderMode.Saml, jellyfinUserId).Any(entry => entry.Value.Any());
+
+    /// <summary>
     /// Turns SSO-only login on (#165), designating <paramref name="breakGlassAdminUsername"/> as the account
     /// whose native password login is never disabled. Requires administrator privileges. Fail-closed: the
     /// last-admin guard runs first, and unless the designated account is an existing, enabled administrator


### PR DESCRIPTION
# What & why

Closes #1136.

Adds `GET sso/SSO-Managed/Status/{jellyfinUserId}`, an elevation-gated read that answers "is this Jellyfin account SSO-managed?" in one call.

The fact was already computed inside the plugin and was not reachable over HTTP. The only related surface is `GET saml/links/{id}` and `GET oid/links/{id}`, so a provisioning tool deciding whether to offer a password field, a reset link, or neither had to make two requests and then infer the answer from link data. The inference is wrong in both directions: an account can hold a canonical link while its `AuthenticationProviderId` still routes password attempts to core's default provider, and an account can carry the SSO stamp with no link left on it. Only the provider id decides whether a password works, which is why the endpoint reports the two facts separately rather than as one "SSO-managed" boolean.

`PasswordLoginDisabled` comes from `SsoAuthenticationProviders.IsSsoProvider`, the same detector the SSO-only feature and the login-path re-assertion use, so the report and the enforcement cannot disagree about what the stamp means. `HasCanonicalLink` reuses `CanonicalLinkService.LinksByUser` over both protocols, so it cannot report a link set the link endpoints would not list. A user id nobody holds is a 404 rather than a report of two falses.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The change is read-only and adds no login, crypto or persistence path. It touches `SSOController.cs`, which is on the sensitive surface, so the list is answered rather than skipped.

- [x] Fail-closed preserved: nothing here accepts or validates anything. The action performs no signature, time-bound or audience decision, and it neither reads nor writes a credential. The 404 for an unknown id is the fail-closed direction for the one decision it does make.
- [x] No secrets logged; secrets are redacted on config export. The action logs nothing at all, and the response carries exactly two boolean members. `TheReport_CarriesTheTwoFactsAndNothingElse` pins that member set and asserts a provider secret present in the configuration the action reads through does not appear in the serialized body, along with the link key itself.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **No adversarial review was run for this change and no second person read it.** That admission stands as written. What is offered in its place is below, under Verification.
- [ ] Review record. There is none, for the reason on the line above. No lens ran, so there are no verdicts and no CONFIRMED or PLAUSIBLE counts to report, and none are claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP-supplied value reaches this action; its only input is a route-bound `Guid`, and it writes no log line.

## Quality checklist

- [x] No duplicated logic. The two facts are read through the existing detector and the existing per-mode link read; the only new logic is the OR across the two protocols, in one four-line private helper.
- [x] The change adds no more code than the problem requires. 48 lines in the controller, of which 27 are documentation and the classification comment.
- [x] Self-documenting, comments explain why. The remark on the action says why the two facts are reported separately rather than restating that they are.
- [x] Architecture-conformance tests pass, and the new structural property is locked in. `EverySensitiveRoute_IsClassified_AsThrottledOrExplicitlyExempt` refused this branch until the new route was classified; it is on `RateLimitExemptRoutes` with its reason, as an elevated read-only report with no outbound fetch. The action name is likewise on the elevation surface anchor in `SSOControllerAuthorizationTests`, so `CoversExactlyTheKnownElevationSurface` would fail if the guard were ever removed from it.
- [x] Docs impact considered. The endpoint is part of the account-management API that #1141 covers for the wiki; that issue is open and already scoped to document this surface, so no separate documentation issue is filed. Nothing in the README or the in-repo docs describes the HTTP surface today.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Built on both target frameworks, 0 warnings and 0 errors on each.
- [x] `dotnet test` is green. Full suite through the built runners: `net9.0` 2796 total, 0 failed, 4 skipped; `net10.0` 2797 total, 0 failed, 4 skipped.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. The diff contains none; it is three `.cs` edits and one new `.cs` file.

### Every guard was deleted and the suite watched

Four mutations, each built and run, each reddening exactly the tests that name the property and no others.

| mutation | red |
| --- | --- |
| drop the SAML arm of the link test | `ALinkOnASamlProviderAlone_IsReported` |
| answer `Ok(false, false)` instead of 404 for an unknown id | `AnUnknownUserId_IsNotFound_RatherThanAnAccountWithNothingSet` |
| test the link map for being non-empty instead of testing its values | `SsoStampedAccountWithNoLinkLeft_StillReportsPasswordLoginDisabled`, `PlainPasswordAccount_ReportsNeitherFact`, `ALinkBelongingToAnotherAccount_IsNotReportedAsThisOnes` |
| replace the provider-id comparison with a non-empty check | `PasswordAccountHoldingALink_ReportsPasswordLoginStillEnabled`, `PlainPasswordAccount_ReportsNeitherFact` |

No mutation left the suite green, and the first three each isolate a single arm of the change.

The four combinations #1136 asks for are one test each: SSO-stamped with a link, SSO-stamped with no link, password account holding a link, plain password account. The non-elevated refusal is not a new test but a new row in an existing one, because `SSOControllerAuthorizationTests` enumerates the live routing table rather than a hand-written list, so the 401 and 403 assertions reach this endpoint the moment it exists.

## Notes

The endpoint answers for one user id. The full roster across all users is #1119 and is untouched here.

The response is an anonymous object, matching `SsoOnlyStatus` next to it, rather than a named DTO. That keeps the two admin status reads the same shape; if the account-management API later needs versioned contracts, that is a change to both and not to this one alone.

Nothing outside `SSOController.cs` and the test project changed, and no existing behaviour was modified.
