### PR TITLE
Add a relogin-only harness pass that reuses an initialised Jellyfin

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -165,6 +165,35 @@ docker compose -f test/e2e/docker-compose.yml down -v
 A green run prints `ALL E2E CHECKS PASSED`. In CI, container logs are dumped automatically on
 failure.
 
+### A second pass over the same server (`RELOGIN_ONLY`)
+
+Step 3 configures everything it then asserts, which overwrites exactly the state a mutation test
+needs to survive. `RELOGIN_ONLY=true` runs the same driver without any of that setup: the
+identity-provider seed, the Jellyfin first-run wizard and the two provider `Add` calls are skipped
+and reported as skipped, the admin token and the provider configuration are read back from the
+persisted `/config`, and every login round-trip and assertion runs as before. So a phase can change
+server state and a following pass can observe what the logins do with it.
+
+```sh
+# First pass: the ordinary run above, which initialises Jellyfin and configures both providers.
+docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+
+# Second pass: same stack, no reconfiguration.
+RELOGIN_ONLY=true docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+```
+
+Run the second pass with `up` on the stopped stack rather than after a `down`. Only the harness
+container's environment changed, so Keycloak and Jellyfin restart in place and keep the realm's SAML
+signing key. A `down` removes the Keycloak container, the realm is re-imported into a fresh instance
+with a **new** signing certificate, and the certificate the first pass wrote into the plugin's SAML
+configuration no longer matches the assertions the IdP signs.
+
+A relogin-only pass refuses to run against an uninitialised server: it needs a Jellyfin whose wizard
+is already complete and whose provider configuration is already persisted, so pointing it at a wiped
+`test/e2e/jellyfin/config` is a fatal error rather than a silent re-initialisation.
+
 **The Zitadel, Pocket ID and Kanidm stacks cannot be re-run in place.** Every other provider is seeded from a file
 (an imported realm, a reapplied blueprint, or a static config) and the driver deliberately reuses an
 already-initialised Jellyfin. These three are seeded imperatively against stateful storage and their seeds

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -70,6 +70,13 @@ services:
       # canonical stack.
       ADMIN_ROLES_JSON: '["jellyfin-admin"]'
       EXTENDED_PHASES: "true"
+      # A second pass over the Jellyfin this stack already initialised (#1123): the seed, the wizard
+      # and the two provider Add calls are skipped and read back instead, so state a phase mutated
+      # survives into the next login. Taken from the invoking shell and defaulting to false, so an
+      # ordinary `docker compose up` is the one-shot run it has always been. The Jellyfin /config is
+      # the bind mount below, which `docker compose down -v` does not clear, so the second pass finds
+      # the completed wizard and the persisted provider configuration.
+      RELOGIN_ONLY: "${RELOGIN_ONLY:-false}"
       # The canonical base URL the plugin publishes in its SP metadata (#928 U8): the SAML/metadata
       # endpoint fails closed without it (the ACS URL must never come from a spoofable request Host).
       # This IS the Jellyfin service URL on the harness network, so the advertised ACS is reachable.

--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -75,6 +75,12 @@ ADMIN_ROLES_JSON="${ADMIN_ROLES_JSON:-[]}"
 # SSO-only login round-trip. Off by default - the canonical Keycloak stack turns them on; other
 # providers opt in once their seeds carry the required roles.
 EXTENDED_PHASES="${EXTENDED_PHASES:-false}"
+# A second, non-reconfiguring pass over a Jellyfin this harness already initialised (#1123). Every
+# phase that WRITES setup state is skipped - the identity-provider seed, the first-run wizard, and the
+# two provider Add calls - and the same facts are read back from the persisted configuration instead.
+# The login round-trips and every assertion still run, so a phase that mutates server state can be
+# followed by a pass that observes what survived. Off by default: an unset run is the one-shot run.
+RELOGIN_ONLY="${RELOGIN_ONLY:-false}"
 # The two OIDC test users' passwords. They default to the username (every other harness seeds them that
 # way); Zitadel's default password policy rejects anything that simple, so that harness overrides both. The
 # SAME variables seed the account and drive the login, so the two can never disagree.
@@ -437,7 +443,11 @@ JSON
 
   log "Zitadel seeded (project=$zproject, client_id=$CLIENT_ID), signing key published"
 }
-idp_seed
+if [ "$RELOGIN_ONLY" = "true" ]; then
+  log "SKIPPED (relogin-only): identity-provider seeding - the client, role and users already exist"
+else
+  idp_seed
+fi
 
 
 # The id_token must be signed with an ASYMMETRIC, JWKS-verifiable algorithm. An identity provider that falls
@@ -486,9 +496,14 @@ jf() {
   fi
 }
 
-# If the wizard is already complete (a re-run against a persisted /config), skip it.
+# If the wizard is already complete (a re-run against a persisted /config), skip it. A relogin-only
+# pass refuses to run it at all rather than relying on that check: the wizard is setup, and a pass
+# that found an uninitialised server is looking at the wrong stack, not at one it may initialise.
 WIZARD_DONE="$(curl -fsS "$JELLYFIN/System/Info/Public" | jq -r '.StartupWizardCompleted // false')"
-if [ "$WIZARD_DONE" != "true" ]; then
+if [ "$RELOGIN_ONLY" = "true" ]; then
+  [ "$WIZARD_DONE" = "true" ] || die "relogin-only: the Jellyfin startup wizard is not complete - this pass reuses an already-initialised server and must not create one"
+  log "SKIPPED (relogin-only): first-run wizard - reusing admin '$ADMIN_USER' from the persisted config"
+elif [ "$WIZARD_DONE" != "true" ]; then
   # Jellyfin answers /System/Info/Public before the startup-wizard controller is fully ready, so poll the
   # wizard config endpoint until it responds - otherwise a fast-booting IdP (e.g. Authelia over TLS) lets
   # the harness race ahead of Jellyfin and the first wizard call fails intermittently (#921).
@@ -546,15 +561,19 @@ OID_CONFIG="$(cat <<JSON
 }
 JSON
 )"
-ADD_STATUS="$(curl -sS -o /tmp/add.out -w '%{http_code}' -X POST "$JELLYFIN/sso/OID/Add/$PROVIDER" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-  -d "$OID_CONFIG")" || true
-if [ "$ADD_STATUS" != "200" ] && [ "$ADD_STATUS" != "204" ]; then
-  log "OID/Add returned HTTP $ADD_STATUS: $(cat /tmp/add.out 2>/dev/null)"
-  die "OID/Add failed (is the plugin loaded? a 404 means it is not)"
+if [ "$RELOGIN_ONLY" = "true" ]; then
+  log "SKIPPED (relogin-only): OID/Add - the provider configuration persisted under /config is reused"
+else
+  ADD_STATUS="$(curl -sS -o /tmp/add.out -w '%{http_code}' -X POST "$JELLYFIN/sso/OID/Add/$PROVIDER" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+    -d "$OID_CONFIG")" || true
+  if [ "$ADD_STATUS" != "200" ] && [ "$ADD_STATUS" != "204" ]; then
+    log "OID/Add returned HTTP $ADD_STATUS: $(cat /tmp/add.out 2>/dev/null)"
+    die "OID/Add failed (is the plugin loaded? a 404 means it is not)"
+  fi
+  log "Provider configured"
 fi
-log "Provider configured"
 
 # --------------------------------------------------------------------------------------------------
 # Phase 3 - assert the plugin loaded and the provider is enabled (milestone 1)
@@ -1268,11 +1287,22 @@ if [ "$EXTENDED_PHASES" = "true" ]; then
   # ------------------------------------------------------------------------------------------------
   log "== Extended: SSO-only login round-trip =="
   PW_USER="pwuser"; PW_PASS="Pw-e2e-1!"
-  NEWU="$(curl -fsS -X POST "$JELLYFIN/Users/New" \
-    -H "Content-Type: application/json" \
+  # A second pass over the same server already has this account: /Users/New refuses a duplicate name,
+  # and creating it is setup rather than the thing under test. Look first, create only when absent -
+  # the phase then asserts the same lockout and restoration against either account.
+  PW_ID="$(curl -fsS "$JELLYFIN/Users" \
     -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-    -d "{\"Name\":\"$PW_USER\",\"Password\":\"$PW_PASS\"}")" || die "extended: creating the password user failed"
-  [ -n "$(printf '%s' "$NEWU" | jq -r '.Id // empty')" ] || die "extended: /Users/New returned no user id"
+    | jq -r --arg n "$PW_USER" '[.[] | select(.Name == $n) | .Id][0] // empty')" || die "extended: could not list users"
+  if [ -n "$PW_ID" ]; then
+    log "Reusing the existing password user '$PW_USER' ($PW_ID)"
+  else
+    NEWU="$(curl -fsS -X POST "$JELLYFIN/Users/New" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+      -d "{\"Name\":\"$PW_USER\",\"Password\":\"$PW_PASS\"}")" || die "extended: creating the password user failed"
+    PW_ID="$(printf '%s' "$NEWU" | jq -r '.Id // empty')"
+    [ -n "$PW_ID" ] || die "extended: /Users/New returned no user id"
+  fi
 
   [ "$(jf_auth_status "$PW_USER" "$PW_PASS")" = "200" ] || die "extended: the fresh password user cannot log in even before SSO-only"
 
@@ -1345,13 +1375,17 @@ SAML_CONFIG="$(cat <<JSON
 }
 JSON
 )"
-SADD_STATUS="$(curl -sS -o /tmp/samladd.out -w '%{http_code}' -X POST "$JELLYFIN/sso/SAML/Add/$PROVIDER" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
-  -d "$SAML_CONFIG")" || true
-if [ "$SADD_STATUS" != "200" ] && [ "$SADD_STATUS" != "204" ]; then
-  log "SAML/Add returned HTTP $SADD_STATUS: $(cat /tmp/samladd.out 2>/dev/null)"
-  die "SAML/Add failed"
+if [ "$RELOGIN_ONLY" = "true" ]; then
+  log "SKIPPED (relogin-only): SAML/Add - the SAML provider configuration persisted under /config is reused"
+else
+  SADD_STATUS="$(curl -sS -o /tmp/samladd.out -w '%{http_code}' -X POST "$JELLYFIN/sso/SAML/Add/$PROVIDER" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: MediaBrowser Token=\"$ADMIN_TOKEN\"" \
+    -d "$SAML_CONFIG")" || true
+  if [ "$SADD_STATUS" != "200" ] && [ "$SADD_STATUS" != "204" ]; then
+    log "SAML/Add returned HTTP $SADD_STATUS: $(cat /tmp/samladd.out 2>/dev/null)"
+    die "SAML/Add failed"
+  fi
 fi
 SNAMES="$(curl -fsS "$JELLYFIN/sso/SAML/GetNames")" || die "SAML GetNames failed"
 log "SAML GetNames => $SNAMES"


### PR DESCRIPTION
# What & why

The end-to-end driver was a one-shot on a fresh Jellyfin. Every run re-seeded the
identity provider, re-wrote both provider configurations through the admin API and
re-linked the accounts, so a phase that mutates server state and then wants a second
login to observe the effect had nowhere to stand: the next run overwrote the state it
needed to survive.

`RELOGIN_ONLY=true` runs the same driver with the setup removed. The identity-provider
seed, the first-run wizard, `OID/Add` and `SAML/Add` are skipped and say so in the
transcript; the admin token and both provider configurations are read back from the
persisted `/config`, which the existing `GetNames` assertions then prove survived. Every
login round-trip and every assertion still runs. Unset, the switch defaults to false and
every provider stack runs byte-unchanged.

Two things the pass needs to be honest about. It refuses an uninitialised server rather
than quietly initialising one, because a pass that found one is looking at the wrong
stack. And the SSO-only phase now looks the password user up before creating it:
`/Users/New` refuses a duplicate name on a second pass, and creating that account is
setup rather than the thing under test.

Closes #1123

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable: no plugin code changes. The diff is the test harness driver, its compose
file and the harness README, and it adds no product surface. The relogin pass drives the
same login legs and pins the same refusals as the default pass, so no fail-closed
assertion was weakened or removed.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The docs half is included: `test/e2e/README.md` documents the two-pass invocation and
the one way it can be run wrong.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The build is the packaged plugin the harness installs, produced by the documented local
route and green:

```
jprm plugin build . --output ./artifacts --dotnet-framework net9.0
./artifacts/community-sso-for-jellyfin_4.3.0.0.zip
```

`dotnet test` is unchanged by this diff, which touches no compiled file, and was not
re-run. Prettier: `npx prettier --check test/e2e/README.md` reports the same CRLF-only
complaint on `origin/main` as on this branch, and `prettier --write` changes nothing in
the content once carriage returns are ignored, so the file is clean as git stores it.

The claim itself, run on the canonical Keycloak stack:

```
docker compose -f test/e2e/docker-compose.yml up \
  --abort-on-container-exit --exit-code-from harness
# exit 0, ALL E2E CHECKS PASSED

RELOGIN_ONLY=true docker compose -f test/e2e/docker-compose.yml up \
  --abort-on-container-exit --exit-code-from harness
# exit 0, ALL E2E CHECKS PASSED
```

The second pass's transcript reports the four setup steps as skipped and then reads the
configuration back:

```
SKIPPED (relogin-only): identity-provider seeding - the client, role and users already exist
SKIPPED (relogin-only): first-run wizard - reusing admin 'e2eadmin' from the persisted config
SKIPPED (relogin-only): OID/Add - the provider configuration persisted under /config is reused
GetNames => ["keycloak"]
SKIPPED (relogin-only): SAML/Add - the SAML provider configuration persisted under /config is reused
SAML GetNames => ["keycloak"]
Reusing the existing password user 'pwuser' (882bf2fe62fa4e37af5f5d841d03cd55)
```

The new fatal guard bites for the reason it names. With `test/e2e/jellyfin/config` wiped
and the plugin re-dropped, the same command dies before touching anything:

```
RELOGIN_ONLY=true docker compose -f test/e2e/docker-compose.yml up \
  --abort-on-container-exit --exit-code-from harness
# exit 1
FATAL: relogin-only: the Jellyfin startup wizard is not complete - this pass reuses an
       already-initialised server and must not create one
```

## Notes

No second reader ran on this change. The evidence above stands in place of one: three
runs of the real stack, one per direction the switch can go plus the falsifier for the
guard it adds.

The second pass must be started with `up` on the stopped stack rather than after a
`down`. Only the harness container's environment changes, so Keycloak and Jellyfin
restart in place and keep the realm's SAML signing key; a `down` removes the Keycloak
container, the realm is re-imported with a new signing certificate, and the certificate
the first pass wrote into the plugin's SAML configuration stops matching. That is written
into the README rather than worked around, because working around it would mean the
relogin pass re-writing the SAML configuration, which is the thing it exists not to do.

Out of scope, found while running this and not fixed here: `test/e2e/README.md` step 2
unpacks `./artifacts/sso-authentication_*.zip`, while `jprm` produces
`community-sso-for-jellyfin_4.3.0.0.zip`, so the documented local run copies nothing and
the stack then boots without the plugin. Separate topic, filed as its own issue.
