### PR TITLE
Export the account-link table as a username-keyed document

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2809,6 +2809,7 @@ public class ArchitectureConformanceTests
         "SAML/Test/{provider}", // LOCAL certificate parse - no outbound fetch (unlike OID/Test)
         "Config/Export", "Config/Import", // elevated config transfer
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
+        "Config/Links/Export", // elevated read-only link snapshot (#1126), in-memory, no outbound fetch
         "saml/links/{jellyfinUserId}", "oid/links/{jellyfinUserId}", // authenticated link listings
         "SSO-Managed/Status/{jellyfinUserId}", // elevated read-only account report (#1136), in-memory, no outbound fetch
         "{viewName}", // SSOViewsController: read-only embedded static asset (ETag/304), no I/O, no login path

--- a/SSO-Auth.Tests/Config/LinkExportTests.cs
+++ b/SSO-Auth.Tests/Config/LinkExportTests.cs
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the portable account-link snapshot (#1126). The document exists to survive a user-database
+/// rebuild, so the properties worth pinning are the ones that decide whether it still means anything on
+/// the other side of one: the username replaces the id, the #186 issuer binding travels with the link it
+/// binds, and a link pointing at an account that no longer exists is absent rather than dangling.
+/// </summary>
+public class LinkExportTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Bob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+    private static readonly Guid Ghost = Guid.Parse("9057c000-0000-0000-0000-000000000003");
+
+    [Fact]
+    public void EveryLinkAcrossBothProtocols_IsExportedWithItsProviderNameAndUsername()
+    {
+        var document = LinkExport.Build(Configuration(), Directory);
+
+        Assert.Equal(LinkExport.FormatVersion, document.FormatVersion);
+        Assert.Equal(
+            new[] { "OpenID/idp/sub-alice/alice", "OpenID/idp/sub-bob/bob", "SAML/adfs/nameid-alice/alice" },
+            document.Links.Select(Describe).OrderBy(d => d, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void AnOpenIdLinksIssuerBinding_TravelsWithTheLinkItBinds()
+    {
+        // The binding is per link, not per provider (#186). Exporting the provider's configured issuer
+        // instead would restore a binding the link never had, which is a relaxation dressed as a restore.
+        var document = LinkExport.Build(Configuration(), Directory);
+
+        Assert.Equal("https://idp.example.test", Link(document, "sub-alice").Issuer);
+    }
+
+    [Fact]
+    public void AnOpenIdLinkWithNoBinding_ExportsNoIssuer()
+    {
+        // A link written before the binding existed has no entry in the issuer map, and null is the honest
+        // answer for it. Substituting the provider's current issuer is the failure this pins against.
+        var document = LinkExport.Build(Configuration(), Directory);
+
+        Assert.Null(Link(document, "sub-bob").Issuer);
+    }
+
+    [Fact]
+    public void ASamlLink_CarriesNoIssuer()
+    {
+        // SAML links have no issuer binding at all; the field is not merely unset for them, there is no
+        // source it could come from.
+        var document = LinkExport.Build(Configuration(), Directory);
+
+        Assert.Null(Link(document, "nameid-alice").Issuer);
+    }
+
+    [Fact]
+    public void ALinkWhoseAccountIsGone_IsDroppedRatherThanExportedDangling()
+    {
+        var configuration = Configuration();
+        configuration.OidConfigs["idp"].CanonicalLinks["sub-ghost"] = Ghost;
+        configuration.SamlConfigs["adfs"].CanonicalLinks["nameid-ghost"] = Ghost;
+
+        var document = LinkExport.Build(configuration, Directory);
+
+        Assert.DoesNotContain(document.Links, link => link.CanonicalName!.EndsWith("ghost", StringComparison.Ordinal));
+        Assert.Equal(3, document.Links.Count);
+    }
+
+    [Fact]
+    public void AProviderStoredWithNoConfigObject_IsSkippedRatherThanDereferenced()
+    {
+        // A null-bodied add (#350) can leave a provider whose config object is null. The read side treats it
+        // the way the link listings do: skipped, never a 500.
+        var configuration = Configuration();
+        configuration.OidConfigs["broken"] = null!;
+        configuration.SamlConfigs["broken"] = null!;
+
+        var document = LinkExport.Build(configuration, Directory);
+
+        Assert.Equal(3, document.Links.Count);
+    }
+
+    [Fact]
+    public void TheSerializedDocument_CarriesNoSecretNoEnvelopeAndNoUserId()
+    {
+        // The user id is the value the whole document exists to replace, and a provider secret is the value
+        // whose escape would matter most. Neither can reach the output, because nothing copies the provider
+        // configuration into it; the assertion is on the bytes rather than on that argument.
+        var configuration = Configuration();
+        configuration.OidConfigs["idp"].OidSecret = "ssoenc:v1:not-a-real-envelope";
+        configuration.SamlConfigs["adfs"].SamlSigningKeyPfx = "ssoenc:v1:also-not-a-real-envelope";
+
+        var json = JsonSerializer.Serialize(LinkExport.Build(configuration, Directory));
+
+        Assert.DoesNotContain("ssoenc:", json, StringComparison.Ordinal);
+        Assert.DoesNotContain(Alice.ToString(), json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(Bob.ToString(), json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("alice", json, StringComparison.Ordinal);
+    }
+
+    // --- helpers ---
+
+    private static PluginConfiguration Configuration()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["idp"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.test",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = Alice, ["sub-bob"] = Bob },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-alice"] = "https://idp.example.test" },
+        };
+        configuration.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-alice"] = Alice },
+        };
+        return configuration;
+    }
+
+    private static string? Directory(Guid userId) => userId == Alice ? "alice" : userId == Bob ? "bob" : null;
+
+    private static string Describe(LinkExportEntry entry) =>
+        string.Join('/', entry.Protocol, entry.Provider, entry.CanonicalName, entry.Username);
+
+    private static LinkExportEntry Link(LinkExportDocument document, string canonicalName) =>
+        document.Links.Single(entry => string.Equals(entry.CanonicalName, canonicalName, StringComparison.Ordinal));
+}

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -40,7 +40,7 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     {
         "OidAdd", "OidDel", "OidProviders", "OidTest", "OidStates",
         "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
-        "ExportConfig", "ImportConfig", "Unregister",
+        "ExportConfig", "ImportConfig", "Unregister", "ExportLinks",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",
         // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for

--- a/SSO-Auth.Tests/Http/SSOControllerExportLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerExportLinksTests.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the link-export endpoint (#1126). The builder's own rules are covered in
+/// <see cref="LinkExportTests"/>; what these pin is the wiring the builder cannot prove about itself - that
+/// the username really comes from Jellyfin's user manager rather than from anything stored beside the link.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerExportLinksTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Ghost = Guid.Parse("9057c000-0000-0000-0000-000000000003");
+
+    [Fact]
+    public void TheExport_ResolvesUsernamesThroughTheUserManager()
+    {
+        var harness = Harness();
+        harness.UserManager.GetUserById(Alice).Returns(TestUsers.Named("alice", Alice));
+
+        var document = Assert.IsType<LinkExportDocument>(Assert.IsType<OkObjectResult>(harness.Controller.ExportLinks()).Value);
+
+        var link = Assert.Single(document.Links);
+        Assert.Equal("alice", link.Username);
+        Assert.Equal("sub-alice", link.CanonicalName);
+        Assert.Equal("idp", link.Provider);
+        Assert.Equal(LinkExport.FormatVersion, document.FormatVersion);
+    }
+
+    [Fact]
+    public void ALinkTheUserManagerNoLongerKnows_IsAbsentFromTheExport()
+    {
+        // The harness's user manager answers null for an id it was never told about, which is exactly the
+        // state a rebuilt user database leaves behind. Without the drop, the document would carry a row
+        // naming an account that does not exist.
+        var harness = Harness(withGhost: true);
+        harness.UserManager.GetUserById(Alice).Returns(TestUsers.Named("alice", Alice));
+
+        var document = Assert.IsType<LinkExportDocument>(Assert.IsType<OkObjectResult>(harness.Controller.ExportLinks()).Value);
+
+        Assert.Equal(new[] { "sub-alice" }, document.Links.Select(link => link.CanonicalName));
+    }
+
+    private static SsoControllerHarness Harness(bool withGhost = false)
+    {
+        return new SsoControllerHarness(configuration =>
+        {
+            var links = new SerializableDictionary<string, Guid> { ["sub-alice"] = Alice };
+            if (withGhost)
+            {
+                links["sub-ghost"] = Ghost;
+            }
+
+            configuration.OidConfigs["idp"] = new OidConfig { Enabled = true, CanonicalLinks = links };
+        });
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1319,6 +1319,31 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Exports the account-link table as a portable, username-keyed document (#1126). Requires
+    /// administrator privileges. Read-only - it changes nothing.
+    /// </summary>
+    /// <remarks>
+    /// A separate download from <c>Config/Export</c> on purpose. That document is defined as carrying no
+    /// link map, and this one carries identity data - usernames paired with identity-provider subject
+    /// identifiers - so an administrator asks for it explicitly instead of receiving it as a side effect of
+    /// exporting provider settings. Keying on the username rather than the Jellyfin user id is what makes
+    /// the snapshot survive the user-database rebuild that invalidates every id the links are stored
+    /// against; a link whose id no longer resolves to an account is dropped rather than exported dangling.
+    /// </remarks>
+    /// <returns>The link export document.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Config/Links/Export")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult ExportLinks()
+    {
+        // Snapshot under the config lock so the two protocols' link maps are read atomically against each
+        // other; the resolution to usernames happens there too, so the document that leaves the lock holds
+        // no user id for the formatter to serialize.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(
+            live => LinkExport.Build(live, userId => _userManager.GetUserById(userId)?.Username)));
+    }
+
+    /// <summary>
     /// Imports a configuration export document into this instance (#161). Requires administrator privileges.
     /// The import is a fail-closed MERGE: the document is validated through the same ProviderConfigValidator
     /// the config-page save uses, and only if the whole document is valid is it merged - atomically, through

--- a/SSO-Auth/Config/LinkExport.cs
+++ b/SSO-Auth/Config/LinkExport.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Builds the portable account-link snapshot (#1126). It reads the two link maps and resolves each
+/// Jellyfin user id to a username, which is the whole of the transformation: the id is what a rebuilt user
+/// database destroys, and the username is what survives it.
+/// </summary>
+/// <remarks>
+/// Nothing here redacts anything, because nothing it reads is a secret. The document is assembled from the
+/// canonical-link maps and the OpenID issuer bindings only; no provider configuration field is copied, so a
+/// client secret or a signing key cannot reach the output by construction rather than by a converter that
+/// has to be remembered. The one value that could leak by accident is the Jellyfin user id, and it is
+/// consumed rather than emitted.
+/// </remarks>
+internal static class LinkExport
+{
+    /// <summary>
+    /// The current document format version. Its own sequence, unrelated to the configuration export's.
+    /// </summary>
+    internal const int FormatVersion = 1;
+
+    private const string OpenIdProtocol = "OpenID";
+    private const string SamlProtocol = "SAML";
+
+    /// <summary>
+    /// Builds the link document from the live configuration. Call it under the config lock (through
+    /// <c>ReadConfiguration</c>) so the two link maps are read atomically against each other; the returned
+    /// document holds only strings, so the JSON formatter serializing it after the lock is released cannot
+    /// tear against a concurrent login writing a link.
+    /// </summary>
+    /// <param name="live">The live plugin configuration to snapshot.</param>
+    /// <param name="resolveUsername">Resolves a Jellyfin user id to its username, or null when no such account exists.</param>
+    /// <returns>The link export document.</returns>
+    internal static LinkExportDocument Build(PluginConfiguration live, Func<Guid, string?> resolveUsername)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        ArgumentNullException.ThrowIfNull(resolveUsername);
+
+        var document = new LinkExportDocument { FormatVersion = FormatVersion };
+
+        foreach (var (provider, config) in Providers(live.OidConfigs))
+        {
+            foreach (var link in config.CanonicalLinks)
+            {
+                // A link pointing at an account that no longer exists is dangling: exporting it would put a
+                // row in the document that nothing could ever be restored to, and a restore that silently
+                // dropped it would differ from the document it claimed to apply. Drop it here, once.
+                if (resolveUsername(link.Value) is not { } username)
+                {
+                    continue;
+                }
+
+                document.Links.Add(new LinkExportEntry
+                {
+                    Protocol = OpenIdProtocol,
+                    Provider = provider,
+                    CanonicalName = link.Key,
+                    Username = username,
+                    // The issuer binding is keyed by the same canonical name as the link (#186). A link
+                    // written before the binding existed has no entry, and null is the honest answer for it
+                    // rather than the provider's currently configured issuer, which was never what bound it.
+                    Issuer = config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null,
+                });
+            }
+        }
+
+        foreach (var (provider, config) in Providers(live.SamlConfigs))
+        {
+            foreach (var link in config.CanonicalLinks)
+            {
+                if (resolveUsername(link.Value) is not { } username)
+                {
+                    continue;
+                }
+
+                document.Links.Add(new LinkExportEntry
+                {
+                    Protocol = SamlProtocol,
+                    Provider = provider,
+                    CanonicalName = link.Key,
+                    Username = username,
+                });
+            }
+        }
+
+        return document;
+    }
+
+    // A provider stored with a null config object is reachable through a null-bodied add (#350), and the
+    // read side treats that the same fail-closed way the link listings do: skipped, never dereferenced.
+    private static IEnumerable<(string Provider, TConfig Config)> Providers<TConfig>(
+        SerializableDictionary<string, TConfig> configs)
+        where TConfig : ProviderConfigBase
+    {
+        if (configs is null)
+        {
+            yield break;
+        }
+
+        foreach (var entry in configs)
+        {
+            if (entry.Value is not null)
+            {
+                yield return (entry.Key, entry.Value);
+            }
+        }
+    }
+}

--- a/SSO-Auth/Config/LinkExportDocument.cs
+++ b/SSO-Auth/Config/LinkExportDocument.cs
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.ObjectModel;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The portable snapshot of the account-link table (#1126), keyed by USERNAME rather than by Jellyfin user
+/// id. The links themselves are stored against a <c>Guid</c>, and a rebuilt user database issues new ones,
+/// so a snapshot carrying the id would restore into a server where every id it names is gone. The username
+/// is the only identifier that survives that rebuild, which is why it is the key here and why this document
+/// exists separately from <see cref="ConfigExportDocument"/> rather than as a version bump on it.
+/// </summary>
+/// <remarks>
+/// This is a deliberately distinct artifact, not a widening of the configuration export. The configuration
+/// export drops <c>CanonicalLinks</c> under <c>[JsonIgnore]</c> and is documented as carrying no link map;
+/// this document carries identity data - usernames paired with identity-provider subject identifiers - so
+/// an administrator must ask for it, rather than receiving it as a side effect of exporting provider
+/// settings. It is a JSON-only transport shape and is never persisted to the config XML, so it carries no
+/// XML-serialization attributes.
+/// </remarks>
+public class LinkExportDocument
+{
+    /// <summary>
+    /// Gets or sets the document format version. It is its own sequence, independent of
+    /// <see cref="ConfigExport.FormatVersion"/>, because the two documents change shape for unrelated
+    /// reasons; an importer refuses a version it does not recognise rather than half-applying it.
+    /// </summary>
+    public int FormatVersion { get; set; }
+
+    /// <summary>
+    /// Gets the exported links, one entry per canonical link across every provider of both protocols. A
+    /// link whose Jellyfin user id no longer resolves to an account is absent rather than exported with a
+    /// blank username, so the document never carries an entry nothing could be restored to.
+    /// </summary>
+    public Collection<LinkExportEntry> Links { get; } = new();
+}
+
+/// <summary>
+/// One canonical link, as it survives a user-database rebuild: which provider issued the identity, the
+/// canonical name that identity is known by, and the username of the Jellyfin account it resolves to.
+/// </summary>
+public class LinkExportEntry
+{
+    /// <summary>
+    /// Gets or sets the protocol the provider speaks. The two protocols keep separate provider namespaces
+    /// and separate link maps, so an entry that named only the provider would be ambiguous on a server
+    /// where an OpenID and a SAML provider share a name.
+    /// </summary>
+    public string? Protocol { get; set; }
+
+    /// <summary>Gets or sets the provider this link belongs to.</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the canonical name the link is keyed by: the identity provider's stable subject for
+    /// this user, or the username it fell back to for a link made before subjects were required.
+    /// </summary>
+    public string? CanonicalName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Jellyfin username the link resolves to. This is the field that makes the document
+    /// portable, and it is resolved at export time rather than stored.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets the issuer this link is bound to (#186), for OpenID links that carry one. It is null
+    /// for SAML links, which have no issuer binding, and for OpenID links written before the binding
+    /// existed. Carrying it means the binding survives the round trip instead of being silently relaxed on
+    /// restore.
+    /// </summary>
+    public string? Issuer { get; set; }
+}


### PR DESCRIPTION
# What & why

Closes #1126.

Adds `GET sso/Config/Links/Export`, an elevation-gated read that emits the account-link table as a portable document keyed by username.

The provider half of the server-migration path shipped in #161 and deliberately drops `CanonicalLinks` under `[JsonIgnore]`, so nothing today carries the link table off a server. The links are stored against a Jellyfin user id, and a rebuilt user database issues new ids, so a snapshot keyed on the id would restore into a server where every id it names is gone. The username is the only identifier that survives that rebuild, which is why it is the key.

One entry per canonical link across every provider of both protocols: protocol, provider, canonical name, and the username resolved through `IUserManager` at export time. An OpenID link carries the issuer it is bound to (#186), so the binding survives the round trip instead of being silently relaxed on restore. A link with no binding exports no issuer rather than the provider's currently configured one, which was never what bound it.

It is a separate document from `ConfigExportDocument`, not a `FormatVersion` bump on it, for the reason the issue gives: the configuration export is defined and documented as carrying no link map, and this one carries identity data, so an administrator asks for it explicitly instead of receiving it as a side effect of exporting provider settings.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The change is read-only and adds no login, crypto or persistence path. It touches `SSOController.cs` and adds two files under `SSO-Auth/Config/`, so the list is answered rather than skipped.

- [x] Fail-closed preserved: the action validates nothing and accepts nothing. The two fail-closed decisions it does make both drop rather than emit: a link whose id no longer resolves to an account, and a provider stored with a null config object (reachable through the null-bodied add of #350, and skipped the way the link listings already skip it).
- [x] No secrets logged; secrets are redacted on config export. The action logs nothing. No provider configuration field is copied into the document at all, so a client secret or a signing key cannot reach it by construction rather than by a converter that has to be remembered. `TheSerializedDocument_CarriesNoSecretNoEnvelopeAndNoUserId` serializes a document built from a configuration holding an `ssoenc:` value in both a client secret and a SAML signing key and asserts neither the envelope prefix nor either user id appears.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **No adversarial review was run for this change and no second person read it.** That admission stands as written. What is offered in its place is under Verification.
- [ ] Review record. There is none, for the reason on the line above. No lens ran, so there are no verdicts and no CONFIRMED or PLAUSIBLE counts to report, and none are claimed.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP-supplied value reaches this action and it writes no log line. The canonical names in the document are IdP-authored and are serialized as JSON string values, never interpolated into a log or a path.

### What the document exposes, stated rather than left implied

The output pairs Jellyfin usernames with identity-provider subject identifiers. That is identity data and it is why this is a distinct, explicitly requested download behind the elevation policy rather than a widening of an existing one. It carries no credential, no session, no envelope and no user id.

## Quality checklist

- [x] No duplicated logic. The builder mirrors `ConfigExport`'s shape and reuses the same `SerializableDictionary` traversal; the only new decision is the drop of a dangling link, in one place, applied to both protocols.
- [x] The change adds no more code than the problem requires. Two new files in `SSO-Auth/Config/`, 25 lines in the controller, and no change to any existing behaviour.
- [x] Self-documenting, comments explain why. The remark on the document says why it is separate from the configuration export rather than restating that it is.
- [x] Architecture-conformance tests pass, and the new structural property is locked in. `EverySensitiveRoute_IsClassified_AsThrottledOrExplicitlyExempt` refused this branch until the new route was classified; it is on `RateLimitExemptRoutes` as an elevated read-only snapshot with no outbound fetch. `ExportLinks` is on the elevation surface anchor in `SSOControllerAuthorizationTests`, so `CoversExactlyTheKnownElevationSurface` fails if the guard is ever removed from it.
- [x] Docs impact considered. The account-management API surface is #1141's scope for the wiki and that issue is open, so no separate documentation issue is filed. The server-migration runbook that would describe what a backup carries is #1135, also open, and this document's contents are what it will describe.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Built on both target frameworks, 0 warnings and 0 errors on each.
- [x] `dotnet test` is green. Full suite through the built runners: `net9.0` 2805 total, 0 failed, 4 skipped; `net10.0` 2806 total, 0 failed, 4 skipped.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. The diff contains none.

### Every guard was deleted and the suite watched

Four mutations, run in two builds, each reddening exactly the tests that name the property and no others.

| mutation | red |
| --- | --- |
| emit a dangling link instead of dropping it | `ALinkWhoseAccountIsGone_IsDroppedRatherThanExportedDangling`, `ALinkTheUserManagerNoLongerKnows_IsAbsentFromTheExport` |
| dereference a provider stored with a null config object | `AProviderStoredWithNoConfigObject_IsSkippedRatherThanDereferenced` |
| fall back to the provider's configured issuer when a link has no binding | `AnOpenIdLinkWithNoBinding_ExportsNoIssuer` |
| put the Jellyfin user id back on the exported entry | `TheSerializedDocument_CarriesNoSecretNoEnvelopeAndNoUserId` |

No mutation left the suite green. The first mutation was applied to the OpenID arm only, which is why it reddens the count assertion and the controller test rather than every case.

The builder's own rules are covered in `SSO-Auth.Tests/Config/LinkExportTests.cs`. `SSO-Auth.Tests/Http/SSOControllerExportLinksTests.cs` covers the one thing the builder cannot prove about itself, that the username really comes from Jellyfin's user manager: the harness's user manager answers null for an id it was never told about, which is the state a rebuilt user database leaves behind, and the export drops that link.

## Notes

This is the read side only. Importing a backup and rebinding each link to the target server's current user ids is #1129 and is untouched here, which is also why `LinkExportDocument` has no deserialization contract beyond being a plain shape: the importer will define what it accepts.

The document's `FormatVersion` is its own sequence rather than sharing the configuration export's, because the two documents change shape for unrelated reasons and a shared number would make one of them bump for the other's benefit.

A username collision cannot produce two entries for one account, since Jellyfin usernames are unique, but a restore into a server where a username is already taken by a different person is a question for #1129 rather than for the export.
