### PR TITLE
Read an account-expiry instant from a configured IdP claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **An account-expiry instant read from a provider claim (#1143).** A provider
+  can name a claim (OpenID) or assertion attribute (SAML) that carries the
+  instant its account access ends, and both protocols now read it onto the
+  verified identity as a UTC timestamp. It is read and carried, nothing more:
+  no login is refused, no account is disabled, and a provider that names no
+  claim behaves exactly as before, which is every provider by default. The
+  value is accepted as a JWT `NumericDate` or an ISO-8601 timestamp with or
+  without an offset, and an offset-less value is read as UTC rather than as the
+  server's local time. A claim that is absent, or whose value is neither shape,
+  carries no instant instead of failing the login. For OpenID the name may be a
+  dotted path into the claim's JSON, the same convention the role claim uses.
+  The field is settable in the plugin configuration; the provider forms in the
+  dashboard do not carry it yet.
 - **OpenID providers on a private network (#1058).** A new per-provider option,
   **Allow Private Network Addresses**, lets a provider's backchannel
   (discovery, JWKS, token, userinfo, back-channel logout) reach an identity

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -4402,6 +4402,12 @@ public class ArchitectureConformanceTests
         // response for a handler to sit in front of, and the screen runs on the string before Newtonsoft is
         // consulted at all (#1324).
         ["SSO-Auth/Api/Oidc/OidcRoleExtractor.cs"] = "SSO-Auth/Api/Oidc/OidcRoleExtractor.cs",
+
+        // The account-expiry claim's value, walked to a scalar when the configured path is dotted (#1143).
+        // Same shape as the role claim above and gated the same way: the value is a claim on an
+        // already-validated token, so the screen runs in the reading file on the string, ahead of
+        // Newtonsoft, over exactly the scopes the walk descends through.
+        ["SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs"] = "SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs",
     };
 
     // Sites over bytes the plugin itself shipped or produced, each with the reason it is not provider

--- a/SSO-Auth.Tests/Identity/AccountExpiryInstantTests.cs
+++ b/SSO-Auth.Tests/Identity/AccountExpiryInstantTests.cs
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="AccountExpiryInstant"/>, the reader both protocols take an account-expiry claim
+/// value through (#1143). The value is attacker-influenced and arrives on a public callback, so the
+/// property under test is two-sided: every shape an identity provider really emits resolves to the right
+/// UTC instant, and every shape the reader does not understand resolves to no instant at all, without
+/// throwing.
+/// </summary>
+public class AccountExpiryInstantTests
+{
+    [Fact]
+    public void NumericDate_IsReadAsSecondsSinceTheUnixEpoch()
+    {
+        // RFC 7519 NumericDate, the shape a JWT claim carries: 2030-01-01T00:00:00Z.
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), AccountExpiryInstant.Read("1893456000"));
+    }
+
+    [Fact]
+    public void NumericDate_ResolvesAUtcInstant()
+    {
+        // #676 was a local-time read of an expiry giving early expiry across a DST step. A deadline whose
+        // Kind is Unspecified compares against DateTime.UtcNow as if it were local, so the Kind is the
+        // property and not an incidental detail of how it was parsed.
+        Assert.Equal(DateTimeKind.Utc, AccountExpiryInstant.Read("1893456000")!.Value.Kind);
+    }
+
+    [Theory]
+    [InlineData("2030-01-01T00:00:00Z")]
+    [InlineData("2030-01-01T01:00:00+01:00")]
+    [InlineData("2029-12-31T23:00:00-01:00")]
+    [InlineData("2030-01-01T00:00:00")]
+    [InlineData("2030-01-01T00:00:00.000Z")]
+    public void IsoTimestamps_WithAndWithoutAnOffset_NormaliseToTheSameUtcInstant(string raw)
+    {
+        // The offset-less case is the one worth stating: it is read as UTC rather than as this server's
+        // local time, so the same assertion holds on a machine in any zone (#676).
+        var read = AccountExpiryInstant.Read(raw);
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), read);
+        Assert.Equal(DateTimeKind.Utc, read!.Value.Kind);
+    }
+
+    [Fact]
+    public void AnInstantInThePast_IsReadRatherThanRefused()
+    {
+        // A deadline that has passed is exactly the case the enforcement step exists for, so the reader
+        // must hand it over rather than treat it as nonsense. Reading is not deciding (#1144 decides).
+        Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), AccountExpiryInstant.Read("946684800"));
+    }
+
+    [Fact]
+    public void AnInstantFarInTheFuture_IsReadRatherThanRefused()
+    {
+        Assert.Equal(new DateTime(2286, 11, 20, 17, 46, 39, DateTimeKind.Utc), AccountExpiryInstant.Read("9999999999"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("never")]
+    [InlineData("2030-13-45T99:99:99Z")]
+    [InlineData("{\"exp\":1893456000}")]
+    [InlineData("1893456000; DROP")]
+    [InlineData("99999999999999999999999")]
+    public void AValueTheReaderDoesNotUnderstand_YieldsNoInstantAndDoesNotThrow(string? raw)
+    {
+        // The whole set in one place, because the contract is "null on anything else" rather than a list of
+        // named refusals: a claim value is attacker-influenced and a throw here is a 500 on a public
+        // callback (#216). The last entry is a digit string past every calendar's range, which is the case
+        // an unchecked FromUnixTimeSeconds throws on.
+        Assert.Null(AccountExpiryInstant.Read(raw));
+    }
+
+    [Theory]
+    [InlineData("١٨٩٣٤٥٦٠٠٠")]
+    [InlineData("１８９３４５６０００")]
+    public void DigitsOfAnotherScript_AreNotReadAsANumericDate(string raw)
+    {
+        // char.IsDigit is true for the decimal digits of every script and long.TryParse accepts several of
+        // them, so a homoglyph deadline would parse to a real instant under the obvious spelling of this
+        // reader. The digits are matched one by one against '0'..'9' for that reason, and this is the test
+        // that goes red if that is ever relaxed to char.IsDigit.
+        Assert.Null(AccountExpiryInstant.Read(raw));
+    }
+
+    [Theory]
+    [InlineData("23:59")]
+    [InlineData("2030-01")]
+    [InlineData("01/01/2030")]
+    public void GeneralParseShapes_ThisReaderRefuses(string raw)
+    {
+        // Measured rather than assumed, and the reason the reader parses against an explicit format list
+        // instead of DateTimeOffset.TryParse: the general parse accepts every one of these. A bare time is
+        // completed against TODAY, a bare year-month against the first of that month, and the slash form is
+        // a locale convention no protocol here defines - each would hand the enforcement step a deadline the
+        // provider never stated.
+        Assert.True(DateTimeOffset.TryParse(raw, CultureInfo.InvariantCulture, DateTimeStyles.None, out _), $"The general parse was expected to accept {raw}.");
+        Assert.Null(AccountExpiryInstant.Read(raw));
+    }
+
+    [Fact]
+    public void SurroundingWhitespace_DoesNotHideAnInstant()
+    {
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), AccountExpiryInstant.Read("  2030-01-01T00:00:00Z  "));
+    }
+}

--- a/SSO-Auth.Tests/Identity/AccountExpiryInstantTests.cs
+++ b/SSO-Auth.Tests/Identity/AccountExpiryInstantTests.cs
@@ -86,10 +86,11 @@ public class AccountExpiryInstantTests
     [InlineData("１８９３４５６０００")]
     public void DigitsOfAnotherScript_AreNotReadAsANumericDate(string raw)
     {
-        // char.IsDigit is true for the decimal digits of every script and long.TryParse accepts several of
-        // them, so a homoglyph deadline would parse to a real instant under the obvious spelling of this
-        // reader. The digits are matched one by one against '0'..'9' for that reason, and this is the test
-        // that goes red if that is ever relaxed to char.IsDigit.
+        // A deadline spelled in Arabic-Indic or fullwidth digits is refused, so the two ways of writing the
+        // same number are not two ways of setting the same deadline. Stated as its own case because it is
+        // the shape somebody would reach for to smuggle one past a reviewer reading the source, and NOT
+        // because a line here is what refuses it: .NET's integer parse takes ASCII digits only, under the
+        // invariant culture and under every other, so no argument of this reader's is load-bearing for it.
         Assert.Null(AccountExpiryInstant.Read(raw));
     }
 

--- a/SSO-Auth.Tests/Oidc/OidcAccountExpiryClaimTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcAccountExpiryClaimTests.cs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the OpenID half of the account-expiry read (#1143): the configured claim reaches the derived
+/// authorize state as a UTC instant, a dotted path walks into the claim's JSON exactly as the role claim's
+/// does, and a provider that configures no claim derives the state it derived before.
+/// </summary>
+public class OidcAccountExpiryClaimTests
+{
+    private static List<Claim> Claims(params (string Type, string Value)[] claims)
+    {
+        var list = new List<Claim>();
+        foreach (var (type, value) in claims)
+        {
+            list.Add(new Claim(type, value));
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public void NoExpiryClaimConfigured_DerivesNoInstant()
+    {
+        // The regression that matters most here: the feature is off by default, so a provider that never
+        // heard of it must derive exactly what it derived before. A claim that WOULD parse is present, so
+        // this fails if the reader ever guesses a claim name instead of being told one.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("sub", "alice"), ("exp_at", "1893456000")),
+            new OidConfig { Roles = Array.Empty<string>() });
+
+        Assert.Null(derived.ExpiresAtUtc);
+    }
+
+    [Theory]
+    [InlineData("1893456000")]
+    [InlineData("2030-01-01T00:00:00Z")]
+    [InlineData("2030-01-01T01:00:00+01:00")]
+    [InlineData("2030-01-01T00:00:00")]
+    public void AConfiguredClaim_IsReadInEveryShapeAProviderEmits(string value)
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("sub", "alice"), ("expires_at", value)),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void AnInstantInThePast_IsCarriedRatherThanDroppedAtTheRead()
+    {
+        // Nothing here decides anything, so an already-passed deadline has to survive the read intact:
+        // dropping it would leave the enforcement step (#1144) unable to tell "expired" from "no deadline".
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("expires_at", "946684800")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void AnInstantFarInTheFuture_IsCarried()
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("expires_at", "9999999999")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(new DateTime(2286, 11, 20, 17, 46, 39, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void AConfiguredClaimTheLoginDoesNotCarry_DerivesNoInstant()
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("sub", "alice")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Null(derived.ExpiresAtUtc);
+    }
+
+    [Theory]
+    [InlineData("never")]
+    [InlineData("")]
+    [InlineData("2030-13-45T99:99:99Z")]
+    public void AClaimValueThatIsNeitherShape_DerivesNoInstantAndDoesNotThrow(string value)
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("expires_at", value)),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Null(derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void NestedNumericDate_IsReadThroughThePath()
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("attrs", "{\"account\":{\"expires_at\":1893456000}}")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "attrs.account.expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void NestedIsoTimestamp_IsReadThroughThePath()
+    {
+        // The case Newtonsoft's default date handling silently breaks: it would turn this member into a
+        // DateTime token, and reading that back as a string yields the round-trip form rather than the
+        // provider's bytes, which this reader refuses. Delete DateParseHandling.None and this goes red.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("attrs", "{\"account\":{\"expires_at\":\"2030-01-01T00:00:00Z\"}}")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "attrs.account.expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Theory]
+    [InlineData("{\"account\":{\"other\":1893456000}}")]
+    [InlineData("{\"account\":\"not-an-object\"}")]
+    [InlineData("{\"account\":{\"expires_at\":{\"at\":1893456000}}}")]
+    [InlineData("{\"account\":{\"expires_at\":[1893456000]}}")]
+    [InlineData("not json at all")]
+    [InlineData("[1893456000]")]
+    public void ANestedPathThatDoesNotResolveToAScalar_DerivesNoInstantAndDoesNotThrow(string claimValue)
+    {
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("attrs", claimValue)),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "attrs.account.expires_at" });
+
+        Assert.Null(derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void AScopeTheWalkEntersNamingAMemberTwice_DerivesNoInstant()
+    {
+        // Two statements about the same deadline, and which one wins would be Newtonsoft's choice rather
+        // than the document's, so the screen refuses ahead of the parse - the same posture the role claim
+        // takes for #1324. Remove the StrictJson.Inspect call and this goes red.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("attrs", "{\"account\":{\"expires_at\":1893456000,\"expires_at\":253370764800}}")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "attrs.account.expires_at" });
+
+        Assert.Null(derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void ARepeatOutsideTheScopesTheWalkEnters_StillReadsTheInstant()
+    {
+        // The other half of #1324's rule, and the reason the screen is given the entered scopes rather than
+        // the whole document: a vendor extension repeating a name somewhere this walk never goes decides
+        // nothing here, and refusing on it would take a working provider's deadline away for no reason.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("attrs", "{\"account\":{\"expires_at\":1893456000},\"other\":{\"x\":1,\"x\":2}}")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "attrs.account.expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void SeveralCopiesOfTheClaim_TheLastOneWins()
+    {
+        // The rule the subject, email_verified and picture resolvers in this builder already follow. Stated
+        // as a test so the expiry read cannot drift into a different one unnoticed.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("expires_at", "946684800"), ("expires_at", "1893456000")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void AnUnreadableLaterCopy_LeavesTheReadableOneStanding()
+    {
+        // Last-wins is over the instants the reader RESOLVED, not over the raw copies: a later copy that
+        // parses to nothing is absent rather than a statement that the deadline was withdrawn.
+        var derived = OidcAuthorizeStateBuilder.Build(
+            Claims(("expires_at", "1893456000"), ("expires_at", "never")),
+            new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc), derived.ExpiresAtUtc);
+    }
+
+    [Fact]
+    public void ConfiguringAnExpiryClaim_ChangesNothingElseAboutTheDerivedState()
+    {
+        // The claim is read and nothing more: no privilege, no validity, no username moves because a
+        // deadline was carried. Comparing the two states field by field is what makes "pure reading" a
+        // property rather than a sentence in a commit message.
+        var claims = Claims(("preferred_username", "alice"), ("sub", "alice-sub"), ("expires_at", "1893456000"));
+        var without = OidcAuthorizeStateBuilder.Build(claims, new OidConfig { Roles = Array.Empty<string>() });
+        var with = OidcAuthorizeStateBuilder.Build(claims, new OidConfig { Roles = Array.Empty<string>(), AccountExpiryClaim = "expires_at" });
+
+        Assert.Equal(without.Username, with.Username);
+        Assert.Equal(without.Subject, with.Subject);
+        Assert.Equal(without.Issuer, with.Issuer);
+        Assert.Equal(without.EmailVerified, with.EmailVerified);
+        Assert.Equal(without.Valid, with.Valid);
+        Assert.Equal(without.Admin, with.Admin);
+        Assert.Equal(without.EnableLiveTv, with.EnableLiveTv);
+        Assert.Equal(without.EnableLiveTvManagement, with.EnableLiveTvManagement);
+        Assert.Equal(without.Folders, with.Folders);
+        Assert.Equal(without.AvatarUrl, with.AvatarUrl);
+        Assert.Equal(without.PermissionGrants, with.PermissionGrants);
+        Assert.Equal(without.MaxParentalRatingScore, with.MaxParentalRatingScore);
+        Assert.Null(without.ExpiresAtUtc);
+        Assert.NotNull(with.ExpiresAtUtc);
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlAccountExpiryAttributeTests.cs
+++ b/SSO-Auth.Tests/Saml/SamlAccountExpiryAttributeTests.cs
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the SAML half of the account-expiry read (#1143). The instant is read from a SIGNED assertion
+/// attribute, so every fixture here goes through the real signature path rather than a hand-built response,
+/// and the same two-sided property holds as on the OpenID side: the shapes an identity provider emits are
+/// read, everything else resolves to no instant and nothing throws.
+/// </summary>
+[Collection("SSOController")]
+public class SamlAccountExpiryAttributeTests
+{
+    private static readonly DateTime ExpectedUtc = new DateTime(2030, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static DateTime? ReadExpiry(string? configuredAttribute, params string[] values)
+    {
+        SamlAssertionValidator.ResetReplaysForTests();
+        var fixture = SamlTestFactory.Create(
+            nameId: "alice",
+            extraAttributeName: values.Length == 0 ? null : "expiresAt",
+            extraAttributeValues: values);
+        var response = new SamlResponse(fixture.CertificateBase64, fixture.EncodeResponse());
+
+        var produced = new SamlAssertionValidator(Substitute.For<ILogger>()).TryProduceVerifiedIdentity(
+            new SamlConfig { AccountExpiryClaim = configuredAttribute },
+            "adfs",
+            response,
+            new List<string> { "jellyfin-users" },
+            out var identity,
+            out _);
+
+        Assert.True(produced);
+        Assert.NotNull(identity);
+        return identity.ExpiresAtUtc;
+    }
+
+    [Fact]
+    public void NoExpiryAttributeConfigured_ReadsNoInstant()
+    {
+        // Off by default: an assertion that happens to carry the attribute changes nothing for a provider
+        // that never configured one. This is the regression the rest of the SAML suite would not catch.
+        Assert.Null(ReadExpiry(null, "1893456000"));
+    }
+
+    [Theory]
+    [InlineData("1893456000")]
+    [InlineData("2030-01-01T00:00:00Z")]
+    [InlineData("2030-01-01T01:00:00+01:00")]
+    [InlineData("2030-01-01T00:00:00")]
+    public void AConfiguredAttribute_IsReadInEveryShapeAProviderEmits(string value)
+    {
+        Assert.Equal(ExpectedUtc, ReadExpiry("expiresAt", value));
+    }
+
+    [Fact]
+    public void AnInstantInThePast_IsCarriedRatherThanDroppedAtTheRead()
+    {
+        Assert.Equal(new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc), ReadExpiry("expiresAt", "946684800"));
+    }
+
+    [Fact]
+    public void AnInstantFarInTheFuture_IsCarried()
+    {
+        Assert.Equal(new DateTime(2286, 11, 20, 17, 46, 39, DateTimeKind.Utc), ReadExpiry("expiresAt", "9999999999"));
+    }
+
+    [Fact]
+    public void AConfiguredAttributeTheAssertionDoesNotCarry_ReadsNoInstant()
+    {
+        Assert.Null(ReadExpiry("expiresAt"));
+    }
+
+    [Theory]
+    [InlineData("never")]
+    [InlineData("2030-13-45T99:99:99Z")]
+    [InlineData("<expires>2030</expires>")]
+    public void AnAttributeValueThatIsNeitherShape_ReadsNoInstantAndDoesNotThrow(string value)
+    {
+        // The third case is the one worth keeping: an attribute value is administrator-named and
+        // provider-supplied, and the reader must treat markup as text it does not understand rather than as
+        // anything to resolve.
+        Assert.Null(ReadExpiry("expiresAt", value));
+    }
+
+    [Fact]
+    public void SeveralValuesUnderOneAttribute_TheLastOneWins()
+    {
+        // A multi-valued attribute is a shape real identity providers emit, and the rule is the OpenID one
+        // so a deployment note covers both protocols rather than one each.
+        Assert.Equal(ExpectedUtc, ReadExpiry("expiresAt", "946684800", "1893456000"));
+    }
+
+    [Fact]
+    public void AnUnreadableLaterValue_LeavesTheReadableOneStanding()
+    {
+        Assert.Equal(ExpectedUtc, ReadExpiry("expiresAt", "1893456000", "never"));
+    }
+
+    [Fact]
+    public void AnAttributeNameCarryingAnXPathPayload_SelectsNothingAndReadsNoInstant()
+    {
+        // The attribute name comes from configuration and reaches GetCustomAttributes, which compares @Name
+        // in C# against a CONSTANT XPath for exactly this reason (#678). A name that would break out of a
+        // quoted predicate must therefore select nothing rather than every Attribute node - and the
+        // assertion below does carry a readable deadline, so a selector that matched anything at all would
+        // return one and redden this.
+        Assert.Null(ReadExpiry("'] | //*['", "1893456000"));
+    }
+
+    [Fact]
+    public void ConfiguringAnExpiryAttribute_ChangesNothingElseAboutTheVerifiedIdentity()
+    {
+        SamlAssertionValidator.ResetReplaysForTests();
+        var fixture = SamlTestFactory.Create(nameId: "alice", extraAttributeName: "expiresAt", extraAttributeValues: new[] { "1893456000" });
+        var encoded = fixture.EncodeResponse();
+        var validator = new SamlAssertionValidator(Substitute.For<ILogger>());
+
+        validator.TryProduceVerifiedIdentity(
+            new SamlConfig(),
+            "adfs",
+            new SamlResponse(fixture.CertificateBase64, encoded),
+            new List<string> { "jellyfin-users" },
+            out var without,
+            out _);
+
+        SamlAssertionValidator.ResetReplaysForTests();
+        validator.TryProduceVerifiedIdentity(
+            new SamlConfig { AccountExpiryClaim = "expiresAt" },
+            "adfs",
+            new SamlResponse(fixture.CertificateBase64, encoded),
+            new List<string> { "jellyfin-users" },
+            out var with,
+            out _);
+
+        Assert.NotNull(without);
+        Assert.NotNull(with);
+        Assert.Equal(without.Subject, with.Subject);
+        Assert.Equal(without.Username, with.Username);
+        Assert.Equal(without.Admin, with.Admin);
+        Assert.Equal(without.EnableLiveTv, with.EnableLiveTv);
+        Assert.Equal(without.EnableLiveTvManagement, with.EnableLiveTvManagement);
+        Assert.Equal(without.Folders, with.Folders);
+        Assert.Equal(without.EmailVerified, with.EmailVerified);
+        Assert.Equal(without.AvatarUrl, with.AvatarUrl);
+        Assert.Equal(without.MaxParentalRatingScore, with.MaxParentalRatingScore);
+        Assert.Null(without.ExpiresAtUtc);
+        Assert.Equal(ExpectedUtc, with.ExpiresAtUtc);
+    }
+}

--- a/SSO-Auth.Tests/Saml/SamlTestFactory.cs
+++ b/SSO-Auth.Tests/Saml/SamlTestFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -75,7 +76,9 @@ internal static class SamlTestFactory
         string[][]? audienceRestrictions = null,
         DateTimeOffset? certNotBefore = null,
         DateTimeOffset? certNotAfter = null,
-        int signingKeyBits = 2048)
+        int signingKeyBits = 2048,
+        string? extraAttributeName = null,
+        string[]? extraAttributeValues = null)
     {
         var audienceList = audiences ?? (audience == null ? null : new[] { audience });
         const string TimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
@@ -115,6 +118,17 @@ internal static class SamlTestFactory
         }
 
         var subjectConfirmationData = "<saml:SubjectConfirmationData" + subjectConfirmationAttributes + " />";
+
+        // One further named attribute beside Role, so a test can put a provider-specific attribute (the
+        // account-expiry attribute, #1143) into the SIGNED assertion rather than into a hand-edited body.
+        // Several values under one Name is the multi-valued shape a real IdP emits and the shape the
+        // last-value-wins read has to be pinned against.
+        var extraAttribute = extraAttributeName == null
+            ? string.Empty
+            : "<saml:Attribute Name=\"" + SecurityElement.Escape(extraAttributeName) + "\">"
+                + string.Concat((extraAttributeValues ?? Array.Empty<string>())
+                    .Select(value => "<saml:AttributeValue>" + SecurityElement.Escape(value) + "</saml:AttributeValue>"))
+                + "</saml:Attribute>";
 
         // One <AudienceRestriction> per inner array when audienceRestrictions is set (for the multi-block
         // AND tests), else a single restriction from audienceList as before.
@@ -184,6 +198,7 @@ internal static class SamlTestFactory
                     authnStatement +
                     "<saml:AttributeStatement>" +
                         "<saml:Attribute Name=\"Role\"><saml:AttributeValue>" + SecurityElement.Escape(role) + "</saml:AttributeValue></saml:Attribute>" +
+                        extraAttribute +
                     "</saml:AttributeStatement>" +
                 "</saml:Assertion>" +
             "</samlp:Response>";

--- a/SSO-Auth/Api/Identity/AccountExpiryInstant.cs
+++ b/SSO-Auth/Api/Identity/AccountExpiryInstant.cs
@@ -63,21 +63,18 @@ internal static class AccountExpiryInstant
     }
 
     // A JWT NumericDate: seconds since 1970-01-01T00:00:00Z, serialised as a JSON number and reaching a
-    // claim as its digits. An ALL-DIGIT value is read here and never as a separator-less calendar date,
+    // claim as its digits. An all-digit value is read here and never as a separator-less calendar date,
     // because NumericDate is the only all-digit instant either protocol defines and a compact "20261231"
-    // is neither RFC 3339 nor xsd:dateTime. Digits are matched one by one rather than through char.IsDigit,
-    // which is true for the Unicode decimal digits of every script, so an Arabic-Indic or fullwidth
-    // homoglyph string cannot reach long.TryParse and be read as an instant.
+    // is neither RFC 3339 nor xsd:dateTime.
+    //
+    // NumberStyles.None is the shape check: it refuses a sign, a thousands separator and surrounding
+    // whitespace, so only bare digits are read as an instant. The invariant culture is stated for the
+    // separator conventions None would otherwise take from the server's locale, and NOT as a guard against
+    // digits of another script - .NET's integer parse takes ASCII digits under every culture, which is
+    // measured in AccountExpiryInstantTests.DigitsOfAnotherScript_AreNotReadAsANumericDate rather than
+    // assumed here.
     private static DateTime? ReadNumericDate(string value)
     {
-        foreach (var c in value)
-        {
-            if (c is < '0' or > '9')
-            {
-                return null;
-            }
-        }
-
         if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
         {
             return null;

--- a/SSO-Auth/Api/Identity/AccountExpiryInstant.cs
+++ b/SSO-Auth/Api/Identity/AccountExpiryInstant.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Identity;
+
+/// <summary>
+/// Reads an account-expiry instant out of one raw identity-provider claim or attribute value (#1143), in
+/// the two shapes an identity provider actually emits: a JWT <c>NumericDate</c> (RFC 7519, seconds since
+/// the Unix epoch) and an ISO-8601 / RFC 3339 timestamp with or without an offset. Pure reading - it makes
+/// no access decision, and what a missing instant MEANS for a configured claim is the enforcement step's
+/// question (#1144), not this one's.
+/// </summary>
+/// <remarks>
+/// The value is attacker-influenced and arrives on a public callback, so every shape this reader does not
+/// understand yields <c>null</c> and nothing throws - the same contract <c>OidcRoleExtractor</c> documents
+/// for #216. The instant is always UTC: #676 was exactly the bug a local-time read produces, an authorize
+/// state expiring early across a DST step, so an offset-less value is read as UTC rather than as server
+/// local time and every parsed result carries <see cref="DateTimeKind.Utc"/>.
+/// <para>
+/// This is a SECOND date reader in the tree, beside <c>SamlAssertionTime.TryParseUtc</c>, and that is
+/// deliberate rather than an oversight. The module DAG gives <c>Identity</c> no import of <c>Saml</c>, and
+/// <c>Oidc</c> may not import <c>Saml</c> either, so a reader both protocols can call cannot reach the SAML
+/// one where it sits. Moving that parser down into this module is possible in principle and is NOT done
+/// here: <c>TryParseUtc</c> is what the SAML <c>NotBefore</c>/<c>NotOnOrAfter</c> bounds are read through
+/// and its <c>XmlConvert</c> choice is argued for #677, so moving it belongs in a change of its own with
+/// the SAML time-bound suite as its oracle, not inside a feature branch. The two readers also answer
+/// different questions: one reads a SIGNED SAML condition the plugin enforces, this one reads a claim value
+/// that decides nothing on its own and yields null on anything it does not understand.
+/// </para>
+/// </remarks>
+internal static class AccountExpiryInstant
+{
+    // ISO-8601 / RFC 3339 with a "T" separator, optional fractional seconds, and an offset that may be
+    // "Z", "+hh:mm"/"-hh:mm", or absent. Parsing against an EXPLICIT format list rather than the general
+    // DateTimeOffset.TryParse is the fail-closed choice on an attacker-influenced value: the general parse
+    // also accepts shapes that are not instants at all - a bare time is completed against TODAY'S date, a
+    // bare "yyyy-MM" against the first of that month - and each of those would hand the enforcement step a
+    // confident deadline the provider never stated. Measured, not assumed: see
+    // AccountExpiryInstantTests.GeneralParseShapes_ThisReaderRefuses.
+    private static readonly string[] TimestampFormats =
+    {
+        "yyyy-MM-dd'T'HH:mm:ssK",
+        "yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+    };
+
+    /// <summary>
+    /// Reads the expiry instant a raw claim value carries.
+    /// </summary>
+    /// <param name="raw">The raw claim or attribute value; null, blank, and every unrecognised shape yield null.</param>
+    /// <returns>The expiry instant in UTC, or null when the value carries none this reader understands.</returns>
+    internal static DateTime? Read(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var value = raw.Trim();
+        return ReadNumericDate(value) ?? ReadTimestamp(value);
+    }
+
+    // A JWT NumericDate: seconds since 1970-01-01T00:00:00Z, serialised as a JSON number and reaching a
+    // claim as its digits. An ALL-DIGIT value is read here and never as a separator-less calendar date,
+    // because NumericDate is the only all-digit instant either protocol defines and a compact "20261231"
+    // is neither RFC 3339 nor xsd:dateTime. Digits are matched one by one rather than through char.IsDigit,
+    // which is true for the Unicode decimal digits of every script, so an Arabic-Indic or fullwidth
+    // homoglyph string cannot reach long.TryParse and be read as an instant.
+    private static DateTime? ReadNumericDate(string value)
+    {
+        foreach (var c in value)
+        {
+            if (c is < '0' or > '9')
+            {
+                return null;
+            }
+        }
+
+        if (!long.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var seconds))
+        {
+            return null;
+        }
+
+        // FromUnixTimeSeconds throws outside the representable range, and a claim is free to carry a
+        // number no calendar can hold, so the range is checked rather than caught.
+        if (seconds > DateTimeOffset.MaxValue.ToUnixTimeSeconds())
+        {
+            return null;
+        }
+
+        return DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
+    }
+
+    // AssumeUniversal reads an offset-less value as UTC (never as server local time, #676) and
+    // AdjustToUniversal normalises a stated offset onto the same basis, so both branches return a
+    // Kind=Utc instant that a downstream comparison against DateTime.UtcNow cannot mismatch.
+    private static DateTime? ReadTimestamp(string value)
+    {
+        return DateTimeOffset.TryParseExact(
+            value,
+            TimestampFormats,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed.UtcDateTime
+            : null;
+    }
+}

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 
@@ -55,4 +56,7 @@ internal sealed record ValidatedLogin
 
     /// <summary>Gets the parental-rating-score ceiling the login resolves (#736), or null when the feature is off or no mapping matched (leave the existing ceiling untouched).</summary>
     internal int? MaxParentalRatingScore { get; init; }
+
+    /// <summary>Gets the account-expiry instant the configured expiry claim resolved (#1143), in UTC, or null when no claim is configured, the claim is absent, or its value is not a shape the reader understands. Carried only; no access decision is made from it (#1144 decides that).</summary>
+    internal DateTime? ExpiresAtUtc { get; init; }
 }

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -55,7 +55,8 @@ internal sealed record VerifiedIdentity
         bool enableLiveTvManagement,
         string? avatarUrl,
         IReadOnlyList<PermissionGrant> permissionGrants,
-        int? maxParentalRatingScore)
+        int? maxParentalRatingScore,
+        DateTime? expiresAtUtc)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -71,6 +72,7 @@ internal sealed record VerifiedIdentity
         AvatarUrl = avatarUrl;
         PermissionGrants = permissionGrants;
         MaxParentalRatingScore = maxParentalRatingScore;
+        ExpiresAtUtc = expiresAtUtc;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -128,6 +130,14 @@ internal sealed record VerifiedIdentity
     internal int? MaxParentalRatingScore { get; }
 
     /// <summary>
+    /// Gets the account-expiry instant the provider's configured expiry claim resolved (#1143), in UTC, or
+    /// null when no claim is configured, the claim is absent, or its value is not a shape the reader
+    /// understands. Carried on the keystone so the enforcement step (#1144) has it at the one point both
+    /// protocols funnel through; nothing reads it yet, so a login behaves exactly as it did before.
+    /// </summary>
+    internal DateTime? ExpiresAtUtc { get; }
+
+    /// <summary>
     /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
     /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
     /// promoted (role-gate-passed) state - so a raw or unvalidated login can never reach it.
@@ -164,5 +174,6 @@ internal sealed record VerifiedIdentity
             login.EnableLiveTvManagement,
             login.AvatarUrl,
             login.PermissionGrants,
-            login.MaxParentalRatingScore);
+            login.MaxParentalRatingScore,
+            login.ExpiresAtUtc);
 }

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -154,6 +154,7 @@ internal abstract class AuthorizeSession
                 AvatarUrl = derived.AvatarUrl,
                 PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
                 MaxParentalRatingScore = derived.MaxParentalRatingScore,
+                ExpiresAtUtc = derived.ExpiresAtUtc,
             });
 
             // Carry the OpenID logout material (#727, SLO-1b) alongside the keystone rather than inside it:

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -9,8 +9,11 @@ using System.Text.RegularExpressions;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
 
@@ -77,6 +80,11 @@ internal static class OidcAuthorizeStateBuilder
         // validity and of the username, like the subject above.
         var emailVerified = ResolveEmailVerified(claimList);
 
+        // The account-expiry deadline the provider states for this login (#1143), read only. Independent of
+        // validity, like the subject and email_verified above; nothing downstream consults it yet, so a
+        // provider with no expiry claim configured resolves exactly the state it resolved before.
+        var expiresAtUtc = ResolveExpiry(claimList, config);
+
         // Assemble the role-derived privileges (folders, admin, Live TV) in the single shared home
         // (#508); OR the assembled validity into the running validity - the SAML builder ignores it.
         var privileges = RolePrivilegeMapper.AssemblePrivileges(roles, config);
@@ -114,7 +122,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -150,6 +158,93 @@ internal static class OidcAuthorizeStateBuilder
         }
 
         return emailVerified;
+    }
+
+    // The account-expiry instant the configured expiry claim carries (#1143), or null when no claim is
+    // configured, none is present, or the value is not a shape AccountExpiryInstant understands. The LAST
+    // matching claim wins, the same rule the subject, email_verified and picture resolvers above already
+    // follow, so an administrator reading one of them has read them all. A dotted path walks into the
+    // claim's JSON object exactly as the role claim does; a path segment that does not resolve, or a
+    // terminal node that is an object or an array rather than a scalar, yields no instant and never throws,
+    // because the value is attacker-influenced and reaches a public callback (#216).
+    private static DateTime? ResolveExpiry(IReadOnlyList<Claim> claims, OidConfig config)
+    {
+        var segments = SplitClaimPath(config.AccountExpiryClaim);
+        if (segments.Length == 0 || string.IsNullOrWhiteSpace(segments[0]))
+        {
+            return null;
+        }
+
+        DateTime? expiresAtUtc = null;
+        foreach (var claim in claims)
+        {
+            if (!string.Equals(claim.Type, segments[0], StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var read = AccountExpiryInstant.Read(WalkToScalar(claim.Value, segments));
+            if (read is not null)
+            {
+                expiresAtUtc = read;
+            }
+        }
+
+        return expiresAtUtc;
+    }
+
+    // Walks a one-segment path to the claim value itself, and a longer one into the claim value parsed as
+    // JSON, returning the scalar the path names. Null on anything else: a value that is not JSON, a segment
+    // that is missing or sits under a non-object, and a terminal that is an object or an array.
+    private static string? WalkToScalar(string claimValue, string[] segments)
+    {
+        if (segments.Length == 1)
+        {
+            return claimValue;
+        }
+
+        // The screen runs BEFORE Newtonsoft, for the reason the role walk states at its own call (#1324): a
+        // scope this walk enters that names a member twice says two things about the deadline, and which of
+        // them wins would be a parser's choice rather than the document's. Only the scopes the walk actually
+        // descends through are screened, so an unrelated repeat elsewhere in the claim cannot take a working
+        // provider's logins offline. The terminal segment is READ and not entered, so it is not in the list.
+        if (StrictJson.Inspect(claimValue, segments.Skip(1).Take(segments.Length - 2).ToList(), out _) != StrictJson.Verdict.Clean)
+        {
+            return null;
+        }
+
+        // DateParseHandling.None is load-bearing rather than tidy. Newtonsoft's default turns a member whose
+        // value LOOKS like a date into a DateTime token, and reading that back as a string yields the
+        // round-trip form rather than the provider's bytes - so an ISO-8601 deadline behind a dotted path
+        // would reach the reader in a shape the reader refuses, and the claim would silently carry nothing.
+        // Verified by OidcAccountExpiryClaimTests.NestedIsoTimestamp_IsReadThroughThePath.
+        try
+        {
+            JToken node = JsonConvert.DeserializeObject<JObject>(
+                claimValue,
+                new JsonSerializerSettings { DateParseHandling = DateParseHandling.None })
+                ?? throw new JsonException("The claim value parsed to no object.");
+
+            for (var i = 1; i < segments.Length; i++)
+            {
+                if (node is not JObject scope || scope[segments[i]] is not { } next)
+                {
+                    return null;
+                }
+
+                node = next;
+            }
+
+            // A scalar only. An object or an array names no single instant, and JValue's own string
+            // conversion is invariant, so a JSON number reaches the reader as its digits.
+            return node is JValue { Value: not null } terminal ? terminal.Value<string>() : null;
+        }
+        catch (JsonException)
+        {
+            // The claim value is attacker-influenced and reaches a public callback, so a malformed body ends
+            // the walk with no instant and never an unhandled 500 (#216).
+            return null;
+        }
     }
 
     // Resolves the avatar URL. With a configured format the template wins: @{claimType} tokens are
@@ -192,11 +287,15 @@ internal static class OidcAuthorizeStateBuilder
 
     // Splits the configured role-claim path on unescaped dots; escaped "\." are normalized to ".".
     // Computed once per login - the path depends only on the configuration, not on any claim.
-    private static string[] SplitRoleClaimPath(OidConfig config)
+    private static string[] SplitRoleClaimPath(OidConfig config) => SplitClaimPath(config.RoleClaim);
+
+    // The one place a configured claim path is split, so the role claim and the expiry claim (#1143) cannot
+    // drift into two escaping conventions an administrator has to keep straight.
+    private static string[] SplitClaimPath(string? path)
     {
-        return string.IsNullOrEmpty(config.RoleClaim)
+        return string.IsNullOrEmpty(path)
             ? Array.Empty<string>()
-            : RoleClaimSplitRegex.Split(config.RoleClaim.Trim())
+            : RoleClaimSplitRegex.Split(path.Trim())
                 .Select(segment => segment.Replace("\\.", "."))
                 .ToArray();
     }
@@ -315,6 +414,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="AvatarUrl">The resolved avatar candidate URL: the configured AvatarUrlFormat template with @{claim} tokens substituted, or - when no template is configured (null/empty) - the standard OIDC "picture" claim (#723); null when neither yields a value. Only a candidate: the fetch is still gated by AvatarUrlValidator.</param>
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
+    /// <param name="ExpiresAtUtc">The account-expiry instant the configured expiry claim resolved (#1143), in UTC; null when no claim is configured, the claim is absent, or its value is not a shape the reader understands.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -327,7 +427,8 @@ internal static class OidcAuthorizeStateBuilder
         List<string> Folders,
         string? AvatarUrl,
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
-        int? MaxParentalRatingScore = null)
+        int? MaxParentalRatingScore = null,
+        DateTime? ExpiresAtUtc = null)
     {
         /// <summary>
         /// Gets the raw OpenID <c>id_token</c>, captured at the callback for a later RP-initiated logout

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -81,6 +81,31 @@ internal sealed class SamlAssertionValidator
     internal static List<string> GetAssertionRoles(SamlResponse samlResponse) =>
         samlResponse.GetCustomAttributes(RoleAttributeName);
 
+    // The account-expiry instant the configured attribute carries (#1143), or null when the provider names
+    // no attribute, the assertion carries none, or no value is a shape the reader understands. The LAST
+    // value wins, matching the OpenID resolvers, so one deployment note covers both protocols. The
+    // attribute name reaches GetCustomAttributes, which compares @Name in C# against a constant XPath, so
+    // an administrator-supplied name cannot select nodes the way an interpolated predicate could (#678).
+    // Nothing decides on the instant here; it is carried for the enforcement step (#1144).
+    private static DateTime? ReadExpiry(SamlConfig config, SamlResponse samlResponse)
+    {
+        if (string.IsNullOrWhiteSpace(config.AccountExpiryClaim))
+        {
+            return null;
+        }
+
+        DateTime? expiresAtUtc = null;
+        foreach (var value in samlResponse.GetCustomAttributes(config.AccountExpiryClaim.Trim()))
+        {
+            if (AccountExpiryInstant.Read(value) is { } read)
+            {
+                expiresAtUtc = read;
+            }
+        }
+
+        return expiresAtUtc;
+    }
+
     /// <summary>
     /// Parses the untrusted response and runs the response-level validation shared by every SAML leg:
     /// signature, time bounds and audience (<see cref="ValidateSaml"/>) plus the opt-in recipient binding.
@@ -231,6 +256,7 @@ internal sealed class SamlAssertionValidator
             AvatarUrl = null,
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
+            ExpiresAtUtc = ReadExpiry(config, samlResponse),
         });
         return true;
     }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -224,6 +224,18 @@ public abstract class ProviderConfigBase
     public bool DisableAccountOnRoleDenied { get; set; }
 
     /// <summary>
+    /// Gets or sets the name of the claim (OpenID) or assertion attribute (SAML) that carries an
+    /// account-expiry instant (#1143). Blank - the default - reads no expiry at all, so no existing provider
+    /// changes behaviour. The value is read as a JWT <c>NumericDate</c> or an ISO-8601 timestamp and
+    /// normalised to UTC; a claim that is absent, or whose value is neither shape, resolves to no instant.
+    /// For OpenID the name may be a dotted path whose first segment names the claim and whose further
+    /// segments walk into that claim's JSON object, the same convention <c>RoleClaim</c> uses. Reading it
+    /// makes no access decision on its own; what the instant does is the enforcement step's question
+    /// (#1144).
+    /// </summary>
+    public string? AccountExpiryClaim { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
     /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
     /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a


### PR DESCRIPTION
# What & why

Closes #1143.

A provider can now name a claim (OpenID) or an assertion attribute (SAML) that
carries an account-expiry instant, and both protocols read it to a UTC
`DateTime` that reaches the login completion path on `VerifiedIdentity`. This is
the read step alone. Nothing consults the instant: no login is refused, no
account is disabled, and with no claim configured, which is every provider by
default, each protocol derives exactly the state it derived before. What a
missing instant MEANS for a provider that did configure a claim is #1144's
question, not this one's.

`AccountExpiryInstant` accepts the two shapes an identity provider actually
emits, a JWT `NumericDate` and an ISO-8601 timestamp with or without an offset,
and yields no instant on everything else without throwing, because the value is
attacker-influenced and arrives on a public callback (the constraint
`OidcRoleExtractor` documents for #216). An offset-less value is read as UTC
rather than as server local time: #676 was that bug on the authorize-state
expiry, and a `Kind=Unspecified` deadline compares against `DateTime.UtcNow` as
if it were local.

Three decisions in the change are worth naming, because each had a defensible
alternative.

**A second date reader, deliberately.** The issue asks for the parser to sit in
`Api/Identity` and to reuse `SamlAssertionTime.TryParseUtc`, and the two cannot
both hold: the module DAG gives `Identity` no import of `Saml`, and `Oidc` may
not import `Saml` either. The shape that satisfies both is to move
`TryParseUtc` down into `Identity` and leave a delegation behind, and that is
not done here. `TryParseUtc` is what the SAML `NotBefore` / `NotOnOrAfter`
bounds are read through and its `XmlConvert` choice is argued for #677, so
moving it belongs in a change of its own with the SAML time-bound suite as its
oracle rather than inside a feature branch. The two readers also answer
different questions: one reads a signed SAML condition the plugin enforces, the
other reads a claim that decides nothing and yields null on anything it does not
understand. The reasoning is in the new file rather than only here.

**An explicit format list rather than the general parse.** `DateTimeOffset.TryParse`
accepts shapes that are not instants at all, and each would hand #1144 a
confident deadline the provider never stated: a bare time is completed against
today's date, a bare `yyyy-MM` against the first of that month. The test asserts
both directions against the same string, so it says what the general parse does
rather than asserting my description of it.

**The dotted OpenID path is screened before it is parsed.** A dotted path walks
into the claim's JSON exactly as the role claim's does, so the same #1324
posture applies: `StrictJson.Inspect` runs ahead of Newtonsoft over the scopes
the walk enters, and a scope naming a member twice yields no instant, because
which of the two wins would otherwise be a parser's choice rather than the
document's. Only the entered scopes are screened, so an unrelated repeat
elsewhere in the claim cannot take a working provider's deadline away.
`DateParseHandling` is switched off on that parse: Newtonsoft's default turns a
date-shaped member into a `DateTime` token whose string form is the round-trip
one rather than the provider's bytes, which this reader refuses, so an ISO
deadline behind a path would silently carry nothing.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. No gate moved. The SAML read runs after
      the whole validation chain, at the same statement that already built the
      identity, and the OpenID read runs in the derivation the role gate already
      consumes. Neither read can make a login valid, and no branch here returns
      a decision.
- [x] No secrets logged; secrets are redacted on config export. Nothing here
      logs, and the new configuration field holds a claim NAME, not a value.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **No second reader ran on
      this change.** The falsification runs in Notes stand in place of one, and
      this line is not to be ticked on the strength of them.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised. Not applicable, no review record
      exists, per the line above.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. The instant reader is one file both protocols call. The claim-path
      split is now one helper the role claim and the expiry claim share, so the
      two cannot drift into two escaping conventions an administrator has to
      keep straight.
- [x] The change adds no more code than the problem requires. One deletion was
      made for this: an explicit ASCII-digit scan came out after the falsifier
      showed it refused nothing the parse did not already refuse. See Notes.
- [x] The code is self-documenting and matches the target architecture (#318).
      The reader sits in `Api/Identity`, which both protocol modules already
      import, so no new edge was added to the module DAG.
- [x] Architecture-conformance tests pass, and the new structural property is
      locked in: the dotted-path walk is a new JSON parse site, so it is
      declared in `GatedJsonReads` with the file its screen is called in, which
      `UntrustedJson_IsParsedOnlyThroughTheScreenedSeam` pins in both
      directions.
- [x] Docs impact considered: the CHANGELOG entry is included and states plainly
      that the dashboard forms do not carry the field yet. See Notes for why the
      admin surface is out of scope here.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, 0 warnings:

      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
      dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q

- [x] `dotnet test` is green:

      ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
      Total: 3049, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
      ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
      Total: 3050, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

      The four skips are the pre-existing off-loopback bind tests (#1227), which
      need an elevation prompt on Windows and were not run.

- [x] Prettier is clean for the `.md` change, checked against the committed
      bytes rather than the working copy, whose line endings are the local
      checkout's:

      git show HEAD:CHANGELOG.md > committed-changelog.md
      npx prettier --check committed-changelog.md
      All matched files use Prettier code style!

## Notes

Each guard was proved by removing it and re-running the expiry tests.

| removed                                          | goes red                                          |
| ------------------------------------------------ | ------------------------------------------------- |
| the `StrictJson.Inspect` call before the walk    | `AScopeTheWalkEntersNamingAMemberTwice_DerivesNoInstant` |
| `DateParseHandling.None` on the nested parse     | `NestedIsoTimestamp_IsReadThroughThePath`         |

A third run falsified a guard I had written and it did not bite, so it came
out. `ReadNumericDate` began with an explicit `'0'..'9'` scan, and its comment
claimed the scan was what stopped a deadline spelled in Arabic-Indic or
fullwidth digits. Relaxing that scan to `char.IsDigit` reddened nothing: .NET's
integer parse takes ASCII digits under every culture, so the scan refused
nothing the parse did not already refuse. The scan is gone, the comment now says
what `NumberStyles.None` actually does, and the homoglyph test stays with its
own reason written on it, that it pins a shape somebody would reach for rather
than a line of this reader's.

Out of scope, and said out loud rather than left to be noticed: the provider
forms in the dashboard. The issue lists `configPage.html` and `config.js` under
Surfaces but not under Done when, the conformance rule over those forms is a
forward check, so a configuration property with no field renders nowhere and
breaks nothing, and the field is settable in the plugin configuration meanwhile.
The consequence is real and belongs on the record: until that lands, an
administrator cannot set the claim from the dashboard. The enforcement step
(#1144) is what makes the field worth surfacing, and the two forms are better
added once there is something for them to switch on.

`ProviderConfigValidator` is also listed under Surfaces and gains nothing here.
There is no invalid value to reject: any string is a legal claim name, an
unmatched name simply carries no instant, and the SAML side compares the name in
C# against a constant XPath (#678), which the new
`AnAttributeNameCarryingAnXPathPayload_SelectsNothingAndReadsNoInstant` test
drives with a payload that would break out of a quoted predicate.

`SamlTestFactory.Create` gained two optional parameters so a test can put a
named attribute into the SIGNED assertion rather than hand-editing a body. Every
existing call is unchanged.
