### PR TITLE
Answer the logout events check instead of throwing out of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,22 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Security
 
+- **A back-channel logout token can no longer break the check that decides
+  whether it is one (#1349).** The plugin looks for a fixed member in a logout
+  token's `events` claim, and found it with the same call #1340 took out of the
+  discovery readers: one that decodes every candidate member name long enough to
+  still match, where a name written with an unpaired surrogate escape has no
+  decoding. A token whose `events` object named only such a member raised an
+  error out of the validator instead of being refused, so the uniform response
+  the endpoint answers every unusable token with was not sent and the rejection
+  never reached the audit trail. The member is now looked up through the same
+  walk that skips a name it cannot decode and keeps going: such a token is
+  refused as not a logout token, with that reason recorded, and a token carrying
+  the real member beside an undecodable one is still recognised and still ends
+  the session it names. Reaching this needed a token that had already passed
+  signature, issuer, audience and lifetime validation, so it was never a way in
+  for a caller without the provider's signing key.
+
 - **A discovery document can no longer break both of the plugin's discovery
   checks with a member name it never had to look at (#1340).** The two readers
   that decide whether a provider advertises PKCE `S256` and the RFC 9207

--- a/SSO-Auth.Tests/Oidc/LogoutTokenEventsNameSurrogateTests.cs
+++ b/SSO-Auth.Tests/Oidc/LogoutTokenEventsNameSurrogateTests.cs
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Duende.IdentityModel.OidcClient;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// <see cref="OidcLogoutTokenValidator"/>'s events check states a total contract - "any parse failure is a
+/// fail-closed 'not a logout_token'" - and read the claim with <c>JsonElement.TryGetProperty</c>, the call
+/// that made both discovery flag readers throw in #1340. That method unescapes every candidate member name
+/// whose raw form is longer than the name being looked for, and an unpaired surrogate escape has no
+/// completion, so the decoder raised <c>InvalidOperationException</c> out of the lookup instead of an answer
+/// (#1349).
+///
+/// The padding is what decides whether the arm is reached at all, so every case here is built from the event
+/// name's OWN length rather than from a hand-written constant, and
+/// <see cref="TheSweepReachesTheDecoder_RatherThanPassingVacuously"/> pins where the boundary actually falls
+/// so a sweep that stopped reaching it could not read as a pass.
+///
+/// Reachability is narrow and worth saying plainly: this arm runs only after the handler has accepted the
+/// signature, issuer, audience and lifetime, so producing one of these tokens means holding the provider's
+/// signing key. What was lost is the refusal itself - the uniform 400 and the audited reason - on a path
+/// whose whole job is to answer rather than to throw.
+/// </summary>
+[Collection("SSOController")]
+public sealed class LogoutTokenEventsNameSurrogateTests : IDisposable
+{
+    private const string Issuer = "https://idp-events.example.test";
+    private const string ClientId = "jellyfin-client";
+    private const string KeyId = "events-name-test-key";
+    private const string LogoutEvent = "http://schemas.openid.net/event/backchannel-logout";
+
+    private static readonly Guid UserA = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private readonly RSA _rsa = RSA.Create(2048);
+    private readonly OidcLogoutTokenValidator _validator = new();
+    private readonly DateTime _now = DateTime.UtcNow;
+
+    public LogoutTokenEventsNameSurrogateTests() => OidcLogoutTokenValidator.ResetReplaysForTests();
+
+    public void Dispose()
+    {
+        _rsa.Dispose();
+        OidcLogoutTokenValidator.ResetReplaysForTests();
+    }
+
+    [Fact]
+    public async Task EventsNamingOnlyAnUndecodableMember_IsNotALogoutToken_AtEveryPadding()
+    {
+        // The refuse path, which is the one that threw. Swept rather than pinned at the measured length,
+        // because the boundary is arithmetic on the event name and a sweep past it cannot be made vacuous
+        // by a later rename of the constant.
+        for (var filler = 0; filler <= LogoutEvent.Length + 8; filler++)
+        {
+            var token = SignedLogoutToken(UndecodableMember(filler));
+
+            var result = await _validator.ValidateAsync(token, Options(), _now);
+
+            Assert.False(result.IsValid);
+            Assert.Equal(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, result.ReasonCode);
+        }
+    }
+
+    [Fact]
+    public async Task UndecodableNameBesideTheRealEvent_IsStillALogoutToken_AtEveryPadding()
+    {
+        // The other direction, and the reason the repair skips the member instead of discarding the claim.
+        // A bare catch around the lookup would answer "not a logout_token" for this token too, so an IdP
+        // that sends one member nobody asked about would stop being able to terminate a session at all.
+        for (var filler = 0; filler <= LogoutEvent.Length + 8; filler++)
+        {
+            var token = SignedLogoutToken(UndecodableMember(filler) + ",\"" + LogoutEvent + "\":{}");
+
+            var result = await _validator.ValidateAsync(token, Options(), _now);
+
+            Assert.True(result.IsValid);
+            Assert.Equal("user-1", result.Subject);
+        }
+    }
+
+    [Fact]
+    public void TheSweepReachesTheDecoder_RatherThanPassingVacuously()
+    {
+        // The must-catch half, over the call the repair replaced rather than over the repaired method: a
+        // sweep whose filler never makes the raw name outrun the name being matched would assert "it did
+        // not throw" about bytes that were never going to. The first throwing padding is the event name's
+        // length less five - the point at which the six-character escape plus the filler first exceeds it -
+        // so this both proves the fixture bites and states the arithmetic the sweeps above rely on.
+        var firstThrowing = -1;
+        for (var filler = 0; filler <= LogoutEvent.Length + 8; filler++)
+        {
+            using var document = JsonDocument.Parse("{" + UndecodableMember(filler) + "}");
+            try
+            {
+                document.RootElement.TryGetProperty(LogoutEvent, out _);
+            }
+            catch (InvalidOperationException)
+            {
+                firstThrowing = filler;
+                break;
+            }
+        }
+
+        Assert.Equal(LogoutEvent.Length - 5, firstThrowing);
+    }
+
+    [Fact]
+    public async Task AtTheEndpoint_TheRefusalIsTheUniform400_AndReachesTheAuditTrail()
+    {
+        // What the throw cost, driven through the endpoint rather than described: the uniform 400 that
+        // exists so no branch is distinguishable to the caller, and the audit line an operator watches. The
+        // padding is the first one the decoder is asked to complete, from the same arithmetic pinned above.
+        var harness = new SsoControllerHarness(
+            config =>
+            {
+                config.EnableSingleLogout = true;
+                config.OidConfigs["kc"] = new OidConfig
+                {
+                    Enabled = true,
+                    OidEndpoint = Issuer,
+                    OidClientId = ClientId,
+                    EnableBackChannelLogout = true,
+                };
+                config.LogoutSessions["a"] = new LogoutSession
+                {
+                    Protocol = "OpenID",
+                    Provider = "kc",
+                    Subject = "user-1",
+                    SessionIndex = "sess-9",
+                    UserId = UserA,
+                    IdToken = "raw.id.token",
+                };
+            },
+            httpResponder: Responder);
+
+        var token = SignedLogoutToken(UndecodableMember(LogoutEvent.Length - 5));
+
+        var result = await harness.Controller.OidBackChannelLogout("kc", token);
+
+        var content = Assert.IsType<ContentResult>(result);
+        Assert.Equal(400, content.StatusCode);
+        Assert.Equal("Logout token could not be processed", content.Content);
+
+        var entry = Assert.Single(harness.ControllerLog.Entries, e => e.Message.Contains("REJECTED", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains(OidcLogoutTokenValidator.RejectReason.NotALogoutToken, entry.Message, StringComparison.Ordinal);
+
+        // Nothing was terminated on a refusal, and the captured session is still there to terminate later.
+        await harness.SessionManager.DidNotReceive().RevokeUserTokens(Arg.Any<Guid>(), Arg.Any<string>());
+        Assert.True(SSOPlugin.Instance.ReadConfiguration(c => c.LogoutSessions.ContainsKey("a")));
+    }
+
+    // `\ud800` is a high surrogate with no low surrogate after it: six raw characters no unescape can
+    // complete. The filler pads the name so the raw member name outruns the name being looked for, which is
+    // the only reason the lookup tries to unescape it at all.
+    private static string UndecodableMember(int filler) => "\"\\ud800" + new string('a', filler) + "\":{}";
+
+    // Signed by hand rather than through a claims dictionary: the serializer would never emit a member name
+    // the decoder cannot complete, and these bytes are the whole point of the fixture. Everything but the
+    // events object is an ordinary valid logout_token, so the only thing under test is the events member.
+    private string SignedLogoutToken(string eventsMembers)
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var payload = "{\"iss\":\"" + Issuer + "\",\"aud\":\"" + ClientId + "\",\"sub\":\"user-1\",\"jti\":\""
+            + Guid.NewGuid() + "\",\"iat\":" + now + ",\"nbf\":" + (now - 60) + ",\"exp\":" + (now + 300)
+            + ",\"events\":{" + eventsMembers + "}}";
+
+        var header = "{\"alg\":\"RS256\",\"typ\":\"JWT\",\"kid\":\"" + KeyId + "\"}";
+        var signingInput = Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(header))
+            + "." + Base64UrlEncoder.Encode(Encoding.UTF8.GetBytes(payload));
+
+        var signature = _rsa.SignData(
+            Encoding.UTF8.GetBytes(signingInput), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        return signingInput + "." + Base64UrlEncoder.Encode(signature);
+    }
+
+    private string Jwks()
+    {
+        var p = _rsa.ExportParameters(false);
+        return "{\"keys\":[{\"kty\":\"RSA\",\"use\":\"sig\",\"kid\":\"" + KeyId + "\",\"n\":\""
+            + Base64UrlEncoder.Encode(p.Modulus) + "\",\"e\":\"" + Base64UrlEncoder.Encode(p.Exponent) + "\"}]}";
+    }
+
+    // The provider options the endpoint hands the validator, built here so the unit sweeps run against the
+    // same issuer, client and key the endpoint test serves.
+    private OidcClientOptions Options() => new OidcClientOptions
+    {
+        ClientId = ClientId,
+        ClockSkew = TimeSpan.FromMinutes(5),
+        ProviderInformation = new ProviderInformation
+        {
+            IssuerName = Issuer,
+            KeySet = new Duende.IdentityModel.Jwk.JsonWebKeySet(Jwks()),
+        },
+    };
+
+    // Serves this test's discovery document and JWKS; any other URL 404s so an unexpected call is visible.
+    private HttpResponseMessage Responder(HttpRequestMessage request)
+    {
+        var url = request.RequestUri!.AbsoluteUri;
+        if (url == Issuer + "/.well-known/openid-configuration")
+        {
+            return Json("{\"issuer\":\"" + Issuer + "\",\"authorization_endpoint\":\"" + Issuer
+                + "/auth\",\"token_endpoint\":\"" + Issuer + "/token\",\"jwks_uri\":\"" + Issuer
+                + "/jwks\",\"response_types_supported\":[\"code\"],\"subject_types_supported\":[\"public\"],"
+                + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
+                + "\"code_challenge_methods_supported\":[\"S256\"]}");
+        }
+
+        if (url == Issuer + "/jwks")
+        {
+            return Json(Jwks());
+        }
+
+        return new HttpResponseMessage(HttpStatusCode.NotFound);
+    }
+
+    private static HttpResponseMessage Json(string body) => new HttpResponseMessage(HttpStatusCode.OK)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+}

--- a/SSO-Auth/Api/Oidc/DiscoveryJson.cs
+++ b/SSO-Auth/Api/Oidc/DiscoveryJson.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
-using System;
 using System.Text.Json;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
@@ -64,58 +63,5 @@ internal static class DiscoveryJson
         // answer to the caller and neither leaks a document nobody closes.
         document.Dispose();
         return null;
-    }
-
-    /// <summary>
-    /// Looks a member up on a discovery root without ever throwing, which is what
-    /// <see cref="JsonElement.TryGetProperty(string, out JsonElement)"/> does not promise. That method
-    /// unescapes any candidate member name long enough to still match after unescaping, and an unpaired
-    /// surrogate escape has no completion, so the decoder raises <see cref="InvalidOperationException"/>
-    /// and the whole lookup is abandoned (#1340). Both discovery facts are read through here so neither
-    /// reader carries the throw, and the padding that selects which one is hit stops being a property of
-    /// the lookup name's length.
-    ///
-    /// An undecodable name is SKIPPED and the walk CONTINUES, which is the load-bearing half rather than a
-    /// detail. Answering "absent" for the whole document would let one member nobody asked about decide the
-    /// PKCE fact, and false there refuses the login wherever <c>RequirePkce</c> is on - so a document
-    /// carrying both an undecodable name and a real <c>code_challenge_methods_supported</c> would take an
-    /// otherwise-working provider offline. This is the same reasoning <c>PkceDiscovery.IsS256</c> already
-    /// applies one level down, on the value side of the same decoder failure.
-    ///
-    /// A name that does not decode also cannot equal the ASCII name being looked for, so skipping it loses
-    /// no match: what is dropped is a candidate that could only ever have answered no.
-    /// </summary>
-    /// <param name="root">The discovery document's root object.</param>
-    /// <param name="name">The member name to find, compared ordinally against each decodable member.</param>
-    /// <param name="value">The first matching member's value; <see langword="default"/> when none matches.</param>
-    /// <returns><see langword="true"/> when a member of that name is present.</returns>
-    internal static bool TryGetMember(JsonElement root, string name, out JsonElement value)
-    {
-        // Walked by hand rather than delegating to TryGetProperty and catching around it: one path answers
-        // for every document, so there is no second comparison that could disagree with the first about the
-        // same bytes. First match wins, exactly as TryGetProperty does - repeated members are refused
-        // upstream by the screen (#1054) and are not this method's decision.
-        foreach (var member in root.EnumerateObject())
-        {
-            try
-            {
-                if (!member.NameEquals(name))
-                {
-                    continue;
-                }
-            }
-            catch (InvalidOperationException)
-            {
-                // This member's name carries an escape the decoder cannot complete. It is not the name being
-                // looked for; the next member still can be.
-                continue;
-            }
-
-            value = member.Value;
-            return true;
-        }
-
-        value = default;
-        return false;
     }
 }

--- a/SSO-Auth/Api/Oidc/JsonMember.cs
+++ b/SSO-Auth/Api/Oidc/JsonMember.cs
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Text.Json;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+
+/// <summary>
+/// The one member lookup on a <see cref="JsonElement"/> object that cannot throw, which is what
+/// <see cref="JsonElement.TryGetProperty(string, out JsonElement)"/> does not promise. That method unescapes
+/// any candidate member name long enough to still match after unescaping, and an unpaired surrogate escape
+/// has no completion, so the decoder raises <see cref="InvalidOperationException"/> and the whole lookup is
+/// abandoned.
+///
+/// Every reader that states a total contract over provider-supplied JSON reads through here, so none of them
+/// carries that throw and the padding that decides which one is hit stops being a property of the lookup
+/// name's length. It was written for the two discovery flag readers (#1340) and is not about discovery: the
+/// back-channel <c>logout_token</c>'s <c>events</c> member is read through it too (#1349), which is why it
+/// lives in a type of its own rather than beside the discovery parse.
+///
+/// An undecodable name is SKIPPED and the walk CONTINUES, which is the load-bearing half rather than a
+/// detail. Answering "absent" for the whole object would let one member nobody asked about decide the
+/// caller's fact, and each of those facts refuses something: false on the PKCE flag refuses the login
+/// wherever <c>RequirePkce</c> is on, and false on the logout event refuses a termination the identity
+/// provider ordered. A document or token carrying an undecodable name BESIDE the real member would otherwise
+/// take a working provider offline. This is the same reasoning <c>PkceDiscovery.IsS256</c> already applies
+/// one level down, on the value side of the same decoder failure.
+///
+/// A name that does not decode also cannot equal the ASCII names these callers look for, so skipping it
+/// loses no match: what is dropped is a candidate that could only ever have answered no.
+/// </summary>
+internal static class JsonMember
+{
+    /// <summary>
+    /// Looks a member up on a JSON object without ever throwing.
+    /// </summary>
+    /// <param name="owner">The object to look the member up on.</param>
+    /// <param name="name">The member name to find, compared ordinally against each decodable member.</param>
+    /// <param name="value">The first matching member's value; <see langword="default"/> when none matches.</param>
+    /// <returns><see langword="true"/> when a member of that name is present.</returns>
+    internal static bool TryGet(JsonElement owner, string name, out JsonElement value)
+    {
+        // Walked by hand rather than delegating to TryGetProperty and catching around it: one path answers
+        // for every input, so there is no second comparison that could disagree with the first about the
+        // same bytes. First match wins, exactly as TryGetProperty does - a repeated member in a discovery
+        // document is refused upstream by the screen (#1054) and is not this method's decision.
+        foreach (var member in owner.EnumerateObject())
+        {
+            try
+            {
+                if (!member.NameEquals(name))
+                {
+                    continue;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // This member's name carries an escape the decoder cannot complete. It is not the name being
+                // looked for; the next member still can be.
+                continue;
+            }
+
+            value = member.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
+++ b/SSO-Auth/Api/Oidc/OidcLogoutTokenValidator.cs
@@ -212,6 +212,16 @@ internal sealed class OidcLogoutTokenValidator
     // The events claim is a JSON object; presence of the back-channel-logout member is what makes this a
     // logout_token. Read it as a JsonElement and require the member - a claim that is absent, not an object,
     // or an object without the member is rejected. Any parse failure is a fail-closed "not a logout_token".
+    //
+    // The member is looked up through the walk that cannot throw rather than through
+    // JsonElement.TryGetProperty, which is what the sentence above claimed and did not do (#1349). That
+    // method unescapes any candidate member name long enough to still match after unescaping, and an
+    // unpaired surrogate escape has no completion, so the decoder raised InvalidOperationException out of
+    // this method - past ValidateAsync, which has no catch, and past the endpoint, which does not cover this
+    // line. The refusal that was owed took the uniform 400 and the audited reason code with it. Skipping the
+    // undecodable name rather than abandoning the claim is the same load-bearing half #1340 settled for the
+    // discovery readers: a name that does not decode cannot equal this ASCII event URI, so nothing that
+    // could have matched is lost, and a token carrying the real member beside one is still recognised.
     private static bool HasBackChannelLogoutEvent(JsonWebToken token)
     {
         if (!token.TryGetPayloadValue<JsonElement>("events", out var events))
@@ -220,7 +230,7 @@ internal sealed class OidcLogoutTokenValidator
         }
 
         return events.ValueKind == JsonValueKind.Object
-            && events.TryGetProperty(BackChannelLogoutEvent, out _);
+            && JsonMember.TryGet(events, BackChannelLogoutEvent, out _);
     }
 
     /// <summary>

--- a/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
+++ b/SSO-Auth/Api/Oidc/OidcResponseIssuer.cs
@@ -80,10 +80,10 @@ internal static class OidcResponseIssuer
         //
         // The ValueKind test on the root is not redundant with the null test, for the same reason it is not
         // in PkceDiscovery: enumerating a non-object element throws rather than answering false. The lookup
-        // itself goes through DiscoveryJson, which skips a member name whose escape the decoder cannot
+        // itself goes through JsonMember, which skips a member name whose escape the decoder cannot
         // complete instead of letting it abandon the read (#1340).
         var advertised = discovery is { ValueKind: JsonValueKind.Object } root
-            && DiscoveryJson.TryGetMember(root, "authorization_response_iss_parameter_supported", out var value)
+            && JsonMember.TryGet(root, "authorization_response_iss_parameter_supported", out var value)
             && value.ValueKind == JsonValueKind.True;
 
         // Post-condition, compiled out of the shipped build (#1082): a document that did not parse advertises

--- a/SSO-Auth/Api/Oidc/PkceDiscovery.cs
+++ b/SSO-Auth/Api/Oidc/PkceDiscovery.cs
@@ -48,11 +48,11 @@ internal static class PkceDiscovery
         // root, which THROWS on a non-object rather than answering false, turning a malformed document into
         // a 500 on the challenge.
         //
-        // The lookup goes through DiscoveryJson so a member name carrying an unpaired surrogate escape is
+        // The lookup goes through JsonMember so a member name carrying an unpaired surrogate escape is
         // skipped rather than thrown out of (#1340); TryGetProperty abandons the whole lookup on one, and
         // an abandoned lookup here reads as "no S256" and refuses every login under RequirePkce.
         var advertised = discovery is { ValueKind: JsonValueKind.Object } root
-            && DiscoveryJson.TryGetMember(root, "code_challenge_methods_supported", out var methods)
+            && JsonMember.TryGet(root, "code_challenge_methods_supported", out var methods)
             && methods.ValueKind == JsonValueKind.Array
             && methods.EnumerateArray().Any(IsS256);
 


### PR DESCRIPTION
# What & why

`OidcLogoutTokenValidator.HasBackChannelLogoutEvent` documented a total contract, "any parse failure is a fail-closed 'not a logout_token'", and read the `events` claim with `JsonElement.TryGetProperty` - the call #1340 took out of the two discovery flag readers for the same reason. That method unescapes every candidate member name whose raw form is longer than the name being matched, and an unpaired surrogate escape has no completion, so the decoder raised `InvalidOperationException` out of the method instead of answering.

I measured it through the endpoint rather than through the two lines alone. The exception leaves `ValidateAsync`, which wraps its body in `try`/`finally` with no `catch`, and leaves `SSOController.OidBackChannelLogout`, whose only `catch` sits further down around the revoke. Stack from the run against the unrepaired tree:

```
System.InvalidOperationException : Cannot read incomplete UTF-16 JSON text as string with missing low surrogate.
   at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   SSO-Auth\Api\Oidc\OidcLogoutTokenValidator.cs(222,0): at ...HasBackChannelLogoutEvent(JsonWebToken token)
   SSO-Auth\Api\Oidc\OidcLogoutTokenValidator.cs(146,0): at ...ValidateAsync(String, OidcClientOptions, DateTime)
   SSO-Auth\Api\Flows\OidcLoginService.cs(733,0): at ...ValidateBackChannelLogoutAsync(OidConfig, String, String)
   SSO-Auth\Api\Http\SSOController.cs(304,0): at ...OidBackChannelLogout(String provider, String logoutToken)
```

So the uniform 400 that exists so no branch is distinguishable to the caller was not returned, and `SsoAudit.BackChannelLogoutRejected` was never written: a refusal that belongs on the trail was absent from it.

The member is now looked up through the walk that skips a name it cannot decode and keeps going. The skip is the load-bearing half rather than a detail - answering "absent" for the whole claim would refuse a token carrying the real back-channel-logout member beside an undecodable one, and refusing that is declining a termination the provider ordered. A name that does not decode cannot equal this ASCII event URI, so nothing that could have matched is lost.

The walk moves out of `DiscoveryJson` into a `JsonMember` of its own, and the two discovery readers follow it there. It was never about discovery, and a token validator reaching into a type named for the discovery parse would have made the single home for this lookup read as a coincidence rather than as the rule.

Reachability is narrow and stays stated rather than implied: the arm runs only after the handler has accepted the signature, issuer, audience and lifetime, so producing one of these tokens means holding the provider's signing key. This is a broken contract and a lost audit line, not a route in for an unauthenticated caller. A logout token also arrives as a form parameter rather than as a fetched JSON body, so the repeated-member screen never sees it.

Closes #1349.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is rejected, never default-accepted. Nothing ahead of this arm changed; the arm itself moves from "throws" to "refuses", which is the fail-closed direction. The accept path is unchanged and pinned in both directions by the sweeps below.
- [x] No secrets logged; secrets are redacted on config export. The reason code stays the fixed `not_a_logout_token` constant, so no token byte reaches the audit line.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **NOT DONE - there is no second reader on this change.** No lens ran over this diff. What stands in its place is the evidence in this body: the pre-repair stack above, the sweeps in both directions, and the padding test that refuses a vacuous pass. Read it as one pair of eyes, not two.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED \_\_ / PLAUSIBLE \_\_** counts as raised. **No review record, for the reason on the line above.** No lens ran, so there are no verdicts, no findings and no dispositions to report, and writing counts of zero here would read as a clean review rather than as an absent one.
- [x] Log inputs from the IdP are sanitized inline at the log call. Untouched by this change; the audit call site is unchanged.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. There is one throw-free member lookup in the tree, now in `JsonMember`, with three call sites and no second copy.
- [x] The change adds no more code than the problem requires. The repair itself is one call; the rest is the move of an existing method and its tests.
- [x] The code is self-documenting and matches the target architecture (#318). `JsonMember` stays inside `Api/Oidc`, so no module edge is added.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule. The property this change establishes - that the lookup has one home - is held by the type existing with no sibling copy; the JSON parse-site table is unmoved, since `JsonMember` parses nothing and `DiscoveryJson` still holds the `JsonDocument.Parse` the table names.
- [x] Docs impact considered: this change needs no README/wiki update. It restores the documented behaviour of an endpoint the public docs do not describe at this level of detail; no user-facing option, default or message changes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Built on both target frameworks with `--warnaserror`, 0 warnings and 0 errors each.
- [x] `dotnet test` is green. `net9.0`: 3096 total, 0 failed, 4 skipped. `net10.0`: 3097 total, 0 failed, 4 skipped. The four skips are the loopback-bind tests that need an administrator (#1227) and are skipped on this machine rather than worked around.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. `CHANGELOG.md` is the only such file here and passes `--check`.

## Notes

The guard is proven by removing it rather than by assertion. Run against the unrepaired tree, the two behaviour tests fail with the exception quoted above at `OidcLogoutTokenValidator.cs:222`, one of them through the controller; with the repair all four pass.

The third test is there so the other two cannot go quiet. It walks the same paddings against `JsonElement.TryGetProperty` directly and asserts which one first makes the decoder refuse - the event name's length less five, 45 for the 50-character name - so a sweep that stopped reaching the arm reddens rather than reporting a pass. That number is the same boundary the issue measured.

Out of scope: what the surrounding server does with an exception escaping a controller action is not measured here and is not claimed either way.
