### PR TITLE
Screen the role claim in the scopes its reader enters

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -4379,6 +4379,12 @@ public class ArchitectureConformanceTests
         // OidcDiscoveryReader.ReadAsync took off a response that came back through RepeatedMemberScreen, so
         // a document naming a member twice was already refused at the transport and never reaches here.
         ["SSO-Auth/Api/Oidc/DiscoveryJson.cs"] = "SSO-Auth/Api/Oidc/RepeatedMemberScreen.cs",
+
+        // The id_token role claim's value. Here the gate is in the reading file itself rather than in a
+        // transport ahead of it: the value arrives as a claim on an already-validated token, so there is no
+        // response for a handler to sit in front of, and the screen runs on the string before Newtonsoft is
+        // consulted at all (#1324).
+        ["SSO-Auth/Api/Oidc/OidcRoleExtractor.cs"] = "SSO-Auth/Api/Oidc/OidcRoleExtractor.cs",
     };
 
     // Sites over bytes the plugin itself shipped or produced, each with the reason it is not provider
@@ -4401,11 +4407,11 @@ public class ArchitectureConformanceTests
     // contents exactly, so closing one of these has to move the entry rather than leave it standing.
     private static readonly SortedDictionary<string, string> UnscreenedUntrustedReads = new(StringComparer.Ordinal)
     {
-        // The role claim's value, straight off the id_token, parsed by Newtonsoft with no repeated-member
-        // check. #1053 is open on exactly this: the screen's Unreadable verdict is fail-closed in the
-        // discovery reader and fail-open here, and deciding what Unreadable MEANS on a privilege path comes
-        // before any code. Until it is decided the site stays visible here rather than filed as trusted.
-        ["SSO-Auth/Api/Oidc/OidcRoleExtractor.cs"] = "the id_token role claim value; the Unreadable-on-a-privilege-path decision is #1053",
+        // EMPTY, and that is a state this rule has to hold rather than a reason to delete the table. The one
+        // entry it carried was the role claim's value, disclosed here while #1053 decided what an unreadable
+        // document means on a privilege path; #1324 put the screen in front of it and the entry moved up to
+        // the gated table. An empty disclosure is the honest reading of the tree today, and the next
+        // unscreened read has a table to land in instead of a decision to re-open.
     };
 
     /// <summary>

--- a/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAuthorizeStateBuilderTests.cs
@@ -866,23 +866,47 @@ public class OidcAuthorizeStateBuilderTests
     // --- the refused-role-claim audit trail (#1149) ---
 
     [Fact]
-    public void AValueThatIsNotJson_AndAPathThatDoesNotResolve_AreAuditedApartByReasonCode()
+    public void AnUnreadableValue_AndAPathThatDoesNotResolve_AreAuditedApartByReasonCode()
     {
         // The whole point of the trail. Both logins end with no roles, and under a configured allow-list
         // both are denied, so from the operator's side they are one symptom with two very different causes:
-        // a provider sending something other than JSON, and a role-claim path that does not match what the
-        // provider actually emits. One entry each, and the codes must differ - a trail that gave both the
+        // a provider sending something the screen cannot read, and a role-claim path that does not match what
+        // the provider actually emits. One entry each, and the codes must differ - a trail that gave both the
         // same code would be no better than the empty role set they already share.
-        var notJson = Audit(c => c.RoleClaim = "realm_access.roles", ("realm_access", "not-json-at-all"));
+        var unreadable = Audit(c => c.RoleClaim = "realm_access.roles", ("realm_access", "not-json-at-all"));
         var unresolved = Audit(c => c.RoleClaim = "realm_access.missing", ("realm_access", "{\"roles\":[\"a\"]}"));
 
-        var first = Assert.Single(notJson.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
+        var first = Assert.Single(unreadable.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
         var second = Assert.Single(unresolved.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
 
         Assert.Equal(LogLevel.Warning, first.Level);
-        Assert.Contains(OidcRoleExtractor.Outcome.ValueNotJson.ToString(), first.Message, StringComparison.Ordinal);
+        Assert.Contains(OidcRoleExtractor.Outcome.Unreadable.ToString(), first.Message, StringComparison.Ordinal);
         Assert.Contains(OidcRoleExtractor.Outcome.PathNotResolved.ToString(), second.Message, StringComparison.Ordinal);
         Assert.DoesNotContain(OidcRoleExtractor.Outcome.PathNotResolved.ToString(), first.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ARepeatedRoleMember_ReachesTheOperatorAsItsOwnReasonCode()
+    {
+        // A repeat is the one refusal an operator cannot diagnose from the outside: the document looks fine,
+        // the path is right, and the login is simply denied. It gets its own code rather than sharing
+        // Unreadable's, because the two ask for different actions - one is a provider serving bytes nobody can
+        // read, the other is a provider serving a document that means two things (#1324).
+        // The repeated member is named distinctively rather than being the role member itself, so the last
+        // assertion is about a string that could only have come from the claim value.
+        const string ProviderAuthoredName = "zzRepeatedMemberMarkerzz";
+        var repeated = Audit(
+            c => c.RoleClaim = "realm_access.roles",
+            ("realm_access", "{\"roles\":[\"a\"],\"" + ProviderAuthoredName + "\":1,\"" + ProviderAuthoredName + "\":2}"));
+
+        var entry = Assert.Single(repeated.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal));
+
+        Assert.Contains(OidcRoleExtractor.Outcome.RepeatedMember.ToString(), entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(OidcRoleExtractor.Outcome.Unreadable.ToString(), entry.Message, StringComparison.Ordinal);
+
+        // The member name is provider-authored and must not travel: it is the one string in this refusal the
+        // claim decides, and the trail carries reason codes only.
+        Assert.DoesNotContain(ProviderAuthoredName, entry.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoleExtractorTests.cs
@@ -216,10 +216,39 @@ public class OidcRoleExtractorTests
     [InlineData("\"scalar\"")]
     [InlineData("123")]
     [InlineData("[\"users\"]")]
-    public void ValueThatIsNotAJsonObject_IsValueNotJson(string claimValue)
+    public void ValueThatIsNotAJsonObject_IsUnreadable(string claimValue)
     {
-        // The claim value never became an object to walk. A literal JSON null deserializes to a null
-        // dictionary and belongs in the same class: nothing was parsed that a path could be applied to.
+        // The claim value never became an object to walk. These all reported ValueNotJson until #1324 put the
+        // screen in front of the parse: the screen reaches them first and none of them establishes anything,
+        // so the reason they now carry says which reader spoke as well as what it found.
+        var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, claimValue, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Unreadable, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    public static TheoryData<string> ScreenedButUnparseable() => new()
+    {
+        // An object inside an array: the screen walks it, and the reader's dictionary deserialization does not
+        // take an array root.
+        "[{\"roles\":[\"users\"]}]",
+
+        // A leading byte-order mark, written as an escape so the byte lives in the fixture rather than in this
+        // source file. The screen strips one and reads the document; Newtonsoft does not and refuses it.
+        "\uFEFF{\"roles\":[\"users\"]}",
+    };
+
+    [Theory]
+    [MemberData(nameof(ScreenedButUnparseable))]
+    public void ValueTheScreenPassesAndTheParserRefuses_IsStillValueNotJson(string claimValue)
+    {
+        // ValueNotJson did not become unreachable when the screen landed ahead of it (#1324), and a reason
+        // nothing can produce is one a later reader deletes as dead. Both rows carry an object and repeat no
+        // member where the reader looks, so the screen admits them; Newtonsoft then refuses both, because an
+        // object inside an array is not a dictionary and a leading BOM is not JSON to it.
+        //
+        // The outcome is its own proof that the screen admitted them: a refusal there returns Unreadable or
+        // RepeatedMember and never reaches the parser that produces this one.
         var result = OidcRoleExtractor.ExtractRoles(new[] { "realm_access", "roles" }, claimValue, false);
 
         Assert.Equal(OidcRoleExtractor.Outcome.ValueNotJson, result.Outcome);

--- a/SSO-Auth.Tests/Oidc/RoleClaimScopeScreenTests.cs
+++ b/SSO-Auth.Tests/Oidc/RoleClaimScopeScreenTests.cs
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The repeated-member screen on the role-claim path (#1324), phase 2 of #1053. That issue settled what an
+/// unreadable role claim means - it establishes nothing, so nothing the document says is used - and left the
+/// code to this one. The substance is the clause about the second parser: the round-2 finding on PR #1032 was
+/// not that an unreadable document produced no roles, it was that it produced "proceed" and the walk then fell
+/// through to Newtonsoft, which granted the attacker's last-occurrence roles.
+/// <para>
+/// The screen is narrowed to the object scopes the configured path enters, and that narrowing is an
+/// availability decision with a security bound. Every member of an entered scope is still compared, because
+/// which members the reader indexes inside a scope is not something the screen can know; but a repeat in a
+/// sibling the reader never opens is admitted, because it changes nothing the reader reads and refusing it
+/// would let an unrelated vendor extension in the provider's own claim deny every login.
+/// </para>
+/// <para>
+/// Every refusing row here has a control beside it - the same document without the repeat, resolving to a
+/// named role set. A screen that refused everything would satisfy the refusals on their own, and the price of
+/// this change is paid in logins, so a false refusal is the failure to guard against as much as a false pass.
+/// </para>
+/// </summary>
+public class RoleClaimScopeScreenTests
+{
+    // The paths the rows are read along. Segment 0 names the claim; the rest is the walk into its value.
+    private static readonly string[] TwoSegment = { "realm_access", "roles" };
+    private static readonly string[] FourSegment = { "claim", "resource_access", "jellyfin", "roles" };
+
+    private const string Authority = "https://idp-scope-screen.example.com";
+
+    public static TheoryData<string> RefusedRepeats() => new()
+    {
+        "the role member named twice at the root of the claim value",
+        "a repeat in an intermediate segment's object",
+        "a repeat inside the terminal object, in object-map mode",
+        "a repeat spelled with a unicode escape on one of its two occurrences",
+    };
+
+    public static TheoryData<string> AdmittedDocuments() => new()
+    {
+        "a repeat in a sibling object the configured path never enters",
+        "sibling scopes legitimately reusing a name",
+        "a member name differing from another only in case",
+        "a repeat inside an object carried by an on-path array",
+        "the ordinary document, two-segment array path",
+        "the ordinary document, four-segment array path",
+        "the ordinary document, one-segment object map",
+        "the ordinary document, two-segment object map",
+        "the ordinary document, one-segment verbatim value",
+    };
+
+    [Theory]
+    [MemberData(nameof(RefusedRepeats))]
+    public void RoleClaimScreen_RefusesARepeatInAScopeTheReaderEnters(string shape)
+    {
+        var (path, objectMap, repeated, control, controlRoles) = Row(shape);
+
+        var refused = OidcRoleExtractor.ExtractRoles(path, repeated, objectMap);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.RepeatedMember, refused.Outcome);
+        Assert.Empty(refused.Roles);
+
+        // The positive control. Without it the row above passes on a screen that refuses every document, and
+        // on a fixture whose path never resolved in the first place.
+        var resolved = OidcRoleExtractor.ExtractRoles(path, control, objectMap);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, resolved.Outcome);
+        Assert.Equal(controlRoles, resolved.Roles);
+    }
+
+    [Theory]
+    [MemberData(nameof(AdmittedDocuments))]
+    public void RoleClaimScreen_AdmitsWhatTheReaderNeverReads(string shape)
+    {
+        var (path, objectMap, _, document, roles) = Row(shape);
+
+        var result = OidcRoleExtractor.ExtractRoles(path, document, objectMap);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Resolved, result.Outcome);
+        Assert.Equal(roles, result.Roles);
+    }
+
+    [Fact]
+    public void ARepeatUnderAnOnPathArray_IsNotRefusedAsARepeat()
+    {
+        // The array frame ends the descent, so the objects an array carries are not the scope the next key
+        // names. Without that, a provider whose intermediate segment holds a list of objects would have every
+        // one of them screened as if it sat on the path.
+        //
+        // Its own row because the outcome is neither a refusal nor a resolution: the reader wants an object at
+        // "resource_access" and finds an array, which is PathNotResolved. Folded into the admitted table it
+        // would have had to assert Resolved, and it would have been dropped instead of stated.
+        var value = "{\"resource_access\":[{\"jellyfin\":1,\"jellyfin\":2}]}";
+
+        var result = OidcRoleExtractor.ExtractRoles(FourSegment, value, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.PathNotResolved, result.Outcome);
+        Assert.Empty(result.Roles);
+    }
+
+    // Rows rather than InlineData, because one of them cannot survive an attribute: a raw unpaired surrogate
+    // in an attribute argument comes back out of metadata as replacement characters, which is a perfectly
+    // readable document and would have made that row assert the opposite of what it is for. Measured - the row
+    // failed exactly that way before it moved here.
+    public static TheoryData<string> UnreadableGrammars() => new()
+    {
+        string.Empty,
+        "   ",
+        "not-json",
+        "{\"roles\":[\"admin\"]",
+        "17",
+        "[1,2,3]",
+        "{\"roles\":[\"admin\"],\"a\\ud800\":1}",
+        "{\"roles\":[\"admin\"],\"a\uD800\":1}",
+    };
+
+    [Theory]
+    [MemberData(nameof(UnreadableGrammars))]
+    public void EveryUnreadableGrammar_YieldsNoRolesWithoutConsultingTheSecondParser(string claimValue)
+    {
+        // One row per grammar the #1053 table calls Unreadable, including the two the reader used to read
+        // perfectly well - the escaped and the raw unpaired surrogate, which resolved with roles before this.
+        var result = OidcRoleExtractor.ExtractRoles(TwoSegment, claimValue, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Unreadable, result.Outcome);
+        Assert.Empty(result.Roles);
+
+        // That Newtonsoft was not consulted is what the reason says, and it says it by being this one.
+        // ValueNotJson is returned only from inside the try that runs the parser, so a fall-through would
+        // report that or a resolution, never Unreadable.
+        Assert.NotEqual(OidcRoleExtractor.Outcome.ValueNotJson, result.Outcome);
+    }
+
+    [Fact]
+    public async Task BothCallersTreatUnreadableTheSameWay()
+    {
+        // The same bytes, to the two places this walk sits on: the discovery read, where it screens a provider
+        // response before the identity library parses it, and the role path, where it screens a claim value
+        // before Newtonsoft does. A document neither can read must be used by neither.
+        //
+        // The CONSEQUENCES differ, and that is a property rather than a discrepancy, so the test says which
+        // and why. The discovery document decides the login anchor and the validation keys, so a read that
+        // establishes nothing leaves nothing to log in against and the whole read is unavailable. The role
+        // claim decides privileges on top of a token that has already been validated, so a claim that
+        // establishes nothing grants no roles and the login is decided by whatever the configuration says
+        // about a user with none. One refusal ends the read; the other ends the grant.
+        const string Unreadable = "{\"a\\ud800\":1}";
+
+        var http = new StubFactory(Unreadable);
+        var logger = new CapturingLogger();
+
+        var discovery = await OidcDiscoveryReader.ReadAsync(OptionsFor(Authority), "kc", http.Factory, logger);
+
+        Assert.False(discovery.Available);
+        Assert.Equal(OidcDiscoveryRefusal.Uninspectable, discovery.Refusal);
+        Assert.Contains(
+            logger.Entries,
+            e => e.Message.Contains(RepeatedMemberScreen.UninspectableReason, StringComparison.Ordinal));
+
+        var roles = OidcRoleExtractor.ExtractRoles(TwoSegment, Unreadable, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.Unreadable, roles.Outcome);
+        Assert.Empty(roles.Roles);
+
+        // Neither used anything the document said. On the discovery side that means the JWKS URL it named was
+        // never requested - one fetch, the document itself - and on the role side it means no role reached the
+        // caller from a value nothing could read.
+        Assert.Equal(1, http.Requests);
+    }
+
+    // shape -> (path, object-map mode, the repeating document, the control document, the control's roles).
+    // One source for both theories so a shape cannot be asserted under one name and defined under another.
+    private static (string[] Path, bool ObjectMap, string Repeated, string Control, List<string> Roles) Row(string shape) => shape switch
+    {
+        "the role member named twice at the root of the claim value" =>
+            (TwoSegment, false, "{\"roles\":[\"admin\"],\"roles\":[\"user\"]}", "{\"roles\":[\"admin\"]}", new List<string> { "admin" }),
+
+        "a repeat in an intermediate segment's object" =>
+            (FourSegment,
+             false,
+             "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]},\"jellyfin\":{\"roles\":[\"admin\"]}}}",
+             "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]}}}",
+             new List<string> { "media" }),
+
+        "a repeat inside the terminal object, in object-map mode" =>
+            (TwoSegment,
+             true,
+             "{\"roles\":{\"media\":{\"org\":\"a\"},\"media\":{\"org\":\"b\"}}}",
+             "{\"roles\":{\"media\":{\"org\":\"a\"}}}",
+             new List<string> { "media" }),
+
+        // \u0072 is "r", so the two names are the same name once unescaped. A screen comparing raw spellings
+        // would see two members and admit the document.
+        "a repeat spelled with a unicode escape on one of its two occurrences" =>
+            (TwoSegment, false, "{\"roles\":[\"admin\"],\"\\u0072oles\":[\"user\"]}", "{\"\\u0072oles\":[\"admin\"]}", new List<string> { "admin" }),
+
+        // The narrowing itself: "vendor" is not on the path, so the reader never opens it.
+        "a repeat in a sibling object the configured path never enters" =>
+            (TwoSegment, false, string.Empty, "{\"roles\":[\"admin\"],\"vendor\":{\"x\":1,\"x\":2}}", new List<string> { "admin" }),
+
+        // Two scopes reusing one name is the ordinary shape of a document, not a repeat - and neither of these
+        // is entered anyway.
+        "sibling scopes legitimately reusing a name" =>
+            (TwoSegment, false, string.Empty, "{\"roles\":[\"admin\"],\"p\":{\"kid\":1},\"q\":{\"kid\":2}}", new List<string> { "admin" }),
+
+        // Ordinal, matching the discovery screen's decision (#1191): every reader on this path indexes a name
+        // it spells itself, so folding case would refuse documents nothing misreads.
+        "a member name differing from another only in case" =>
+            (TwoSegment, false, string.Empty, "{\"roles\":[\"admin\"],\"ROLES\":[\"user\"]}", new List<string> { "admin" }),
+
+        // An array under the terminal key carries objects the reader skips (only string elements are taken),
+        // so a repeat inside one is not a scope anything reads.
+        "a repeat inside an object carried by an on-path array" =>
+            (TwoSegment, false, string.Empty, "{\"roles\":[\"admin\",{\"x\":1,\"x\":2}]}", new List<string> { "admin" }),
+
+        "the ordinary document, two-segment array path" =>
+            (TwoSegment, false, string.Empty, "{\"roles\":[\"admin\",\"user\"]}", new List<string> { "admin", "user" }),
+
+        "the ordinary document, four-segment array path" =>
+            (FourSegment, false, string.Empty, "{\"resource_access\":{\"jellyfin\":{\"roles\":[\"media\"]}}}", new List<string> { "media" }),
+
+        "the ordinary document, one-segment object map" =>
+            (new[] { "urn:zitadel:iam:org:project:roles" }, true, string.Empty, "{\"admin\":{\"org\":\"a\"},\"user\":{\"org\":\"a\"}}", new List<string> { "admin", "user" }),
+
+        "the ordinary document, two-segment object map" =>
+            (TwoSegment, true, string.Empty, "{\"roles\":{\"admin\":{\"org\":\"a\"}}}", new List<string> { "admin" }),
+
+        // A one-segment path in array mode never parses the value at all, so the screen must not turn a plain
+        // role string into an unreadable document.
+        "the ordinary document, one-segment verbatim value" =>
+            (new[] { "Role" }, false, string.Empty, "jellyfin-admin", new List<string> { "jellyfin-admin" }),
+
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, "No row is defined for this shape."),
+    };
+
+    private static OidcClientOptions OptionsFor(string authority)
+    {
+        var options = new OidcClientOptions { Authority = authority };
+        options.Policy.Discovery.AdditionalEndpointBaseAddresses.Add(new Uri(authority).GetLeftPart(UriPartial.Authority));
+        options.Policy.Discovery.RequireHttps = true;
+        options.Policy.Discovery.ValidateIssuerName = true;
+        options.Policy.Discovery.ValidateEndpoints = true;
+        return options;
+    }
+
+    // Serves one body to everything and counts what was asked for, so "the document's own URLs were never
+    // dereferenced" is an observation rather than an inference.
+    private sealed class StubFactory
+    {
+        private readonly string _body;
+
+        internal StubFactory(string body)
+        {
+            _body = body;
+            var factory = Substitute.For<IHttpClientFactory>();
+            factory.CreateClient(Arg.Any<string>()).Returns(_ => new HttpClient(new StubHttpMessageHandler(Handle)));
+            Factory = factory;
+        }
+
+        internal IHttpClientFactory Factory { get; }
+
+        internal int Requests { get; private set; }
+
+        private HttpResponseMessage Handle(HttpRequestMessage request)
+        {
+            Requests++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+}

--- a/SSO-Auth.Tests/Oidc/UnreadableRoleClaimPostureTests.cs
+++ b/SSO-Auth.Tests/Oidc/UnreadableRoleClaimPostureTests.cs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
@@ -15,7 +18,14 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// walk cannot read and the reader can. This table is that measurement, taken rather than remembered: the
 /// issue carried an assertion of six such grammars from an earlier round and named none of them.
 /// <para>
-/// Each row feeds one claim value to <see cref="StrictJson.Inspect"/> and to
+/// The table outlived the question it was taken for. #1324 put the walk in front of the reader on this path,
+/// so the outcome column now records what each grammar produces WITH that screen rather than without it, and
+/// the divergence it measured is closed. It is kept, and kept in this shape, because the two-column form is
+/// what makes a reopening visible: a row that drifts back to a verdict of <c>Unreadable</c> beside an outcome
+/// that resolved is the fail-open shape, whatever the code that produced it looks like.
+/// </para>
+/// <para>
+/// Each row feeds one claim value to <see cref="StrictJson.Inspect(string?, out string?)"/> and to
 /// <see cref="OidcRoleExtractor.ExtractRoles"/> along the same two-segment path, and pins both answers. The
 /// rows are the input classes the walk's own contract calls <c>Unreadable</c> - no body, malformed, past the
 /// depth cap, an unpaired surrogate in a member name spelled raw and spelled as an escape, and a document
@@ -54,24 +64,27 @@ public class UnreadableRoleClaimPostureTests
         ("clean", "{" + ResolvingBody + "}", StrictJson.Verdict.Clean, OidcRoleExtractor.Outcome.Resolved),
         ("a nested sibling object", "{" + ResolvingBody + ",\"deep\":{\"a\":1}}", StrictJson.Verdict.Clean, OidcRoleExtractor.Outcome.Resolved),
 
-        // The attack the walk exists for, on this path. What the repeat resolves TO is pinned in its own
-        // test below, because the outcome column alone would not show it.
-        ("the role member named twice", "{" + ResolvingBody + ",\"roles\":[\"user\"]}", StrictJson.Verdict.Repeated, OidcRoleExtractor.Outcome.Resolved),
+        // The attack the walk exists for, on this path. What the repeat used to resolve to is pinned in its
+        // own test below, because the outcome column alone would not show what the refusal replaced.
+        ("the role member named twice", "{" + ResolvingBody + ",\"roles\":[\"user\"]}", StrictJson.Verdict.Repeated, OidcRoleExtractor.Outcome.RepeatedMember),
 
         // Every grammar the walk calls Unreadable and the reader ALSO refuses. Refusing on Unreadable costs
         // these rows nothing: they already carry no roles.
-        ("empty", "", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
-        ("whitespace", "   ", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
-        ("truncated", "{" + ResolvingBody, StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
-        ("not json at all", "not-json", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
-        ("a bare scalar", "17", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
-        ("an array of scalars", "[1,2,3]", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.ValueNotJson),
+        ("empty", "", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("whitespace", "   ", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("truncated", "{" + ResolvingBody, StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("not json at all", "not-json", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("a bare scalar", "17", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("an array of scalars", "[1,2,3]", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
 
-        // THE DIVERGENCE, and the point of the table: two grammars the walk cannot read and the reader reads
-        // perfectly well, roles and all. These rows are the entire availability price of treating Unreadable
-        // as a refusal on this path.
-        ("an escaped unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\\ud800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Resolved),
-        ("a raw unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\uD800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Resolved),
+        // WHAT WAS THE DIVERGENCE, and the point the table was taken for: two grammars the walk cannot read
+        // and the reader read perfectly well, roles and all. They were the entire availability price of
+        // treating Unreadable as a refusal here, the price was accepted on #1053, and #1324 charged it - the
+        // reader now consults the walk instead of a second parser, so these two rows carry no roles either.
+        // Kept as rows rather than deleted: they are what the price WAS, and a later edit that let a
+        // surrogate through would put them back on the divergent side where the sentinel below reddens.
+        ("an escaped unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\\ud800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
+        ("a raw unpaired surrogate in a member name", "{" + ResolvingBody + ",\"a\uD800\":1}", StrictJson.Verdict.Unreadable, OidcRoleExtractor.Outcome.Unreadable),
 
         // The divergence in the OTHER direction. The walk strips one leading BOM and reports an affirmative
         // Clean, while the reader on this path refuses the same bytes. It is not exploitable - the reader's
@@ -114,35 +127,53 @@ public class UnreadableRoleClaimPostureTests
         var deep = "{" + ResolvingBody + ",\"deep\":" + NestedTo(65) + "}";
 
         Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(deep, out _));
-        Assert.Equal(OidcRoleExtractor.Outcome.ValueNotJson, OidcRoleExtractor.ExtractRoles(Path, deep, false).Outcome);
+        Assert.Equal(OidcRoleExtractor.Outcome.Unreadable, OidcRoleExtractor.ExtractRoles(Path, deep, false).Outcome);
     }
 
     [Fact]
-    public void ARepeatedRoleMember_GrantsTheLastOccurrence()
+    public void ARepeatedRoleMember_GrantsNothing_AndTheLastOccurrenceIsWhatItUsedToGrant()
     {
-        // The table pins that a repeat RESOLVES; this pins what it resolves TO, which is why the repeat
-        // matters at all. The first occurrence's roles are gone, so a provider - or anyone who can answer as
-        // one - appends a second member and REPLACES the role set rather than adding to it.
-        var result = OidcRoleExtractor.ExtractRoles(Path, "{\"roles\":[\"admin\"],\"roles\":[\"user\"]}", false);
+        // Why the repeat matters at all, in one place: appending a second member REPLACED the role set rather
+        // than adding to it, so a provider - or anyone who can answer as one - decided the roles by putting
+        // its own member last. The screen refuses that value now, and the two halves are asserted together so
+        // the refusal cannot be read as a document that was harmless anyway.
+        const string Repeated = "{\"roles\":[\"admin\"],\"roles\":[\"user\"]}";
 
-        Assert.Equal(new List<string> { "user" }, result.Roles);
-        Assert.DoesNotContain("admin", result.Roles);
+        var result = OidcRoleExtractor.ExtractRoles(Path, Repeated, false);
+
+        Assert.Equal(OidcRoleExtractor.Outcome.RepeatedMember, result.Outcome);
+        Assert.Empty(result.Roles);
+
+        // What the refused document would have granted, taken from the parser the reader no longer reaches on
+        // it rather than from memory. Without this the row above says only "no roles", which is also what a
+        // typo in the configured path produces.
+        var lastOccurrence = JsonConvert.DeserializeObject<IDictionary<string, object>>(Repeated)!["roles"];
+        Assert.Equal(new List<string> { "user" }, ((JArray)lastOccurrence).Select(token => token.Value<string>()!).ToList());
     }
 
     [Fact]
-    public void TheDivergenceSetIsTwoGrammars_NotSix()
+    public void TheDivergenceSetIsEmpty_AndWasTwoGrammars()
     {
         // The number this table exists to produce, derived from the rows rather than restated in prose: the
         // grammars where the walk establishes nothing and the reader still hands back roles. An earlier round
         // put it at six and used that as the argument for handling Unreadable as "proceed", which is the
-        // fail-open direction on a privilege path. If a future edit to the walk widens or narrows the set,
-        // this is the row that says so instead of the argument silently going stale.
+        // fail-open direction on a privilege path; the measurement put it at two, #1053 decided to pay it, and
+        // #1324 closed it. Zero is now the assertion, so a future edit that lets any grammar the walk cannot
+        // read hand back roles again reddens here rather than going unnoticed.
         var divergent = Measured
             .Where(row => row.Verdict == StrictJson.Verdict.Unreadable && row.Outcome == OidcRoleExtractor.Outcome.Resolved)
             .Select(row => row.Grammar)
             .ToList();
 
-        Assert.Equal(2, divergent.Count);
-        Assert.All(divergent, grammar => Assert.Contains("surrogate", grammar));
+        Assert.Empty(divergent);
+
+        // And the two that used to be in it are still in the table, on the refusing side. Asserting the empty
+        // set alone would also pass on a table somebody had deleted the surrogate rows from, which is the
+        // cheapest way to make a divergence disappear without closing it.
+        Assert.Equal(
+            2,
+            Measured.Count(row => row.Grammar.Contains("surrogate", StringComparison.Ordinal)
+                && row.Verdict == StrictJson.Verdict.Unreadable
+                && row.Outcome == OidcRoleExtractor.Outcome.Unreadable));
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
+++ b/SSO-Auth/Api/Oidc/OidcRoleExtractor.cs
@@ -45,6 +45,19 @@ internal static class OidcRoleExtractor
 
         /// <summary>The terminal node was reached but is not the configured shape - a non-array where an array was expected, or a non-object in object-map mode.</summary>
         TerminalWrongShape,
+
+        /// <summary>
+        /// An object scope this walk enters names a member twice, so the claim value means two things and
+        /// which of them decides the roles is a parser's choice rather than the document's (#1324).
+        /// </summary>
+        RepeatedMember,
+
+        /// <summary>
+        /// The screen could not read the claim value to the end, so nothing about it was established (#1053).
+        /// Distinct from <see cref="ValueNotJson"/>, which is Newtonsoft's answer AFTER it ran: this one is
+        /// returned instead of consulting it, so the two names also say which reader spoke.
+        /// </summary>
+        Unreadable,
     }
 
     /// <summary>
@@ -67,8 +80,13 @@ internal static class OidcRoleExtractor
     /// claim value as a single role. Every non-resolving shape (missing segment, non-object node, wrong
     /// terminal type) and a malformed claim value carry no roles AND a refusal reason - a parse failure
     /// fails closed rather than throwing (#216). The refusal reasons exist so a caller can tell a broken
-    /// path from a provider that legitimately sent no roles; the ROLE SET this returns is exactly the one
-    /// the previous bare-list version returned, for every input.
+    /// path from a provider that legitimately sent no roles.
+    /// <para>
+    /// Two shapes carry no roles that once did, and both are #1324 rather than an accident. A claim value
+    /// naming a member twice in a scope this walk enters is refused instead of resolving to whichever
+    /// occurrence a parser happens to keep, and a claim value the screen cannot read to the end is refused
+    /// instead of being handed to a second parser that can. Everything else returns what it always returned.
+    /// </para>
     /// </returns>
     internal static Result ExtractRoles(string[] roleClaimSegments, string claimValue, bool terminalIsObjectMap)
     {
@@ -77,6 +95,25 @@ internal static class OidcRoleExtractor
         if (roleClaimSegments.Length == 1 && !terminalIsObjectMap)
         {
             return Resolved(new List<string> { claimValue });
+        }
+
+        // The screen runs BEFORE Newtonsoft, and that ordering is the substance of #1324 rather than a
+        // preference. The round-2 finding on PR #1032 was not that an unreadable document produced no roles,
+        // it was that it produced "proceed" and the code then fell through to a second parser, which granted
+        // the attacker's last-occurrence roles. A refusal here consults no second reader, so the value's
+        // meaning never becomes a question of which parser read it.
+        //
+        // Only the scopes this walk enters are screened. A repeat anywhere the walk does not go changes
+        // nothing it reads, and refusing on one would let an unrelated sibling in the provider's own claim -
+        // a vendor extension repeating a name - wipe the role set of every login (#1324).
+        //
+        // The repeated member's NAME is deliberately dropped. This value carries group DNs and e-mail
+        // addresses, the audit trail below records the outcome's own name and never anything derived from the
+        // claim, and a member name is derived from the claim.
+        var screened = StrictJson.Inspect(claimValue, EnteredScopeKeys(roleClaimSegments, terminalIsObjectMap), out _);
+        if (screened != StrictJson.Verdict.Clean)
+        {
+            return Refused(screened == StrictJson.Verdict.Repeated ? Outcome.RepeatedMember : Outcome.Unreadable);
         }
 
         // Everything else parses the claim value as a JSON object and walks it. The claim value is
@@ -142,6 +179,31 @@ internal static class OidcRoleExtractor
         {
             return Refused(Outcome.ValueNotJson);
         }
+    }
+
+    // The object scopes the walk below opens, named for the screen, in the order it descends them. The root
+    // is not listed because every reader starts there and the screen enters it by definition.
+    //
+    // Read off the walk rather than off the configuration's shape: the intermediates are exactly the segments
+    // the loop descends, and the terminal joins them only in object-map mode, where the roles ARE that
+    // object's member names. In array mode the terminal is an array, whose elements carry no names to repeat,
+    // and an object among them is skipped by the string filter - so entering it would screen a scope no role
+    // is ever read out of.
+    private static List<string> EnteredScopeKeys(string[] roleClaimSegments, bool terminalIsObjectMap)
+    {
+        var keys = new List<string>();
+        for (int i = 1; i < roleClaimSegments.Length - 1; i++)
+        {
+            keys.Add(roleClaimSegments[i]);
+        }
+
+        // A one-segment object-map path has no key: the claim value's root IS the terminal object.
+        if (terminalIsObjectMap && roleClaimSegments.Length > 1)
+        {
+            keys.Add(roleClaimSegments[^1]);
+        }
+
+        return keys;
     }
 
     private static Result Resolved(List<string> roles) => new(Outcome.Resolved, roles);

--- a/SSO-Auth/Api/Oidc/StrictJson.cs
+++ b/SSO-Auth/Api/Oidc/StrictJson.cs
@@ -34,12 +34,18 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 /// two are easily conflated: this is not the control that stops a hostile <c>issuer</c> VALUE, which is
 /// <c>ValidateIssuerName</c>'s job whether that value is repeated or not.
 ///
-/// Every member at every object scope is compared, rather than a caller-supplied list of the members the
-/// caller happens to index. The screen sits ahead of the identity library, whose own typed mapping and key-set
-/// materialisation are consumers too, and their indexed-member sets are internal to two pinned versions -
-/// an allowlist would have to enumerate them and would go quietly wrong at the next bump. It is also the rule
-/// .NET 10's <c>JsonSerializerOptions.Strict</c> preset already enforces, so this converges on the platform
-/// posture rather than inventing one.
+/// Every member is compared, rather than a caller-supplied list of the members the caller happens to index.
+/// The screen sits ahead of the identity library, whose own typed mapping and key-set materialisation are
+/// consumers too, and their indexed-member sets are internal to two pinned versions - an allowlist would have
+/// to enumerate them and would go quietly wrong at the next bump. It is also the rule .NET 10's
+/// <c>JsonSerializerOptions.Strict</c> preset already enforces, so this converges on the platform posture
+/// rather than inventing one.
+///
+/// WHICH SCOPES those members are compared in is the caller's to narrow, and only that (#1324). A caller
+/// reading a document along a configured path knows where its reader goes even though it does not know which
+/// members the reader names once it is there, so it names the scopes and the members inside them are still all
+/// compared. The default is every scope, and the overload taking no key list is that default rather than a
+/// separate walk.
 ///
 /// Deliberately a raw <see cref="Utf8JsonReader"/> walk rather than a <c>JsonSerializerOptions</c> setting.
 /// The plugin binds the HOST's System.Text.Json - .NET 9's in the Jellyfin 10.11 line, .NET 10's in the 12.0
@@ -65,7 +71,7 @@ internal static class StrictJson
     private const int MaxDepth = 64;
 
     /// <summary>
-    /// What <see cref="Inspect"/> found. Three outcomes and not a <c>bool</c>, because "this document names a
+    /// What <see cref="Inspect(string?, out string?)"/> found. Three outcomes and not a <c>bool</c>, because "this document names a
     /// member twice" and "this document could not be inspected" are different facts: the first is the attack
     /// this walk exists for, the second is everything from a truncated body to a hostile escape, and a caller
     /// handed one flag for both cannot report the reason it refused.
@@ -142,7 +148,42 @@ internal static class StrictJson
     ///
     /// Never throws.
     /// </returns>
-    internal static Verdict Inspect(string? json, out string? repeatedMember)
+    internal static Verdict Inspect(string? json, out string? repeatedMember) =>
+        Inspect(json, null, out repeatedMember);
+
+    /// <summary>
+    /// Walks <paramref name="json"/> and reports whether a member is named twice in an object scope the
+    /// caller's reader actually enters (#1324).
+    /// </summary>
+    /// <param name="json">The raw document, as received from the provider.</param>
+    /// <param name="enteredScopeKeys">
+    /// The member names the caller's reader descends through, in order, starting at the root object - which
+    /// is entered by definition, because a reader that indexes anything at all indexes it there. An object
+    /// reached by any other member is NOT entered, and neither is anything below it. Null means every object
+    /// scope is entered, which is the discovery posture: that caller hands the whole document to a library
+    /// whose indexed-member set it does not control, so there is no smaller set of scopes to name.
+    /// <para>
+    /// Naming SCOPES rather than members is the whole of the narrowing, and the reason is the one the class
+    /// summary gives for refusing member allowlists: inside a scope the reader enters, which members it
+    /// indexes today is not a thing this walk can know. What it can know is where the reader goes, because
+    /// the caller states it. So a repeat in a sibling the reader never opens is admitted - it changes nothing
+    /// the reader reads, and refusing it would let an unrelated vendor extension take a login offline - while
+    /// a repeat where the reader looks is refused whether or not the repeated member is one it names.
+    /// </para>
+    /// </param>
+    /// <param name="repeatedMember">
+    /// The repeated member's name when the verdict is <see cref="Verdict.Repeated"/>; otherwise null. It is
+    /// provider-authored, so a caller that logs it strips line endings inline at its own log call.
+    /// </param>
+    /// <returns>
+    /// The same three verdicts, decided the same way, over a narrower set of scopes.
+    /// <see cref="Verdict.Unreadable"/> is NOT narrowed and stays a fact about the whole document: bytes the
+    /// walk cannot get to the end of leave it unable to say where the scopes are at all, so a name it cannot
+    /// decode in a scope nobody enters still establishes nothing. Narrowing what is REFUSED is safe because
+    /// the unentered scope changes no reading; narrowing what is READ would be the walk claiming a scope
+    /// boundary it did not verify.
+    /// </returns>
+    internal static Verdict Inspect(string? json, IReadOnlyList<string>? enteredScopeKeys, out string? repeatedMember)
     {
         repeatedMember = null;
         if (string.IsNullOrWhiteSpace(json))
@@ -169,8 +210,13 @@ internal static class StrictJson
         // One name set per open object, so sibling scopes may reuse a name - every JWKS entry repeats `kty`
         // and `kid`, so a walk pooling names document-wide would refuse real documents while reporting an
         // attack. Only a repeat within the SAME object is a document that means two things.
-        var scopes = new Stack<HashSet<string>>();
+        //
+        // Arrays are pushed too, and carry no name set. They hold no members of their own, and an object
+        // inside one was not reached by naming a member, so an array frame ends the descent through it -
+        // otherwise the objects in an on-path array would each inherit that key's position.
+        var scopes = new Stack<Scope>();
         var sawObject = false;
+        string? memberName = null;
         try
         {
             // Throw-on-invalid rather than the default replacement fallback: replacement maps every unpaired
@@ -185,10 +231,15 @@ internal static class StrictJson
                 {
                     case JsonTokenType.StartObject:
                         sawObject = true;
-                        scopes.Push(new HashSet<string>(StringComparer.Ordinal));
+                        scopes.Push(Open(scopes, memberName, enteredScopeKeys));
+                        break;
+
+                    case JsonTokenType.StartArray:
+                        scopes.Push(default);
                         break;
 
                     case JsonTokenType.EndObject:
+                    case JsonTokenType.EndArray:
                         scopes.Pop();
                         break;
 
@@ -196,13 +247,22 @@ internal static class StrictJson
                         // GetString returns null only for a JSON null, which cannot be a member name, so the fallback is
                         // unreachable - but folding it to "" would make the empty name and "no name" the same
                         // key, and the empty name is a legal member a provider can repeat.
+                        //
+                        // It is read on EVERY property, entered scope or not, and that is what keeps Unreadable a
+                        // fact about the document: a name the decoder cannot complete raises here rather than
+                        // being skipped because nobody indexes it.
                         var name = reader.GetString() ?? string.Empty;
-                        if (!scopes.Peek().Add(name))
+                        var scope = scopes.Peek();
+                        if (scope.Names is not null && !scope.Names.Add(name))
                         {
                             repeatedMember = name;
                             return Verdict.Repeated;
                         }
 
+                        // Only ever consulted by the StartObject one token later. A stale value cannot admit a
+                        // scope: the sole frame that reads it is an object whose parent is an entered OBJECT,
+                        // and an object in that position is always immediately preceded by its own name.
+                        memberName = name;
                         break;
 
                     default:
@@ -240,4 +300,32 @@ internal static class StrictJson
         // EMPTY object is different and stays Clean: it has a scope, and that scope genuinely repeats nothing.
         return sawObject ? Verdict.Clean : Verdict.Unreadable;
     }
+
+    // Decides whether the object now opening is one the caller's reader enters, and how far along the key
+    // chain it sits. The root is entered whatever the caller named, because that is where any reading starts;
+    // below it, an object is entered only when its own member name is the next key the parent still owes, so
+    // the chain is followed in order rather than matched anywhere it happens to appear.
+    private static Scope Open(Stack<Scope> scopes, string? memberName, IReadOnlyList<string>? enteredScopeKeys)
+    {
+        if (enteredScopeKeys is null || scopes.Count == 0)
+        {
+            return new Scope(0, new HashSet<string>(StringComparer.Ordinal));
+        }
+
+        var parent = scopes.Peek();
+        var entered = parent.Names is not null
+            && parent.Descended < enteredScopeKeys.Count
+            && string.Equals(memberName, enteredScopeKeys[parent.Descended], StringComparison.Ordinal);
+
+        return entered ? new Scope(parent.Descended + 1, new HashSet<string>(StringComparer.Ordinal)) : default;
+    }
+
+    /// <summary>
+    /// One open object or array. A frame with no name set is one whose members are not compared - an array,
+    /// which has none, or an object the caller's reader never opens - and <c>default</c> is deliberately that
+    /// frame, so a frame pushed without a decision compares nothing rather than everything.
+    /// </summary>
+    /// <param name="Descended">How many of the caller's keys the chain down to this frame has consumed.</param>
+    /// <param name="Names">The names seen in this scope, or null when this scope is not compared.</param>
+    private readonly record struct Scope(int Descended, HashSet<string>? Names);
 }


### PR DESCRIPTION
# What & why

Phase 2 of #1053. That issue settled what an unreadable role claim means and left the code
to a separate issue; this is it. Nothing here reopens the decision.

An unreadable role claim establishes nothing, so nothing the document says is used: no roles,
the refusal recorded with its reason, and the second parser not consulted. The last clause is
the substance. The round-2 finding on PR #1032 was not that an unreadable document produced
no roles, it was that it produced "proceed" and the walk then fell through to Newtonsoft,
which granted the attacker's last-occurrence roles. `StrictJson.Inspect` now runs on the claim
value before Newtonsoft is reached at all, so a refusal consults no second reader.

A repeat is refused only in an object scope the configured path actually enters: the root,
every intermediate segment's object, and, in object-map mode, the terminal object whose member
names ARE the roles. Inside those scopes every member is still compared, because which members
the reader indexes there is not something the screen can know. A repeat in a sibling the reader
never opens is admitted, because it changes nothing the reader reads and refusing it would let
an unrelated vendor extension in the provider's own claim deny every login.

`StrictJson` takes the scope list as an optional argument rather than gaining a second walk;
the discovery caller passes none and keeps the every-scope posture it had. `Unreadable` is
deliberately not narrowed: bytes the walk cannot reach the end of leave it unable to say where
the scopes are, so a name it cannot decode in a scope nobody enters still establishes nothing.

What the tree held before this, on `main` at `54c5bf4`:

```
$ git grep -c StrictJson 54c5bf4 -- SSO-Auth/Api/Oidc/OidcRoleExtractor.cs ; echo "exit=$?"
exit=1
```

Closes #1324

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No second reader has looked at this change, and the two review boxes above are unticked for
that reason rather than pending. What stands in place of one is the falsifier table below and
the availability reasoning in this body, both of which are checkable by re-running them.

The repeated member's NAME is dropped rather than logged on this path. The claim value carries
group DNs and mail addresses, the existing audit trail records the outcome's own name and never
anything derived from the claim, and a member name is derived from the claim.
`ARepeatedRoleMember_ReachesTheOperatorAsItsOwnReasonCode` asserts that a distinctively named
repeated member does not appear in the entry.

## What this costs in logins

The availability question, stated rather than implied, because this change denies role sets
that were previously granted.

A provider whose role claim repeats a member in a scope the reader enters loses its role set,
and under a configured allow-list its users are denied. That is the decision #1053 took, and
the narrowing is what keeps the price at its minimum: before this scoping, a repeat anywhere in
the claim value would have done it, including in a vendor extension no login reads.
`RoleClaimScreen_AdmitsWhatTheReaderNeverReads` is the row that holds that open, with nine
shapes across every configured path form.

The two grammars #1053 measured as diverging, an escaped and a raw unpaired surrogate in a
member name, now carry no roles where they used to resolve. That is the whole of the measured
price, it was accepted on #1053, and `TheDivergenceSetIsEmpty_AndWasTwoGrammars` is where it
is now recorded as paid.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki surface describes this behaviour, and the
      refusal reaches an operator through the `[SSO Audit]` reason code the trail already
      documents.

The role claim's read moves out of the conformance suite's `UnscreenedUntrustedReads`
disclosure into `GatedJsonReads`, which is what that disclosure was open for. The table is now
empty and is kept rather than deleted, so the next unscreened read has somewhere to land
instead of a decision to reopen.

## Verification

Both target frameworks, full suite, analyzer gate on the test project:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.
    0 Warnung(en)
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
SSO-Auth.Tests  Total: 2882, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Der Buildvorgang wurde erfolgreich ausgefuehrt.
    0 Warnung(en)
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
SSO-Auth.Tests  Total: 2883, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The two build lines are quoted as the toolchain printed them, in German.

**Every refusal shown non-vacuous.** Six weakenings, applied one at a time to the shipped code
at this commit, each built and run against the full suite and then reverted. Baseline is 0
failed.

| weakening | failed | what reddened |
|---|---|---|
| the screen is not consulted at all, straight through to Newtonsoft | 32 | every refusal row, the #1053 table, both audit reason codes, `BothCallersTreatUnreadableTheSameWay` |
| `Unreadable` proceeds, only a repeat refuses | 25 | `EveryUnreadableGrammar_YieldsNoRolesWithoutConsultingTheSecondParser`, the table's Unreadable rows, `ValueThatIsNotAJsonObject_IsUnreadable`, the audit row |
| every object scope entered, the path narrowing removed | 1 | `RoleClaimScreen_AdmitsWhatTheReaderNeverReads`, the sibling-object row |
| only the root is entered, the descent removed | 2 | `RoleClaimScreen_RefusesARepeatInAScopeTheReaderEnters`, the intermediate-object and object-map-terminal rows |
| arrays push no frame, so an on-path array's objects are treated as on-path | 1 | `ARepeatUnderAnOnPathArray_IsNotRefusedAsARepeat` |
| member names compared case-insensitively | 3 | `RoleClaimScreen_AdmitsWhatTheReaderNeverReads`, the case row, plus two existing `StrictJsonTests` rows |

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No `.js`, `.html`, `.md` or `.css` file changes here, so Prettier was not run for this branch.

## Notes

Out of scope, from the issue: the BOM row in the #1053 table, where the walk strips one leading
BOM and reports `Clean` while the role reader refuses the same bytes. It is a divergence in the
other direction, it is not exploitable because the reader's refusal is what decides the roles
and it grants none, and it is still pinned by the table. That row is also what keeps
`ValueNotJson` reachable, which is why `ValueTheScreenPassesAndTheParserRefuses_IsStillValueNotJson`
was added rather than the reason being left to look dead.

One observation about the suite rather than about this change, recorded because it was seen
rather than because it is understood: during two runs made while the machine was heavily loaded,
the suite took 130s instead of 25s and five `SSOControllerAuthorizationTests` rows failed. They
pass on every run at normal speed, including immediately before and after those two, and none of
them touches this code. Not investigated here.
