### PR TITLE
Read both discovery flags through a lookup that cannot throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,23 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **A discovery document can no longer break both of the plugin's discovery
+  checks with a member name it never had to look at (#1340).** The two readers
+  that decide whether a provider advertises PKCE `S256` and the RFC 9207
+  response `iss` parameter both looked their member up with a call that decodes
+  every candidate name long enough to still match. A name written with an
+  unpaired surrogate escape has no decoding, so the lookup raised an error
+  instead of answering, and which of the two readers it hit depended only on how
+  long that unrelated name was. Both facts are now read through one lookup that
+  skips a name it cannot decode and keeps going, so a provider that does
+  advertise `S256` beside such a name still reads as advertising it, rather than
+  having every login under **Require PKCE** refused. Both answers are otherwise
+  unchanged, each still failing in the direction it is documented to: PKCE
+  support closed, the response `iss` flag tolerant. No login on the shipped
+  configuration reached this - the repeated-member screen already reports such a
+  body unreadable before either reader sees it - and the two documents that
+  reach it join the fuzz corpus so the smoke gate replays them.
+
 - **A token minted for one endpoint is no longer read as a token for the other
   (#1317).** Neither JWT the plugin verifies used to have its `typ` header
   looked at, so the only thing separating an id_token from a back-channel

--- a/SSO-Auth.Fuzz/corpus/discovery/lone-surrogate-name-pkce-length.json
+++ b/SSO-Auth.Fuzz/corpus/discovery/lone-surrogate-name-pkce-length.json
@@ -1,0 +1,1 @@
+{"\ud800aaaaaaaaaaaaaaaaaaaaaaaaaaa":1,"code_challenge_methods_supported":["S256"]}

--- a/SSO-Auth.Fuzz/corpus/discovery/lone-surrogate-name-response-iss-length.json
+++ b/SSO-Auth.Fuzz/corpus/discovery/lone-surrogate-name-response-iss-length.json
@@ -1,0 +1,1 @@
+{"\ud800aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":1,"authorization_response_iss_parameter_supported":true}

--- a/SSO-Auth.Tests/Oidc/DiscoveryMemberNameSurrogateTests.cs
+++ b/SSO-Auth.Tests/Oidc/DiscoveryMemberNameSurrogateTests.cs
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Both discovery flag readers state a total contract - <see cref="PkceDiscovery.SupportsS256(string?)"/>
+/// answers <c>false</c> on anything unexpected, <see cref="OidcResponseIssuer"/>'s flag fails tolerant - and
+/// neither said it throws. Both did (#1340), on a document naming a member with an unpaired surrogate escape:
+/// <c>JsonElement.TryGetProperty</c> unescapes every candidate whose raw name is longer than the name being
+/// looked for, and a lone high surrogate has no completion, so the decoder raises
+/// <c>InvalidOperationException</c> out of the lookup.
+///
+/// The padding is what selected which reader fell over, which is why every case here is built from the
+/// reader's OWN property-name length rather than from one hand-written document. Measured on the unfixed
+/// readers: the throw begins at 27 filler characters for <c>code_challenge_methods_supported</c> (32 bytes)
+/// and at 41 for <c>authorization_response_iss_parameter_supported</c> (46 bytes) - the first padding at
+/// which the six-byte escape makes the raw name longer than the name being matched. A repair to one reader
+/// that leaves the other therefore reddens the other reader's sweep here rather than passing.
+/// </summary>
+public class DiscoveryMemberNameSurrogateTests
+{
+    private const string PkceName = "code_challenge_methods_supported";
+
+    private const string ResponseIssuerName = "authorization_response_iss_parameter_supported";
+
+    [Fact]
+    public void SupportsS256_MemberNameCarryingALoneSurrogateEscape_AnswersFalseRatherThanThrowing()
+    {
+        // Swept rather than pinned at the one measured length, because the boundary is arithmetic on the
+        // property name and a sweep past it cannot be made vacuous by a later rename.
+        for (var filler = 0; filler <= PkceName.Length + 8; filler++)
+        {
+            var json = UndecodableNameOnly(filler);
+            Assert.False(PkceDiscovery.SupportsS256(json));
+            Assert.False(PkceDiscovery.SupportsS256(Root(json)));
+        }
+    }
+
+    [Fact]
+    public void DiscoveryAdvertisesResponseIssuer_MemberNameCarryingALoneSurrogateEscape_AnswersFalseRatherThanThrowing()
+    {
+        for (var filler = 0; filler <= ResponseIssuerName.Length + 8; filler++)
+        {
+            var json = UndecodableNameOnly(filler);
+            Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json));
+            Assert.False(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(Root(json)));
+        }
+    }
+
+    [Fact]
+    public void SupportsS256_UndecodableNameBesideTheRealMember_StillReadsS256()
+    {
+        // The availability half, and the reason the repair skips the member instead of answering "absent"
+        // for the document. False here refuses every login wherever RequirePkce is on, so one member name
+        // the decoder cannot complete must not be able to take a provider that does advertise S256 offline.
+        var json = "{" + UndecodableMember(PkceName.Length - 5)
+            + ",\"" + PkceName + "\":[\"S256\"]}";
+
+        Assert.True(PkceDiscovery.SupportsS256(json));
+        Assert.True(PkceDiscovery.SupportsS256(Root(json)));
+    }
+
+    [Fact]
+    public void DiscoveryAdvertisesResponseIssuer_UndecodableNameBesideTheFlag_StillReadsTrue()
+    {
+        var json = "{" + UndecodableMember(ResponseIssuerName.Length - 5)
+            + ",\"" + ResponseIssuerName + "\":true}";
+
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json));
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(Root(json)));
+    }
+
+    [Fact]
+    public void UndecodableNameAtTheOtherReadersLength_LeavesEachReadersOwnAnswerIntact()
+    {
+        // The issue's table, kept as a test: padding to one reader's name length is what used to decide which
+        // reader fell over, so a document carrying both paddings has to leave both facts readable.
+        var json = "{" + UndecodableMember(PkceName.Length - 5)
+            + "," + UndecodableMember(ResponseIssuerName.Length - 5)
+            + ",\"" + PkceName + "\":[\"S256\"]"
+            + ",\"" + ResponseIssuerName + "\":true}";
+
+        Assert.True(PkceDiscovery.SupportsS256(json));
+        Assert.True(OidcResponseIssuer.DiscoveryAdvertisesResponseIssuer(json));
+    }
+
+    [Theory]
+    [InlineData("{\"\\ud800aaaaaaaaaaaaaaaaaaaaaaaaaaa\":1,\"code_challenge_methods_supported\":[\"S256\"]}", PkceName)]
+    [InlineData("{\"\\ud800aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\":1,\"authorization_response_iss_parameter_supported\":true}", ResponseIssuerName)]
+    public void CommittedFuzzSeedsCarryThePaddingThatReachesTheArm(string seed, string name)
+    {
+        // The two seeds in SSO-Auth.Fuzz/corpus/discovery/ are what makes the smoke gate replay this arm, and
+        // a seed whose filler is one character short reaches nothing while still parsing and still passing a
+        // "it did not throw" assertion. So the padding is compared rather than trusted: each literal is the
+        // committed seed body, and has to open with the undecodable member this file builds for that
+        // reader's own name length.
+        Assert.StartsWith("{" + UndecodableMember(name.Length - 5) + ",\"" + name + "\":", seed, StringComparison.Ordinal);
+    }
+
+    // A document whose ONLY member is the undecodable name, so neither fact is present and the honest answer
+    // is false for both readers - which is also the answer a throw was hiding.
+    private static string UndecodableNameOnly(int filler) => "{" + UndecodableMember(filler) + "}";
+
+    // `\ud800` is a high surrogate with no low surrogate after it: six raw characters that no unescape can
+    // complete. The filler pads the name so the raw member name outruns the name being looked for, which is
+    // the only reason the lookup tries to unescape it at all.
+    private static string UndecodableMember(int filler) => "\"\\ud800" + new string('a', filler) + "\":1";
+
+    private static JsonElement? Root(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/SSO-Auth/Api/Oidc/DiscoveryJson.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryJson.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Text.Json;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -63,5 +64,58 @@ internal static class DiscoveryJson
         // answer to the caller and neither leaks a document nobody closes.
         document.Dispose();
         return null;
+    }
+
+    /// <summary>
+    /// Looks a member up on a discovery root without ever throwing, which is what
+    /// <see cref="JsonElement.TryGetProperty(string, out JsonElement)"/> does not promise. That method
+    /// unescapes any candidate member name long enough to still match after unescaping, and an unpaired
+    /// surrogate escape has no completion, so the decoder raises <see cref="InvalidOperationException"/>
+    /// and the whole lookup is abandoned (#1340). Both discovery facts are read through here so neither
+    /// reader carries the throw, and the padding that selects which one is hit stops being a property of
+    /// the lookup name's length.
+    ///
+    /// An undecodable name is SKIPPED and the walk CONTINUES, which is the load-bearing half rather than a
+    /// detail. Answering "absent" for the whole document would let one member nobody asked about decide the
+    /// PKCE fact, and false there refuses the login wherever <c>RequirePkce</c> is on - so a document
+    /// carrying both an undecodable name and a real <c>code_challenge_methods_supported</c> would take an
+    /// otherwise-working provider offline. This is the same reasoning <c>PkceDiscovery.IsS256</c> already
+    /// applies one level down, on the value side of the same decoder failure.
+    ///
+    /// A name that does not decode also cannot equal the ASCII name being looked for, so skipping it loses
+    /// no match: what is dropped is a candidate that could only ever have answered no.
+    /// </summary>
+    /// <param name="root">The discovery document's root object.</param>
+    /// <param name="name">The member name to find, compared ordinally against each decodable member.</param>
+    /// <param name="value">The first matching member's value; <see langword="default"/> when none matches.</param>
+    /// <returns><see langword="true"/> when a member of that name is present.</returns>
+    internal static bool TryGetMember(JsonElement root, string name, out JsonElement value)
+    {
+        // Walked by hand rather than delegating to TryGetProperty and catching around it: one path answers
+        // for every document, so there is no second comparison that could disagree with the first about the
+        // same bytes. First match wins, exactly as TryGetProperty does - repeated members are refused
+        // upstream by the screen (#1054) and are not this method's decision.
+        foreach (var member in root.EnumerateObject())
+        {
+            try
+            {
+                if (!member.NameEquals(name))
+                {
+                    continue;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // This member's name carries an escape the decoder cannot complete. It is not the name being
+                // looked for; the next member still can be.
+                continue;
+            }
+
+            value = member.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
     }
 }

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -79,9 +79,11 @@ internal static class OidcResponseIssuer
         // provider did not write as a boolean would lock out a provider that never sends one.
         //
         // The ValueKind test on the root is not redundant with the null test, for the same reason it is not
-        // in PkceDiscovery: TryGetProperty throws on a non-object element rather than answering false.
+        // in PkceDiscovery: enumerating a non-object element throws rather than answering false. The lookup
+        // itself goes through DiscoveryJson, which skips a member name whose escape the decoder cannot
+        // complete instead of letting it abandon the read (#1340).
         var advertised = discovery is { ValueKind: JsonValueKind.Object } root
-            && root.TryGetProperty("authorization_response_iss_parameter_supported", out var value)
+            && DiscoveryJson.TryGetMember(root, "authorization_response_iss_parameter_supported", out var value)
             && value.ValueKind == JsonValueKind.True;
 
         // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -44,10 +44,15 @@ internal static class PkceDiscovery
     internal static bool SupportsS256(JsonElement? discovery)
     {
         // The ValueKind test is not redundant with the null test: a caller can hold a JsonElement that is
-        // non-null and not an object - default(JsonElement) is Undefined - and TryGetProperty THROWS on one
-        // rather than answering false, which would turn a malformed document into a 500 on the challenge.
+        // non-null and not an object - default(JsonElement) is Undefined - and the member walk enumerates a
+        // root, which THROWS on a non-object rather than answering false, turning a malformed document into
+        // a 500 on the challenge.
+        //
+        // The lookup goes through DiscoveryJson so a member name carrying an unpaired surrogate escape is
+        // skipped rather than thrown out of (#1340); TryGetProperty abandons the whole lookup on one, and
+        // an abandoned lookup here reads as "no S256" and refuses every login under RequirePkce.
         var advertised = discovery is { ValueKind: JsonValueKind.Object } root
-            && root.TryGetProperty("code_challenge_methods_supported", out var methods)
+            && DiscoveryJson.TryGetMember(root, "code_challenge_methods_supported", out var methods)
             && methods.ValueKind == JsonValueKind.Array
             && methods.EnumerateArray().Any(IsS256);
 


### PR DESCRIPTION
# What & why

`JsonElement.TryGetProperty` unescapes every candidate member name whose raw form is longer than the name being matched. An unpaired surrogate escape has no completion, so the decoder raises `InvalidOperationException` and the whole lookup is abandoned. Both discovery flag readers called it while documenting a total contract, and which of the two a document knocked over was decided only by how long the undecodable name happened to be.

Measured on the unfixed readers, by sweeping the filler length of a document whose only member is `"\ud800"` plus padding:

```
pkce=[27..90] iss=[41..90] pkceNameLen=32 issNameLen=46
```

27 and 41 are `name.Length - 5`: the first padding at which the six-character escape makes the raw name outrun the name being matched.

Both facts are now read through `DiscoveryJson.TryGetMember`, which walks the root and **skips** a name it cannot decode rather than abandoning the read. The skip is the load-bearing half, not a detail: answering "absent" for the whole document would let one member nobody asked about decide the PKCE fact, and `false` there refuses every login wherever `RequirePkce` is on, so a provider that does advertise `S256` beside such a name would go offline. That is the reasoning `PkceDiscovery.IsS256` already applies one level down, on the value side of the same decoder failure. A name that does not decode cannot equal the ASCII name being looked for, so no candidate that could have matched is dropped.

Closes #1340.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: each reader still answers in the direction its own contract names. `SupportsS256` fails closed, the response-`iss` flag fails tolerant. Both are `false` where the fact is absent, which is what the throw was hiding.
- [x] No secrets logged; secrets are redacted on config export. This change logs nothing at all.
- [ ] **A security review was NOT performed for this change.** No second reader ran on it. This box stays unticked rather than being read as satisfied by what is below.
- [ ] **No review record exists, so there are no per-lens verdicts and no CONFIRMED / PLAUSIBLE counts to report.** What stands in its place is executed evidence, not an argument, and it is set out under Verification.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added or moved.

Reachability, stated as narrowly as it is true and no wider. No login on the shipped configuration reached this. The repeated-member screen walks the body at the transport and reports such a document unreadable before either reader is called, and `OidcDiscoveryReader.ReadAsync` wraps its body in a catch-all that fails the login closed. What reached it is the fuzz driver, which calls the readers directly because it is testing them rather than the pipeline. That is why this lands as a latent defect repaired, not as a live one.

## Quality checklist

- [x] No duplicated logic. The lookup exists once, in `DiscoveryJson`, which is already the one place a discovery document is turned into an object graph, and both readers call it.
- [x] The change adds no more code than the problem requires: one method, and one call site changed in each reader.
- [x] Comments say why. The one at `TryGetMember` says why the walk continues past an undecodable name instead of answering absent, because that is the half a later reader would be tempted to simplify away.
- [x] Architecture-conformance tests pass. No new structural property is established: no file, namespace or dependency edge is added.
- [x] Docs impact: none. The change is invisible from the README and the wiki, and the behaviour a reader could observe is unchanged except that a throw became the answer both contracts already promised. The CHANGELOG entry is included here.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror` and the same for `-f net10.0`: build succeeded, 0 warnings, 0 errors on both.
- [x] Full suite, run from the built xunit-v3 executable: `Total: 3056, Failed: 0, Skipped: 4` on net9.0 and `Total: 3057, Failed: 0, Skipped: 4` on net10.0. The four skips are the pre-existing loopback-bind tests (#1227), skipped because binding off loopback raises a Windows firewall consent dialog that needs an administrator. They are unrelated to this change and were skipped before it.
- [x] Prettier: `CHANGELOG.md` is the only file this change touches that Prettier reads, and `npx prettier --check CHANGELOG.md` passes.

The guard is proven by deleting it. With the two lookups reverted to `TryGetProperty` and nothing else changed:

```
DiscoveryMemberNameSurrogateTests.SupportsS256_MemberNameCarryingALoneSurrogateEscape_... [FAIL]
DiscoveryMemberNameSurrogateTests.DiscoveryAdvertisesResponseIssuer_MemberNameCarryingALoneSurrogateEscape_... [FAIL]
Total: 7, Failed: 2
```

Exactly the two sweeps, one per reader, so a repair to one that left the other would redden the other. On the same reverted build the discovery smoke gate crashes rather than reporting:

```
$ SSO_FUZZ_SMOKE=1 SSO_FUZZ_TARGET=discovery dotnet bin/Release/net9.0/SSO-Auth.Fuzz.dll
Unhandled exception. System.InvalidOperationException: Cannot read incomplete UTF-16 JSON text as string with missing low surrogate.
   at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   at Jellyfin.Plugin.SSO_Auth.Api.Oidc.PkceDiscovery.SupportsS256(...)
```

Restored, it reports:

```
Smoke OK: 7 seed(s) for target 'discovery' handled fail-closed with no unmapped exception.
```

Seven rather than the previous five: the two new seeds are padded to each reader's own property-name length, so the gate replays both arms and a seed shortened by one character stops reaching them. That is why `CommittedFuzzSeedsCarryThePaddingThatReachesTheArm` compares the padding against the reader's name length instead of trusting the literal.

## Notes

The three availability tests here pass on the unfixed readers too, and that is expected rather than a weakness: `TryGetProperty` matches an exact-length raw candidate before it ever unescapes a longer one, so the real member is found first. They guard the repair rather than the original defect, because a walk-based lookup is exactly the shape that could have regressed them.

Out of scope and untouched, as the issue asks: the repeated-member screen's own handling, and `OidcDiscoveryReader`'s catch-all.

One adjacent surface was found while reading for this and is deliberately not fixed here: `OidcLogoutTokenValidator.HasBackChannelLogoutEvent` reads the `events` claim with the same `TryGetProperty` call, inside a `try`/`finally` that has no `catch`. Whether the payload reader reaches that member at all has not been measured, so nothing is claimed about it beyond the shape of the call. It is a different token, a different entry point and a different reachability argument, and it gets its own issue rather than a widened scope here.
