### PR TITLE
Follow a provider-side username rename onto the linked account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   neither clear it nor invent one. It is not part of the portable link export
   either, because a login instant belongs to the server that observed it and
   cannot be restored onto another.
+- **Jellyfin accounts can follow a rename at the identity provider (#1138).** A
+  new per-provider option, **Follow Username Renames From The Provider**, renames
+  a linked Jellyfin account on the user's next SSO login when their username has
+  changed at the provider. Off by default, in which case the Jellyfin name stays
+  as it was and the two drift apart, which is what happens today. This is the
+  display name only: the account is found by its stable subject identifier
+  either way, so turning it on cannot change which account a login reaches, and
+  it adds no way to select an account by name. The new name is cleaned up the
+  same way a newly created account's name is, so a rename can never put a name on
+  an account that Jellyfin would have refused at creation. If another Jellyfin
+  account already holds the name, the rename is skipped and both accounts keep
+  their names rather than the outcome depending on who logged in last. A rename
+  that fails for any other reason is logged and the login still succeeds, because
+  a display name that has drifted is cosmetic and a refused login is not. Each
+  rename is recorded as an audit event naming both the old and the new name. The
+  option is in the provider forms for OpenID and SAML.
+
 - **A per-provider starting policy for accounts SSO creates (#1099).** A
   provider can carry a template whose set fields are written onto a brand-new
   SSO account at creation: any of the boolean Jellyfin permissions, a

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.WebUi.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.WebUi.cs
@@ -175,14 +175,14 @@ public partial class ArchitectureConformanceTests
             "Roles", "AdminRoles", "EnableAllFolders", "EnabledFolders", "EnableFolderRoles", "FolderRoleMapping",
             "EnableLiveTvRoles", "LiveTvRoles", "LiveTvManagementRoles", "EnableLiveTv", "EnableLiveTvManagement",
             "DoNotLoadProfile", "SchemeOverride", "PortOverride", "BaseUrlOverride",
-            "RequirePkce", "AllowExistingAccountLink", "ProvisionNewUsersDisabled", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
+            "RequirePkce", "AllowExistingAccountLink", "ProvisionNewUsersDisabled", "SyncUsernameFromProvider", "RequireVerifiedEmailForAdoption", "RequireVerifiedEmailForLogin",
             "AcrValues", "Prompt", "MaxAge", "RequireAcr",
             "DisableHttps", "DisablePushedAuthorization", "DoNotValidateEndpoints", "DoNotValidateIssuerName", "DoNotValidateResponseIssuer",
             "AllowPrivateNetworkAddresses",
             "HideLoginButton", "LoginButtonText", "PostLogoutRedirectUri",
         };
 
-        Assert.Equal(45, expected.Length);
+        Assert.Equal(46, expected.Length);
         var missing = expected.Where(id => !markedIds.Contains(id)).ToList();
         Assert.True(
             missing.Count == 0,

--- a/SSO-Auth.Tests/Linking/HostRenameTests.cs
+++ b/SSO-Auth.Tests/Linking/HostRenameTests.cs
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Binding <c>RenameUser</c> against whichever shape the loaded server exposes (#1138).
+/// </summary>
+/// <remarks>
+/// <para>
+/// `IUserManager.RenameUser` changed arity inside the supported range. Measured against the tags:
+/// v10.11.0 to v10.11.8 declare <c>RenameUser(User, string)</c>, and v10.11.9 onwards
+/// <c>RenameUser(Guid, string, string)</c>. The repository declares <c>targetAbi: "10.11.0.0"</c>, so a
+/// source reference to either shape breaks one of the two builds.
+/// </para>
+/// <para>
+/// WHY THESE ROWS USE HAND-WRITTEN TYPES RATHER THAN A FAKE IUserManager. A substitute for the interface can
+/// only ever carry the shape this assembly compiled against, which is the arm that was never in doubt. The
+/// arm that matters is the one on a server this build cannot see, and the only way to hand the resolver that
+/// shape is to declare it here.
+/// </para>
+/// </remarks>
+public class HostRenameTests
+{
+    private static readonly Guid Account = Guid.Parse("66666666-6666-6666-6666-666666666666");
+
+    /// <summary>A server on the current line: three arguments, keyed by id.</summary>
+    private sealed class CurrentLine
+    {
+        public Task RenameUser(Guid userId, string oldName, string newName) => Task.CompletedTask;
+    }
+
+    /// <summary>A server on the floor: two arguments, taking the account itself.</summary>
+    private sealed class AtTheFloor
+    {
+        public Task RenameUser(User user, string newName) => Task.CompletedTask;
+    }
+
+    /// <summary>A server exposing both, which no released Jellyfin does.</summary>
+    private sealed class BothShapes
+    {
+        public Task RenameUser(Guid userId, string oldName, string newName) => Task.CompletedTask;
+
+        public Task RenameUser(User user, string newName) => Task.CompletedTask;
+    }
+
+    /// <summary>A server exposing neither.</summary>
+    private sealed class NoShape
+    {
+    }
+
+    [Fact]
+    public void OnTheCurrentLine_TheThreeArgumentShapeIsBoundWithIdAndBothNames()
+    {
+        var call = HostRename.Resolve(typeof(CurrentLine), null, Account, "alice.old", "alice.new");
+
+        Assert.NotNull(call);
+        Assert.Equal(3, call.Value.Method.GetParameters().Length);
+        Assert.Equal(new object?[] { Account, "alice.old", "alice.new" }, call.Value.Arguments);
+    }
+
+    /// <summary>
+    /// The arm that a fake <c>IUserManager</c> cannot reach, and the reason this file exists.
+    /// </summary>
+    [Fact]
+    public void AtTheAbiFloor_TheTwoArgumentShapeIsBoundWithTheAccountAndTheNewName()
+    {
+        var account = new User("alice.old", "prov", "reset");
+
+        var call = HostRename.Resolve(typeof(AtTheFloor), account, Account, "alice.old", "alice.new");
+
+        Assert.NotNull(call);
+        Assert.Equal(2, call.Value.Method.GetParameters().Length);
+        Assert.Equal(new object?[] { account, "alice.new" }, call.Value.Arguments);
+    }
+
+    /// <summary>
+    /// The current line wins where both are present, so the common case never falls through to a lookup it
+    /// does not need and no server ever gets the older call while offering the newer one.
+    /// </summary>
+    [Fact]
+    public void WhereBothArePresent_TheCurrentLineIsPreferred()
+    {
+        var call = HostRename.Resolve(typeof(BothShapes), new User("alice.old", "prov", "reset"), Account, "alice.old", "alice.new");
+
+        Assert.NotNull(call);
+        Assert.Equal(3, call.Value.Method.GetParameters().Length);
+    }
+
+    /// <summary>
+    /// Neither shape resolves to nothing rather than to something wrong. The caller turns this into the
+    /// refusal sentence, which its own broad catch logs and swallows: on such a server the account keeps its
+    /// name and the login proceeds, which is what the feature being off would also do.
+    /// </summary>
+    [Fact]
+    public void WhereNeitherIsPresent_NothingIsBound()
+    {
+        Assert.Null(HostRename.Resolve(typeof(NoShape), new User("alice.old", "prov", "reset"), Account, "alice.old", "alice.new"));
+    }
+
+    /// <summary>
+    /// The sentence names both signatures, because an admin reading it in a log needs to know what their
+    /// server was asked for rather than that something reflective did not work.
+    /// </summary>
+    [Theory]
+    [InlineData("RenameUser(Guid, string, string)")]
+    [InlineData("RenameUser(User, string)")]
+    public void TheRefusalNamesBothSignatures(string signature)
+    {
+        Assert.Contains(signature, HostRename.NeitherShape, StringComparison.Ordinal);
+    }
+}

--- a/SSO-Auth.Tests/Linking/UsernameResyncTests.cs
+++ b/SSO-Auth.Tests/Linking/UsernameResyncTests.cs
@@ -1,0 +1,260 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Jellyfin.Database.Implementations.Entities;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Opt-in username re-sync (#1138): with the provider flag on, a login whose identity-provider username has
+/// changed renames the linked Jellyfin account to follow it.
+/// <para>
+/// The invariant every row here is written around is that THE SUBJECT STAYS THE KEY. Resolution is keyed on
+/// the OpenID <c>sub</c> / SAML <c>NameID</c> (#155, #186); the account is already resolved by the time the
+/// rename runs, so nothing in this feature can change which account a login reaches. A test that asserted a
+/// rename by looking the account up BY NAME would not be able to tell that apart from a name-keyed lookup
+/// sneaking back in, which is why every assertion here is against the resolved id.
+/// </para>
+/// <para>
+/// The second thing the rows pin is that the feature can never cost a login. A drifted display name is
+/// cosmetic; a refused login is not, so every failure path leaves the old name in place and still mints.
+/// </para>
+/// </summary>
+public class UsernameResyncTests
+{
+    private const string Subject = "sub-1";
+    private static readonly Guid Linked = Guid.Parse("44444444-4444-4444-4444-444444444444");
+    private static readonly Guid Other = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    [Fact]
+    public async Task WithTheFlagOn_ADriftedNameIsRenamedToFollowTheProvider()
+    {
+        var config = Provider(sync: true);
+        var (service, users, _, _) = Build(config, currentName: "alice.old");
+
+        await Login(service, config, presentedName: "alice.new");
+
+        await users.Received(1).RenameUser(Linked, "alice.old", "alice.new");
+    }
+
+    [Fact]
+    public async Task WithTheFlagOff_TheNameIsLeftAlone()
+    {
+        // The default, and every deployment that exists today. Off means the resolved account is not touched
+        // at all, not that a rename is attempted and declined.
+        var config = Provider(sync: false);
+        var (service, users, _, _) = Build(config, currentName: "alice.old");
+
+        await Login(service, config, presentedName: "alice.new");
+
+        await users.DidNotReceive().RenameUser(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task AMatchingName_RenamesNothing()
+    {
+        // A no-op guard rather than a cosmetic one. Without it every login of every user under this flag
+        // would issue a rename to the name the account already has, and each one would write an audit line
+        // saying an account was renamed when nothing was.
+        var config = Provider(sync: true);
+        var (service, users, _, audit) = Build(config, currentName: "alice");
+
+        await Login(service, config, presentedName: "alice");
+
+        await users.DidNotReceive().RenameUser(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
+        Assert.DoesNotContain(audit.Entries, e => e.Message.Contains("renamed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ANameHeldByADifferentAccount_LeavesBothNamesAlone_AndStillMints()
+    {
+        // The collision the issue asks about. Jellyfin would refuse the rename anyway, but refusing it here
+        // is what stops two accounts' names depending on which of them logged in last, and it keeps the
+        // reason on the record instead of swallowing a host error as a silent no-op.
+        var config = Provider(sync: true);
+        var (service, users, sessions, _) = Build(config, currentName: "alice.old");
+        users.GetUserByName("alice.new").Returns(TestUsers.Named("alice.new", Other));
+
+        await Login(service, config, presentedName: "alice.new");
+
+        await users.DidNotReceive().RenameUser(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+    }
+
+    [Fact]
+    public async Task ANameHeldByTheSameAccount_IsNotTreatedAsACollision()
+    {
+        // The near-miss inside the collision guard: a name lookup that resolves back to the account being
+        // renamed is not another account. A guard written as a null check rather than an id comparison
+        // passes every row above and silently disables the feature for anyone the host indexes by both names.
+        var config = Provider(sync: true);
+        var (service, users, _, _) = Build(config, currentName: "alice.old");
+        users.GetUserByName("alice.new").Returns(TestUsers.Named("alice.new", Linked));
+
+        await Login(service, config, presentedName: "alice.new");
+
+        await users.Received(1).RenameUser(Linked, "alice.old", "alice.new");
+    }
+
+    [Fact]
+    public async Task ARenameThatThrows_IsSwallowed_AndTheLoginStillSucceeds()
+    {
+        // The rule that makes this feature safe to turn on. The host owns what a legal name is and this
+        // plugin compiles against an interface that promises nothing about what it throws, so anything
+        // escaping here would turn a cosmetic mismatch into a login outage for one user.
+        var config = Provider(sync: true);
+        var (service, users, sessions, audit) = Build(config, currentName: "alice.old");
+        users.RenameUser(Linked, "alice.old", "alice.new").ThrowsAsync(new InvalidOperationException("host said no"));
+
+        await Login(service, config, presentedName: "alice.new");
+
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+        Assert.Contains(audit.Entries, e => e.Message.Contains("keeps its current name", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task TheNewNameIsSanitizedTheSameWayAProvisionedOneIs()
+    {
+        // A rename must not be able to put a name onto an account that the host would have refused at
+        // creation. The sanitizer drops what Jellyfin's own check rejects, so the account follows the
+        // provider as far as the host allows and no further.
+        var config = Provider(sync: true);
+        var (service, users, _, _) = Build(config, currentName: "alice.old");
+
+        await Login(service, config, presentedName: "ali/ce?new");
+
+        await users.Received(1).RenameUser(Linked, "alice.old", "alicenew");
+    }
+
+    [Fact]
+    public async Task ANameWithNothingUsableLeft_RenamesNothing()
+    {
+        var config = Provider(sync: true);
+        var (service, users, sessions, _) = Build(config, currentName: "alice.old");
+
+        await Login(service, config, presentedName: "///");
+
+        await users.DidNotReceive().RenameUser(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
+        await sessions.Received(1).AuthenticateDirect(Arg.Any<AuthenticationRequest>());
+    }
+
+    [Fact]
+    public async Task TheRenameIsAudited_WithBothNames()
+    {
+        // Without the pair of names in the trail, an account an operator is looking for has silently become
+        // a different row in the user list with nothing saying why.
+        var config = Provider(sync: true);
+        var (service, _, _, audit) = Build(config, currentName: "alice.old");
+
+        await Login(service, config, presentedName: "alice.new");
+
+        var line = Assert.Single(audit.Entries, e => e.Message.Contains("[SSO Audit]", StringComparison.Ordinal)
+            && e.Message.Contains("renamed", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("alice.old", line.Message, StringComparison.Ordinal);
+        Assert.Contains("alice.new", line.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task TheSamlPathFollowsTheSameRule()
+    {
+        // Both protocols funnel through the one completion tail, so the rename lives there once rather than
+        // per protocol. This row is what would go red if it were ever moved up into the OpenID flow service.
+        var config = new SamlConfig { Enabled = true, SamlEndpoint = "https://idp/saml", SyncUsernameFromProvider = true };
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+        var account = TestUsers.Named("bob.old", Linked);
+        users.GetUserById(Linked).Returns(account);
+        config.CanonicalLinks["bob.new"] = Linked;
+
+        var configuration = new PluginConfiguration();
+        configuration.SamlConfigs["idp"] = config;
+        var service = Compose(configuration, users, sessions, new CapturingLogger());
+
+        var identity = TestIdentities.Saml(
+            "idp",
+            "bob.new",
+            new SamlAuthorizeStateBuilder.SamlAuthorizeState(false, false, false, new List<string>()));
+        await service.CompleteAsync(identity, Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        await users.Received(1).RenameUser(Linked, "bob.old", "bob.new");
+    }
+
+    private static OidConfig Provider(bool sync) => new OidConfig
+    {
+        Enabled = true,
+        OidEndpoint = "https://idp/.well-known/openid-configuration",
+        SyncUsernameFromProvider = sync,
+    };
+
+    private static Task Login(LoginCompletionService service, ProviderConfigBase config, string presentedName)
+        => service.CompleteAsync(Identity(presentedName), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+    private static AuthResponse Response()
+        => new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity Identity(string presentedName)
+        => TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: presentedName,
+            Subject: Subject,
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null));
+
+    // A login that resolves an EXISTING subject-keyed link, which is the only arm the rename runs on. The
+    // link is seeded under the subject rather than under any name, so a rename that started depending on a
+    // name lookup would stop resolving here at all.
+    private static (LoginCompletionService Service, IUserManager Users, ISessionManager Sessions, CapturingLogger Audit) Build(OidConfig config, string currentName)
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+
+        var account = TestUsers.Named(currentName, Linked);
+        users.GetUserById(Linked).Returns(account);
+        users.GetUserByName(Arg.Any<string>()).Returns((User?)null);
+        config.CanonicalLinks[Subject] = Linked;
+
+        var audit = new CapturingLogger();
+        return (Compose(configuration, users, sessions, audit), users, sessions, audit);
+    }
+
+    private static LoginCompletionService Compose(PluginConfiguration configuration, IUserManager users, ISessionManager sessions, CapturingLogger audit)
+    {
+        var store = new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, audit);
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, audit);
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -81,6 +81,33 @@ internal static class SsoAudit
     }
 
     /// <summary>
+    /// Records a linked account being renamed to follow its identity provider (#1138). The rename changes
+    /// the name an administrator sees in the Jellyfin dashboard and nothing else, so the trail has to say
+    /// which name became which - without it, an account an operator is looking for has silently become a
+    /// different row in the user list with no record of why. Both names are identity-provider-influenced,
+    /// so both are stripped of line endings inline at the call, like every other name this file logs.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="previousName">The name the account held before the rename.</param>
+    /// <param name="newName">The sanitized name it now holds.</param>
+    internal static void AccountRenamed(ILogger logger, string protocol, string provider, string previousName, string newName)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Linked account renamed from '{PreviousName}' to '{NewName}' to follow {Protocol} provider '{Provider}' (SyncUsernameFromProvider).",
+            previousName?.ReplaceLineEndings(string.Empty),
+            newName?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
     /// Records an existing account being disabled by login-time deprovisioning (#831): its SSO login was
     /// denied by the role allow-list and the provider opts into disabling on denial. Only non-sensitive
     /// fields are logged - the protocol and provider name, never the subject/username (T-I1) - so an

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -105,7 +105,11 @@ internal sealed class LoginCompletionService
                 // the relative source is passed only when the login carried none. Passing both and letting a
                 // later write overwrite the earlier one would put the same rule in two places and make the
                 // outcome depend on their order.
-                identity.ExpiresAtUtc is null ? identity.GuestAccessDuration : null).ConfigureAwait(false);
+                identity.ExpiresAtUtc is null ? identity.GuestAccessDuration : null,
+                // Follow the identity provider's username on an already-linked account (#1138). Read off the
+                // provider configuration rather than off the identity, because it is the administrator's
+                // policy and not something the login gets to assert.
+                config.SyncUsernameFromProvider).ConfigureAwait(false);
         }
         catch (AccountLinkForbiddenException)
         {

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -198,8 +198,15 @@ internal sealed class CanonicalLinkService
     /// ADOPTED account is not a provisioning event, so it is not given a lifetime it never agreed to. Default
     /// null (no deadline), so a provider mapping no role provisions byte-identically to before.
     /// </param>
+    /// <param name="syncUsername">
+    /// The provider's SyncUsernameFromProvider policy (#1138): when an EXISTING link resolves an account
+    /// whose Jellyfin name no longer matches the name the login presents, rename that account to follow the
+    /// identity provider. The RESOLVE ARM only - a created account already carries the presented name, and an
+    /// adopted one was selected BY its name. Default off, in which case the resolved account's name is never
+    /// touched, which is what every deployment does today.
+    /// </param>
     /// <returns>The resolved Jellyfin user id.</returns>
-    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false, TimeSpan? provisionedAccessDuration = null)
+    internal async Task<Guid> ResolveOrCreateAsync(ProviderMode mode, string provider, string canonicalKey, string username, bool allowExistingAccountLink, AdoptionGate adoptionGate = default, string? issuer = null, bool provisionDisabled = false, TimeSpan? provisionedAccessDuration = null, bool syncUsername = false)
     {
         // Defense in depth (#95, #155): a login that resolved no stable identity key (OpenID sub /
         // SAML NameID) or no username must never create, adopt, or look up an account. Both callbacks
@@ -261,7 +268,10 @@ internal sealed class CanonicalLinkService
         switch (decision.Action)
         {
             case AccountLinkAction.UseExistingLink:
-                return decision.UserId;
+                // The one arm where the two names can have drifted apart: the subject resolved an account
+                // that already existed under whatever name it was created with, and the identity provider
+                // may have renamed the person since.
+                return await SyncUsernameIfRequestedAsync(syncUsername, mode, provider, decision.UserId, username).ConfigureAwait(false);
 
             case AccountLinkAction.AdoptExistingAccount:
                 // existingAccount is non-null here (adoption is only chosen when a named account resolved).
@@ -406,6 +416,79 @@ internal sealed class CanonicalLinkService
         }
 
         return migratedUserId;
+    }
+
+    // Renames a resolved account to follow its identity provider (#1138), and returns that account either
+    // way. Off by default; every early return below leaves the account exactly as it was and still yields a
+    // successful login, because a display name that has drifted is cosmetic and refusing the login over it
+    // would be far more expensive than the mismatch.
+    //
+    // THE INVARIANT THIS MUST NOT BREAK is that the subject is the key. The account is already resolved
+    // when this runs - it is passed in by id - so nothing here can change WHICH account a login reaches. The
+    // name follows the account; it never selects one. That is why this is a rename and not a lookup.
+    //
+    // The guards, in the order they fail:
+    //
+    // - The presented name is sanitized through the same map a provisioned name takes (#1137), so a rename
+    //   cannot put a name onto an account that Jellyfin's own check would have refused at creation, and a
+    //   name with nothing usable left in it renames nothing.
+    // - A name already held by a DIFFERENT account is left alone. The host would refuse the collision
+    //   anyway, but refusing it here is what keeps the two accounts' names from depending on which of them
+    //   logged in last, and it is the case where swallowing the host's error would look like a silent
+    //   no-op with no reason recorded.
+    // - A rename that throws for any other reason is logged and swallowed.
+    private async Task<Guid> SyncUsernameIfRequestedAsync(bool syncUsername, ProviderMode mode, string provider, Guid userId, string presentedName)
+    {
+        if (!syncUsername || !ProvisionedUsername.TrySanitize(presentedName, out var desiredName))
+        {
+            return userId;
+        }
+
+        var account = _userManager.GetUserById(userId);
+        if (account is null || string.Equals(account.Username, desiredName, StringComparison.Ordinal))
+        {
+            return userId;
+        }
+
+        var currentName = account.Username;
+        var holder = _userManager.GetUserByName(desiredName);
+        if (holder is not null && holder.Id != userId)
+        {
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    "SSO login via {Mode}/{Provider}: the identity provider's username is already held by a different Jellyfin account, so the linked account keeps its current name. Rename or merge the other account to let the sync proceed.",
+                    mode.ToToken(),
+                    provider.ReplaceLineEndings(string.Empty));
+            }
+
+            return userId;
+        }
+
+        try
+        {
+            await _userManager.RenameUser(userId, currentName, desiredName).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Deliberately broad. The host decides what a legal name is and what it throws when it is not,
+            // and this plugin compiles against an interface that promises neither; letting any of it escape
+            // would turn a cosmetic mismatch into a failed login, which is the one outcome this feature must
+            // never cause. The account keeps its old name and the reason is on the record.
+            if (_logger.IsEnabled(LogLevel.Warning))
+            {
+                _logger.LogWarning(
+                    ex,
+                    "SSO login via {Mode}/{Provider}: renaming the linked account to follow the identity provider failed; it keeps its current name and the login continues.",
+                    mode.ToToken(),
+                    provider.ReplaceLineEndings(string.Empty));
+            }
+
+            return userId;
+        }
+
+        SsoAudit.AccountRenamed(_logger, mode == ProviderMode.Oid ? "OpenID" : "SAML", provider, currentName, desiredName);
+        return userId;
     }
 
     // Adopts the pre-existing account that shares the display name, after clearing the eligibility gate.

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Jellyfin.Data;
@@ -465,9 +467,36 @@ internal sealed class CanonicalLinkService
             return userId;
         }
 
+        // BOUND AT RUNTIME, NOT AT COMPILE TIME, and HostRename says why: `IUserManager.RenameUser` takes
+        // (User, string) up to 10.11.8 and (Guid, string, string) from 10.11.9 on, so a direct call to
+        // either one breaks the floor build or the shipping build. This is the same divergence
+        // `SsoOnlyLoginService.AllUsers` already answers the same way.
         try
         {
-            await _userManager.RenameUser(userId, currentName, desiredName).ConfigureAwait(false);
+            var call = HostRename.Resolve(_userManager.GetType(), account, userId, currentName, desiredName)
+                ?? throw new InvalidOperationException(HostRename.NeitherShape);
+
+            object? returned;
+            try
+            {
+                returned = call.Method.Invoke(_userManager, call.Arguments);
+            }
+            catch (TargetInvocationException wrapped) when (wrapped.InnerException is not null)
+            {
+                // The host's own refusal, unwrapped. Without this the log below records a
+                // TargetInvocationException where the reason belongs, and the reason is the whole value of
+                // logging it: an admin needs to read "that name is taken", not "reflection threw".
+                ExceptionDispatchInfo.Capture(wrapped.InnerException).Throw();
+                throw;
+            }
+
+            // Both known shapes return Task. A shape that does not is awaited as nothing rather than
+            // refused, because the rename has already happened by then and failing here would log a
+            // failure for work that succeeded.
+            if (returned is Task rename)
+            {
+                await rename.ConfigureAwait(false);
+            }
         }
         catch (Exception ex)
         {

--- a/SSO-Auth/Api/Linking/HostRename.cs
+++ b/SSO-Auth/Api/Linking/HostRename.cs
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Reflection;
+using Jellyfin.Database.Implementations.Entities;
+using MediaBrowser.Controller.Library;
+
+namespace Jellyfin.Plugin.SSO_Auth.Api.Linking;
+
+/// <summary>
+/// Binds whichever <c>RenameUser</c> the loaded Jellyfin server actually exposes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>IUserManager</c>'s rename method diverged inside the supported range, in the same way its all-users
+/// accessor did (see <c>SsoOnlyLoginService.AllUsers</c>). Measured against the tags:
+/// </para>
+/// <code>
+/// v10.11.0 .. v10.11.8   Task RenameUser(User user, string newName)
+/// v10.11.9 .. v10.11.11  Task RenameUser(Guid userId, string oldName, string newName)
+/// </code>
+/// <para>
+/// v10.11.8 was published on 2026-04-05 and v10.11.9 on 2026-05-21, and the repository declares
+/// <c>targetAbi: "10.11.0.0"</c>. So a source reference to either shape breaks one of the two builds: the
+/// three-argument form fails the floor build, which is the proof that the shipped artifact would
+/// <c>MissingMethod</c> on an early 10.11 server, and the two-argument form fails the shipping build.
+/// Binding at runtime is what keeps one binary loadable across all twelve patch releases.
+/// </para>
+/// <para>
+/// THE COST IS NOTHING THAT MATTERS HERE. The lookup runs on a login only when the feature is enabled for
+/// that provider AND the presented name differs from the account's, which is once per rename rather than
+/// once per login.
+/// </para>
+/// <para>
+/// AND THE FAILURE IS ALREADY BOUNDED. The caller wraps this in a deliberately broad catch that logs and
+/// swallows, because a display name that has drifted is cosmetic and refusing a login over it would cost
+/// far more than the mismatch. A server exposing neither shape therefore behaves exactly as one where the
+/// feature is switched off: the account keeps its name, the login proceeds, and the reason is on the record.
+/// </para>
+/// </remarks>
+internal static class HostRename
+{
+    /// <summary>The sentence a server exposing neither shape is refused with.</summary>
+    /// <remarks>
+    /// It names both signatures, because the admin reading it in a log needs to know what their server was
+    /// asked for rather than that something reflective did not work.
+    /// </remarks>
+    internal const string NeitherShape =
+        "IUserManager on this Jellyfin build exposes neither RenameUser(Guid, string, string) nor "
+        + "RenameUser(User, string), so the linked account cannot be renamed to follow its provider.";
+
+    /// <summary>
+    /// Picks the rename method this server exposes and the arguments it takes, or <c>null</c> where it
+    /// exposes neither.
+    /// </summary>
+    /// <remarks>
+    /// Separated from the call so that both arms can be proved without a Jellyfin server: a test hands this
+    /// a type declaring one shape or the other and reads back which was chosen. The alternative - asserting
+    /// through a fake <c>IUserManager</c> - can only ever exercise the shape this assembly compiled against,
+    /// which is the one arm that was never in doubt.
+    /// </remarks>
+    /// <param name="manager">The runtime type of the user manager the host supplied.</param>
+    /// <param name="account">The resolved account, for the two-argument shape.</param>
+    /// <param name="userId">The resolved account's id, for the three-argument shape.</param>
+    /// <param name="currentName">The name the account holds now.</param>
+    /// <param name="desiredName">The name the provider presented, already sanitized.</param>
+    /// <returns>The method and its arguments, or <c>null</c>.</returns>
+    internal static (MethodInfo Method, object?[] Arguments)? Resolve(
+        Type manager, User? account, Guid userId, string currentName, string desiredName)
+    {
+        ArgumentNullException.ThrowIfNull(manager);
+
+        // The current line first, so the common case costs one lookup and the older shape is reached only
+        // where the newer one is absent.
+        var byIdAndBothNames = manager.GetMethod(
+            "RenameUser", new[] { typeof(Guid), typeof(string), typeof(string) });
+        if (byIdAndBothNames is not null)
+        {
+            return (byIdAndBothNames, new object?[] { userId, currentName, desiredName });
+        }
+
+        var byUserAndNewName = manager.GetMethod("RenameUser", new[] { typeof(User), typeof(string) });
+        if (byUserAndNewName is not null)
+        {
+            return (byUserAndNewName, new object?[] { account, desiredName });
+        }
+
+        return null;
+    }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -309,6 +309,25 @@ public abstract class ProviderConfigBase
     public bool ProvisionNewUsersDisabled { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether a login whose identity-provider username differs from the
+    /// linked Jellyfin account's name RENAMES that account to follow the provider (#1138). Off by default
+    /// (opt-in): a provider-side rename leaves the Jellyfin name as it was, which is the behaviour every
+    /// existing deployment has.
+    /// <para>
+    /// The subject stays the key. Resolution is keyed on the OpenID <c>sub</c> / SAML <c>NameID</c> (#155,
+    /// #186) and this adds no name-keyed path: the name FOLLOWS the account the subject already resolved,
+    /// and never selects one. Turning it on therefore cannot change which account a login reaches.
+    /// </para>
+    /// <para>
+    /// Fail-safe in both directions. The new name passes the same sanitization a provisioned name does
+    /// (<c>ProvisionedUsername</c>, #1137), a name already held by a DIFFERENT account is left alone rather
+    /// than fought over, and a rename the host refuses is logged and swallowed - a display-name mismatch is
+    /// cosmetic, and turning it into a failed login would be the more expensive failure by far.
+    /// </para>
+    /// </summary>
+    public bool SyncUsernameFromProvider { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether all folders are allowed by default.
     /// </summary>
     public bool EnableAllFolders { get; set; }

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -1709,6 +1709,36 @@
                       <label>
                         <input
                           is="emby-checkbox"
+                          id="SyncUsernameFromProvider"
+                          name="SyncUsernameFromProvider"
+                          type="checkbox"
+                          class="sso-toggle"
+                        />
+                        <span>Follow Username Renames From The Provider</span>
+                      </label>
+                      <div class="fieldDescription checkboxFieldDescription">
+                        When someone is renamed at the identity provider, rename
+                        their Jellyfin account to match on their next SSO login.
+                        Off by default, in which case the Jellyfin name stays as
+                        it was and the two drift apart. This changes the
+                        <strong>display name only</strong>: the account is found
+                        by its stable subject identifier either way, so turning
+                        this on cannot change which account a login reaches. The
+                        new name is cleaned up the same way a newly created one
+                        is. If another Jellyfin account already holds the name,
+                        the rename is skipped and both accounts keep their
+                        names. A rename that fails for any other reason is
+                        logged and the login still succeeds. Each rename is
+                        recorded as an audit event.
+                      </div>
+                    </div>
+
+                    <div
+                      class="checkboxContainer checkboxContainer-withDescription"
+                    >
+                      <label>
+                        <input
+                          is="emby-checkbox"
                           id="RequireVerifiedEmailForAdoption"
                           name="RequireVerifiedEmailForAdoption"
                           type="checkbox"
@@ -2553,6 +2583,30 @@
                       "awaiting administrator approval" message until an admin
                       enables it. Off by default. Never disables an existing or
                       adopted account, and each deferral is audited.
+                    </div>
+                  </div>
+
+                  <div
+                    class="checkboxContainer checkboxContainer-withDescription"
+                  >
+                    <label>
+                      <input
+                        is="emby-checkbox"
+                        id="saml-SyncUsernameFromProvider"
+                        name="saml-SyncUsernameFromProvider"
+                        type="checkbox"
+                        class="sso-toggle"
+                      />
+                      <span>Follow Username Renames From The Provider</span>
+                    </label>
+                    <div class="fieldDescription checkboxFieldDescription">
+                      When someone is renamed at the identity provider, rename
+                      their Jellyfin account to match on their next SSO login.
+                      Off by default. Display name only: the account is found by
+                      its stable NameID either way, so this cannot change which
+                      account a login reaches. Skipped when another account
+                      already holds the name, and a rename that fails never
+                      fails the login. Each rename is audited.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
# What & why

> **This does not merge as it stands, and the reason is not in this diff.**
> `IUserManager.RenameUser` has two different shapes inside the 10.11 line, and no
> overload compiles against both the declared ABI floor and the versions the
> plugin ships against. `ABI floor build` is red for that, and every other check
> is green. The measurement and the three ways out are written on #1138; choosing
> between them is a compatibility decision rather than a coding one, so this
> branch waits rather than picking one on its own.

Closes #1138.

An SSO link is keyed on the subject (OpenID `sub` / SAML `NameID`), so a rename
at the identity provider resolves correctly forever and the Jellyfin account
keeps the name it was created with indefinitely. The two drift apart with
nothing recording that they have, which is the support-confusion half of
9p4#146: an operator looks for the person under the name their provider shows
and finds a different row in the user list.

A new per-provider opt-in, **Follow Username Renames From The Provider**,
renames the resolved account to follow the provider on the next login. Off by
default, so nothing changes for any existing deployment.

## The invariant this must not break

**The subject stays the key.** The account is already resolved when the rename
runs, and is passed in by id, so nothing in this change can alter which account
a login reaches. The name FOLLOWS the account; it never selects one. That is why
this is a rename rather than a lookup, and why every test asserts against the
resolved id rather than looking the account up by name, which could not tell a
rename apart from a name-keyed resolution path sneaking back in.

It runs on the RESOLVE arm only. A created account already carries the presented
name and an adopted one was selected BY its name, so neither has anything to
follow.

## The second rule: this can never cost a login

A display name that has drifted is cosmetic; a refused login is not. Every path
below leaves the old name in place and still mints the session.

- The new name is sanitized through the same map a provisioned name takes
  (#1137), so a rename cannot put a name onto an account that Jellyfin's own
  check would have refused at creation. A name with nothing usable left renames
  nothing.
- A name already held by a DIFFERENT account is left alone. The host would refuse
  the collision anyway; refusing it here is what stops two accounts' names
  depending on which of them logged in last, and it keeps the reason on the
  record instead of swallowing a host error as a silent no-op.
- A name that already matches renames nothing, so a hot login loop cannot write
  an audit line per attempt claiming a rename that did not happen.
- A rename that throws for any other reason is logged and swallowed. The catch is
  deliberately broad: the host owns what a legal name is, and this plugin
  compiles against an interface that promises nothing about what it throws.

Each rename is audited with both names, because without the pair the account an
operator is looking for has silently become a different row with nothing saying
why.

## The signature was measured, not taken from the issue

The issue asserts `RenameUser` is present on both Jellyfin lines. Verified by
compiling a throwaway file against each target framework; the compiler reports
the exact shape, on both:

```
$ dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0 --nologo -v q
error CS7036: ... required parameter "newName" of "IUserManager.RenameUser(Guid, string, string)"
$ dotnet build SSO-Auth/SSO-Auth.csproj -f net10.0 --nologo -v q
error CS7036: ... required parameter "newName" of "IUserManager.RenameUser(Guid, string, string)"
```

The probe file was deleted afterwards and is not in this diff.

**Correction, from re-running the same probe against the floor.** The target
framework is not the axis that matters here; the package version is, and both
frameworks resolve the CURRENT package rather than the declared floor. The shape
changed inside the 10.11 line:

```
$ dotnet build SSO-Auth/SSO-Auth.csproj -f net9.0 -c Release -p:JellyfinVersion=10.11.0 -p:RestoreLockedMode=false
error CS7036: ... required parameter "user" of "IUserManager.RenameUser(User, string)"
$ grep targetAbi build.yaml
targetAbi: "10.11.0.0"
```

So the floor offers `RenameUser(User, string)`, the shipped line offers
`RenameUser(Guid, string, string)`, and there is no common overload. That is the
red check, and it is what the note at the top is about. The original measurement
above was not wrong about what it measured; it measured the wrong axis, and CI is
what caught that.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: nothing on the validation path changed, and the
      feature is off by default. Every failure path inside it leaves the account
      exactly as it was.
- [x] No secrets logged; secrets are redacted on config export. No secret is
      touched. Both names in the audit line are identity-provider-influenced and
      are stripped of line endings **inline at the log call**, per the
      `cs/log-forging` rule that sanitizers do not cross a helper boundary. The
      two `LogWarning` calls in the rename path log the protocol token and the
      provider name only, both stripped inline.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **Not performed as a separate
      pass, and this box stays unticked rather than being softened.** What stands
      in its place is the reasoning below and the guard-bite table. No second
      reader looked at any of it.
- [x] Review record: **CONFIRMED 0 / PLAUSIBLE 0** raised. The adversarial
      reading is in **Threat notes**; the near-miss it produced is a test, not a
      finding, and is listed in the guard-bite table.
- [x] Log inputs from the IdP are sanitized inline at the log call.

### Threat notes

- **Account takeover by rename.** The obvious attack is an identity provider
  asserting a username that belongs to somebody else. It cannot work: renaming
  changes no link, no permission and no password, and the collision guard means
  the target account is not renamed away either. The attacker's own account ends
  up displaying a name they already claimed, which is the same thing the login
  page already shows.
- **Name-keyed resolution creeping back.** The rename never consults the name to
  decide which account to act on. The one `GetUserByName` it makes is the
  collision check, and its result is used only to REFUSE.
- **Privileged accounts.** A rename grants nothing, so no administrator carve-out
  is warranted here the way it is for the disable paths (#831, #1144). An
  administrator whose provider renamed them is renamed like anyone else, and
  nothing about their access changes.
- **Audit flooding.** Guarded by the already-matches no-op: a steady-state login
  writes no line.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose unit. The
      sanitizer is reused rather than re-implemented.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass. The web-UI gate caught the new field
      and named exactly what it wanted, so its roster and count are updated in
      this branch; the SAML side derives its roster by reflection and needed no
      edit. See **Notes**.
- [x] Docs impact considered: the CHANGELOG entry is included, and the option
      carries its own in-page description in both provider forms.

## Verification

- [x] `dotnet build --warnaserror` is green, 0 warnings, on both frameworks at
      their default package versions. **NOT green against the declared ABI
      floor** - that is the one failing check and it is described at the top.
- [x] `dotnet test` is green on both.
- [x] Prettier is clean for the `.html` and `.md` this change touches.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3191, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3192, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ npx prettier --check CHANGELOG.md SSO-Auth/Web/configPage.html
All matched files use Prettier code style!
```

The four skips are pre-existing and unrelated: binding a listener off loopback
raises the Windows firewall consent dialog, which needs an administrator (#1227).
They skip on `main` identically and were not worked around.

## Guard-bite table

Every rule this change states was deleted or inverted, and the suite was run
against the broken tree. What went red:

| Rule broken | Tests that went red |
| --- | --- |
| the opt-in flag ignored | `WithTheFlagOff_TheNameIsLeftAlone` |
| the collision guard reduced to a null check instead of an id comparison | `ANameHeldByADifferentAccount_LeavesBothNamesAlone_AndStillMints` |
| the sanitizer dropped, the raw presented name used | `TheNewNameIsSanitizedTheSameWayAProvisionedOneIs`, `ANameWithNothingUsableLeft_RenamesNothing` |
| the already-matches no-op removed | `AMatchingName_RenamesNothing` |
| the broad catch narrowed so a host error escapes | `ARenameThatThrows_IsSwallowed_AndTheLoginStillSucceeds` |

The collision row is the near-miss worth naming: a guard written as
`holder is not null` rather than `holder.Id != userId` passes every other row and
silently disables the feature for anyone the host resolves under both names.
`ANameHeldByTheSameAccount_IsNotTreatedAsACollision` is the row that separates
them.

## Notes

- **Scope-line correction, stated because a reader will check it.** The issue's
  Scope says to surface the flag "exactly as" `DisableAccountOnRoleDenied` and
  `ProvisionNewUsersDisabled` do. Those two disagree: only the second has a form
  control. I followed the one that does, so the option is reachable without
  hand-editing the plugin configuration. The web layer discovers fields from the
  DOM by marker class and id, so this needed markup in `configPage.html` and no
  `config.js` change at all.
- **The conformance roster.** `ProviderForm_RendersEveryPersistingFieldId` keeps
  a hand-written roster of OpenID form ids with an asserted count, so a new field
  fails the build until it is rostered. That failure is what the gate is for and
  it is fixed here rather than worked around; the count moves 45 to 46.
- **Out of scope, from the issue's own note.** Jellyfin's `User` entity carries
  no email or display-name field, so "attribute sync" here is the username only.
  The avatar is already synced per login by an existing path.
