### PR TITLE
Measure and gate branch coverage on the security surface

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -131,20 +131,21 @@ jobs:
         echo "Replayed ${targets} target(s) with no unmapped exception."
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    # Line coverage for the RC coverage gate (#718). A second, instrumented run
-    # of the net10.0 leg (the MTP CodeCoverage extension emits Cobertura); the
+    # Line and branch coverage for the RC coverage gate (#718, #1109). A second,
+    # instrumented run of the net10.0 leg (the MTP CodeCoverage extension emits
+    # Cobertura, carrying the branch counts per line as condition-coverage); the
     # plain run above stays the canonical pass/fail signal for test correctness,
     # so a test failure under instrumentation (exit code 2 - timing heisenbugs
     # under the ~13x instrumentation overhead) is ignored HERE only; the
     # zero-tests exit (8) and any collector failure still fail this step.
     - name: Coverage (net10.0)
       run: dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --no-build --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml --ignore-exit-code 2
-    - name: Enforce the security-surface coverage bar
-      # Fail-closed threshold on the security-decision surface only (#718): the
-      # whole-codebase number is reported and tracked in docs/METRICS.md, but the
-      # gate keys on the modules that decide auth/authz/linking/abuse outcomes, so
-      # a trivially-thin non-critical path cannot trip it and a security-path
-      # regression cannot slip through it.
+    - name: Enforce the security-surface coverage bars
+      # Fail-closed thresholds on the security-decision surface only (#718, #1109):
+      # the whole-codebase line and branch numbers are reported into the job
+      # summary below and go no further, while the gate keys on the modules that
+      # decide auth/authz/linking/abuse outcomes, so a trivially-thin non-critical
+      # path cannot trip it and a security-path regression cannot slip through it.
       #
       # set -o pipefail is LOAD-BEARING: without it the step's status is tee's
       # exit 0 and every rejection the script makes (below-bar, unreadable or

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,25 +1,38 @@
 #!/usr/bin/env python3
-"""Coverage gate for the RC coverage goal (#718).
+"""Coverage gate for the RC coverage goal (#718, #1109).
 
 Parses the Cobertura report `dotnet test --coverage` emits and enforces the
-security-surface LINE-coverage bar: the modules that take security decisions
+security-surface LINE and BRANCH bars: the modules that take security decisions
 (SAML validation, OIDC state/issuer/PKCE, account linking, authz, rate limit,
 avatar SSRF, network trust, logout, secrets, session mint, audit) must stay at
-or above the pinned threshold, or the job fails. The whole-codebase number is
-reported (the >=80% line RC baseline is tracked in docs/METRICS.md) but
-deliberately not enforced, so the gate cannot be tripped by a trivially-thin
-non-critical path; only the security surface hard-gates.
+or above both pinned thresholds, or the job fails. The whole-codebase numbers
+are reported but deliberately not enforced, so the gate cannot be tripped by a
+trivially-thin non-critical path; only the security surface hard-gates.
 
-Counting is per executable line (lines-covered / lines-valid), never a
+Both bars are checked and both are reported before either verdict is returned,
+so one run says everything that is wrong rather than hiding the second failure
+behind the first.
+
+Line counting is per executable line (lines-covered / lines-valid), never a
 per-class average, so a large uncovered class cannot hide behind many small
-covered ones. Only each class's class-level <lines> block is counted - the
-per-method <line> entries duplicate the same lines and would double-count.
-Fail-closed: a missing report, an unparsable report, or zero matched
-security-surface lines is an error, not a pass.
+covered ones. Branch counting is the same shape, read off the per-line
+`condition-coverage="P% (c/v)"` the collector writes on every `branch="True"`
+line: the c and v are summed across the population rather than the percentages
+averaged, for the same reason. The class-level `branch-rate` attribute is
+deliberately NOT used - it is already a ratio, so accumulating it would be the
+per-class average this file exists not to compute.
+
+Only each class's class-level <lines> block is counted - the per-method <line>
+entries duplicate the same lines and would double-count. Fail-closed: a missing
+report, an unparsable report, a branch line whose condition-coverage cannot be
+read, or zero matched security-surface lines or branches is an error, not a
+pass. A population with no branch points is that same error rather than 0%,
+which would otherwise read as a total regression.
 
 Usage: check-coverage.py <coverage.cobertura.xml>
 """
 
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import PurePosixPath, PureWindowsPath
@@ -61,11 +74,38 @@ SECURITY_CONFIG_FILES = {
     "ProviderConfigStore.cs",
 }
 
-# The pinned bar. Set just below the first honest measurement (93.4% on
-# 2026-07-21, line-level over 5124 security-surface lines) so real regressions
-# fail while instrumentation jitter does not; ratchet it up as the number
-# climbs, never down without a documented decision.
+# The pinned bars. Each is set just below its first honest measurement so real
+# regressions fail while instrumentation jitter does not; ratchet them up as the
+# numbers climb, never down without a documented decision.
+#
+# Line: 93.4% on 2026-07-21, over 5124 security-surface lines.
+# Branch: 86.3% on 2026-08-10, over 2888 security-surface branches.
 SECURITY_LINE_BAR = 92.0
+SECURITY_BRANCH_BAR = 85.0
+
+# The collector writes the branch counts only inside the percentage string, as
+# `condition-coverage="66.67% (2/3)"`. The trailing pair is what is read; the
+# percentage in front of it is derived from the same two numbers and is not.
+CONDITION_COVERAGE = re.compile(r"\((\d+)/(\d+)\)\s*$")
+
+
+def branch_counts(line: ET.Element) -> tuple[int, int]:
+    """Returns (covered, valid) branches for one <line>, or (0, 0) if it has none.
+
+    A line the collector marked `branch="True"` but whose condition-coverage
+    cannot be read is a report this script does not understand, so it raises
+    rather than contributing nothing: silently skipping such a line would shrink
+    the denominator and let the measured percentage rise as the report drifts.
+    """
+    if (line.get("branch") or "").lower() != "true":
+        return 0, 0
+    match = CONDITION_COVERAGE.search(line.get("condition-coverage") or "")
+    if match is None:
+        raise ValueError(
+            f"line {line.get('number')} is marked branch=\"True\" but its "
+            f"condition-coverage {line.get('condition-coverage')!r} carries no (covered/valid) pair"
+        )
+    return int(match.group(1)), int(match.group(2))
 
 
 def module_of(filename: str) -> str | None:
@@ -97,6 +137,8 @@ def main() -> int:
 
     total_valid = total_covered = 0
     sec_valid = sec_covered = 0
+    total_br_valid = total_br_covered = 0
+    sec_br_valid = sec_br_covered = 0
     for cls in root.iter("class"):
         filename = cls.get("filename", "")
         module = module_of(filename)
@@ -108,29 +150,62 @@ def main() -> int:
             continue
         for line in lines_block.iter("line"):
             hits = int(line.get("hits", "0"))
+            try:
+                br_covered, br_valid = branch_counts(line)
+            except ValueError as err:
+                print(f"::error::Could not read the coverage report: {filename}: {err}", file=sys.stderr)
+                return 1
             total_valid += 1
             total_covered += 1 if hits > 0 else 0
+            total_br_valid += br_valid
+            total_br_covered += br_covered
             if is_security:
                 sec_valid += 1
                 sec_covered += 1 if hits > 0 else 0
+                sec_br_valid += br_valid
+                sec_br_covered += br_covered
 
     if total_valid == 0 or sec_valid == 0:
         print("::error::The coverage report contains no matched lines - refusing to pass an empty measurement.", file=sys.stderr)
         return 1
+    # Nothing on this surface is branch-free, so an empty branch denominator is
+    # a report that stopped carrying condition-coverage rather than a codebase
+    # without conditions. Refusing here is what keeps the branch bar from being
+    # satisfied by a measurement that never happened.
+    if total_br_valid == 0 or sec_br_valid == 0:
+        print("::error::The coverage report contains no matched branches - refusing to pass an empty measurement.", file=sys.stderr)
+        return 1
 
     overall = 100.0 * total_covered / total_valid
     security = 100.0 * sec_covered / sec_valid
-    print(f"Overall line coverage:          {overall:.1f}% ({total_covered}/{total_valid} lines)")
-    print(f"Security-surface line coverage: {security:.1f}% ({sec_covered}/{sec_valid} lines)")
-    print(f"Security-surface bar (pinned):  {SECURITY_LINE_BAR:.1f}%")
+    overall_branch = 100.0 * total_br_covered / total_br_valid
+    security_branch = 100.0 * sec_br_covered / sec_br_valid
+    print(f"Overall line coverage:            {overall:.1f}% ({total_covered}/{total_valid} lines)")
+    print(f"Security-surface line coverage:   {security:.1f}% ({sec_covered}/{sec_valid} lines)")
+    print(f"Security-surface line bar:        {SECURITY_LINE_BAR:.1f}%")
+    print(f"Overall branch coverage:          {overall_branch:.1f}% ({total_br_covered}/{total_br_valid} branches)")
+    print(f"Security-surface branch coverage: {security_branch:.1f}% ({sec_br_covered}/{sec_br_valid} branches)")
+    print(f"Security-surface branch bar:      {SECURITY_BRANCH_BAR:.1f}%")
 
+    failed = False
     if security < SECURITY_LINE_BAR:
+        failed = True
         print(
             f"::error::Security-surface line coverage {security:.1f}% fell below the pinned "
             f"{SECURITY_LINE_BAR:.1f}% bar (#718). Cover the security-decision paths you touched, "
             "or raise coverage elsewhere on the surface - the bar does not move down.",
             file=sys.stderr,
         )
+    if security_branch < SECURITY_BRANCH_BAR:
+        failed = True
+        print(
+            f"::error::Security-surface branch coverage {security_branch:.1f}% fell below the pinned "
+            f"{SECURITY_BRANCH_BAR:.1f}% bar (#1109). A branch left untaken on a security-decision "
+            "path is a decision nothing exercised - cover it, or raise branch coverage elsewhere on "
+            "the surface; the bar does not move down.",
+            file=sys.stderr,
+        )
+    if failed:
         return 1
     print("Coverage gate: PASS")
     return 0

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -79,9 +79,13 @@ SECURITY_CONFIG_FILES = {
 # numbers climb, never down without a documented decision.
 #
 # Line: 93.4% on 2026-07-21, over 5124 security-surface lines.
-# Branch: 86.3% on 2026-08-10, over 2888 security-surface branches.
+# Branch: 86.4% on 2026-08-10, over 2888 security-surface branches, measured by the
+# first CI run of this gate and rounded down. Eleven branches of headroom, which is
+# far outside the run-to-run jitter: the same report on a developer machine that day
+# read 2493/2888 against CI's 2494/2888, one branch apart on an identical
+# denominator.
 SECURITY_LINE_BAR = 92.0
-SECURITY_BRANCH_BAR = 85.0
+SECURITY_BRANCH_BAR = 86.0
 
 # The collector writes the branch counts only inside the percentage string, as
 # `condition-coverage="66.67% (2/3)"`. The trailing pair is what is read; the


### PR DESCRIPTION
# What & why

The coverage gate parsed the Cobertura report and read only `hits` off each line, so
the branch data the collector already writes was thrown away. OpenSSF `test_most` is
written about branches, so the number the job printed did not answer the question it
was being read for, and a security-decision path could lose every one of its untaken
branches with the reported percentage standing still.

This adds the branch measurement next to the line one, for the same two populations,
and pins a branch bar on the security surface. No test is added and no coverage is
raised here.

Closes #1109.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. The change touches `scripts/check-coverage.py` and the comment above
the step that runs it in `.github/workflows/dotnet.yml`. Nothing on the login path,
in SAML or OIDC validation, in config persistence or in the release pipeline is
touched.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

There is no second reader on this change. The evidence below stands in place of one,
and every number in it carries the command that produced it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The new logic is one function, `branch_counts`, returning the pair off one `<line>`.
The conformance suite is untouched and green; the structural property this change
establishes lives in a Python script the C# suite cannot read, so it is proven by the
weakenings below instead. No README or wiki page describes the coverage gate, so
nothing there goes stale.

## How the branch numbers are counted, and what is deliberately not used

The report marks each conditional line `branch="True"` and carries the counts inside
the percentage string:

```
$ grep -o '<line [^>]*>' TestResults/coverage.cobertura.xml \
    | sed 's/number="[0-9]*"/number="N"/; s/hits="[0-9]*"/hits="H"/' | sort -u | head -4
<line number="N" hits="H" branch="False" />
<line number="N" hits="H" branch="True" condition-coverage="0% (0/2)">
<line number="N" hits="H" branch="True" condition-coverage="0% (0/4)">
<line number="N" hits="H" branch="True" condition-coverage="100% (10/10)">
```

The trailing `(c/v)` pairs are summed across each population. The `branch-rate`
attribute on `<class>` is not used: it is already a ratio, and accumulating ratios is
the per-class average this script's own docstring exists to refuse.

The issue predicted a lowercase `branch="true"`; the collector writes `branch="True"`,
and the comparison in `branch_counts` is case-folded rather than pinned to either
spelling.

That the walk sees every counted element exactly once is checkable against the
report's own header, which the script never reads:

```
$ python3 scripts/check-coverage.py TestResults/coverage.cobertura.xml
Overall line coverage:            94.2% (6991/7425 lines)
Security-surface line coverage:   95.1% (5768/6067 lines)
Security-surface line bar:        92.0%
Overall branch coverage:          85.9% (2953/3437 branches)
Security-surface branch coverage: 86.3% (2493/2888 branches)
Security-surface branch bar:      86.0%
Coverage gate: PASS

$ grep -o 'lines-covered="[0-9]*" lines-valid="[0-9]*"' TestResults/coverage.cobertura.xml | head -1
lines-covered="6991" lines-valid="7425"
$ grep -o 'branches-covered="[0-9]*" branches-valid="[0-9]*"' TestResults/coverage.cobertura.xml | head -1
branches-covered="2953" branches-valid="3437"
```

Both overall totals match the header exactly, which is what says the class-level-only
walk neither skips a counted line nor double-counts a per-method copy.

## The weakenings that redden each new refusal

Each was run against the same report. The report itself is produced by the same
command the workflow runs:

```
$ dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --no-build \
    --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml \
    --ignore-exit-code 2
  gesamt: 2825  fehlgeschlagen: 0  erfolgreich: 2821  uebersprungen: 4
```

**The bar is compared.** `SECURITY_BRANCH_BAR` raised to 87.0, above the
measurement:

```
::error::Security-surface branch coverage 86.3% fell below the pinned 87.0% bar (#1109). ...
exit=1
```

**An unreadable branch line is refused rather than skipped.** `condition-coverage`
deleted from one line inside a class-level `<lines>` block:

```
::error::Could not read the coverage report: ...\SsoOnlyServiceRegistrator.cs: line 43 is
marked branch="True" but its condition-coverage None carries no (covered/valid) pair
exit=1
```

This is the weakening worth having, and the first attempt at it did not bite. A text
substitution on the first matching line in file order hits a per-method `<line>` copy,
which the gate deliberately skips, so the run passed unchanged with the totals still
at 2953/3437. The weakening only reaches the guard when it targets the population the
gate actually counts. Recorded because the near-miss is the interesting half: a
future reader weakening this the obvious way would conclude the refusal is vacuous.

**An empty branch measurement cannot pass.** Every `branch="True"` line in the report
rewritten to `branch="False"`, 2472 of them:

```
::error::The coverage report contains no matched branches - refusing to pass an empty measurement.
exit=1
```

**The pair is what is read, not the percentage in front of it.** One counted
security-surface line kept its `100%` prefix while its pair was changed to `(0/2)`:

```
W4 target: SamlAcsUrlBuilder.cs line 23 100% (2/2) -> 100% (0/2)
Overall branch coverage:          85.9% (2951/3437 branches)
Security-surface branch coverage: 86.3% (2491/2888 branches)
```

Both covered counts fall by exactly two. A gate reading the leading percentage would
not have moved.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)   0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)   0 Fehler
$ dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --no-build --coverage ...
  gesamt: 2825  fehlgeschlagen: 0  erfolgreich: 2821  uebersprungen: 4
```

No `.js`, `.html`, `.md`, `.css` or `.scss` file is touched, so Prettier has nothing
to say about this diff.

## Notes

The branch bar is pinned at 86.0, which is the first CI run of this gate rounded
down. It shipped in the first commit at 85.0 against the developer-machine number
above, and the second commit replaces that with the CI measurement the issue asks
for:

```
$ gh run view --job 93610532074 --log | grep -E 'Overall branch|Security-surface branch'
Overall branch coverage:          86.2% (2962/3437 branches)
Security-surface branch coverage: 86.4% (2494/2888 branches)
Security-surface branch bar:      85.0%
```

The two runs are one branch apart on an identical denominator, 2493/2888 here against
CI's 2494/2888, so 86.0 leaves eleven branches of headroom below the measurement and
is well outside that jitter. The line bar's headroom is wider (92.0 against 93.4%) and
is not narrowed here.

The docstring and the workflow comment both pointed at `docs/METRICS.md` for the
whole-codebase number. That path is not in the tree and cannot be:

```
$ git ls-tree --name-only origin/main docs/
docs/README.md
docs/SECURITY-REMEDIATION-POLICY.md
$ git show origin/main:.gitignore | grep -n -A2 'docs/[*]'
469:docs/*
470-!docs/README.md
471-!docs/SECURITY-REMEDIATION-POLICY.md
```

So both references are dropped rather than a third added, and the text now names
where those numbers actually go, which is the job summary and the uploaded report.
The issue quoted the workflow reference at `dotnet.yml:76`; it sits at line 144 on
current `main`.

Out of scope, from the issue's own wording: raising the thin non-critical paths, and
flipping OpenSSF `test_most`. Those are #1113. The whole-codebase branch number stays
reported and ungated, exactly as the line number is.
