### PR TITLE
Recognise the managed login-button region by its stable token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,25 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   configuration are unchanged, so the rename lands as an in-place update that
   keeps every existing setting.
 
+### Fixed
+
+- **A second, unremovable set of sign-in buttons on the login page (#1344).**
+  The plugin fences the buttons it manages inside the login disclaimer with a
+  marker comment, and finds that region again by an exact search on the next
+  sync. The opening marker's wording changed in an earlier release, so on any
+  server whose disclaimer already held the previous wording the plugin stopped
+  recognising its own region: it added a second set of buttons beside the first,
+  and nothing it could do afterwards removed the first. Turning the buttons off
+  removed only the newer set and left the older one behind, so the duplicate
+  outlived the feature that created it and only a hand edit of the disclaimer
+  cleared it. The region is now recognised by the stable
+  `<!-- SSO-LOGIN-BUTTONS:BEGIN` token alone, and the wording that follows it is
+  no longer read, so a server holding either wording converges to exactly one
+  managed set on its next sync and to none when the buttons are turned off -
+  including a server already left holding two. An admin's own disclaimer text,
+  before, between and after the managed regions, is preserved as it always was.
+  A future edit to that wording can no longer orphan anything.
+
 ### Security
 
 - **A token minted for one endpoint is no longer read as a token for the other

--- a/SSO-Auth.Tests/LoginButtons/LoginButtonFenceUpgradeTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonFenceUpgradeTests.cs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// What happens to a login disclaimer that already holds an opening fence this version no longer writes
+/// (#1344). The fence is written into every installation's disclaimer and found again by an exact search on
+/// the next sync, so an edit to the literal that is MATCHED stops the plugin recognising its own region: it
+/// appends a second block beside the first, and no later action removes the first, because content outside
+/// the fences is an admin's own disclaimer and is preserved on purpose. A typographic pass over this tree
+/// made that edit and it shipped, so the state these tests describe can exist on disk.
+///
+/// The repair is that recognition reads only the stable token and never the parenthetical, so these tests
+/// pin BOTH directions: an old fence is still recognised, and a fence whose parenthetical is something
+/// nobody has written yet is recognised too. The second is what stops the next edit to that prose from
+/// costing another release.
+/// </summary>
+public class LoginButtonFenceUpgradeTests
+{
+    // The literal as it stood before the typographic pass, with the one character that changed built from its
+    // code point rather than typed. Typing it would put the character back into this tree, which is the thing
+    // the pass removed, and the test needs the exact bytes rather than the exact source spelling.
+    private static readonly string PreSweepBeginMarker =
+        "<!-- SSO-LOGIN-BUTTONS:BEGIN (managed by jellyfin-plugin-sso "
+        + char.ConvertFromUtf32(0x2014)
+        + " do not edit inside) -->";
+
+    private static IReadOnlyList<LoginButton> One(string name, string text)
+        => new[] { new LoginButton(LoginButtonProtocol.Oidc, name, text) };
+
+    [Fact]
+    public void ThePreSweepFenceIsNotTheOneWrittenToday_WhichIsWhyTheseTestsExist()
+    {
+        // Guards the premise. If the two literals ever became equal again, every test below would still pass
+        // while proving nothing, and this one would go red to say so.
+        Assert.NotEqual(LoginButtonInjector.BeginMarker, PreSweepBeginMarker);
+        Assert.StartsWith(LoginButtonInjector.BeginMarkerPrefix, PreSweepBeginMarker, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ADisclaimerCarryingThePreSweepFence_SyncsToExactlyOneManagedBlock()
+    {
+        var disclaimer = "House rules apply.\n\n" + PreSweepBlock("keycloak", "Keycloak");
+
+        var merged = LoginButtonInjector.Merge(disclaimer, LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+
+        Assert.Equal(1, CountBlocks(merged));
+        Assert.DoesNotContain(PreSweepBeginMarker, merged, StringComparison.Ordinal);
+        Assert.Contains("House rules apply.", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ADisclaimerCarryingThePreSweepFence_LeavesNoManagedBlockWhenTheButtonsAreTurnedOff()
+    {
+        var disclaimer = "House rules apply.\n\n" + PreSweepBlock("keycloak", "Keycloak");
+
+        var merged = LoginButtonInjector.Merge(disclaimer, string.Empty);
+
+        Assert.Equal(0, CountBlocks(merged));
+        Assert.DoesNotContain(LoginButtonInjector.BeginMarkerPrefix, merged, StringComparison.Ordinal);
+        Assert.Equal("House rules apply.", merged);
+    }
+
+    [Fact]
+    public void AnInstallationAlreadyLeftHoldingTwoBlocks_ConvergesToOne()
+    {
+        // The state an installation reaches by upgrading and then syncing once under the unrepaired code: the
+        // orphan first, the block the plugin now recognises second. Both have to end up as one.
+        var disclaimer = PreSweepBlock("keycloak", "Old label")
+            + "\n\n" + LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+
+        var merged = LoginButtonInjector.Merge(disclaimer, LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+
+        Assert.Equal(1, CountBlocks(merged));
+        Assert.DoesNotContain("Old label", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnInstallationAlreadyLeftHoldingTwoBlocks_LeavesNoneWhenTheButtonsAreTurnedOff()
+    {
+        // This is the arm that made the defect more than an upgrade artefact: under the unrepaired code the
+        // orphan outlived the feature that created it, and only a hand edit removed it.
+        var disclaimer = PreSweepBlock("keycloak", "Old label")
+            + "\n\n" + LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+
+        var merged = LoginButtonInjector.Merge(disclaimer, string.Empty);
+
+        Assert.Equal(0, CountBlocks(merged));
+        Assert.Equal(string.Empty, merged);
+    }
+
+    [Fact]
+    public void AdminContentAroundAndBetweenTwoBlocks_Survives()
+    {
+        var disclaimer = "Top notice.\n\n"
+            + PreSweepBlock("keycloak", "Old label")
+            + "\n\nMiddle notice.\n\n"
+            + LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"))
+            + "\n\nBottom notice.";
+
+        var merged = LoginButtonInjector.Merge(disclaimer, LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+
+        Assert.Equal(1, CountBlocks(merged));
+        Assert.Contains("Top notice.", merged, StringComparison.Ordinal);
+        Assert.Contains("Middle notice.", merged, StringComparison.Ordinal);
+        Assert.Contains("Bottom notice.", merged, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AFenceWhoseParentheticalNobodyHasWrittenYet_IsStillRecognised()
+    {
+        // The forward half. The next edit to the prose inside the opening comment must cost nothing, which is
+        // exactly what the previous one did cost.
+        var future = LoginButtonInjector.BeginMarkerPrefix + " (anything at all, rewritten later) -->";
+        var disclaimer = "Notice.\n\n" + future + "\n<div class=\"sso-login-buttons\">\n</div>\n" + LoginButtonInjector.EndMarker;
+
+        Assert.Equal(1, CountBlocks(LoginButtonInjector.Merge(disclaimer, LoginButtonInjector.BuildBlock(One("k", "K")))));
+        Assert.Equal("Notice.", LoginButtonInjector.Merge(disclaimer, string.Empty));
+    }
+
+    [Fact]
+    public void ATypedFragmentWithNoCommentCloseOnItsLine_IsNotAnOpener_AndTheRealRegionBelowIsUntouched()
+    {
+        // An admin who typed the token by hand and never closed the comment must not have the text below it
+        // swallowed when the region is replaced. The fences this type writes are whole lines, so an opener
+        // whose comment close is on another line is not one.
+        var fragment = LoginButtonInjector.BeginMarkerPrefix + " I was mid-sentence when\nI stopped.";
+        var disclaimer = fragment + "\n\n" + LoginButtonInjector.BuildBlock(One("keycloak", "Old label"));
+
+        var merged = LoginButtonInjector.Merge(disclaimer, LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")));
+
+        Assert.Equal(1, CountBlocks(merged));
+        Assert.Contains(fragment, merged, StringComparison.Ordinal);
+        Assert.DoesNotContain("Old label", merged, StringComparison.Ordinal);
+    }
+
+    // The pre-sweep block is the block this version builds with its opening fence swapped for the one that
+    // shipped before the pass, so the fixture cannot drift away from what an installation actually holds.
+    private static string PreSweepBlock(string name, string text)
+        => PreSweepBeginMarker + LoginButtonInjector.BuildBlock(One(name, text))[LoginButtonInjector.BeginMarker.Length..];
+
+    // Counted on the CLOSING fence, which the sweep never touched, so the count is the same for an old block
+    // and a new one.
+    private static int CountBlocks(string disclaimer)
+    {
+        var count = 0;
+        var at = disclaimer.IndexOf(LoginButtonInjector.EndMarker, StringComparison.Ordinal);
+        while (at >= 0)
+        {
+            count++;
+            at = disclaimer.IndexOf(LoginButtonInjector.EndMarker, at + LoginButtonInjector.EndMarker.Length, StringComparison.Ordinal);
+        }
+
+        return count;
+    }
+}

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -24,11 +24,34 @@ namespace Jellyfin.Plugin.SSO_Auth.Api.LoginButtons;
 /// </remarks>
 public static class LoginButtonInjector
 {
-    /// <summary>The opening fence of the plugin-managed region inside the login disclaimer.</summary>
-    internal const string BeginMarker = "<!-- SSO-LOGIN-BUTTONS:BEGIN (managed by jellyfin-plugin-sso - do not edit inside) -->";
+    /// <summary>
+    /// What an opening fence is RECOGNISED by, and the whole of it. Everything after this token, up to and
+    /// including the <c>--&gt;</c> that closes the comment on the same line, is prose the matcher does not
+    /// read (#1344).
+    ///
+    /// That split is the point. The opener is written into every installation's login disclaimer and is found
+    /// again by an exact search on the next sync, so any edit to the literal that is matched orphans every
+    /// block already on disk: the plugin stops recognising its own region, appends a second one beside it, and
+    /// no later action - not disabling the buttons, not reconfiguring them - can remove the first. That is
+    /// what a typographic pass over this tree did to the parenthetical below, and it shipped. Recognising
+    /// only this token makes the parenthetical safe to rewrite, and the token itself carries nothing a
+    /// typographic pass looks for: the hyphens in <c>SSO-LOGIN-BUTTONS</c> are already plain ASCII, which is
+    /// the direction such a pass converts TOWARDS rather than away from.
+    /// </summary>
+    internal const string BeginMarkerPrefix = "<!-- SSO-LOGIN-BUTTONS:BEGIN";
+
+    /// <summary>
+    /// The opening fence this version WRITES. Older installations carry a different spelling of the
+    /// parenthetical and are recognised all the same, because recognition is
+    /// <see cref="BeginMarkerPrefix"/> and never this constant.
+    /// </summary>
+    internal const string BeginMarker = BeginMarkerPrefix + " (managed by jellyfin-plugin-sso - do not edit inside) -->";
 
     /// <summary>The closing fence of the plugin-managed region.</summary>
     internal const string EndMarker = "<!-- SSO-LOGIN-BUTTONS:END -->";
+
+    /// <summary>The three characters that close an HTML comment, and so an opening fence.</summary>
+    private const string CommentClose = "-->";
 
     /// <summary>
     /// Renders the managed button block, or the empty string when there are no buttons. The returned string,
@@ -74,12 +97,15 @@ public static class LoginButtonInjector
     }
 
     /// <summary>
-    /// Splices <paramref name="block"/> into <paramref name="existingDisclaimer"/> idempotently: an existing
-    /// managed region (between the markers) is replaced; when none is present the block is appended; and an
-    /// empty <paramref name="block"/> removes the managed region entirely, restoring the surrounding admin
-    /// content. Content outside the markers - an admin's own disclaimer - is preserved, aside from the
-    /// blank-line separator the managed region introduces, which is collapsed on removal so repeated
-    /// enable/disable cycles cannot accumulate whitespace.
+    /// Splices <paramref name="block"/> into <paramref name="existingDisclaimer"/> idempotently: the FIRST
+    /// managed region is replaced, every further managed region is removed, when none is present the block is
+    /// appended, and an empty <paramref name="block"/> removes them all. Content outside the fences - an
+    /// admin's own disclaimer - is preserved, aside from the blank-line separator a managed region introduces,
+    /// which is collapsed on removal so repeated enable/disable cycles cannot accumulate whitespace.
+    ///
+    /// Removing the extra regions rather than only the first is what repairs an installation that was already
+    /// left holding two blocks by the orphaning described at <see cref="BeginMarkerPrefix"/>: it converges to
+    /// exactly one on the next sync, and to none when the buttons are turned off, from any number of them.
     /// </summary>
     /// <param name="existingDisclaimer">The current login disclaimer (may be null/empty).</param>
     /// <param name="block">The managed block from <see cref="BuildBlock"/> (empty to remove the region).</param>
@@ -88,24 +114,9 @@ public static class LoginButtonInjector
     {
         ArgumentNullException.ThrowIfNull(block);
         var current = existingDisclaimer ?? string.Empty;
+        var regions = FindRegions(current);
 
-        var begin = current.IndexOf(BeginMarker, StringComparison.Ordinal);
-
-        // Search for the CLOSING fence only AFTER the opener. Searching from 0 would let a stray END that a
-        // hand-edited disclaimer placed BEFORE the BEGIN make the region look malformed on every sync, so a
-        // fresh block would be re-appended each time - and because a login's canonical-link write also raises
-        // the config-changed event, that would grow the disclaimer without bound, once per login. Anchoring
-        // the END search past the BEGIN ignores the stray marker and converges instead.
-        var end = begin >= 0
-            ? current.IndexOf(EndMarker, begin + BeginMarker.Length, StringComparison.Ordinal)
-            : -1;
-
-        // A well-formed existing region is BEGIN then END-after-BEGIN. Anything else (only one marker) is
-        // treated as "no managed region": we never parse a partial fence, so we cannot corrupt surrounding
-        // content. A fresh block then appends cleanly.
-        var hasRegion = begin >= 0 && end >= 0;
-
-        if (!hasRegion)
+        if (regions.Count == 0)
         {
             if (block.Length == 0)
             {
@@ -116,23 +127,94 @@ public static class LoginButtonInjector
             return current.Length == 0 ? block : current.TrimEnd('\n') + "\n\n" + block;
         }
 
-        var before = current[..begin];
-        var after = current[(end + EndMarker.Length)..];
-
-        if (block.Length == 0)
+        // Last to first, so an earlier region's offsets are still valid when its turn comes. Only the first
+        // region keeps a block; the rest are orphans and are spliced out.
+        for (var i = regions.Count - 1; i > 0; i--)
         {
-            // Remove the region and heal the seam: collapse the blank-line separator the insert introduced so
-            // repeated enable/disable cycles do not accumulate whitespace, then trim a now-trailing gap.
-            var healed = before.TrimEnd('\n');
-            var tail = after.TrimStart('\n');
-            if (healed.Length == 0)
-            {
-                return tail;
-            }
-
-            return tail.Length == 0 ? healed : healed + "\n\n" + tail;
+            current = Splice(current, regions[i], string.Empty);
         }
 
-        return before + block + after;
+        return Splice(current, regions[0], block);
+    }
+
+    /// <summary>
+    /// Every well-formed managed region in <paramref name="current"/>, in order, as (start, end-exclusive)
+    /// character offsets spanning the opening fence through the closing one.
+    ///
+    /// What is recognised: an opening fence is <see cref="BeginMarkerPrefix"/> followed by the first
+    /// <c>--&gt;</c> that occurs BEFORE the next newline, and a region is such an opener followed by
+    /// <see cref="EndMarker"/> somewhere after it.
+    ///
+    /// What is not, and each for its own reason. The prefix with no comment close on its line is not an
+    /// opener: the fences this type writes are whole lines, so a search that crossed one would let a
+    /// hand-typed fragment swallow the real opener below it and take the admin's own content with it when the
+    /// region was replaced. An opener with no closing fence after it is not a region: a partial fence is never
+    /// parsed, so surrounding content cannot be corrupted, and a fresh block appends cleanly instead. And the
+    /// closing fence is searched for only AFTER an opener, so a stray END that a hand-edited disclaimer placed
+    /// ahead of one is ignored rather than making the region look malformed on every sync - which would
+    /// re-append a block each time, and because a login's canonical-link write also raises the config-changed
+    /// event, would grow the disclaimer without bound, once per login.
+    /// </summary>
+    /// <param name="current">The disclaimer to scan.</param>
+    /// <returns>The regions found, in document order; empty when there are none.</returns>
+    private static List<(int Start, int End)> FindRegions(string current)
+    {
+        var regions = new List<(int Start, int End)>();
+        var from = 0;
+
+        while (from < current.Length)
+        {
+            var begin = current.IndexOf(BeginMarkerPrefix, from, StringComparison.Ordinal);
+            if (begin < 0)
+            {
+                break;
+            }
+
+            var afterPrefix = begin + BeginMarkerPrefix.Length;
+            var close = current.IndexOf(CommentClose, afterPrefix, StringComparison.Ordinal);
+            var newline = current.IndexOf('\n', afterPrefix);
+            if (close < 0 || (newline >= 0 && newline < close))
+            {
+                from = afterPrefix;
+                continue;
+            }
+
+            var openerEnd = close + CommentClose.Length;
+            var end = current.IndexOf(EndMarker, openerEnd, StringComparison.Ordinal);
+            if (end < 0)
+            {
+                from = afterPrefix;
+                continue;
+            }
+
+            var regionEnd = end + EndMarker.Length;
+            regions.Add((begin, regionEnd));
+            from = regionEnd;
+        }
+
+        return regions;
+    }
+
+    // Replaces one region's characters with a replacement, healing the seam when the replacement is empty:
+    // the blank-line separator the insert introduced is collapsed, so repeated enable/disable cycles do not
+    // accumulate whitespace, and a now-trailing gap is trimmed.
+    private static string Splice(string current, (int Start, int End) region, string replacement)
+    {
+        var before = current[..region.Start];
+        var after = current[region.End..];
+
+        if (replacement.Length != 0)
+        {
+            return before + replacement + after;
+        }
+
+        var healed = before.TrimEnd('\n');
+        var tail = after.TrimStart('\n');
+        if (healed.Length == 0)
+        {
+            return tail;
+        }
+
+        return tail.Length == 0 ? healed : healed + "\n\n" + tail;
     }
 }


### PR DESCRIPTION
# What & why

The opening fence of the managed login-button region is written into every installation's login disclaimer and found again by an exact ordinal search on the next sync. Any edit to the literal that is MATCHED therefore orphans every block already on disk: the plugin stops recognising its own region, appends a second one beside it, and because content outside the fences is an admin's own disclaimer and is preserved on purpose, nothing it can do afterwards removes the first. A typographic pass made that edit.

## The reading the issue said the choice depended on

The issue left three shapes open and named the missing measurement: whether a release has already shipped the new literal. It has, ten times.

```
$ git tag --contains ed93f90
4.3.0-beta.30
4.3.0-beta.31
4.3.0-beta.32
4.3.0-beta.33
4.3.0-beta.34
5.0.0-JF12-beta.44
5.0.0-JF12-beta.45
5.0.0-JF12-beta.46
5.0.0-JF12-beta.47
5.0.0-JF12-beta.48
```

That rules out restoring the old spelling: it is no longer the repair that leaves no orphan anywhere, because orphans can already exist. Of the two forward repairs left, matching on the stable prefix does everything recognising-both-openers does, plus it needs no second literal kept until a date nobody can establish, and it is the only one that satisfies the issue's third done-condition on its own.

## What lands

Recognition is `<!-- SSO-LOGIN-BUTTONS:BEGIN` followed by the first `-->` on the same line. Everything between is prose the matcher does not read, so either spelling of the parenthetical is recognised and rewriting it again costs nothing. The token carries nothing a typographic pass looks for: the hyphens in it are already plain ASCII, which is the direction such a pass converts towards, so the literal and the typographic rule are separated by construction rather than by a carve-out somebody has to remember.

`Merge` now replaces the first managed region and removes every further one. That is what repairs a server ALREADY left holding two blocks, which is the state the unrepaired code converged to and which no plugin action could clear: turning the buttons off removed the newer region and returned the older one untouched, so the duplicate outlived the feature that created it. From any number of regions it converges to one, and to none when the buttons are off.

What is NOT recognised is written at the scan rather than left to be inferred. The token with no comment close on its own line is not an opener, because the fences this type writes are whole lines and a search that crossed one would let a hand-typed fragment swallow the real opener below it and take the admin's content with it. An opener with no closing fence after it is not a region, so a partial fence is never parsed. And the closing fence is searched for only after an opener, so a stray END placed ahead of one is still ignored, which is the existing convergence property and is unchanged.

Closes #1344.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This does not touch the login path's authentication, crypto or config persistence, but the output is HTML on the anonymous pre-auth login page, so the relevant lines are answered rather than skipped.

- [x] Fail-closed preserved. Nothing here decides an authentication outcome. The one direction that matters is that a partial or unrecognised fence is still treated as no region, so surrounding content is never parsed into.
- [x] No secrets logged. This type does no I/O and writes no log.
- [ ] **A security review was NOT performed for this change.** No second reader ran on it. The box stays unticked rather than being read as satisfied by the evidence below.
- [ ] **No review record exists**, so there are no per-lens verdicts and no CONFIRMED / PLAUSIBLE counts to report. Executed evidence stands in its place, under Verification.
- [x] Log inputs from the IdP are sanitized inline at the log call. No log call is added or moved.

The XSS surface is untouched. `BuildBlock` is unchanged, so every interpolated value is still HTML-encoded and every provider name in a URL is still additionally escaped, and the existing encoding pins still run. The change is confined to WHERE a region is found, never to what is written into it.

## Quality checklist

- [x] No duplicated logic. The seam-healing that removal needs existed once inside `Merge` and is now one `Splice` helper used by both the removal and the replacement path, so the two cannot drift.
- [x] The change adds no more code than the problem requires. The scan is one loop; the rest is the same string arithmetic as before.
- [x] Comments say why. The constant says why recognition is split from the literal, and the scan says what it refuses and what each refusal is protecting.
- [x] Architecture-conformance tests pass. No file, namespace or dependency edge is added.
- [x] Docs impact: none. The marker is not documented in the README or the wiki, and an admin sees no new option. The CHANGELOG entry is included here.

## Verification

- [x] `dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj --warnaserror` on `-f net9.0` and `-f net10.0`: build succeeded, 0 warnings, 0 errors on both.
- [x] Full suite from the built xunit-v3 executable, on this branch with `main` merged in: `Total: 3064, Failed: 0, Skipped: 4` on net9.0 and `Total: 3065, Failed: 0, Skipped: 4` on net10.0. The four skips are the pre-existing loopback-bind tests (#1227), skipped because binding off loopback raises a Windows firewall consent dialog that needs an administrator. They are unrelated to this change and were skipped before it.
- [x] Prettier: `CHANGELOG.md` is the only file here Prettier reads, and `npx prettier --check CHANGELOG.md` passes.

Both halves of the repair are proven by deleting them, one at a time, and each falsifier is a single edit with nothing else changed.

Searching the whole literal instead of the token:

```
Total: 30, Failed: 6
  ADisclaimerCarryingThePreSweepFence_SyncsToExactlyOneManagedBlock
  ADisclaimerCarryingThePreSweepFence_LeavesNoManagedBlockWhenTheButtonsAreTurnedOff
  AnInstallationAlreadyLeftHoldingTwoBlocks_ConvergesToOne
  AnInstallationAlreadyLeftHoldingTwoBlocks_LeavesNoneWhenTheButtonsAreTurnedOff
  AdminContentAroundAndBetweenTwoBlocks_Survives
  AFenceWhoseParentheticalNobodyHasWrittenYet_IsStillRecognised
```

All fourteen existing `LoginButtonInjectorTests` stay green under that falsifier, which is the evidence that the recognition change is what the six are measuring.

Keeping the token but processing only the first region:

```
Total: 30, Failed: 3
  AnInstallationAlreadyLeftHoldingTwoBlocks_ConvergesToOne
  AnInstallationAlreadyLeftHoldingTwoBlocks_LeavesNoneWhenTheButtonsAreTurnedOff
  AdminContentAroundAndBetweenTwoBlocks_Survives
```

The pre-sweep literal is built in the fixture from its code point rather than typed, so proving the defect does not put the character the typographic pass removed back into this tree. `ThePreSweepFenceIsNotTheOneWrittenToday_WhichIsWhyTheseTestsExist` guards that premise: if the two literals ever became equal again, every other test here would pass while proving nothing, and that one would go red to say so.

## Notes

Not measured, and not claimed: I read no installation. What is established here is the literal's history on the mainline, which tags contain the change, and the behaviour of the merge over disclaimers holding each fence. Whether any particular deployment has upgraded across `ed93f90` is not readable from a checkout.

The two-block convergence removes the extra regions rather than only the first, which is a behaviour change beyond the fence literal itself. It is in scope because an installation that has already synced once under the unrepaired code holds two blocks, and the issue's first done-condition asks that such a server end up with exactly one after a sync and none after the buttons are disabled. A repair that only fixed recognition would leave those servers at two forever.
