### PR TITLE
Gate the legacy plaintext secret migration with a scripted phase

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -58,6 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.pick.outputs.matrix }}
+      # Whether this is a full-matrix run. Published separately from the matrix itself because a step
+      # can be gated on the TRIGGER without being gated on which provider it is looking at, and the
+      # release-only phases below need exactly that (#1140).
+      full: ${{ steps.pick.outputs.full }}
     steps:
       - id: pick
         env:
@@ -78,10 +82,13 @@ jobs:
           # now has a harness here; adding one is a further object plus its test/e2e/<provider>/ directory.
           if [ "$IS_RELEASE" = "true" ] || [ "$DISPATCH_ALL" = "true" ]; then
             include="[$keycloak,$authelia,$authentik,$dex,$zitadel,$pocketid,$kanidm]"
+            full=true
           else
             include="[$keycloak]"
+            full=false
           fi
           echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+          echo "full=$full" >> "$GITHUB_OUTPUT"
 
   e2e:
     needs: select
@@ -191,6 +198,22 @@ jobs:
               echo "::error::expected audit line missing from the Jellyfin log: $expected"; exit 1
             fi
           done
+
+      - name: Legacy plaintext secret migrates to ssoenc:v1 (#1140)
+        # A pre-#158 config carried its provider secret in plaintext. This plants one back into the
+        # persisted configuration, restarts Jellyfin against it, and requires the login to keep working
+        # and the value to be rewritten as an envelope. It was verified by hand once in the #717 live
+        # pass and nothing re-checked it since, so a migration regression would only have surfaced on a
+        # real upgrade.
+        #
+        # Release and `providers: all` only, and only on the canonical Keycloak stack: it costs two extra
+        # login passes, and it is the one stack that can be re-run in place (the seeds behind Zitadel,
+        # Pocket ID and Kanidm are not idempotent) and whose expected client secret the compose file
+        # states. Runs on a green harness only, so a real login failure surfaces as the harness failure.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: test/e2e/phases/legacy-secret-migration.sh
 
       - name: Dump container logs on failure
         if: failure()

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -199,6 +199,28 @@ A relogin-only pass refuses to run against an uninitialised server: it needs a J
 is already complete and whose provider configuration is already persisted, so pointing it at a wiped
 `test/e2e/jellyfin/config` is a fatal error rather than a silent re-initialisation.
 
+### Legacy plaintext secret migrates on load
+
+`test/e2e/phases/legacy-secret-migration.sh` is a phase built on that second pass. It replaces the
+persisted `ssoenc:v1` envelope with the plaintext a pre-#158 configuration carried, restarts Jellyfin
+against it, and requires two things: the login keeps working, and the value is rewritten as an
+envelope with the plaintext gone from the file. A third pass then drives one more login, so the login
+that proves the migrated secret still decrypts is one made after the envelope exists.
+
+It runs on the host rather than in the harness container, which mounts only `/harness` and can
+therefore neither read the persisted configuration nor restart Jellyfin. Run it after a green
+canonical pass, with the stack stopped but not torn down:
+
+```sh
+docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+
+test/e2e/phases/legacy-secret-migration.sh
+```
+
+A green run prints `LEGACY SECRET MIGRATION PHASE PASSED`. In CI it runs on a release, a beta
+release, or a `providers: all` dispatch, on the Keycloak entry only.
+
 **The Zitadel, Pocket ID and Kanidm stacks cannot be re-run in place.** Every other provider is seeded from a file
 (an imported realm, a reapplied blueprint, or a static config) and the driver deliberately reuses an
 already-initialised Jellyfin. These three are seeded imperatively against stateful storage and their seeds

--- a/test/e2e/phases/legacy-secret-migration.sh
+++ b/test/e2e/phases/legacy-secret-migration.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# A pre-#158 PLAINTEXT provider secret is migrated to an ssoenc:v1 envelope, and logins keep working
+# across the migration (#1140). Verified by hand once in the #717 live pass; this is the scripted
+# version, so a migration regression cannot reach a release unnoticed.
+#
+# It runs on the HOST rather than inside the harness container, for the same reason the workflow's
+# secrets-at-rest assertion does: the harness mounts only /harness, so it can neither read the
+# persisted config nor restart Jellyfin. Both are what this phase is made of.
+#
+# The shape, and why each step is where it is:
+#
+#   pass 1     the ordinary canonical run, which the caller has already made green. It leaves a
+#              configured Jellyfin whose secret is an ssoenc:v1 envelope, and it leaves the
+#              containers STOPPED rather than removed, which is what makes the rest possible.
+#   plant      the envelope is replaced on disk with the plaintext a pre-#158 config carried. Done
+#              with the stack down, so nothing is racing the write.
+#   pass 2     RELOGIN_ONLY, which restarts Jellyfin against the planted config and skips the seed,
+#              the wizard and the provider Add - without that the re-seed would rewrite the very
+#              secret the phase just planted and the run would assert nothing (#1123).
+#   pass 3     a second RELOGIN_ONLY pass, so the login that proves the migrated secret still
+#              decrypts is one driven AFTER the envelope exists. Pass 2's login happens while the
+#              plaintext is still on disk and is what triggers the rewrite, so it cannot be that
+#              login.
+#
+# Never `docker compose down` between the passes: that removes Keycloak, the realm is re-imported
+# into a fresh instance with a NEW SAML signing certificate, and the certificate pass 1 wrote into
+# the plugin's SAML configuration would no longer match the assertions the IdP signs.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
+CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
+
+log()  { printf '%s\n' "== $* =="; }
+die()  { printf '::error::%s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+# The plaintext to plant is read out of the resolved compose configuration rather than written here.
+# It has to be the secret the identity provider actually expects: a wrong value would make pass 2's
+# login fail, and the phase would go red while the product behaved correctly, which is the worst
+# shape a regression gate can take.
+PLAINTEXT="$(docker compose -f "$COMPOSE" config 2>/dev/null \
+  | sed -n 's/^[[:space:]]*OIDC_CLIENT_SECRET:[[:space:]]*//p' | head -1 | tr -d '"')"
+[ -n "$PLAINTEXT" ] || die "could not read OIDC_CLIENT_SECRET out of $COMPOSE - nothing to plant"
+
+secret_element() { grep -o '<OidSecret>[^<]*</OidSecret>' "$CONFIG" | head -1; }
+
+log "Preconditions"
+[ -s "$CONFIG" ] || die "the plugin persisted no configuration at $CONFIG - run the canonical pass first"
+case "$(secret_element)" in
+  *'<OidSecret>ssoenc:v1:'*) pass "the starting state is an ssoenc:v1 envelope" ;;
+  *) die "the starting state is not an ssoenc:v1 envelope, so this phase would prove nothing: $(secret_element)" ;;
+esac
+
+log "Planting a pre-#158 plaintext secret"
+# One element, matched on its own tags, so a value containing markup could not widen the edit.
+perl -i -pe "s#<OidSecret>[^<]*</OidSecret>#<OidSecret>${PLAINTEXT}</OidSecret>#" "$CONFIG"
+grep -qF ">${PLAINTEXT}<" "$CONFIG" || die "the plant did not take - $CONFIG still holds no plaintext secret"
+grep -q 'ssoenc:v1:' "$CONFIG" && die "an ssoenc:v1 envelope survived the plant, so the config is not in the legacy shape"
+pass "the persisted secret is now plaintext, exactly as a pre-#158 config carried it"
+
+log "Pass 2: restart against the planted config and drive a login"
+RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \
+  --abort-on-container-exit --exit-code-from harness \
+  || die "the login against the planted plaintext secret failed - a legacy config is no longer readable"
+pass "the login succeeded with a plaintext secret on disk"
+
+log "Asserting the migration"
+case "$(secret_element)" in
+  *'<OidSecret>ssoenc:v1:'*) pass "the persisted secret is an ssoenc:v1 envelope again" ;;
+  *) die "the secret was not migrated: $(secret_element)" ;;
+esac
+# Over the whole file rather than the one element: a migration that re-wrapped the provider secret
+# while leaving a copy of the plaintext anywhere else in the document has not removed the secret.
+if grep -qF "$PLAINTEXT" "$CONFIG"; then
+  die "the plaintext secret still appears in $CONFIG after the migration"
+fi
+pass "the plaintext value appears nowhere in the persisted configuration"
+
+log "Pass 3: a login driven after the migration"
+RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \
+  --abort-on-container-exit --exit-code-from harness \
+  || die "the login after the migration failed - the migrated envelope does not decrypt to the right value"
+pass "the migrated secret still decrypts to the value the provider accepts"
+
+printf '\nLEGACY SECRET MIGRATION PHASE PASSED\n'


### PR DESCRIPTION
# What & why

A pre-#158 configuration carried its OpenID client secret in plaintext, and the plugin rewrites such
a value as an `ssoenc:v1` envelope. That was verified by hand once in the #717 live pass and nothing
re-checked it since, so a migration regression would only have surfaced on a real upgrade.

`test/e2e/phases/legacy-secret-migration.sh` plants a plaintext secret back into the persisted
configuration, restarts Jellyfin against it, and requires the login to keep working, the value to
come back as an envelope, and the plaintext to be gone from the file. A third pass drives one more
login, so the login that proves the migrated secret still decrypts is one made **after** the envelope
exists rather than the login that caused the rewrite.

Closes #1140

## The blocker this issue carried is gone

Three rounds recorded the same prerequisite: the harness had no non-reconfiguring pass, so a planted
secret would be overwritten by the re-seed before anything read it. #1123 landed that pass, and it is
in the tree:

```
$ git rev-parse origin/main
a9638e6763b679ed2d6baa7fb4ddc0e3d0d64c6b
$ git show origin/main:test/e2e/harness/harness.sh | grep -c 'RELOGIN_ONLY'
5
```

So the phase is buildable, and the shape those notes asked for is what this is.

## Three things decided its shape

It runs on the **host**, not inside the harness container. The harness mounts only `/harness`, so it
can neither read the persisted configuration nor restart Jellyfin, and both are what this phase is
made of. That is not a new precedent: the workflow's existing "Assert secrets-at-rest and the audit
trail" step is on the host and says the same thing in its own comment.

It uses **`RELOGIN_ONLY`**. Without it every pass re-posts the provider configuration, secret
included, which would restore exactly what the phase destroyed; the phase would then go red while the
product behaved correctly.

The plaintext it plants is **read out of the resolved compose configuration** rather than written into
the script:

```
$ docker compose -f test/e2e/docker-compose.yml config | grep OIDC_CLIENT_SECRET
      OIDC_CLIENT_SECRET: jellyfin-oidc-secret
```

A wrong value would fail the login for a reason that has nothing to do with the migration, and it
would read as the product failing.

The passes deliberately never `docker compose down` between them: that removes Keycloak, the realm is
re-imported with a new SAML signing certificate, and the certificate pass 1 wrote into the plugin's
SAML configuration would stop matching.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [x] Refactor / code quality / docs

A regression gate rather than a product change: nothing under `SSO-Auth/` is touched.

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

No second reader has looked at this change, and the two review boxes are unticked for that reason
rather than pending. The only secret this handles is the test stack's own client secret, which is
already in the compose file in the clear; nothing here reaches a shipped file.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: `test/e2e/README.md` gains the section for it. No wiki page describes
      the harness internals.

## Verification

The phase was run end to end on a real Docker stack, from this branch, following the README:

```
== Preconditions ==
PASS: the starting state is an ssoenc:v1 envelope
== Planting a pre-#158 plaintext secret ==
PASS: the persisted secret is now plaintext, exactly as a pre-#158 config carried it
== Pass 2: restart against the planted config and drive a login ==
PASS: the login succeeded with a plaintext secret on disk
== Asserting the migration ==
PASS: the persisted secret is an ssoenc:v1 envelope again
PASS: the plaintext value appears nowhere in the persisted configuration
== Pass 3: a login driven after the migration ==
PASS: the migrated secret still decrypts to the value the provider accepts

LEGACY SECRET MIGRATION PHASE PASSED
```

**The gate is shown non-vacuous.** With both login passes replaced by a no-op, so the restart happens
and no login drives the rewrite, the phase fails on the assertion it exists for and names the state
it found:

```
== Asserting the migration ==
::error::the secret was not migrated: <OidSecret>jellyfin-oidc-secret</OidSecret>
$ echo "exit=$?"
exit=1
```

That also measured something worth writing down: the migration is triggered by the config write a
successful login performs, not by the load itself. `SSOPlugin.PersistBase` encrypts on the way to
disk, so a planted plaintext value survives a restart untouched until something saves. The claim in
this issue's title reads "on load"; what the phase asserts, and what the product does, is that a
legacy value stays readable across a restart and is rewritten encrypted on the next save. The three
passes are arranged so the phase proves that rather than assuming it.

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

No `.cs` file changes here, so neither build box was run for this branch. Prettier passes on the LF
bytes CI reads:

```
$ sed 's/\r$//' test/e2e/README.md > /tmp/plf2/test/e2e/README.md
$ (cd /tmp/plf2 && npx prettier --check test/e2e/README.md)
Checking formatting...
All matched files use Prettier code style!
```

## Notes

**CI will not exercise this on this pull request, by design.** The issue asks for the phase to be
gated onto the release and `providers: all` matrix and off the per-PR path, and that is how it is
wired: the `select` job now publishes whether the run is a full-matrix one, and the step is
additionally restricted to the canonical Keycloak entry, the one stack that re-runs in place and
whose expected client secret the compose file states. So the green checks on this pull request say
nothing about the phase, and the local run above is the evidence in their place. The first CI
execution will be a `providers: all` dispatch or a release.

`#1130`, the KEK-loss phase, is the sibling of this one and is not in scope here. It needs two things
this phase did not: a copy of the key material taken aside before it is destroyed, so the restore leg
restores the same key rather than a new one, and a refusal status to pin. It stays open.
