### PR TITLE
Ship the OpenVEX document on every release leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,3 +142,18 @@ jobs:
           retention-days: 30
           if-no-files-found: error
           path: ${{ steps.sbom.outputs.sbom-path }}
+
+      # The committed OpenVEX document, uploaded as its own artifact so the release leg
+      # can ship it beside the SBOM without checking out a tree over its downloaded assets
+      # (#1092/#1093). It rides this job because this job already has the tree, not because
+      # it is generated here - the statements are reviewed in the repository and shipped as
+      # reviewed. `if-no-files-found: error` keeps a deleted or moved document a red release
+      # rather than a release that quietly stops carrying its dispositions. The whole job is
+      # release-only (`if: inputs.attest`), so no CI or PR run pays for this.
+      - name: Upload VEX
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # tag=v7.0.1
+        with:
+          name: vex-artifact
+          retention-days: 30
+          if-no-files-found: error
+          path: security/vex/openvex.json

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,6 +53,13 @@ jobs:
       # document (#1092). Structural only: the product-against-SBOM leg of the same checker takes the
       # SBOM as a second argument, and no SBOM exists at this point in the job.
       run: python3 scripts/check-vex.py security/vex/openvex.json
+    - name: Release-leg VEX check
+      # A valid document nobody ships is worth nothing to a consumer, so the leg set is
+      # checked here too: every workflow that stages the SBOM as a release asset also stages
+      # the VEX, with a sha256 and no md5 (#1093). Static, because the release legs run on a
+      # tag rather than on a pull request - this is the only route that reads them before the
+      # release they would have shipped from.
+      run: python3 scripts/check-release-vex.py
     - name: Restore dependencies
       # --locked-mode fails the restore if the committed packages.lock.json files would change,
       # so a drifted or tampered dependency graph cannot build in CI.

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -164,6 +164,11 @@ jobs:
         output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
+        # The committed OpenVEX document joins the SBOM in the staging dir, so a consumer
+        # gets this build's component list and its triaged non-exploitable dispositions from
+        # one release (#1092/#1093). It is copied rather than generated: the statements are
+        # reviewed in the repository, and a release must ship the reviewed bytes.
+        cp security/vex/openvex.json _dist/openvex.json
         pushd _dist
         # ONLY the plugin zip gets a `.md5`. Defence in depth: the generator this repo now
         # owns pairs a release's checksum with ITS zip by name, but the third-party one it
@@ -171,13 +176,16 @@ jobs:
         # renaming the plugin to `community-sso-for-jellyfin` moved its md5 ahead of
         # `sbom.cyclonedx.md5` alphabetically and made the manifest publish the SBOM's
         # checksum, breaking every install (#942). One `.md5` per release keeps that class
-        # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
-        # integrity value for it.
+        # unreachable however the manifest is built. The SBOM and the VEX keep a sha256, the
+        # meaningful integrity value for them.
         for file in ./*.zip; do
           md5sum ${file#./} > ${file%.*}.md5
           sha256sum ${file#./} > ${file%.*}.sha256
         done
         sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
+        # Also the staging check: sha256sum exits non-zero on a missing file under `bash -e`,
+        # so a leg that failed to place the document reds here instead of publishing without it.
+        sha256sum openvex.json > openvex.sha256
         ls -l
         popd
     - name: Upload beta assets to a draft release

--- a/.github/workflows/publish-jf12-beta.yml
+++ b/.github/workflows/publish-jf12-beta.yml
@@ -152,6 +152,9 @@ jobs:
         output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
+        # The committed OpenVEX document joins the SBOM in the staging dir - see the same
+        # note in publish-beta.yml (#1092/#1093).
+        cp security/vex/openvex.json _dist/openvex.json
         pushd _dist
         # ONLY the plugin zip gets a `.md5` - see the same note in publish-beta.yml. The
         # manifest generator keeps the LAST asset ending in `.md5`, so a second one
@@ -162,6 +165,9 @@ jobs:
           sha256sum ${file#./} > ${file%.*}.sha256
         done
         sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
+        # Also the staging check: sha256sum exits non-zero on a missing file under `bash -e`,
+        # so a leg that failed to place the document reds here instead of publishing without it.
+        sha256sum openvex.json > openvex.sha256
         ls -l
         popd
     - name: Upload JF12 beta assets to a draft release

--- a/.github/workflows/publish-jf12-stable.yml
+++ b/.github/workflows/publish-jf12-stable.yml
@@ -86,6 +86,9 @@ jobs:
         output-dir: _dist
     - name: Prepare GitHub Release assets
       run: |-
+        # The committed OpenVEX document joins the SBOM in the staging dir - see the same
+        # note in publish-beta.yml (#1092/#1093).
+        cp security/vex/openvex.json _dist/openvex.json
         pushd _dist
         # ONLY the plugin zip gets a `.md5` - see the same note in publish-beta.yml. The
         # manifest generator keeps the LAST asset ending in `.md5`, so a second one
@@ -96,6 +99,9 @@ jobs:
           sha256sum ${file#./} > ${file%.*}.sha256
         done
         sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
+        # Also the staging check: sha256sum exits non-zero on a missing file under `bash -e`,
+        # so a leg that failed to place the document reds here instead of publishing without it.
+        sha256sum openvex.json > openvex.sha256
         ls -l
         popd
     - name: Publish output artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,15 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: sbom-artifact
+    # The committed OpenVEX document, carried here as an artifact rather than read from a
+    # checkout: this job has no working tree, and checking one out over a directory that
+    # already holds the downloaded zip is how a release loses an asset. The reusable
+    # workflow's `sbom` job already has the tree, so it uploads the reviewed bytes from
+    # there and this leg ships them beside the SBOM (#1092/#1093).
+    - name: Download VEX
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: vex-artifact
     - name: Prepare GitHub Release assets
       run: |-
         # ONLY the plugin zip gets a `.md5`. Defence in depth: the generator this repo now
@@ -79,13 +88,16 @@ jobs:
         # renaming the plugin to `community-sso-for-jellyfin` moved its md5 ahead of
         # `sbom.cyclonedx.md5` alphabetically and made the manifest publish the SBOM's
         # checksum, breaking every install (#942). One `.md5` per release keeps that class
-        # unreachable however the manifest is built. The SBOM keeps a sha256, the meaningful
-        # integrity value for it.
+        # unreachable however the manifest is built. The SBOM and the VEX keep a sha256, the
+        # meaningful integrity value for them.
         for file in ./*.zip; do
           md5sum ${file#./} > ${file%.*}.md5
           sha256sum ${file#./} > ${file%.*}.sha256
         done
         sha256sum sbom.cyclonedx.json > sbom.cyclonedx.sha256
+        # Also the staging check: sha256sum exits non-zero on a missing file under `bash -e`,
+        # so a leg that failed to place the document reds here instead of publishing without it.
+        sha256sum openvex.json > openvex.sha256
         ls -l
     - name: Publish output artifacts
       id: publish-assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   disclaimer text; provider names and labels are HTML-encoded. Per provider,
   **Hide login button** omits one provider's button and **Login button text**
   overrides its label.
+- **Every release now carries an OpenVEX document (#1093).** `openvex.json` and
+  its `openvex.sha256` ship as release assets beside `sbom.cyclonedx.json` on
+  all four release legs, so a scanner that flags an advisory in a transitive
+  dependency can read the recorded disposition for it instead of guessing. Only
+  the plugin zip still carries an `.md5`, which is what keeps the manifest
+  checksum paired with the build it belongs to.
 
 ### Changed
 

--- a/scripts/check-release-vex.py
+++ b/scripts/check-release-vex.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Release-leg VEX gate (#1093).
+
+Every release leg that ships the CycloneDX SBOM also ships the committed OpenVEX
+document, so a consumer never gets this build's component list without the
+dispositions that say which of its advisories are not exploitable here.
+
+Nothing in a workflow file makes that true by itself. A leg is copied from its
+neighbour when a new channel is opened, and the line that is easiest to forget is
+the one that ships a side-document nobody sees until a scanner joins the two. So
+the leg set is DERIVED rather than listed: any workflow that writes
+`sbom.cyclonedx.sha256` is a leg shipping the SBOM, and is held to the rest.
+
+What it refuses, and the failure each one prevents:
+
+* the document missing from the path the legs name - a moved or deleted file
+  turns four green releases into four releases that quietly stopped carrying
+  their dispositions;
+* a leg that ships the SBOM and never places the VEX document, by copy or by
+  artifact - the leg publishes half the supply-chain pair;
+* a leg that places it and emits no `openvex.sha256` - the asset ships with no
+  integrity value, and the sha256 line is also the run-time proof the document
+  reached the staging dir, since `sha256sum` on a missing file reds the step
+  under `bash -e`;
+* an `.md5` emitted for the VEX. Only the plugin zip may carry one. The manifest
+  generator this repo replaced kept the LAST asset ending in `.md5` with no
+  pairing, which is how the SBOM's checksum was published as the plugin's and
+  broke every install (#942). A second `.md5` is that class reopened;
+* a leg downloading the `vex-artifact` no job uploads - a rename on one side of
+  that pair fails the release at its last step, after the build.
+
+Fail-closed: anything unreadable is an error, not a pass.
+
+Usage: check-release-vex.py [<repo-root>]
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# The committed document. The legs name this path; so does this gate, and a move
+# that updates one and not the other is what the first check below catches.
+VEX_SOURCE = Path("security/vex/openvex.json")
+
+# Written by a leg that stages the SBOM as a release asset. This string is the
+# subject derivation, not a formatting choice: it is what makes a new leg a leg.
+SBOM_MARKER = "sbom.cyclonedx.sha256"
+
+# One of these places the document in the staging dir the release uploads from.
+PLACEMENTS = (f"cp {VEX_SOURCE.as_posix()}", "name: vex-artifact")
+
+VEX_CHECKSUM = "openvex.sha256"
+
+# Any of these would give the VEX an md5 sidecar, which is the #942 class.
+FORBIDDEN_MD5 = ("openvex.md5", "md5sum openvex")
+
+DOWNLOAD_MARKER = "download-artifact"
+UPLOAD_MARKER = "upload-artifact"
+
+# The artifact name, matched as a WHOLE yaml value rather than as a substring. A
+# rename to `vex-artifacts` is the near-miss this exists for, and `"vex-artifact"
+# in text` reads that as a match on both sides of the pair - the first draft of
+# this gate did, and passed a mutation that renamed the upload and not the
+# download.
+ARTIFACT_LINE = re.compile(r"^\s*name:\s*vex-artifact\s*$")
+USES_LINE = re.compile(r"^\s*(?:-\s*)?uses:\s*(\S+)")
+
+
+def fail(message):
+    print(f"::error::{message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def workflow_texts(root):
+    """Every workflow file, read once, as (path, text) pairs."""
+    directory = root / ".github" / "workflows"
+    if not directory.is_dir():
+        fail(f"no workflow directory at {directory}")
+
+    files = sorted(p for p in directory.iterdir() if p.suffix in (".yml", ".yaml"))
+    if not files:
+        fail(f"no workflow files under {directory}")
+
+    texts = []
+    for path in files:
+        try:
+            texts.append((path, path.read_text(encoding="utf-8")))
+        except OSError as error:
+            fail(f"cannot read {path}: {error}")
+    return texts
+
+
+def artifact_uses(path, text):
+    """Which action each `name: vex-artifact` line belongs to, in this file.
+
+    Read by walking the lines and remembering the most recent `uses:`, because a
+    step's action and its `with: name:` are two lines of one block and the pair
+    is what has to agree.
+    """
+    action = ""
+    for line in text.splitlines():
+        match = USES_LINE.match(line)
+        if match:
+            action = match.group(1)
+        elif ARTIFACT_LINE.match(line):
+            yield path, action
+
+
+def check_artifact_pairing(texts):
+    """A leg downloading `vex-artifact` needs a job somewhere that uploads it."""
+    pairs = [pair for path, text in texts for pair in artifact_uses(path, text)]
+    downloads = [path for path, action in pairs if DOWNLOAD_MARKER in action]
+    uploads = [path for path, action in pairs if UPLOAD_MARKER in action]
+    if downloads and not uploads:
+        named = ", ".join(sorted({path.name for path in downloads}))
+        fail(
+            f"{named} downloads the vex-artifact, but no workflow uploads an artifact of "
+            f"that exact name; a rename on one side of the pair fails the release at its "
+            f"last step, after the build"
+        )
+    return uploads
+
+
+def check_leg(path, text):
+    name = path.name
+
+    if not any(placement in text for placement in PLACEMENTS):
+        fail(
+            f"{name} ships the SBOM but never places {VEX_SOURCE.as_posix()}: "
+            f"expected one of {' | '.join(PLACEMENTS)}"
+        )
+
+    # Checked before the sha256, so a leg that swapped one sidecar for the other is
+    # refused for the reason that matters rather than for the missing sha256.
+    for forbidden in FORBIDDEN_MD5:
+        if forbidden in text:
+            fail(
+                f"{name} writes an md5 for the VEX ({forbidden!r}); only the plugin zip "
+                f"may carry one, or the manifest can publish the wrong checksum (#942)"
+            )
+
+    if VEX_CHECKSUM not in text:
+        fail(f"{name} ships the VEX document but writes no {VEX_CHECKSUM}")
+
+
+def main(argv):
+    root = Path(argv[1]) if len(argv) > 1 else Path.cwd()
+
+    if not (root / VEX_SOURCE).is_file():
+        fail(
+            f"no VEX document at {(root / VEX_SOURCE).as_posix()}; the release legs copy "
+            f"that path, so a release would ship the SBOM with no dispositions beside it"
+        )
+
+    texts = workflow_texts(root)
+    uploads = check_artifact_pairing(texts)
+
+    legs = [(p, t) for p, t in texts if SBOM_MARKER in t]
+    if not legs:
+        fail(
+            f"no workflow writes {SBOM_MARKER}, so this gate has no subject; either the "
+            f"release legs stopped shipping the SBOM or the marker moved"
+        )
+
+    for path, text in legs:
+        check_leg(path, text)
+
+    named = ", ".join(sorted(path.name for path, _ in legs))
+    carriers = ", ".join(sorted(path.name for path in uploads))
+    print(
+        f"ok: {len(legs)} release leg(s) ship the OpenVEX document with a sha256 and no md5: "
+        f"{named}" + (f" (artifact uploaded by {carriers})" if carriers else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
# What & why

Closes #1093.

#1092 committed `security/vex/openvex.json` and #1094 wrote the triage flow that
produces its statements, but no release carried the document. A scanner that
flagged an advisory in a transitive dependency could read a release's component
list and had nothing to read the disposition from.

All four release legs now stage `openvex.json` beside `sbom.cyclonedx.json` and
write an `openvex.sha256` for it:

- `publish-beta.yml`, `publish-jf12-beta.yml` and `publish-jf12-stable.yml` build
  into `_dist` from a full checkout, so they copy the committed file.
- `publish.yml`'s upload job has no working tree. It downloads a new
  `vex-artifact` that `build.yml`'s `sbom` job uploads, because that job already
  has the tree. Checking a tree out over a directory that already holds the
  downloaded zip is how a release loses an asset, so the artifact route is
  deliberate rather than incidental.

No VEX content is authored here, as the issue asks.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing here touches a validation path.
      The release-side analogue holds in both directions: `sha256sum` exits
      non-zero on a missing file under `bash -e`, so a leg that failed to place
      the document reds instead of publishing without it, and
      `if-no-files-found: error` does the same for the artifact upload.
- [x] No secrets logged; secrets are redacted on config export. No secret is
      read, written or passed; no permission block changes.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. The record is below.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      2 / PLAUSIBLE 0**. Both were found by executing the proof rather than by
      reading it, both are in the new gate rather than in the shipped legs, and
      both are FIXED in this branch.

This board had no second reader for this change tonight, so the review is one
reader's and the evidence below stands in place of the second. Stated plainly
rather than ticked.

**#942 regression lens**, the one the issue names as the thing to watch. PASS.
The manifest generator selects a release's zip by `.zip` suffix, refuses to
guess when a release carries more than one, and takes the checksum from the
sidecar named for THAT zip, refusing an unresolvable pair
(`.github/actions/generate-manifest/action.yml:159-205`). The VEX asset ends in
neither suffix, so it cannot be selected. Belt as well as braces: only the plugin
zip gets an `.md5`, and the new gate refuses a leg that gives the VEX one.

**Asset-collision lens.** PASS. `openvex.json` and `openvex.sha256` collide with
no existing asset name, and the two `download-artifact` steps in `publish.yml`'s
upload job extract disjoint filenames into the same directory.

**Availability lens**, a release that cannot publish. PASS with the residual
stated: a deleted or moved `security/vex/openvex.json` now reds every leg instead
of publishing silently without it. That is the intended direction, and the new
gate refuses that deletion on the pull request that makes it, before a release
run can meet it.

**Permissions and supply-chain lens.** PASS. No `permissions:` block changes, so
the reusable-workflow caller contract documented at the top of `build.yml` is
untouched. The two new steps reuse the action SHAs already pinned in the same
files. The `sbom` job stays release-only (`if: inputs.attest`), so no CI or
pull-request run pays for the upload.

**CONFIRMED 1, FIXED.** The gate matched the artifact name as a substring, so
renaming the upload to `vex-artifacts` and leaving the download alone passed it.
Reproduced as case 4 in the table below, green before the fix and red after. It
now matches the whole yaml value and pairs each name with the action of the step
it sits in.

**CONFIRMED 2, FIXED.** The gate checked the `sha256` before the `md5`, so a leg
that swapped one sidecar for the other was refused for the missing sha256 rather
than for the reopened #942 class. Reproduced as case 3a. The md5 check now runs
first.

- [x] Log inputs from the IdP are sanitized inline at the log call. No log call
      is touched.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. `scripts/check-release-vex.py` is one file with one job.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule. The property is locked in as a
      script rather than as a conformance rule, deliberately: its subject is
      workflow YAML, which `ArchitectureConformanceTests` has no reader for, and
      the sibling gate over the same document (#1092, `scripts/check-vex.py`) is
      a script in the same directory, run from the same job. A second home for it
      would be the drift the single-home doctrine exists against.
- [x] Docs impact considered. `CHANGELOG.md` carries the entry.
      `docs/SECURITY-REMEDIATION-POLICY.md` already describes the triage-to-VEX
      flow from #1094 and needs no edit for where the document is published. No
      README or wiki claim moves.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.
      `npx prettier --check CHANGELOG.md` reports `All matched files use Prettier
      code style!`.

The change contains no C#. What it does contain is a guard, and a guard is proven
by deleting it and watching the run go red. Each case below is one mutation of a
clean tree, restored before the next:

```
0.  unmutated (this branch)                       exit=0  ok: 4 release leg(s) ship the OpenVEX document with a sha256 and no md5: publish-beta.yml, publish-jf12-beta.yml, publish-jf12-stable.yml, publish.yml (artifact uploaded by build.yml)
1.  one leg loses its cp line                     exit=1  publish-jf12-stable.yml ships the SBOM but never places security/vex/openvex.json
2.  one leg loses its sha256 line                 exit=1  publish-beta.yml ships the VEX document but writes no openvex.sha256
3a. a leg swaps the sha256 for an md5             exit=1  publish.yml writes an md5 for the VEX ('openvex.md5')
3b. a leg ADDS an md5 beside the sha256           exit=1  publish-jf12-beta.yml writes an md5 for the VEX ('openvex.md5')
4.  upload renamed to vex-artifacts, download not exit=1  publish.yml downloads the vex-artifact, but no workflow uploads an artifact of that exact name
4b. the upload step loses its name                exit=1  publish.yml downloads the vex-artifact, but no workflow uploads an artifact of that exact name
5.  the document is moved away                    exit=1  no VEX document at .../security/vex/openvex.json
6.  the sbom.cyclonedx.sha256 marker vanishes     exit=1  no workflow writes sbom.cyclonedx.sha256, so this gate has no subject
7.  the legs as they stand on origin/main         exit=1  publish-beta.yml ships the SBOM but never places security/vex/openvex.json
8.  restored                                      exit=0  ok: 4 release leg(s) ...
```

Case 7 is the one that says the gate is not vacuous: pointed at the tree this
branch starts from, it refuses it.

The six changed workflow files parse (`yaml.safe_load` over each), and
`python3 scripts/check-vex.py security/vex/openvex.json` still reports the
document valid.

## Notes

**The Done-when is met in one half and not the other, and I am not closing the
gap by hand.** The issue asks for a dry-run or an actual release on each of the
four legs. A release is a tag push, which is not mine to make, and no leg has a
dry-run mode that stops before creating a release. So what stands behind this is
the static gate above plus the run-time behaviour of the two lines each leg
gained, rather than four observed releases. The first real run on each channel is
where the assets are seen, and the nightly beta scheduler exercises
`publish-beta.yml` and `publish-jf12-beta.yml` on its next run with nobody doing
anything.

The #942 regression check the issue asks for is answered by reading the generator
that selects the checksum, quoted above, rather than by watching a release. That
is the stronger answer of the two: it holds for every release rather than for the
one that happened to be watched.
