### PR TITLE
Give a guest or trial group a fixed access duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   rather than checked against a list, so any code Jellyfin accepts works. As with
   the rest of the template, these are set in the plugin configuration and the
   provider forms in the dashboard do not carry them yet.
+- **A guest or trial group can carry a fixed access duration (#1146).** A
+  provider can map identity-provider roles to a length of access in hours, and
+  an account created by a login holding one of those roles is given a deadline
+  of that moment plus the mapped duration. It is the second way into the expiry
+  machinery: the claim below is the provider naming a date, this one is you
+  naming a length, which is what a guest or trial group usually needs. The
+  deadline is stamped once, when the account is created, and a later login by
+  the same account leaves it exactly where it is, so a trial does not quietly
+  become unlimited access for anyone who keeps signing in. A login holding two
+  mapped roles takes the shorter of the two. Where a login carries both a mapped
+  role and an expiry claim, the claim wins, because the provider is the
+  authority on a date it emitted. Only a newly created account is given a
+  deadline: an SSO login that takes over an existing Jellyfin account is not,
+  and losing the role later neither extends nor clears a deadline already
+  recorded. Nothing changes for a provider that maps no role, which is every
+  provider by default. A duration of zero or less is refused when you save, as
+  is one longer than a century, and so is a mapping that lists no roles. The
+  mappings are set in the plugin configuration; the provider forms in the
+  dashboard do not carry them yet.
 - **Account expiry now ends access on the deadline rather than at the next
   login (#1145).** The instant a login carries is persisted against that
   account's SSO link, and an hourly background pass disables any linked account

--- a/SSO-Auth.Tests/Authz/GuestAccessDurationPolicyTests.cs
+++ b/SSO-Auth.Tests/Authz/GuestAccessDurationPolicyTests.cs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Api.Authz;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="GuestAccessDurationPolicy"/> - the role → fixed access duration reducer (#1146).
+/// Fail closed toward the SHORTER outcome: when several mappings match, the smallest duration wins, so a
+/// user who happens to hold a second, looser group never has their deadline pushed out by it.
+/// <para>
+/// The skip rows are the ones worth reading twice. Every one of them is a value the save-time validator
+/// refuses, so the only way it reaches here is a config XML edited by hand - and the answer to all of them
+/// is to map NOTHING rather than to throw, because throwing on this path would turn a bad line in a config
+/// file into a failed login for a provider that is otherwise fine.
+/// </para>
+/// </summary>
+public class GuestAccessDurationPolicyTests
+{
+    private static OidConfig Config(params GuestAccessDurationRoleMap[] maps) => new OidConfig
+    {
+        GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap>(maps),
+    };
+
+    private static GuestAccessDurationRoleMap Map(int hours, params string[] roles)
+        => new GuestAccessDurationRoleMap { DurationHours = hours, Roles = roles };
+
+    [Fact]
+    public void Resolve_NoMappingsConfigured_ReturnsNull()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, new OidConfig()));
+
+    [Fact]
+    public void Resolve_EmptyMappingList_ReturnsNull()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config()));
+
+    [Fact]
+    public void Resolve_NoRoleMatches_ReturnsNull()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "staff" }, Config(Map(24, "guest"))));
+
+    [Fact]
+    public void Resolve_NoRolesAtAll_ReturnsNull()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(Array.Empty<string>(), Config(Map(24, "guest"))));
+
+    [Fact]
+    public void Resolve_SingleMatch_ReturnsItsDuration()
+        => Assert.Equal(TimeSpan.FromHours(24), GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(24, "guest"))));
+
+    [Fact]
+    public void Resolve_TwoMappedRoles_TakesTheShorter()
+    {
+        // The parent's rule that expiry disables and never silently extends (#832), at the resolver. A user
+        // in both "trial" and "guest" gets the trial's day, not the guest's month.
+        var resolved = GuestAccessDurationPolicy.Resolve(new[] { "guest", "trial" }, Config(Map(720, "guest"), Map(24, "trial")));
+
+        Assert.Equal(TimeSpan.FromHours(24), resolved);
+    }
+
+    [Fact]
+    public void Resolve_TwoMappedRoles_TakesTheShorter_EvenWhenTheLongerComesSecond()
+    {
+        // The same claim with the entries swapped. Without both rows a min() written as a max() passes one
+        // of them, which is exactly the one-character mistake this pair exists to catch.
+        var resolved = GuestAccessDurationPolicy.Resolve(new[] { "guest", "trial" }, Config(Map(24, "trial"), Map(720, "guest")));
+
+        Assert.Equal(TimeSpan.FromHours(24), resolved);
+    }
+
+    [Fact]
+    public void Resolve_OneRoleListedOnSeveralMappings_TakesTheShortest()
+        => Assert.Equal(TimeSpan.FromHours(6), GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(48, "guest"), Map(6, "guest"), Map(72, "guest"))));
+
+    [Fact]
+    public void Resolve_ZeroDuration_IsSkipped_NotTreatedAsAnInstantExpiry()
+    {
+        // A zero-hour mapping would resolve to a deadline equal to the provisioning instant, which the sweep
+        // reads as already expired: the account would be created and disabled minutes later with no
+        // explanation. It is refused on save and skipped here, so the user gets no deadline instead.
+        Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(0, "guest"))));
+    }
+
+    [Fact]
+    public void Resolve_NegativeDuration_IsSkipped_NeverAPastDeadline()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(-1, "guest"))));
+
+    [Fact]
+    public void Resolve_DurationAboveTheGuard_IsSkipped()
+    {
+        // The overflow near-miss. int.MaxValue hours added to the provisioning instant leaves DateTime's
+        // range and AddHours THROWS, so an unbounded value hand-written into the config XML would turn every
+        // provisioning login for the provider into a 500. Skipping is what keeps that a no-deadline account.
+        Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(int.MaxValue, "guest"))));
+    }
+
+    [Fact]
+    public void Resolve_TheGuardBoundaryItself_IsAccepted()
+        => Assert.Equal(
+            TimeSpan.FromHours(GuestAccessDurationRoleMap.MaxDurationHours),
+            GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(GuestAccessDurationRoleMap.MaxDurationHours, "guest"))));
+
+    [Fact]
+    public void Resolve_AnOutOfRangeEntry_DoesNotSuppressAValidOne()
+        => Assert.Equal(TimeSpan.FromHours(12), GuestAccessDurationPolicy.Resolve(new[] { "guest", "trial" }, Config(Map(0, "guest"), Map(12, "trial"))));
+
+    [Fact]
+    public void Resolve_NullEntry_IsSkipped_OtherMatchesStillApply()
+        => Assert.Equal(TimeSpan.FromHours(8), GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(null!, Map(8, "guest"))));
+
+    [Fact]
+    public void Resolve_MappingWithNoRoles_NeverMatches()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(new GuestAccessDurationRoleMap { DurationHours = 8, Roles = null })));
+
+    [Fact]
+    public void Resolve_MappingWithAnEmptyRoleList_NeverMatches()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(8))));
+
+    [Fact]
+    public void Resolve_BlankRoleEntry_IsSkipped_AndDoesNotMatchABlankLoginRole()
+        => Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "   " }, Config(Map(8, "   "))));
+
+    [Fact]
+    public void Resolve_ConfiguredRoleIsTrimmed_BeforeMatching()
+        => Assert.Equal(TimeSpan.FromHours(8), GuestAccessDurationPolicy.Resolve(new[] { "guest" }, Config(Map(8, "  guest  "))));
+
+    [Fact]
+    public void Resolve_RoleMatchingIsCaseSensitive()
+    {
+        // Ordinal, exactly like every other role policy in the tree. Recorded so a later change to one
+        // matcher cannot quietly leave this one on a different rule.
+        Assert.Null(GuestAccessDurationPolicy.Resolve(new[] { "Guest" }, Config(Map(8, "guest"))));
+    }
+
+    [Fact]
+    public void Resolve_ReadsTheSamlProviderShapeToo()
+        => Assert.Equal(
+            TimeSpan.FromHours(24),
+            GuestAccessDurationPolicy.Resolve(
+                new[] { "guest" },
+                new SamlConfig { GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap> { Map(24, "guest") } }));
+}

--- a/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
+++ b/SSO-Auth.Tests/Config/ConfigXmlLifecycleTests.cs
@@ -278,6 +278,51 @@ public class ConfigXmlLifecycleTests
         }
     }
 
+    [Fact]
+    public void GuestAccessDurationMappings_SurviveTheDiskCycle_AndStayVisibleToTheAdminSurface()
+    {
+        // Two properties of the #1146 mapping, both of which fail SILENTLY if they are wrong, which is why
+        // they are pinned rather than read off the attributes.
+        //
+        // The first is that a populated mapping list survives the disk cycle at all, nested inside a
+        // provider inside the configuration document, rather than coming back null or empty.
+        //
+        // WHAT THIS DOES NOT COVER, measured rather than assumed: renaming the XmlArrayItem element does not
+        // redden it. Both halves of a round-trip read the same attribute, so a rename is self-consistent
+        // here and only breaks against a document written by an EARLIER build. That risk is nil while the
+        // element has never shipped, and it is the reason the comment on the neighbouring dictionary calls
+        // its element name load-bearing; nothing in this file can stand in for that.
+        //
+        // The second is the config-page save. The admin page rebuilds a provider from the object it fetched
+        // and overwrites only the fields it knows, so a field it does not know survives a save - but only
+        // while the server actually serializes it out. A [JsonIgnore] added here by analogy with the
+        // server-managed maps beside it would make the page fetch a provider without the mappings and post
+        // that back, erasing them on the next unrelated settings change.
+        var original = new PluginConfiguration();
+        original.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known/openid-configuration",
+            GuestAccessDurationRoleMappings = new System.Collections.Generic.List<GuestAccessDurationRoleMap>
+            {
+                new GuestAccessDurationRoleMap { DurationHours = 24, Roles = new[] { "trial" } },
+                new GuestAccessDurationRoleMap { DurationHours = 720, Roles = new[] { "guest", "visitor" } },
+            },
+        };
+
+        var back = RoundTripXml(original);
+
+        var mappings = back.OidConfigs["kc"].GuestAccessDurationRoleMappings;
+        Assert.NotNull(mappings);
+        Assert.Equal(2, mappings!.Count);
+        Assert.Equal(24, mappings[0].DurationHours);
+        Assert.Equal(new[] { "trial" }, mappings[0].Roles);
+        Assert.Equal(720, mappings[1].DurationHours);
+        Assert.Equal(new[] { "guest", "visitor" }, mappings[1].Roles);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(original.OidConfigs["kc"]);
+        Assert.Contains("GuestAccessDurationRoleMappings", json, StringComparison.Ordinal);
+    }
+
     private static string Serialize<T>(T value)
     {
         var serializer = new XmlSerializer(typeof(T));

--- a/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
+++ b/SSO-Auth.Tests/Config/ProviderConfigValidatorTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using Jellyfin.Plugin.SSO_Auth.Config;
 using Xunit;
@@ -78,6 +79,86 @@ public class ProviderConfigValidatorTests
             ProviderConfigValidator.ValidateParentalRatingMappings("OpenID", "kc", new ParentalRatingRoleMap[] { null! }); // a null entry is tolerated
             ProviderConfigValidator.ValidateParentalRatingMappings("OpenID", "kc", null); // no mappings at all
         }));
+    }
+
+    // --- ValidateGuestAccessDurations (#1146): reject a non-positive or overflowing duration, or no roles ---
+
+    [Theory]
+    [InlineData(0)] // would be a deadline equal to the provisioning instant: created, then swept away
+    [InlineData(-1)] // would be a deadline already in the past
+    public void ValidateGuestAccessDurations_NonPositiveDuration_Throws(int hours)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateGuestAccessDurations(
+            "OpenID", "kc", new[] { new GuestAccessDurationRoleMap { DurationHours = hours, Roles = new[] { "guest" } } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("kc", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("greater than zero", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateGuestAccessDurations_DurationBeyondTheGuard_Throws()
+    {
+        // The overflow near-miss at the save door. Adding int.MaxValue hours to the provisioning instant
+        // leaves DateTime's range and AddHours throws, so refusing it here is what keeps a mis-typed field
+        // from becoming a failed login rather than a very distant deadline.
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateGuestAccessDurations(
+            "OpenID", "kc", new[] { new GuestAccessDurationRoleMap { DurationHours = int.MaxValue, Roles = new[] { "guest" } } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("maximum", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateGuestAccessDurations_NullRoles_Throws()
+        => AssertDurationNoRolesRejected(null);
+
+    [Fact]
+    public void ValidateGuestAccessDurations_EmptyRoles_Throws()
+        => AssertDurationNoRolesRejected(Array.Empty<string>());
+
+    private static void AssertDurationNoRolesRejected(string[]? roles)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => ProviderConfigValidator.ValidateGuestAccessDurations(
+            "SAML", "idp", new[] { new GuestAccessDurationRoleMap { DurationHours = 24, Roles = roles! } }));
+
+        Assert.Equal("mappings", ex.ParamName);
+        Assert.Contains("no roles", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ValidateGuestAccessDurations_ValidOrNullOrEmpty_DoesNotThrow()
+    {
+        Assert.Null(Record.Exception(() =>
+        {
+            ProviderConfigValidator.ValidateGuestAccessDurations("OpenID", "kc", new[] { new GuestAccessDurationRoleMap { DurationHours = 1, Roles = new[] { "guest" } } });
+            ProviderConfigValidator.ValidateGuestAccessDurations("OpenID", "kc", new[] { new GuestAccessDurationRoleMap { DurationHours = GuestAccessDurationRoleMap.MaxDurationHours, Roles = new[] { "guest" } } }); // the boundary itself is allowed
+            ProviderConfigValidator.ValidateGuestAccessDurations("OpenID", "kc", new GuestAccessDurationRoleMap[] { null! }); // a null entry is tolerated
+            ProviderConfigValidator.ValidateGuestAccessDurations("OpenID", "kc", null); // no mappings at all
+        }));
+    }
+
+    [Fact]
+    public void Validate_WholeConfig_RejectsAnInvalidDurationOnEitherProtocol()
+    {
+        // The composition row: the per-provider check above is only load-bearing if the config-page save
+        // actually calls it, on both maps. Without this a bad mapping is refused at the Add endpoints and
+        // waved through by the save path that most administrators use.
+        var oidc = new PluginConfiguration();
+        oidc.OidConfigs["kc"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known",
+            GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap> { new GuestAccessDurationRoleMap { DurationHours = 0, Roles = new[] { "guest" } } },
+        };
+        Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(oidc, new PluginConfiguration()));
+
+        var saml = new PluginConfiguration();
+        saml.SamlConfigs["idp"] = new SamlConfig
+        {
+            SamlEndpoint = "https://idp/saml",
+            GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap> { new GuestAccessDurationRoleMap { DurationHours = 0, Roles = new[] { "guest" } } },
+        };
+        Assert.Throws<ArgumentException>(() => ProviderConfigValidator.Validate(saml, new PluginConfiguration()));
     }
 
     // --- ValidateProviderName (#336, #360): reject a NEW round-trip-breaking name; exempt existing names ---

--- a/SSO-Auth.Tests/Linking/GuestAccessDurationProvisioningTests.cs
+++ b/SSO-Auth.Tests/Linking/GuestAccessDurationProvisioningTests.cs
@@ -1,0 +1,291 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Data;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The provisioning half of guest/trial access (#1146): a role-mapped duration becomes a deadline on the
+/// canonical link, stamped ONCE, at the moment the account is created, and never again.
+/// <para>
+/// The stamped-once rule carries the whole feature. A deadline re-anchored on every login would move forward
+/// faster than it is reached for anyone who keeps using their account, so a "24-hour trial" would in practice
+/// be unlimited access for exactly the users a time limit exists to bound - and nothing would look wrong:
+/// the account stays enabled, the map stays populated, and the sweep simply never finds a due entry.
+/// <see cref="ASecondLoginDaysLater_LeavesTheRecordedDeadlineExactlyWhereItWas"/> is the row that refuses it.
+/// </para>
+/// <para>
+/// Enforcement is deliberately absent from this file. The deadline this writes is read by the between-logins
+/// sweep (#1145) and by the login-time gate (#1144), both already covered by their own suites; what is new
+/// here is only where the instant comes from.
+/// </para>
+/// </summary>
+public class GuestAccessDurationProvisioningTests
+{
+    private const string Subject = "sub-guest";
+    private static readonly Guid Provisioned = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid Existing = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    // A fixed anchor, so the assertion is an equality against a computed instant rather than a tolerance
+    // around the wall clock. A test that asserted "roughly now plus a day" would pass a stamp anchored to
+    // the wrong moment by seconds, which is the sort of drift a clock injection exists to make visible.
+    private static readonly DateTime Anchor = new(2026, 3, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AFirstLoginHoldingAMappedRole_ProvisionsWithADeadlineOfNowPlusTheDuration()
+    {
+        var config = GuestProvider(Map(24, "guest"));
+        var harness = Provisioning(config);
+
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24)));
+
+        Assert.Equal(Anchor.AddHours(24), config.CanonicalLinkDeadlines[Subject]);
+    }
+
+    [Fact]
+    public async Task ASecondLoginDaysLater_LeavesTheRecordedDeadlineExactlyWhereItWas()
+    {
+        // The sliding-window defect, pinned. The second login resolves the link the first one wrote, so it
+        // never reaches the stamp - if it did, the deadline would be five days later than the trial allows
+        // and would keep moving for as long as the user kept coming back.
+        var config = GuestProvider(Map(24, "guest"));
+        var harness = Provisioning(config);
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24)));
+        var stamped = config.CanonicalLinkDeadlines[Subject];
+
+        harness.Now = Anchor.AddDays(5);
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24)));
+
+        Assert.Equal(stamped, config.CanonicalLinkDeadlines[Subject]);
+        Assert.Equal(Anchor.AddHours(24), config.CanonicalLinkDeadlines[Subject]);
+    }
+
+    [Fact]
+    public async Task ALoginHoldingTwoMappedRoles_TakesTheShorterDuration()
+    {
+        var config = GuestProvider(Map(720, "guest"), Map(24, "trial"));
+        var harness = Provisioning(config);
+
+        // The duration the protocol layer resolves for these roles, resolved through the real policy rather
+        // than hand-picked, so this row would also go red if the reducer stopped preferring the shorter one.
+        var resolved = Jellyfin.Plugin.SSO_Auth.Api.Authz.GuestAccessDurationPolicy.Resolve(new[] { "guest", "trial" }, config);
+        await harness.Login(Identity(config, resolved));
+
+        Assert.Equal(Anchor.AddHours(24), config.CanonicalLinkDeadlines[Subject]);
+    }
+
+    [Fact]
+    public async Task ALoginCarryingBothAMappedRoleAndAnAbsoluteClaim_TakesTheClaimsInstant()
+    {
+        // The identity provider is the authority on a date it emitted, so the absolute source wins. Written
+        // as a single test rather than two because what matters is that ONE of the two instants lands: a
+        // change that let both write would leave the outcome depending on which ran last.
+        var claimInstant = new DateTime(2027, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var config = GuestProvider(Map(24, "guest"));
+        config.AccountExpiryClaim = "access_expires";
+        var harness = Provisioning(config);
+
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24), expiresAtUtc: claimInstant));
+
+        Assert.Equal(claimInstant, config.CanonicalLinkDeadlines[Subject]);
+        Assert.NotEqual(Anchor.AddHours(24), config.CanonicalLinkDeadlines[Subject]);
+    }
+
+    [Fact]
+    public async Task AnAlreadyExpiredClaimOnAProvisioningLogin_LeavesNoFutureDeadlineBehind()
+    {
+        // The row above passes for the wrong reason on its own, and this is the one that pins the rule.
+        // Where the claim resolves a FUTURE instant, the enforcement gate overwrites whatever the group
+        // stamped, so the outcome is right whether or not the sources are ordered - measured by deleting the
+        // condition and watching that row stay green.
+        //
+        // A PAST instant separates them. The gate disables the account and records nothing, so a group
+        // duration allowed through would be the only writer, and the just-expired account would be left
+        // holding a deadline a day into the future: an account the plugin refused would look, to the sweep
+        // and to anyone reading the config, like one with access until tomorrow.
+        var config = GuestProvider(Map(24, "guest"));
+        config.AccountExpiryClaim = "access_expires";
+        var harness = Provisioning(config);
+
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24), expiresAtUtc: Anchor.AddDays(-1)));
+
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public async Task AProviderWithNoDurationMappings_ProvisionsWithNoDeadlineAtAll()
+    {
+        // The no-change row. Every existing deployment is this one, and a deadline appearing here would be a
+        // time limit nobody configured, on an account that should keep working forever.
+        var config = new OidConfig { Enabled = true, OidEndpoint = "https://idp/.well-known" };
+        var harness = Provisioning(config);
+
+        await harness.Login(Identity(config, duration: null));
+
+        Assert.Equal(Provisioned, config.CanonicalLinks[Subject]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public async Task ALoginHoldingNoMappedRole_ProvisionsWithNoDeadline()
+    {
+        var config = GuestProvider(Map(24, "guest"));
+        var harness = Provisioning(config);
+
+        await harness.Login(Identity(config, Jellyfin.Plugin.SSO_Auth.Api.Authz.GuestAccessDurationPolicy.Resolve(new[] { "staff" }, config)));
+
+        Assert.Equal(Provisioned, config.CanonicalLinks[Subject]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public async Task AnADOPTEDAccountIsNotGivenALifetime()
+    {
+        // Adoption takes over an account that already existed with its own history; it is not a provisioning
+        // event, and stamping there would put an expiry on somebody's established account because their IdP
+        // happened to list them in a guest group. The duration is passed exactly as on the create arm, so
+        // this row goes red the moment the stamp is moved up to cover both.
+        var config = GuestProvider(Map(24, "guest"));
+        config.AllowExistingAccountLink = true;
+        var harness = Provisioning(config, adoptable: TestUsers.Named("alice", Existing));
+
+        await harness.Login(Identity(config, duration: TimeSpan.FromHours(24)));
+
+        Assert.Equal(Existing, config.CanonicalLinks[Subject]);
+        Assert.Empty(config.CanonicalLinkDeadlines);
+    }
+
+    [Fact]
+    public async Task TheSamlPathStampsIdentically()
+    {
+        // Both protocols funnel through the one completion tail and the one create arm, so the stamp is
+        // written once rather than per protocol. This row is what would go red if it were ever moved up into
+        // the OpenID flow service, where SAML would silently stop being covered.
+        var config = new SamlConfig
+        {
+            Enabled = true,
+            SamlEndpoint = "https://idp/saml",
+            GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap> { Map(24, "guest") },
+        };
+        var harness = Provisioning(configuration => configuration.SamlConfigs["idp"] = config, adoptable: null);
+
+        var identity = TestIdentities.Saml(
+            "idp",
+            Subject,
+            new SamlAuthorizeStateBuilder.SamlAuthorizeState(
+                Admin: false,
+                EnableLiveTv: false,
+                EnableLiveTvManagement: false,
+                Folders: new List<string>(),
+                GuestAccessDuration: TimeSpan.FromHours(24)));
+        await harness.Login(identity, config);
+
+        Assert.Equal(Anchor.AddHours(24), config.CanonicalLinkDeadlines[Subject]);
+    }
+
+    private static GuestAccessDurationRoleMap Map(int hours, params string[] roles)
+        => new GuestAccessDurationRoleMap { DurationHours = hours, Roles = roles };
+
+    private static OidConfig GuestProvider(params GuestAccessDurationRoleMap[] maps) => new OidConfig
+    {
+        Enabled = true,
+        OidEndpoint = "https://idp/.well-known",
+        GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap>(maps),
+    };
+
+    private static VerifiedIdentity Identity(ProviderConfigBase config, TimeSpan? duration, DateTime? expiresAtUtc = null)
+        => TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: Subject,
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null,
+            ExpiresAtUtc: expiresAtUtc,
+            GuestAccessDuration: duration));
+
+    private static Harness Provisioning(OidConfig config, User? adoptable = null)
+        => Provisioning(configuration => configuration.OidConfigs["kc"] = config, adoptable, config);
+
+    private static Harness Provisioning(Action<PluginConfiguration> register, User? adoptable)
+        => Provisioning(register, adoptable, null);
+
+    // One completion path over a real ProviderConfigStore and a real CanonicalLinkService, with only the
+    // Jellyfin host substituted. The clock is injected because the assertion is an exact instant: with the
+    // wall clock the anchor could only be checked to a tolerance, and a stamp taken at the wrong moment - at
+    // the callback rather than at the link write - would sit inside any tolerance loose enough to be stable.
+    private static Harness Provisioning(Action<PluginConfiguration> register, User? adoptable, ProviderConfigBase? defaultConfig)
+    {
+        var configuration = new PluginConfiguration();
+        register(configuration);
+
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var harness = new Harness { Now = Anchor };
+
+        users.GetUserByName("alice").Returns(adoptable);
+        users.GetUserByName(Subject).Returns(adoptable);
+        var created = TestUsers.Named("alice", Provisioned);
+        users.CreateUserAsync(Arg.Any<string>()).Returns(created);
+        users.GetUserById(Provisioned).Returns(created);
+        if (adoptable is not null)
+        {
+            users.GetUserById(Existing).Returns(adoptable);
+        }
+
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger(), clock: () => harness.Now);
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+
+        harness.Service = new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, new CapturingLogger());
+        harness.DefaultConfig = defaultConfig;
+        return harness;
+    }
+
+    private sealed class Harness
+    {
+        internal LoginCompletionService Service { get; set; } = null!;
+
+        internal ProviderConfigBase? DefaultConfig { get; set; }
+
+        internal DateTime Now { get; set; }
+
+        internal Task Login(VerifiedIdentity identity, ProviderConfigBase? config = null)
+            => Service.CompleteAsync(
+                identity,
+                new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" },
+                config ?? DefaultConfig!,
+                AdoptionGate.None,
+                () => "203.0.113.9");
+    }
+}

--- a/SSO-Auth.Tests/_Support/TestIdentities.cs
+++ b/SSO-Auth.Tests/_Support/TestIdentities.cs
@@ -35,6 +35,7 @@ internal static class TestIdentities
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
             ExpiresAtUtc = derived.ExpiresAtUtc,
+            GuestAccessDuration = derived.GuestAccessDuration,
         });
 
     internal static VerifiedIdentity Saml(string provider, string nameId, SamlAuthorizeStateBuilder.SamlAuthorizeState privileges, DateTime? expiresAtUtc = null) =>
@@ -53,5 +54,6 @@ internal static class TestIdentities
             PermissionGrants = privileges.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = privileges.MaxParentalRatingScore,
             ExpiresAtUtc = expiresAtUtc,
+            GuestAccessDuration = privileges.GuestAccessDuration,
         });
 }

--- a/SSO-Auth/Api/Authz/GuestAccessDurationPolicy.cs
+++ b/SSO-Auth/Api/Authz/GuestAccessDurationPolicy.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Jellyfin.Plugin.SSO_Auth.Config;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Authz;
+
+/// <summary>
+/// Reduces a login's roles to a fixed access duration (#1146), the relative counterpart of the absolute
+/// expiry claim read by <c>AccountExpiryInstant</c>. Each configured mapping whose roles the login holds
+/// contributes its duration, and the MOST RESTRICTIVE (shortest) wins - never the longest. A login that
+/// matches no mapping yields null, so nothing is stamped and the account has no deadline at all.
+/// </summary>
+/// <remarks>
+/// It returns a DURATION rather than an instant on purpose: the deadline is anchored to the moment the
+/// account is actually provisioned, which this pure function has no business knowing and which is decided
+/// one layer down, inside the same locked transaction that writes the link. Resolving an instant here would
+/// anchor it to whenever the protocol layer happened to run instead.
+/// <para>
+/// The roles are the ones the login already produced - the same values <see cref="PermissionRolePolicy"/>
+/// and <see cref="ParentalRatingPolicy"/> are handed - so no second role read is added to either protocol,
+/// and a role claim the extractor refused (#216) reaches here as an empty set and maps nothing.
+/// </para>
+/// </remarks>
+internal static class GuestAccessDurationPolicy
+{
+    /// <summary>
+    /// The access duration the login's roles resolve to, or null when no mapping is configured or none
+    /// matched (provision with no deadline).
+    /// </summary>
+    /// <param name="roles">The login's role values.</param>
+    /// <param name="config">The provider configuration carrying the mappings.</param>
+    /// <returns>The shortest matched duration, or null when nothing applies.</returns>
+    internal static TimeSpan? Resolve(IEnumerable<string> roles, ProviderConfigBase config)
+    {
+        // No mappings configured (the default): this provider grants no time-limited access, so a
+        // provisioning login stamps nothing and behaves byte-for-byte as it did before #1146. There is
+        // deliberately NO master switch beside the map - an empty map already means off, and a second
+        // switch would be a second place for the feature to be silently half-enabled from.
+        if (config.GuestAccessDurationRoleMappings is null)
+        {
+            return null;
+        }
+
+        var loginRoles = roles as IReadOnlyCollection<string> ?? new List<string>(roles);
+
+        TimeSpan? shortest = null;
+        foreach (var mapping in config.GuestAccessDurationRoleMappings)
+        {
+            // A null entry, a non-positive duration, or one beyond the guard contributes nothing. All three
+            // are rejected at config-save validation; at runtime they are SKIPPED rather than thrown on, so
+            // a single bad entry hand-written into the config XML cannot 500 a login - and the out-of-range
+            // skip is what keeps DateTime.AddHours below from throwing at the stamp.
+            if (mapping is null
+                || mapping.DurationHours <= 0
+                || mapping.DurationHours > GuestAccessDurationRoleMap.MaxDurationHours
+                || !MatchesAnyRole(mapping.Roles, loginRoles))
+            {
+                continue;
+            }
+
+            // Shortest-wins: a login holding both a "trial" and a "guest" role ends up on the stricter of
+            // the two rather than having the looser one extend it. Consistent with the parent's rule that
+            // expiry disables and never silently extends (#832).
+            var candidate = TimeSpan.FromHours(mapping.DurationHours);
+            shortest = shortest is { } current && current <= candidate ? current : candidate;
+        }
+
+        return shortest;
+    }
+
+    // A login holding any of the mapping's roles matches. The configured role is trimmed and compared
+    // ordinally to the (verbatim) login roles, null-safe - the same matching every other role policy uses.
+    private static bool MatchesAnyRole(string[]? mappingRoles, IReadOnlyCollection<string> loginRoles)
+    {
+        if (mappingRoles is null)
+        {
+            return false;
+        }
+
+        foreach (var role in mappingRoles)
+        {
+            var trimmed = role?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                continue;
+            }
+
+            foreach (var loginRole in loginRoles)
+            {
+                if (string.Equals(loginRole, trimmed, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -98,7 +98,14 @@ internal sealed class LoginCompletionService
                 config.AllowExistingAccountLink,
                 adoptionGate,
                 identity.Issuer,
-                config.ProvisionNewUsersDisabled).ConfigureAwait(false);
+                config.ProvisionNewUsersDisabled,
+                // The role-mapped access duration (#1146), handed down so the create arm can anchor a
+                // deadline to the exact moment it writes the link. THE RESOLUTION ORDER IS STATED HERE, once
+                // and in one expression: an absolute instant the identity provider emitted (#1143) wins, so
+                // the relative source is passed only when the login carried none. Passing both and letting a
+                // later write overwrite the earlier one would put the same rule in two places and make the
+                // outcome depend on their order.
+                identity.ExpiresAtUtc is null ? identity.GuestAccessDuration : null).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -688,6 +688,10 @@ public class SSOController : ControllerBase
         // Reject an invalid parental-rating mapping (#736) at the door too (negative score / no roles), like
         // the permission-role guard above - the Add endpoints bypass the config-page save-time validation.
         ProviderConfigValidator.ValidateParentalRatingMappings(OpenIdProtocol, provider, config.ParentalRatingRoleMappings);
+        // And an invalid access-duration mapping (#1146), for the same reason: a non-positive or out-of-range
+        // duration reaching the login path would silently stamp nothing, so it is refused at every write door
+        // rather than only at the config page.
+        ProviderConfigValidator.ValidateGuestAccessDurations(OpenIdProtocol, provider, config.GuestAccessDurationRoleMappings);
         // Reject RequireAcr with no acr_values at the door too (#757): an empty allow-list would refuse every
         // login for the provider (a silent single-provider lockout). Mirrors the config-page/import validation
         // so this Add path - which persists through MutateConfiguration and bypasses the save-time Validate -
@@ -1175,6 +1179,7 @@ public class SSOController : ControllerBase
         // Reject a malformed generic permission-role mapping (#164) at the door, as OidAdd does.
         ProviderConfigValidator.ValidatePermissionRoleMappings(SamlProtocol, provider, newConfig.PermissionRoleMappings);
         ProviderConfigValidator.ValidateParentalRatingMappings(SamlProtocol, provider, newConfig.ParentalRatingRoleMappings);
+        ProviderConfigValidator.ValidateGuestAccessDurations(SamlProtocol, provider, newConfig.GuestAccessDurationRoleMappings);
         SSOPlugin.Instance.MutateConfiguration(configuration =>
         {
             // The name guard needs the under-lock existence check (#336) and runs before any mutation,

--- a/SSO-Auth/Api/Identity/ValidatedLogin.cs
+++ b/SSO-Auth/Api/Identity/ValidatedLogin.cs
@@ -59,4 +59,7 @@ internal sealed record ValidatedLogin
 
     /// <summary>Gets the account-expiry instant the configured expiry claim resolved (#1143), in UTC, or null when no claim is configured, the claim is absent, or its value is not a shape the reader understands. Carried only; no access decision is made from it (#1144 decides that).</summary>
     internal DateTime? ExpiresAtUtc { get; init; }
+
+    /// <summary>Gets the fixed access duration the login's roles resolved (#1146), or null when the provider maps no role to a duration or the login held none. A DURATION, not an instant: it is anchored to the moment an account is actually provisioned, and it is read on that arm only.</summary>
+    internal TimeSpan? GuestAccessDuration { get; init; }
 }

--- a/SSO-Auth/Api/Identity/VerifiedIdentity.cs
+++ b/SSO-Auth/Api/Identity/VerifiedIdentity.cs
@@ -56,7 +56,8 @@ internal sealed record VerifiedIdentity
         string? avatarUrl,
         IReadOnlyList<PermissionGrant> permissionGrants,
         int? maxParentalRatingScore,
-        DateTime? expiresAtUtc)
+        DateTime? expiresAtUtc,
+        TimeSpan? guestAccessDuration)
     {
         LinkMode = linkMode;
         AuditProtocol = auditProtocol;
@@ -73,6 +74,7 @@ internal sealed record VerifiedIdentity
         PermissionGrants = permissionGrants;
         MaxParentalRatingScore = maxParentalRatingScore;
         ExpiresAtUtc = expiresAtUtc;
+        GuestAccessDuration = guestAccessDuration;
     }
 
     /// <summary>Gets the protocol the canonical-link store keys this identity under (#369).</summary>
@@ -138,6 +140,16 @@ internal sealed record VerifiedIdentity
     internal DateTime? ExpiresAtUtc { get; }
 
     /// <summary>
+    /// Gets the fixed access duration the provider maps the login's roles to (#1146), or null when the
+    /// provider maps no role to a duration or the login held none. It is a DURATION rather than an instant
+    /// because it is anchored to the moment an account is actually provisioned, inside the same locked
+    /// transaction that writes the link - a login resolving an EXISTING account never reads it, which is what
+    /// makes the deadline stamped once rather than slid forward on every visit. Where a login carries both
+    /// this and <see cref="ExpiresAtUtc"/>, the absolute instant wins.
+    /// </summary>
+    internal TimeSpan? GuestAccessDuration { get; }
+
+    /// <summary>
     /// Mints the verified identity of an OpenID login. Called only from the OpenID redeem path
     /// (<c>AuthorizeSession.Ready</c>), which the store hands out only through its one-time atomic redeem of a
     /// promoted (role-gate-passed) state - so a raw or unvalidated login can never reach it.
@@ -175,5 +187,6 @@ internal sealed record VerifiedIdentity
             login.AvatarUrl,
             login.PermissionGrants,
             login.MaxParentalRatingScore,
-            login.ExpiresAtUtc);
+            login.ExpiresAtUtc,
+            login.GuestAccessDuration);
 }

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -190,8 +190,16 @@ internal sealed class CanonicalLinkService
     /// to approve. Never disables an existing or adopted account. Default off (a new account is created
     /// enabled); the caller inspects the resolved account via <see cref="IsAccountAwaitingApproval"/>.
     /// </param>
+    /// <param name="provisionedAccessDuration">
+    /// The role-mapped fixed access duration (#1146). When a brand-new account is created on this login - the
+    /// CREATE ARM ONLY - its canonical link is stamped with a deadline of the link-write instant plus this
+    /// duration. Every other arm ignores it: an existing link resolved by a later login is left exactly as it
+    /// was, which is what makes the deadline stamped once rather than slid forward on every visit, and an
+    /// ADOPTED account is not a provisioning event, so it is not given a lifetime it never agreed to. Default
+    /// null (no deadline), so a provider mapping no role provisions byte-identically to before.
+    /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false)
+    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false, TimeSpan? provisionedAccessDuration = null)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -260,7 +268,7 @@ internal sealed class CanonicalLinkService
                 return AdoptExistingAccount(mode, provider, canonicalKey, username, issuer, existingAccount!, adoptionGate, decision.UserId);
 
             case AccountLinkAction.CreateNewAccount:
-                return await CreateNewAccountAsync(mode, provider, canonicalKey, username, issuer, candidates.LegacyLink, provisionDisabled).ConfigureAwait(false);
+                return await CreateNewAccountAsync(mode, provider, canonicalKey, username, issuer, candidates.LegacyLink, provisionDisabled, provisionedAccessDuration).ConfigureAwait(false);
 
             case AccountLinkAction.RejectNameTaken:
                 throw RejectNameTaken(candidates.LegacyLink, mode, provider, username);
@@ -460,7 +468,7 @@ internal sealed class CanonicalLinkService
     // when a now-orphaned legacy link is being left behind. When provisionDisabled is set (the provider's
     // ProvisionNewUsersDisabled policy, #737), the brand-new account is created disabled and persisted here
     // so it exists inert for an administrator to approve; the caller then refuses the login without minting.
-    private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string? issuer, Guid? legacyLink, bool provisionDisabled)
+    private async Task<Guid> CreateNewAccountAsync(ProviderMode mode, string provider, string canonicalKey, string username, string? issuer, Guid? legacyLink, bool provisionDisabled, TimeSpan? provisionedAccessDuration)
     {
         // Resolved FIRST, ahead of the orphan warning below (#1137). That warning states that a fresh
         // account is being provisioned and the legacy target is now orphaned; a refusal after it would
@@ -549,7 +557,11 @@ internal sealed class CanonicalLinkService
         // linked meanwhile, use its account - this freshly created user is left unlinked rather
         // than overwriting the winner's link (a rare, benign orphan, not a duplicate login). The
         // link write stamps the login's issuer (#186), so the new link is issuer-bound.
-        var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer);
+        // The role-mapped access duration (#1146) travels with the link write and is stamped only when THIS
+        // call actually wrote the link, in the same transaction. That placement is the whole guarantee: the
+        // #133 race loser writes no link and therefore stamps no deadline over the winner's, and a deadline
+        // can only ever come into existence beside a live link, which is what bounds the map.
+        var (effectiveUserId, _) = LinkCanonicalIfAbsent(mode, provider, canonicalKey, user.Id, issuer, provisionedAccessDuration);
         return effectiveUserId;
     }
 
@@ -1156,7 +1168,7 @@ internal sealed class CanonicalLinkService
     // reports WroteLink=false (so the caller does not re-emit the adoption audit). The link write goes
     // straight into the config (no discarded ActionResult), so a failure to persist propagates rather
     // than falling through as a successful adoption.
-    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId, string? issuer)
+    private (Guid EffectiveUserId, bool WroteLink) LinkCanonicalIfAbsent(ProviderMode mode, string provider, string canonicalKey, Guid candidateUserId, string? issuer, TimeSpan? provisionedAccessDuration = null)
     {
         return _configStore.Mutate(configuration =>
         {
@@ -1181,6 +1193,14 @@ internal sealed class CanonicalLinkService
                 // A link written under this login carries this login's issuer (#186). The #133 race loser
                 // (wroteLink == false) uses the winner's already-stamped link, so it stamps nothing.
                 StampIssuerInPlace(configuration, mode, provider, canonicalKey, issuer);
+
+                // A link written by a PROVISIONING login carries the role-mapped access deadline (#1146),
+                // anchored to this instant. Only the create arm passes a duration - adoption passes none - and
+                // only the writer reaches here, so a second login of the same account resolves the existing
+                // link, never re-enters this branch, and leaves the recorded deadline exactly where it is. A
+                // sliding deadline is the one defect this direction of the feature can have, and this is the
+                // single place it is prevented rather than a rule restated at each caller.
+                StampProvisionedDeadlineInPlace(configuration, mode, provider, canonicalKey, provisionedAccessDuration);
             }
 
             return (effectiveUserId, wroteLink);
@@ -1369,6 +1389,34 @@ internal sealed class CanonicalLinkService
         if (configuration.OidConfigs.TryGetValue(provider, out var config) && config is not null)
         {
             config.CanonicalLinkIssuers[canonicalKey] = issuer;
+        }
+    }
+
+    // Stamps the role-mapped access deadline beside a link this transaction just wrote (#1146), inside the
+    // caller's config lock so the deadline and the link it describes land together or not at all. Called
+    // from the create arm only; every other caller passes null and this is a no-op.
+    //
+    // The clock read is the instance clock, so the suite can pin the anchor instead of racing the wall
+    // clock. Both protocols are handled - unlike the issuer stamp, which is OpenID-only - because the map it
+    // writes into is carried by ProviderConfigBase and is swept for both.
+    //
+    // The duration is re-checked against the same bounds the policy and the save-time validator apply,
+    // because the guard has to sit where the arithmetic is: DateTime.AddHours THROWS past DateTime.MaxValue,
+    // and a value hand-edited into the config XML reaches this line without passing the save path at all. A
+    // duration outside the bounds stamps NOTHING rather than throwing, so the login still succeeds and the
+    // account simply carries no deadline - which is exactly what the same provider does today.
+    private void StampProvisionedDeadlineInPlace(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey, TimeSpan? provisionedAccessDuration)
+    {
+        if (provisionedAccessDuration is not { } duration
+            || duration <= TimeSpan.Zero
+            || duration > TimeSpan.FromHours(GuestAccessDurationRoleMap.MaxDurationHours))
+        {
+            return;
+        }
+
+        if (TryGetProvider(configuration, mode, provider, out var config))
+        {
+            config.CanonicalLinkDeadlines[canonicalKey] = _clock().ToUniversalTime() + duration;
         }
     }
 

--- a/SSO-Auth/Api/Oidc/AuthorizeSession.cs
+++ b/SSO-Auth/Api/Oidc/AuthorizeSession.cs
@@ -155,6 +155,7 @@ internal abstract class AuthorizeSession
                 PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
                 MaxParentalRatingScore = derived.MaxParentalRatingScore,
                 ExpiresAtUtc = derived.ExpiresAtUtc,
+                GuestAccessDuration = derived.GuestAccessDuration,
             });
 
             // Carry the OpenID logout material (#727, SLO-1b) alongside the keystone rather than inside it:

--- a/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs
@@ -102,6 +102,11 @@ internal static class OidcAuthorizeStateBuilder
         // mapping matched, so the mint leaves the account's existing ceiling untouched.
         var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
 
+        // Reduce the SAME role set to a fixed access duration (#1146): null when the provider maps no role
+        // to a duration or this login held none, in which case a provisioned account gets no deadline. It is
+        // resolved here, beside the other role reductions, so no second role read is added to the callback.
+        var guestAccessDuration = GuestAccessDurationPolicy.Resolve(roles, config);
+
         // If nothing has validated the login yet, fall back to the stable "sub" as the username. The
         // subject was already resolved above (last "sub" wins), so this reuses it instead of scanning
         // the claims a second time. Faithful to the original: unlike the preferred-username branch, this
@@ -122,7 +127,7 @@ internal static class OidcAuthorizeStateBuilder
         // validation rejects it anyway, so no legitimate login can carry one.
         valid = valid && !string.IsNullOrWhiteSpace(username);
 
-        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc);
+        return new OidcAuthorizeState(username, subject, issuer, emailVerified, valid, admin, enableLiveTv, enableLiveTvManagement, folders, avatarUrl, permissionGrants, maxParentalRatingScore, expiresAtUtc, guestAccessDuration);
     }
 
     // The last "sub" claim value, or null when none is present. Kept separate from the username
@@ -415,6 +420,7 @@ internal static class OidcAuthorizeStateBuilder
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
     /// <param name="ExpiresAtUtc">The account-expiry instant the configured expiry claim resolved (#1143), in UTC; null when no claim is configured, the claim is absent, or its value is not a shape the reader understands.</param>
+    /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
     internal readonly record struct OidcAuthorizeState(
         string? Username,
         string? Subject,
@@ -428,7 +434,8 @@ internal static class OidcAuthorizeStateBuilder
         string? AvatarUrl,
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
         int? MaxParentalRatingScore = null,
-        DateTime? ExpiresAtUtc = null)
+        DateTime? ExpiresAtUtc = null,
+        TimeSpan? GuestAccessDuration = null)
     {
         /// <summary>
         /// Gets the raw OpenID <c>id_token</c>, captured at the callback for a later RP-initiated logout

--- a/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
+++ b/SSO-Auth/Api/Saml/SamlAssertionValidator.cs
@@ -257,6 +257,7 @@ internal sealed class SamlAssertionValidator
             PermissionGrants = derived.PermissionGrants ?? Array.Empty<PermissionGrant>(),
             MaxParentalRatingScore = derived.MaxParentalRatingScore,
             ExpiresAtUtc = ReadExpiry(config, samlResponse),
+            GuestAccessDuration = derived.GuestAccessDuration,
         });
         return true;
     }

--- a/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
+++ b/SSO-Auth/Api/Saml/SamlAuthorizeStateBuilder.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Jellyfin.Plugin.SSO_Auth.Api.Authz;
 using Jellyfin.Plugin.SSO_Auth.Config;
@@ -39,7 +40,12 @@ internal static class SamlAuthorizeStateBuilder
         // mapping matched, so the mint leaves the account's existing ceiling untouched.
         var maxParentalRatingScore = ParentalRatingPolicy.Resolve(roles, config);
 
-        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore);
+        // Reduce the SAME role set to a fixed access duration (#1146): null when the provider maps no role to
+        // a duration or this login held none, in which case a provisioned account gets no deadline. Resolved
+        // here, beside the other role reductions, so no second attribute read is added to the callback.
+        var guestAccessDuration = GuestAccessDurationPolicy.Resolve(roles, config);
+
+        return new SamlAuthorizeState(privileges.Admin, privileges.EnableLiveTv, privileges.EnableLiveTvManagement, privileges.Folders, permissionGrants, maxParentalRatingScore, guestAccessDuration);
     }
 
     /// <summary>
@@ -51,11 +57,13 @@ internal static class SamlAuthorizeStateBuilder
     /// <param name="Folders">The enabled folders (statically enabled plus role-granted).</param>
     /// <param name="PermissionGrants">The generic role→permission grants (#164); null (treated as empty) when the feature is off.</param>
     /// <param name="MaxParentalRatingScore">The parental-rating-score ceiling (#736); null when the feature is off or no mapping matched (leave the existing ceiling untouched).</param>
+    /// <param name="GuestAccessDuration">The fixed access duration the login's roles resolved (#1146); null when the provider maps no role to a duration or the login held none. Read only on the arm that provisions a brand-new account.</param>
     internal readonly record struct SamlAuthorizeState(
         bool Admin,
         bool EnableLiveTv,
         bool EnableLiveTvManagement,
         List<string> Folders,
         IReadOnlyList<PermissionGrant>? PermissionGrants = null,
-        int? MaxParentalRatingScore = null);
+        int? MaxParentalRatingScore = null,
+        TimeSpan? GuestAccessDuration = null);
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -237,6 +237,30 @@ public abstract class ProviderConfigBase
     public string? AccountExpiryClaim { get; set; }
 
     /// <summary>
+    /// Gets or sets the role-to-duration mappings that give a brand-new account a fixed access lifetime
+    /// (#1146), the second of the two expiry sources: a login provisioning a new account while holding a
+    /// mapped role gets a deadline of that moment plus the mapped duration. Null or empty - the default -
+    /// maps nothing, so a provider carrying none provisions byte-identically to before.
+    /// <para>
+    /// It is the RELATIVE source and <see cref="AccountExpiryClaim"/> is the absolute one. Where a login
+    /// carries both, the claim wins: the identity provider is the authority on a date it emitted. Where
+    /// several mapped roles match, the SHORTEST duration wins, which is the fail-closed direction and
+    /// matches the minimum-wins rule <see cref="ParentalRatingRoleMap"/> already states for a ceiling.
+    /// </para>
+    /// <para>
+    /// Stamped ONCE, on the arm that creates the account, and anchored to that moment rather than re-read
+    /// per login - so a later login of the same account leaves the recorded deadline exactly where it was.
+    /// A sliding deadline would be indistinguishable from unlimited access for anyone who keeps logging in,
+    /// which is the whole failure this direction of the feature can have and the absolute claim cannot.
+    /// Losing the role later neither extends nor clears the deadline; removing access for a role a user no
+    /// longer holds is the allow-list's and #831's job, not this one's.
+    /// </para>
+    /// </summary>
+    [XmlArray("GuestAccessDurationRoleMappings")]
+    [XmlArrayItem(typeof(GuestAccessDurationRoleMap), ElementName = "GuestAccessDurationRoleMappings")]
+    public List<GuestAccessDurationRoleMap>? GuestAccessDurationRoleMappings { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether this provider is HIDDEN from the managed login-page buttons
     /// (#722), when <see cref="PluginConfiguration.ManageLoginPageButtons"/> is on. Off by default: an enabled
     /// provider gets a button. Set it to keep a provider usable via its direct start URL without advertising a
@@ -972,6 +996,40 @@ public class ParentalRatingRoleMap
     /// <summary>
     /// Gets or sets the roles the ceiling applies to. A login holding any of these roles is capped at
     /// <see cref="Score"/>; a login holding none is left untouched.
+    /// </summary>
+    public string[]? Roles { get; set; }
+}
+
+/// <summary>
+/// Maps a set of provider roles to a fixed access duration (#1146): an account provisioned by a login
+/// holding any of the listed roles is stamped with a deadline of the provisioning moment plus
+/// <see cref="DurationHours"/>. When a login matches several entries the SHORTEST duration wins, which is
+/// the fail-closed direction. Validated on save: the role list must be non-empty and the duration must be
+/// positive and within <see cref="MaxDurationHours"/>.
+/// </summary>
+public class GuestAccessDurationRoleMap
+{
+    /// <summary>
+    /// The largest duration a mapping may carry, in hours - a hundred 365-day years. It is a guard rather
+    /// than a policy: the duration is added to the provisioning instant on the login path, and
+    /// <see cref="DateTime.AddHours"/> THROWS once the result leaves <see cref="DateTime.MaxValue"/>, so an
+    /// unbounded value hand-edited into the config XML would turn every provisioning login for that provider
+    /// into a 500 rather than into a very distant deadline. Anything needing longer than a century is not a
+    /// time limit and should carry no mapping at all.
+    /// </summary>
+    public const int MaxDurationHours = 876_000;
+
+    /// <summary>
+    /// Gets or sets the access duration granted to the listed roles, in hours, counted from the moment the
+    /// account is provisioned. Hours rather than days so a short trial (a 12-hour pass) and a long one (a
+    /// 30-day guest, 720) are both expressible in one field. A shorter value is more restrictive; when
+    /// several mappings match a login the smallest wins.
+    /// </summary>
+    public int DurationHours { get; set; }
+
+    /// <summary>
+    /// Gets or sets the roles the duration applies to. A login holding any of these roles provisions with the
+    /// deadline; a login holding none provisions with no deadline at all.
     /// </summary>
     public string[]? Roles { get; set; }
 }

--- a/SSO-Auth/Config/ProviderConfigValidator.cs
+++ b/SSO-Auth/Config/ProviderConfigValidator.cs
@@ -63,6 +63,7 @@ internal static class ProviderConfigValidator
                 ValidatePostLogoutRedirectUri("OpenID", kvp.Key, kvp.Value?.BaseUrlOverride, kvp.Value?.PostLogoutRedirectUri);
                 ValidatePermissionRoleMappings("OpenID", kvp.Key, kvp.Value?.PermissionRoleMappings);
                 ValidateParentalRatingMappings("OpenID", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
+                ValidateGuestAccessDurations("OpenID", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("OpenID", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
                 ValidateAcrRequirement(kvp.Key, kvp.Value);
             }
@@ -84,6 +85,7 @@ internal static class ProviderConfigValidator
                 ValidateSamlSigningKey(kvp.Key, kvp.Value?.SamlRolloverSigningKeyPfx);
                 ValidatePermissionRoleMappings("SAML", kvp.Key, kvp.Value?.PermissionRoleMappings);
                 ValidateParentalRatingMappings("SAML", kvp.Key, kvp.Value?.ParentalRatingRoleMappings);
+                ValidateGuestAccessDurations("SAML", kvp.Key, kvp.Value?.GuestAccessDurationRoleMappings);
                 ValidateProvisioningTemplate("SAML", kvp.Key, kvp.Value?.ProvisioningPolicyTemplate);
             }
         }
@@ -466,6 +468,56 @@ internal static class ProviderConfigValidator
             {
                 throw new ArgumentException(
                     $"{protocol} provider '{echoName}' has a parental-rating mapping with no roles: each mapping must list at least one role the ceiling applies to.",
+                    nameof(mappings));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rejects an access-duration mapping (#1146) whose duration is not positive, is longer than
+    /// <see cref="GuestAccessDurationRoleMap.MaxDurationHours"/>, or which lists no roles. The upper bound is
+    /// a guard rather than a policy: the duration is added to the provisioning instant on the login path and
+    /// <see cref="DateTime.AddHours"/> throws past <see cref="DateTime.MaxValue"/>, so an unbounded value
+    /// would turn every provisioning login for that provider into a 500. A null mappings collection or a null
+    /// entry maps nothing and is tolerated.
+    /// </summary>
+    /// <param name="protocol">The protocol label ("OpenID" or "SAML") echoed in the rejection message.</param>
+    /// <param name="provider">The provider name, echoed (line-ending-stripped) in the rejection message.</param>
+    /// <param name="mappings">The access-duration mappings to check.</param>
+    /// <exception cref="ArgumentException">An entry has a non-positive or out-of-range duration, or lists no roles.</exception>
+    internal static void ValidateGuestAccessDurations(string protocol, string provider, System.Collections.Generic.IEnumerable<GuestAccessDurationRoleMap>? mappings)
+    {
+        if (mappings == null)
+        {
+            return;
+        }
+
+        foreach (var mapping in mappings)
+        {
+            if (mapping == null)
+            {
+                continue;
+            }
+
+            var echoName = (provider ?? string.Empty).ReplaceLineEndings(string.Empty);
+            if (mapping.DurationHours <= 0)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has an invalid access-duration mapping: the duration must be greater than zero hours (remove the mapping to leave access unlimited).",
+                    nameof(mappings));
+            }
+
+            if (mapping.DurationHours > GuestAccessDurationRoleMap.MaxDurationHours)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has an access-duration mapping above the {GuestAccessDurationRoleMap.MaxDurationHours}-hour maximum: a longer limit is not a time limit, so remove the mapping instead.",
+                    nameof(mappings));
+            }
+
+            if (mapping.Roles == null || mapping.Roles.Length == 0)
+            {
+                throw new ArgumentException(
+                    $"{protocol} provider '{echoName}' has an access-duration mapping with no roles: each mapping must list at least one role the duration applies to.",
                     nameof(mappings));
             }
         }


### PR DESCRIPTION
# What & why

Closes #1146.

The expiry machinery had one source: an absolute instant the identity provider
emits (#1143), enforced at login (#1144) and between logins by the sweep
(#1145). That covers a provider that knows the date. It does not cover the case
the parent issue names first, where the operator knows the LENGTH: a `guest` or
`trial` group that should be worth a day, or a month, counted from the moment
the account is made.

A provider can now map identity-provider roles to hours. An account created by a
login holding a mapped role is stamped with a deadline of that instant plus the
mapped duration, into the same per-link map the sweep already reads, so
enforcement is entirely the existing paths and only the instant is new.

The duration is resolved from the role set each protocol already produced, beside
the parental-rating and permission reductions, so no second role read is added to
either callback. It is carried as a DURATION rather than an instant, because the
anchor is the moment the link is written and that is one layer further down.

## The three rules, and where each is enforced

- **Shortest wins** across matching roles, in `GuestAccessDurationPolicy`. A user
  who happens to hold a looser second group never has their deadline pushed out
  by it, which is the parent rule that expiry disables and never silently
  extends.
- **The absolute claim wins** over a mapped role, stated once in
  `LoginCompletionService` as the expression that decides what is passed down.
  The provider is the authority on a date it emitted.
- **The stamp is written on the arm that CREATES the account and nowhere else.**
  It rides the link write itself, inside that transaction, so a deadline can only
  come into existence beside a live link and the #133 race loser stamps nothing
  over the winner. This is what the whole feature rests on: a deadline
  re-anchored per login moves forward faster than it is reached for anyone who
  keeps signing in, so a 24-hour trial would be unlimited access for exactly the
  users a limit exists to bound, with nothing looking wrong. It is also what
  keeps an SSO login that ADOPTS an established Jellyfin account from putting an
  expiry on it.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing on the validation path changed.
      The new value can only ever SHORTEN access: holding an extra mapped role
      takes the shorter duration, and holding none leaves the account with no
      deadline, which is today's behaviour.
- [x] No secrets logged; secrets are redacted on config export. The change logs
      nothing and touches no secret. The validator messages echo the provider
      name through the same inline `ReplaceLineEndings` the neighbouring
      validators use.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **Not performed as a separate
      pass, and this box stays unticked rather than being softened.** What stands
      in its place is the evidence below and the guard-bite table. No second
      reader looked at any of it.
- [x] Review record: the adversarial reading I did make, with its dispositions,
      is in **Findings** below. Counts as raised: **CONFIRMED 2 / PLAUSIBLE 0**.
      Both were reproduced before being called, and both are fixed in this
      branch.
- [x] Log inputs from the IdP are sanitized inline at the log call. No new log
      call takes IdP-supplied text.

### Threat notes

- **Mass lockout.** A mapping only ever gives a deadline to accounts created
  after it is configured, one at a time, and always in the future. No existing
  account is touched. The disable that eventually acts on the deadline is the
  sweep's shared body, which already carries the T-D1 administrator exemption, so
  a mis-set duration can strand at most the non-admin accounts it created.
- **Attacker influence.** The duration comes from admin-set configuration; the
  identity provider only selects among the mappings by which roles it asserts.
  Because shortest wins, asserting an extra mapped role can never lengthen
  access, and dropping one is the same as not being in the group, which is the
  provider's decision to make and arrives signed.
- **Arithmetic.** The duration is added to a `DateTime` on the login path, and
  `AddHours` throws past `DateTime.MaxValue`. Bounded at 876,000 hours at the
  save door AND re-checked at the stamp, because a value hand-edited into the
  config XML never passes the save path.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. `GuestAccessDurationPolicy` is a pure reducer next to the two role
      policies it mirrors.
- [x] The change adds no more code than the problem requires. There is
      deliberately no master switch beside the map: an empty map already means
      off, and a second switch would be a second place for the feature to be
      half-enabled from.
- [x] The code is self-documenting and matches the target architecture (#318).
      No new `Api/` module; the reducer lands in the existing `Api/Authz`.
- [x] Architecture-conformance tests pass.
- [x] Docs impact considered: the CHANGELOG entry is included here and states the
      dashboard gap plainly. See **Notes** for the wiki follow-up.

## Verification

- [x] `dotnet build --warnaserror` is green, 0 warnings, on **both** target
      frameworks.
- [x] `dotnet test` is green on both.
- [x] Prettier is clean for the one `.md` this change touches.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3181, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3182, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ npx prettier --check CHANGELOG.md
All matched files use Prettier code style!
```

The four skips are pre-existing and unrelated: binding a listener off loopback
raises the Windows firewall consent dialog, which needs an administrator (#1227).
They skip on `main` identically and were not worked around.

## Guard-bite table

Every rule this change states was deleted or inverted, and the suite was run
against the broken tree. What went red:

| Rule broken | Tests that went red |
| --- | --- |
| shortest-wins inverted to longest-wins | 4, incl. `Resolve_TwoMappedRoles_TakesTheShorter` and `ALoginHoldingTwoMappedRoles_TakesTheShorterDuration` |
| the policy upper-bound check deleted | 1, `Resolve_DurationAboveTheGuard_IsSkipped` |
| the claim-wins condition deleted | 1, `AnAlreadyExpiredClaimOnAProvisioningLogin_LeavesNoFutureDeadlineBehind` |
| the duration passed to the ADOPT arm as well | 1, `AnADOPTEDAccountIsNotGivenALifetime` |
| the deadline re-anchored on every login (the sliding window) | 5, incl. `ASecondLoginDaysLater_LeavesTheRecordedDeadlineExactlyWhereItWas` |
| `[JsonIgnore]` added to the mapping | 1, `GuestAccessDurationMappings_SurviveTheDiskCycle_AndStayVisibleToTheAdminSurface` |

One mutation produced NO red and is recorded because it is a bound on what the
tests prove: renaming the `XmlArrayItem` element leaves the round-trip test
green, because both halves read the same attribute. It only breaks against a
document written by an earlier build, which is nil while the element has never
shipped. That limitation is written into the test rather than left to be
assumed.

## Findings

Two, both found by running a mutation rather than by reading, both reproduced,
both fixed here.

**1. The both-sources test was vacuous for its own guard. CONFIRMED, FIXED.**
The first version asserted that a login carrying both a mapped role and a future
expiry claim ends up with the claim's instant. It passed with the claim-wins
condition deleted, because the enforcement gate runs after resolve-or-create and
overwrites whatever the group stamped, so the right answer came out for the
wrong reason and the rule was being carried by write order rather than by the
condition. Replaced with the case that separates the two: an already-expired
claim, where the gate disables the account and records nothing. Without the
guard, that login leaves a just-refused account holding a deadline a day in the
future. The original assertion is kept alongside it.

**2. A `[JsonIgnore]` here would silently erase the mappings. CONFIRMED, GUARDED.**
The three maps immediately above this property in the same file all carry
`[JsonIgnore]`, for a reason that does not apply to an admin-edited field. The
config page rebuilds a provider from the object it fetched and overwrites only
the fields it knows, so it preserves a field it does not know, but only while the
server serializes it out. Adding the attribute by analogy would make the page
fetch a provider without the mappings and post that back, erasing them on the
next unrelated settings change, with no error anywhere. Reproduced by adding the
attribute; `GuestAccessDurationMappings_SurviveTheDiskCycle_AndStayVisibleToTheAdminSurface`
is what refuses it now.

## Notes

Not covered, stated rather than left to be discovered.

- **No dashboard fields.** The provider forms do not carry these mappings; they
  are set in the plugin configuration. That matches every neighbour in this
  family: `AccountExpiryClaim` (#1143), `ParentalRatingRoleMappings` (#736),
  `PermissionRoleMappings` (#164) and `DisableAccountOnRoleDenied` (#831) all
  ship without a form control, and the issue's Done-when names no UI clause. A
  form surface for the whole family is worth one issue rather than one per field.
- **Enforcement reason code for a claim-less provider.** A provider that maps
  roles but names no expiry claim is enforced by the sweep only: the login-time
  gate is entered on the claim being configured, and widening it would refuse
  every login for such a provider, since that gate reads a missing instant as
  fail-closed. The consequence is that after the sweep disables an expired guest,
  their next login is refused as a disabled account rather than as an expired
  one. Access ends correctly and on time; only the wording of the refusal
  differs. Left as-is rather than reshaped inside a feature branch.
- **CHANGELOG** entry is included. No README or wiki text describes the expiry
  family today, so this adds no drift; a wiki page covering all three expiry
  sources together belongs with the form surface above.
