### PR TITLE
Write the red-branch watcher in English [#1362]

### DIFF
--- a/.github/workflows/publish-failure-alert.yml
+++ b/.github/workflows/publish-failure-alert.yml
@@ -95,23 +95,23 @@ jobs:
           echo "Examined $(jq length runs.json) run(s) on ${BRANCH}; $(wc -l < red.tsv) non-success since ${cutoff}."
           if [ ! -s red.tsv ]; then
             echo "Nothing red."
-            # NICHTS ROT HEISST SCHLIESSEN, und zwar durch den Waechter selbst.
+            # NOTHING RED MEANS CLOSE, and the watcher does the closing itself.
             #
-            # Er hat es nie getan. #1314 wurde um 21:20 gruen und blieb offen,
-            # bis ein Mensch sie um 21:50 schloss - und weil sie DANN zu war,
-            # legte der naechste Takt #1354 neu an, fuer einen Fehler, den es
-            # nicht mehr gab. Ein Melder, der nur oeffnet, erzeugt Karteileichen
-            # und Doppelmeldungen aus demselben Grund.
-            offen=$(gh issue list --repo "$REPO" --state open --label release-alert \
+            # It never did. #1314 went green at 21:20 and stayed open until it
+            # was closed by hand at 21:50 - and because it was closed THEN, the
+            # next tick filed #1354 afresh, for a failure that no longer
+            # existed. A reporter that only ever opens produces dead entries and
+            # duplicate reports, and for the same reason.
+            open_issue=$(gh issue list --repo "$REPO" --state open --label release-alert \
               --json number --jq '.[0].number // empty')
-            if [ -n "${offen:-}" ]; then
+            if [ -n "${open_issue:-}" ]; then
               if [ "$DRY_RUN" = "true" ]; then
-                echo "DRY RUN: would close #${offen}."
+                echo "DRY RUN: would close #${open_issue}."
               else
-                gh issue comment "$offen" --repo "$REPO" --body "Nothing on \`${BRANCH}\` is red any more; \
+                gh issue comment "$open_issue" --repo "$REPO" --body "Nothing on \`${BRANCH}\` is red any more; \
           closing. Examined $(jq length runs.json) run(s) since ${cutoff}."
-                gh issue close "$offen" --repo "$REPO" --reason completed
-                echo "Closed #${offen}."
+                gh issue close "$open_issue" --repo "$REPO" --reason completed
+                echo "Closed #${open_issue}."
               fi
             else
               echo "No open alert issue to close."
@@ -138,92 +138,90 @@ jobs:
               --jq '.body, (.comments[].body)')
           fi
 
-          # WAS ROT IST, MIT GRUND - und der Grund kommt aus dem Protokoll.
+          # WHAT IS RED, WITH THE REASON - and the reason comes from the log.
           #
-          # Bis zum 17.08. stand hier eine feste Vorlage: Name, Ausgang, Ausloeser,
-          # Link. Sie sagte, DASS etwas rot ist, und nie WAS. #1314 lief damit
-          # sieben Tage und 29 gleichlautende Kommentare, waehrend die Ursache -
-          # ein fehlender Bindestrich in einem Wiki-Anker - die ganze Zeit im
-          # Protokoll des ersten Laufs stand.
+          # Until 2026-08-17 a fixed template stood here: name, conclusion,
+          # trigger, link. It said THAT something was red, and never WHAT. #1314
+          # ran on that template for seven days and 29 identically worded
+          # comments, while the cause - a missing hyphen in a wiki anchor - sat
+          # in the first run's log the entire time.
           #
-          # `gh run view --log-failed` liefert genau den gescheiterten Schritt.
-          # Der Waechter hatte die Lauf-Nummer immer; er hat nur nie gefragt.
-          : > zustand.md
-          : > schluessel.txt
-          # EIN ABSCHNITT JE WORKFLOW, NICHT JE LAUF.
+          # `gh run view --log-failed` returns exactly the step that failed. The
+          # watcher always had the run number; it simply never asked.
+          : > state.md
+          : > key.txt
+          # ONE SECTION PER WORKFLOW, NOT PER RUN.
           #
-          # Der zweite Trockenlauf vom 17.08. schrieb `### Wiki Lint` zweimal
-          # untereinander, weil drei rote Laeufe desselben Workflows in red.tsv
-          # standen. Das ist dieselbe Wiederholung, die als 29 Kommentare
-          # angefangen hat - nur in einen Koerper verschoben statt behoben.
+          # The second dry run on 2026-08-17 wrote `### Wiki Lint` twice, one
+          # under the other, because three red runs of the same workflow stood
+          # in red.tsv. That is the same repetition that began as 29 comments,
+          # moved into one body rather than fixed.
           #
-          # red.tsv ist nach Aktualitaet sortiert, also ist der ERSTE Eintrag je
-          # Workflow der neueste; die Zahl der Laeufe steht ohnehin separat im
-          # Text.
-          awk -F'\t' '!gesehen[$4]++' red.tsv > je-workflow.tsv
+          # red.tsv is sorted by recency, so the FIRST entry per workflow is the
+          # newest; the number of runs is carried separately in the text anyway.
+          awk -F'\t' '!seen[$4]++' red.tsv > per-workflow.tsv
           while IFS=$'\t' read -r url conclusion event wf_name; do
             run_id="${url##*/}"
-            schritt=$(gh run view "$run_id" --repo "$REPO" --json jobs \
+            step=$(gh run view "$run_id" --repo "$REPO" --json jobs \
               --jq '[.jobs[] | select(.conclusion=="failure") | .steps[]
-                     | select(.conclusion=="failure") | .name][0] // "unbekannt"' 2>/dev/null || echo "unbekannt")
-            # DAS PROTOKOLLENDE, GEKAPPT. Ein ganzes Joblog sprengt jede Issue
-            # und wird deshalb nicht gelesen; die letzten Zeilen des roten
-            # Schritts sind das, was ein Mensch zuerst ansehen wuerde.
-            # NUR DIE ZEILEN DES GESCHEITERTEN SCHRITTS, und der Grund steht im
-            # Trockenlauf vom 17.08.: `tail` auf das ganze Joblog liefert den
-            # ABBAU - "Removing SSH command configuration", "Cleaning up orphan
-            # processes" - und nicht den Fehler, der weiter oben steht. Der
-            # Bericht waere ausfuehrlicher und genauso nutzlos gewesen wie die
-            # Vorlage, die er ersetzt.
+                     | select(.conclusion=="failure") | .name][0] // "unknown"' 2>/dev/null || echo "unknown")
+            # THE END OF THE LOG, CAPPED. A whole job log bursts any issue and
+            # for that reason goes unread; the last lines of the red step are
+            # what a reader looks at first.
+            # ONLY THE LINES OF THE FAILED STEP, and the reason is in the dry
+            # run of 2026-08-17: `tail` over the whole job log returns the
+            # TEARDOWN - "Removing SSH command configuration", "Cleaning up
+            # orphan processes" - and not the error, which stands further up.
+            # The report would have been longer and exactly as useless as the
+            # template it replaces.
             #
-            # UND NICHT UEBER DIE SCHRITT-SPALTE, denn die traegt nichts.
-            # Gemessen am 17.08. an einem roten Lauf: `--log-failed` schrieb
-            # ALLE 175 Zeilen mit `UNKNOWN STEP`, waehrend die Jobs-API den
-            # Schritt sauber benennt. Ein Filter darauf trifft nie und liefert
-            # "(kein Protokoll abrufbar)" - im zweiten Trockenlauf genau so
-            # passiert.
+            # AND NOT VIA THE STEP COLUMN, because that column carries nothing.
+            # Measured on 2026-08-17 against a red run: `--log-failed` wrote ALL
+            # 175 lines with `UNKNOWN STEP`, while the jobs API names the step
+            # cleanly. A filter on it never matches and yields "(no log
+            # available)" - which is exactly what the second dry run produced.
             #
-            # Der verlaessliche Anker ist die Fehlermarke, die der Runner selbst
-            # setzt: die Zeilen VOR dem ersten `##[error]` sind die Ausgabe, die
-            # den Lauf gekippt hat. Der Abbau steht dahinter und faellt damit
-            # von selbst weg.
-            schwanz=$(gh run view "$run_id" --repo "$REPO" --log-failed 2>/dev/null \
+            # The reliable anchor is the error marker the runner sets itself:
+            # the lines BEFORE the first `##[error]` are the output that tipped
+            # the run over. The teardown sits behind it and so drops away by
+            # itself.
+            log_excerpt=$(gh run view "$run_id" --repo "$REPO" --log-failed 2>/dev/null \
               | sed 's/\r$//' \
               | sed 's/^[^\t]*\t[^\t]*\t//' | sed 's/^[0-9TZ:.-]\{20,\} //' \
               | grep -vE '^\s*$' | grep -vE '^##\[(group|endgroup)\]' \
-              | awk '/##\[error\]/ { gefunden=1; for (i=1;i<=n;i++) print puffer[i]; print; exit }
-                     { puffer[++n]=$0; if (n>12) { for (i=1;i<n;i++) puffer[i]=puffer[i+1]; n-- } }
-                     END { if (!gefunden) for (i=1;i<=n;i++) print puffer[i] }' \
+              | awk '/##\[error\]/ { found=1; for (i=1;i<=n;i++) print buffer[i]; print; exit }
+                     { buffer[++n]=$0; if (n>12) { for (i=1;i<n;i++) buffer[i]=buffer[i+1]; n-- } }
+                     END { if (!found) for (i=1;i<=n;i++) print buffer[i] }' \
               | cut -c1-200 || true)
-            [ -n "$schwanz" ] || schwanz="(kein Protokoll abrufbar)"
-            printf '%s\t%s\n' "$wf_name" "$schritt" >> schluessel.txt
-            # Wie viele rote Laeufe dieses Workflows, und seit wann.
-            zahl=$(cut -f4 red.tsv | grep -cxF "$wf_name" || echo 1)
-            seit=$(jq -r --arg w "$wf_name" '[.[] | select(.workflowName==$w)
+            [ -n "$log_excerpt" ] || log_excerpt="(no log available)"
+            printf '%s\t%s\n' "$wf_name" "$step" >> key.txt
+            # How many red runs of this workflow, and since when.
+            count=$(cut -f4 red.tsv | grep -cxF "$wf_name" || echo 1)
+            since=$(jq -r --arg w "$wf_name" '[.[] | select(.workflowName==$w)
                      | select((.conclusion // "") as $c
                               | $c != "success" and $c != "skipped" and $c != "cancelled" and $c != "")
                      | .updatedAt] | sort | .[0] // ""' runs.json)
             {
               printf '### %s\n\n' "$wf_name"
               printf 'Failing step: **%s** (conclusion `%s`, trigger `%s`)\n\n' \
-                "$schritt" "$conclusion" "$event"
-              printf '```\n%s\n```\n\n' "$schwanz"
+                "$step" "$conclusion" "$event"
+              printf '```\n%s\n```\n\n' "$log_excerpt"
               printf 'Red since `%s`, %s run(s) in this window. Latest: %s\n\n' \
-                "${seit:-unknown}" "$zahl" "$url"
-            } >> zustand.md
-          done < je-workflow.tsv
+                "${since:-unknown}" "$count" "$url"
+            } >> state.md
+          done < per-workflow.tsv
 
-          # DER KOERPER HAELT DEN ZUSTAND, KOMMENTARE HALTEN UEBERGAENGE.
+          # THE BODY HOLDS THE STATE, COMMENTS HOLD THE TRANSITIONS.
           #
-          # Der alte Waechter kommentierte je ROTEM LAUF, und sein
-          # Dedup-Schluessel war die Lauf-URL - die sich per Definition bei
-          # jedem Lauf aendert. Jeder Push nach main erzeugte damit einen
-          # weiteren gleichlautenden Kommentar. 29 fuer eine Ursache.
+          # The old watcher commented per RED RUN, and its dedup key was the run
+          # URL - which by definition changes with every run. Every push to main
+          # therefore produced one more identically worded comment. 29 of them
+          # for a single cause.
           #
-          # Der Schluessel ist jetzt Workflow PLUS gescheiterter Schritt. Aendert
-          # sich daran nichts, wird nur der Koerper aktualisiert und still
-          # geschwiegen; kommt ein neuer Schritt dazu, ist das eine Nachricht.
-          kopf="Workflows on \`${BRANCH}\` are red. This body is rewritten each tick and always
+          # The key is now workflow PLUS failed step. If that does not change,
+          # only the body is updated and nothing is said; if a new step appears,
+          # that is news.
+          header="Workflows on \`${BRANCH}\` are red. This body is rewritten each tick and always
           shows the CURRENT state; comments below mark changes only.
 
           A failure on the default branch is not a required pull-request check and is not emailed, so it
@@ -234,28 +232,31 @@ jobs:
           The watcher closes this issue itself once nothing is red.
 
           Refs #982, #1015, #1357."
-          body="$kopf
+          body="$header
 
-          $(cat zustand.md)"
-          neu_schluessel=$(sort -u schluessel.txt | tr '\t' ':' | tr '\n' ';')
+          $(cat state.md)"
+          new_key=$(sort -u key.txt | tr '\t' ':' | tr '\n' ';')
 
           if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY RUN, filing nothing. Would report: ${neu_schluessel}"
+            echo "DRY RUN, filing nothing. Would report: ${new_key}"
             echo "--- body ---"; echo "$body"
             exit 0
           fi
 
           if [ -n "${num:-}" ]; then
-            alt_schluessel=$(printf '%s' "$reported" | sed -n 's/.*<!-- schluessel: \(.*\) -->.*/\1/p' | head -1)
+            # The marker was spelled differently before #1362 renamed it, so on the first tick after
+            # that change this read finds nothing and the comparison below reports a transition. That
+            # is one comment, once, and the semantics of the key are unchanged: workflow plus step.
+            old_key=$(printf '%s' "$reported" | sed -n 's/.*<!-- key: \(.*\) -->.*/\1/p' | head -1)
             gh issue edit "$num" --repo "$REPO" --body "$body
 
-          <!-- schluessel: ${neu_schluessel} -->"
-            if [ "$alt_schluessel" != "$neu_schluessel" ]; then
+          <!-- key: ${new_key} -->"
+            if [ "$old_key" != "$new_key" ]; then
               echo "Failing set changed; commenting."
               gh issue comment "$num" --repo "$REPO" --body "The set of red workflows changed.
 
-          Now: ${neu_schluessel}
-          Before: ${alt_schluessel:-(nothing recorded)}
+          Now: ${new_key}
+          Before: ${old_key:-(nothing recorded)}
 
           The body above carries the current state and the failing step's log."
             else
@@ -267,5 +268,5 @@ jobs:
               --title "A workflow concluded non-success on the default branch" \
               --body "$body
 
-          <!-- schluessel: ${neu_schluessel} -->" | grep -o '[0-9]*$')
+          <!-- key: ${new_key} -->" | grep -o '[0-9]*$')
           fi


### PR DESCRIPTION
# What & why

`.github/workflows/publish-failure-alert.yml` had stopped being written in English. Its reasoning, its shell identifiers and two of its output strings were in German, and one of those strings leaves the repository: the fallback for a run whose log cannot be fetched is written straight into the alert issue body, so the first tick meeting an unreadable log would have filed a German sentence on this public repository.

I translated the comments, renamed the fourteen identifiers and the two intermediate files, and replaced both fallback strings.

The second string is one the issue did not name. The failing-step fallback was `unbekannt`, and it is published twice over, once in the `Failing step:` line of the body and once inside the dedup key. The issue's identifier grep is a fixed list and does not contain it, so it would have survived a change that satisfied that grep exactly. It is translated here as `unknown`.

This is a rename and a translation, not a redesign. The dedup key still means workflow plus failed step, the close-on-green path is untouched, and the log extraction still anchors on the first `##[error]` marker.

One consequence is deliberate rather than discovered. The body marker `<!-- schluessel: ... -->` is now `<!-- key: ... -->`, so the first tick after this lands parses no previous key out of an issue that is already open, reads that as a changed failing set, and posts one transition comment. That is one comment, once. I exercised both sides of it below.

Closes #1362

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

This touches the release pipeline, so the section is filled in.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

The first and last boxes are left unticked because they do not apply rather than because they failed. There is no signature, time bound or audience on this route, and no value here originates from an identity provider. Ticking either would be a claim about a surface this file does not have.

Review record, CONFIRMED 0 / PLAUSIBLE 1. Read against four lenses, and the reading is bounded by what the diff can reach.

Injection, PASS. No `${{ }}` interpolation, no permission line and no token line appears in the diff at all, which is derived rather than remembered:

```
$ git diff origin/main...HEAD -- .github/workflows/publish-failure-alert.yml \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -E 'permissions|GH_TOKEN|\$\{\{|secrets\.|token'
(no match)
```

Quoting, PASS. Every renamed variable is still referenced double-quoted, so no rename opened a word-splitting or glob path:

```
$ grep -nE '\$(step|log_excerpt|open_issue|new_key|old_key|count|since|header)\b' \
    .github/workflows/publish-failure-alert.yml \
  | grep -vE '"\$\{?(step|log_excerpt|open_issue|new_key|old_key|count|since|header)'
(no match)
```

Availability, PASS. The failure modes of the watcher are that it stops filing, or that it files forever. Both close-on-green and the silence-when-unchanged branch are exercised under Verification below, and the second is what keeps a steady red state from generating a comment per tick.

Secret exposure, PLAUSIBLE 1, disposition DECLINE. This workflow publishes up to thirteen lines of a failed job's log into a public issue. That is the entire point of the change that landed in #1357 and it is not introduced, altered or widened here. Actions masks registered secrets in log output, and the diff does not touch the extraction, the cap or the destination. I am recording it because it is a real property of a public board rather than because this change creates it, and I did not verify the masking behaviour myself, so this is a claim and not a measurement.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [ ] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

No new logic is added. The file gains one net line, a three-line comment recording the marker rename against two comment lines that merged. The conformance box is unticked because it is about the C# tree and this change contains no C#; the suite is unaffected and I did not run it.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

All three are left unticked deliberately. This change contains no C# and no file of any type Prettier is configured to read, so I did not run the .NET build, the test suite or Prettier locally, and I am not claiming a result for them. The `build` check on this pull request is the evidence for the first two.

What I did run, all at the head commit of this branch.

Both greps from the issue's Done-when. The first returns `0` and the second returns an empty set:

```
$ grep -cE '^\s*#.*\b(nicht|nichts|und|der|die|das|ein|eine|wird|wurde|steht|hat|nie|schrieb|liefert|Waechter|Schritt|Zeilen|Koerper|Grund|Protokoll|Lauf|Laeufe|Trockenlauf|Vorlage|Fehler|Mensch|Kommentar|Kommentare|Zahl|Abbau|Melder)\b' .github/workflows/publish-failure-alert.yml
0
$ grep -oE '\b(offen|schritt|schwanz|zustand\.md|schluessel\.txt|neu_schluessel|alt_schluessel|zahl|seit|kopf|je-workflow\.tsv|gesehen|puffer|gefunden)\b' .github/workflows/publish-failure-alert.yml | sort -u
(empty)
```

Those two are the issue's own test and I did not want to rest on them alone, since both are fixed word lists that a miss can walk through. No non-ASCII byte survives anywhere in the file:

```
$ grep -nP '[^\x00-\x7F]' .github/workflows/publish-failure-alert.yml
(no match)
```

The `run:` block still parses, since no route in CI executes this workflow on a pull request. Extracted and dedented into a scratch file, 201 lines, then:

```
$ awk '/^        run: \|$/{f=1;next} f{ if ($0 ~ /^[^ ]/ && $0 !~ /^$/) exit; sub(/^          /,""); print }' \
    .github/workflows/publish-failure-alert.yml > run-block.sh
$ bash -n run-block.sh && echo PARSE OK
PARSE OK
```

The same extraction backs a static check that the rename left nothing dangling: every `$name` referenced in the block is either assigned in it, declared in the step's `env:`, or a `jq --arg` parameter. The set of referenced-but-never-assigned names is empty.

`actionlint`, on this file and on the same file at `origin/main`, so the result is a comparison rather than a bare pass. Both exit `0`.

Behaviour is held by a diff rather than by assertion. With comment and blank lines stripped from both sides the file has 141 code lines before and after, and every differing line is one of the renames or one of the three string changes.

`bash -n` proves only that the script parses, so I drove it. I stubbed `gh` and ran the block against fixtures. Four paths, and the fourth carries its own falsifier:

- Red runs present. The body comes out in English, one section per workflow rather than one per run, this workflow excluded from its own sweep, and the `##[error]` anchor drops the teardown line that follows the error.
- The log cannot be fetched. This is the case the issue exists for and the one nobody watches until it happens. The body reads `(no log available)`.
- The step cannot be resolved. Reached two ways, through the `// "unknown"` default run against real `jq` and through the `|| echo` branch with `gh` exiting non-zero. Both report `unknown`.
- Nothing red and an issue open. The watcher comments and closes it.
- An open issue carrying the old marker. One transition comment, as described above. With the new marker present and the same failing set the run prints `Same failing set as before; body refreshed, no comment` and posts nothing, which is the falsifier for the line above it: if the transition were not one-time, that case would comment too.

The stub is a stub. It answers on the first two words of the command line and does not implement gh's own `--jq`, which is why the step fallback needed checking against real `jq` separately. Nothing here was run against the live Actions API, and I make no claim about how a real tick behaves.

## Notes

The `<!-- key: ... -->` rename produces exactly one transition comment on the currently open alert issue, if one is open when this lands. That is stated in the issue's Done-when as acceptable and is recorded here rather than left to be discovered.

One thing I read and deliberately did not change, because it is a second topic. `count=$(cut -f4 red.tsv | grep -cxF "$wf_name" || echo 1)` takes the `|| echo 1` branch when `grep -c` exits non-zero, and `grep -c` exits non-zero on zero matches while still printing `0`, so that branch would capture `0` and `1` together. It cannot fire today, because `$wf_name` is read out of `red.tsv` and therefore always matches at least once. I am leaving it alone rather than folding a behaviour change into a translation.

No second reader looked at any of this.
