### PR TITLE
Report both release lines on the README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@
 <img alt="GPL 3.0 License" src="https://img.shields.io/github/license/Flowfin/jellyfin-plugin-sso.svg"/>
 </a>
 <a href="https://github.com/Flowfin/jellyfin-plugin-sso/releases">
-<img alt="Latest release" src="https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&label=release"/>
+<img alt="Latest release for Jellyfin 10.11" src="https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&include_prereleases&filter=4.*&label=release%20(Jellyfin%2010.11)"/>
+</a>
+<a href="https://github.com/Flowfin/jellyfin-plugin-sso/releases">
+<img alt="Latest release for Jellyfin 12" src="https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&include_prereleases&filter=5.*&label=release%20(Jellyfin%2012)"/>
 </a>
 <a href="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml">
 <img alt="Build Status" src="https://github.com/Flowfin/jellyfin-plugin-sso/actions/workflows/dotnet.yml/badge.svg"/>


### PR DESCRIPTION
# What & why

The release badge on the README reported one number while two release lines are published, and the paragraph a few lines below it says as much: one repository URL serves a Jellyfin 10.11 build and a Jellyfin 12 build. Shields shows the release GitHub calls latest, and that is the 4.3.0 line, because the newer 5.0.0-JF12 tag is marked as a prerelease and does not qualify:

```
$ gh api repos/Flowfin/jellyfin-plugin-sso/releases/latest --jq '[.tag_name,.prerelease,.published_at]|@tsv'
4.3.0-beta.32   false   2026-08-12T05:44:52Z
$ gh api repos/Flowfin/jellyfin-plugin-sso/releases --jq '.[0:3][]|[.tag_name,.prerelease,.published_at]|@tsv'
5.0.0-JF12-beta.46      true    2026-08-12T05:47:37Z
4.3.0-beta.32   false   2026-08-12T05:44:52Z
5.0.0-JF12-beta.45      true    2026-08-11T05:20:23Z
```

Nothing there was untrue, which is what makes it worth fixing at Release Candidate rather than leaving: a visitor who reads the badge as the current version gets no signal that the Jellyfin 12 line exists.

Two badges now, each filtered to its own tag family and labelled with the Jellyfin version it serves, so neither can be read as speaking for the other. This is the first of the two repairs the badge-honesty box on #822 names, the one that stops the badge being a single number.

Part of #822. That box is not ticked by this change and the issue stays open, because its other half is the OpenSSF Best Practices registration, which is not a change to this tree.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

One file, four lines added and one removed:

```
$ git diff --stat origin/main...HEAD
 README.md | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)
```

## Security checklist

Not applicable. This change touches no login path, no crypto, no config persistence and no release pipeline; it changes two image URLs in a README.

- [x] Fail-closed preserved: no behaviour is touched.
- [x] No secrets logged; nothing is logged.
- [ ] A security review was performed. **It was not**, and none is owed for a README badge. There is also no second reader on this change, which is stated rather than left implied.
- [ ] Review record per lens. **No lens ran.**
- [x] Log inputs from the IdP are sanitized inline at the log call: no log call exists here.

## Quality checklist

- [x] No duplicated logic.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting: each badge's label names the Jellyfin line it reports, so the distinction is visible on the rendered page and not only in this history.
- [x] Architecture-conformance tests pass. No structural property is involved.
- [x] Docs impact considered: this IS the docs change, and it is confined to the README badge row.

## Verification

Both badge URLs were read rather than reasoned about, and the labels are what they render:

```
$ curl -s "https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&include_prereleases&filter=4.*&label=release%20(Jellyfin%2010.11)" | grep -o "<title>[^<]*</title>"
<title>release (Jellyfin 10.11): v4.3.0-beta.32</title>
$ curl -s "https://img.shields.io/github/v/release/Flowfin/jellyfin-plugin-sso?display_name=tag&include_prereleases&filter=5.*&label=release%20(Jellyfin%2012)"     | grep -o "<title>[^<]*</title>"
<title>release (Jellyfin 12): v5.0.0-JF12-beta.46</title>
```

Both carry `include_prereleases`, so a badge does not go blank the day a line's newest tag is flagged differently from today's. Without it the Jellyfin 12 badge would have nothing to show at all, since every tag on that line is a prerelease.

- [x] Prettier clean for the changed `.md`:

```
$ npx prettier --check --end-of-line auto README.md
Checking formatting...
All matched files use Prettier code style!
```

`--end-of-line auto` is passed because a Windows checkout holds this file with CRLF, which the default `lf` setting reports as a style issue for every line of an unmodified README as well. The CI job runs on an LF checkout, so it checks the same content without the flag.

- [x] `dotnet build` and `dotnet test`: no code file is touched, so neither is affected. Not run for this change, and not claimed.

## Notes

What stays open on #822 after this, so the box is not read as done:

The OpenSSF Best Practices badge is registered against a different repository URL. Project 13660 is the one the README links to, and its record still names the pre-rename URL in both fields:

```
$ curl -s "https://www.bestpractices.dev/projects/13660.json" | tr ',' '\n' | grep -E '"repo_url|"homepage_url"|"badge_percentage_0|"repo_url_updated_at'
"homepage_url":"https://github.com/iderex/jellyfin-plugin-sso"
"repo_url":"https://github.com/iderex/jellyfin-plugin-sso"
"badge_percentage_0":100
"repo_url_updated_at":null
```

The passing level is genuine. What is not accurate is that a badge on this repository's front page points at a registration naming another repository as its subject. That is a field on bestpractices.dev rather than a change here, and it needs the account that owns the entry.

The other unticked boxes on #822 are #731 and #751, neither of which this touches. Its #766 box is unticked in the body while the issue itself is closed, which is worth correcting on the issue rather than here:

```
$ gh issue view 766 --json number,state --jq '"\(.number) \(.state)"'
766 CLOSED
$ gh issue view 731 --json number,state --jq '"\(.number) \(.state)"'
731 OPEN
$ gh issue view 751 --json number,state --jq '"\(.number) \(.state)"'
751 OPEN
```
