### PR TITLE
Measure what refusing an unreadable role claim would cost [#1053]

### DIFF
--- a/SSO-Auth.Tests/Oidc/UnreadableRoleClaimPostureTests.cs
+++ b/SSO-Auth.Tests/Oidc/UnreadableRoleClaimPostureTests.cs
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// What the repeated-member walk and the role path's own reader each make of the same claim value (#1053).
+/// The role claim decides privileges, so what an <c>Unreadable</c> verdict should MEAN there cannot be
+/// settled without knowing what refusing on it would cost, and that cost is exactly the set of grammars the
+/// walk cannot read and the reader can. This table is that measurement, taken rather than remembered: the
+/// issue carried an assertion of six such grammars from an earlier round and named none of them.
+/// <para>
+/// Each row feeds one claim value to <see cref="StrictJson.Inspect"/> and to
+/// <see cref="OidcRoleExtractor.ExtractRoles"/> along the same two-segment path, and pins both answers. The
+/// rows are the input classes the walk's own contract calls <c>Unreadable</c> - no body, malformed, past the
+/// depth cap, an unpaired surrogate in a member name spelled raw and spelled as an escape, and a document
+/// carrying no object - plus the controls that make the table readable: a clean document, the boundary below
+/// the depth cap, a leading BOM, and the repeat itself.
+/// </para>
+/// <para>
+/// A null claim value is deliberately absent. <c>Claim.Value</c> is never null, so the row would pin the
+/// behaviour of an input the caller cannot produce; fed one, the reader raises out of Newtonsoft rather than
+/// refusing, which is worth knowing and is not worth a permanent row.
+/// </para>
+/// </summary>
+public class UnreadableRoleClaimPostureTests
+{
+    // The role-claim path every row is read along: segment 0 names the claim, segment 1 is the terminal key
+    // whose array holds the roles. Two segments is the shape that parses the claim value at all - a
+    // one-segment path takes the value verbatim and never reaches a parser, so it could not show a divergence.
+    private static readonly string[] Path = { "realm_access", "roles" };
+
+    // A body that resolves, embedded in every row, so a row that refuses is refusing because of the grammar
+    // wrapped around it and not because there was nothing to find.
+    private const string ResolvingBody = "\"roles\":[\"admin\"]";
+
+    // The BOM as an escape rather than as a character in this file: a document prefixed with one is the
+    // subject of a row, and writing it raw would put the byte into the source instead of into the fixture.
+    private const string Bom = "\uFEFF";
+
+    private static string NestedTo(int depth) =>
+        string.Concat(Enumerable.Repeat("{\"a\":", depth)) + "1" + new string('}', depth);
+
+    // The one source the theory and its coverage sentinel both read, so a row cannot be dropped from the run
+    // while the count that guards the table stays green.
+    private static readonly (string Grammar, string ClaimValue, StrictJson.Verdict Verdict, OidcRoleExtractor.Outcome Outcome)[] Measured =
+    {
+        // The controls. Without them a walk that refused everything would satisfy every refusal row.
+        ("clean", "{" + ResolvingBody + "}", StrictJson.Verdict.Clean, OidcRoleExtractor.Outcome.Resolved),
+        ("a nested sibling object", "{" + ResolvingBody + ",\"deep\":{\"a\":1}}", StrictJson.Verdict.Clean, OidcRoleExtractor.Outcome.Resolved),
+
+        // The attack the walk exists for, on this path. What the repeat resolves TO is pinned in its own
+        // test below, because the outcome column alone would not show it.
+        ("the role member named twice", "{" + ResolvingBody + ",\"roles\":[\"user\"]}", StrictJson.Verdict.Repeated, OidcRoleExtractor.Outcome.Resolved),
+
+        // Every grammar the walk calls Unreadable and the reader ALSO refuses. Refusing on Unreadable costs
+        // these rows nothing: they already carry no roles.
+        ("empty", "", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("whitespace", "   ", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("truncated", "{" + ResolvingBody, StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("not json at all", "not-json", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("a bare scalar", "17", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("an array of scalars", "[1,2,3]", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+
+        // THE DIVERGENCE, and the point of the table: two grammars the walk cannot read and the reader reads
+        // perfectly well, roles and all. These rows are the entire availability price of treating Unreadable
+        // as a refusal on this path.
+        ("an escaped unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\\ud800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Resolved),
+        ("a raw unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\uD800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Resolved),
+
+        // The divergence in the OTHER direction. The walk strips one leading BOM and reports an affirmative
+        // Clean, while the reader on this path refuses the same bytes. It is not exploitable - the reader's
+        // refusal is what decides the roles and it grants none - but it is the walk saying something
+        // affirmative about a document its consumer cannot read, which is the shape the walk exists to
+        // prevent, and it is recorded here rather than left to be rediscovered.
+        ("a leading BOM", Bom + "{" + ResolvingBody + "}", StrictJson.Verdict.Clean, OidcRoleExtractor.Outcome.ValueNotJson),
+    };
+
+    public static TheoryData<string> Grammars()
+    {
+        var data = new TheoryData<string>();
+        foreach (var row in Measured)
+        {
+            data.Add(row.Grammar);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(Grammars))]
+    public void TheWalkAndTheRolePathReader_AgreeExceptWhereThisTableSaysTheyDoNot(string grammar)
+    {
+        var (_, claimValue, expectedVerdict, expectedOutcome) = Measured.Single(row => row.Grammar == grammar);
+
+        var verdict = StrictJson.Inspect(claimValue, out _);
+        Assert.True(expectedVerdict == verdict, $"{grammar}: the walk answered {verdict}, the table says {expectedVerdict}");
+
+        var outcome = OidcRoleExtractor.ExtractRoles(Path, claimValue, false).Outcome;
+        Assert.True(expectedOutcome == outcome, $"{grammar}: the role path answered {outcome}, the table says {expectedOutcome}");
+    }
+
+    [Fact]
+    public void NestingPastTheDepthCap_IsUnreadableToBothOfThem()
+    {
+        // Kept out of the table because the fixture is generated rather than written, and a 65-deep literal
+        // in a row would be unreadable in the sense this file is not about. Both sides refuse it, so it joins
+        // the rows where a refusal on Unreadable costs nothing.
+        var deep = "{" + ResolvingBody + ",\"deep\":" + NestedTo(65) + "}";
+
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(deep, out _));
+        Assert.Equal(OidcRoleExtractor.Outcome.ValueNotJson, OidcRoleExtractor.ExtractRoles(Path, deep, false).Outcome);
+    }
+
+    [Fact]
+    public void ARepeatedRoleMember_GrantsTheLastOccurrence()
+    {
+        // The table pins that a repeat RESOLVES; this pins what it resolves TO, which is why the repeat
+        // matters at all. The first occurrence's roles are gone, so a provider - or anyone who can answer as
+        // one - appends a second member and REPLACES the role set rather than adding to it.
+        var result = OidcRoleExtractor.ExtractRoles(Path, "{\"roles\":[\"admin\"],\"roles\":[\"user\"]}", false);
+
+        Assert.Equal(new List<string> { "user" }, result.Roles);
+        Assert.DoesNotContain("admin", result.Roles);
+    }
+
+    [Fact]
+    public void TheDivergenceSetIsTwoGrammars_NotSix()
+    {
+        // The number this table exists to produce, derived from the rows rather than restated in prose: the
+        // grammars where the walk establishes nothing and the reader still hands back roles. An earlier round
+        // put it at six and used that as the argument for handling Unreadable as "proceed", which is the
+        // fail-open direction on a privilege path. If a future edit to the walk widens or narrows the set,
+        // this is the row that says so instead of the argument silently going stale.
+        var divergent = Measured
+            .Where(row => row.Verdict == StrictJson.Verdict.Unreadable && row.Outcome == OidcRoleExtractor.Outcome.Resolved)
+            .Select(row => row.Grammar)
+            .ToList();
+
+        Assert.Equal(2, divergent.Count);
+        Assert.All(divergent, grammar => Assert.Contains("surrogate", grammar));
+    }
+}


### PR DESCRIPTION
# What & why

Refs #1053. It does not close it: the decision that issue holds is recorded on the
issue itself, and this is the measurement the decision rests on.

#1053 asks, before any code, for the grammars the repeated-member walk cannot read
to be enumerated from the source rather than from memory. An earlier round put the
number at six, named none of them, and used the count as the argument for treating
an `Unreadable` verdict as "proceed" on the path that decides privileges. That is
the fail-open direction, and the count was never checked.

This lands the table. Each row feeds one claim value to `StrictJson.Inspect` and to
`OidcRoleExtractor.ExtractRoles` along the same two-segment path and pins both
answers, so the divergence between the walk and the reader is a measurement that
goes red when either side moves.

What it says:

- The divergence set is **two** grammars, not six, and both are an unpaired
  surrogate in a member name - once spelled raw, once as an escape. The walk
  refuses them, the reader reads them and hands back the roles.
- Every other grammar the walk calls `Unreadable` is one the reader already
  refuses: empty, whitespace, truncated, not JSON, a bare scalar, an array of
  scalars, and nesting past the depth cap. Refusing on `Unreadable` costs those
  nothing, because they carry no roles today either.
- A divergence in the other direction that no round of this discussion had noticed:
  a leading BOM is `Clean` to the walk, which strips one, and unreadable to the
  reader on this path, which does not. Not exploitable, because the reader's
  refusal decides the roles and it grants none, but it is the walk saying something
  affirmative about a document its consumer cannot read.
- The attack itself, pinned rather than described: a role claim naming its member
  twice resolves to the **last** occurrence, so a second member replaces the role
  set instead of adding to it.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff is one new test file and touches no production code:

```
$ git diff --stat origin/main...HEAD
 SSO-Auth.Tests/Oidc/UnreadableRoleClaimPostureTests.cs | 148 ++++++++++++++++++
 1 file changed, 148 insertions(+)
```

No screen is wired onto the role path here. That is phase 2 and it waits on the
decision this feeds, exactly as the issue requires. The four boxes below are left
unticked rather than ticked as vacuously true, because there is no behaviour change
for them to be about.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No adversarial review lens was run on this change, and no second reader has read
it.** The evidence below stands in place of one.

One fixture note, since it is the kind of thing a reader should not have to take on
trust: no non-ASCII byte reaches this file. The BOM and the surrogate are C#
escapes, which `LC_ALL=C grep -n '[^ -~\t]'` over the file confirms returns nothing.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`
      - this change establishes none; it measures two existing components against
      each other.
- [x] Docs impact considered: a measurement between two internal components is not
      operator-facing, so no README or wiki text changes and no documentation issue
      is owed.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - none are
      touched.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en) / 0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   Total: 2824, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   Total: 2825, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The four skipped are the loopback-binding tests that need an elevated prompt on
Windows. They were not run and nothing is claimed about them.

### The table was watched going red, for the reason it names

A measurement pins two things at once, so weakening either side has to move it. The
walk's encoder arm was changed to report `Clean` where it reports `Unreadable` -
the fail-open direction - and then reverted:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*UnreadableRoleClaimPosture*"
  UnreadableRoleClaimPostureTests.TheWalkAndTheRolePathReader_AgreeExceptWhereThisTableSaysTheyDoNot
  (grammar: "a raw unpaired surrogate in a member name") [FAIL]
    a raw unpaired surrogate in a member name: the walk answered Clean, the table
    says Unreadable
  Total: 15, Failed: 1
```

`TheDivergenceSetIsTwoGrammars_NotSix` derives its count from the same rows rather
than restating it, so the number cannot go stale against the table it describes.

## Notes

The table deliberately omits a null claim value. `Claim.Value` is never null, so
the row would pin the behaviour of an input the caller cannot produce; fed one, the
reader raises out of Newtonsoft rather than refusing. Worth knowing, not worth a
permanent row, and recorded here instead.
