### PR TITLE
Pin the request body to one reader, and refuse a second [#1033]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -4528,21 +4528,135 @@ internal sealed class Whatever : JsonConverter<string?>
         Assert.Equal(expected, HoldsAParseCall(line));
     }
 
+    // The spellings that hand a second reader the bytes the host's binder already consumed.
+    // "Request.Body" also matches "Request.BodyReader" - both return the same stream - and
+    // EnableBuffering is the call that makes a second read possible at all. The form half of the boundary
+    // is here too: SamlLoginService avoids Request.Form by hand today, for a different failure (#206), and
+    // this list is what stops that choice from resting on the comment that records it.
+    private static readonly string[] SecondBodyReadSpellings =
+    {
+        "Request.Body", "EnableBuffering", "Request.Form", "ReadFormAsync",
+    };
+
+    /// <summary>
+    /// The duplicate-key posture of the ASP.NET request-body boundary (#1033), and the artefact that holds
+    /// it: a request body is read ONCE, by the host's binder, and nothing in the plugin reads those bytes
+    /// again.
+    /// <para>
+    /// The plugin does not own the input formatter behind <c>[FromBody]</c>, so it does not get to decide
+    /// how a body naming one property twice is bound - every parser in the dependency set keeps the LAST
+    /// occurrence. What makes that safe is not the formatter. A repeated name becomes a vulnerability when
+    /// a validator reads one occurrence and a consumer reads another, and that split needs two readers of
+    /// one body. With one reader there is no second occurrence for anything to reach, whichever one the
+    /// formatter kept, so the posture holds without the plugin knowing which that is.
+    /// </para>
+    /// <para>
+    /// Rejecting a repeat at this boundary instead would ADD the second reader the defect needs, and it
+    /// could not be proved here: no test in this project loads the <c>System.Text.Json</c> the plugin binds
+    /// in production - the test process loads a 10.x on both target legs while the plugin binds the host's
+    /// copy - so an assertion about the formatter's behaviour would be measuring an assembly that never
+    /// runs. The property below needs no such assertion. It is a fact about this tree's source, and a
+    /// source scan decides it.
+    /// </para>
+    /// <para>
+    /// Stated at the boundary rather than per route, deliberately. The controller binds a body at ten
+    /// actions and <c>AuthResponse</c> at three of them; a posture written per route has to be restated
+    /// ten times and drifts, and deciding for three leaves the same crack open next door.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void RequestBodies_AreReadOnceByTheHostBinder()
+    {
+        var strays = PluginSourceFiles()
+            .Select(path => (Path: Path.GetRelativePath(RepoTree.Root, path).Replace(Path.DirectorySeparatorChar, '/'), Source: File.ReadAllText(path)))
+            .SelectMany(file => SecondBodyReadSpellings
+                .Where(spelling => SourceCallsInCode(file.Source, spelling))
+                .Select(spelling => $"{file.Path}: {spelling}"))
+            .OrderBy(stray => stray, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            strays.Count == 0,
+            "A request body is bound once by the host and never read again (#1033); reading it a second time is what lets a validator and a consumer disagree about a repeated property name. Found: " + string.Join(" | ", strays));
+    }
+
+    [Fact]
+    public void TheRequestBodyScan_RefusesAVacuousPass()
+    {
+        // Two ways this rule could report success while covering nothing. The scan could walk a tree with
+        // no .cs files in it; and the boundary it is about could stop existing, because an endpoint set
+        // that binds no body has no posture to hold and the silence would read as compliance. Both are
+        // pinned, and the second is counted on CODE lines so a [FromBody] left in prose cannot keep it
+        // alive.
+        Assert.NotEmpty(PluginSourceFiles());
+
+        var boundBodies = ControllerSourceFiles()
+            .SelectMany(CodeLines)
+            .Count(line => line.Text.Contains("[FromBody]", StringComparison.Ordinal));
+
+        Assert.True(
+            boundBodies > 0,
+            "No controller action binds [FromBody] any more, so the request-body posture this rule holds (#1033) covers nothing; re-decide the boundary rather than leaving the rule standing.");
+    }
+
+    [Fact]
+    public void ASecondReadOfARequestBody_IsRejectedByTheScan()
+    {
+        // The must-catch half, over the predicate rather than over the tree, spelled the way somebody
+        // adding a duplicate-key check at this boundary would spell it: rewind the body and read it again
+        // beside the object the host already bound. That IS the validator/consumer split, written as
+        // diligence.
+        const string Source = @"
+internal static class Whatever
+{
+    internal static void Screen(HttpRequest request)
+    {
+        request.EnableBuffering();
+        request.Body.Position = 0;
+    }
+}";
+
+        Assert.True(HoldsASecondBodyRead(Source));
+    }
+
+    [Fact]
+    public void TheRequestItself_IsNotFlaggedByTheScan()
+    {
+        // The must-not-catch twin, and the near-miss is one member wide: handing HttpContext.Request to the
+        // authorization reader is what every elevated endpoint here does and touches no body, while adding
+        // ".Body" to that same expression is the thing refused. The comment naming the banned spelling is
+        // in the fixture on purpose - three such lines stand in the tree today, all of them prose
+        // explaining why the form is bound rather than read (#206).
+        const string Source = @"
+internal static class Whatever
+{
+    // Bound via [FromForm] rather than reading Request.Form directly (#206).
+    internal static async Task<AuthorizationInfo> Read(HttpContext context)
+        => await _authContext.GetAuthorizationInfo(context.Request);
+}";
+
+        Assert.False(HoldsASecondBodyRead(Source));
+    }
+
+    // Whether a source text reaches a request body outside the host's binder, on a code line.
+    private static bool HoldsASecondBodyRead(string source) =>
+        SecondBodyReadSpellings.Any(spelling => SourceCallsInCode(source, spelling));
+
+    // Every hand-written .cs file the shipped plugin is built from. Shared by the parse-site scan and the
+    // request-body scan, so the two cannot drift apart on which tree they walk.
+    private static IEnumerable<string> PluginSourceFiles() =>
+        Directory.EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path));
+
     // Every repo-relative path under SSO-Auth/ whose code calls a parser, forward slashes so the table
     // entries read the same on either platform. Exact paths rather than file names: two files can share a
     // name, and an allowlist keyed on the short one would admit the wrong one.
-    private static IReadOnlyList<string> ParseSites()
-    {
-        var root = RepoTree.Root;
-        var pluginRoot = Path.Combine(root, "SSO-Auth");
-
-        return Directory.EnumerateFiles(pluginRoot, "*.cs", SearchOption.AllDirectories)
-            .Where(path => !IsBuildOutput(path))
+    private static IReadOnlyList<string> ParseSites() =>
+        PluginSourceFiles()
             .Where(path => HoldsAParseCall(File.ReadAllText(path)))
-            .Select(path => Path.GetRelativePath(root, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .Select(path => Path.GetRelativePath(RepoTree.Root, path).Replace(Path.DirectorySeparatorChar, '/'))
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToList();
-    }
 
     // Whether a source text calls a parser on a code line.
     private static bool HoldsAParseCall(string source) =>


### PR DESCRIPTION
# What & why

Closes #1033.

The issue asked for the duplicate-key posture of the ASP.NET request-body
boundary to be decided and then made enforceable. The posture is: **a request
body is read once, by the host's binder, and nothing in the plugin reaches
those bytes again.**

The plugin does not own the input formatter behind `[FromBody]`, so it does not
get to decide how a body naming one property twice is bound - every parser in
the dependency set keeps the last occurrence. What makes that safe is not the
formatter. A repeated property name becomes a vulnerability when a validator
reads one occurrence and a consumer reads another, and that split needs two
readers of one body. With one reader there is no second occurrence for anything
to reach, whichever one the formatter kept, so the posture holds without the
plugin knowing which that is.

Rejecting a repeat at the boundary instead would add the second reader the
defect needs, and it could not be proved here. The issue records the
measurement: no test in this project loads the `System.Text.Json` the plugin
binds in production - the test process loads a 10.x on both target legs while
the plugin binds the host's copy - so an assertion about the formatter's
behaviour would be measuring an assembly that never runs. The property chosen
needs no such assertion. It is a fact about this tree's source, and a source
scan decides it.

Stated once at the boundary rather than at each route, for the reason the issue
gives: the controller binds a body at ten actions and `AuthResponse` at three of
them, so a posture written per route has to be restated ten times and drifts,
and deciding for three leaves the same crack open next door.

The form half of the boundary already works this way, by hand, for a different
failure. `SSO-Auth/Api/Flows/SamlLoginService.cs:210` explains that `SAMLResponse`
is bound via `[FromForm]` rather than read off `Request.Form` so a non-form
content-type cannot throw a 500 (#206). That was a comment and nothing else; the
rule is what stops the choice resting on it.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The shipped diff touches one file, `SSO-Auth.Tests/ArchitectureConformanceTests.cs`,
and no production code:

```
$ git diff --stat origin/main...HEAD
 SSO-Auth.Tests/ArchitectureConformanceTests.cs | 132 +++++++++++++++++++++++--
 1 file changed, 123 insertions(+), 9 deletions(-)
```

No login-path, crypto, config-persistence or release-pipeline file changes, so
there is no behaviour for the four boxes below to be about. They are left
unticked rather than ticked as vacuously true.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review lens was run on this change, and no second reader has
read it.** The evidence below stands in place of one.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki text describes this boundary,
      and the posture's in-repo home is the rule's own XML documentation, the
      same home the SAML attack-family mapping uses. No documentation issue is
      owed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - none
      are touched.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2809, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2810, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

### The guard was watched refusing, for the reason it names

A second read inserted into `ImportConfig`, then reverted:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*RequestBodies_AreReadOnceByTheHostBinder*"
  ArchitectureConformanceTests.RequestBodies_AreReadOnceByTheHostBinder [FAIL]
    A request body is bound once by the host and never read again (#1033);
    reading it a second time is what lets a validator and a consumer disagree
    about a repeated property name. Found:
    SSO-Auth/Api/Http/SSOController.cs: EnableBuffering |
    SSO-Auth/Api/Http/SSOController.cs: Request.Body
  Total: 1, Failed: 1
```

And the vacuous-pass sentinel, with the boundary marker pointed at a spelling
the tree does not carry, then reverted:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*TheRequestBodyScan_RefusesAVacuousPass*"
  ArchitectureConformanceTests.TheRequestBodyScan_RefusesAVacuousPass [FAIL]
    No controller action binds [FromBody] any more, so the request-body posture
    this rule holds (#1033) covers nothing
  Total: 1, Failed: 1
```

The must-catch and must-not-catch pair runs over the predicate rather than the
tree, and the near-miss between them is one member wide: `context.Request`
handed to the authorization reader passes, `request.Body` refuses. The
must-not-catch fixture also carries a comment line quoting the banned spelling,
because three such lines stand in the tree today and all of them are prose.

## Notes

The rule scans code lines only, through the same reader every other call-site
rule in this file uses, so removing a read and describing the removal in a
comment that still names it does not keep the scan green (#1122).

Out of scope, and unchanged by this: what the host's formatter does with a
repeated name. That remains unobservable from this test process, which is why
the posture is built on a property that does not depend on it.
