### PR TITLE
Normalize the IdP username before provisioning a new account

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -3183,6 +3183,23 @@ public class ArchitectureConformanceTests
     }
 
     [Fact]
+    public void TheProvisionedUsernameAllowlist_StillMirrorsTheRecordedHostRule()
+    {
+        // ProvisionedUsername.AllowedPunctuation is a hand-copy of Jellyfin's own account-name check, which
+        // the plugin cannot reference: it lives in the server, off the Controller/Model surface compiled
+        // against. Its one in-repo record is the regex written into AvatarService's comment (#447), so the
+        // copy is pinned to that record here. Nothing can pin either against the server - that residual is
+        // stated on ProvisionedUsername - but the two halves inside this tree can no longer drift apart in
+        // silence, which is the near-miss worth the rule: an editor widening or narrowing one spelling and
+        // never learning that the other one decides what a brand-new account is actually named.
+        var avatar = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Api", "Avatar", "AvatarService.cs"));
+        var recorded = Regex.Match(avatar, @"\^\(\?!\\s\)\[\\w(?<members>[^\]]*)\]\+\(\?<!\\s\)\$", RegexOptions.None, TimeSpan.FromSeconds(5));
+
+        Assert.True(recorded.Success, $"{nameof(AvatarService)} no longer records the host username regex, which is the only source {nameof(ProvisionedUsername)}'s allowlist is derived from (#1137).");
+        Assert.Equal(ProvisionedUsername.AllowedPunctuation, recorded.Groups["members"].Value.Replace(@"\-", "-", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void TheOidcCallbackPathScan_LeavesTheSamlBuilderAlone()
     {
         // Must-not-catch, named by #1162: the SAML AssertionConsumerServiceURL is the sibling issue's subject

--- a/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
+++ b/SSO-Auth.Tests/Linking/CanonicalLinkServiceTests.cs
@@ -1718,4 +1718,95 @@ public class CanonicalLinkServiceTests
         Assert.Equal(Existing, resolved);
         Assert.Equal(Existing, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
     }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_IdpNameCarriesRejectedCharacters_ProvisionsUnderTheSanitizedName()
+    {
+        // #1137, the 9p4#199 shape. Jellyfin's own CreateUserAsync refuses this name, so before the
+        // sanitizer the first login threw a host-shaped error and no account was ever created. The link is
+        // still written on the SUBJECT, so the rename decides nothing about which account later logins find.
+        var (service, cfg, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = TestUsers.Named("alice.smith", Other);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        users.CreateUserAsync("alice.smith").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        var resolved = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "<alice.smith>", allowExistingAccountLink: false);
+
+        Assert.Equal(Other, resolved);
+        await users.Received(1).CreateUserAsync("alice.smith");
+        await users.DidNotReceive().CreateUserAsync("<alice.smith>");
+        Assert.Equal(Other, cfg.OidConfigs["kc"].CanonicalLinks["sub-1"]);
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_AcceptableIdpName_MakesNoSecondNameLookup()
+    {
+        // The no-behaviour-change half of #1137: a name that needs no sanitization must take byte-for-byte
+        // the pre-#1137 path. The sanitized-name collision check is the one new name lookup, and it is
+        // reached only when the name actually changed - pinned here by the call count on GetUserByName,
+        // which the resolve path makes exactly once for an unchanged name.
+        var (service, _, users, _) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        var created = TestUsers.Named("alice", Other);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Other).Returns(created);
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        users.Received(1).GetUserByName("alice");
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_SanitizedNameIsTaken_RefusesRatherThanAdoptingByName()
+    {
+        // Adopting here would be a name-keyed match on a value the PLUGIN invented rather than one the
+        // provider sent, which is the takeover shape #829 rules the sanitizer out of. Refuse instead, and
+        // never reach CreateUserAsync, which would throw the host's own "already exists" anyway.
+        var (service, _, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName("alice!").Returns((User?)null);
+        users.GetUserByName("alice").Returns(TestUsers.Named("alice", Existing));
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice!", allowExistingAccountLink: false));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.Single(log.Entries, e => e.Message.Contains("already bears", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_IdpNameSanitizesToNothing_RefusesWithoutInventingAName()
+    {
+        // The empty-result fallback. An all-dots name passes Jellyfin's own check and is path traversal at
+        // the profile directory (#447), so it is treated as nothing surviving; the login is refused rather
+        // than an account being provisioned under a name no identity provider sent.
+        var (service, _, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "..", allowExistingAccountLink: false));
+
+        await users.DidNotReceive().CreateUserAsync(Arg.Any<string>());
+        Assert.Single(log.Entries, e => e.Message.Contains("no character Jellyfin accepts", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ResolveOrCreateAsync_RefusedProvisioning_DoesNotClaimTheLegacyTargetWasOrphaned()
+    {
+        // The orphan warning states that a fresh account IS being provisioned and the legacy target is now
+        // orphaned. Refusing after it would leave both halves untrue on the one line an operator recovers
+        // from, so the name is resolved ahead of it; this pins that ordering rather than the comment.
+        var (service, _, users, log) = Build(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { [".."] = Existing },
+        });
+        users.GetUserById(Existing).Returns(TestUsers.Named("renamed-alice", Existing));
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+
+        await Assert.ThrowsAsync<AccountLinkForbiddenException>(() =>
+            service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "..", allowExistingAccountLink: false));
+
+        Assert.DoesNotContain(log.Entries, e => e.Message.Contains("orphaned", StringComparison.Ordinal));
+    }
 }

--- a/SSO-Auth.Tests/Linking/ProvisionedUsernameTests.cs
+++ b/SSO-Auth.Tests/Linking/ProvisionedUsernameTests.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Direct tests of <see cref="ProvisionedUsername"/> - the map from an IdP-supplied username to the name a
+/// brand-new Jellyfin account is created under (#1137). The security-relevant half is what the map REFUSES
+/// to hand back: an empty or all-dots result, because "." and ".." are inside the host's own accepted set
+/// and are path traversal once a username reaches the per-user profile directory (#447). The rest pins the
+/// allowlist itself, one rejected class at a time, so a widening is a deliberate edit with a red test in
+/// front of it rather than a quiet one.
+/// </summary>
+public class ProvisionedUsernameTests
+{
+    [Theory]
+    // The literal members of the host's set, which must survive untouched.
+    [InlineData("alice", "alice")]
+    [InlineData("alice.smith", "alice.smith")]
+    [InlineData("alice-smith", "alice-smith")]
+    [InlineData("alice_smith", "alice_smith")]
+    [InlineData("alice+tag", "alice+tag")]
+    [InlineData("alice@example.com", "alice@example.com")]
+    [InlineData("Alice O'Hara", "Alice O'Hara")]
+    [InlineData("user1234", "user1234")]
+    public void TrySanitize_NameAlreadyAcceptable_IsReturnedByteForByte(string raw, string expected)
+    {
+        Assert.True(ProvisionedUsername.TrySanitize(raw, out var provisioned));
+        Assert.Equal(expected, provisioned);
+    }
+
+    [Theory]
+    // One rejected class per row, each around the same accepted stem so the diff is the class alone.
+    [InlineData("al!ice", "alice")]                 // punctuation outside the set
+    [InlineData("al#ice", "alice")]
+    [InlineData("al$ice", "alice")]
+    [InlineData("al%ice", "alice")]
+    [InlineData("al&ice", "alice")]
+    [InlineData("al*ice", "alice")]
+    [InlineData("al(ice)", "alice")]
+    [InlineData("al=ice", "alice")]
+    [InlineData("al|ice", "alice")]
+    [InlineData("al:ice", "alice")]
+    [InlineData("al;ice", "alice")]
+    [InlineData("al,ice", "alice")]
+    [InlineData("al?ice", "alice")]
+    [InlineData("al~ice", "alice")]
+    [InlineData("<alice>", "alice")]
+    [InlineData("\"alice\"", "alice")]
+    [InlineData("al/ice", "alice")]                 // path separators, the profile-directory hazard
+    [InlineData("al\\ice", "alice")]
+    [InlineData("../alice", "..alice")]             // the slash goes; the dots are the host's own set
+    [InlineData("al\nice", "alice")]                // control characters, including the log-forging pair
+    [InlineData("al\rice", "alice")]
+    [InlineData("al\tice", "alice")]
+    [InlineData("al\0ice", "alice")]
+    [InlineData("al\u00A0ice", "alice")]            // whitespace the set does not admit: no-break space
+    [InlineData("al\u2003ice", "alice")]            // em space
+    [InlineData("alice\U0001F600", "alice")]      // astral plane, reached as a surrogate pair
+    public void TrySanitize_RejectedCharacter_IsDroppedRatherThanSubstituted(string raw, string expected)
+    {
+        Assert.True(ProvisionedUsername.TrySanitize(raw, out var provisioned));
+        Assert.Equal(expected, provisioned);
+    }
+
+    [Theory]
+    // The non-ASCII decision, recorded as tests rather than only as prose: Unicode letters, digits and
+    // combining marks are inside .NET's \w and therefore inside the host's own set, so they are PRESERVED
+    // and never transliterated. Transliterating would rename an account the host would have taken as sent.
+    [InlineData("Jörg")]
+    [InlineData("Ærlig")]
+    [InlineData("Ярослав")]
+    [InlineData("中村")]
+    [InlineData("محمد")]
+    [InlineData("Ωμέγα")]
+    [InlineData("Nguyễn")]
+    [InlineData("élodie")]
+    public void TrySanitize_NonAsciiLetters_ArePreserved(string raw)
+    {
+        Assert.True(ProvisionedUsername.TrySanitize(raw, out var provisioned));
+        Assert.Equal(raw, provisioned);
+    }
+
+    [Theory]
+    // The host's anchors forbid leading and trailing whitespace. Space is the only whitespace the allowlist
+    // admits, so the filter plus this trim is the whole of that rule; interior spaces stay.
+    [InlineData(" alice ", "alice")]
+    [InlineData("\talice\t", "alice")]
+    [InlineData("  Alice O'Hara  ", "Alice O'Hara")]
+    [InlineData("!alice!", "alice")]
+    public void TrySanitize_LeadingAndTrailingWhitespace_IsRemoved(string raw, string expected)
+    {
+        Assert.True(ProvisionedUsername.TrySanitize(raw, out var provisioned));
+        Assert.Equal(expected, provisioned);
+    }
+
+    [Theory]
+    // The empty-result fallback. Nothing usable survived, so no name is offered and the caller refuses the
+    // login; the all-dots rows are the ones that would otherwise pass the host's own check and then escape
+    // the user-configuration directory at the profile path (#447).
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    [InlineData("<>/\\")]
+    [InlineData("\n\t")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("...")]
+    [InlineData("./..")]
+    [InlineData("\U0001F600")]
+    public void TrySanitize_NothingAcceptableSurvives_YieldsNoName(string? raw)
+    {
+        Assert.False(ProvisionedUsername.TrySanitize(raw, out var provisioned));
+        Assert.Equal(string.Empty, provisioned);
+    }
+
+    [Theory]
+    [InlineData("alice")]
+    [InlineData(" al!ice ")]
+    [InlineData("../alice")]
+    [InlineData("Jörg\u00A0Müller")]
+    [InlineData("a.b_c-d+e@f'g h")]
+    public void TrySanitize_IsIdempotent(string raw)
+    {
+        Assert.True(ProvisionedUsername.TrySanitize(raw, out var once));
+        Assert.True(ProvisionedUsername.TrySanitize(once, out var twice));
+        Assert.Equal(once, twice);
+    }
+
+    [Fact]
+    public void TrySanitize_EveryAcceptedPunctuationMember_SurvivesInsideAName()
+    {
+        // Derived from the constant the conformance rule pins against the recorded host regex, so widening
+        // the allowlist without widening this cover is not possible: the loop grows with the constant.
+        foreach (var member in ProvisionedUsername.AllowedPunctuation)
+        {
+            Assert.True(ProvisionedUsername.TrySanitize($"a{member}b", out var provisioned));
+            Assert.Equal($"a{member}b", provisioned);
+        }
+    }
+}

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -448,6 +448,11 @@ internal sealed class CanonicalLinkService
     // so it exists inert for an administrator to approve; the caller then refuses the login without minting.
     private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string? issuer, Guid? legacyLink, bool provisionDisabled)
     {
+        // Resolved FIRST, ahead of the orphan warning below (#1137). That warning states that a fresh
+        // account is being provisioned and the legacy target is now orphaned; a refusal after it would
+        // leave both halves of that sentence untrue in the log, on the one line an operator recovers from.
+        var provisionedName = ResolveProvisionedName(mode, provider, username);
+
         if (legacyLink.HasValue && _legacyLinkWarnGate.TryEnter(_clock()))
         {
             // The dangerous, previously-silent case (#354/#361): a legacy username-keyed link
@@ -474,10 +479,10 @@ internal sealed class CanonicalLinkService
 
         if (_logger.IsEnabled(LogLevel.Information))
         {
-            _logger.LogInformation("SSO user {Name} doesn't exist, creating...", username.ReplaceLineEndings(string.Empty));
+            _logger.LogInformation("SSO user {Name} doesn't exist, creating...", provisionedName.ReplaceLineEndings(string.Empty));
         }
 
-        var user = await _userManager.CreateUserAsync(username).ConfigureAwait(false);
+        var user = await _userManager.CreateUserAsync(provisionedName).ConfigureAwait(false);
         user.AuthenticationProviderId = SsoManagedProviderId.Value;
         // https://jonathancrozier.com/blog/how-to-generate-a-cryptographically-secure-random-string-in-dot-net-with-c-sharp
         user.Password = _cryptoProvider.CreatePasswordHash(Convert.ToBase64String(RandomNumberGenerator.GetBytes(64))).ToString();
@@ -515,7 +520,7 @@ internal sealed class CanonicalLinkService
             // later refused login of the now-pending account) and is always accurate - the completion-path
             // gate that refuses the login covers any disabled account, including one an admin disabled, so
             // auditing there would mislabel a deliberate ban as a fresh provisioning.
-            SsoAudit.ProvisionedPendingApproval(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, username);
+            SsoAudit.ProvisionedPendingApproval(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, provisionedName);
         }
 
         // Atomic check-then-link (#133): if a concurrent first-login for the same identity
@@ -524,6 +529,75 @@ internal sealed class CanonicalLinkService
         // link write stamps the login's issuer (#186), so the new link is issuer-bound.
         var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer);
         return effectiveUserId;
+    }
+
+    // The name a BRAND-NEW account is created under (#1137). Jellyfin's CreateUserAsync throws for a name
+    // outside its own character set, so an IdP that emits one (the 9p4#199 shape) used to fail the login
+    // with a host-shaped error and no actionable signal; sanitizing here turns that into a first login that
+    // succeeds under a normalized name. This runs on the CREATE arm only and touches nothing else: the link
+    // key stays the subject, and the raw IdP name is still what the legacy username key, the same-name
+    // lookup and the adoption comparison above are made against. That divergence is deliberate. Sanitizing
+    // the value those reads use would re-point an existing legacy link and change which account a login
+    // resolves to, which is exactly what #829 forbids this issue from doing; and it cannot strand this
+    // account, because every later login for the same identity resolves through the subject-keyed link
+    // written below rather than by name.
+    private string ResolveProvisionedName(ProviderMode mode, string provider, string username)
+    {
+        if (!ProvisionedUsername.TrySanitize(username, out var provisionedName))
+        {
+            // Nothing Jellyfin would accept survived. Refuse with a named plugin-side reason rather than
+            // letting CreateUserAsync throw a host-shaped error, and never invent a substitute name - an
+            // account an administrator sees has to come from something the identity provider actually sent.
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login via {Mode}/{Provider} refused: the identity provider's username has no character Jellyfin accepts in an account name, so no account can be provisioned for it.",
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty));
+            }
+
+            throw new AccountLinkForbiddenException("The SSO username contains no character Jellyfin accepts in an account name; refusing to provision an account under an invented name.");
+        }
+
+        if (string.Equals(provisionedName, username, StringComparison.Ordinal))
+        {
+            // Unchanged, so the name-taken check the caller already made still stands and no second lookup
+            // is made. A login whose name needs no sanitization therefore takes byte-for-byte the pre-#1137
+            // path, which is what the regression test over the existing flow pins.
+            return provisionedName;
+        }
+
+        if (_userManager.GetUserByName(provisionedName) != null)
+        {
+            // The normalized name is already worn by an account this identity has not proved it owns.
+            // Adopting it would be a name-keyed match on a value the plugin invented rather than one the
+            // provider sent, which is the takeover shape #829 rules out; appending a suffix would hand an
+            // administrator an account name nobody chose. Refuse instead, and name both spellings so the
+            // operator can rename one side.
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login for {Name} via {Mode}/{Provider} refused: the name normalizes to {Provisioned}, which an existing Jellyfin account already bears. Rename that account or the identity provider's username.",
+                    username?.ReplaceLineEndings(string.Empty),
+                    mode.ToToken(),
+                    provider?.ReplaceLineEndings(string.Empty),
+                    provisionedName.ReplaceLineEndings(string.Empty));
+            }
+
+            throw new AccountLinkForbiddenException("The sanitized SSO username is already taken by another Jellyfin account; refusing to adopt it by name.");
+        }
+
+        if (_logger.IsEnabled(LogLevel.Information))
+        {
+            _logger.LogInformation(
+                "SSO username {Name} via {Mode}/{Provider} carries characters Jellyfin does not accept in an account name; provisioning as {Provisioned}. The account link is keyed on the provider subject, so the rename does not affect which account later logins resolve to.",
+                username?.ReplaceLineEndings(string.Empty),
+                mode.ToToken(),
+                provider?.ReplaceLineEndings(string.Empty),
+                provisionedName.ReplaceLineEndings(string.Empty));
+        }
+
+        return provisionedName;
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Linking/ProvisionedUsername.cs
+++ b/SSO-Auth/Api/Linking/ProvisionedUsername.cs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// Maps an identity-provider-supplied username to the name a brand-new Jellyfin account is created
+/// under (#1137). Pure and deterministic: it makes no authorization decision, reads no configuration,
+/// and never decides which account a login resolves to - resolution stays keyed on the subject
+/// (OpenID <c>sub</c> / SAML <c>NameID</c>), so this is name PRESENTATION only.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Jellyfin's own <c>CreateUserAsync</c> refuses a name outside <c>^(?!\s)[\w \-'._@+]+(?&lt;!\s)$</c>,
+/// and the plugin cannot reference that check: it lives in the server, off the Controller/Model surface
+/// the plugin compiles against, so this allowlist is a hand-copy of the one in-repo record of it (the
+/// comment in <c>AvatarService.IsUsernameSafeForProfilePath</c>) and a conformance rule pins the two
+/// together. Nothing can pin either against the server, which is the residual: an IdP name this class
+/// narrows that the host would in fact have taken costs a cosmetic rename of a brand-new account, while
+/// a name it passed that the host refused would be the host-shaped login failure this class exists to
+/// remove. The allowlist is therefore deliberately the conservative direction of that trade.
+/// </para>
+/// <para>
+/// The rejected characters are DROPPED rather than substituted. A substitution would turn a name made
+/// entirely of rejected characters into an invented one (<c>!!!</c> becoming <c>___</c>), which reads as
+/// a real name an administrator never chose; dropping makes that case visible as an empty result the
+/// caller has to decide about. Dropping also makes the map idempotent - the output holds only accepted
+/// characters and no leading or trailing space, so a second pass changes nothing.
+/// </para>
+/// <para>
+/// The host's set admits <c>.</c>, so it admits <c>.</c> and <c>..</c> as whole names, and those escape
+/// the per-user configuration directory when they reach a profile path (#447, the reason
+/// <c>AvatarService.IsUsernameSafeForProfilePath</c> exists). An all-dots result is therefore treated as
+/// no result rather than handed back.
+/// </para>
+/// </remarks>
+internal static class ProvisionedUsername
+{
+    /// <summary>
+    /// The characters Jellyfin's username check accepts that are not matched by the Unicode
+    /// <c>\w</c> class - the literal members of <c>[\w \-'._@+]</c>. Kept as one string so the
+    /// conformance rule can read it back out of the source and compare it to the recorded regex.
+    /// </summary>
+    internal const string AllowedPunctuation = " -'._@+";
+
+    /// <summary>
+    /// Maps an IdP-supplied username to the name a new account may be provisioned under, dropping every
+    /// character Jellyfin's own check refuses.
+    /// </summary>
+    /// <param name="raw">The raw IdP-supplied username. Null, empty and whitespace-only all yield no name.</param>
+    /// <param name="provisioned">
+    /// On success, the sanitized name - non-empty, made only of accepted characters, with no leading or
+    /// trailing space, and not made only of dots. Otherwise the empty string.
+    /// </param>
+    /// <returns>True when a name survived sanitization; false when nothing usable is left.</returns>
+    internal static bool TrySanitize(string? raw, out string provisioned)
+    {
+        provisioned = string.Empty;
+        if (string.IsNullOrEmpty(raw))
+        {
+            return false;
+        }
+
+        var kept = new StringBuilder(raw.Length);
+        foreach (var character in raw)
+        {
+            if (IsAccepted(character))
+            {
+                kept.Append(character);
+            }
+        }
+
+        // The host anchors forbid a leading or trailing whitespace character. Space is the only whitespace
+        // the allowlist admits, so trimming it is the whole of that rule after the filter has run.
+        var trimmed = kept.ToString().Trim(' ');
+        if (trimmed.Length == 0 || IsOnlyDots(trimmed))
+        {
+            return false;
+        }
+
+        provisioned = trimmed;
+        return true;
+    }
+
+    // Unicode \w, which .NET resolves to letters, non-spacing marks, decimal digits and connector
+    // punctuation, plus the literal members of the host's set. Non-ASCII letters and digits are therefore
+    // PRESERVED rather than transliterated: they are already inside \w, so the host takes them, and
+    // transliterating a name the host accepts would rename an account for no reason the host asked for.
+    private static bool IsAccepted(char character) =>
+        AllowedPunctuation.Contains(character, StringComparison.Ordinal)
+        || CharUnicodeInfo.GetUnicodeCategory(character) is UnicodeCategory.UppercaseLetter
+            or UnicodeCategory.LowercaseLetter
+            or UnicodeCategory.TitlecaseLetter
+            or UnicodeCategory.ModifierLetter
+            or UnicodeCategory.OtherLetter
+            or UnicodeCategory.NonSpacingMark
+            or UnicodeCategory.DecimalDigitNumber
+            or UnicodeCategory.ConnectorPunctuation;
+
+    // "." and ".." are accepted by the host and are path traversal at the profile directory (#447); a name
+    // of any other all-dots shape is equally not a name. Treated as an empty result rather than returned.
+    private static bool IsOnlyDots(string candidate)
+    {
+        foreach (var character in candidate)
+        {
+            if (character != '.')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -29,6 +29,7 @@
   "link.disabled_note": " (disabled)",
   "config.title": "SSO Settings:",
   "config.sso_only_summary": "SSO-only login (disable password login)",
+  "config.username_normalization_note": "A provider username carrying characters Jellyfin does not accept in an account name is normalized before a new account is created, and a login whose name normalizes to nothing usable, or to a name another account already bears, is refused rather than provisioned under an invented one. Account links are keyed on the provider subject, so a normalized name never changes which account a later login resolves to.",
   "config.placeholder_keep_secret": "Leave blank to keep the current secret",
   "config.placeholder_keep_key": "Leave blank to keep the current key",
   "config.oidc_providers": "SSO providers",

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -41,6 +41,16 @@
                 Making changes to this configuration requires a restart of
                 Jellyfin.
                 <br />
+                <span data-i18n="config.username_normalization_note"
+                  >A provider username carrying characters Jellyfin does not
+                  accept in an account name is normalized before a new account
+                  is created, and a login whose name normalizes to nothing
+                  usable, or to a name another account already bears, is refused
+                  rather than provisioned under an invented one. Account links
+                  are keyed on the provider subject, so a normalized name never
+                  changes which account a later login resolves to.</span
+                >
+                <br />
                 This plug-in is at the Release Candidate stage of its maturity
                 ladder (In-Development &rarr; Alpha &rarr; Beta &rarr; Release
                 Candidate &rarr; Full Release); not all configuration options


### PR DESCRIPTION
# What & why

Jellyfin's `CreateUserAsync` refuses an account name outside
`^(?!\s)[\w \-'._@+]+(?<!\s)$`, and `CanonicalLinkService.CreateNewAccountAsync`
handed it the raw identity-provider name. A provider that emits a name with a
rejected character therefore broke the first login with a host-shaped error and
no operator signal, which is the 9p4#199 shape.

`ProvisionedUsername` maps that name to one the host accepts, on the create arm
and nowhere else. Rejected characters are dropped rather than substituted, so a
name made only of them stays visibly empty instead of becoming an invented one
(`!!!` would otherwise read as `___`, a name nobody chose). Non-ASCII letters,
digits and combining marks are preserved: .NET's `\w` is Unicode, so the host
already takes them, and transliterating would rename an account the host asked
nothing about.

Closes #1137

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**The two unticked boxes are unticked because no second reader was available
for this change, and nothing here should be read as one having run.** What
stands in its place is the evidence below rather than an assurance. Three
properties this change rests on were falsified by breaking them and watching
the suite go red, each for the reason it names:

| Break | Test that reddens |
| --- | --- |
| call site reverted to the raw name | `ResolveOrCreateAsync_IdpNameCarriesRejectedCharacters_ProvisionsUnderTheSanitizedName` |
| `AllowedPunctuation` widened by one character | `TheProvisionedUsernameAllowlist_StillMirrorsTheRecordedHostRule` |
| the resolve moved back after the orphan warning | `ResolveOrCreateAsync_RefusedProvisioning_DoesNotClaimTheLegacyTargetWasOrphaned` |

The fail-safes those cover:

- **Resolution is untouched.** The legacy username key, the same-name lookup
  and the adoption comparison all still read the raw name, so no existing link
  changes which account it resolves to, and the constraint carried down from
  #829 holds. A name needing no sanitization takes byte-for-byte the previous
  path, pinned by the `GetUserByName` call count in
  `ResolveOrCreateAsync_AcceptableIdpName_MakesNoSecondNameLookup`. The
  divergence the issue asks to be reasoned about is deliberate: sanitizing the
  value the lookups use would re-point an existing legacy link, and it cannot
  strand the new account, because every later login for that identity resolves
  through the subject-keyed link rather than by name.
- **Nothing usable left means refuse, not invent.** `.` and `..` pass the
  host's own check and escape the user-configuration directory at the profile
  path (#447), so an all-dots result is treated as no result.
- **A taken sanitized name refuses rather than adopts.** Adopting there would
  be a name-keyed match on a value this plugin invented rather than one the
  provider sent. Neither refusal is an availability regression: both cases
  already failed today, inside `CreateUserAsync`, with a worse message.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: see Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2976, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 2977, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

Prettier reports the whole of `configPage.html` as unformatted on this machine,
and it reports the same on the file as it stands on `main` with no change
applied, so the report is a working-copy line-ending artefact rather than
something this branch introduces. Against an LF copy of the changed file, in
the tree so `.editorconfig` applies, it is clean:

```
$ npx prettier --check SSO-Auth/Web/lfprobe.html
All matched files use Prettier code style!
```

## Notes

The allowlist is a hand-copy of a rule the plugin cannot reference, because it
lives in the server rather than on the Controller/Model surface compiled
against. Its one in-repo record is the regex in `AvatarService`'s comment, and
the new conformance rule derives the punctuation members back out of that
record and compares them to the constant. Nothing can pin either against the
server. That residual is stated on the class, and it is why the allowlist is
the conservative direction of the trade: a name it narrows that the host would
have taken costs a cosmetic rename of a brand-new account, while a name it
passed that the host refused would be the failure this change exists to remove.

The try-then-fall-back design is ruled out rather than skipped. The contract
the plugin compiles against documents `ArgumentException` for a name that
already EXISTS and does not document the invalid-character refusal at all, so
retrying a sanitized name after that exception would re-provision under a
mangled name on a plain name collision.

Out of scope in this change, and not done:

- The wiki `Provider-Setup` page. Wiki edits are gated and are not made from a
  branch, so the rule is not written there yet.
- The admin config surface note **is** included, in the collapsible notes block
  on the configuration page, behind the new `config.username_normalization_note`
  catalog key so it localizes like every other string on that page.
