### PR TITLE
Refuse a JWT that declares itself a token for the other endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **A token minted for one endpoint is no longer read as a token for the other
+  (#1317).** Neither JWT the plugin verifies used to have its `typ` header
+  looked at, so the only thing separating an id_token from a back-channel
+  logout token was the shape of its payload. Measured before the fix: a genuine
+  logout token, correctly typed and signed by the provider's own key, validated
+  on the login path and produced a user; and a logout token whose header said
+  `at+jwt` validated at the logout endpoint. Both entry points now refuse a
+  token that declares itself an access token (`at+jwt`), a DPoP proof
+  (`dpop+jwt`) or, on the login path, a security event (`secevent+jwt`) or a
+  logout token (`logout+jwt`), in every spelling of those media types. Nothing
+  a working provider sends is affected: `typ` is optional in an id_token, so a
+  token that omits it, sends the generic `JWT`, or sends a vendor value of the
+  provider's own is accepted exactly as before. An absent header is not treated
+  as a wrong one.
+
 - **A single dropped discovery response no longer cancels a sign-out the
   identity provider ordered (#1183).** On an inbound back-channel logout the
   plugin reads the provider's discovery document to obtain the keys the logout

--- a/SSO-Auth.Tests/Oidc/OidcTokenTypeConfusionTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcTokenTypeConfusionTests.cs
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// RFC 7519 §4.1.9 on both token paths (#1317): a JWT whose header declares one of the media types this
+/// plugin can attribute to another endpoint is refused there, so the token families are separated by what
+/// they say they are and not only by the shape of their payloads.
+/// <para>
+/// Both directions were accepted before this rule existed, measured on the shipped validators: a genuine
+/// <c>logout+jwt</c> validated on the id_token path, and a <c>logout_token</c> whose header said
+/// <c>at+jwt</c> validated on the logout path. That is the reason the rows below exist in both directions
+/// rather than only in the one the payload rules already cover.
+/// </para>
+/// <para>
+/// Every token here is GENUINELY SIGNED by the key the JWKS advertises and is otherwise valid, and each
+/// rejection is paired with the same token minus the header. Without that pairing a rejection proves
+/// nothing about <c>typ</c>: a fixture the validator would refuse anyway passes for a reason it does not
+/// name.
+/// </para>
+/// </summary>
+[Collection("SSOController")]
+public sealed class OidcTokenTypeConfusionTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "test-signing-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcIdTokenValidator _idTokenValidator = new();
+    private readonly OidcLogoutTokenValidator _logoutValidator = new();
+
+    public OidcTokenTypeConfusionTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    /// <summary>
+    /// The media types that name a purpose other than an id_token, in every spelling one can arrive in.
+    /// <para>
+    /// The prefixed and case-variant rows are the near-miss this file is built around, and they are the
+    /// rows that die if the screen compares the raw header value with an ordinal equality: RFC 7519 §5.1
+    /// lets a producer omit the <c>application/</c> prefix and media types are case-insensitive, so
+    /// <c>application/logout+jwt</c> and <c>LOGOUT+JWT</c> are the same declaration as <c>logout+jwt</c>
+    /// and a screen that misses them is bypassed by re-spelling one header field.
+    /// </para>
+    /// </summary>
+    public static TheoryData<string, string> ForeignToIdToken => new()
+    {
+        { "logout-token", "logout+jwt" },
+        { "logout-token-prefixed", "application/logout+jwt" },
+        { "logout-token-upper", "LOGOUT+JWT" },
+        { "logout-token-mixed-prefix", "Application/Logout+Jwt" },
+        { "access-token", "at+jwt" },
+        { "access-token-prefixed", "application/at+jwt" },
+        { "dpop-proof", "dpop+jwt" },
+        { "security-event", "secevent+jwt" },
+    };
+
+    /// <summary>
+    /// The media types foreign to the back-channel logout endpoint. Smaller than the set above, and the
+    /// asymmetry is the point: a <c>logout_token</c> IS a security event token, so <c>secevent+jwt</c> and
+    /// <c>logout+jwt</c> are its own family, and an id_token has no reserved media type for a screen to
+    /// name. The id_token replayed here stays the job of the forbidden <c>nonce</c> and the required
+    /// <c>events</c> member, which have their own tests.
+    /// </summary>
+    public static TheoryData<string, string> ForeignToLogoutToken => new()
+    {
+        { "access-token", "at+jwt" },
+        { "access-token-prefixed", "application/at+jwt" },
+        { "access-token-upper", "AT+JWT" },
+        { "dpop-proof", "dpop+jwt" },
+    };
+
+    /// <summary>
+    /// Values that declare no purpose this plugin can attribute, and are therefore admitted by the screen
+    /// and left to every rule that follows. This is the availability half of the decision, written as
+    /// tests so it is a choice rather than an accident: <c>typ</c> is optional, and providers omit it, send
+    /// the generic <c>JWT</c>, or send a value of their own. Refusing those would lock out working
+    /// providers to gain nothing, since none of them names another endpoint.
+    /// </summary>
+    public static TheoryData<string, string> AcceptedTokenTypes => new()
+    {
+        { "generic", "JWT" },
+        { "generic-lowercase", "jwt" },
+        { "generic-prefixed", "application/jwt" },
+        { "vendor", "vnd.example.token+jwt" },
+        { "unrelated", "example" },
+    };
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public async Task IdToken_WithoutTypHeader_IsAccepted()
+    {
+        // The positive control every rejection below is read against: this fixture differs from them by the
+        // header member and nothing else, so a rejection there is attributable to typ.
+        var result = await _idTokenValidator.ValidateAsync(IdToken(), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+    }
+
+    [Theory]
+    [MemberData(nameof(ForeignToIdToken))]
+    public async Task IdToken_DeclaringAForeignType_IsRejected(string shape, string typ)
+    {
+        var result = await _idTokenValidator.ValidateAsync(IdToken(typ), Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError, shape);
+        Assert.Contains("unacceptable token type", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task IdToken_RefusalIsNotTheSignatureCode()
+    {
+        // "invalid_signature" is a contract with OidcClient: it refreshes the discovery JWKS and retries
+        // once. Reporting a type refusal that way would spend a JWKS fetch on a token that will be refused
+        // identically the second time.
+        var result = await _idTokenValidator.ValidateAsync(IdToken("logout+jwt"), Options(), TestContext.Current.CancellationToken);
+
+        Assert.NotEqual("invalid_signature", result.Error);
+    }
+
+    [Fact]
+    public async Task GenuineLogoutToken_IsRejectedOnTheIdTokenPath()
+    {
+        // The measured direction, end to end: a real back-channel logout token, correctly typed, signed by
+        // the trusted key and addressed to this client, used as a login credential. Before #1317 this
+        // returned a principal.
+        var logoutToken = Sign(LogoutClaims(), "logout+jwt");
+
+        var result = await _idTokenValidator.ValidateAsync(logoutToken, Options(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Null(result.User);
+    }
+
+    [Theory]
+    [MemberData(nameof(AcceptedTokenTypes))]
+    public async Task IdToken_DeclaringAnUnattributableType_IsAccepted(string shape, string typ)
+    {
+        var result = await _idTokenValidator.ValidateAsync(IdToken(typ), Options(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, $"{shape}: {result.Error}");
+    }
+
+    [Fact]
+    public async Task LogoutToken_WithoutTypHeader_IsAccepted()
+    {
+        var result = await _logoutValidator.ValidateAsync(LogoutToken(), Options(), DateTime.UtcNow);
+
+        Assert.True(result.IsValid, result.ReasonCode);
+        Assert.Equal("user-1", result.Subject);
+    }
+
+    [Fact]
+    public async Task LogoutToken_DeclaringItsOwnTypes_IsAccepted()
+    {
+        // The asymmetry asserted rather than assumed. Both of these name this token's own family, so
+        // refusing either would reject a spec-conformant provider at the endpoint the spec recommends the
+        // value for.
+        foreach (var typ in new[] { "logout+jwt", "secevent+jwt" })
+        {
+            var result = await _logoutValidator.ValidateAsync(LogoutToken(typ), Options(), DateTime.UtcNow);
+
+            Assert.True(result.IsValid, $"{typ}: {result.ReasonCode}");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ForeignToLogoutToken))]
+    public async Task LogoutToken_DeclaringAForeignType_IsRejected(string shape, string typ)
+    {
+        var result = await _logoutValidator.ValidateAsync(LogoutToken(typ), Options(), DateTime.UtcNow);
+
+        Assert.False(result.IsValid, shape);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.UnacceptableTokenType, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task LogoutToken_TypeRefusal_IsNotTheGenericInvalidCode()
+    {
+        // The code is what an operator alerts on. Collapsed into the generic code, a provider sending the
+        // wrong media type reads as a forgery attempt, and the two want different responses.
+        var result = await _logoutValidator.ValidateAsync(LogoutToken("at+jwt"), Options(), DateTime.UtcNow);
+
+        Assert.NotEqual(OidcLogoutTokenValidator.RejectReason.Invalid, result.ReasonCode);
+    }
+
+    [Fact]
+    public async Task LogoutToken_RefusedForItsType_IsNotConsumedFromTheReplaySet()
+    {
+        // The screen runs before the jti is consumed, so a refused token has not spent its one use. A
+        // provider that mislabels one delivery and re-sends it correctly must still be able to log the
+        // session out; the reverse ordering would turn a header mistake into a permanent no-op.
+        var jti = Guid.NewGuid().ToString();
+
+        var refused = await _logoutValidator.ValidateAsync(Sign(LogoutClaims(jti), "at+jwt"), Options(), DateTime.UtcNow);
+        var accepted = await _logoutValidator.ValidateAsync(Sign(LogoutClaims(jti), null), Options(), DateTime.UtcNow);
+
+        Assert.False(refused.IsValid);
+        Assert.True(accepted.IsValid, accepted.ReasonCode);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("!!!.eyJpc3MiOiJoIn0.sig")]
+    [InlineData(".eyJhbGciOiJSUzI1NiJ9.sig")]
+    [InlineData("eyJub3QtanNvbg.payload.sig")]
+    public void UnreadableHeader_IsNotRefusedHere(string? token)
+    {
+        // The gate is not the fail-closed floor and must not pretend to be one: a header it cannot read
+        // goes to the handler, which refuses the token on its own terms and with an accurate reason. These
+        // inputs also reach the two catch arms from outside, and the back-channel endpoint is anonymous, so
+        // an unhandled decode failure here would be a 500 an unauthenticated caller can drive.
+        Assert.True(OidcSignatureKeys.TokenTypeIsAcceptableForIdToken(token));
+        Assert.True(OidcSignatureKeys.TokenTypeIsAcceptableForLogoutToken(token));
+    }
+
+    [Fact]
+    public void NonStringTypHeader_IsNotRefusedHere()
+    {
+        // A typ that is not a string is malformed rather than a declaration of another purpose, so it is
+        // admitted and judged by the rules that follow. Pinned so the behaviour is a decision on the
+        // record: the alternative, refusing anything unreadable in that member, is a fail-closed choice
+        // this screen deliberately does not make, because it is not the floor.
+        var numeric = Sign(new Dictionary<string, object> { ["sub"] = "user-1" }, null, new Dictionary<string, object> { ["typ"] = 5 });
+
+        Assert.True(OidcSignatureKeys.TokenTypeIsAcceptableForIdToken(numeric));
+    }
+
+    // --- helpers ---
+
+    private OidcClientOptions Options()
+    {
+        var p = _rsa.ExportParameters(false);
+        var jwks = $$"""
+            {"keys":[{"kty":"RSA","use":"sig","kid":"{{KeyId}}",
+              "n":"{{Base64UrlEncoder.Encode(p.Modulus)}}","e":"{{Base64UrlEncoder.Encode(p.Exponent)}}"}]}
+            """;
+        return new OidcClientOptions
+        {
+            ClientId = ClientId,
+            ClockSkew = TimeSpan.FromMinutes(5),
+            ProviderInformation = new ProviderInformation
+            {
+                IssuerName = Issuer,
+                KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(jwks),
+            },
+        };
+    }
+
+    private static Dictionary<string, object> LogoutClaims(string? jti = null) => new()
+    {
+        ["events"] = new Dictionary<string, object> { [LogoutEvent] = new Dictionary<string, object>() },
+        ["jti"] = jti ?? Guid.NewGuid().ToString(),
+        ["sub"] = "user-1",
+    };
+
+    private string IdToken(string? typ = null) =>
+        Sign(new Dictionary<string, object> { ["sub"] = "user-1", ["preferred_username"] = "alice" }, typ);
+
+    private string LogoutToken(string? typ = null) => Sign(LogoutClaims(), typ);
+
+    private string Sign(IDictionary<string, object> claims, string? typ, IDictionary<string, object>? header = null)
+    {
+        var now = DateTime.UtcNow;
+        return new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = now - TimeSpan.FromMinutes(1),
+            NotBefore = now - TimeSpan.FromMinutes(1),
+            Expires = now + TimeSpan.FromMinutes(5),
+            Claims = claims,
+            TokenType = typ,
+            AdditionalHeaderClaims = header,
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = KeyId }, SecurityAlgorithms.RsaSha256),
+        });
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcIdTokenValidator.cs
@@ -59,6 +59,15 @@ internal sealed class OidcIdTokenValidator : IIdentityTokenValidator
                 return Reject("Identity token validation failed: unprocessed critical header");
             }
 
+            // RFC 7519 4.1.9: a token declaring itself an access token, a DPoP proof, a security event or a
+            // logout_token was minted for another endpoint and must not log anybody in here (#1317). Nothing
+            // else separated the two token families before: the handler never reads typ, and a genuine
+            // logout_token signed by the trusted key validated on this path.
+            if (!OidcSignatureKeys.TokenTypeIsAcceptableForIdToken(identityToken))
+            {
+                return Reject("Identity token validation failed: unacceptable token type");
+            }
+
             var handler = new JsonWebTokenHandler { MapInboundClaims = false };
             var result = await handler.ValidateTokenAsync(identityToken, OidcSignatureKeys.BuildValidationParameters(options, ephemeralKeys)).ConfigureAwait(false);
             if (!result.IsValid)

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -73,6 +73,14 @@ internal sealed class OidcLogoutTokenValidator
             return new Result(false, null, null, RejectReason.CriticalHeader);
         }
 
+        // RFC 7519 4.1.9, from the same shared table the id_token path screens against (#1317). This
+        // endpoint revokes sessions, so a token minted as an access token or a DPoP proof and replayed here
+        // must be refused for declaring itself something else, not left to the payload rules to catch.
+        if (!OidcSignatureKeys.TokenTypeIsAcceptableForLogoutToken(logoutToken))
+        {
+            return new Result(false, null, null, RejectReason.UnacceptableTokenType);
+        }
+
         // The algorithm is judged before the handler runs, purely so the refusal can be named. The handler
         // refuses a disallowed alg on its own - nothing new is rejected here - but it reports alg: none, a
         // case-variant spelling and an HS256 token keyed with the advertised public key as
@@ -286,6 +294,9 @@ internal sealed class OidcLogoutTokenValidator
 
         /// <summary>The header kid carries characters outside the accepted set, or is over-length (#1167).</summary>
         internal const string UnacceptableKeyId = "unacceptable_kid";
+
+        /// <summary>The header typ declares a media type minted for another endpoint (#1317).</summary>
+        internal const string UnacceptableTokenType = "unacceptable_typ";
 
         /// <summary>
         /// The provider's discovery document could not be read, so the signing keys never arrived and the

--- a/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
+++ b/SSO-Auth/Api/Oidc/OidcSignatureKeys.cs
@@ -32,6 +32,27 @@ internal static class OidcSignatureKeys
     /// </summary>
     private const int MaxKeyIdLength = 256;
 
+    // RFC 7519 §5.1: the "application/" prefix on a typ value MAY be omitted, so both spellings of one
+    // media type have to be recognised as the same declaration.
+    private const string MediaTypePrefix = "application/";
+
+    // The JWT media types this plugin can attribute to a purpose, and therefore the only ones a typ screen
+    // can act on. Each is a registered value with one meaning, so a token carrying it is telling the reader
+    // which endpoint minted it: RFC 9068 for an OAuth access token, RFC 9449 for a DPoP proof, RFC 8417 for
+    // a security event token, and OIDC Back-Channel Logout 1.0 §2.4 for a logout_token.
+    private const string AccessTokenType = "at+jwt";
+    private const string DpopProofType = "dpop+jwt";
+    private const string SecurityEventType = "secevent+jwt";
+    private const string LogoutTokenType = "logout+jwt";
+
+    // What each entry point refuses. Two lists rather than one because the families are not symmetric: a
+    // logout_token IS a security event token, so secevent+jwt and logout+jwt are its own types and only
+    // foreign to the id_token path.
+    private static readonly ImmutableArray<string> ForeignToIdToken =
+        [AccessTokenType, DpopProofType, SecurityEventType, LogoutTokenType];
+
+    private static readonly ImmutableArray<string> ForeignToLogoutToken = [AccessTokenType, DpopProofType];
+
     /// <summary>
     /// Gets the asymmetric signature algorithms the plugin accepts (RFC 7518). Symmetric HS* would accept a
     /// token minted by anyone holding the shared client secret, and <c>none</c> is unauthenticated by
@@ -246,6 +267,71 @@ internal static class OidcSignatureKeys
             // documents. This endpoint is anonymous, so an escaping decode failure would be a 500 an
             // unauthenticated caller can drive.
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Whether a compact-serialized JWT may be read as an id_token, judged on the <c>typ</c> header alone
+    /// (#1317). A token declaring itself an access token, a DPoP proof, a security event or a
+    /// <c>logout_token</c> was minted for a different endpoint and is refused here rather than left to be
+    /// separated by the shape of its payload.
+    /// </summary>
+    /// <param name="token">The raw compact-serialized JWT.</param>
+    /// <returns><c>false</c> only when the header positively declares one of the foreign media types.</returns>
+    internal static bool TokenTypeIsAcceptableForIdToken(string? token) => !DeclaresForeignType(token, ForeignToIdToken);
+
+    /// <summary>
+    /// Whether a compact-serialized JWT may be read as a back-channel <c>logout_token</c>, judged on the
+    /// <c>typ</c> header alone (#1317). The foreign set is smaller than the id_token's on purpose:
+    /// <c>secevent+jwt</c> and <c>logout+jwt</c> name this token's OWN family, and an id_token has no
+    /// reserved media type to name, so the reverse confusion is caught by the forbidden <c>nonce</c> and
+    /// the required <c>events</c> member instead.
+    /// </summary>
+    /// <param name="token">The raw compact-serialized JWT.</param>
+    /// <returns><c>false</c> only when the header positively declares one of the foreign media types.</returns>
+    internal static bool TokenTypeIsAcceptableForLogoutToken(string? token) => !DeclaresForeignType(token, ForeignToLogoutToken);
+
+    // Whether the header declares one of the media types this plugin can attribute to another purpose.
+    //
+    // RFC 7519 §5.1 lets a producer omit the "application/" prefix, and media types are case-insensitive,
+    // so "application/Logout+JWT" and "logout+jwt" are the same declaration and both are matched. Comparing
+    // the raw header value with Ordinal equality is the one-character mistake that would let either spelling
+    // through, which is why the spellings have rows of their own in the test file.
+    //
+    // Absent, empty, non-string and unrecognised values all return false. That is the availability half of
+    // the decision and it is deliberate: typ is optional in an id_token, real providers omit it, send "JWT",
+    // or send a vendor value, so anything narrower than "declares a purpose this plugin knows is not this
+    // one" would refuse working providers. A value that is not a string declares nothing attributable and is
+    // not evidence of a foreign purpose - the token still has to pass every payload rule that follows.
+    private static bool DeclaresForeignType(string? token, ImmutableArray<string> foreign)
+    {
+        if (string.IsNullOrEmpty(token))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!new JsonWebToken(token).TryGetHeaderValue<string>("typ", out var declared) || string.IsNullOrEmpty(declared))
+            {
+                return false;
+            }
+
+            var mediaType = declared.StartsWith(MediaTypePrefix, StringComparison.OrdinalIgnoreCase)
+                ? declared[MediaTypePrefix.Length..]
+                : declared;
+            return foreign.Contains(mediaType, StringComparer.OrdinalIgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            // Not a readable JWT; the handler refuses it on its own terms, as with the two gates above.
+            return false;
+        }
+        catch (FormatException)
+        {
+            // A segment that will not base64url-decode. The back-channel endpoint is anonymous, so an
+            // escaping decode failure here would be a 500 an unauthenticated caller can drive.
+            return false;
         }
     }
 


### PR DESCRIPTION
# What & why

Neither JWT the plugin verifies had its `typ` header looked at, so the only thing
separating an id_token from a back-channel logout token was the shape of its payload. A
genuine logout token, correctly typed and signed by the provider's own key, validated on
the login path and yielded a principal; a logout token whose header said `at+jwt`
validated at the logout endpoint.

Both entry points now screen the header against one table of the JWT media types this
plugin can attribute to a purpose: `at+jwt` (RFC 9068), `dpop+jwt` (RFC 9449),
`secevent+jwt` (RFC 8417) and `logout+jwt` (Back-Channel Logout 1.0 §2.4). The login path
refuses all four. The logout path refuses the first two only, because a logout token IS a
security event token and an id_token has no reserved media type to name, so the reverse
confusion stays the job of the forbidden `nonce` and the required `events` member.

The availability half is a decision rather than an omission, and this is where it is
written down. `typ` is optional in an id_token and real providers omit it, send the
generic `JWT`, or send a vendor value, so anything narrower than "declares a purpose this
plugin knows is not this one" would refuse working providers. An absent header is not
treated as the same fact as a wrong one, and neither is a `typ` that is not a string:
both are admitted and left to every rule that follows. Both spellings RFC 7519 §5.1
allows are matched, prefixed and unprefixed, case-insensitive, so re-spelling the field
does not walk through the screen.

One ordering detail worth naming: the screen runs before the `jti` is consumed, so a
mislabelled logout token has not spent its one use and the provider can re-send it
correctly. The reverse ordering would turn a header mistake into a permanent no-op for
that session.

Closes #1317. Unblocks #1175, whose two rows were held back because both directions were
accepted.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No second reader ran on this change and no review record exists, so the two boxes above
stay unticked. The evidence below stands in place of one and is not a substitute for it.

Fail-closed is preserved in the direction that matters and relaxed in none: the screen
only ever refuses, it is placed after the kid and `crit` gates and before the handler,
and every check that ran before still runs. It is not itself the floor, and says so: a
token it cannot read is passed to the handler, which refuses it on its own terms and with
an accurate reason. The refusal on the login path is deliberately not `invalid_signature`,
which is a contract with OidcClient that triggers a JWKS refresh and one retry; spending a
fetch on a token that will be refused identically the second time is the availability cost
of getting that wrong, and a test pins it. Nothing IdP-supplied reaches a log line from
this path: the logout refusal is the fixed code `unacceptable_typ`, and the login refusal
is a constant string.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the conformance box, what is true is narrower than the sentence and worth stating.
The policy has one home by construction: both predicates read the same private table in
`OidcSignatureKeys`, so there is no second place for a path to drift to, and the
cross-path property is asserted behaviourally by one test file that drives both
validators, exactly as the `crit` screen (#1038) is held. No new rule was added to
`ArchitectureConformanceTests`, and the existing suite passes unchanged.

The docs impact is the CHANGELOG entry included here. The user-facing surface is
unchanged: no option, no message an operator configures.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both frameworks, zero warnings, and the full suite green on each:

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
# 0 Warnung(en) / 0 Fehler
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
# 0 Warnung(en) / 0 Fehler

./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
# Total: 2856, Errors: 0, Failed: 0, Skipped: 4
./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
# Total: 2857, Errors: 0, Failed: 0, Skipped: 4
```

Four of those are skipped, and one of them is disclosed rather than worked around:
binding a listener off loopback raises the Windows firewall consent dialog, which needs an
administrator (#1227), so that test does not run here.

Prettier: `npx prettier --check CHANGELOG.md` reports the same CRLF-only complaint on this
branch as on `origin/main`, and `prettier --write` changes nothing in the content once
carriage returns are ignored, so the file is clean as git stores it.

### The guards bite, one weakening per property

Emptying the login path's table fails 9 rows, including the direction this issue was
filed on. That failure is the before-state, measured from this tree rather than quoted
from the report:

```
Jellyfin.Plugin.SSO_Auth.Tests.OidcTokenTypeConfusionTests.GenuineLogoutToken_IsRejectedOnTheIdTokenPath [FAIL]
  Assert.True() Failure
...IdToken_DeclaringAForeignType_IsRejected(shape: "logout-token", typ: "logout+jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "logout-token-prefixed", typ: "application/logout+jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "logout-token-upper", typ: "LOGOUT+JWT") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "logout-token-mixed-prefix", typ: "Application/Logout+Jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "access-token", typ: "at+jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "access-token-prefixed", typ: "application/at+jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "dpop-proof", typ: "dpop+jwt") [FAIL]
...IdToken_DeclaringAForeignType_IsRejected(shape: "security-event", typ: "secevent+jwt") [FAIL]
Total: 32, Errors: 0, Failed: 9
```

Emptying the logout path's table fails 5. Dropping the `application/` strip and comparing
ordinally fails 6, which is the one-character mistake the prefixed and case-variant rows
exist for:

```
# ForeignToLogoutToken = ImmutableArray<string>.Empty
Total: 32, Errors: 0, Failed: 5
# prefix strip removed, StringComparer.Ordinal
Total: 32, Errors: 0, Failed: 6
```

Each rejection row is paired with the same token minus the header, so a rejection cannot
be read as proof of a rule the fixture never reached. The accepted-type rows are the other
pairing: they are what says the screen refuses a declaration rather than a header.

## Notes

The set is the media types that can be attributed, not every value that could be wrong.
A provider inventing `application/id-token+jwt` is unaffected, which is the intended
trade: no registry entry means no attribution, and refusing on a guess is how an
allowlist locks out a working deployment.

#1175 asked that a direction found to be accepted not have its acceptance pinned, and
held both of its rows for this. Both are now refusals, so those rows can be written
against real behaviour.
