### PR TITLE
Give the OIDC round-trip scaffolding one home

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.TestSuite.cs
@@ -40,6 +40,18 @@ public partial class ArchitectureConformanceTests
     // SSOPlugin.Instance and clears the flow caches.
     private const string HarnessDoor = "new SsoControllerHarness";
 
+    // The same door reached one call deeper. A support type that builds the harness for its callers opens it
+    // on their behalf, and the scan reads each test file's OWN code lines, so those callers stop naming
+    // HarnessDoor the moment the construction moves behind such a type - the rule keeps passing while
+    // covering less. Measured when the OpenID round-trip scaffolding was lifted into _Support (#1351): both
+    // classes named the harness door at the commit before, and neither did after.
+    //
+    // Seeded by hand rather than derived, for the reason the derivation itself cannot reach: what makes this
+    // a door is that the method it names constructs the harness, which is a fact about test-support code,
+    // and ProcessWideDoors derives from the production tree. A support type that builds a harness belongs
+    // here, and the entry is spelled exactly as a call site spells it.
+    private const string ScaffoldDoor = "OidcRoundTrip.BuildHarness";
+
     // A door no test names because it sits behind another one: a production reset hook opens it, so every
     // test opening THAT door opens this one too. Keyed door -> the door that opens it. The rule proves both
     // halves rather than trusting the table, so an entry whose indirection is removed fails as loudly as a
@@ -210,13 +222,14 @@ public partial class ArchitectureConformanceTests
             : DoorsNamedByTestBearingSource(source, doors);
 
     // Every process-wide door a test can reach: the test-only hooks the production tree declares, keyed
-    // Type.Method exactly as a call site spells them, plus the harness construction. Derived rather than
-    // listed, so a new hook cannot create a door the rule above is blind to.
+    // Type.Method exactly as a call site spells them, plus the harness construction and the support method
+    // that performs it for a caller. The hooks are derived rather than listed, so a new hook cannot create a
+    // door the rule above is blind to; the two seeds are what no reading of the production tree could find.
     private static IReadOnlyList<string> ProcessWideDoors()
     {
         var declaration = new Regex(@"\b(?:class|record|struct)\s+(?<type>[A-Za-z0-9_]+)");
         var hook = new Regex(@"\binternal\s+static\s+[^;=]*?\b(?<hook>[A-Za-z0-9_]+ForTests)\s*\(");
-        var doors = new List<string> { HarnessDoor };
+        var doors = new List<string> { HarnessDoor, ScaffoldDoor };
 
         foreach (var src in Directory.EnumerateFiles(Path.Combine(RepoTree.Root, "SSO-Auth"), "*.cs", SearchOption.AllDirectories))
         {

--- a/SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs
@@ -63,7 +63,7 @@ public class OidcIdTokenIsNeverACredentialTests
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
         var served = new List<string>();
-        var harness = BuildHarness(fixture, request => Serve(fixture, request, idToken, served));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken, served: served));
 
         var user = TestUsers.Named("alice", Guid.Parse("1a999999-1111-1111-1111-111111111111"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
@@ -74,10 +74,10 @@ public class OidcIdTokenIsNeverACredentialTests
             .AuthenticateDirect(Arg.Do<AuthenticationRequest>(request => mint = request))
             .Returns(new AuthenticationResult());
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
-        var authed = await harness.Controller.OidAuth("kc", Redeem(state));
+        var authed = await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state));
 
         // Control one: the flow really ran on this token. Without this, every absence below would also hold
         // for a login that failed before the token was ever redeemed.
@@ -114,10 +114,10 @@ public class OidcIdTokenIsNeverACredentialTests
         using var foreign = new OidcTokenFixture(Authority, "jf");
         var idToken = foreign.IdToken(subject: "sub-1", username: "alice");
         var served = new List<string>();
-        var harness = BuildHarness(fixture, request => Serve(fixture, request, idToken, served));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken, served: served));
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, $"?code=test-code&state={state}");
         var callback = await harness.Controller.OidCallback("kc", state);
 
         // The token was signed by a key this provider does not advertise, so the callback must refuse it. If
@@ -141,7 +141,7 @@ public class OidcIdTokenIsNeverACredentialTests
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
         var served = new List<string>();
-        var harness = BuildHarness(fixture, request => Serve(fixture, request, idToken, served), c => c.EnableSingleLogout = true);
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken, served: served), plugin: c => c.EnableSingleLogout = true);
 
         var user = TestUsers.Named("alice", Guid.Parse("1b999999-1111-1111-1111-111111111111"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
@@ -152,10 +152,10 @@ public class OidcIdTokenIsNeverACredentialTests
             .AuthenticateDirect(Arg.Do<AuthenticationRequest>(request => mint = request))
             .Returns(new AuthenticationResult { SessionInfo = new SessionInfoDto { Id = "session-key-slo" } });
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
-        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state)));
         Assert.NotNull(mint);
         Assert.Contains(served, body => Carries(body, idToken));
 
@@ -215,110 +215,4 @@ public class OidcIdTokenIsNeverACredentialTests
         ObjectResult obj => obj.Value?.ToString() ?? string.Empty,
         _ => result.ToString() ?? string.Empty,
     };
-
-    // The challenge/callback/redeem scaffolding below is the same shape OidcRoundTripTests uses privately.
-    // It is repeated here rather than lifted out of that file, because lifting it would rewrite fourteen call
-    // sites in a file this change has no other reason to touch. #1351 carries the extraction.
-
-    // A harness with one enabled provider "kc" pointed at the fixture's authority. Pushed authorization off so
-    // the challenge is a plain redirect, profile loading off so the id_token claims are the whole identity, and
-    // the authorization/link toggles off so the redeem takes the first-time-provision path.
-    private static SsoControllerHarness BuildHarness(
-        OidcTokenFixture fixture,
-        Func<HttpRequestMessage, HttpResponseMessage> responder,
-        Action<PluginConfiguration>? configure = null) =>
-        new SsoControllerHarness(
-            c =>
-            {
-                c.OidConfigs["kc"] = new OidConfig
-                {
-                    Enabled = true,
-                    OidEndpoint = fixture.Issuer,
-                    OidClientId = fixture.ClientId,
-                    OidScopes = Array.Empty<string>(),
-                    DisablePushedAuthorization = true,
-                    DoNotLoadProfile = true,
-                    EnableAuthorization = false,
-                    AllowExistingAccountLink = false,
-                };
-                configure?.Invoke(c);
-            },
-            httpResponder: responder);
-
-    // Drives a real challenge and returns the state token and browser-binding cookie it minted.
-    private static async Task<(string State, string Binding)> DriveChallenge(SsoControllerHarness harness)
-    {
-        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
-        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
-        Assert.StartsWith(Authority + "/authorize", challenge.Url, StringComparison.Ordinal);
-
-        var state = UrlEncodedQuery.Find(challenge.Url, "state") ?? string.Empty;
-        Assert.False(string.IsNullOrEmpty(state));
-        var binding = BindingCookie(harness.Controller.Response);
-        Assert.False(string.IsNullOrEmpty(binding));
-        return (state, binding);
-    }
-
-    // Re-points the same context at the callback route, carrying the binding cookie the challenge set (#326).
-    private static void RepointToCallback(SsoControllerHarness harness, string state, string binding, string query)
-    {
-        harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
-        harness.Controller.HttpContext.Request.QueryString = new QueryString(query);
-        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={binding}";
-    }
-
-    private static AuthResponse Redeem(string state) => new AuthResponse
-    {
-        Data = state,
-        DeviceID = "device-1",
-        DeviceName = "Test Device",
-        AppName = "Jellyfin Web",
-        AppVersion = "1.0",
-    };
-
-    private static string BindingCookie(HttpResponse response)
-    {
-        var prefix = AuthorizeStateBinding.CookieName + "=";
-        foreach (var header in response.Headers.SetCookie)
-        {
-            if (header is not null && header.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                var value = header.Substring(prefix.Length);
-                var end = value.IndexOf(';', StringComparison.Ordinal);
-                return end >= 0 ? value.Substring(0, end) : value;
-            }
-        }
-
-        return string.Empty;
-    }
-
-    // The provider's endpoints, recording every body served so the search can be shown to work against one
-    // that really carries the token.
-    private static HttpResponseMessage Serve(OidcTokenFixture fixture, HttpRequestMessage request, string idToken, List<string> served)
-    {
-        var url = request.RequestUri!.AbsoluteUri;
-        string body;
-        if (url == fixture.DiscoveryUrl)
-        {
-            body = fixture.Discovery();
-        }
-        else if (url == fixture.JwksUrl)
-        {
-            body = fixture.Jwks();
-        }
-        else if (url == fixture.TokenUrl)
-        {
-            body = fixture.TokenEndpointJson(idToken);
-        }
-        else
-        {
-            return new HttpResponseMessage(HttpStatusCode.NotFound);
-        }
-
-        served.Add(body);
-        return new HttpResponseMessage(HttpStatusCode.OK)
-        {
-            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
-        };
-    }
 }

--- a/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
+++ b/SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs
@@ -51,25 +51,25 @@ public class OidcRoundTripTests
         // A valid id_token signed by the IdP's own key, carrying the sub + preferred_username the login keys
         // the account on (DoNotLoadProfile skips the userinfo fetch, so these claims are the whole identity).
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken));
 
         // Provision hooks the completion tail drives for a first-time login of "alice".
         var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111111"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
-        var (state, binding) = await DriveChallenge(harness);
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
 
         // Callback: OidcClient exchanges the code at the fake token endpoint and the real OidcIdTokenValidator
         // verifies the id_token signature against the fixture's advertised JWKS. Reaching the text/html auth
         // page (rather than a plain-text error) proves the exchange + signature + sub resolution all passed.
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
         Assert.Equal("text/html", callback.ContentType);
 
         // Authenticate: the browser-bound state minted by the challenge is redeemed once and the account is
         // provisioned. An OkObjectResult is the logged-in outcome the client completes the session from.
-        var authed = await harness.Controller.OidAuth("kc", Redeem(state));
+        var authed = await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state));
         Assert.IsType<OkObjectResult>(authed);
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
@@ -85,16 +85,16 @@ public class OidcRoundTripTests
         // fake IdP whose token was minted by a foreign key.
         using var foreignSigner = new OidcTokenFixture(Authority, "jf");
         var forgedToken = foreignSigner.IdToken(subject: "sub-1", username: "alice");
-        var harness = BuildHarness(idp, request => ServeIdp(idp, request, forgedToken));
+        var harness = OidcRoundTrip.BuildHarness(idp, request => OidcRoundTrip.ServeIdp(idp, request, forgedToken));
 
-        var (state, binding) = await DriveChallenge(harness);
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, idp);
 
         // The callback must fail closed: the signature does not verify against the advertised JWKS, so the
         // real validator rejects and CallbackAsync returns the plain-text 400 login error (never the
         // text/html auth page). The body is the fixed generic message - the library's error detail
         // (invalid_signature) is logged server-side, not reflected into the browser page (#708) - so this
         // asserts the generic body and that the detail is absent rather than pinning on the reflected reason.
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
         Assert.Equal(400, callback.StatusCode);
         Assert.Equal("text/plain", callback.ContentType);
@@ -104,7 +104,7 @@ public class OidcRoundTripTests
         // End-to-end fail-closed: because the callback never promoted the state to a redeemable Ready, the
         // authenticate leg finds no state to redeem and provisions nothing - no login is minted from a token
         // the IdP's own key did not sign.
-        var authed = await harness.Controller.OidAuth("kc", Redeem(state));
+        var authed = await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state));
         var content = Assert.IsType<ContentResult>(authed);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Invalid or expired state", content.Content);
@@ -116,7 +116,7 @@ public class OidcRoundTripTests
     {
         // #757 part A: the configured acr_values / prompt / max_age appear on the authorization redirect.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")), cfg =>
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")), cfg =>
         {
             cfg.AcrValues = "phr mfa";
             cfg.Prompt = "login";
@@ -136,7 +136,7 @@ public class OidcRoundTripTests
     {
         // Upgrade-safe: an unconfigured provider's authorize request carries none of the step-up parameters.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
 
         harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
@@ -155,7 +155,7 @@ public class OidcRoundTripTests
         // #757 part B, happy path: RequireAcr on + the id_token returns an acr within the allow-list ⇒ login.
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice", acr: "mfa");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg =>
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken), cfg =>
         {
             cfg.AcrValues = "phr mfa";
             cfg.RequireAcr = true;
@@ -164,12 +164,12 @@ public class OidcRoundTripTests
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
         Assert.Equal("text/html", callback.ContentType);
 
-        var authed = await harness.Controller.OidAuth("kc", Redeem(state));
+        var authed = await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state));
         Assert.IsType<OkObjectResult>(authed);
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
@@ -183,18 +183,18 @@ public class OidcRoundTripTests
         // the callback denies before promoting a Ready, so the redeem finds no state and mints nothing.
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice", acr: acr);
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg =>
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken), cfg =>
         {
             cfg.AcrValues = "mfa";
             cfg.RequireAcr = true;
         });
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
         Assert.Equal(403, callback.StatusCode);
 
-        var authed = await harness.Controller.OidAuth("kc", Redeem(state));
+        var authed = await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state));
         var content = Assert.IsType<ContentResult>(authed);
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Invalid or expired state", content.Content);
@@ -208,15 +208,15 @@ public class OidcRoundTripTests
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var recent = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 30;
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice", authTimeUnixSeconds: recent);
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
         var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111114"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
-        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state)));
         await harness.UserManager.Received(1).CreateUserAsync("alice");
     }
 
@@ -228,13 +228,13 @@ public class OidcRoundTripTests
         // the whole point of the gate - a provider that ignores max_age must not pass silently.
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice"); // no auth_time
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         Assert.Equal(403, Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).StatusCode);
 
-        var content = Assert.IsType<ContentResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        var content = Assert.IsType<ContentResult>(await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state)));
         Assert.Equal(400, content.StatusCode);
         Assert.Equal("Invalid or expired state", content.Content);
         await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
@@ -248,10 +248,10 @@ public class OidcRoundTripTests
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var stale = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 3600;
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice", authTimeUnixSeconds: stale);
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, idToken), cfg => cfg.MaxAge = 300);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         Assert.Equal(403, Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).StatusCode);
         await harness.UserManager.DidNotReceive().CreateUserAsync(Arg.Any<string>());
     }
@@ -261,15 +261,15 @@ public class OidcRoundTripTests
     {
         // Upgrade-safe: with MaxAge unset, an id_token without auth_time logs in unchanged (no new gate).
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
         var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111115"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
-        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state)));
     }
 
     [Fact]
@@ -277,15 +277,15 @@ public class OidcRoundTripTests
     {
         // Default: with RequireAcr off, an id_token that carries no acr logs in unchanged (no new gate).
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
         var user = TestUsers.Named("alice", Guid.Parse("19999999-1111-1111-1111-111111111113"));
         harness.UserManager.CreateUserAsync("alice").Returns(user);
         harness.UserManager.GetUserById(user.Id).Returns(user);
 
-        var (state, binding) = await DriveChallenge(harness);
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         Assert.Equal("text/html", Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state)).ContentType);
-        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", Redeem(state)));
+        Assert.IsType<OkObjectResult>(await harness.Controller.OidAuth("kc", OidcRoundTrip.Redeem(state)));
     }
 
     [Fact]
@@ -296,7 +296,7 @@ public class OidcRoundTripTests
         // whose summary says linking, which is what the callback later uses to route to the link workflow
         // instead of a login.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
 
         harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
         Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc", isLinking: true));
@@ -318,17 +318,17 @@ public class OidcRoundTripTests
         // channel (that is PAR's confidentiality point).
         using var fixture = new OidcTokenFixture(Authority, "jf");
         string? pushedBody = null;
-        var harness = BuildHarness(
+        var harness = OidcRoundTrip.BuildHarness(
             fixture,
             request =>
             {
                 if (request.RequestUri!.AbsoluteUri == fixture.ParUrl)
                 {
                     pushedBody = request.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
-                    return Json("{\"request_uri\":\"urn:ietf:params:oauth:request_uri:par-1\",\"expires_in\":60}");
+                    return OidcRoundTrip.Json("{\"request_uri\":\"urn:ietf:params:oauth:request_uri:par-1\",\"expires_in\":60}");
                 }
 
-                return ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice"), advertisePar: true);
+                return OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice"), advertisePar: true);
             },
             cfg => cfg.DisablePushedAuthorization = false);
 
@@ -350,11 +350,11 @@ public class OidcRoundTripTests
         // fall back to a plain front-channel redirect (that downgrade would defeat the reason an operator
         // deployed PAR). It fails the login attempt instead.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(
+        var harness = OidcRoundTrip.BuildHarness(
             fixture,
             request => request.RequestUri!.AbsoluteUri == fixture.ParUrl
                 ? new HttpResponseMessage(HttpStatusCode.InternalServerError)
-                : ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice"), advertisePar: true),
+                : OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice"), advertisePar: true),
             cfg => cfg.DisablePushedAuthorization = false);
 
         var result = await harness.Controller.OidChallenge("kc");
@@ -386,7 +386,7 @@ public class OidcRoundTripTests
         // and worse than absent because it reads as a control. This row goes red on that day, and its
         // failure is the signal to build the negatives rather than to relax the assertion.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(fixture, request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
+        var harness = OidcRoundTrip.BuildHarness(fixture, request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")));
 
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
 
@@ -403,9 +403,9 @@ public class OidcRoundTripTests
         // still gets the ordinary front-channel redirect - PAR-on is safe against non-PAR providers, which
         // is what makes default-on shippable.
         using var fixture = new OidcTokenFixture(Authority, "jf");
-        var harness = BuildHarness(
+        var harness = OidcRoundTrip.BuildHarness(
             fixture,
-            request => ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")),
+            request => OidcRoundTrip.ServeIdp(fixture, request, fixture.IdToken("sub-1", "alice")),
             cfg => cfg.DisablePushedAuthorization = false);
 
         var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
@@ -431,20 +431,20 @@ public class OidcRoundTripTests
         using var fixture = new OidcTokenFixture(Authority, "jf");
         var idToken = fixture.IdToken(subject: "sub-1", username: "alice");
         var requested = new System.Collections.Generic.List<string>();
-        var harness = BuildHarness(fixture, request =>
+        var harness = OidcRoundTrip.BuildHarness(fixture, request =>
         {
             requested.Add(request.RequestUri!.AbsoluteUri);
-            return ServeIdp(fixture, request, idToken);
+            return OidcRoundTrip.ServeIdp(fixture, request, idToken);
         });
 
-        var (state, binding) = await DriveChallenge(harness);
+        var (state, binding) = await OidcRoundTrip.DriveChallenge(harness, fixture);
 
         // The challenge leg legitimately reads both documents, through the screened reader. Only what the
         // CALLBACK asks for is the subject here.
         Assert.Contains(fixture.DiscoveryUrl, requested);
         requested.Clear();
 
-        RepointToCallback(harness, state, binding, query: $"?code=test-code&state={state}");
+        OidcRoundTrip.RepointToCallback(harness, binding, query: $"?code=test-code&state={state}");
         var callback = Assert.IsType<ContentResult>(await harness.Controller.OidCallback("kc", state));
 
         // The leg really ran to completion, so the absences below are absences and not a callback that
@@ -455,103 +455,4 @@ public class OidcRoundTripTests
         Assert.DoesNotContain(fixture.DiscoveryUrl, requested);
         Assert.DoesNotContain(fixture.JwksUrl, requested);
     }
-
-    // Builds a harness with a single enabled provider "kc" pointed at the fixture's authority, served by the
-    // supplied responder. DisablePushedAuthorization keeps the challenge to a plain redirect; DoNotLoadProfile
-    // makes the id_token claims the whole identity (no userinfo fetch); EnableAuthorization/AllowExistingAccountLink
-    // are off to keep the redeem on the first-time-provision path these round-trips assert.
-    private static SsoControllerHarness BuildHarness(OidcTokenFixture fixture, Func<HttpRequestMessage, HttpResponseMessage> responder, Action<OidConfig>? configure = null) =>
-        new SsoControllerHarness(
-            c =>
-            {
-                var cfg = new OidConfig
-                {
-                    Enabled = true,
-                    OidEndpoint = fixture.Issuer,
-                    OidClientId = fixture.ClientId,
-                    OidScopes = Array.Empty<string>(),
-                    DisablePushedAuthorization = true,
-                    DoNotLoadProfile = true,
-                    EnableAuthorization = false,
-                    AllowExistingAccountLink = false,
-                };
-                configure?.Invoke(cfg);
-                c.OidConfigs["kc"] = cfg;
-            },
-            httpResponder: responder);
-
-    // Serves the fixture's discovery, JWKS, and token endpoints; any other URL 404s so a regression that
-    // reaches an unexpected endpoint is caught. The token endpoint returns the supplied id_token.
-    private static HttpResponseMessage ServeIdp(OidcTokenFixture fixture, HttpRequestMessage request, string idToken, bool advertisePar = false)
-    {
-        var url = request.RequestUri!.AbsoluteUri;
-        if (url == fixture.DiscoveryUrl)
-        {
-            return Json(fixture.Discovery(advertisePar: advertisePar));
-        }
-
-        if (url == fixture.JwksUrl)
-        {
-            return Json(fixture.Jwks());
-        }
-
-        return url == fixture.TokenUrl
-            ? Json(fixture.TokenEndpointJson(idToken))
-            : new HttpResponseMessage(HttpStatusCode.NotFound);
-    }
-
-    // Drives a real OidChallenge on the descriptive start route and returns the state token + browser-binding
-    // cookie value it minted - the exact pair the callback and redeem legs must present.
-    private static async Task<(string State, string Binding)> DriveChallenge(SsoControllerHarness harness)
-    {
-        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
-        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
-        Assert.StartsWith(Authority + "/authorize", challenge.Url);
-
-        // An absent state reads back as empty here, so the assertion below reports it rather than a throw.
-        var state = UrlEncodedQuery.Find(challenge.Url, "state") ?? string.Empty;
-        Assert.False(string.IsNullOrEmpty(state));
-        var binding = BindingCookie(harness.Controller.Response);
-        Assert.False(string.IsNullOrEmpty(binding));
-        return (state, binding);
-    }
-
-    // Re-points the same context at the callback route the IdP redirects back to, carrying the browser-binding
-    // cookie the challenge set (#326) so the state's binding gate is satisfied, and sets the callback query.
-    private static void RepointToCallback(SsoControllerHarness harness, string state, string binding, string query)
-    {
-        harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
-        harness.Controller.HttpContext.Request.QueryString = new QueryString(query);
-        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={binding}";
-    }
-
-    // A fully-populated redeem request for the given state token.
-    private static AuthResponse Redeem(string state) => new AuthResponse
-    {
-        Data = state,
-        DeviceID = "device-1",
-        DeviceName = "Test Device",
-        AppName = "Jellyfin Web",
-        AppVersion = "1.0",
-    };
-
-    // Extracts the browser-binding cookie value the challenge wrote to the response's Set-Cookie header.
-    private static string BindingCookie(HttpResponse response)
-    {
-        var prefix = AuthorizeStateBinding.CookieName + "=";
-        foreach (var header in response.Headers.SetCookie)
-        {
-            if (header is not null && header.StartsWith(prefix, StringComparison.Ordinal))
-            {
-                var value = header.Substring(prefix.Length);
-                var end = value.IndexOf(';');
-                return end >= 0 ? value.Substring(0, end) : value;
-            }
-        }
-
-        return string.Empty;
-    }
-
-    private static HttpResponseMessage Json(string body) =>
-        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
 }

--- a/SSO-Auth.Tests/_Support/OidcRoundTrip.cs
+++ b/SSO-Auth.Tests/_Support/OidcRoundTrip.cs
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The one home for the scaffolding that drives a real OpenID login through the controller - challenge,
+/// callback, redeem - against the in-test provider <see cref="OidcTokenFixture"/> serves. It had two homes
+/// until #1351: <c>OidcRoundTripTests</c> kept it privately and <c>OidcIdTokenIsNeverACredentialTests</c>
+/// repeated it, and a copy that drifts fails quietly, because both copies keep passing while one of them is
+/// driving a flow the plugin no longer has.
+///
+/// It is scaffolding and not a fixture: it holds no state, asserts only what a caller needs true before its
+/// own assertions can mean anything (the challenge really redirected, and really minted a state and a
+/// binding), and returns the values that pass between the legs. Every claim a test makes stays in the test.
+/// </summary>
+internal static class OidcRoundTrip
+{
+    /// <summary>
+    /// Builds a controller harness with one enabled provider <c>kc</c> pointed at the fixture's authority.
+    /// Pushed authorization is off so the challenge is a plain redirect, profile loading is off so the
+    /// id_token claims are the whole identity, and the authorization/link toggles are off so the redeem
+    /// takes the first-time-provision path.
+    /// </summary>
+    /// <param name="fixture">The in-test identity provider the harness points at.</param>
+    /// <param name="responder">The stub HTTP responder serving that provider's endpoints.</param>
+    /// <param name="provider">Applied to the provider's own configuration before it is stored.</param>
+    /// <param name="plugin">Applied to the whole plugin configuration, for options that are not per-provider.</param>
+    /// <returns>The harness, with the provider configured.</returns>
+    internal static SsoControllerHarness BuildHarness(
+        OidcTokenFixture fixture,
+        Func<HttpRequestMessage, HttpResponseMessage> responder,
+        Action<OidConfig>? provider = null,
+        Action<PluginConfiguration>? plugin = null)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        return new SsoControllerHarness(
+            configuration =>
+            {
+                var config = new OidConfig
+                {
+                    Enabled = true,
+                    OidEndpoint = fixture.Issuer,
+                    OidClientId = fixture.ClientId,
+                    OidScopes = Array.Empty<string>(),
+                    DisablePushedAuthorization = true,
+                    DoNotLoadProfile = true,
+                    EnableAuthorization = false,
+                    AllowExistingAccountLink = false,
+                };
+                provider?.Invoke(config);
+                configuration.OidConfigs["kc"] = config;
+                plugin?.Invoke(configuration);
+            },
+            httpResponder: responder);
+    }
+
+    /// <summary>
+    /// Serves the fixture's discovery, JWKS and token endpoints; any other URL 404s, so a regression that
+    /// reaches an unexpected endpoint is caught rather than absorbed. The token endpoint returns the
+    /// supplied id_token.
+    /// </summary>
+    /// <param name="fixture">The in-test identity provider whose endpoints are served.</param>
+    /// <param name="request">The outbound request the stub handler intercepted.</param>
+    /// <param name="idToken">The id_token the token endpoint returns.</param>
+    /// <param name="advertisePar">Whether the discovery document advertises pushed authorization.</param>
+    /// <param name="served">When given, every body served is appended to it, so a search can be shown to work against a body that really carries the token.</param>
+    /// <returns>The response for that URL.</returns>
+    internal static HttpResponseMessage ServeIdp(
+        OidcTokenFixture fixture,
+        HttpRequestMessage request,
+        string idToken,
+        bool advertisePar = false,
+        List<string>? served = null)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var url = request.RequestUri!.AbsoluteUri;
+        string body;
+        if (url == fixture.DiscoveryUrl)
+        {
+            body = fixture.Discovery(advertisePar: advertisePar);
+        }
+        else if (url == fixture.JwksUrl)
+        {
+            body = fixture.Jwks();
+        }
+        else if (url == fixture.TokenUrl)
+        {
+            body = fixture.TokenEndpointJson(idToken);
+        }
+        else
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound);
+        }
+
+        served?.Add(body);
+        return Json(body);
+    }
+
+    /// <summary>
+    /// Drives a real <c>OidChallenge</c> on the descriptive start route and returns the state token and
+    /// browser-binding cookie value it minted - the exact pair the callback and redeem legs must present.
+    /// </summary>
+    /// <param name="harness">The harness whose controller is driven.</param>
+    /// <param name="fixture">The provider the challenge must redirect to.</param>
+    /// <returns>The state token and the browser-binding cookie value.</returns>
+    internal static async Task<(string State, string Binding)> DriveChallenge(SsoControllerHarness harness, OidcTokenFixture fixture)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/start/kc";
+        var challenge = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+        Assert.StartsWith(fixture.Issuer + "/authorize", challenge.Url, StringComparison.Ordinal);
+
+        // An absent state reads back as empty here, so the assertion below reports it rather than a throw.
+        var state = UrlEncodedQuery.Find(challenge.Url, "state") ?? string.Empty;
+        Assert.False(string.IsNullOrEmpty(state));
+        var binding = BindingCookie(harness.Controller.Response);
+        Assert.False(string.IsNullOrEmpty(binding));
+        return (state, binding);
+    }
+
+    /// <summary>
+    /// Re-points the same context at the callback route the identity provider redirects back to, carrying
+    /// the browser-binding cookie the challenge set (#326) so the state's binding gate is satisfied, and
+    /// sets the callback query.
+    /// </summary>
+    /// <param name="harness">The harness whose controller is re-pointed.</param>
+    /// <param name="binding">The browser-binding cookie value the challenge minted.</param>
+    /// <param name="query">The callback query string, leading question mark included.</param>
+    internal static void RepointToCallback(SsoControllerHarness harness, string binding, string query)
+    {
+        ArgumentNullException.ThrowIfNull(harness);
+
+        harness.Controller.HttpContext.Request.Path = "/sso/OID/redirect/kc";
+        harness.Controller.HttpContext.Request.QueryString = new QueryString(query);
+        harness.Controller.HttpContext.Request.Headers.Cookie = $"{AuthorizeStateBinding.CookieName}={binding}";
+    }
+
+    /// <summary>A fully populated redeem request for the given state token.</summary>
+    /// <param name="state">The state token the challenge minted.</param>
+    /// <returns>The redeem request.</returns>
+    internal static AuthResponse Redeem(string state) => new AuthResponse
+    {
+        Data = state,
+        DeviceID = "device-1",
+        DeviceName = "Test Device",
+        AppName = "Jellyfin Web",
+        AppVersion = "1.0",
+    };
+
+    /// <summary>Extracts the browser-binding cookie value the challenge wrote to the response's Set-Cookie header.</summary>
+    /// <param name="response">The response the challenge wrote to.</param>
+    /// <returns>The cookie value, or empty when the header is absent.</returns>
+    internal static string BindingCookie(HttpResponse response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var prefix = AuthorizeStateBinding.CookieName + "=";
+        foreach (var header in response.Headers.SetCookie)
+        {
+            if (header is not null && header.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                var value = header.Substring(prefix.Length);
+                var end = value.IndexOf(';', StringComparison.Ordinal);
+                return end >= 0 ? value.Substring(0, end) : value;
+            }
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>An <c>application/json</c> 200 carrying the given body, for a responder serving one endpoint itself.</summary>
+    /// <param name="body">The response body.</param>
+    /// <returns>The response.</returns>
+    internal static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+}


### PR DESCRIPTION
# What & why

`OidcRoundTripTests` kept its challenge/callback/redeem scaffolding as private statics, and `OidcIdTokenIsNeverACredentialTests` repeated it rather than lift it out, with a comment saying so and naming this issue. Two copies of a login driver fail quietly: a fix to one leaves the other driving a flow the plugin no longer has, and both keep passing.

The scaffolding now lives in `SSO-Auth.Tests/_Support/OidcRoundTrip.cs`, and both classes drive their round trips through it. No assertion moved.

Where the two copies differed, the stricter one is kept: the challenge redirect is compared ordinally, as the second copy already did. Three shapes are unified rather than duplicated:

- the harness builder takes both a provider-config and a plugin-config mutator, because one caller needed `EnableSingleLogout` and the rest configure the provider;
- the responder takes an optional list, so the caller that proves its search works against a body really carrying the token still records what was served;
- `RepointToCallback` drops the `state` parameter that both copies accepted and neither read.

Closes #1351.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable in the sense the section asks about: this change touches no shipped code. Every file in the diff is under `SSO-Auth.Tests/`, and `git diff --stat` names four of them. Two entries are still worth an answer rather than a dash.

- [x] Fail-closed preserved. Nothing in the login path is edited, and the tests that assert it fail closed run unchanged. The one behaviour that did move is a conformance rule, and it moved in the strict direction (below).
- [x] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **NOT DONE, and the checkbox is ticked for the scope rather than for the review.** No lens ran over this diff, and there is no second reader on this change. It edits no validation, no persistence and no pipeline, so what stands in for a review is the suite itself running unchanged assertions against the extracted driver.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit. That is the whole change: `grep -rn 'Task<(string State, string Binding)> DriveChallenge' SSO-Auth.Tests/` returns exactly one line.
- [x] The change adds no more code than the problem requires. 273 insertions against 269 deletions, and the insertions are the moved bodies plus their documentation.
- [x] The code is self-documenting and matches the target architecture (#318). `OidcRoundTrip` is a support type holding no state; every claim stays in the test that makes it.
- [x] Architecture-conformance tests pass, and the new structural property is locked in as a rule. See below - this is the part of the change worth reading.
- [x] Docs impact considered: this change needs no README/wiki update. It is test scaffolding with no user-visible effect, and for the same reason it carries no CHANGELOG entry.

### The hole the extraction opened, and the rule that closes it

`EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection` reads each test file's OWN code lines for `new SsoControllerHarness`, so lifting the construction behind a support type takes the callers out of its reach. Measured rather than reasoned about, at the commit before this one and at this one:

```
$ git grep -c "new SsoControllerHarness" origin/main -- \
    SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs
origin/main:SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs:1
origin/main:SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs:1

$ grep -c "new SsoControllerHarness" \
    SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs
SSO-Auth.Tests/Oidc/OidcRoundTripTests.cs:0
SSO-Auth.Tests/Oidc/OidcIdTokenIsNeverACredentialTests.cs:0
```

So the rule would have kept passing while covering two classes fewer, which is the failure mode that rule class exists against. `OidcRoundTrip.BuildHarness` is seeded as a second door beside the harness construction, spelled exactly as a call site spells it.

The seed bites, proved by taking the guard away rather than by assertion. With `[Collection("SSOController")]` removed from `OidcRoundTripTests`:

```
Jellyfin.Plugin.SSO_Auth.Tests.ArchitectureConformanceTests.EveryTestClassOpeningAProcessWideDoor_IsInTheNonParallelControllerCollection [FAIL]
  A test class reaching a process-wide door must carry [Collection("SSOController")], or it runs in
  parallel with another class clearing the same static: OidcRoundTripTests.cs opens OidcRoundTrip.BuildHarness
```

The attribute is back, and the rule passes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target frameworks, 0 warnings and 0 errors each.
- [x] `dotnet test` is green. `net9.0`: 3096 total, 0 failed, 4 skipped. `net10.0`: 3097 total, 0 failed, 4 skipped. Same counts as before the change on both, since no test was added or removed. The four skips are the loopback-bind tests that need an administrator (#1227), skipped rather than worked around.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. There are none in this diff.

## Notes

The issue's done-condition quotes `git grep -n 'private static async Task<(string State, string Binding)> DriveChallenge'` and asks for exactly one hit. That literal now returns nothing, because the one surviving declaration is `internal` - as a support type's members are in every other file under `_Support/`. The visibility-agnostic form returns exactly one, and it is quoted above.

Out of scope: the other private helpers in both classes that are genuinely local to them, and every test class that builds a harness directly. Nothing else in the suite shares this driver today.
