### PR TITLE
Seed playback defaults from the provisioning template [#1100]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,23 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   quietly changed. Zero means no limit and unlimited, as it does elsewhere in
   Jellyfin. The template is set in the plugin configuration; the provider forms
   in the dashboard do not carry it yet.
+- **The starting policy can also seed playback preferences (#1100).** The same
+  per-provider template now carries the language and playback block: preferred
+  audio language, preferred subtitle language, subtitle mode, whether the
+  default audio track plays, and whether audio and subtitle selections are
+  remembered. It behaves exactly like the rest of the template. Each field is
+  opt-in, anything left unset stays at Jellyfin's own default, and the values are
+  written once when the account is created and never re-applied, so a preference
+  you or the user change afterwards survives every later login. Clearing one of
+  the three switches is a real setting rather than an absent one, so a template
+  can turn it off and have it stick. The subtitle mode is the one field with a
+  fixed vocabulary: an unrecognised name is refused when you save, naming the
+  modes Jellyfin accepts, and refused again when the template is written, so a
+  configuration file edited by hand cannot slip one through and leave an account
+  on a mode nobody chose. The two language fields are passed to Jellyfin as given
+  rather than checked against a list, so any code Jellyfin accepts works. As with
+  the rest of the template, these are set in the plugin configuration and the
+  provider forms in the dashboard do not carry them yet.
 - **Account expiry now ends access on the deadline rather than at the next
   login (#1145).** The instant a login carries is persisted against that
   account's SSO link, and an hourly background pass disables any linked account

--- a/SSO-Auth.Tests/Linking/ProvisioningPolicyTemplateTests.cs
+++ b/SSO-Auth.Tests/Linking/ProvisioningPolicyTemplateTests.cs
@@ -243,6 +243,160 @@ public class ProvisioningPolicyTemplateTests
         Assert.Equal(2, created.MaxActiveSessions);
     }
 
+    [Fact]
+    public async Task ANewAccount_ComesOutWithExactlyTheTemplatedPlaybackDefaults()
+    {
+        // The playback block (#1100). These are columns on the account like the two ceilings above rather
+        // than permissions, so they ride the same create-arm write and inherit the same "never re-applied"
+        // contract instead of needing a second one.
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate
+        {
+            AudioLanguagePreference = "eng",
+            SubtitleLanguagePreference = "ger",
+            SubtitleMode = nameof(SubtitlePlaybackMode.Smart),
+            PlayDefaultAudioTrack = true,
+            RememberAudioSelections = false,
+            RememberSubtitleSelections = true,
+        };
+        var created = Provisionable(users, "alice");
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal("eng", created.AudioLanguagePreference);
+        Assert.Equal("ger", created.SubtitleLanguagePreference);
+        Assert.Equal(SubtitlePlaybackMode.Smart, created.SubtitleMode);
+        Assert.True(created.PlayDefaultAudioTrack);
+        Assert.False(created.RememberAudioSelections);
+        Assert.True(created.RememberSubtitleSelections);
+    }
+
+    [Fact]
+    public async Task AnUnsetPlaybackField_IsLeftAtJellyfinsOwnDefault()
+    {
+        // Opt-in per field here too: naming an audio language must not drag the other five along and
+        // flatten preferences the administrator never mentioned.
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { AudioLanguagePreference = "eng" };
+        var created = Provisionable(users, "alice");
+        created.SubtitleLanguagePreference = "fre";
+        created.SubtitleMode = SubtitlePlaybackMode.Always;
+        created.RememberAudioSelections = true;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal("eng", created.AudioLanguagePreference);
+        Assert.Equal("fre", created.SubtitleLanguagePreference);
+        Assert.Equal(SubtitlePlaybackMode.Always, created.SubtitleMode);
+        Assert.True(created.RememberAudioSelections);
+    }
+
+    [Fact]
+    public async Task FalseIsAMeaningfulPreference_AndIsWritten_NotTreatedAsUnset()
+    {
+        // The bool twin of the zero-ceiling row above, and the reason all three of these are nullable
+        // bools. A writer testing truthiness instead of presence would skip a deliberate false, leaving
+        // Jellyfin's own default standing while the config shows the box cleared.
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate
+        {
+            PlayDefaultAudioTrack = false,
+            RememberAudioSelections = false,
+            RememberSubtitleSelections = false,
+        };
+        var created = Provisionable(users, "alice");
+        created.PlayDefaultAudioTrack = true;
+        created.RememberAudioSelections = true;
+        created.RememberSubtitleSelections = true;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.False(created.PlayDefaultAudioTrack);
+        Assert.False(created.RememberAudioSelections);
+        Assert.False(created.RememberSubtitleSelections);
+    }
+
+    [Fact]
+    public async Task ASecondLogin_LeavesALaterPlaybackEdit_Intact()
+    {
+        // The same contract the row above pins for the policy fields, asserted for the playback block,
+        // since these are the fields a USER is most likely to change for themselves after provisioning.
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate
+        {
+            AudioLanguagePreference = "eng",
+            SubtitleMode = nameof(SubtitlePlaybackMode.Smart),
+        };
+        var created = Provisionable(users, "alice");
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+        Assert.Equal("eng", created.AudioLanguagePreference);
+
+        created.AudioLanguagePreference = "jpn";
+        created.SubtitleMode = SubtitlePlaybackMode.None;
+        var second = await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(Created, second);
+        Assert.Equal("jpn", created.AudioLanguagePreference);
+        Assert.Equal(SubtitlePlaybackMode.None, created.SubtitleMode);
+        await users.Received(1).CreateUserAsync("alice");
+    }
+
+    [Theory]
+    [InlineData("NotAMode")]
+    [InlineData("smart")]
+    [InlineData("")]
+    public async Task AnUnknownSubtitleMode_IsRefusedAtSaveAndWritesNothing(string mode)
+    {
+        // Both halves again, and the lowercase row is the one-character mistake somebody actually makes:
+        // the parse is deliberately case-SENSITIVE, so "smart" is refused rather than quietly accepted.
+        // The writer's skip is what a config file edited around the validator meets, and without it an
+        // unparsable name would land on the enum's zero value - a real mode the administrator never chose.
+        Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateProvisioningTemplate(
+            "OpenID",
+            "kc",
+            new ProvisioningPolicyTemplate { SubtitleMode = mode }));
+
+        var (service, config, users) = Build();
+        config.ProvisioningPolicyTemplate = new ProvisioningPolicyTemplate { SubtitleMode = mode };
+        var created = Provisionable(users, "alice");
+        created.SubtitleMode = SubtitlePlaybackMode.Always;
+
+        await service.ResolveOrCreateAsync(ProviderMode.Oid, "kc", "sub-1", "alice", allowExistingAccountLink: false);
+
+        Assert.Equal(SubtitlePlaybackMode.Always, created.SubtitleMode);
+    }
+
+    [Fact]
+    public void EverySubtitleModeJellyfinDefines_IsAccepted_AndTheRefusalNamesRealOnes()
+    {
+        // Derived from the enum rather than from a list written out here, so a mode Jellyfin adds is
+        // accepted the day it lands instead of being refused by a vocabulary that drifted.
+        foreach (var mode in Enum.GetValues<SubtitlePlaybackMode>())
+        {
+            ProviderConfigValidator.ValidateProvisioningTemplate(
+                "OpenID",
+                "kc",
+                new ProvisioningPolicyTemplate { SubtitleMode = mode.ToString() });
+        }
+
+        // The refusal message offers examples, and an example that does not parse would send an
+        // administrator round the loop a second time. Nothing else checks a string inside a message.
+        foreach (var example in new[] { "Default", "Always", "OnlyForced", "Smart" })
+        {
+            Assert.True(Enum.TryParse<SubtitlePlaybackMode>(example, out _), example);
+        }
+    }
+
+    [Fact]
+    public void ANullSubtitleMode_PassesValidation_BecauseUnsetIsHowAFieldIsDeclined()
+    {
+        ProviderConfigValidator.ValidateProvisioningTemplate(
+            "SAML",
+            "idp",
+            new ProvisioningPolicyTemplate { AudioLanguagePreference = "eng", SubtitleMode = null });
+    }
+
     // --- helpers ---
 
     private static (CanonicalLinkService Service, OidConfig Config, IUserManager Users) Build()

--- a/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
+++ b/SSO-Auth/Api/Authz/ProvisioningPolicy.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Jellyfin.Data;
 using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Config;
 
 namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
@@ -73,6 +74,50 @@ internal static class ProvisioningPolicy
         if (template.MaxActiveSessions is { } sessions)
         {
             user.MaxActiveSessions = sessions;
+            written++;
+        }
+
+        // The playback preferences (#1100). These are columns on the account itself, alongside the two
+        // numbers above, so they are written here on the same create arm rather than through a second
+        // persistence call - which also means they inherit "never re-applied" for free instead of needing
+        // their own guard. They grant nothing: no field below can widen an account's access.
+        if (template.AudioLanguagePreference is { } audioLanguage)
+        {
+            user.AudioLanguagePreference = audioLanguage;
+            written++;
+        }
+
+        if (template.SubtitleLanguagePreference is { } subtitleLanguage)
+        {
+            user.SubtitleLanguagePreference = subtitleLanguage;
+            written++;
+        }
+
+        // Parsed rather than cast, and skipped when it does not parse. Save-time validation already refuses
+        // an unknown name; this is the same second refusal the permission entries get above, for the same
+        // reason - a config file edited by hand around the validator still reaches this writer. Falling back
+        // to the enum's zero value would quietly set a mode nobody asked for.
+        if (Enum.TryParse<SubtitlePlaybackMode>(template.SubtitleMode, ignoreCase: false, out var subtitleMode))
+        {
+            user.SubtitleMode = subtitleMode;
+            written++;
+        }
+
+        if (template.PlayDefaultAudioTrack is { } playDefaultAudioTrack)
+        {
+            user.PlayDefaultAudioTrack = playDefaultAudioTrack;
+            written++;
+        }
+
+        if (template.RememberAudioSelections is { } rememberAudio)
+        {
+            user.RememberAudioSelections = rememberAudio;
+            written++;
+        }
+
+        if (template.RememberSubtitleSelections is { } rememberSubtitles)
+        {
+            user.RememberSubtitleSelections = rememberSubtitles;
             written++;
         }
 

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -866,6 +866,51 @@ public class ProvisioningPolicyTemplate
     /// it is distinct from unset; a negative value is rejected on save.
     /// </summary>
     public int? MaxActiveSessions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preferred audio language written onto a brand-new account (#1100), as the language
+    /// code Jellyfin itself stores (for example <c>eng</c>). Null leaves Jellyfin's own default alone.
+    /// </summary>
+    /// <remarks>
+    /// This and the five fields below it are playback preferences rather than permissions, so unlike the
+    /// permission entries above they grant nothing and can widen no account's access. The two language
+    /// fields are not validated against a language list: Jellyfin stores whatever code it is given, and a
+    /// plugin-side allow-list would drift against it and begin refusing languages Jellyfin accepts.
+    /// </remarks>
+    public string? AudioLanguagePreference { get; set; }
+
+    /// <summary>
+    /// Gets or sets the preferred subtitle language written onto a brand-new account (#1100), as the
+    /// language code Jellyfin itself stores. Null leaves Jellyfin's own default alone.
+    /// </summary>
+    public string? SubtitleLanguagePreference { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subtitle playback mode written onto a brand-new account (#1100), as the exact
+    /// <c>SubtitlePlaybackMode</c> enum name (for example <c>Smart</c>). Null leaves Jellyfin's own default
+    /// alone, and an unknown name is rejected on save rather than falling back to the enum's zero value,
+    /// which would silently be a mode the administrator did not ask for.
+    /// </summary>
+    public string? SubtitleMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the default audio track is played, written onto a brand-new
+    /// account (#1100). Null leaves Jellyfin's own default alone, which is why this is a nullable bool:
+    /// with a plain one an unset field is indistinguishable from a deliberate <see langword="false"/>.
+    /// </summary>
+    public bool? PlayDefaultAudioTrack { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether audio selections are remembered, written onto a brand-new
+    /// account (#1100). Null leaves Jellyfin's own default alone.
+    /// </summary>
+    public bool? RememberAudioSelections { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether subtitle selections are remembered, written onto a brand-new
+    /// account (#1100). Null leaves Jellyfin's own default alone.
+    /// </summary>
+    public bool? RememberSubtitleSelections { get; set; }
 }
 
 /// <summary>

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Jellyfin.Database.Implementations.Enums;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Api.Net;
@@ -405,6 +406,21 @@ internal static class ProviderConfigValidator
         {
             throw new ArgumentException(
                 $"{protocol} provider '{echoName}' has an invalid provisioning template: the maximum active sessions must be zero or greater (zero means unlimited; leave it unset to keep Jellyfin's default).",
+                nameof(template));
+        }
+
+        // The subtitle mode (#1100) is the one playback preference with a closed vocabulary, so it is the one
+        // that can be mis-set rather than merely unusual. Refused here rather than clamped: an unknown name
+        // that fell through would land on the enum's zero value, which is itself a real mode, so the
+        // administrator would get a setting they never chose and nothing would say so. The two language
+        // fields are deliberately NOT checked against a list - Jellyfin stores what it is given, and a
+        // plugin-side allow-list would drift against it and begin refusing codes Jellyfin accepts.
+        if (template.SubtitleMode != null
+            && !Enum.TryParse<SubtitlePlaybackMode>(template.SubtitleMode, ignoreCase: false, out _))
+        {
+            var echoMode = string.Concat(template.SubtitleMode.Where(c => !char.IsControl(c))).ReplaceLineEndings(string.Empty);
+            throw new ArgumentException(
+                $"{protocol} provider '{echoName}' has an invalid provisioning template: it names subtitle mode '{echoMode}', which is not a known Jellyfin SubtitlePlaybackMode. Use the exact enum name (for example Default, Always, OnlyForced, or Smart), or leave it unset to keep Jellyfin's default.",
                 nameof(template));
         }
     }


### PR DESCRIPTION
# What & why

The per-provider provisioning template from #1099 wrote permissions and two numeric ceilings onto a brand-new SSO account. It now also carries the language and playback block: preferred audio language, preferred subtitle language, subtitle mode, play-default-audio-track, and the two remember-selections switches.

One thing in the issue did not survive contact with the tree, and it made the change smaller. The issue expects these to be `UserConfiguration` fields written through `IUserManager.UpdateConfiguration`, and says they are their own step for that reason. All six are columns on the `User` entity in both target framework versions, so the writer assigns them directly, on the same create arm as the ceilings, and the existing caller persists. The compiler is the evidence: the assignments build clean on `net9.0` and `net10.0`. That also means the playback block inherits "written once, never re-applied" from the call site it shares, rather than needing a guard of its own.

Each field is opt-in and nullable, so unset leaves Jellyfin's own default alone. The three booleans are nullable bools deliberately: with a plain `bool` an unset field is indistinguishable from a deliberate `false`, and a template that clears a switch has to make it stick.

Subtitle mode is the one field with a closed vocabulary, so it is the one that can be mis-set rather than merely unusual. It is refused twice, the shape the permission entries already use. Once at save, naming the modes Jellyfin accepts, and again at write time, because a config file edited by hand around the validator still reaches the writer. The parse is case-sensitive, so `smart` is refused rather than quietly accepted. Without the second refusal an unparsable name would land on the enum's zero value, which is itself a real mode, so an account would end up somewhere nobody chose and nothing would say so.

The two language fields are deliberately not validated against a list. Jellyfin stores what it is given, and a plugin-side allow-list would drift against it and begin refusing codes Jellyfin accepts.

Closes #1100

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

This touches config persistence, so the section is filled in.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The fail-closed box is ticked for the sense that applies here. There is no signature or audience on this route, and the analogous decision is what an unrecognised subtitle mode does: it is refused at save and skipped at write rather than defaulting to the enum's zero value.

Review record, CONFIRMED 0 / PLAUSIBLE 0.

Privilege, PASS. The central question for anything writing onto an account is whether it can widen access. No field in this block is a permission: all six are playback preferences. The permission path is untouched, and the existing rows that bar `IsAdministrator` and `IsDisabled` from a template still pass.

Fail-closed, PASS, and proven by removal rather than by reading. Both new guards were deleted in turn and the suite went red each time, then restored:

- delete the save-time refusal, and the three `AnUnknownSubtitleMode_IsRefusedAtSaveAndWritesNothing` rows fail
- delete the writer's parse skip so an unparsable name falls back to the zero value, and those three fail together with `AnUnsetPlaybackField_IsLeftAtJellyfinsOwnDefault`

The tree carries no trace of either edit; `git grep FALSIFIER` over `SSO-Auth/` returns nothing.

Log injection, PASS. The one new string that can reach a message is the rejected subtitle mode, and it is control-stripped inline at the throw with `string.Concat(... where !char.IsControl ...).ReplaceLineEndings(string.Empty)`, the same treatment the neighbouring permission-name rejection gives its echo. Nothing here is logged, and no value on this route comes from an identity provider: a template is administrator-supplied configuration.

Persistence, PASS. No new secret-bearing field, so `WriteOnlySecretConverter` and the config-export redaction are unaffected. No package was added and neither `packages.lock.json` moved.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The tests go into the existing `ProvisioningPolicyTemplateTests` rather than a new file, so they reuse its `Build` and `Provisionable` helpers instead of copying them. It is the same mechanism under test. No new module or folder is introduced, so the module DAG is unchanged and needed no new `[InlineData]` row; the conformance suite runs as part of the full suite below.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

All at the head commit of this branch, on both target frameworks, since the repo builds two:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
0 warnings, 0 errors
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
0 warnings, 0 errors

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
Total: 3144, Errors: 0, Failed: 0, Skipped: 4
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
Total: 3145, Errors: 0, Failed: 0, Skipped: 4
```

`--warnaserror` is on the test-project build because that is where the analyzers are promoted; `dotnet test` alone does not promote them.

The four skips are pre-existing and unrelated to this change. They bind a listener off loopback, which raises a Windows firewall consent dialog that needs an administrator (#1227), and the suite skips them and says so. They were not worked around.

Prettier: `CHANGELOG.md` is the only file this change touches that Prettier reads, and `npx prettier --check CHANGELOG.md` passes. The repo-wide glob reports pre-existing failures in other files on this machine, and it reports one MORE of them against untouched `main` than against this branch, so nothing here added one.

What the new rows pin, beyond the issue's Done-when:

- every value `SubtitlePlaybackMode` defines is accepted, derived from `Enum.GetValues` rather than from a list written into the test, so a mode Jellyfin adds is accepted the day it lands instead of meeting a vocabulary that drifted
- the example mode names offered inside the rejection message are asserted to parse, because nothing else checks a string inside a message and an example that did not parse would send an administrator round the loop twice
- `false` is written rather than treated as unset, which is the bool twin of the existing zero-ceiling row

## Notes

The dashboard provider forms do not carry these fields. That is not a gap this change opens: the #1099 template is not on those forms either, and its changelog entry says so. Surfacing the whole template, both halves at once, is filed as its own issue rather than half-built here, because adding a UI for the playback block alone would put six fields on the page while the permissions and ceilings beside them stayed invisible. The issue is linked from this pull request.

One correction to the issue body rather than to the code: its premise that these fields need `IUserManager.UpdateConfiguration` does not hold against this tree, for the reason measured at the top. Nothing was changed in the issue.

No second reader looked at any of this.
