### PR TITLE
Read the discovery facts with the parser family the screen walks

### DIFF
--- a/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
@@ -5,20 +5,20 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Jellyfin.Plugin.SSO_Auth.Tests;
 
 /// <summary>
 /// Tests for <see cref="DiscoveryJson"/> - the single parse a discovery response gets, out of which both
-/// challenge-time facts are read (#1170). Before this the two readers each walked the same body for one
-/// boolean apiece. They pin: the parse answers null for every body that is not a JSON object rather than
-/// throwing; one parsed root serves both facts; the fail-closed / fail-tolerant asymmetry between the two
-/// readers survives the move, on the raw entry point and on the root one alike; and the plugin holds no
-/// second parse site.
+/// challenge-time facts are read (#1170), taken by the same parser family the repeated-member screen walks
+/// the body with (#1054). They pin: the parse answers null for every body that is not a JSON object rather
+/// than throwing; one parsed root serves both facts, and the readers genuinely read off it; the fail-closed /
+/// fail-tolerant asymmetry between the two readers survives the move, on the raw entry point and on the root
+/// one alike; the plugin holds no second parse site; and the reader admits no document the screen refuses.
 /// </summary>
 public class DiscoveryJsonTests
 {
@@ -33,7 +33,9 @@ public class DiscoveryJsonTests
     [InlineData("{\"issuer\":\"https://idp.example.com\"}")]
     public void AJsonObject_Parses(string discoveryJson)
     {
-        Assert.NotNull(DiscoveryJson.TryParse(discoveryJson));
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+
+        Assert.NotNull(document);
     }
 
     [Theory]
@@ -50,26 +52,29 @@ public class DiscoveryJsonTests
         // The readers below turn a null root into their own answer, and the two answers differ. Throwing
         // here instead would take that decision away from them and hand the whole read to
         // OidcDiscoveryReader's catch-all, which fails the login closed - including for the tolerant fact.
-        Assert.Null(DiscoveryJson.TryParse(discoveryJson));
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+
+        Assert.Null(document);
     }
 
     [Fact]
     public void OneParsedRoot_ServesBothFacts()
     {
-        // What "parsed once" is observable as: both readers answer off the instance they were handed, so a
-        // change made to that one instance moves both answers. A reader holding its own parse of the same
-        // bytes could not see either removal.
-        var root = DiscoveryJson.TryParse(BothFacts);
+        // What "parsed once" is observable as: both readers answer off the instance they were handed. The
+        // document is disposed while the root they were given is still in hand, and a reader holding its own
+        // parse of the same bytes could not notice - the disposal is the discriminator, and it is why this
+        // is not written as two equal answers, which a second parse would also produce.
+        var document = DiscoveryJson.TryParse(BothFacts);
+        Assert.NotNull(document);
+        var root = document.RootElement;
 
-        Assert.NotNull(root);
         Assert.True(PkceDiscovery.SupportsS256(root));
         Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
 
-        root.Remove("code_challenge_methods_supported");
-        root.Remove("authorization_response_iss_parameter_supported");
+        document.Dispose();
 
-        Assert.False(PkceDiscovery.SupportsS256(root));
-        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
+        Assert.Throws<ObjectDisposedException>(() => PkceDiscovery.SupportsS256(root));
+        Assert.Throws<ObjectDisposedException>(() => OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
     }
 
     [Fact]
@@ -80,14 +85,25 @@ public class DiscoveryJsonTests
         // flag nobody could read must never lock out a provider that omits iss (#210). Both are false here,
         // and they are false for opposite reasons - the rows below are what keeps the pair from drifting
         // into one answer.
-        Assert.False(PkceDiscovery.SupportsS256((JObject?)null));
-        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer((JObject?)null));
+        Assert.False(PkceDiscovery.SupportsS256((JsonElement?)null));
+        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer((JsonElement?)null));
 
         // Tolerant means: an advertised flag on an otherwise empty document still reads true, and a
         // document that omits it reads false without the read having failed.
-        var advertised = DiscoveryJson.TryParse("{\"authorization_response_iss_parameter_supported\":true}");
-        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(advertised));
-        Assert.False(PkceDiscovery.SupportsS256(advertised));
+        using var advertised = DiscoveryJson.TryParse("{\"authorization_response_iss_parameter_supported\":true}");
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(advertised?.RootElement));
+        Assert.False(PkceDiscovery.SupportsS256(advertised?.RootElement));
+    }
+
+    [Fact]
+    public void ARootThatIsNotAnObject_AnswersRatherThanThrowing()
+    {
+        // TryParse never hands one back, so this is about the overloads' own contract: an element that is
+        // neither null nor an object - default(JsonElement), whose ValueKind is Undefined - reaches
+        // TryGetProperty, which THROWS on it. A reader that let that escape would turn a caller's uninitialised
+        // field into a 500 on the anonymous challenge endpoint rather than into a refusal.
+        Assert.False(PkceDiscovery.SupportsS256(default(JsonElement)));
+        Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(default(JsonElement)));
     }
 
     [Theory]
@@ -113,12 +129,46 @@ public class DiscoveryJsonTests
         Assert.Equal(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(discoveryJson), facts.ResponseIssuerAdvertised);
     }
 
+    /// <param name="discoveryJson">A body some JSON reader accepts and some other reader does not.</param>
+    [Theory]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"] /* fine by some readers */}")]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"],}")]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"],\"x\":NaN}")]
+    [InlineData("{\"code_challenge_methods_supported\":[\"S256\"],\"x\":'single'}")]
+    public void NoDocumentTheScreenRefuses_IsOneTheFactReaderStillReads(string discoveryJson)
+    {
+        // The claim #1054 is about, stated as one property over one body rather than as an argument about
+        // two libraries. Each row is a document a LENIENT reader accepts - comments, a trailing comma, NaN,
+        // single-quoted strings - and every one of them advertises S256, so a reader that admitted it would
+        // report a fact off bytes the screen threw away.
+        //
+        // The screen's verdict is measured here, not assumed: if a row ever stops being refused, this stops
+        // proving anything, and the assertion below would be about a document nobody screens.
+        Assert.Equal(StrictJson.Verdict.Unreadable, StrictJson.Inspect(discoveryJson, out _));
+
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+        Assert.Null(document);
+        Assert.False(OidcDiscoveryReader.FactsFrom(discoveryJson).PkceS256);
+    }
+
+    [Fact]
+    public void TheDocumentTheScreenAdmits_IsOneTheFactReaderReads()
+    {
+        // The positive control the rows above need. Without it every one of them would pass against a reader
+        // that returned null for everything, which is the shape a fail-closed guard fails into silently.
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(BothFacts, out _));
+
+        using var document = DiscoveryJson.TryParse(BothFacts);
+        Assert.NotNull(document);
+        Assert.True(OidcDiscoveryReader.FactsFrom(BothFacts).PkceS256);
+    }
+
     [Fact]
     public void TheShippedPluginHoldsOneParseSite()
     {
-        // The rule the refactor is: one document, one parse. Nothing stops a later reader from adding its
-        // own JObject.Parse next to the shared one, and nothing about that would fail a behaviour test -
-        // both parses would agree. So the count is asserted directly.
+        // The rule the refactor is: one document, one parse, one parser family. Nothing stops a later reader
+        // from adding its own JsonDocument.Parse next to the shared one, and nothing about that would fail a
+        // behaviour test - both parses would agree. So the count is asserted directly.
         //
         // The scan is over raw file text, so a mention inside a comment counts as a site. That is
         // deliberate: it needs no agreement with anyone else's idea of what a comment is, and prose can say
@@ -126,14 +176,20 @@ public class DiscoveryJsonTests
         var pluginRoot = Path.Combine(RepoTree.Root, "SSO-Auth");
         var owner = Path.Combine("Api", "Oidc", "DiscoveryJson.cs");
 
-        var sites = Directory.EnumerateFiles(pluginRoot, "*.cs", SearchOption.AllDirectories)
+        Assert.Equal(new List<string> { owner }, SitesCalling(pluginRoot, "JsonDocument.Parse("));
+
+        // And the family it moved OFF. Newtonsoft still ships in this plugin - the id_token role claim is
+        // read with it - so the absence that matters is on this path rather than in the assembly, and an
+        // empty list is what says the discovery facts no longer cross a second parser.
+        Assert.Empty(SitesCalling(pluginRoot, "JObject.Parse("));
+    }
+
+    private static List<string> SitesCalling(string pluginRoot, string call) =>
+        Directory.EnumerateFiles(pluginRoot, "*.cs", SearchOption.AllDirectories)
             .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
                 && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            .Where(path => File.ReadAllText(path).Contains("JObject.Parse(", StringComparison.Ordinal))
+            .Where(path => File.ReadAllText(path).Contains(call, StringComparison.Ordinal))
             .Select(path => Path.GetRelativePath(pluginRoot, path))
             .OrderBy(path => path, StringComparer.Ordinal)
             .ToList();
-
-        Assert.Equal(new List<string> { owner }, sites);
-    }
 }

--- a/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
+++ b/SSO-Auth.Tests/Oidc/DiscoveryJsonTests.cs
@@ -152,6 +152,27 @@ public class DiscoveryJsonTests
     }
 
     [Fact]
+    public void AnUndecodableMethodBesideS256_NeitherThrowsNorHidesTheS256()
+    {
+        // The screen decodes member NAMES, not values, so it reports this document Clean and the element
+        // arrives at the reader. Reading its text throws - an unpaired surrogate escape is text the decoder
+        // cannot complete - and the scan has to survive that without either escaping or stopping.
+        //
+        // Both halves are the point. A throw reaches OidcDiscoveryReader's catch-all and turns a document the
+        // screen admitted into a failed read, and answering false would refuse the login wherever RequirePkce
+        // is on. Either way a provider that works today goes offline over one bad array element.
+        const string Undecodable = "{\"code_challenge_methods_supported\":[\"\\uD800\",\"S256\"]}";
+
+        Assert.Equal(StrictJson.Verdict.Clean, StrictJson.Inspect(Undecodable, out _));
+        Assert.True(PkceDiscovery.SupportsS256(Undecodable));
+        Assert.True(OidcDiscoveryReader.FactsFrom(Undecodable).PkceS256);
+
+        // And the undecodable element is not itself read as an advertisement, which is what would make the
+        // row above pass for the wrong reason.
+        Assert.False(PkceDiscovery.SupportsS256("{\"code_challenge_methods_supported\":[\"\\uD800\"]}"));
+    }
+
+    [Fact]
     public void TheDocumentTheScreenAdmits_IsOneTheFactReaderReads()
     {
         // The positive control the rows above need. Without it every one of them would pass against a reader

--- a/SSO-Auth.Tests/Oidc/DuplicateJsonKeyPostureTests.cs
+++ b/SSO-Auth.Tests/Oidc/DuplicateJsonKeyPostureTests.cs
@@ -22,11 +22,15 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// <summary>
 /// The duplicate-key posture behind the screened discovery seam (#1186, unit 2 of #1005's ladder).
 ///
-/// Two tests that only make sense together. The plugin reads its discovery facts through Newtonsoft
-/// (<see cref="DiscoveryJson"/>) while the identity library reads the same bytes through System.Text.Json,
-/// so a document naming a member twice is read by two parsers that were never promised to agree about it.
-/// <see cref="ParserDuplicateKeyPosture_IsPinned"/> is the measurement of what they actually do, executed
-/// rather than quoted, so a dependency bump that flips a row fails here instead of in production;
+/// Two tests that only make sense together. A document naming a member twice is read by parsers that were
+/// never promised to agree about it - RFC 8259 §4 leaves the handling unspecified - and the rows below are
+/// what this dependency set actually does with one. Since #1054 the plugin's own fact read
+/// (<see cref="DiscoveryJson"/>) is System.Text.Json, the family the screen tokenizes with, so the pair the
+/// table used to be about - a Newtonsoft read behind a System.Text.Json screen - is no longer on this path.
+/// It is still measured, because the identity library's typed read and the plugin's role-claim read are both
+/// downstream of documents like this one, and a bump that flipped a row would move a decision nobody would
+/// see move. <see cref="ParserDuplicateKeyPosture_IsPinned"/> is that measurement, executed rather than
+/// quoted, so it fails here instead of in production;
 /// <see cref="EveryReaderOfTheDiscoveryDocument_ReachesTheSameDecision"/> is the property that measurement
 /// makes load-bearing - the document is refused at the transport, before either reader observes a value,
 /// so the two can never be made to differ.

--- a/SSO-Auth/Api/Oidc/DiscoveryJson.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryJson.cs
@@ -1,21 +1,29 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
 /// <summary>
-/// The one place a provider's OpenID discovery document is turned into a Newtonsoft object graph. Both
-/// security facts the challenge reads - PKCE-S256 (#141) and the RFC 9207 response-<c>iss</c> parameter
-/// (#210) - are read out of the root this returns, so one discovery response is walked once for both
-/// instead of once per fact (#1170).
+/// The one place a provider's OpenID discovery document is turned into an object graph. Both security facts
+/// the challenge reads - PKCE-S256 (#141) and the RFC 9207 response-<c>iss</c> parameter (#210) - are read
+/// out of the root this returns, so one discovery response is walked once for both instead of once per fact
+/// (#1170).
+///
+/// It parses with System.Text.Json, the same family <see cref="StrictJson"/> tokenizes the body with on its
+/// way through <see cref="RepeatedMemberScreen"/> (#1054). Before that it was Newtonsoft, which put a second
+/// parser family behind the screen: the screen and the reader could be made to disagree about the same bytes,
+/// and every such disagreement is a document one of them admits and the other does not. The disagreement was
+/// fail-closed in both directions and so was never a bypass, but a screen whose verdict does not bind the
+/// reader it screens for is a guard that has to be argued about rather than one that holds by construction.
+/// Same family, same grammar, same escape handling: what the screen refuses, this refuses.
 ///
 /// Returns <see langword="null"/> rather than throwing for every input that is not a JSON object: a null,
-/// empty or blank body, and any document Newtonsoft refuses. Each reader decides for itself what a null
-/// root means, and the two answers differ on purpose - PKCE support fails CLOSED, the response-<c>iss</c>
-/// flag fails TOLERANT so an unreadable flag never locks out a provider that omits <c>iss</c>.
+/// empty or blank body, any document the reader refuses, and a well-formed document whose root is an array or
+/// a scalar. Each reader decides for itself what a null root means, and the two answers differ on purpose -
+/// PKCE support fails CLOSED, the response-<c>iss</c> flag fails TOLERANT so an unreadable flag never locks
+/// out a provider that omits <c>iss</c>.
 /// </summary>
 internal static class DiscoveryJson
 {
@@ -23,21 +31,37 @@ internal static class DiscoveryJson
     /// Parses a discovery document into its root object.
     /// </summary>
     /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
-    /// <returns>The parsed root, or <see langword="null"/> when the document is absent, blank or malformed.</returns>
-    internal static JObject? TryParse(string? discoveryJson)
+    /// <returns>
+    /// The parsed document, whose root is an object, or <see langword="null"/> when the document is absent,
+    /// blank, malformed, or rooted at anything but an object. The caller owns the returned document and
+    /// disposes it; its <see cref="JsonDocument.RootElement"/> is only readable until it does.
+    /// </returns>
+    internal static JsonDocument? TryParse(string? discoveryJson)
     {
         if (string.IsNullOrWhiteSpace(discoveryJson))
         {
             return null;
         }
 
+        JsonDocument document;
         try
         {
-            return JObject.Parse(discoveryJson);
+            document = JsonDocument.Parse(discoveryJson);
         }
         catch (JsonException)
         {
             return null;
         }
+
+        if (document.RootElement.ValueKind == JsonValueKind.Object)
+        {
+            return document;
+        }
+
+        // A well-formed array or scalar is not a discovery document, and the readers below index a root by
+        // member name. Disposed here rather than handed back, so "not an object" and "did not parse" are one
+        // answer to the caller and neither leaks a document nobody closes.
+        document.Dispose();
+        return null;
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
+++ b/SSO-Auth/Api/Oidc/OidcDiscoveryReader.cs
@@ -184,9 +184,10 @@ internal static class OidcDiscoveryReader
     /// <returns>The two facts this document advertises.</returns>
     internal static DiscoveryFacts FactsFrom(string? discoveryJson)
     {
-        var document = DiscoveryJson.TryParse(discoveryJson);
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+        var root = document?.RootElement;
         return new DiscoveryFacts(
-            PkceDiscovery.SupportsS256(document),
-            OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(document));
+            PkceDiscovery.SupportsS256(root),
+            OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(root));
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -3,9 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
-using Newtonsoft.Json.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
@@ -59,20 +59,30 @@ internal static class OidcResponseIssuer
     /// </summary>
     /// <param name="discoveryJson">The raw OpenID discovery document JSON.</param>
     /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
-    internal static bool DiscoveryAdvertisesResponseIssuer(string? discoveryJson) =>
-        DiscoveryAdvertisesResponseIssuer(DiscoveryJson.TryParse(discoveryJson));
+    internal static bool DiscoveryAdvertisesResponseIssuer(string? discoveryJson)
+    {
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+        return DiscoveryAdvertisesResponseIssuer(document?.RootElement);
+    }
 
     /// <summary>
     /// The same flag read off an already-parsed document, so the challenge reads both of its discovery facts
     /// out of one parse (#1170). Stays tolerant (<c>false</c>) on a null root, exactly as the raw-JSON entry
     /// point is on absent, blank or malformed input.
     /// </summary>
-    /// <param name="discovery">The parsed discovery document, or <see langword="null"/> when it could not be parsed.</param>
+    /// <param name="discovery">The parsed discovery document's root, or <see langword="null"/> when it could not be parsed.</param>
     /// <returns><c>true</c> only when the parameter is explicitly advertised as <c>true</c>.</returns>
-    internal static bool DiscoveryAdvertisesResponseIssuer(JObject? discovery)
+    internal static bool DiscoveryAdvertisesResponseIssuer(JsonElement? discovery)
     {
-        var advertised = discovery?["authorization_response_iss_parameter_supported"] is JValue { Type: JTokenType.Boolean } value
-            && value.Value<bool>();
+        // Only the JSON literal `true` advertises the parameter. A string "true", a 1, or the literal `false`
+        // all read as not advertised, which is the tolerant direction: requiring `iss` off a value the
+        // provider did not write as a boolean would lock out a provider that never sends one.
+        //
+        // The ValueKind test on the root is not redundant with the null test, for the same reason it is not
+        // in PkceDiscovery: TryGetProperty throws on a non-object element rather than answering false.
+        var advertised = discovery is { ValueKind: JsonValueKind.Object } root
+            && root.TryGetProperty("authorization_response_iss_parameter_supported", out var value)
+            && value.ValueKind == JsonValueKind.True;
 
         // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises
         // nothing. Reading true off an unparsed document would make the callback REQUIRE an iss parameter the

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -49,14 +49,39 @@ internal static class PkceDiscovery
         var advertised = discovery is { ValueKind: JsonValueKind.Object } root
             && root.TryGetProperty("code_challenge_methods_supported", out var methods)
             && methods.ValueKind == JsonValueKind.Array
-            && methods.EnumerateArray().Any(method =>
-                method.ValueKind == JsonValueKind.String
-                && string.Equals(method.GetString(), "S256", StringComparison.Ordinal));
+            && methods.EnumerateArray().Any(IsS256);
 
         // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises
         // nothing. This is the fail-closed half of RFC 9700 2.1.1 - the answer a caller acts on when the
         // discovery read failed must come from the absence of evidence, never from a default.
         Debug.Assert(discovery is not null || !advertised, "SupportsS256 reported S256 for a document that did not parse.");
         return advertised;
+    }
+
+    // Whether ONE advertised method is S256. Reading the text is what can fail: GetString refuses a string
+    // whose escape the decoder cannot complete, and an unpaired surrogate escape is the measured instance -
+    // the repeated-member screen reports such an array element Clean, because it decodes member NAMES and
+    // not values, so the element does arrive here.
+    //
+    // Such an element is not S256: it establishes no text at all, which is the same answer the screen gives
+    // a name it cannot decode. The scan CONTINUES past it rather than abandoning the array, and that is the
+    // load-bearing half. Abandoning would answer false for ["<undecodable>","S256"], and false here means
+    // the login is refused wherever RequirePkce is on, so one undecodable element beside a real S256 would
+    // take an otherwise-working provider offline.
+    private static bool IsS256(JsonElement method)
+    {
+        if (method.ValueKind != JsonValueKind.String)
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(method.GetString(), "S256", StringComparison.Ordinal);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 }

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using Newtonsoft.Json.Linq;
+using System.Text.Json;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
@@ -26,24 +26,32 @@ internal static class PkceDiscovery
     /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
     /// a non-array value, non-string elements, or malformed/blank JSON.
     /// </returns>
-    internal static bool SupportsS256(string? discoveryJson) => SupportsS256(DiscoveryJson.TryParse(discoveryJson));
+    internal static bool SupportsS256(string? discoveryJson)
+    {
+        using var document = DiscoveryJson.TryParse(discoveryJson);
+        return SupportsS256(document?.RootElement);
+    }
 
     /// <summary>
     /// The same decision taken on an already-parsed document, so the challenge reads both of its discovery
     /// facts out of one parse (#1170).
     /// </summary>
-    /// <param name="discovery">The parsed discovery document, or <see langword="null"/> when it could not be parsed.</param>
+    /// <param name="discovery">The parsed discovery document's root, or <see langword="null"/> when it could not be parsed.</param>
     /// <returns>
     /// <c>true</c> only when <c>S256</c> is advertised; <c>false</c> on absence, an empty/other-only set,
     /// a non-array value, non-string elements, or a null root.
     /// </returns>
-    internal static bool SupportsS256(JObject? discovery)
+    internal static bool SupportsS256(JsonElement? discovery)
     {
-        var methods = discovery?["code_challenge_methods_supported"] as JArray;
-        var advertised = methods is not null
-            && methods.Any(method =>
-                method.Type == JTokenType.String
-                && string.Equals(method.Value<string>(), "S256", StringComparison.Ordinal));
+        // The ValueKind test is not redundant with the null test: a caller can hold a JsonElement that is
+        // non-null and not an object - default(JsonElement) is Undefined - and TryGetProperty THROWS on one
+        // rather than answering false, which would turn a malformed document into a 500 on the challenge.
+        var advertised = discovery is { ValueKind: JsonValueKind.Object } root
+            && root.TryGetProperty("code_challenge_methods_supported", out var methods)
+            && methods.ValueKind == JsonValueKind.Array
+            && methods.EnumerateArray().Any(method =>
+                method.ValueKind == JsonValueKind.String
+                && string.Equals(method.GetString(), "S256", StringComparison.Ordinal));
 
         // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises
         // nothing. This is the fail-closed half of RFC 9700 2.1.1 - the answer a caller acts on when the


### PR DESCRIPTION
# What & why

The OpenID challenge reads two facts out of a provider's discovery document:
whether the authorization server advertises PKCE with S256 (#141, RFC 9700
2.1.1) and whether it advertises the RFC 9207 authorization-response `iss`
parameter (#210). Those facts were read off a Newtonsoft parse, while the body
they are read from had already been walked by `StrictJson` inside
`RepeatedMemberScreen` on the transport, which is System.Text.Json.

Two parser families over one body is a differential. The screen and the reader
can be made to disagree about the same bytes, and every disagreement is a
document one of them admits and the other does not. #1054 is that finding,
deferred out of PR #1032 rather than treated as a defect in it, and its reason
still stands: the disagreement was fail-closed in both directions and was never
a bypass. What this removes is the argument. A screen whose verdict does not
bind the reader it screens for is a guard that has to be reasoned about instead
of one that holds by construction.

`DiscoveryJson` now parses with System.Text.Json and returns a `JsonDocument`
whose root is an object; `PkceDiscovery.SupportsS256` and
`OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer` index a `JsonElement`
root instead of a `JObject`; `OidcDiscoveryReader.FactsFrom` owns the
document's lifetime for the one read. Same family, same grammar, same escape
handling: what the screen refuses, the reader refuses.

Closes #1054

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Filed as refactor rather than as hardening on purpose. No document that reaches
the login path today is decided differently by this change, because the screen
already refuses every document the two parsers disagree about. What changes is
that the property no longer depends on the screen being in the right place.

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The two review boxes are unticked and they stay unticked. Nobody but me has read
this change. There was no second reader available for it, and the evidence below
stands in place of one rather than alongside one; read the mutation table as what
a reviewer would have been asked to attack first.

The fail-closed box is ticked on a narrow reading and the reading is stated so it
can be checked. The asymmetry this path turns on is unchanged and pinned: PKCE
support fails CLOSED on a document that could not be read, the response-`iss`
flag stays TOLERANT so an unreadable flag never locks out a provider that omits
`iss`. `ANullRoot_KeepsTheAsymmetryBetweenTheTwoFacts` is where that is asserted,
and it asserts the two are false for opposite reasons rather than merely both
false.

The direction of the grammar change is the strict one, which is the direction
that can cost availability rather than security: a provider whose discovery
document carries a comment, a trailing comma, `NaN`, or a single-quoted string
now reads as unparseable where Newtonsoft read it. That provider was ALREADY
refused before this change, by the screen, at the transport, so no deployment
that works today stops working. That is what
`NoDocumentTheScreenRefuses_IsOneTheFactReaderStillReads` measures rather than
assumes: it asserts the screen's verdict on each of those four bodies in the same
test that asserts the reader's.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

On the conformance box: the structural property here is a count of parse sites,
and it already had a home in
`DiscoveryJsonTests.TheShippedPluginHoldsOneParseSite` rather than in
`ArchitectureConformanceTests`. It is re-pointed at `JsonDocument.Parse(` and
gains a second half - `JObject.Parse(` must now appear in no plugin file at all.
Newtonsoft still ships here, the id_token role claim is read with it, so the
absence that matters is on this path rather than in the assembly.

`ArchitectureConformanceTests.GatedJsonReads` already maps
`SSO-Auth/Api/Oidc/DiscoveryJson.cs` to the screen that gates it, and
`JsonDocument.Parse` is already in its `ParseCalls` table, so the file keeps its
entry and the mapping needs no edit.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Prettier is ticked vacuously and the vacuity is the honest answer: the diff
touches six `.cs` files and nothing Prettier reads.

Both target frameworks, test project built with `--warnaserror`, full suite via
the built runners:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2901, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,269s
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2902, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 28,826s
```

The four skips are the suite's own, on both frameworks: `SsoHttpTests` binds a
listener off loopback, which raises a Windows firewall consent dialog needing an
administrator (#1227). They are skipped rather than worked around, and they are
unrelated to this diff.

### The mutation, run rather than described

The new rows are worth nothing if they cannot go red for the reason they name.
`DiscoveryJson` was reverted to the previous grammar - `JObject.Parse`,
re-projected onto a `JsonDocument` so only the GRAMMAR changed and no signature
did - and the four rows were re-run:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*NoDocumentTheScreenRefuses*"
   SSO-Auth.Tests  Total: 4, Errors: 0, Failed: 4, Skipped: 0, Not Run: 0, Time: 0,271s
      Assert.Null() Failure: Value is not null
      Actual:   JsonDocument { RootElement = {"code_challenge_methods_supported":["S256"],"x":"NaN"} }
      Assert.Null() Failure: Value is not null
      Actual:   JsonDocument { RootElement = {"code_challenge_methods_supported":["S256"],"x":"single"} }
```

All four red, and the failure text names the values the old grammar admitted:
`NaN` arrived as the string `NaN`, and the single-quoted literal arrived as a
string. Restored, both frameworks green again.

Each row is a document that advertises `S256`, so a reader that admitted it would
report a live security fact off bytes the screen threw away.
`TheDocumentTheScreenAdmits_IsOneTheFactReaderReads` is the positive control:
without it every row would also pass against a reader that returned null for
everything, which is how a fail-closed guard goes vacuous without anyone
noticing.

### What attacking the change found, and the second commit

The first commit was wrong in one case, and it is written up here rather than
folded away, because with no second reader the only account of what went wrong
is the one I write.

The screen decodes member NAMES and not values. So an array ELEMENT whose escape
the decoder cannot complete is reported `Clean` by the screen and arrives at the
fact reader. `JsonElement.GetString` refuses such an element and Newtonsoft did
not, which turned this document from advertising S256 into a throw:

```
{"code_challenge_methods_supported":["\uD800","S256"]}
```

Measured on all three placements of an unpaired surrogate escape before deciding
anything:

| where the escape sits | screen | reader, first commit | reader, on `main` |
| --- | --- | --- | --- |
| an unrelated value | `Clean` | `true`, no throw | `true` |
| an element of `code_challenge_methods_supported` | `Clean` | THROWS | `true` |
| a member name | `Unreadable` | not reachable on the login path | n/a |

Only the middle row moves, and its consequence is availability rather than
security: the throw reaches `OidcDiscoveryReader`'s catch-all, so the login fails
closed rather than returning a 500, but a provider whose document carries one
such element would stop working where it works today.

The scan now skips an element it cannot decode and keeps looking. That element
establishes no text, so it is not S256, which is the same answer the screen gives
a name it cannot decode. Continuing rather than abandoning the array is the
load-bearing half, because abandoning answers `false`, and `false` refuses the
login wherever `RequirePkce` is on.

Both mutations were run against
`AnUndecodableMethodBesideS256_NeitherThrowsNorHidesTheS256`:

```
# guard removed entirely
System.InvalidOperationException : Cannot read incomplete UTF-16 JSON text as string with missing low surrogate.
   at Jellyfin.Plugin.SSO_Auth.Api.Oidc.PkceDiscovery.IsS256(JsonElement method)

# guard moved out to wrap the whole enumeration
Assert.True() Failure
Expected: True
Actual:   False
```

The row also carries its own negative, so it cannot pass by the reader answering
`true` for everything: an array holding ONLY the undecodable element reads
`false`.

`OneParsedRoot_ServesBothFacts` had to be rewritten and the reason is worth
recording, because the replacement is stronger than what it replaces. The old
version removed two members from the shared `JObject` and watched both answers
flip; `JsonElement` is immutable, so that observation is not available. The new
version disposes the document while the readers still hold its root and requires
both to throw `ObjectDisposedException`. A reader holding its own parse of the
same bytes could not notice the disposal, so this discriminates where two equal
answers would not.

## Notes

**What this is not.** The issue title asks for the facts to be read off the
tokens the screen already walks, and that is not what this does. It is stated
here rather than left for a reader to notice.

The screen is an `HttpMessageHandler`, and it screens BOTH documents a discovery
read fetches - the well-known document and the JWKS it points at. Folding fact
capture into it means a login fact travelling out of a transport handler that
also handles a document the fact has nothing to do with, and it entangles a
security control that carries its own threat model with a reader that carries
none. This takes the other route to the same property: move the reader onto the
screen's parser family, so exactly one family decides the facts the login acts on
and the differential is gone by construction rather than by position.

All three benefits the issue lists are met - the differential is removed rather
than failed closed around, the Newtonsoft read of an already-parsed body is
deleted, one family decides the facts. The token-walk shape would additionally
save one pass over the bytes, which is #1041's subject, not this one's.

**One premise on the issue has moved since it was written.** It describes "two
separate Newtonsoft readers" of the body. #1170 already reduced that to one
shared parse, so what this deletes is one Newtonsoft read, not two. The remaining
claim is unaffected.

**Docs.** No README or wiki surface describes which parser reads the discovery
facts, so nothing there goes stale. The class-level remark on
`DuplicateJsonKeyPostureTests` DID say the plugin reads its facts through
Newtonsoft, which this makes false, so it is corrected in the same diff rather
than left to be found later. The table it introduces stays: it measures the
dependency set's duplicate-key posture, which the identity library's typed read
and the role-claim read are still downstream of.
