### PR TITLE
Export one account's SSO linkages on their own endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   disclaimer text; provider names and labels are HTML-encoded. Per provider,
   **Hide login button** omits one provider's button and **Login button text**
   overrides its label.
+- **An export of one account's SSO linkages (#1091).** A new administrator-only
+  endpoint, `GET /SSO/Links/Export/{jellyfinUserId}`, returns every OpenID and
+  SAML linkage held for one Jellyfin account in a single document, in the same
+  shape the whole-table export already produces. Answering an access request
+  previously meant either two calls per protocol against the per-user listings
+  or exporting the whole link table and redacting every other account by hand.
+  The document names the account by username rather than by its internal id and
+  carries no provider secret, signing key or token; an account that exists but
+  holds no linkage exports an empty document, which is a different answer from
+  the 404 an unknown id returns. The endpoint is rate-limited under a budget of
+  its own, so an administrator session cannot be used to walk the user table one
+  id at a time, and the throttle is applied before the account lookup so the
+  404 cannot be used to test for an account either.
 
 ### Changed
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -1312,7 +1312,7 @@ public class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 14;
+        const int expectedTypedCallSites = 15;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);
@@ -2795,6 +2795,9 @@ public class ArchitectureConformanceTests
         "SAML/Logout/{provider}", "SAML/ImportMetadata", "SAML/Auth/{provider}",
         "Unregister/{username}", "{mode}/Link/{provider}/{jellyfinUserId}",
         "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}",
+        // The per-subject link export (#1091): elevation-gated and read-only, but it answers per user id,
+        // so an unthrottled one is a user-table enumeration an administrator can drive in a loop.
+        "Links/Export/{jellyfinUserId}",
     };
 
     // Routes deliberately NOT rate-limited, each with the reason it is safe: an elevation-gated admin

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -40,7 +40,7 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     {
         "OidAdd", "OidDel", "OidProviders", "OidTest", "OidStates",
         "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
-        "ExportConfig", "ImportConfig", "Unregister", "ExportLinks",
+        "ExportConfig", "ImportConfig", "Unregister", "ExportLinks", "ExportUserLinks",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.
         "EnableSsoOnly", "DisableSsoOnly", "DesignateBreakGlassAdmin", "SsoOnlyStatus",
         // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for

--- a/SSO-Auth.Tests/Http/SSOControllerExportUserLinksTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerExportUserLinksTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the per-subject link export (#1091). The document shape and the builder's own rules
+/// belong to <see cref="LinkExportTests"/> and <see cref="SSOControllerExportLinksTests"/>; what these pin is
+/// the property that makes this endpoint worth having separately from the whole-table export - it answers for
+/// the requested account and for nobody else. An operator producing a data-subject access response must not
+/// have to receive every other account's linkages and redact them by hand, and a filter that leaked one
+/// neighbouring row would defeat the reason the route exists.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerExportUserLinksTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Bob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+
+    [Fact]
+    public void TheExport_CarriesBothProtocolsForTheRequestedAccount()
+    {
+        var harness = Harness();
+        harness.UserManager.GetUserById(Alice).Returns(TestUsers.Named("alice", Alice));
+
+        var document = Document(harness.Controller.ExportUserLinks(Alice));
+
+        Assert.Equal(LinkExport.FormatVersion, document.FormatVersion);
+        Assert.Equal(
+            new[] { ("OpenID", "idp", "sub-alice"), ("SAML", "adfs", "alice@example.test") },
+            document.Links
+                .Select(link => (link.Protocol!, link.Provider!, link.CanonicalName!))
+                .OrderBy(entry => entry.Item1, StringComparer.Ordinal)
+                .ToArray());
+        Assert.All(document.Links, link => Assert.Equal("alice", link.Username));
+    }
+
+    [Fact]
+    public void AnotherAccountsLinks_AreAbsent()
+    {
+        // The whole point of the per-subject route. Bob's account resolves perfectly well through the same
+        // user manager, so nothing about the environment excludes his row - only the requested id does.
+        var harness = Harness();
+        harness.UserManager.GetUserById(Alice).Returns(TestUsers.Named("alice", Alice));
+        harness.UserManager.GetUserById(Bob).Returns(TestUsers.Named("bob", Bob));
+
+        var document = Document(harness.Controller.ExportUserLinks(Alice));
+
+        Assert.DoesNotContain("sub-bob", document.Links.Select(link => link.CanonicalName));
+        Assert.Equal(2, document.Links.Count);
+    }
+
+    [Fact]
+    public void AnAccountWithNoLinks_ExportsAnEmptyDocument()
+    {
+        // "We hold nothing for this person" is an answer an access request needs, and it is not the same
+        // answer as "no such account" - an empty document is the honest one, not a 404.
+        var harness = Harness();
+        var unlinked = Guid.Parse("c0ffee00-0000-0000-0000-000000000003");
+        harness.UserManager.GetUserById(unlinked).Returns(TestUsers.Named("carol", unlinked));
+
+        var document = Document(harness.Controller.ExportUserLinks(unlinked));
+
+        Assert.Empty(document.Links);
+    }
+
+    [Fact]
+    public void AnUnknownUserId_IsNotFound()
+    {
+        // The harness's user manager answers null for an id it was never told about. Exporting an empty
+        // document for it would tell an operator the account holds no linkages, when the truth is that the
+        // account does not exist.
+        var harness = Harness();
+
+        Assert.IsType<NotFoundObjectResult>(harness.Controller.ExportUserLinks(Bob));
+    }
+
+    private static LinkExportDocument Document(ActionResult result) =>
+        Assert.IsType<LinkExportDocument>(Assert.IsType<OkObjectResult>(result).Value);
+
+    private static SsoControllerHarness Harness()
+    {
+        return new SsoControllerHarness(configuration =>
+        {
+            configuration.OidConfigs["idp"] = new OidConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = Alice, ["sub-bob"] = Bob },
+            };
+            configuration.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice@example.test"] = Alice },
+            };
+        });
+    }
+}

--- a/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerRateLimitTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.SSO_Auth.Api;
@@ -124,6 +125,19 @@ public class SSOControllerRateLimitTests
         await harness.Controller.SamlAuth("does-not-exist", new AuthResponse());
 
         AssertThrottled(harness, await harness.Controller.SamlAuth("does-not-exist", new AuthResponse()));
+    }
+
+    [Fact]
+    public void ExportUserLinks_OverRateLimit_Returns429()
+    {
+        // #1091. The gate is what stops an administrator's session, borrowed or scripted, from walking the
+        // whole user table one id at a time - the endpoint answers per user id and its 404 is an existence
+        // signal, so the throttle has to fire before the lookup, not after it.
+        var harness = Throttling(IPAddress.Parse("8.8.8.9"));
+
+        harness.Controller.ExportUserLinks(Guid.Parse("00000000-0000-0000-0000-0000000000ff"));
+
+        AssertThrottled(harness, harness.Controller.ExportUserLinks(Guid.Parse("00000000-0000-0000-0000-0000000000fe")));
     }
 
     [Fact]

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1344,6 +1344,48 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Exports the SSO linkages held for ONE Jellyfin account, across both protocols, as the same document
+    /// shape <c>Config/Links/Export</c> produces (#1091). Requires administrator privileges. Read-only - it
+    /// changes nothing.
+    /// </summary>
+    /// <remarks>
+    /// The per-subject counterpart to the whole-table export, and the reason it is a separate route rather
+    /// than a filter on the existing one: an operator answering a data-subject access request must be able
+    /// to produce that subject's linkages WITHOUT handling every other account's, which the whole-table
+    /// document would force them to do and then redact by hand. The two protocol-specific listings
+    /// (<c>saml/links/{jellyfinUserId}</c>, <c>oid/links/{jellyfinUserId}</c>) answer for one protocol each
+    /// and are unthrottled; this answers for both at once and is throttled, because it is the surface an
+    /// authenticated administrator is most likely to drive in a loop over the whole user list.
+    /// </remarks>
+    /// <param name="jellyfinUserId">The Jellyfin user id to export the linkages of.</param>
+    /// <returns>The link export document for that account, or 404 when no such account exists.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Links/Export/{jellyfinUserId}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult ExportUserLinks(Guid jellyfinUserId)
+    {
+        // Throttle before the account lookup, exactly as Unregister does: the 404 an unknown id produces is
+        // an existence answer, and an unthrottled one would enumerate the user table for an administrator
+        // whose elevation was borrowed rather than earned.
+        if (RateLimitCheck(SsoRateLimitClass.Export) is { } throttled)
+        {
+            return throttled;
+        }
+
+        if (_userManager.GetUserById(jellyfinUserId)?.Username is not { } username)
+        {
+            return NotFound("No Jellyfin account exists with that user id.");
+        }
+
+        // The export is the whole-table builder with a resolver that answers for this one id and null for
+        // every other, so the filtering falls out of the rule that already drops a link no account resolves
+        // to - there is no second walk of the link maps to keep in step with the first. Resolved once here
+        // rather than inside the lambda so the user manager is not called under the config lock.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(
+            live => LinkExport.Build(live, userId => userId == jellyfinUserId ? username : null)));
+    }
+
+    /// <summary>
     /// Imports a configuration export document into this instance (#161). Requires administrator privileges.
     /// The import is a fail-closed MERGE: the document is validated through the same ProviderConfigValidator
     /// the config-page save uses, and only if the whole document is valid is it merged - atomically, through

--- a/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
+++ b/SSO-Auth/Api/Shared/SsoRateLimitClass.cs
@@ -43,4 +43,12 @@ internal static class SsoRateLimitClass
 
     /// <summary>The anonymous inbound SAML <c>LogoutRequest</c> Single Logout surface (#727, SLO-3b). (The authenticated OIDC RP-initiated logout route is caller-scoped and not rate-limited today.)</summary>
     internal const string Logout = "logout";
+
+    /// <summary>
+    /// The elevation-gated per-subject link export (#1091). Its own budget rather than a share of
+    /// <see cref="Unregister"/>'s: the export is a read an operator may run repeatedly while servicing an
+    /// access request, and spending the revoke budget on it would throttle the one write an administrator
+    /// needs during an incident.
+    /// </summary>
+    internal const string Export = "export";
 }


### PR DESCRIPTION
# What & why

Closes #1091.

Answering a data-subject access request for one Jellyfin account meant either two
calls against the per-protocol listings (`SSO/oid/links/{id}` and
`SSO/saml/links/{id}`) or taking the whole-table export added by #1126 and
redacting every other account by hand. The second is the shape that goes wrong:
the operator handles every other data subject's linkages in order to disclose one
person's.

`GET /SSO/Links/Export/{jellyfinUserId}` returns every OpenID and SAML linkage
held for one account, in the same document shape `Config/Links/Export` already
produces. It reuses that builder with a resolver answering for the requested id
and null for every other, so the filtering falls out of the rule that already
drops a link no account resolves to, and there is no second walk of the link maps
to keep in step with the first.

Behaviour, and where each part is pinned:

- Elevation-gated. `ExportUserLinks` is registered in the known elevation surface
  in `SSOControllerAuthorizationTests`, so the live routing-table battery drives
  401 unauthenticated and 403 authenticated-non-admin against it, and
  `CoversExactlyTheKnownElevationSurface` fails if the guard is later dropped.
- Rate-limited under `SsoRateLimitClass.Export`, a budget of its own rather than a
  share of the revoke budget, so a read run in a loop cannot starve the one write
  an administrator needs during an incident.
- The throttle runs BEFORE the account lookup. The 404 an unknown id returns is an
  existence answer, and an unthrottled one would enumerate the user table for a
  borrowed administrator session.
- An account that exists but holds no linkage exports an empty document. That is a
  different answer from the 404, and the honest one for an access request.
- The document names the account by username rather than by its internal id, and
  its type carries no field a provider secret, signing key or token could ride in.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing on the login path changed. The new
      endpoint is a read; it validates no assertion and mints no session.
- [x] No secrets logged; secrets are redacted on config export. The endpoint logs
      nothing, and `LinkExportDocument` has no field a secret could reach.
- [ ] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline. **No second reader ran on this
      change.** The evidence below stands in place of one, and this line is not to
      be ticked on the strength of it.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised. Not applicable - no review record
      exists, per the line above.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The filter is one lambda over the existing `LinkExport.Build`.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and the new route is classified:
      `MustThrottleRoutes` gains `Links/Export/{jellyfinUserId}`, and the typed
      call-site sentinel moves 14 -> 15.
- [x] Docs impact considered: the CHANGELOG entry is included. The issue also asks
      for the `docs/PRIVACY.md` runbook line to be repointed at this endpoint;
      `docs/` is git-ignored below `README.md` and `SECURITY-REMEDIATION-POLICY.md`
      (`.gitignore:469-471`) and no `docs/PRIVACY.md` exists in the tree, so no
      such edit can appear in a diff. See Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks,
      0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q

- [x] `dotnet test` is green:

      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
      Total: 2983, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
      ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
      Total: 2984, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

      The four skips are the pre-existing off-loopback bind tests (#1227), which
      need an elevation prompt on Windows and were not run.

      These numbers were measured at `86dd99d`, the head after `origin/main` was
      merged in to clear a `CHANGELOG.md` conflict. The conflict was two Unreleased
      entries added at the same anchor, #1093's and this one's, and the resolution
      keeps both. The build and both suites above were re-run at that merged head,
      not at the head that was pushed first.

- [x] Prettier is clean for the `.md` change: `npx prettier --check CHANGELOG.md`
      reports "All matched files use Prettier code style!".

## Notes

Each guard was proved by deleting it and re-running the suite:

| removed                                          | goes red                                                                   |
| ------------------------------------------------ | -------------------------------------------------------------------------- |
| the `RateLimitCheck` call                        | `ExportUserLinks_OverRateLimit_Returns429`, `EveryMustThrottleEndpoint_CallsTheRateLimitGate` |
| the filtering resolver, replaced by the table one | `AnotherAccountsLinks_AreAbsent`                                           |
| the 404, replaced by an empty document           | `AnUnknownUserId_IsNotFound`                                               |

Out of scope, and deliberately: the `docs/PRIVACY.md` line the issue asks to
repoint. That file is not in the tree and cannot be, so the sentence naming this
endpoint has to be written wherever that runbook is actually kept. Nothing here
depends on it.

The route sits at `Links/Export/{jellyfinUserId}` rather than under `Config/`,
where the whole-table export lives. `Config/Links/Export` is part of the transfer
and migration surface and its document is meant to be restored somewhere; this one
is a disclosure about one person and should not read as a migration artefact.

