### PR TITLE
Enforce the account-expiry deadline at login

### DIFF
--- a/SSO-Auth.Tests/Flows/AccountExpiryEnforcementTests.cs
+++ b/SSO-Auth.Tests/Flows/AccountExpiryEnforcementTests.cs
@@ -1,0 +1,294 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Login-time enforcement of a provider's account-expiry deadline (#1144): an identity whose expiry instant
+/// has passed gets no session, its linked account is disabled and its live tokens are revoked. Both halves
+/// matter and they fail differently. Refusing the mint alone leaves a token issued before the deadline
+/// working until it expires on its own, which is "time-limited" in name only; revoking alone leaves the
+/// account able to log straight back in.
+/// <para>
+/// THE GUARD IS THE POINT OF THIS FILE, and it is a mass-lockout defence (T-D1) rather than a courtesy.
+/// An identity provider that starts emitting a past instant, or a claim mapped to the wrong attribute,
+/// hits every account at once. An administrator is therefore exempt from the whole gate and not merely from
+/// the disable: <see cref="ExpiredDeadline_OnAnAdministrator_LeavesItEnabled_AndLogsIn"/> requires the
+/// administrator to LOG IN, because an admin who is left enabled but refused cannot reach the settings page
+/// that would repair the configuration. Deleting the exemption in
+/// <c>LoginCompletionService.EnforceAccountExpiryAsync</c> turns that row red.
+/// </para>
+/// <para>
+/// The claim being CONFIGURED is what arms the gate, and a configured claim that produced no readable
+/// instant is the case both careless answers get wrong. Treating it as unlimited hands a transient identity
+/// provider change the same outcome as an account with no deadline; treating it as expired hands that same
+/// transient change the same outcome as a real expiry, and disables accounts over it. This refuses the one
+/// login and touches nothing, which is the only answer that stays reversible.
+/// </para>
+/// </summary>
+public class AccountExpiryEnforcementTests
+{
+    private const string ExpiryClaim = "access_expires";
+
+    // The fixed part of the audit line SsoAudit.AccountExpired emits, matched rather than reproduced so a
+    // reworded message fails one place instead of eight.
+    private const string ExpiryAuditMarker = "disabled by account expiry";
+    private static readonly Guid Linked = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly DateTime Past = new(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Future = new(2999, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task ExpiredDeadline_DisablesTheAccount_RevokesItsTokens_AndMintsNoSession()
+    {
+        var (service, config, users, sessions, audit) = Build();
+        var user = LinkedUser(users, config, admin: false);
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.Received(1).RevokeUserTokens(Linked, null);
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.Single(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheAuditLine_NamesTheProvider_AndNeitherTheSubjectNorTheDeadline()
+    {
+        // T-I1: the trail an operator reads must carry the protocol and provider and nothing an identity
+        // provider chose. The deadline is excluded with them, because an instant is as identifying as the
+        // subject once it is rare.
+        var (service, config, users, _, audit) = Build();
+        LinkedUser(users, config, admin: false);
+
+        await service.CompleteAsync(OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        var line = Assert.Single(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal)).Message;
+        Assert.Contains("kc", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", line, StringComparison.Ordinal);
+        Assert.DoesNotContain("2000", line, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ExpiredDeadline_OnAnAdministrator_LeavesItEnabled_AndLogsIn()
+    {
+        // THE GUARD. Not "is not disabled" but "logs in": the recovery route this defence exists to keep
+        // open runs through the admin's own session, so an administrator refused at the door is stranded
+        // just as surely as one whose account was disabled.
+        var (service, config, users, sessions, audit) = Build();
+        var admin = LinkedUser(users, config, admin: true);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.False(admin.HasPermission(PermissionKind.IsDisabled));
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        await sessions.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ASecondExpiredLogin_RefusesWithoutReAuditingOrRevokingAgain()
+    {
+        // A refused identity keeps trying. The disable, the audit line and the revocation are transition
+        // events, so a login loop must not flood the trail or re-revoke on every attempt - and it must not
+        // fall through to the pending-approval message either, which would tell an expired user to wait for
+        // an approval nobody is going to give.
+        var (service, config, users, sessions, audit) = Build();
+        var user = LinkedUser(users, config, admin: false);
+
+        await service.CompleteAsync(OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+        var second = await service.CompleteAsync(OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ContentResult>(second).StatusCode);
+        Assert.Contains("expired", Assert.IsType<ContentResult>(second).Content!, StringComparison.OrdinalIgnoreCase);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.Received(1).RevokeUserTokens(Linked, null);
+        Assert.Single(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ADeadlineInTheFuture_LogsInAndChangesNothing()
+    {
+        var (service, config, users, sessions, audit) = Build();
+        var user = LinkedUser(users, config, admin: false);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(Future), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AConfiguredClaimThatProducedNoInstant_RefusesTheLogin_AndDisablesNothing()
+    {
+        // Fail closed on the session, reversible on the account. A missing or unreadable value cannot be
+        // told apart from an identity provider that changed its claim shape this morning, so it must not
+        // grant access and must not spend a disable on the guess.
+        var (service, config, users, sessions, audit) = Build();
+        var user = LinkedUser(users, config, admin: false);
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(null), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task WithNoExpiryClaimConfigured_AnInstantInThePastIsIgnored()
+    {
+        // The opt-in floor, and the row that keeps the feature from reaching a deployment that did not ask
+        // for it. The identity carries a past instant; the provider configures no claim, so the whole gate
+        // is off and the login takes its pre-#1144 path.
+        var (service, config, users, sessions, _) = Build(expiryClaim: null);
+        var user = LinkedUser(users, config, admin: false);
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.IsType<OkObjectResult>(result);
+        Assert.False(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
+    [Fact]
+    public async Task AFirstLoginThatIsAlreadyExpired_ProvisionsTheAccountInert_AndMintsNothing()
+    {
+        // Recorded because it is the arm a reader would guess wrong. The gate runs after resolve-or-create,
+        // so an identity arriving already past its deadline DOES get a Jellyfin account, and that account is
+        // disabled in the same request and never issued a session. Refusing before the resolve instead would
+        // give the gate no account to disable and no administrator exemption to read, so this is the price of
+        // both; what matters is that it fails closed, which the mint assertion below is what pins.
+        var (service, config, users, sessions, audit) = Build();
+        var created = TestUsers.Named("alice", Linked);
+        users.GetUserByName("alice").Returns((User?)null);
+        users.CreateUserAsync("alice").Returns(created);
+        users.GetUserById(Linked).Returns(created);
+
+        var result = await service.CompleteAsync(
+            OidcIdentity(Past), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.True(created.HasPermission(PermissionKind.IsDisabled));
+        await sessions.DidNotReceive().AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.Single(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheSamlPathIsEnforcedIdentically()
+    {
+        // Both protocols funnel through the one completion tail, so the deadline is enforced once rather
+        // than per protocol. This row is what would go red if the enforcement were ever moved up into the
+        // OpenID flow service, where SAML would silently stop being covered.
+        var config = new SamlConfig { Enabled = true, AccountExpiryClaim = ExpiryClaim };
+        var audit = new CapturingLogger();
+        var (service, users, sessions) = BuildFor(c => c.SamlConfigs["idp"] = config, audit);
+        var user = TestUsers.Named("bob", Linked);
+        users.GetUserById(Linked).Returns(user);
+        config.CanonicalLinks["bob"] = Linked;
+
+        var identity = TestIdentities.Saml(
+            "idp",
+            "bob",
+            new SamlAuthorizeStateBuilder.SamlAuthorizeState(
+                Admin: false, EnableLiveTv: false, EnableLiveTvManagement: false, Folders: new List<string>()),
+            Past);
+
+        var result = await service.CompleteAsync(identity, Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(StatusCodes.Status403Forbidden, Assert.IsType<ContentResult>(result).StatusCode);
+        Assert.True(user.HasPermission(PermissionKind.IsDisabled));
+        await sessions.Received(1).RevokeUserTokens(Linked, null);
+        Assert.Single(audit.Entries, e => e.Message.Contains(ExpiryAuditMarker, StringComparison.Ordinal));
+    }
+
+    // --- helpers ---
+
+    private static AuthResponse Response() =>
+        new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity OidcIdentity(DateTime? expiresAtUtc) =>
+        TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: "sub-1",
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null,
+            ExpiresAtUtc: expiresAtUtc));
+
+    private static (LoginCompletionService Service, OidConfig Config, IUserManager Users, ISessionManager Sessions, CapturingLogger Audit) Build(string? expiryClaim = ExpiryClaim)
+    {
+        var config = new OidConfig { Enabled = true, AccountExpiryClaim = expiryClaim };
+        var audit = new CapturingLogger();
+        var (service, users, sessions) = BuildFor(c => c.OidConfigs["kc"] = config, audit);
+        return (service, config, users, sessions, audit);
+    }
+
+    private static (LoginCompletionService Service, IUserManager Users, ISessionManager Sessions) BuildFor(Action<PluginConfiguration> seed, CapturingLogger audit)
+    {
+        var configuration = new PluginConfiguration();
+        seed(configuration);
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, audit), users, sessions);
+    }
+
+    // An account that already exists and is already linked, so every row below acts on a resolved link
+    // rather than on a first login: this path must never create or adopt an account, only act on one the
+    // identity has already proved it owns.
+    private static User LinkedUser(IUserManager users, ProviderConfigBase config, bool admin)
+    {
+        var user = TestUsers.Named("alice", Linked);
+        user.SetPermission(PermissionKind.IsAdministrator, admin);
+        users.GetUserById(Linked).Returns(user);
+        config.CanonicalLinks["sub-1"] = Linked;
+        return user;
+    }
+}

--- a/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/LoginCompletionServiceTests.cs
@@ -55,7 +55,7 @@ public class LoginCompletionServiceTests
         var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
         var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
         var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
-        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, auditLog ?? new CapturingLogger()), cfg, users, sessions);
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, auditLog ?? new CapturingLogger()), cfg, users, sessions);
     }
 
     private static AuthResponse Response() =>

--- a/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/OidcLoginServiceTests.cs
@@ -138,9 +138,10 @@ public class OidcLoginServiceTests
 
         var canonicalLinks = new CanonicalLinkService(harness.UserManager, new FakeCryptoProvider(), SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(harness.UserManager, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), logger, SsoHttp.UserAgent);
-        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, Substitute.For<ISessionManager>(), logger);
+        var sessionManager = Substitute.For<ISessionManager>();
+        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, sessionManager, logger);
         var ssoOnly = new SsoOnlyLoginService(harness.UserManager, SSOPlugin.Instance.ConfigStore, logger);
-        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, ssoOnly, SSOPlugin.Instance.ConfigStore, logger);
+        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, ssoOnly, SSOPlugin.Instance.ConfigStore, sessionManager, logger);
         var service = new OidcLoginService(loginCompletion, canonicalLinks, Substitute.For<IHttpClientFactory>(), Substitute.For<ILoggerFactory>(), logger);
 
         var context = new DefaultHttpContext();

--- a/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
+++ b/SSO-Auth.Tests/Flows/SamlLoginServiceTests.cs
@@ -160,9 +160,10 @@ public class SamlLoginServiceTests
 
         var canonicalLinks = new CanonicalLinkService(harness.UserManager, new FakeCryptoProvider(), SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(harness.UserManager, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), logger, SsoHttp.UserAgent);
-        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, Substitute.For<ISessionManager>(), logger);
+        var sessionManager = Substitute.For<ISessionManager>();
+        var sessionMinter = new SessionMinter(harness.UserManager, avatarService, sessionManager, logger);
         var ssoOnly = new SsoOnlyLoginService(harness.UserManager, SSOPlugin.Instance.ConfigStore, logger);
-        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, ssoOnly, SSOPlugin.Instance.ConfigStore, logger);
+        var loginCompletion = new LoginCompletionService(canonicalLinks, sessionMinter, ssoOnly, SSOPlugin.Instance.ConfigStore, sessionManager, logger);
         var service = new SamlLoginService(loginCompletion, canonicalLinks, logger);
 
         var context = new DefaultHttpContext();

--- a/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
+++ b/SSO-Auth.Tests/Session/LoginStatusMapperTests.cs
@@ -38,6 +38,7 @@ public class LoginStatusMapperTests
             (PublicReason.AwaitingApproval, 403, "Your account is not active. It is awaiting administrator approval."),
             (PublicReason.AcrNotSatisfied, 403, "A stronger authentication level (for example MFA) is required to log in."),
             (PublicReason.AuthTooOld, 403, "You authenticated too long ago; please sign in again."),
+            (PublicReason.AccessExpired, 403, "Your access has expired. Contact the server administrator if this is unexpected."),
         };
 
         // The table itself must stay total: a new member without a row fails here.

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -34,9 +34,10 @@ internal static class TestIdentities
             AvatarUrl = derived.AvatarUrl,
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
+            ExpiresAtUtc = derived.ExpiresAtUtc,
         });
 
-    internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges) =>
+    internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges, DateTime? expiresAtUtc = null) =>
         VerifiedIdentity.FromValidatedSaml(new ValidatedLogin
         {
             Provider = provider,
@@ -51,5 +52,6 @@ internal static class TestIdentities
             AvatarUrl = null,
             PermissionGrants = privileges.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = privileges.MaxParentalRatingScore,
+            ExpiresAtUtc = expiresAtUtc,
         });
 }

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -102,6 +102,30 @@ internal static class SsoAudit
             provider?.ReplaceLineEndings(string.Empty));
     }
 
+    /// <summary>
+    /// Records an existing account being disabled because its access deadline has passed (#1144): the
+    /// provider configures an account-expiry claim and the login carried an instant at or before now. Fired
+    /// once, at the transition, never on the later refused logins of an account already disabled by it. Only
+    /// non-sensitive fields are logged - the protocol and provider name, never the subject/username or the
+    /// deadline itself (T-I1) - so an offboarding, or a mass-expiry incident from an identity provider that
+    /// starts emitting a past instant, leaves an operator trail.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    internal static void AccountExpired(ILogger logger, string protocol, string provider)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Account disabled by account expiry: an SSO login via {Protocol} provider '{Provider}' carried an expiry instant at or before now, so the account was disabled and its tokens were revoked (AccountExpiryClaim). Administrators are never disabled by this path.",
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+    }
+
     /// <summary>Records a provider being added or updated.</summary>
     /// <param name="logger">The logger.</param>
     /// <param name="protocol">The protocol (OpenID or SAML).</param>

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -12,6 +12,7 @@ using Jellyfin.Plugin.SSO_Auth.Api.Logout;
 using Jellyfin.Plugin.SSO_Auth.Api.Session;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Session;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
@@ -38,6 +39,7 @@ internal sealed class LoginCompletionService
     private readonly SessionMinter _sessionMinter;
     private readonly SsoOnlyLoginService _ssoOnly;
     private readonly ProviderConfigStore _configStore;
+    private readonly ISessionManager _sessionManager;
     private readonly ILogger _logger;
 
     /// <summary>
@@ -48,13 +50,15 @@ internal sealed class LoginCompletionService
     /// <param name="sessionMinter">The session minter run under the in-flight revocation gate.</param>
     /// <param name="ssoOnly">The SSO-only login enforcement service.</param>
     /// <param name="configStore">The provider configuration store.</param>
+    /// <param name="sessionManager">Jellyfin session manager, used to revoke an account's live tokens when the account-expiry gate disables it (#1144); without it a token minted before the deadline would outlive it.</param>
     /// <param name="logger">The logger.</param>
-    internal LoginCompletionService(CanonicalLinkService canonicalLinks, SessionMinter sessionMinter, SsoOnlyLoginService ssoOnly, ProviderConfigStore configStore, ILogger logger)
+    internal LoginCompletionService(CanonicalLinkService canonicalLinks, SessionMinter sessionMinter, SsoOnlyLoginService ssoOnly, ProviderConfigStore configStore, ISessionManager sessionManager, ILogger logger)
     {
         _canonicalLinks = canonicalLinks ?? throw new ArgumentNullException(nameof(canonicalLinks));
         _sessionMinter = sessionMinter ?? throw new ArgumentNullException(nameof(sessionMinter));
         _ssoOnly = ssoOnly ?? throw new ArgumentNullException(nameof(ssoOnly));
         _configStore = configStore ?? throw new ArgumentNullException(nameof(configStore));
+        _sessionManager = sessionManager ?? throw new ArgumentNullException(nameof(sessionManager));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -99,6 +103,19 @@ internal sealed class LoginCompletionService
         catch (AccountLinkForbiddenException)
         {
             return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccountLinkForbidden));
+        }
+
+        // Account-expiry gate (#1144), ahead of the pending-approval gate so an account this path already
+        // disabled is refused under its own reason rather than reported as awaiting an approval nobody is
+        // waiting to give. Opt-in: with no AccountExpiryClaim configured for the provider, nothing here runs
+        // and the login takes byte-for-byte its pre-#1144 path.
+        if (!string.IsNullOrWhiteSpace(config.AccountExpiryClaim))
+        {
+            var expiryRefusal = await EnforceAccountExpiryAsync(identity, userId).ConfigureAwait(false);
+            if (expiryRefusal is not null)
+            {
+                return expiryRefusal;
+            }
         }
 
         // Pending-approval gate (#737): a resolved account that is disabled - a brand-new user just
@@ -156,6 +173,59 @@ internal sealed class LoginCompletionService
         CaptureLogoutState(identity, userId, logoutContext, authenticationResult);
 
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));
+    }
+
+    // Enforces a configured account-expiry deadline against the resolved account (#1144). Returns the
+    // refusal to send, or null to let the login continue.
+    //
+    // THE GUARD (T-D1, mass-lockout defence): an administrator is exempt from the whole gate, not merely
+    // from the disable. An identity provider that starts emitting a past instant - or a claim mapped to the
+    // wrong attribute - must be able to strand at most the non-admin accounts, so an administrator both
+    // stays enabled and stays able to log in and repair the configuration. That is why the exemption is read
+    // from the RESOLVED account before anything else happens rather than inferred from a disable that
+    // declined to act; the two are not the same, and only the first keeps the recovery door open. The basis
+    // is the account, never identity.Admin, which is the identity provider's own say-so.
+    //
+    // A configured claim that produced no readable instant refuses the login and disables nothing. Granting
+    // unlimited access on a claim the reader could not parse would make a transient identity-provider change
+    // indistinguishable from an unlimited account, and disabling on it would make that same transient change
+    // indistinguishable from a real expiry - so the fail-closed answer is to refuse this login and leave the
+    // account exactly as it was.
+    private async Task<ActionResult?> EnforceAccountExpiryAsync(VerifiedIdentity identity, Guid userId)
+    {
+        if (_canonicalLinks.IsAccountAdministrator(userId))
+        {
+            return null;
+        }
+
+        if (identity.ExpiresAtUtc is not { } deadline)
+        {
+            return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccessExpired));
+        }
+
+        if (deadline > DateTime.UtcNow)
+        {
+            return null;
+        }
+
+        // Fired at the transition only. A second expired login finds the account already disabled, the
+        // disable returns false, and neither the audit line nor the revocation runs again - so a login loop
+        // against an expired identity cannot flood the trail or mass-revoke on every attempt.
+        if (await _canonicalLinks.DisableExpiredAccountAsync(identity.LinkMode, identity.Provider, identity.Subject, identity.Issuer).ConfigureAwait(false))
+        {
+            SsoAudit.AccountExpired(_logger, identity.AuditProtocol, identity.Provider);
+
+            // Without this, "time-limited" means only that no NEW session is minted while a token issued
+            // before the deadline keeps working until it expires on its own. Scoped strictly to this one
+            // user id, which is what separates it from the per-provider disable that deliberately does not
+            // revoke (#468): there the id is one of many behind a provider and revoking would be an
+            // unscoped mass-logout, here it is the single subject whose access just ended. Runs after the
+            // disable is persisted, so a revoke that throws leaves the account already disabled rather than
+            // the pair half-done.
+            await _sessionManager.RevokeUserTokens(userId, null).ConfigureAwait(false);
+        }
+
+        return LoginStatusMapper.ToActionResult(new LoginOutcome.Rejected(PublicReason.AccessExpired));
     }
 
     // Persist the per-session Single Logout state (#727, SLO-1b), only when the feature is on. Runs AFTER a

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -131,7 +131,7 @@ public class SSOController : ControllerBase
         _ssoOnly = new SsoOnlyLoginService(userManager, SSOPlugin.Instance.ConfigStore, logger);
         var avatarService = new AvatarService(userManager, providerManager, serverConfigurationManager, logger, SsoHttp.UserAgent);
         var sessionMinter = new SessionMinter(userManager, avatarService, sessionManager, logger);
-        _loginCompletion = new LoginCompletionService(_canonicalLinks, sessionMinter, _ssoOnly, SSOPlugin.Instance.ConfigStore, logger);
+        _loginCompletion = new LoginCompletionService(_canonicalLinks, sessionMinter, _ssoOnly, SSOPlugin.Instance.ConfigStore, sessionManager, logger);
         _oidc = new Flows.OidcLoginService(_loginCompletion, _canonicalLinks, httpClientFactory, loggerFactory, logger);
         _saml = new Flows.SamlLoginService(_loginCompletion, _canonicalLinks, logger);
         _logger.LogInformation("SSO Controller initialized");

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -617,6 +617,23 @@ internal sealed class CanonicalLinkService
     }
 
     /// <summary>
+    /// Whether the resolved account holds <see cref="PermissionKind.IsAdministrator"/>. The read the
+    /// mass-lockout guard (T-D1) is made from where a caller has to decide BEFORE acting rather than learn
+    /// it from a refusal - the account-expiry gate (#1144) has to let an administrator log in rather than
+    /// merely leave it enabled, so it cannot infer the guard from a disable that returned false. Basis is
+    /// the RESOLVED account, never the identity provider's admin claim, which is the same basis the disable
+    /// paths use. A user that vanished between resolution and here reports false, so the guard opens no door
+    /// for an account that is not there.
+    /// </summary>
+    /// <param name="userId">The resolved Jellyfin user id.</param>
+    /// <returns><see langword="true"/> when the account exists and is an administrator.</returns>
+    internal bool IsAccountAdministrator(Guid userId)
+    {
+        var user = _userManager.GetUserById(userId);
+        return user is not null && user.HasPermission(PermissionKind.IsAdministrator);
+    }
+
+    /// <summary>
     /// Login-time deprovisioning (#831): when an SSO login is DENIED by the role allow-list, disable the
     /// existing linked Jellyfin account so a user offboarded at the identity provider loses Jellyfin access
     /// immediately, rather than keeping any session until a role change would otherwise apply. Opt-in per
@@ -635,7 +652,37 @@ internal sealed class CanonicalLinkService
     /// <param name="canonicalKey">The identity's stable subject key (OpenID sub / SAML NameID) whose login was denied.</param>
     /// <param name="issuer">The denied login's token issuer (OpenID only; null for SAML), checked against the link's stored issuer binding (#186) so a colliding subject from a repointed identity provider cannot disable the prior provider's account.</param>
     /// <returns><see langword="true"/> when an enabled non-admin account was actually disabled (so the caller audits it); otherwise <see langword="false"/>.</returns>
-    internal async Task<bool> DisableDeniedAccountAsync(ProviderMode mode, string provider, string? canonicalKey, string? issuer = null)
+    internal Task<bool> DisableDeniedAccountAsync(ProviderMode mode, string provider, string? canonicalKey, string? issuer = null) =>
+        DisableLinkedAccountAsync(mode, provider, canonicalKey, issuer);
+
+    /// <summary>
+    /// Login-time enforcement of an account-expiry deadline (#1144): when a login carries an expiry instant
+    /// at or before now, disable the existing linked Jellyfin account so a time-limited or guest identity
+    /// loses Jellyfin access at its deadline rather than for as long as its tokens happen to live. Opt-in per
+    /// provider (<see cref="ProviderConfigBase.AccountExpiryClaim"/>).
+    /// <para>
+    /// One rule, one implementation: this shares every safety property of
+    /// <see cref="DisableDeniedAccountAsync"/> - the same mass-lockout guard (T-D1), the same issuer binding
+    /// (#186), the same never-create/never-adopt resolution, the same no-op on an already-disabled account -
+    /// because it is the same code, and a second copy would be a second place for the guard to be dropped
+    /// from. The two names exist because the two callers mean different things by disabling, and each owes
+    /// its own audit line.
+    /// </para>
+    /// </summary>
+    /// <param name="mode">The provider protocol.</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="canonicalKey">The identity's stable subject key (OpenID sub / SAML NameID) whose deadline has passed.</param>
+    /// <param name="issuer">The login's token issuer (OpenID only; null for SAML), checked against the link's stored issuer binding (#186).</param>
+    /// <returns><see langword="true"/> when an enabled non-admin account was actually disabled (so the caller audits it once, at the transition); otherwise <see langword="false"/>.</returns>
+    internal Task<bool> DisableExpiredAccountAsync(ProviderMode mode, string provider, string? canonicalKey, string? issuer = null) =>
+        DisableLinkedAccountAsync(mode, provider, canonicalKey, issuer);
+
+    // The shared body of both login-time disable paths above. Kept private and unnamed for either caller so
+    // neither reason can acquire a guard the other lacks: PermissionRolePolicy bars IsDisabled from SSO role
+    // mapping precisely so no login can disable an account, and these are its two sanctioned exceptions
+    // (#831, #1144, alongside #737). Two exceptions sharing one body is what keeps that policy's invariant
+    // readable - the guard below is stated once and cannot be present in one exception and absent in the other.
+    private async Task<bool> DisableLinkedAccountAsync(ProviderMode mode, string provider, string? canonicalKey, string? issuer)
     {
         if (string.IsNullOrWhiteSpace(canonicalKey))
         {

--- a/SSO-Auth/Api/Session/LoginStatusMapper.cs
+++ b/SSO-Auth/Api/Session/LoginStatusMapper.cs
@@ -101,6 +101,7 @@ internal static class LoginStatusMapper
         PublicReason.AwaitingApproval => Emit(StatusCodes.Status403Forbidden, "Your account is not active. It is awaiting administrator approval."),
         PublicReason.AcrNotSatisfied => Emit(StatusCodes.Status403Forbidden, "A stronger authentication level (for example MFA) is required to log in."),
         PublicReason.AuthTooOld => Emit(StatusCodes.Status403Forbidden, "You authenticated too long ago; please sign in again."),
+        PublicReason.AccessExpired => Emit(StatusCodes.Status403Forbidden, "Your access has expired. Contact the server administrator if this is unexpected."),
         // A new PublicReason member without a mapper entry fails loudly here, and the totality test
         // enumerating every member catches it before it can ship - never a fall-through.
         _ => throw new InvalidOperationException($"Unmapped public reason: {reason}"),

--- a/SSO-Auth/Api/Session/PublicReason.cs
+++ b/SSO-Auth/Api/Session/PublicReason.cs
@@ -40,4 +40,7 @@ internal enum PublicReason
 
     /// <summary>max_age is configured but the id_token's auth_time was absent or older than the window (#961) - the user authenticated too long ago. Operator-facing by design.</summary>
     AuthTooOld,
+
+    /// <summary>An account-expiry claim is configured and the login's deadline has passed, or the configured claim produced no readable instant at all (#1144) - one body for both, so an expired subject cannot tell the two apart. User-facing by design.</summary>
+    AccessExpired,
 }

--- a/SSO-Auth/Localization/en.json
+++ b/SSO-Auth/Localization/en.json
@@ -13,6 +13,7 @@
   "error.awaiting_approval": "Your account is not active. It is awaiting administrator approval.",
   "error.acr_not_satisfied": "A stronger authentication level (for example MFA) is required to log in.",
   "error.auth_too_old": "You authenticated too long ago; please sign in again.",
+  "error.access_expired": "Your access has expired. Contact the server administrator if this is unexpected.",
   "page.logging_in": "Logging in...",
   "page.enable_javascript": "Please enable Javascript to complete the login",
   "page.account_linked": "Account linked. You can now log in with SSO.",


### PR DESCRIPTION
# What & why

Closes #1144.

The expiry instant has been readable on both protocols since the read step
landed, and nothing consumed it. Measured before writing anything, at `ba0d4a4`:

```
$ git grep -n "ExpiresAtUtc" origin/main -- SSO-Auth/
SSO-Auth/Api/Identity/ValidatedLogin.cs:61:    internal DateTime? ExpiresAtUtc { get; init; }
SSO-Auth/Api/Identity/VerifiedIdentity.cs:75:        ExpiresAtUtc = expiresAtUtc;
SSO-Auth/Api/Identity/VerifiedIdentity.cs:138:    internal DateTime? ExpiresAtUtc { get; }
SSO-Auth/Api/Identity/VerifiedIdentity.cs:178:            login.ExpiresAtUtc);
SSO-Auth/Api/Oidc/AuthorizeSession.cs:157:                ExpiresAtUtc = derived.ExpiresAtUtc,
SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs:431:        DateTime? ExpiresAtUtc = null)
SSO-Auth/Api/Saml/SamlAssertionValidator.cs:259:            ExpiresAtUtc = ReadExpiry(config, samlResponse),
```

The record that carries it, the two readers that fill it, and no reader of the
value. A deadline nothing enforces is a configuration field that reads as a
control and is not one.

The gate lives on the shared completion tail, so one implementation covers both
protocols, and it runs ahead of the pending-approval gate so an account it has
already disabled is refused under its own reason rather than told to wait for an
approval nobody is going to give. It is opt-in: with no `AccountExpiryClaim`
configured for the provider, nothing runs and the login takes its previous path,
which `WithNoExpiryClaimConfigured_AnInstantInThePastIsIgnored` pins.

Both halves of the outcome are needed and they fail differently. Refusing the
mint alone leaves a token issued before the deadline working until it expires on
its own, which is time-limited in name only; revoking alone leaves the account
able to log straight back in.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved. Every arm that cannot establish a live entitlement
      refuses: a passed deadline, a configured claim with no readable instant, a
      link that resolves to no user. The mint is reached only by a deadline in
      the future or by the administrator exemption.
- [x] No secrets logged. The audit line carries the protocol and the provider
      and neither the subject nor the deadline;
      `TheAuditLine_NamesTheProvider_AndNeitherTheSubjectNorTheDeadline` asserts
      those absences rather than describing them.
- [ ] A security review was performed. **No.** No lens reviewed this change and
      no second person read it. The four weakening runs below are what stands in
      place of that, and it is stated as the substitution it is.
- [ ] Review record. **None**, per the line above. CONFIRMED 0 / PLAUSIBLE 0
      because no review ran, not because one ran and found nothing.
- [x] Log inputs from the IdP are sanitized inline at the log call. The audit
      helper applies `ReplaceLineEndings` to the provider name at the call, in
      the same shape as its neighbours.

## The guard, and why it is wider here

An administrator is exempt from the whole gate rather than only from the
disable. The mass-lockout case this defends against is an identity provider that
starts emitting a past instant, or a claim mapped to the wrong attribute, which
hits every account at once. An administrator who is left enabled but refused at
the door cannot reach the settings page that would repair the configuration, so
"never disabled" is not sufficient here and "logs in" is what the row asserts.
The exemption is read from the RESOLVED account, never from the identity
provider's admin claim.

A configured claim that produced no readable instant refuses the login and
disables nothing. Granting access on an unreadable value makes a transient
provider change indistinguishable from an account with no deadline; disabling on
it makes that same change indistinguishable from a real expiry. Refusing one
login and touching nothing is the only answer that stays reversible.

## Weakening runs, each on the shipped code

```
delete the administrator exemption in EnforceAccountExpiryAsync
  ExpiredDeadline_OnAnAdministrator_LeavesItEnabled_AndLogsIn [FAIL]
  Total: 9, Failed: 1

drop the RevokeUserTokens call
  ExpiredDeadline_DisablesTheAccount_RevokesItsTokens_AndMintsNoSession [FAIL]
  ASecondExpiredLogin_RefusesWithoutReAuditingOrRevokingAgain [FAIL]
  TheSamlPathIsEnforcedIdentically [FAIL]
  Total: 9, Failed: 3

treat an unreadable instant as unlimited
  AConfiguredClaimThatProducedNoInstant_RefusesTheLogin_AndDisablesNothing [FAIL]
  Total: 9, Failed: 1

remove the gate from the completion path entirely
  Total: 9, Failed: 6
```

One arm is pinned rather than left to be discovered. A first login arriving
already past its deadline does get a Jellyfin account, disabled in the same
request and never issued a session, because the gate runs after
resolve-or-create and needs a resolved account both to disable and to read the
administrator exemption from.
`AFirstLoginThatIsAlreadyExpired_ProvisionsTheAccountInert_AndMintsNothing`
records that, so the behaviour is a decision in the tree rather than a surprise.

## Quality checklist

- [x] No duplicated logic. The disable body is shared with the role-denial path
      rather than copied, so the administrator guard, the issuer binding (#186),
      the never-create/never-adopt resolution and the no-op on an already-disabled
      account are stated once. `PermissionRolePolicy` bars `IsDisabled` from SSO
      role mapping precisely so no login can disable an account; #831 and this
      are its two sanctioned exceptions, and sharing one body is what keeps that
      invariant readable instead of letting one exception drift from the other.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting; comments say why an arm exists, not what it does.
- [x] Architecture-conformance tests pass. No new module or folder, so no new
      structural rule is established. Two existing totality gates refused the
      first version and are why the diff is wider than the gate itself: a new
      `PublicReason` member needs a mapper row
      (`Rejected_MapsEveryReasonToTheExactStatusAndBody`), and its body must be a
      known English catalog value (`EveryRejectionBody_IsALocalizableCatalogValue`,
      #913), so `error.access_expired` lands in `Localization/en.json`.
- [x] Docs impact considered. `AccountExpiryClaim` has no admin-UI surface today,
      so there is nothing under `SSO-Auth/Web/` to keep in sync; the wiki entry
      for what the claim does at its deadline is filed separately and linked in
      Notes.

## Verification

- [x] `--warnaserror` green on both target frameworks, 0 warnings, plugin and
      test project.
- [x] Full suite green on both. `Total: 3092` on `net9.0` and `Total: 3093` on
      `net10.0`, 0 failures, 4 skips each, unchanged.
- [x] Prettier: no `.js`, `.html`, `.md` or `.css` file is touched. The one
      `.json` file changed is outside the globs the job checks.

## Notes

No CHANGELOG entry is included. This issue's Done-when does not ask for one, and
that file is being edited on another line of work right now; adding a line here
would put two changes in one file for no gain.

`TestIdentities` gained the `ExpiresAtUtc` carry it was silently dropping, which
is why a fixture file appears in the diff. Without it the OpenID factory did not
mirror `AuthorizeSession.Ready`, and no test could have exercised this path at
all.

No second reader looked at this.
