### PR TITLE
Fuzz the parse surface with its assertions compiled in

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,6 +16,18 @@
 # crasher and the evolved corpus as artifacts and, when a crasher is found, marks
 # the run red purely as a notification signal to me.
 #
+# ASSERTIONS ARE COMPILED IN HERE AND NOWHERE ELSE (#1081). The parse-surface
+# post-conditions from #1082 are `Debug.Assert`, so the shipped Release compile
+# strips the calls and a fuzz run against it would exercise a surface with none
+# of them live. The build step below defines DEBUG for this build alone. It is
+# passed on the command line rather than written into a build file on purpose:
+# `ParseSurfaceAssertions_NeverReachTheShippedBuild` refuses a DefineConstants in
+# Directory.Build.props or SSO-Auth.csproj outright, so keeping the constant here
+# leaves that guard at full strength and no publish route can inherit it. A
+# failing assertion aborts the process, which libFuzzer records as an ordinary
+# crasher and the report step below turns red; it is triaged exactly like any
+# other reproducer, per the harness README.
+#
 # Hardened per the repo workflow policy (see zizmor.yml): every action is
 # SHA-pinned with a version comment, checkout runs with persist-credentials:false,
 # permissions are deny-all at the top level with the job granted only
@@ -99,8 +111,15 @@ jobs:
         # a drifted/tampered dependency graph cannot build here either.
         run: dotnet restore SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj --locked-mode
 
-      - name: Build harness (Release)
-        run: dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror
+      - name: Build harness (Release, assertions enabled)
+        # DEBUG is what keeps the [Conditional("DEBUG")] post-conditions on the parse
+        # surface through the compile. TRACE is restated because this property
+        # REPLACES the default constant set rather than adding to it, and Release
+        # defines TRACE; %3B is MSBuild's escape for the separator, which keeps the
+        # value one argument whatever the shell does with a semicolon. Configuration
+        # stays Release, so the fuzzer keeps optimized code and the output paths in
+        # `env` above do not move.
+        run: dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --no-restore --warnaserror -p:DefineConstants=DEBUG%3BTRACE
 
       - name: Install clang (libFuzzer)
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends clang

--- a/SSO-Auth.Fuzz/README.md
+++ b/SSO-Auth.Fuzz/README.md
@@ -92,11 +92,61 @@ exhaust. The marginal value is modest (the raw parsing is delegated to already-h
 parsers - `System.Xml` with DTD prohibited, `Newtonsoft.Json`, `Microsoft.IdentityModel`), but real and
 low-maintenance, and it is the surface #174 already committed to.
 
+## The configuration that is fuzzed
+
+The weekly job builds **Release with `-p:DefineConstants=DEBUG%3BTRACE`** (#1081), and that is the only
+build in the repository which defines `DEBUG`. It matters because the post-conditions #1082 put on the
+parse surface are `Debug.Assert`, which the compiler removes outside a `DEBUG` compile, so the plain
+Release assembly the plugin ships carries none of them:
+
+```sh
+$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --warnaserror
+$ tr -d '\000' < SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll | grep -ac "collapsed an absent NameID"
+0
+$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --warnaserror -p:DefineConstants=DEBUG%3BTRACE
+$ tr -d '\000' < SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll | grep -ac "collapsed an absent NameID"
+1
+```
+
+Three things about that spelling, none of them incidental.
+
+It is a command-line property and not a line in a build file, because
+`ParseSurfaceAssertions_NeverReachTheShippedBuild` refuses a `DefineConstants` in
+`Directory.Build.props` or `SSO-Auth.csproj` outright, and keeping the constant out of both leaves that
+refusal at full strength. Nothing that ships is built this way, and nothing that ships can inherit it: an
+assertion left live in production auth code turns an input the login path is meant to reject into a
+process abort.
+
+`TRACE` is restated because the property replaces the default constant set instead of adding to it, and
+Release defines `TRACE`. Without it the fuzzed build would differ from Release in a second, unrelated
+way. `%3B` is MSBuild's escape for the separator, so the value survives whatever the shell would
+otherwise do with a bare semicolon.
+
+The configuration stays Release, so the assertions cost the fuzzer none of its optimized code:
+
+```sh
+$ dotnet msbuild SSO-Auth/SSO-Auth.csproj -p:Configuration=Release -p:DefineConstants=DEBUG%3BTRACE \
+      -getProperty:DefineConstants -getProperty:Optimize
+{ "Properties": { "DefineConstants": "DEBUG;TRACE", "Optimize": "true" } }
+```
+
+### An assertion failure is an ordinary crasher
+
+A failed `Debug.Assert` prints its message and stack and terminates the process, so libFuzzer records
+it the same way it records any other crash: a reproducer under `findings/<target>/`, archived by the
+`sharpfuzz-crashers-<target>` artifact, and the "Report findings" step turns that leg red.
+
+Triage is the same as for any other reproducer, and the rule against fixing it in the harness applies
+unchanged: **do not delete or weaken the assertion to make the run green.** A failing post-condition
+says the parser returned a shape the code around it already assumes it cannot return, so the reproducer
+is minimised and filed, and the fix goes into the parser or into the post-condition's own statement of
+the invariant, in a separate change.
+
 ## Running it (Linux)
 
 ```sh
-# 1. Build the harness (Release).
-dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release
+# 1. Build the harness (Release, with the parse-surface assertions compiled in).
+dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release -p:DefineConstants=DEBUG%3BTRACE
 
 # 2. Instrument the plugin assembly SharpFuzz will fuzz through.
 dotnet tool install --global SharpFuzz.CommandLine

--- a/SSO-Auth.Tests/Fuzz/FuzzAssertionBuildTests.cs
+++ b/SSO-Auth.Tests/Fuzz/FuzzAssertionBuildTests.cs
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Holds the parse-surface assertions to exactly one build: the weekly fuzz job (#1081).
+/// <para>
+/// The post-conditions #1082 put on the SAML and OpenID parsers are <c>Debug.Assert</c>, which the
+/// compiler removes from any build that does not define <c>DEBUG</c>. That removal is what makes them
+/// acceptable on an authentication path, and it is also what makes them useless to a fuzzer unless one
+/// build asks for them back. <c>ParseSurfaceAssertions_NeverReachTheShippedBuild</c> refuses the constant
+/// in <c>Directory.Build.props</c> and <c>SSO-Auth.csproj</c>, so the fuzz job passes it on the command
+/// line instead - and a constant on a command line is exactly the kind of thing that gets dropped in an
+/// unrelated edit to a workflow nobody rereads on a green week.
+/// </para>
+/// <para>
+/// Both directions are the rule. Dropping the constant from the fuzz job leaves the weekly run driving a
+/// surface that asserts nothing while every artefact still says it does; adding it to any other workflow
+/// puts an abort-on-failure check into a build that can be published, where a fault the login path is
+/// meant to reject becomes a process abort instead.
+/// </para>
+/// <para>
+/// WHAT THIS DOES NOT DO. It reads workflow text, so it judges what the repository asks for and never
+/// what a runner did with it: a job whose build step is skipped, or whose SDK ignores the property, looks
+/// identical here. The evidence that the constant reaches the assembly is the differential recorded on
+/// #1081, and the evidence that a failing assertion lands as a libFuzzer reproducer is the dispatch run
+/// linked there. This rule keeps the configuration those two measurements were taken against.
+/// </para>
+/// </summary>
+public class FuzzAssertionBuildTests
+{
+    // The workflow that is allowed to compile the assertions in. Named rather than discovered: the claim is
+    // about one job, and a scan that took whichever workflow happened to build the harness would move with
+    // the tree instead of pinning it.
+    private const string FuzzWorkflow = "fuzz.yml";
+
+    // The project the fuzz job builds. A build line that does not name it is some other build and is not
+    // what this rule is about.
+    private const string HarnessProject = "SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj";
+
+    // The property spelling that carries the constant. Matched on the property NAME alone, so a rewrite of
+    // the value (a third constant, a different separator escape) is read by the assertions below rather
+    // than slipping past a match on the whole literal.
+    private const string ConstantProperty = "-p:DefineConstants=";
+
+    [Fact]
+    public void OnlyTheFuzzWorkflow_CompilesTheParseSurfaceAssertions()
+    {
+        var workflows = Directory
+            .EnumerateFiles(Path.Combine(RepoTree.Root, ".github", "workflows"), "*.yml", SearchOption.TopDirectoryOnly)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            workflows.Count > 0,
+            "No workflow file was found under .github/workflows - the directory moved, so this rule would pass vacuously (#1081).");
+
+        var definers = workflows
+            .Where(path => DefinesDebug(File.ReadAllText(path)))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.True(
+            definers.Count == 1 && string.Equals(definers[0], FuzzWorkflow, StringComparison.Ordinal),
+            $"DEBUG may be defined by {FuzzWorkflow} and by no other workflow: it carries every parse-surface Debug.Assert into the assembly that build produces, and outside the fuzz job that assembly can be published (#1081/#1082). Definers: "
+                + (definers.Count == 0 ? "(none)" : string.Join(", ", definers)));
+    }
+
+    [Fact]
+    public void TheFuzzWorkflow_BuildsTheHarnessWithTheAssertionsAndNothingElseDropped()
+    {
+        var buildLines = File
+            .ReadAllLines(Path.Combine(RepoTree.Root, ".github", "workflows", FuzzWorkflow))
+            .Select(line => line.Trim())
+            .Where(line => !line.StartsWith('#')
+                && line.Contains("dotnet build", StringComparison.Ordinal)
+                && line.Contains(HarnessProject, StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(
+            buildLines.Count == 1,
+            $"Expected exactly one step in {FuzzWorkflow} building {HarnessProject}, so there is one place the constant can be read off; found {buildLines.Count} (#1081).");
+
+        var build = buildLines[0];
+
+        Assert.True(
+            build.Contains(ConstantProperty, StringComparison.Ordinal),
+            $"The fuzz build must pass {ConstantProperty}: without it the parse-surface post-conditions are compiled out and the weekly run asserts nothing (#1081). Line: {build}");
+
+        var constants = Constants(build);
+
+        Assert.Contains("DEBUG", constants, StringComparer.Ordinal);
+
+        // TRACE is not decoration. The property REPLACES the default constant set rather than adding to it,
+        // and Release defines TRACE, so a value naming DEBUG alone would silently make the fuzzed build
+        // differ from Release in a second way that has nothing to do with assertions.
+        Assert.Contains("TRACE", constants, StringComparer.Ordinal);
+
+        // Release, because the assertions are meant to cost the fuzzer checks and not its optimized code:
+        // -c Debug would buy the same constant and spend the run's -max_total_time budget on unoptimized IL.
+        Assert.Contains("-c Release", build, StringComparison.Ordinal);
+    }
+
+    // Reads the value of the constant property off a command line and splits it into the constants it
+    // names. %3B is MSBuild's escape for the separator and is what the fuzz job uses, so a value spelled
+    // with a literal semicolon reads identically here rather than looking like one long constant.
+    private static IReadOnlyList<string> Constants(string commandLine)
+    {
+        var start = commandLine.IndexOf(ConstantProperty, StringComparison.Ordinal) + ConstantProperty.Length;
+        var value = commandLine[start..].Split(' ')[0].Trim('"', '\'');
+
+        return value
+            .Replace("%3B", ";", StringComparison.OrdinalIgnoreCase)
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    // A workflow defines DEBUG when a command line in it sets the constant property to a value naming it.
+    // Comment lines are read too, deliberately: this file's own prose aside, a commented-out build step is
+    // not what the rule is about, but a DEBUG sitting in a workflow's text is worth a reader's attention
+    // either way, and treating the two the same keeps the check from depending on YAML structure.
+    private static bool DefinesDebug(string workflow) =>
+        workflow.Contains(ConstantProperty, StringComparison.Ordinal)
+        && workflow
+            .Split('\n')
+            .Where(line => line.Contains(ConstantProperty, StringComparison.Ordinal))
+            .Any(line => Constants(line).Contains("DEBUG", StringComparer.Ordinal));
+}


### PR DESCRIPTION
# What & why

The post-conditions #1082 put on the SAML and OpenID parsers are `Debug.Assert`, which the compiler removes from any build that does not define `DEBUG`. The weekly fuzz job built `-c Release`, so every one of them was stripped before libFuzzer saw the assembly: the run drove a surface that asserted nothing, while the harness README and the issue trail both read as though it did. This is the build/CI half of #714; the assertions themselves already landed.

The build step now passes `-p:DefineConstants=DEBUG%3BTRACE`. Measured on this branch:

```
$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --warnaserror
$ tr -d '\000' < SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll | grep -ac "collapsed an absent NameID"
0
$ dotnet build SSO-Auth.Fuzz/SSO-Auth.Fuzz.csproj -c Release --warnaserror -p:DefineConstants=DEBUG%3BTRACE
$ tr -d '\000' < SSO-Auth.Fuzz/bin/Release/net9.0/SSO-Auth.dll | grep -ac "collapsed an absent NameID"
1
$ dotnet msbuild SSO-Auth/SSO-Auth.csproj -p:Configuration=Release -p:DefineConstants=DEBUG%3BTRACE \
      -getProperty:DefineConstants -getProperty:Optimize
{ "Properties": { "DefineConstants": "DEBUG;TRACE", "Optimize": "true" } }
```

Three choices in that spelling. The constant is a command-line property rather than a line in a build file because `ParseSurfaceAssertions_NeverReachTheShippedBuild` refuses a `DefineConstants` in `Directory.Build.props` or `SSO-Auth.csproj` outright; the first attempt at this change put it there and that test refused it, which is the guard working. `TRACE` is restated because the property replaces the default constant set instead of adding to it, and Release defines `TRACE`. The configuration stays Release, so the checks cost the fuzzer none of its optimized code, where `-c Debug` would buy the same constant and spend the run's `-max_total_time` budget on unoptimized IL.

Closes #1081.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No plugin source changes here; `git diff origin/main --stat -- SSO-Auth/` is empty, so no login-path decision moves.
- [x] No secrets logged; secrets are redacted on config export. Nothing is logged that was not logged before.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call. Unchanged; no log call is touched.

The two unticked boxes are the honest answer and not an oversight. No second reader looked at this branch, and no lens review was run against it. What stands in place of one is the pair of dispatch runs under Verification, which exercise the changed configuration end to end on the real job, and the fact that the diff changes no shipped code.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`. The property lives in a new `SSO-Auth.Tests/Fuzz/FuzzAssertionBuildTests.cs` rather than in the 3,300-line file, matching the per-surface conformance files already beside it and the direction #1045 asks for.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes). `SSO-Auth.Fuzz/README.md` carries the configuration and the assertion-failure triage path, in this change.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks, 0 warnings.
- [x] `dotnet test` is green. 2978 tests on net9.0 and 2979 on net10.0, 0 failed, 4 skipped. The four skips are the pre-existing `SsoHttpTests` cases that need a listener off loopback, which raises a firewall consent dialog on this machine (#1227); they are skipped, not worked around.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. `npx prettier --check SSO-Auth.Fuzz/README.md` passes.

Two `workflow_dispatch` runs of the job itself, which is the only way this change can be verified:

- Clean branch, `max_total_time=120`: https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/31698811511. Every leg restored `--locked-mode`, built `--warnaserror` with `0 Warning(s) 0 Error(s)`, instrumented and ran libFuzzer. Four legs green; `discovery` red on a real crasher, filed as #1340 and discussed below.
- A throwaway branch carrying one deliberately broken post-condition, `max_total_time=60`: https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/31699026237. The `saml` leg printed `Process terminated. Assertion failed.` with the probe's message, libFuzzer wrote `findings/saml/crash-6155b0f680df959a317b18860490832935c6b4e6`, the `sharpfuzz-crashers-saml` artifact archived it and the "Report findings" step turned the leg red. That is the second half of the issue's done-condition: a failing assertion lands as an ordinary reproducer. The branch is `probe/1081-assertion-crasher`; nothing on it is merged here.

Both new guards were proven by breaking them. Removing the flag from the build step reddens both tests; adding the same flag to `dotnet.yml` reddens the one that says only the fuzz job may define `DEBUG`. Both were restored.

## Notes

The first assertions-enabled run found a real crasher on the `discovery` target within five seconds: `JsonElement.TryGetProperty` throws `InvalidOperationException` on a document whose member names carry an unpaired surrogate escape, and both discovery flag readers call it while documenting that they never throw. It is **not** caused by this change - it replays identically on a plain Release build with the assertions absent from the assembly - and a login does not reach it today, because the repeated-member screen reports that document unreadable at the transport before either reader runs. Filed as #1340 with the reproducer, the measurement per reader, and the reachability stated at exactly that width. Per the harness rule it is neither fixed here nor silenced in the harness.

The weekly job will therefore be red on `discovery` until #1340 lands. That is the job reporting a finding rather than a broken configuration, and it is the reason the workflow marks itself red at all.

Out of scope: `-c Debug`, considered and rejected above for the throughput it costs; anything under `SSO-Auth/`.
