### PR TITLE
Refuse an advertised symmetric key, and show which control refuses it

### DIFF
--- a/SSO-Auth.Tests/Oidc/OidcAdvertisedSymmetricKeyTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAdvertisedSymmetricKeyTests.cs
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// A key the provider ADVERTISES may still be unusable, and a symmetric one is the case where believing the
+/// advertisement is fatal (#1004). RFC 7517 §6.1 defines <c>kty: oct</c>, whose secret travels in the JWKS
+/// as the <c>k</c> member, so an HMAC key published in a discovery document is known to everyone who can
+/// fetch that document. A verifier that turned such an entry into an issuer signing key would accept a
+/// token minted by any reader of a public URL, on either JWT path the plugin runs.
+/// <para>
+/// Two independent controls stand between the plugin and that outcome, and the rows here are arranged so
+/// each is visible on its own rather than hidden behind the other. The algorithm allowlist in
+/// <see cref="OidcSignatureKeys.AllowedSignatureAlgorithms"/> lists no <c>HS*</c> entry, and
+/// <see cref="OidcSignatureKeys.Convert"/> reads only the RSA <c>e</c>/<c>n</c> pair and the EC
+/// <c>crv</c>/<c>x</c>/<c>y</c> triple, so a <c>k</c> member reaches no key at all. Existing coverage
+/// asks the algorithm question with a key the provider never advertised
+/// (<c>OidcIdTokenValidatorTests</c>, <c>OidcLogoutTokenValidatorTests</c>); nothing asked whether an
+/// ADVERTISED secret becomes a signing key, which is the conversion half and the one this file holds.
+/// </para>
+/// <para>
+/// EVERY REJECTION ROW HERE IS PAIRED WITH A CONTROL, for the reason #1052 was split out of #1004: a
+/// fixture the verifier never understood is refused for its malformedness, and the row goes green while
+/// the property it names does not hold.
+/// <see cref="TheMacdToken_Authenticates_OnceTheAdvertisedSecretIsInTheBasis"/> installs into the SHIPPED
+/// basis the one behaviour these rows say is absent - the signing key a <c>k</c>-reading converter would
+/// have produced - and requires the forgery to be ACCEPTED, so the refusals cannot be coming from a claim,
+/// a time bound or a broken segment. <see cref="TheAlgorithmAllowlist_IsNotWhatRefusesTheMac"/> is its
+/// mirror: with <c>HS256</c> added to the shipped allowlist and the key still absent, the token is refused
+/// anyway, which is what attributes the refusal to conversion rather than to the algorithm list that
+/// <c>TokenValidationBasisConformanceTests</c> already guards.
+/// </para>
+/// <para>
+/// WHAT IS PROVEN UNEVENLY, stated here rather than left to be counted off the rows. On the back-channel
+/// path the production algorithm gate (#1164) judges <c>alg</c> before the handler runs, so
+/// <see cref="LogoutToken_MacdWithTheAdvertisedSecret_IsRejected"/> records THAT the token is refused and
+/// cannot attribute the refusal - its reason code says as much. The attribution rows below run against the
+/// shipped validation basis both paths derive from, which is the shared surface the conversion property
+/// lives on.
+/// </para>
+/// <para>
+/// Serialized because the back-channel row reaches the process-wide replay cache through
+/// <c>OidcLogoutTokenValidator.ResetReplaysForTests</c>. The reset is kept rather than reasoned away: this
+/// file's token is refused before any <c>jti</c> could be recorded, but a neighbouring class clearing that
+/// static under a one-time-use assertion is the intermittent failure #1171 exists to stop, and the cost of
+/// the collection is six fast rows not running in parallel.
+/// </para>
+/// </summary>
+[Collection("SSOController")]
+public sealed class OidcAdvertisedSymmetricKeyTests : IDisposable
+{
+    private const string Issuer = "https://idp.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string SymmetricKeyId = "advertised-hmac-key";
+    private const string RsaKeyId = "advertised-signing-key";
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly byte[] _secret = RandomNumberGenerator.GetBytes(32);
+    private readonly OidcIdTokenValidator _idTokenValidator = new();
+    private readonly OidcLogoutTokenValidator _logoutValidator = new();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public void AnAdvertisedSymmetricKey_IsNeverConvertedToASigningKey()
+    {
+        // The conversion property at its own level, where no token, algorithm or claim can stand in for it.
+        var ephemeralKeys = new List<IDisposable>();
+        try
+        {
+            Assert.Empty(OidcSignatureKeys.Convert(KeySet(SymmetricJwk()), ephemeralKeys));
+
+            // Beside a usable key the secret is still dropped, and dropping it does not cost the set: a
+            // converter that threw on the unfamiliar entry would take the provider's real key down with it.
+            var mixed = OidcSignatureKeys.Convert(KeySet(SymmetricJwk() + "," + RsaJwk()), ephemeralKeys);
+
+            var kept = Assert.Single(mixed);
+            Assert.IsType<RsaSecurityKey>(kept);
+            Assert.Equal(RsaKeyId, kept.KeyId);
+        }
+        finally
+        {
+            ephemeralKeys.ForEach(key => key.Dispose());
+        }
+    }
+
+    [Fact]
+    public async Task IdToken_MacdWithTheAdvertisedSecret_IsRejected()
+    {
+        // The login path. The secret is taken from the JWKS the provider published, so this is what any
+        // reader of that document can mint, not what a key holder can.
+        var result = await _idTokenValidator.ValidateAsync(
+            MacdToken(null), OptionsFor(SymmetricJwk()), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsError);
+        Assert.Null(result.User);
+    }
+
+    [Fact]
+    public async Task LogoutToken_MacdWithTheAdvertisedSecret_IsRejected()
+    {
+        // The back-channel path shares the one validation basis, so it must share the property; a drift
+        // here revokes a named user's sessions on the say-so of anyone who read the discovery JWKS. The
+        // reason code is the honest one: the #1164 algorithm gate answers first on this path, so this row
+        // records the refusal and the attribution rows below carry the conversion property.
+        var result = await _logoutValidator.ValidateAsync(MacdToken(LogoutClaims()), OptionsFor(SymmetricJwk()), _now);
+
+        Assert.False(result.IsValid);
+        Assert.Equal(OidcLogoutTokenValidator.RejectReason.AlgorithmNotAllowed, result.ReasonCode);
+        Assert.Null(result.Subject);
+        Assert.Null(result.SessionIndex);
+    }
+
+    [Fact]
+    public async Task TheAlgorithmAllowlist_IsNotWhatRefusesTheMac()
+    {
+        // One control at a time. HS256 is added to the shipped basis, which removes the algorithm allowlist
+        // from the answer entirely, and the token is still refused - because no key in the basis can verify
+        // an HMAC. This is what makes the rows above evidence about conversion rather than about a list
+        // TokenValidationBasisConformanceTests already pins.
+        var ephemeralKeys = new List<IDisposable>();
+        try
+        {
+            var parameters = OidcSignatureKeys.BuildValidationParameters(OptionsFor(SymmetricJwk()), ephemeralKeys);
+            parameters.ValidAlgorithms = [.. OidcSignatureKeys.AllowedSignatureAlgorithms, SecurityAlgorithms.HmacSha256];
+
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(MacdToken(null), parameters);
+
+            // The behavioural assertion comes first on purpose: a converter that read the k member turns
+            // this row red on the token rather than on the collection, which is the finding worth having.
+            Assert.False(result.IsValid);
+            Assert.DoesNotContain(parameters.IssuerSigningKeys, key => key is SymmetricSecurityKey);
+        }
+        finally
+        {
+            ephemeralKeys.ForEach(key => key.Dispose());
+        }
+    }
+
+    [Fact]
+    public async Task TheMacdToken_Authenticates_OnceTheAdvertisedSecretIsInTheBasis()
+    {
+        // #1052's technique. Same bytes, the SHIPPED basis rather than one reassembled here, and the single
+        // behaviour this file says is absent installed into it: the signing key a converter that read the
+        // JWKS "k" member would have produced. Under it the forgery MUST authenticate. It failing would mean
+        // the token is refused for something other than whose key signed it, and every row above would be
+        // green for the wrong reason.
+        var ephemeralKeys = new List<IDisposable>();
+        try
+        {
+            var parameters = OidcSignatureKeys.BuildValidationParameters(OptionsFor(SymmetricJwk()), ephemeralKeys);
+            parameters.ValidAlgorithms = [.. OidcSignatureKeys.AllowedSignatureAlgorithms, SecurityAlgorithms.HmacSha256];
+            parameters.IssuerSigningKeys = [new SymmetricSecurityKey(_secret) { KeyId = SymmetricKeyId }];
+
+            var result = await new JsonWebTokenHandler().ValidateTokenAsync(MacdToken(null), parameters);
+
+            Assert.True(result.IsValid, result.Exception?.Message);
+        }
+        finally
+        {
+            ephemeralKeys.ForEach(key => key.Dispose());
+        }
+    }
+
+    [Fact]
+    public async Task TheAdvertisedAsymmetricKeyBesideIt_StillValidates()
+    {
+        // The availability floor, end to end rather than at the converter: a provider that advertises a
+        // secret alongside its real signing key keeps working. Without this row a basis that refused every
+        // token from such a JWKS would satisfy each rejection above.
+        var token = new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = _now - TimeSpan.FromMinutes(1),
+            NotBefore = _now - TimeSpan.FromMinutes(1),
+            Expires = _now + TimeSpan.FromMinutes(5),
+            Claims = new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(new RsaSecurityKey(_rsa) { KeyId = RsaKeyId }, SecurityAlgorithms.RsaSha256),
+        });
+
+        var result = await _idTokenValidator.ValidateAsync(
+            token, OptionsFor(SymmetricJwk() + "," + RsaJwk()), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsError, result.Error);
+        Assert.Equal("RS256", result.SignatureAlgorithm);
+    }
+
+    // --- helpers ---
+
+    private static Dictionary<string, object> LogoutClaims() => new()
+    {
+        ["sub"] = "user-1",
+        ["jti"] = Guid.NewGuid().ToString("N"),
+        ["events"] = new Dictionary<string, object>
+        {
+            ["http://schemas.openid.net/event/backchannel-logout"] = new Dictionary<string, object>(),
+        },
+    };
+
+    private static Duende.IdentityModel.Jwk.JsonWebKeySet KeySet(string keys) =>
+        new("{\"keys\":[" + keys + "]}");
+
+    // A published HMAC key, exactly as RFC 7517 6.1 spells one: kty oct, the secret in k, marked for
+    // signature use so nothing about the entry disqualifies it other than being symmetric.
+    private string SymmetricJwk() =>
+        "{\"kty\":\"oct\",\"use\":\"sig\",\"alg\":\"HS256\",\"kid\":\"" + SymmetricKeyId + "\","
+        + "\"k\":\"" + Base64UrlEncoder.Encode(_secret) + "\"}";
+
+    private string RsaJwk()
+    {
+        var p = _rsa.ExportParameters(false);
+        return "{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + RsaKeyId + "\",\"alg\":\"RS256\","
+            + "\"n\":\"" + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}";
+    }
+
+    // The forgery: a well-formed token for this issuer and audience, MAC'd with the advertised secret and
+    // naming the advertised kid, so everything a verifier could check about it agrees with the JWKS.
+    private string MacdToken(IDictionary<string, object>? claims) =>
+        new JsonWebTokenHandler().CreateToken(new SecurityTokenDescriptor
+        {
+            Issuer = Issuer,
+            Audience = ClientId,
+            IssuedAt = _now - TimeSpan.FromMinutes(1),
+            NotBefore = _now - TimeSpan.FromMinutes(1),
+            Expires = _now + TimeSpan.FromMinutes(5),
+            Claims = claims ?? new Dictionary<string, object> { ["sub"] = "user-1" },
+            SigningCredentials = new SigningCredentials(
+                new SymmetricSecurityKey(_secret) { KeyId = SymmetricKeyId }, SecurityAlgorithms.HmacSha256),
+        });
+
+    private OidcClientOptions OptionsFor(string keys) => new()
+    {
+        ClientId = ClientId,
+        ClockSkew = TimeSpan.FromMinutes(5),
+        ProviderInformation = new ProviderInformation
+        {
+            IssuerName = Issuer,
+            KeySet = KeySet(keys),
+        },
+    };
+}


### PR DESCRIPTION
# What & why

RFC 7517 §6.1 lets a JWKS carry a symmetric key: `kty: oct`, with the secret travelling in the `k` member. A discovery document is public, so an HMAC key published in one is known to everyone who can fetch the URL. A verifier that turned such an entry into an issuer signing key would accept a token minted by any reader of that URL, on the login path and on the back-channel logout path alike.

Nothing in the tree asked that question before this change. What exists covers the neighbouring one:

```
$ git grep -n -E "SymmetricSecurityKey|HmacSha256" origin/main -- 'SSO-Auth.Tests/*'
origin/main:SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs:117:            new SymmetricSecurityKey(new byte[32]) { KeyId = KeyId }, SecurityAlgorithms.HmacSha256);
origin/main:SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs:250:            new SymmetricSecurityKey(publicKey) { KeyId = KeyId },
origin/main:SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs:251:            SecurityAlgorithms.HmacSha256);
$ git grep -c -E '\\"kty\\":\\"oct' origin/main -- 'SSO-Auth.Tests/Oidc/OidcIdTokenValidatorTests.cs' 'SSO-Auth.Tests/Oidc/OidcLogoutTokenValidatorTests.cs' ; echo "exit=$?"
exit=1
```

Both of those sign with a key the provider never advertised, so they exercise the algorithm allowlist. The conversion half, whether an **advertised** secret becomes a signing key, had no row.

Part of #1004. That issue's scope names `OidcSignatureKeys_NeverAcceptsSymmetricKeyMaterial`, and its 2026-08-06 status note lists that name as absent from the tree. This delivers the property for that family; the issue stays open for the rest of its list and nothing here claims the others.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

Test-only. No production file changes:

```
$ git diff --name-only origin/main...HEAD
SSO-Auth.Tests/Oidc/OidcAdvertisedSymmetricKeyTests.cs
```

## Security checklist

- [x] Fail-closed preserved: the change asserts the existing posture and alters no production code, so nothing about what is accepted moves.
- [x] No secrets logged; no logging is touched.
- [ ] A security review was performed. **It was not.** There is no second reader on this change. Rather than leave that as an unticked box, the executed evidence below is what stands in its place.
- [ ] Review record per lens. **No lens ran.** Stated as a negative and not softened.
- [x] Log inputs from the IdP are sanitized inline at the log call: no log call is added.

### The evidence carried in place of a review

Two independent controls stand between the plugin and an advertised secret, and the rows are arranged so each is visible on its own rather than hidden behind the other. `OidcSignatureKeys.Convert` reads only the RSA `e`/`n` pair and the EC `crv`/`x`/`y` triple, so a `k` member reaches no key at all; `AllowedSignatureAlgorithms` lists no `HS*` entry.

**Control 1, the fixture is otherwise perfect.** `TheMacdToken_Authenticates_OnceTheAdvertisedSecretIsInTheBasis` takes the shipped basis from `OidcSignatureKeys.BuildValidationParameters` and installs the one behaviour the rows say is absent, the signing key a `k`-reading converter would have produced, then requires the forgery to be ACCEPTED. A token refused for a claim, a time bound or a broken segment could not pass that.

**Control 2, the refusal is attributed.** `TheAlgorithmAllowlist_IsNotWhatRefusesTheMac` adds `HS256` to the shipped basis, which removes the allowlist from the answer entirely, and requires the token to be refused anyway. That is what makes the other rows evidence about conversion rather than about a list `TokenValidationBasisConformanceTests` already pins.

**Weakening run 1, the converter reads `k`.** One production line, in `TryConvertSigningKey`, building a `SymmetricSecurityKey` from the `k` member when one is present:

```
Jellyfin.Plugin.SSO_Auth.Tests.OidcAdvertisedSymmetricKeyTests.TheAlgorithmAllowlist_IsNotWhatRefusesTheMac [FAIL]
      Assert.False() Failure
Jellyfin.Plugin.SSO_Auth.Tests.OidcAdvertisedSymmetricKeyTests.AnAdvertisedSymmetricKey_IsNeverConvertedToASigningKey [FAIL]
      Assert.Empty() Failure: Collection was not empty
Total: 6, Errors: 0, Failed: 2, Skipped: 0
```

The first run of that weakening reddened the attribution row on its collection assertion rather than on the token, so the row was recording a shape and not a behaviour. The assertions are ordered behaviour-first now, and the red above is the token authenticating.

**Weakening run 2, `HS256` added to the allowlist as well.** Both controls removed:

```
IdToken_MacdWithTheAdvertisedSecret_IsRejected [FAIL]
TheAlgorithmAllowlist_IsNotWhatRefusesTheMac [FAIL]
AnAdvertisedSymmetricKey_IsNeverConvertedToASigningKey [FAIL]
LogoutToken_MacdWithTheAdvertisedSecret_IsRejected [FAIL]
Total: 6, Errors: 0, Failed: 4, Skipped: 0
```

The two that stay green are the two that assert acceptance, which is what a weakening should leave alone. Between the two runs: removing one control does not make the forgery validate on either token path, and removing both does. That is the defence-in-depth claim measured rather than asserted, and it is also why the two path rows cannot be reddened by a single weakening.

Both weakenings were reverted before the commit:

```
$ git diff --stat origin/main -- SSO-Auth/ ; echo "exit=$?"
exit=0
```

**What is proven unevenly.** On the back-channel path the production algorithm gate (#1164) judges `alg` before the handler runs, so `LogoutToken_MacdWithTheAdvertisedSecret_IsRejected` records THAT the token is refused and cannot attribute the refusal; its reason code, `algorithm_not_allowed`, says so. The attribution rows run against the shipped validation basis both paths derive from. The file's class comment carries the same statement, so the row count cannot be read as uniform strength.

## Quality checklist

- [x] No duplicated logic. The existing HS256 negatives use a key the provider never advertised; this asks the different question of a secret the provider publishes.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and follows the conventions of the neighbouring `OidcHeaderKeyMaterialTests` (shipped-basis controls, availability floor, helper block at the foot).
- [x] Architecture-conformance tests pass. No new structural property is established: this pins behaviour, not shape. `EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection` caught the first version of this file, which reached the replay-cache reset hook without `[Collection("SSOController")]`; the class is serialized now and the reset is kept rather than reasoned away.
- [x] Docs impact considered: no README or wiki surface changes.

## Verification

- [x] `dotnet build --warnaserror` green on both target frameworks, 0 warnings.
- [x] `dotnet test` green on both.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q   ->  0 Warnung(en), 0 Fehler
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q   ->  0 Warnung(en), 0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2907, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2908, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

Four skips on each, unchanged from `main`, one of them the documented Windows loopback-bind skip (#1227).

- [x] Prettier: not applicable, no `.js` / `.html` / `.md` / `.css` file is touched.

## Notes

Scope deliberately not widened. The `alg` family, the `kid` family and the header-key-material family are covered by `OidcIdTokenValidatorTests`, the #1164 algorithm gate, `OidcSignatureKeysKidTests` and `OidcHeaderKeyMaterialTests`; repeating any of them would give one rule a second home.

#1004's remaining criteria are untouched by this change. The id_token-is-never-a-session-credential assertion and the claim negatives it also lists are still absent from the tree, and the issue stays open for them.
