### PR TITLE
List every linked account on one administrator endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   disclaimer text; provider names and labels are HTML-encoded. Per provider,
   **Hide login button** omits one provider's button and **Login button text**
   overrides its label.
+- **A linked-account roster for administrators (#1119).** A new
+  administrator-only endpoint, `GET /SSO/Links/Roster`, lists every Jellyfin
+  account that holds an SSO link, with the provider and canonical name behind
+  each one, in a single read. Finding out _which_ accounts were linked
+  previously meant walking the whole Jellyfin user list and asking the per-user
+  listings one request at a time. An account linked to several providers is one
+  row carrying several links, and a link whose account has since been deleted is
+  reported as an orphan rather than dropped, which is the one place that state is
+  visible at all. The roster is assembled from the link maps alone, so no
+  provider secret, signing key or certificate can appear in it.
 
 ### Changed
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -2810,6 +2810,7 @@ public class ArchitectureConformanceTests
         "Config/Export", "Config/Import", // elevated config transfer
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
         "Config/Links/Export", // elevated read-only link snapshot (#1126), in-memory, no outbound fetch
+        "Links/Roster", // elevated read-only link roster (#1119), in-memory, no outbound fetch, takes no caller-supplied id
         "saml/links/{jellyfinUserId}", "oid/links/{jellyfinUserId}", // authenticated link listings
         "SSO-Managed/Status/{jellyfinUserId}", // elevated read-only account report (#1136), in-memory, no outbound fetch
         "{viewName}", // SSOViewsController: read-only embedded static asset (ETag/304), no I/O, no login path

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -46,6 +46,9 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The per-account SSO-managed report (#1136): read-only, and elevation-gated because it answers for
         // an account other than the caller's.
         "SsoManagedStatus",
+        // The linked-account roster (#1119): read-only, and elevation-gated because it names every linked
+        // account on the server.
+        "LinkedAccountRoster",
     };
 
     // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) - the canonical

--- a/SSO-Auth.Tests/Http/SSOControllerLinkRosterTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerLinkRosterTests.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the linked-account roster (#1119). Two properties carry the endpoint: an account
+/// linked to several providers is ONE row rather than one row per link, and a link whose user id resolves
+/// to no account is reported rather than dropped. The second is what separates this document from the
+/// portable export, which drops exactly that row on purpose, so it is asserted here rather than left to be
+/// inferred from the builder they share.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerLinkRosterTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Bob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+    private static readonly Guid Ghost = Guid.Parse("9057c000-0000-0000-0000-000000000003");
+
+    [Fact]
+    public void AnAccountLinkedToTwoProviders_IsOneRowWithTwoLinks()
+    {
+        var harness = Harness();
+        Know(harness, Alice, "alice");
+        Know(harness, Bob, "bob");
+
+        var alice = Assert.Single(Roster(harness).Accounts, account => account.UserId == Alice);
+
+        Assert.Equal("alice", alice.Username);
+        Assert.True(alice.AccountExists);
+        Assert.Equal(
+            new[] { ("OpenID", "idp", "sub-alice"), ("SAML", "adfs", "alice@example.test") },
+            alice.Links
+                .Select(link => (link.Protocol!, link.Provider!, link.CanonicalName!))
+                .OrderBy(entry => entry.Item1, StringComparer.Ordinal)
+                .ToArray());
+    }
+
+    [Fact]
+    public void AnAccountWithNoLink_IsAbsent()
+    {
+        // The roster answers "who is linked". A server's whole user list is not the answer, and an
+        // administrator reading one to find the other is the work this endpoint exists to remove.
+        var harness = Harness();
+        Know(harness, Alice, "alice");
+        Know(harness, Bob, "bob");
+        var unlinked = Guid.Parse("c0ffee00-0000-0000-0000-000000000004");
+        Know(harness, unlinked, "carol");
+
+        Assert.DoesNotContain(unlinked, Roster(harness).Accounts.Select(account => account.UserId));
+    }
+
+    [Fact]
+    public void ALinkTheUserManagerNoLongerKnows_IsReportedNotDropped()
+    {
+        // The harness's user manager answers null for an id it was never told about, which is the state a
+        // deleted account leaves behind. Dropping the row would hide the one thing no other surface shows.
+        var harness = Harness(withGhost: true);
+        Know(harness, Alice, "alice");
+        Know(harness, Bob, "bob");
+
+        var ghost = Assert.Single(Roster(harness).Accounts, account => account.UserId == Ghost);
+
+        Assert.False(ghost.AccountExists);
+        Assert.Null(ghost.Username);
+        Assert.Equal("sub-ghost", Assert.Single(ghost.Links).CanonicalName);
+    }
+
+    [Fact]
+    public void TheRosterCarriesNoProviderConfiguration()
+    {
+        // The roster is assembled from the link maps alone. Nothing copies a provider field, so a client
+        // secret cannot ride along - this pins that the seeded secret is nowhere in the serialized answer,
+        // which is the form a leak would actually take.
+        var harness = Harness(secret: "super-secret-value");
+        Know(harness, Alice, "alice");
+        Know(harness, Bob, "bob");
+
+        var json = System.Text.Json.JsonSerializer.Serialize(Roster(harness));
+
+        Assert.DoesNotContain("super-secret-value", json, StringComparison.Ordinal);
+    }
+
+    private static LinkRosterDocument Roster(SsoControllerHarness harness) =>
+        Assert.IsType<LinkRosterDocument>(Assert.IsType<OkObjectResult>(harness.Controller.LinkedAccountRoster()).Value);
+
+    private static void Know(SsoControllerHarness harness, Guid id, string name) =>
+        harness.UserManager.GetUserById(id).Returns(TestUsers.Named(name, id));
+
+    private static SsoControllerHarness Harness(bool withGhost = false, string? secret = null)
+    {
+        return new SsoControllerHarness(configuration =>
+        {
+            var oidLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = Alice, ["sub-bob"] = Bob };
+            if (withGhost)
+            {
+                oidLinks["sub-ghost"] = Ghost;
+            }
+
+            configuration.OidConfigs["idp"] = new OidConfig
+            {
+                Enabled = true,
+                OidSecret = secret,
+                CanonicalLinks = oidLinks,
+            };
+            configuration.SamlConfigs["adfs"] = new SamlConfig
+            {
+                Enabled = true,
+                CanonicalLinks = new SerializableDictionary<string, Guid> { ["alice@example.test"] = Alice },
+            };
+        });
+    }
+}

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1344,6 +1344,31 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Lists every Jellyfin account that holds an SSO link, with the provider and canonical name behind
+    /// each link (#1119). Requires administrator privileges. Read-only - it changes nothing.
+    /// </summary>
+    /// <remarks>
+    /// The per-user listings (<c>saml/links/{jellyfinUserId}</c>, <c>oid/links/{jellyfinUserId}</c>) answer
+    /// only for an id the caller already has, so finding out WHICH accounts are linked meant walking the
+    /// whole Jellyfin user list one request at a time. This answers that question in one read. Unlike the
+    /// portable export it reports a link whose user id resolves to no account rather than dropping it: an
+    /// orphaned link is left behind by a deleted account and is the thing an administrator opens this to
+    /// find, and it is invisible from every other surface.
+    /// </remarks>
+    /// <returns>The linked-account roster.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("Links/Roster")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult LinkedAccountRoster()
+    {
+        // Snapshot under the config lock so the two protocols' link maps are inverted against each other
+        // atomically; the document that leaves the lock holds only strings and ids, so the JSON formatter
+        // cannot tear against a concurrent login writing a link.
+        return Ok(SSOPlugin.Instance.ReadConfiguration(
+            live => LinkRoster.Build(live, userId => _userManager.GetUserById(userId)?.Username)));
+    }
+
+    /// <summary>
     /// Imports a configuration export document into this instance (#161). Requires administrator privileges.
     /// The import is a fail-closed MERGE: the document is validated through the same ProviderConfigValidator
     /// the config-page save uses, and only if the whole document is valid is it merged - atomically, through

--- a/SSO-Auth/Config/LinkExport.cs
+++ b/SSO-Auth/Config/LinkExport.cs
@@ -7,6 +7,19 @@ using System.Collections.Generic;
 namespace Jellyfin.Plugin.SSO_Auth.Config;
 
 /// <summary>
+/// One canonical link exactly as the configuration holds it, before any decision about what a reader of it
+/// is allowed to see (#1119). It is the single walk of the two link maps; every document assembled from
+/// those maps projects from this sequence rather than repeating the walk, so a provider shape the walk
+/// learns to skip is skipped for all of them at once.
+/// </summary>
+/// <param name="Protocol">The protocol the provider speaks.</param>
+/// <param name="Provider">The provider the link belongs to.</param>
+/// <param name="CanonicalName">The identity key the link is stored under.</param>
+/// <param name="UserId">The Jellyfin user id the link points at, which may no longer resolve to an account.</param>
+/// <param name="Issuer">The issuer this OpenID link is bound to (#186), or null for SAML and for links written before the binding existed.</param>
+internal readonly record struct CanonicalLinkRow(string Protocol, string Provider, string CanonicalName, Guid UserId, string? Issuer);
+
+/// <summary>
 /// Builds the portable account-link snapshot (#1126). It reads the two link maps and resolves each
 /// Jellyfin user id to a username, which is the whole of the transformation: the id is what a rebuilt user
 /// database destroys, and the username is what survives it.
@@ -25,8 +38,47 @@ internal static class LinkExport
     /// </summary>
     internal const int FormatVersion = 1;
 
-    private const string OpenIdProtocol = "OpenID";
-    private const string SamlProtocol = "SAML";
+    /// <summary>The protocol name an OpenID link is reported under.</summary>
+    internal const string OpenIdProtocol = "OpenID";
+
+    /// <summary>The protocol name a SAML link is reported under.</summary>
+    internal const string SamlProtocol = "SAML";
+
+    /// <summary>
+    /// Walks both protocols' canonical-link maps once, in a fixed order (every OpenID link, then every
+    /// SAML link). Call it under the config lock (through <c>ReadConfiguration</c>) so the two maps are
+    /// read atomically against each other.
+    /// </summary>
+    /// <param name="live">The live plugin configuration to walk.</param>
+    /// <returns>Every canonical link the configuration holds.</returns>
+    internal static IEnumerable<CanonicalLinkRow> Rows(PluginConfiguration live)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+
+        foreach (var (provider, config) in Providers(live.OidConfigs))
+        {
+            foreach (var link in config.CanonicalLinks)
+            {
+                // The issuer binding is keyed by the same canonical name as the link (#186). A link
+                // written before the binding existed has no entry, and null is the honest answer for it
+                // rather than the provider's currently configured issuer, which was never what bound it.
+                yield return new CanonicalLinkRow(
+                    OpenIdProtocol,
+                    provider,
+                    link.Key,
+                    link.Value,
+                    config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null);
+            }
+        }
+
+        foreach (var (provider, config) in Providers(live.SamlConfigs))
+        {
+            foreach (var link in config.CanonicalLinks)
+            {
+                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null);
+            }
+        }
+    }
 
     /// <summary>
     /// Builds the link document from the live configuration. Call it under the config lock (through
@@ -44,49 +96,24 @@ internal static class LinkExport
 
         var document = new LinkExportDocument { FormatVersion = FormatVersion };
 
-        foreach (var (provider, config) in Providers(live.OidConfigs))
+        foreach (var row in Rows(live))
         {
-            foreach (var link in config.CanonicalLinks)
+            // A link pointing at an account that no longer exists is dangling: exporting it would put a
+            // row in the document that nothing could ever be restored to, and a restore that silently
+            // dropped it would differ from the document it claimed to apply. Drop it here, once.
+            if (resolveUsername(row.UserId) is not { } username)
             {
-                // A link pointing at an account that no longer exists is dangling: exporting it would put a
-                // row in the document that nothing could ever be restored to, and a restore that silently
-                // dropped it would differ from the document it claimed to apply. Drop it here, once.
-                if (resolveUsername(link.Value) is not { } username)
-                {
-                    continue;
-                }
-
-                document.Links.Add(new LinkExportEntry
-                {
-                    Protocol = OpenIdProtocol,
-                    Provider = provider,
-                    CanonicalName = link.Key,
-                    Username = username,
-                    // The issuer binding is keyed by the same canonical name as the link (#186). A link
-                    // written before the binding existed has no entry, and null is the honest answer for it
-                    // rather than the provider's currently configured issuer, which was never what bound it.
-                    Issuer = config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null,
-                });
+                continue;
             }
-        }
 
-        foreach (var (provider, config) in Providers(live.SamlConfigs))
-        {
-            foreach (var link in config.CanonicalLinks)
+            document.Links.Add(new LinkExportEntry
             {
-                if (resolveUsername(link.Value) is not { } username)
-                {
-                    continue;
-                }
-
-                document.Links.Add(new LinkExportEntry
-                {
-                    Protocol = SamlProtocol,
-                    Provider = provider,
-                    CanonicalName = link.Key,
-                    Username = username,
-                });
-            }
+                Protocol = row.Protocol,
+                Provider = row.Provider,
+                CanonicalName = row.CanonicalName,
+                Username = username,
+                Issuer = row.Issuer,
+            });
         }
 
         return document;

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Inverts the canonical-link maps into the administrator's roster (#1119): the maps are stored per
+/// provider, keyed by identity, and the question an administrator asks is the other way round - which
+/// accounts are linked, and to what.
+/// </summary>
+/// <remarks>
+/// It walks the same <see cref="LinkExport.Rows"/> sequence the portable export does, so the two cannot
+/// disagree about which providers are readable or which links exist. What differs is what each does with a
+/// link whose user id resolves to no account: the export drops it, because nothing could restore it, and
+/// this keeps it, because an orphaned link is exactly what an administrator opens the roster to find. As
+/// with the export, no provider configuration field is copied, so no client secret, signing key or
+/// certificate can reach the output by construction.
+/// </remarks>
+internal static class LinkRoster
+{
+    /// <summary>
+    /// Builds the roster from the live configuration. Call it under the config lock (through
+    /// <c>ReadConfiguration</c>) so both link maps are read atomically against each other.
+    /// </summary>
+    /// <param name="live">The live plugin configuration to read.</param>
+    /// <param name="resolveUsername">Resolves a Jellyfin user id to its username, or null when no such account exists.</param>
+    /// <returns>The roster document.</returns>
+    internal static LinkRosterDocument Build(PluginConfiguration live, Func<Guid, string?> resolveUsername)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        ArgumentNullException.ThrowIfNull(resolveUsername);
+
+        var document = new LinkRosterDocument();
+        var byUser = new Dictionary<Guid, LinkedAccount>();
+
+        foreach (var row in LinkExport.Rows(live))
+        {
+            if (!byUser.TryGetValue(row.UserId, out var account))
+            {
+                // Resolved once per account rather than once per link: an account linked to four providers
+                // is one user-manager read, and the answer cannot differ between its own rows.
+                var username = resolveUsername(row.UserId);
+                account = new LinkedAccount
+                {
+                    UserId = row.UserId,
+                    Username = username,
+                    AccountExists = username is not null,
+                };
+                byUser[row.UserId] = account;
+
+                // Added on first sight, so the accounts come out in the order their first link is walked
+                // and a reader gets a stable list rather than a dictionary's enumeration order.
+                document.Accounts.Add(account);
+            }
+
+            account.Links.Add(new LinkedAccountEntry
+            {
+                Protocol = row.Protocol,
+                Provider = row.Provider,
+                CanonicalName = row.CanonicalName,
+            });
+        }
+
+        return document;
+    }
+}

--- a/SSO-Auth/Config/LinkRosterDocument.cs
+++ b/SSO-Auth/Config/LinkRosterDocument.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.ObjectModel;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// The administrator's view of every Jellyfin account that holds an SSO link (#1119), one row per account
+/// rather than one per link, so an account linked to two providers reads as one account with two links.
+/// </summary>
+/// <remarks>
+/// Deliberately not the same document as <see cref="LinkExportDocument"/>, and the difference is the point
+/// rather than an oversight. That one is a portable snapshot meant to be restored somewhere, so it is keyed
+/// by username and drops a link whose user id resolves to nothing. This one is a report on the state of
+/// THIS server, where a link pointing at an account that no longer exists is the single most useful thing
+/// it can show, so it carries the user id and reports the account as absent instead of dropping the row.
+/// It is a JSON-only transport shape and is never persisted to the config XML, so it carries no
+/// XML-serialization attributes.
+/// </remarks>
+public class LinkRosterDocument
+{
+    /// <summary>
+    /// Gets the linked accounts, one entry per Jellyfin user id that at least one canonical link points
+    /// at. An account holding no link is absent: the roster answers "who is linked", and listing every
+    /// unlinked account would bury that answer under the whole user table.
+    /// </summary>
+    public Collection<LinkedAccount> Accounts { get; } = new();
+}
+
+/// <summary>
+/// One Jellyfin account and every SSO link that resolves to it.
+/// </summary>
+public class LinkedAccount
+{
+    /// <summary>
+    /// Gets or sets the Jellyfin user id the links are stored against. It is the only identifier an
+    /// orphaned row has, and the value an administrator needs in order to act on one.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the account's display name, or null when no account with this id exists any more.
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an account with this id still exists. An orphaned link is
+    /// reported rather than dropped, and this flag is what says so: a null username alone would read as a
+    /// nameless account rather than an absent one.
+    /// </summary>
+    public bool AccountExists { get; set; }
+
+    /// <summary>Gets the links resolving to this account, across both protocols and every provider.</summary>
+    public Collection<LinkedAccountEntry> Links { get; } = new();
+}
+
+/// <summary>
+/// One link on a roster row: which provider issued the identity, and the canonical name it is known by.
+/// </summary>
+public class LinkedAccountEntry
+{
+    /// <summary>
+    /// Gets or sets the protocol the provider speaks. The two protocols keep separate provider namespaces,
+    /// so an entry naming only the provider would be ambiguous on a server where an OpenID and a SAML
+    /// provider share a name.
+    /// </summary>
+    public string? Protocol { get; set; }
+
+    /// <summary>Gets or sets the provider this link belongs to.</summary>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Gets or sets the canonical name the link is keyed by: the identity provider's stable subject for
+    /// this user, or the username it fell back to for a link made before subjects were required.
+    /// </summary>
+    public string? CanonicalName { get; set; }
+}


### PR DESCRIPTION
# What & why

Closes #1119.

The only link-read surface was per-user: `SSO/oid/links/{id}` and
`SSO/saml/links/{id}` answer for an id the caller already has. Finding out _which_
accounts hold an SSO link therefore meant walking the whole Jellyfin user list and
asking once per account, which is why an administrator ends up reading logs or
scripting the API instead.

`GET /SSO/Links/Roster` inverts both providers' link maps in one read: one row per
Jellyfin account, carrying every link that resolves to it across both protocols.

The walk itself is not new code. `LinkExport` already walked the same two maps for
the portable export (#1126), so that walk becomes one sequence (`LinkExport.Rows`)
that both documents project from, rather than a second copy that would drift from
the first. The projections differ in exactly one decision, and it is the decision
that makes this endpoint worth having:

- the portable export DROPS a link whose user id resolves to no account, because
  nothing could restore such a row;
- the roster KEEPS it and marks the account absent, because an orphaned link left
  behind by a deleted account is invisible from every other surface, and is what an
  administrator opens the roster to find.

Deviation from the issue's "where it lives": the aggregate read is asked for on
`CanonicalLinkService`, next to `LinksByUser`. It went beside `LinkExport` in
`Config/` instead, because that is where the identical whole-table walk already
lives, and putting a second one on the service is the duplication the reuse above
removes. The lock discipline the issue asks for is unchanged - it is called through
`ReadConfiguration`, exactly as `ExportLinks` is.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved. Nothing on the login path changed; the endpoint is a
      read that validates no assertion and mints no session. A provider stored with
      a null config object is skipped rather than dereferenced, unchanged from the
      walk it inherits.
- [x] No secrets logged; secrets are redacted on config export. The roster is
      assembled from the canonical-link maps alone, so no provider field can reach
      it. `TheRosterCarriesNoProviderConfiguration` seeds an `OidSecret` and asserts
      it is absent from the serialized answer.
- [ ] A security review was performed for changes to SAML/OIDC validation, config
      persistence, or the release pipeline. **No second reader ran on this change.**
      The evidence below stands in place of one, and this line is not to be ticked
      on the strength of it.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised. Not applicable - no review record
      exists, per the line above.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The change removes a duplicate walk rather than adding one.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318). The
      new types sit in `Config/` beside the sibling document they share a walk with;
      `Http` already imports nothing new.
- [x] Architecture-conformance tests pass, and the new route is classified:
      `Links/Roster` is added to `RateLimitExemptRoutes` with its reason (in-memory,
      no outbound fetch, no caller-supplied id).
- [x] Docs impact considered: the CHANGELOG entry is included. No README or wiki
      page describes the link-read API surface today, so nothing there goes stale.
      The admin UI panel that consumes this is #1121 and is deliberately out of
      scope here.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks,
      0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q

- [x] `dotnet test` is green:

      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
      Total: 2987, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
      ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
      Total: 2988, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

      The four skips are the pre-existing off-loopback bind tests (#1227), which need
      an elevation prompt on Windows and were not run.

      These numbers were measured at `ec498e9`, the head after `origin/main` was
      merged in twice to clear conflicts this branch did not cause. The first
      merge was a `CHANGELOG.md` collision with #1093's Unreleased entry. The
      second came after #1091 landed on `main`: its entry took the same anchor in
      `CHANGELOG.md`, and its endpoint took the same insertion point in
      `SSOController.cs`, directly after `ExportLinks`. Both resolutions keep both
      sides, and the two endpoints are independent methods that share nothing but
      their neighbourhood in the file. The build and both suites above were re-run
      at that merged head, not at the head that was pushed first.

- [x] Prettier is clean for the `.md` change: `npx prettier --check CHANGELOG.md`
      reports "All matched files use Prettier code style!".

## Notes

Each guard was proved by deleting it and re-running the suite:

| removed                                       | goes red                                            |
| --------------------------------------------- | --------------------------------------------------- |
| the orphan row, dropped instead of reported   | `ALinkTheUserManagerNoLongerKnows_IsReportedNotDropped` |
| the per-account collapse, one row per link    | `AnAccountLinkedToTwoProviders_IsOneRowWithTwoLinks` |
| the `[Authorize(RequiresElevation)]` attribute | `CoversExactlyTheKnownElevationSurface`             |

That `LinkExport` keeps its behaviour across the refactor is carried by its own
suite, which was not touched and stays green (`LinkExportTests`,
`SSOControllerExportLinksTests`).

Out of scope, as the issue states: last-SSO-login timestamps (no such field is
persisted), any UI, and revoke (`POST Unregister/{username}` already exists and is
unchanged).

This branch is cut from the same base as the one for #1091, which also adds an
action to the elevation surface list. Whichever lands second needs a one-line
rebase on `ExpectedElevationActions` and on the CHANGELOG's Added section.

