### PR TITLE
Stamp a bounded last-SSO-login instant against each canonical link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Added
 
+- **The account-link roster now reports the last SSO login (#1120).** Each link
+  in the roster carries the moment a login last signed in through it, so an
+  administrator can tell a live link from one nobody has used. Nothing is added
+  to the log: the plugin keeps one timestamp per link that already exists,
+  overwritten by the next login rather than appended to, and it is removed the
+  moment the link is - by unlinking, by removing an account's links from the
+  dashboard, and by deleting or repointing the provider. The stored value is
+  deliberately coarse. It is rewritten only once it is more than an hour old, so
+  signing in repeatedly costs no write to the plugin configuration, and the
+  roster reports "not later than" rather than a precise instant. A link nobody
+  has used since this version, or one made before it, reports nothing at all
+  instead of a made-up date. The value is withheld from the configuration page
+  in both directions: it cannot be read back through it, and a settings save can
+  neither clear it nor invent one. It is not part of the portable link export
+  either, because a login instant belongs to the server that observed it and
+  cannot be restored onto another.
 - **A per-provider starting policy for accounts SSO creates (#1099).** A
   provider can carry a template whose set fields are written onto a brand-new
   SSO account at creation: any of the boolean Jellyfin permissions, a

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.State.cs
@@ -57,8 +57,14 @@ public partial class ArchitectureConformanceTests
         //   (#1145), the exact parallel of _canonicalLinks and bounded BY it - an entry is only ever written
         //   beside a live link and is removed with that link, so the link map is its ceiling and no separate
         //   cap or sweep convention is owed. Serialized config mutated only under the config lock.
+        // - ProviderConfigBase._canonicalLinkLastLogins: the persisted per-link last-SSO-login instants
+        //   (#1120), bounded by the link map in exactly the same way - one entry per live link, overwritten
+        //   rather than appended by a repeat login, removed with the link on every erasure route. It is the
+        //   ONE shape this rule has to keep out: a per-login event log would need a cap and a sweep, and the
+        //   reason this needs neither is the bound, so the exemption is granted to the bounded design and not
+        //   to the subject matter.
         var storeLike = new[] { "Store", "Cache", "Limiter" };
-        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines" };
+        var exemptions = new[] { "ProviderConfigBase._canonicalLinks", "OidConfig._canonicalLinkIssuers", "PluginConfiguration._logoutSessions", "ProviderConfigBase._canonicalLinkDeadlines", "ProviderConfigBase._canonicalLinkLastLogins" };
 
         var offenders = PluginClasses
             .Where(t => !storeLike.Any(s => SimpleName(t).EndsWith(s, StringComparison.Ordinal)))

--- a/SSO-Auth.Tests/Config/LastSsoLoginStampTests.cs
+++ b/SSO-Auth.Tests/Config/LastSsoLoginStampTests.cs
@@ -1,0 +1,468 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Avatar;
+using Jellyfin.Plugin.SSO_Auth.Api.Flows;
+using Jellyfin.Plugin.SSO_Auth.Api.Identity;
+using Jellyfin.Plugin.SSO_Auth.Api.Linking;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Provider;
+using Jellyfin.Plugin.SSO_Auth.Api.Session;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Session;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// The bounded last-SSO-login stamp (#1120): where it is written, that it stays one entry per existing link
+/// rather than becoming an event log, that it is erased by every route that erases the link, and that the
+/// roster can tell "never" from an instant.
+/// <para>
+/// The boundedness is the whole review. The acceptance criterion this issue inherits is "no new unbounded PII
+/// store", and the design that satisfies it is one entry beside a link that already exists - so the tests
+/// below assert the cardinality directly (N logins, one entry) rather than trusting the shape of the code.
+/// </para>
+/// <para>
+/// The second property is a cost one, and it is a security property here rather than a performance nicety: an
+/// established user's repeat login pays no configuration persist today, and the file this would write on every
+/// login carries every provider secret envelope and every link map. <see cref="ASecondLoginInsideTheWindow_WritesNothing"/>
+/// is what refuses a write-through stamp sneaking back in.
+/// </para>
+/// </summary>
+public class LastSsoLoginStampTests
+{
+    private static readonly Guid User = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly DateTime Now = new(2026, 8, 17, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task ASuccessfulLogin_StampsTheLinkItResolved()
+    {
+        // The call site. Without it the map is a field nothing fills, and the roster column it exists for
+        // would read "never" for every account forever.
+        var config = new OidConfig { Enabled = true };
+        var (service, users, _) = BuildLogin(config, out _);
+        users.GetUserById(User).Returns(TestUsers.Named("alice", User));
+        config.CanonicalLinks["sub-1"] = User;
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.True(config.CanonicalLinkLastLogins.ContainsKey("sub-1"));
+        Assert.Equal(DateTimeKind.Utc, config.CanonicalLinkLastLogins["sub-1"].Kind);
+    }
+
+    [Fact]
+    public async Task ManyLoginsForOneSubject_LeaveExactlyOneEntry()
+    {
+        // The boundedness clause, asserted as cardinality. An append-per-login design would pass every other
+        // test in this file and fail exactly here, which is why the count is the assertion rather than the
+        // presence of the key.
+        var config = new OidConfig { Enabled = true };
+        var (service, users, _) = BuildLogin(config, out _);
+        users.GetUserById(User).Returns(TestUsers.Named("alice", User));
+        config.CanonicalLinks["sub-1"] = User;
+
+        for (var i = 0; i < 5; i++)
+        {
+            await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+        }
+
+        Assert.Single(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public async Task ASecondLoginInsideTheWindow_WritesNothing()
+    {
+        // The flush policy, proven by counting persists rather than by reading the code. The first login of a
+        // link stamps it and pays one write; the second inside the granularity window must pay none, because
+        // the login path deliberately performs no configuration persist for an established user.
+        var config = new OidConfig { Enabled = true };
+        var (service, users, _) = BuildLogin(config, out var persists);
+        users.GetUserById(User).Returns(TestUsers.Named("alice", User));
+        config.CanonicalLinks["sub-1"] = User;
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+        var afterFirst = persists.Count;
+
+        await service.CompleteAsync(Identity(), Response(), config, AdoptionGate.None, () => "203.0.113.9");
+
+        Assert.Equal(1, afterFirst);
+        Assert.Equal(afterFirst, persists.Count);
+    }
+
+    [Fact]
+    public void AStampOlderThanTheGranularity_IsRewritten()
+    {
+        // The other half of the same rule: coalescing may not become "written once and then frozen", or the
+        // roster would report a user's first-ever login as their last one for the rest of the deployment.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkLastLogins["sub-1"] = Now - ProviderConfigBase.LastSsoLoginGranularity - TimeSpan.FromMinutes(1);
+
+        LinkService(configuration, () => Now).RecordLastSsoLogin(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(Now, config.CanonicalLinkLastLogins["sub-1"]);
+    }
+
+    [Fact]
+    public void AStampStoredInTheFuture_IsCorrectedRatherThanFrozen()
+    {
+        // The near-miss the age comparison invites, and a one-character mistake away from shipping: with the
+        // test written as `now - stored >= granularity` alone, a stamp ahead of the clock - a configuration
+        // restored from a machine whose clock ran fast, or a clock stepped back - is never overdue, so it is
+        // frozen forever and the roster keeps reporting a login from the future.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkLastLogins["sub-1"] = Now + TimeSpan.FromDays(30);
+
+        LinkService(configuration, () => Now).RecordLastSsoLogin(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Equal(Now, config.CanonicalLinkLastLogins["sub-1"]);
+    }
+
+    [Fact]
+    public void AStampIsNeverWritten_ForASubjectThatHasNoLink()
+    {
+        // The ceiling on the map's size: an entry can only exist beside a live link, so the link map bounds
+        // this one. Without it the stamp would be a scratch space any resolved-but-unlinked identity could
+        // grow, which is the unbounded store the parent issue's criterion forbids.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+
+        LinkService(configuration, () => Now).RecordLastSsoLogin(ProviderMode.Oid, "kc", "sub-unlinked");
+
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void AStampIsNeverWritten_ForAnUnknownProvider_OrABlankKey()
+    {
+        // Two fail-closed arms of the only writer, both reachable from a real login: a provider deleted by a
+        // save while a login for it was in flight, and the blank key an identity that did not resolve carries.
+        // Neither may create an entry, and neither may throw out of a login that has already minted a session.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        var service = LinkService(configuration, () => Now);
+
+        service.RecordLastSsoLogin(ProviderMode.Oid, "deleted-provider", "sub-1");
+        service.RecordLastSsoLogin(ProviderMode.Oid, "kc", "   ");
+
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void RemovingALink_RemovesItsStamp()
+    {
+        // Unlinking IS the erasure route the retention promise names, so a stamp surviving it would be login
+        // history retained for a subject the server no longer knows - and a re-link of the same key would
+        // report a last login belonging to the previous holder of it.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkLastLogins["sub-1"] = Now;
+
+        LinkService(configuration, () => Now).TryRemoveLink(ProviderMode.Oid, "kc", "sub-1", User);
+
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void RevokingAUserEverywhere_PrunesTheirStamps_OnBothProtocols()
+    {
+        // The administrator Unregister path removes links directly rather than through TryRemoveLink, so it
+        // carries its own prune. SAML is asserted beside OpenID on purpose: the neighbouring issuer map is
+        // OpenID-only, so an implementation copied from it prunes the OpenID arm and silently leaves every
+        // SAML stamp behind - a test that only unlinked an OpenID user would pass over exactly that defect.
+        var configuration = new PluginConfiguration();
+        var oid = new OidConfig { Enabled = true };
+        var saml = new SamlConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = oid;
+        configuration.SamlConfigs["idp"] = saml;
+        oid.CanonicalLinks["sub-1"] = User;
+        oid.CanonicalLinkLastLogins["sub-1"] = Now;
+        saml.CanonicalLinks["nameid-1"] = User;
+        saml.CanonicalLinkLastLogins["nameid-1"] = Now;
+
+        LinkService(configuration, () => Now).RemoveUserEverywhere(User);
+
+        Assert.Empty(oid.CanonicalLinkLastLogins);
+        Assert.Empty(saml.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void TheSamlArm_StampsAndRemovesToo()
+    {
+        // Both protocols carry the map, so both arms of the provider lookup have to be reachable rather than
+        // inherited from the OpenID bookkeeping.
+        var configuration = new PluginConfiguration();
+        var config = new SamlConfig { Enabled = true };
+        configuration.SamlConfigs["idp"] = config;
+        config.CanonicalLinks["nameid-1"] = User;
+        var service = LinkService(configuration, () => Now);
+
+        service.RecordLastSsoLogin(ProviderMode.Saml, "idp", "nameid-1");
+        Assert.Equal(Now, config.CanonicalLinkLastLogins["nameid-1"]);
+
+        service.TryRemoveLink(ProviderMode.Saml, "idp", "nameid-1", User);
+        Assert.Empty(config.CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void AStampWrittenFromALocalClock_IsStoredAsUtc()
+    {
+        // One clock basis throughout (#676). Stored in the server's local time it would be serialized without
+        // a zone and read by the roster as UTC, so the same login would appear hours out depending on where
+        // the server is - the kind of defect nobody reports as a bug.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        var local = new DateTime(2026, 8, 17, 14, 0, 0, DateTimeKind.Local);
+
+        LinkService(configuration, () => local).RecordLastSsoLogin(ProviderMode.Oid, "kc", "sub-1");
+
+        var stored = config.CanonicalLinkLastLogins["sub-1"];
+        Assert.Equal(DateTimeKind.Utc, stored.Kind);
+        Assert.Equal(local.ToUniversalTime(), stored);
+    }
+
+    [Fact]
+    public void Preserve_ReinjectsLiveStamps_IntoAStaleIncomingSave()
+    {
+        // The config-PUT regression, on both protocols. The map is withheld from JSON, so a config-page save
+        // always arrives with it empty; without the re-injection an unrelated settings change resets every
+        // "last SSO login" in the roster to never.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+            CanonicalLinkLastLogins = new SerializableDictionary<string, DateTime> { ["sub-1"] = Now },
+        };
+        live.SamlConfigs["saml"] = new SamlConfig
+        {
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-1"] = User },
+            CanonicalLinkLastLogins = new SerializableDictionary<string, DateTime> { ["nameid-1"] = Now },
+        };
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://idp/.well-known" };
+        incoming.SamlConfigs["saml"] = new SamlConfig();
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Equal(Now, incoming.OidConfigs["idp"].CanonicalLinkLastLogins["sub-1"]);
+        Assert.Equal(Now, incoming.SamlConfigs["saml"].CanonicalLinkLastLogins["nameid-1"]);
+    }
+
+    [Fact]
+    public void Preserve_OidEndpointChanged_ClearsTheStampsWithTheLinks()
+    {
+        // The repoint belt (#186) reaches the stamps. A different discovery URL is potentially a different
+        // identity provider, and the links it drops are the ones these stamps key off - so keeping them would
+        // retain login history for subjects this provider no longer knows, with no erasure route left.
+        var live = new PluginConfiguration();
+        live.OidConfigs["idp"] = new OidConfig
+        {
+            OidEndpoint = "https://idp/.well-known",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-1"] = User },
+            CanonicalLinkLastLogins = new SerializableDictionary<string, DateTime> { ["sub-1"] = Now },
+        };
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["idp"] = new OidConfig { OidEndpoint = "https://other-idp/.well-known" };
+
+        ServerManagedFields.Preserve(incoming, live);
+
+        Assert.Empty(incoming.OidConfigs["idp"].CanonicalLinks);
+        Assert.Empty(incoming.OidConfigs["idp"].CanonicalLinkLastLogins);
+    }
+
+    [Fact]
+    public void Stamps_AreOmittedFromJson_ButSurviveTheXmlRoundTrip()
+    {
+        // Server-managed exactly like the links: withheld from JSON so a config PUT can neither read a
+        // subject's login history back out nor forge an entry, and persisted in the XML so the roster still
+        // answers after a restart rather than resetting to never on every server bounce.
+        var config = new OidConfig
+        {
+            OidClientId = "client",
+            CanonicalLinkLastLogins = new SerializableDictionary<string, DateTime> { ["sub-secret"] = Now },
+        };
+
+        var json = System.Text.Json.JsonSerializer.Serialize(config);
+        Assert.DoesNotContain("CanonicalLinkLastLogins", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-secret", json, StringComparison.Ordinal);
+
+        var serializer = new XmlSerializer(typeof(OidConfig));
+        using var writer = new System.IO.StringWriter();
+        serializer.Serialize(writer, config);
+        var xml = writer.ToString();
+        Assert.Contains("CanonicalLinkLastLogins", xml, StringComparison.Ordinal);
+
+        using var reader = new System.IO.StringReader(xml);
+        using var xmlReader = System.Xml.XmlReader.Create(
+            reader,
+            new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit, XmlResolver = null });
+        var back = (OidConfig)serializer.Deserialize(xmlReader)!;
+
+        Assert.Equal(Now, back.CanonicalLinkLastLogins["sub-secret"].ToUniversalTime());
+    }
+
+    [Fact]
+    public void TheRoster_CarriesTheStamp_AndReportsNeverAsNull()
+    {
+        // The reporting clause, including the half that is easy to get wrong: a link with no stamp has to come
+        // out as null rather than as a default DateTime, which a client would render as a login in year one -
+        // a fabricated date is worse than an admitted gap.
+        var live = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        live.OidConfigs["kc"] = config;
+        config.CanonicalLinks["seen"] = User;
+        config.CanonicalLinks["never"] = User;
+        config.CanonicalLinkLastLogins["seen"] = Now;
+
+        var document = LinkRoster.Build(live, _ => "alice");
+
+        var links = Assert.Single(document.Accounts).Links;
+        Assert.Equal(Now, Assert.Single(links, l => l.CanonicalName == "seen").LastSsoLoginUtc);
+        Assert.Null(Assert.Single(links, l => l.CanonicalName == "never").LastSsoLoginUtc);
+    }
+
+    [Fact]
+    public void ThePortableLinkExport_DoesNotCarryTheStamp()
+    {
+        // Deliberate, and pinned so it cannot drift in by someone adding the field to the shared walk. The
+        // export exists to be re-applied to a rebuilt server: restoring a login instant would assert a login
+        // that never happened there, and shipping it off the machine widens where the personal data travels
+        // for nothing. The roster is a read of the live server and is the one document that reports it.
+        var live = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        live.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkLastLogins["sub-1"] = Now;
+
+        var json = System.Text.Json.JsonSerializer.Serialize(LinkExport.Build(live, _ => "alice"));
+
+        Assert.DoesNotContain("LastSsoLogin", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(Now.Year.ToString(System.Globalization.CultureInfo.InvariantCulture), json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AFailedConfigurationPersist_DoesNotEscapeIntoTheLogin()
+    {
+        // The availability arm, and the reason the write is wrapped at all. The stamp is written after the
+        // session has been minted, so an exception out of the persist would turn a login that has ALREADY
+        // succeeded into an error - on every login, for as long as the volume stays read-only or full. A stale
+        // roster column is the correct price; SSO refusing every login on the server is not.
+        var configuration = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        configuration.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        var logger = new CapturingLogger();
+        var service = new CanonicalLinkService(
+            Substitute.For<IUserManager>(),
+            new FakeCryptoProvider(),
+            new ProviderConfigStore(() => configuration, _ => throw new System.IO.IOException("read-only volume"), logger),
+            logger,
+            clock: () => Now);
+
+        service.RecordLastSsoLogin(ProviderMode.Oid, "kc", "sub-1");
+
+        Assert.Contains(logger.Entries, e => e.Message.Contains("last SSO login", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TheConfigExport_WithholdsTheStamp()
+    {
+        // Named by the Done-when. The export shares the live provider objects and relies entirely on the JSON
+        // attributes to withhold the server-managed maps, so nothing in that file mentions this one - which is
+        // exactly why the omission has to be pinned here rather than read out of the export's own source.
+        var live = new PluginConfiguration();
+        var config = new OidConfig { Enabled = true };
+        live.OidConfigs["kc"] = config;
+        config.CanonicalLinks["sub-1"] = User;
+        config.CanonicalLinkLastLogins["sub-1"] = Now;
+
+        var json = System.Text.Json.JsonSerializer.Serialize(ConfigExport.Build(live));
+
+        Assert.DoesNotContain("CanonicalLinkLastLogins", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-1", json, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AConfigPut_CanNeitherSetNorReadTheStamp()
+    {
+        // The forge arm. The map is withheld in BOTH directions: a posted body naming it deserializes to
+        // nothing, so an administrator - or anyone who reaches that route - cannot plant a login history for a
+        // guessed subject, and cannot read one back out either.
+        var posted = System.Text.Json.JsonSerializer.Deserialize<OidConfig>(
+            """{"OidClientId":"client","CanonicalLinkLastLogins":{"sub-1":"2026-08-17T12:00:00Z"}}""");
+
+        Assert.NotNull(posted);
+        Assert.Empty(posted.CanonicalLinkLastLogins);
+    }
+
+    // --- helpers ---
+
+    private static CanonicalLinkService LinkService(PluginConfiguration configuration, Func<DateTime> clock) =>
+        new CanonicalLinkService(
+            Substitute.For<IUserManager>(),
+            new FakeCryptoProvider(),
+            new ProviderConfigStore(() => configuration, _ => { }, new CapturingLogger()),
+            new CapturingLogger(),
+            clock: clock);
+
+    private static AuthResponse Response() =>
+        new AuthResponse { AppName = "app", AppVersion = "1", DeviceID = "d", DeviceName = "dev" };
+
+    private static VerifiedIdentity Identity() =>
+        TestIdentities.Oidc("kc", new OidcAuthorizeStateBuilder.OidcAuthorizeState(
+            Username: "alice",
+            Subject: "sub-1",
+            Issuer: null,
+            EmailVerified: null,
+            Valid: true,
+            Admin: false,
+            EnableLiveTv: false,
+            EnableLiveTvManagement: false,
+            Folders: new List<string>(),
+            AvatarUrl: null,
+            ExpiresAtUtc: null));
+
+    // The login service under test, plus the list every configuration persist lands in - the flush-policy test
+    // counts that list rather than inspecting the code, so a write-through stamp reddens it.
+    private static (LoginCompletionService Service, IUserManager Users, ISessionManager Sessions) BuildLogin(OidConfig config, out List<int> persists)
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["kc"] = config;
+        var writes = new List<int>();
+        persists = writes;
+        var users = Substitute.For<IUserManager>();
+        var sessions = Substitute.For<ISessionManager>();
+        sessions.AuthenticateDirect(Arg.Any<AuthenticationRequest>()).Returns(new AuthenticationResult());
+        var store = new ProviderConfigStore(() => configuration, _ => writes.Add(1), new CapturingLogger());
+        var canonicalLinks = new CanonicalLinkService(users, new FakeCryptoProvider(), store, new CapturingLogger());
+        var avatar = new AvatarService(users, Substitute.For<IProviderManager>(), Substitute.For<IServerConfigurationManager>(), new CapturingLogger(), "test-agent");
+        var minter = new SessionMinter(users, avatar, sessions, new CapturingLogger());
+        var ssoOnly = new SsoOnlyLoginService(users, store, new CapturingLogger());
+        return (new LoginCompletionService(canonicalLinks, minter, ssoOnly, store, sessions, new CapturingLogger()), users, sessions);
+    }
+}

--- a/SSO-Auth/Api/Flows/LoginCompletionService.cs
+++ b/SSO-Auth/Api/Flows/LoginCompletionService.cs
@@ -177,6 +177,13 @@ internal sealed class LoginCompletionService
             () => _canonicalLinks.IsIdentityStillLinked(identity.LinkMode, identity.Provider, identity.Subject, userId)).ConfigureAwait(false);
         SsoAudit.LoginSucceeded(_logger, identity.AuditProtocol, identity.Provider, identity.Username, identity.Admin);
 
+        // Stamp the link the login resolved (#1120), at the one point that knows both that the mint succeeded
+        // and which link carried it. Placed AFTER the mint on purpose: a refused or failed login must leave no
+        // trace in a field the roster presents as "last SSO login", and a stamp written before the mint would
+        // record attempts. Bounded and coalesced inside the service - see RecordLastSsoLogin - so an
+        // established user's repeat login still pays no configuration persist.
+        _canonicalLinks.RecordLastSsoLogin(identity.LinkMode, identity.Provider, identity.Subject);
+
         CaptureLogoutState(identity, userId, logoutContext, authenticationResult);
 
         return LoginStatusMapper.ToActionResult(new LoginOutcome.Success(authenticationResult));

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -777,6 +777,85 @@ internal sealed class CanonicalLinkService
     }
 
     /// <summary>
+    /// Stamps the instant of a successful SSO login against the canonical link it resolved (#1120), so the
+    /// administrator roster can answer "last SSO login" without any event log being kept.
+    /// <para>
+    /// Bounded by construction, which is the whole design: an entry is only ever written beside a live link,
+    /// so the map's cardinality is the link map's, a repeat login overwrites one value rather than appending,
+    /// and <see cref="TryRemoveLink"/> / <see cref="RemoveUserEverywhere"/> take the entry away with the link.
+    /// </para>
+    /// <para>
+    /// Coarse on purpose. An established user's repeat login pays no configuration persist today, and this is
+    /// the login hot path, so a write-through stamp would add one write per login to the file that carries
+    /// every provider secret envelope and every link map. The stamp is therefore only rewritten once it has
+    /// aged past <see cref="ProviderConfigBase.LastSsoLoginGranularity"/>: the value is accurate to that
+    /// resolution and never fresher, and the roster's wording has to promise no more than that.
+    /// </para>
+    /// </summary>
+    /// <param name="mode">The provider protocol the link belongs to.</param>
+    /// <param name="provider">The provider name.</param>
+    /// <param name="canonicalKey">The stable subject key the link is stored under.</param>
+    internal void RecordLastSsoLogin(ProviderMode mode, string provider, string? canonicalKey)
+    {
+        if (string.IsNullOrWhiteSpace(canonicalKey))
+        {
+            return;
+        }
+
+        var nowUtc = _clock().ToUniversalTime();
+
+        // Decided under a locked READ so the common case - an established user logging in again inside the
+        // granularity window - reaches no write at all. The decision and the write are two lock acquisitions
+        // deliberately: the field is last-writer-wins by definition, so the worst a login racing another can
+        // produce is one redundant write of an equivalent instant, and there is nothing a single held lock
+        // would protect. A stored instant in the FUTURE (a config restored from a machine whose clock ran
+        // ahead, or a clock stepped back) is also due, because `now - stored` is negative there and a stamp
+        // that is never overdue would be frozen forever.
+        var due = _configStore.Read(configuration =>
+            TryGetProvider(configuration, mode, provider, out var config)
+            && config.CanonicalLinks.ContainsKey(canonicalKey)
+            && (!config.CanonicalLinkLastLogins.TryGetValue(canonicalKey, out var stored)
+                || stored.ToUniversalTime() > nowUtc
+                || nowUtc - stored.ToUniversalTime() >= ProviderConfigBase.LastSsoLoginGranularity));
+
+        if (!due)
+        {
+            return;
+        }
+
+        // AVAILABILITY. This is bookkeeping for a roster column and it runs AFTER the session has been minted,
+        // so a configuration persist that throws - a read-only or full volume being the ordinary way - must not
+        // turn a login that has already succeeded into an error the user sees, which is what an escaping
+        // exception here would do. It is deliberately swallowed to a warning: the cost of the failure is a
+        // stale "last SSO login", and letting it out would trade a cosmetic gap for SSO refusing every login
+        // on the server. The deadline writer above is deliberately NOT given the same treatment, because a
+        // lost deadline is lost ENFORCEMENT rather than a lost display.
+        try
+        {
+            _configStore.Mutate(configuration =>
+            {
+                // Re-tested inside the write lock rather than trusted from the read above: an unlink landing
+                // between the two acquisitions must not resurrect a stamp for a subject that no longer holds
+                // a link, which is the bound every other guarantee here rests on.
+                if (TryGetProvider(configuration, mode, provider, out var config) && config.CanonicalLinks.ContainsKey(canonicalKey))
+                {
+                    config.CanonicalLinkLastLogins[canonicalKey] = nowUtc;
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            // The provider only, never the subject: this names whose bookkeeping failed and nothing that
+            // identifies the account, which is the rule the audit trail already holds itself to. Line endings
+            // are stripped AT the call rather than in a helper, because the sanitizer does not survive one.
+            _logger.LogWarning(
+                ex,
+                "[SSO] Could not record the last SSO login for provider {Provider}. The login itself succeeded; the roster timestamp is stale.",
+                provider?.ReplaceLineEndings(string.Empty));
+        }
+    }
+
+    /// <summary>
     /// The canonical links whose persisted deadline is at or before <paramref name="nowUtc"/>, across the
     /// providers of both protocols, materialized in one locked pass (#1145).
     /// </summary>
@@ -1006,6 +1085,12 @@ internal sealed class CanonicalLinkService
             // subject must start with no deadline rather than inherit the removed link's.
             RemoveDeadline(configuration, mode, provider, canonicalName);
 
+            // Drop the last-SSO-login stamp alongside the link (#1120). Unlinking IS the erasure route an
+            // administrator has for that personal data, so a stamp that survived the unlink would be login
+            // history retained for a subject the server no longer knows, and a re-link of the same subject
+            // would report a "last SSO login" that belongs to the previous holder of the key.
+            RemoveLastSsoLogin(configuration, mode, provider, canonicalName);
+
             // Whether the user keeps any other canonical link across ALL providers, read in the SAME
             // transaction as the removal (#468): computing it here rather than in a second lock acquisition
             // means a concurrent link add/remove cannot interleave between the remove and the check and
@@ -1097,6 +1182,16 @@ internal sealed class CanonicalLinkService
                     foreach (var staleKey in config.CanonicalLinkDeadlines.Keys.Where(k => !remaining.ContainsKey(k)).ToList())
                     {
                         config.CanonicalLinkDeadlines.Remove(staleKey);
+                    }
+
+                    // And the last-SSO-login stamps (#1120), on both protocols for the same reason the
+                    // deadlines are: this path removes the links directly rather than through TryRemoveLink,
+                    // so it needs its own prune, and the admin Unregister is the erasure route the retention
+                    // promise names. A stamp left behind here would be login history for an account whose
+                    // links were just revoked, with nothing left in the roster to reach it by.
+                    foreach (var staleKey in config.CanonicalLinkLastLogins.Keys.Where(k => !remaining.ContainsKey(k)).ToList())
+                    {
+                        config.CanonicalLinkLastLogins.Remove(staleKey);
                     }
                 }
             }
@@ -1322,6 +1417,18 @@ internal sealed class CanonicalLinkService
         if (TryGetProvider(configuration, mode, provider, out var config))
         {
             config.CanonicalLinkDeadlines.Remove(canonicalKey);
+        }
+    }
+
+    // Drops a link's last-SSO-login stamp within the caller's already-held config transaction (#1120), called
+    // alongside a link removal. Kept as its own named step beside RemoveDeadline rather than folded into it,
+    // because the two are removed for different reasons: an orphan deadline is bookkeeping the sweep would act
+    // on, an orphan stamp is retained personal data whose erasure route was just taken.
+    private static void RemoveLastSsoLogin(PluginConfiguration configuration, ProviderMode mode, string provider, string canonicalKey)
+    {
+        if (TryGetProvider(configuration, mode, provider, out var config))
+        {
+            config.CanonicalLinkLastLogins.Remove(canonicalKey);
         }
     }
 

--- a/SSO-Auth/Config/LinkExport.cs
+++ b/SSO-Auth/Config/LinkExport.cs
@@ -17,7 +17,8 @@ namespace Jellyfin.Plugin.SSO_Auth.Config;
 /// <param name="CanonicalName">The identity key the link is stored under.</param>
 /// <param name="UserId">The Jellyfin user id the link points at, which may no longer resolve to an account.</param>
 /// <param name="Issuer">The issuer this OpenID link is bound to (#186), or null for SAML and for links written before the binding existed.</param>
-internal readonly record struct CanonicalLinkRow(string Protocol, string Provider, string CanonicalName, Guid UserId, string? Issuer);
+/// <param name="LastSsoLoginUtc">The instant of the last successful SSO login through this link (#1120), or null when none has been stamped since the field existed.</param>
+internal readonly record struct CanonicalLinkRow(string Protocol, string Provider, string CanonicalName, Guid UserId, string? Issuer, DateTime? LastSsoLoginUtc);
 
 /// <summary>
 /// Builds the portable account-link snapshot (#1126). It reads the two link maps and resolves each
@@ -67,7 +68,8 @@ internal static class LinkExport
                     provider,
                     link.Key,
                     link.Value,
-                    config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null);
+                    config.CanonicalLinkIssuers.TryGetValue(link.Key, out var issuer) ? issuer : null,
+                    LastSsoLogin(config, link.Key));
             }
         }
 
@@ -75,7 +77,7 @@ internal static class LinkExport
         {
             foreach (var link in config.CanonicalLinks)
             {
-                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null);
+                yield return new CanonicalLinkRow(SamlProtocol, provider, link.Key, link.Value, null, LastSsoLogin(config, link.Key));
             }
         }
     }
@@ -106,6 +108,11 @@ internal static class LinkExport
                 continue;
             }
 
+            // The last-SSO-login stamp on the row is deliberately NOT carried into this document (#1120). The
+            // export exists to be re-applied to a rebuilt server, and a login instant is an observation rather
+            // than restorable state: writing it back would assert a login that never happened on the new
+            // server, and shipping it out widens where that personal data travels for no gain. The roster,
+            // which is a read of the live server, is the one document that reports it.
             document.Links.Add(new LinkExportEntry
             {
                 Protocol = row.Protocol,
@@ -118,6 +125,17 @@ internal static class LinkExport
 
         return document;
     }
+
+    // The last-SSO-login stamp for one link (#1120), keyed by the same canonical name as the link itself and
+    // carried on both protocols. Null when no login has been stamped since the field existed, which is the
+    // honest answer a reader has to be able to distinguish from an instant: a default DateTime here would be
+    // rendered as a login in year one rather than as "never". Normalized to UTC on the way out, the same way
+    // every other reader of these maps does it, so what the roster serializes carries a Z and cannot be read
+    // as the server's local wall clock.
+    private static DateTime? LastSsoLogin(ProviderConfigBase config, string canonicalName) =>
+        config.CanonicalLinkLastLogins.TryGetValue(canonicalName, out var stamped)
+            ? stamped.ToUniversalTime()
+            : null;
 
     // A provider stored with a null config object is reachable through a null-bodied add (#350), and the
     // read side treats that the same fail-closed way the link listings do: skipped, never dereferenced.

--- a/SSO-Auth/Config/LinkRoster.cs
+++ b/SSO-Auth/Config/LinkRoster.cs
@@ -61,6 +61,7 @@ internal static class LinkRoster
                 Protocol = row.Protocol,
                 Provider = row.Provider,
                 CanonicalName = row.CanonicalName,
+                LastSsoLoginUtc = row.LastSsoLoginUtc,
             });
         }
 

--- a/SSO-Auth/Config/LinkRosterDocument.cs
+++ b/SSO-Auth/Config/LinkRosterDocument.cs
@@ -76,4 +76,17 @@ public class LinkedAccountEntry
     /// this user, or the username it fell back to for a link made before subjects were required.
     /// </summary>
     public string? CanonicalName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last successful SSO login through this link (#1120), in UTC, or null when none has
+    /// been recorded. Null means exactly "never seen since this field existed" - a link that predates it, or
+    /// one whose account has not signed in since - and never a login at an unknown time, which is why it is
+    /// nullable rather than a default instant a reader would render as a date in year one.
+    /// <para>
+    /// It is accurate to the granularity the stamp is coalesced at, not to the second: the plugin rewrites the
+    /// stored instant only once it has aged, so that an ordinary repeat login costs no configuration write.
+    /// Read it as "not later than", and do not build a session timeline on it.
+    /// </para>
+    /// </summary>
+    public DateTime? LastSsoLoginUtc { get; set; }
 }

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -173,8 +173,17 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
 // is the disposition rather than a per-property annotation.
 public abstract class ProviderConfigBase
 {
+    /// <summary>
+    /// The resolution <see cref="CanonicalLinkLastLogins"/> is kept to: a successful login rewrites a stored
+    /// instant only once it is this much older than now, so the write cost of the stamp is at most one
+    /// configuration persist per link per hour rather than one per login. It lives here, beside the map, so
+    /// the promise a reader of the value gets and the rule the writer applies are the same sentence.
+    /// </summary>
+    internal static readonly TimeSpan LastSsoLoginGranularity = TimeSpan.FromHours(1);
+
     private SerializableDictionary<string, Guid>? _canonicalLinks;
     private SerializableDictionary<string, DateTime>? _canonicalLinkDeadlines;
+    private SerializableDictionary<string, DateTime>? _canonicalLinkLastLogins;
 
     /// <summary>
     /// Gets or sets the canonical external base URL for this provider, e.g.
@@ -491,6 +500,33 @@ public abstract class ProviderConfigBase
     {
         get => _canonicalLinkDeadlines ??= new SerializableDictionary<string, DateTime>();
         set => _canonicalLinkDeadlines = value;
+    }
+
+    /// <summary>
+    /// Gets or sets, per canonical link, the instant of the last successful SSO login that resolved it
+    /// (#1120), in UTC. Keyed by the same stable subject as <see cref="CanonicalLinks"/>, so the map's
+    /// cardinality IS the link map's: a repeat login overwrites one value and never appends, and the entry is
+    /// removed with the link it describes. That is what makes it a bounded per-link field rather than an
+    /// event log, which is the property the roster's "last SSO login" column had to be built on.
+    /// <para>
+    /// It is deliberately coarse. A successful login only rewrites the stored instant once it is older than
+    /// <see cref="LastSsoLoginGranularity"/>, because the ordinary repeat login of an established user pays
+    /// no configuration persist at all today and a write-through stamp would put one on the login path - on
+    /// the file that carries every provider secret envelope and every link map. The trade is stated where a
+    /// reader of the value will meet it: the instant is accurate to the granularity, never fresher.
+    /// </para>
+    /// </summary>
+    // Server-managed exactly like CanonicalLinks and CanonicalLinkDeadlines: written by logins, never
+    // admin-edited, persisted in the config XML but withheld from every JSON response ([JsonIgnore]) so a
+    // config PUT can neither read the login history of a guessed subject back out nor forge an entry.
+    // Preserved on save by ServerManagedFields.Preserve. Self-healing lazy init, so a direct index
+    // assignment persists into the stored map.
+    [XmlElement("CanonicalLinkLastLogins")]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public SerializableDictionary<string, DateTime> CanonicalLinkLastLogins
+    {
+        get => _canonicalLinkLastLogins ??= new SerializableDictionary<string, DateTime>();
+        set => _canonicalLinkLastLogins = value;
     }
 }
 

--- a/SSO-Auth/Config/ServerManagedFields.cs
+++ b/SSO-Auth/Config/ServerManagedFields.cs
@@ -116,6 +116,12 @@ internal static class ServerManagedFields
         // one across a repoint would hand a different identity provider's subject an inherited deadline.
         incoming.CanonicalLinkDeadlines = endpointUnchanged ? live.CanonicalLinkDeadlines : new SerializableDictionary<string, DateTime>();
 
+        // The last-SSO-login stamps ride with the links on both arms too (#1120), and the DROP arm is the one
+        // that matters for a personal-data field: a repoint re-identifies the provider, so carrying the login
+        // history of subjects whose links were just dropped would retain personal data about accounts this
+        // provider no longer knows, with no administrator route left to erase it.
+        incoming.CanonicalLinkLastLogins = endpointUnchanged ? live.CanonicalLinkLastLogins : new SerializableDictionary<string, DateTime>();
+
         incoming.OidSecret = ResolveUpdatedSecret(incoming, live);
     }
 
@@ -146,6 +152,11 @@ internal static class ServerManagedFields
         // save silently clearing every stored deadline - which would leave the sweep nothing to act on and
         // turn a time-limited account back into an unlimited one. SAML has no repoint belt to gate it on.
         incoming.CanonicalLinkDeadlines = live.CanonicalLinkDeadlines;
+
+        // Same shape for the last-SSO-login stamps (#1120): withheld from JSON, so a config-page save arrives
+        // with the map empty and re-injecting the live one is what stops an unrelated settings change silently
+        // resetting every "last SSO login" in the roster to never.
+        incoming.CanonicalLinkLastLogins = live.CanonicalLinkLastLogins;
         incoming.SamlSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlSigningKeyPfx, live.SamlSigningKeyPfx);
         incoming.SamlRolloverSigningKeyPfx = PreserveSigningKeyIfBlank(incoming.SamlRolloverSigningKeyPfx, live.SamlRolloverSigningKeyPfx);
     }


### PR DESCRIPTION
# What & why

Closes #1120.

The account-link roster could already say which accounts are linked and to what,
but not whether anyone had ever used a link. No login instant existed anywhere in
the tree, so an orphaned link and a link somebody signs in through daily looked
identical.

Each provider now carries one more server-managed map beside its links: the
canonical key to the UTC instant of the last successful SSO login that resolved
it. `LinkRoster` projects it onto every roster entry as `LastSsoLoginUtc`, and a
link with no stamp comes out as `null` rather than as a default date a client
would render as a login in year one.

The boundedness is the change, not the field. The map's cardinality is the link
map's cardinality:

- an entry is only ever written beside a link that already exists, so the link
  map is the ceiling;
- a repeat login overwrites one value rather than appending, so it is not an
  event log;
- every route that removes a link removes the stamp in the same transaction, on
  both protocols: manual unlink, the admin `Unregister` sweep, and a provider
  delete or endpoint repoint.

That last point is also the retention answer. The erasure route for this personal
data is the one an administrator already has, and it needs no new control.

## Two decisions this issue left open, and how they went

**Flush policy: coarsening, not write-through and not a background flush.** The
issue asked for the policy to be decided and justified here. An established
user's repeat login pays no configuration persist today, which
`SsoOnlyLoginService.ResolveLoginEnforcement` states in the source, and the file
this writes carries every provider secret envelope and every link map. A
write-through stamp would add one persist per login to that path. The stored
instant is therefore rewritten only once it has aged past
`ProviderConfigBase.LastSsoLoginGranularity` (one hour), so the cost is at most
one write per link per hour. The trade is stated where a reader meets the value:
the roster promises "not later than", not a precise time, in the API doc comment
and in the changelog.

**A bookkeeping write may not refuse a login.** The stamp runs after the session
is minted, so an exception out of the persist would turn a login that has already
succeeded into an error, on every login, for as long as a volume stays read-only
or full. It is caught and logged as a warning naming the provider only. A stale
roster column is the right price; SSO refusing every login is not. The deadline
writer beside it deliberately does not get the same treatment, because a lost
deadline is lost enforcement rather than a lost display.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted. Nothing on the validation path is
      touched. The new writer's own fail-closed arms are a blank canonical key
      and an unknown provider, both of which write nothing and neither of which
      may throw out of a login.
- [x] No secrets logged; secrets are redacted on config export. The one new log
      line carries the provider name and no subject, claim or username, matching
      the audit trail's rule, and `TheConfigExport_WithholdsTheStamp` pins that
      the export carries no stamp.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline. **NOT DONE.** No second
      reader looked at this change and no review lens was run over it. What
      stands in place of one is the falsification table below, in which every
      new guard was deleted and observed to redden a named test, plus the CI
      checks on this pull request. This box stays unticked.
- [ ] Review record: per lens, its verdict and its findings. **NONE.** No lens
      ran, so there is no record and no CONFIRMED / PLAUSIBLE count to report.
      Stating a count here would be inventing one.
- [x] Log inputs from the IdP are sanitized inline at the log call. The provider
      name is stripped with `ReplaceLineEndings` at the call site rather than in
      a helper, per the rule that the sanitizer does not survive a helper
      boundary.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit. `RecordLastSsoLogin` is the only writer and `RemoveLastSsoLogin` the
      only eraser, both following the shape `CanonicalLinkDeadlines` already
      established. The roster reads through the single `LinkExport.Rows` walk
      rather than adding a second walk of the same maps.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in
      `ArchitectureConformanceTests`. `MutableKeyedState_LivesOnlyInsideStoreLikeTypes`
      refused the new map until it carried a documented exemption; the exemption
      added there is granted to the bounded design and says so, so a per-login
      event log would still be refused.
- [ ] Docs impact considered. **PARTLY, and one half is not landable here.** The
      changelog entry is included. The issue also asks for retention text in two
      places this repository does not hold: the wiki privacy section, which is a
      separate repository, and the config page help text "for the panel", where
      no roster panel exists in `SSO-Auth/Web/` yet. See Notes.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green. Both target
      frameworks, plugin and test project, 0 warnings and 0 errors.
- [x] `dotnet test` is green. Full suite on both frameworks: `net9.0` 3200
      total, 0 failed, 4 skipped; `net10.0` 3201 total, 0 failed, 4 skipped.
      One earlier run of the same commits reported 5 failures at roughly four
      times the usual wall time and I did not capture which tests they were; two
      later runs at normal wall time were clean on both frameworks. That run is
      reported rather than dropped, and it is unexplained.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. Only
      `CHANGELOG.md` is touched among covered files, and the added paragraph
      survives a `prettier` reformat of that file unchanged. The locally resolved
      prettier (3.9.6) reports every tracked markdown file in the repository as
      unformatted, including files this branch does not touch, so it is not the
      version the gate runs; the CI check is the authority here.

## Falsification

Every new guard was removed or inverted, the suite re-run, and the named test
observed to fail. Each edit was made to compile, because warnings are errors
repo-wide and a deletion that does not build proves nothing.

| Guard broken | Test that went red |
| --- | --- |
| the stored-instant-in-the-future arm dropped | `AStampStoredInTheFuture_IsCorrectedRatherThanFrozen` |
| the `Unregister` prune selects nothing | `RevokingAUserEverywhere_PrunesTheirStamps_OnBothProtocols` |
| that prune written OpenID-only, the way the neighbouring issuer map is | `RevokingAUserEverywhere_PrunesTheirStamps_OnBothProtocols` |
| the unlink erasure targets the wrong key | `RemovingALink_RemovesItsStamp` |
| granularity set to zero, so every login writes | `ASecondLoginInsideTheWindow_WritesNothing` |
| the config-PUT re-injection dropped on both arms | `Preserve_ReinjectsLiveStamps_IntoAStaleIncomingSave` |
| the availability wrapper narrowed so the persist escapes | `AFailedConfigurationPersist_DoesNotEscapeIntoTheLogin` |
| a default date returned in place of `null` | `TheRoster_CarriesTheStamp_AndReportsNeverAsNull` |

The OpenID-only variant is the near-miss worth naming: the neighbouring
`CanonicalLinkIssuers` prune is legitimately OpenID-only, so an implementation
copied from it prunes one protocol and silently leaves every SAML stamp behind.

## Notes

The retention documentation the issue asks for has two homes and neither is
reachable from this branch. The wiki privacy and retention section is a separate
repository. The "config page help text for the panel" has no subject yet: there
is no roster panel in `SSO-Auth/Web/`, and a case-insensitive search for
`roster` across that directory returns nothing, so the roster is an API surface
only today. The wiki half is filed as #1371 rather than left implied, and the
help text belongs to whichever change first renders the roster in the dashboard.

The stamp is deliberately absent from the portable link export. That document
exists to be re-applied to a rebuilt server, and a login instant is an
observation rather than restorable state: writing it back would assert a login
that never happened there, and shipping it out widens where the personal data
travels for nothing. `ThePortableLinkExport_DoesNotCarryTheStamp` pins the
omission so it cannot drift in through the shared walk.

The granularity is a single constant beside the map rather than a setting. Making
it configurable would let an administrator choose a per-login write on the login
path, which is the thing the constant exists to prevent.
