### PR TITLE
Unpack the archive the documented local build actually writes

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -147,11 +147,16 @@ Local Docker must be working. The harness installs the **packaged** plugin, so b
 
 ```sh
 # 1. Build the packaged plugin zip (requires the .NET 9 SDK and JPRM: `pip install jprm`).
-jprm --verbosity=debug plugin build . --output ./artifacts --dotnet-framework net9.0
+#    jprm refuses an output directory that does not exist, and `artifacts/` is git-ignored,
+#    so a clean checkout has to create it. Everything jprm reports goes to stderr except the
+#    path of the archive it wrote, which is its only line of stdout - capture that instead of
+#    naming the file, because the name is derived from `name:` in build.yaml and moves with it.
+mkdir -p ./artifacts
+plugin_zip=$(jprm --verbosity=debug plugin build . --output ./artifacts --dotnet-framework net9.0)
 
 # 2. Unpack it into the Jellyfin plugins directory the compose stack mounts.
 mkdir -p test/e2e/jellyfin/config/plugins/SSO-Auth
-unzip -o ./artifacts/sso-authentication_*.zip -d test/e2e/jellyfin/config/plugins/SSO-Auth
+unzip -o "$plugin_zip" -d test/e2e/jellyfin/config/plugins/SSO-Auth
 chmod -R 0777 test/e2e/jellyfin
 
 # 3. Boot the stack and run the harness (its exit code is the run's exit code).


### PR DESCRIPTION
# What & why

The local end-to-end route in `test/e2e/README.md` copied no plugin into the stack, so the
harness died at its first assertion with a message about the login rather than about the
missing copy. Two things were broken in the same block.

Step 2 unpacked `./artifacts/sso-authentication_*.zip`, a name the build has not written
since the plugin was renamed:

```
$ git show origin/main:build.yaml | grep -n "^name"
1:name: "Community SSO for Jellyfin"
$ jprm --verbosity=debug plugin build . --output ./artifacts --dotnet-framework net9.0
./artifacts\community-sso-for-jellyfin_4.3.0.0.zip
```

The glob matched nothing, the shell passed it through literally, `unzip` failed on a path
that was not there, and step 3 booted Jellyfin anyway. Following the README as written, the
run ends at:

```
harness-1   | FATAL: OID/Add failed (is the plugin loaded? a 404 means it is not)
```

Step 1 also failed before that, on a clean tree. `artifacts/` is git-ignored (`.gitignore:63`),
so a fresh checkout does not have it, and jprm refuses an output directory that is not there:

```
error: [Errno 2] No such file or directory: './artifacts\community-sso-for-jellyfin_4.3.0.0.zip'
```

Step 1 now creates the directory and captures the archive path from jprm's stdout, which
carries that one line and nothing else (everything else it prints goes to stderr, measured by
capturing the two streams separately). Step 2 unpacks what step 1 reported, so the name is
derived from `name:` in `build.yaml` rather than written down a second place the next rename
can invalidate.

The workflow is untouched and needs no change: it already reads the path out of the jprm
action's own output (`.github/workflows/e2e-login.yml`, `ARTIFACT: ${{ steps.jprm.outputs.artifact }}`),
which is why CI stayed green while the documented route did not work.

Closes #1328

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable: the change is four lines of a developer-facing README. It touches no login
path, no crypto, no config persistence and no release pipeline, and no shipped file changes.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change is the docs update.

## Verification

The whole point of this change is that the documented route works, so it was run end to end
from this branch, on this machine, with Docker and a `pip install jprm` in a throwaway venv.
Steps 1 to 4 exactly as the edited README prints them:

```
== step 1 ==
plugin_zip=[./artifacts\community-sso-for-jellyfin_4.3.0.0.zip]
== step 2 ==
unzip exit=0
== step 3 ==
harness-1   | ALL E2E CHECKS PASSED
compose exit=0
```

The same script against the unedited README ends at `unzip exit=9` and the `OID/Add failed`
line quoted above, so the fix is what moved it.

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The two unticked boxes are honest rather than pending: no `.cs` file changes here, so neither
was run for this branch. The Prettier box is ticked on the content and needs its bound stated.
`prettier --check` warns on the working-tree file both before and after this commit, because
`core.autocrlf=true` gives it CRLF on this machine; on the LF bytes CI sees, the edited file
passes:

```
$ sed 's/\r$//' test/e2e/README.md > /tmp/plf/test/e2e/README.md
$ (cd /tmp/plf && npx prettier --check test/e2e/README.md)
Checking formatting...
All matched files use Prettier code style!
```

## Notes

Out of scope, from the issue: the workflow, which is correct as it stands.

The three provider blocks further down the same file that refer to "the plugin drop from step
2" still read correctly; the step numbering did not move.

This section was produced by an automated re-run, not by a second person. No second reader has
looked at this change.
