### PR TITLE
Carry the padding Jellyfin's runtime restyle takes away

### DIFF
--- a/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
+++ b/SSO-Auth.Tests/LoginButtons/LoginButtonInjectorTests.cs
@@ -41,6 +41,64 @@ public class LoginButtonInjectorTests
             LoginButtonInjector.BuildBlock(One("corp", "Corp", LoginButtonProtocol.Saml)));
     }
 
+    /// <summary>
+    /// The button carries the inline style that survives Jellyfin's runtime restyle.
+    /// </summary>
+    /// <remarks>
+    /// The login controller adds `button-link` to every anchor in the disclaimer, and that class zeroes the
+    /// padding and margin `emby-button` set and underlines on hover. An inline style beats a class rule in
+    /// every state. Reported in discussion #1342, where an admin needed nine declarations of Custom CSS to
+    /// get back what the runtime class had taken away.
+    /// </remarks>
+    [Fact]
+    public void BuildBlock_CarriesTheInlineStyleThatSurvivesTheRuntimeRestyle()
+    {
+        var block = LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak"));
+
+        Assert.Contains("style=\"margin:0.25em 0;padding:0.9em 1em;text-decoration:none;color:inherit\"", block, System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every declaration in the style answers one thing `button-link` does, and none of them is decoration.
+    /// </summary>
+    /// <remarks>
+    /// Pinned one by one rather than as a single string so that removing any of them names which behaviour
+    /// came back. `.button-link { margin: 0; padding: 0 }` at line 47 of `emby-button.scss` beats
+    /// `.emby-button { padding: 0.9em 1em }` at line 1 by declaration order at equal specificity, and
+    /// `.button-link:hover` adds the underline.
+    /// </remarks>
+    [Theory]
+    [InlineData("padding:0.9em 1em")]
+    [InlineData("margin:0.25em 0")]
+    [InlineData("text-decoration:none")]
+    [InlineData("color:inherit")]
+    public void BuildBlock_TheStyleAnswersEachThingTheRuntimeClassTakesAway(string declaration)
+    {
+        Assert.Contains(declaration, LoginButtonInjector.BuildBlock(One("keycloak", "Keycloak")), System.StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The style is a fixed literal and no part of it comes from configuration.
+    /// </summary>
+    /// <remarks>
+    /// A `style` attribute is the one place in this block where CSS is interpreted, so an admin-supplied
+    /// string reaching it would be a new injection surface on the login page. The name and the label are
+    /// HTML-encoded elsewhere; this asserts that neither is anywhere near the attribute.
+    /// </remarks>
+    [Fact]
+    public void BuildBlock_TheStyleTakesNothingFromConfiguration()
+    {
+        var block = LoginButtonInjector.BuildBlock(One("style=\"x\":expression(alert(1))", "url(javascript:alert(1))"));
+
+        // The VALUE of the attribute, not the line it sits on. The provider name reaches the href and the
+        // label, where words like `expression` are ordinary encoded text; asserting over the whole tag would
+        // fail on that and prove nothing about the style.
+        var opened = block.IndexOf("style=\"", System.StringComparison.Ordinal) + "style=\"".Length;
+        var value = block[opened..block.IndexOf('"', opened)];
+
+        Assert.Equal(LoginButtonInjector.ButtonStyle, value);
+    }
+
     [Fact]
     public void BuildBlock_HtmlEncodesAHostileLabel_NoScriptSurvives()
     {
@@ -163,8 +221,11 @@ public class LoginButtonInjectorTests
             .Replace("<div class=\"sso-login-buttons\">", string.Empty, System.StringComparison.Ordinal)
             .Replace("</div>", string.Empty, System.StringComparison.Ordinal)
             .Replace("</a>", string.Empty, System.StringComparison.Ordinal);
-        // The anchor open tag's href value is encoded (contains no quote), so [^"]* matches it exactly.
-        stripped = Regex.Replace(stripped, "<a class=\"[^\"]*\" href=\"[^\"]*\">", string.Empty);
+        // The anchor open tag's attribute values contain no quote - the style is a fixed literal and the href
+        // is encoded - so [^"]* matches each of them exactly. The style attribute is named here rather than
+        // matched loosely: a pattern that skipped unknown attributes would strip an attribute an injection had
+        // introduced, and this test exists to see exactly that.
+        stripped = Regex.Replace(stripped, "<a class=\"[^\"]*\" style=\"[^\"]*\" href=\"[^\"]*\">", string.Empty);
 
         Assert.DoesNotContain("<", stripped, System.StringComparison.Ordinal);
     }

--- a/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
+++ b/SSO-Auth/Api/LoginButtons/LoginButtonInjector.cs
@@ -54,6 +54,58 @@ public static class LoginButtonInjector
     private const string CommentClose = "-->";
 
     /// <summary>
+    /// What each button carries as an inline <c>style</c>, and why an inline style rather than a stylesheet.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// JELLYFIN RESTYLES THIS ANCHOR AFTER THE PLUGIN HAS WRITTEN IT. The login controller takes every link in
+    /// the disclaimer and adds its own classes at runtime
+    /// (<c>src/apps/legacy/controllers/session/login/index.js</c>):
+    /// </para>
+    /// <code>
+    /// for (const elem of loginDisclaimer.querySelectorAll('a')) {
+    ///     elem.rel = 'noopener noreferrer';
+    ///     elem.target = '_blank';
+    ///     elem.classList.add('button-link');
+    ///     elem.setAttribute('is', 'emby-linkbutton');
+    /// }
+    /// </code>
+    /// <para>
+    /// `button-link` and `emby-button` have the same specificity and `button-link` is declared later in
+    /// `emby-button.scss`, so it wins. What it takes away is exactly what makes a button look like one:
+    /// </para>
+    /// <code>
+    /// .emby-button       { padding: 0.9em 1em; }   /* line 1  */
+    /// .emby-button.block { margin: 0.25em 0; }     /* line 78 */
+    /// .button-link       { margin: 0; padding: 0; }/* line 47, later, so it wins */
+    /// .button-link:hover { text-decoration: underline; }
+    /// </code>
+    /// <para>
+    /// So the shipped button renders with no padding and underlines on hover, which is what discussion #1342
+    /// reported and worked around with nine declarations of Custom CSS. An inline style beats any class rule
+    /// that does not carry <c>!important</c>, in every state including <c>:hover</c>, so the four declarations
+    /// below restore what the runtime class removed and nothing more.
+    /// </para>
+    /// <para>
+    /// IT SURVIVES SANITISING, which is the reason this is possible at all. The disclaimer is rendered through
+    /// markdown-it and then DOMPurify before it reaches the page, and `style` is in DOMPurify 2.5.9's default
+    /// attribute allow-list (`src/attrs.js`, the `html` set). The plugin pins nothing here: if a future Jellyfin
+    /// narrows that list, the attribute is dropped and the button falls back to today's appearance rather than
+    /// to a broken one.
+    /// </para>
+    /// <para>
+    /// WHAT IT DELIBERATELY DOES NOT DO is make the button full width. `.loginDisclaimerContainer` is
+    /// `display: flex` and `.loginDisclaimer` is a flex item, so the region shrinks to its content and
+    /// `.emby-button.block`'s `width: 100%` resolves against a width that came from the content. Widening it
+    /// means restyling Jellyfin's own containers, which are outside this plugin's fence, and this plugin's
+    /// promise is that it manages its own region and leaves an admin's page alone. The wiki carries the
+    /// two-line snippet for admins who want it.
+    /// </para>
+    /// </remarks>
+    internal const string ButtonStyle =
+        "margin:0.25em 0;padding:0.9em 1em;text-decoration:none;color:inherit";
+
+    /// <summary>
     /// Renders the managed button block, or the empty string when there are no buttons. The returned string,
     /// when non-empty, always begins with <see cref="BeginMarker"/> and ends with <see cref="EndMarker"/>.
     /// </summary>
@@ -83,7 +135,9 @@ public static class LoginButtonInjector
             // Both the href attribute value and the visible label are HTML-encoded, so a name/label such as
             // `"><script>…` renders as inert text, never markup. HtmlEncode also encodes the quotes that
             // would otherwise break out of the attribute.
-            sb.Append("  <a class=\"raised block emby-button sso-login-button\" href=\"")
+            sb.Append("  <a class=\"raised block emby-button sso-login-button\" style=\"")
+                .Append(ButtonStyle)
+                .Append("\" href=\"")
                 .Append(WebUtility.HtmlEncode(href))
                 .Append("\">")
                 .Append(WebUtility.HtmlEncode(button.Text))


### PR DESCRIPTION
Closes #1372. Co-authored with @teekennedy, whose custom CSS in discussion #1342 is the measurement this is built on.

## The cause, from Jellyfin's own source

The login controller takes every anchor in the branding disclaimer and adds its own classes at runtime - `src/apps/legacy/controllers/session/login/index.js`:

```js
for (const elem of loginDisclaimer.querySelectorAll('a')) {
    elem.rel = 'noopener noreferrer';
    elem.target = '_blank';
    elem.classList.add('button-link');
    elem.setAttribute('is', 'emby-linkbutton');
}
```

`button-link` and `emby-button` have equal specificity, and `button-link` is declared later in `emby-button.scss`, so it wins:

```scss
.emby-button       { padding: 0.9em 1em; }     // line 1
.emby-button.block { margin: 0.25em 0; }       // line 78
.button-link       { margin: 0; padding: 0; }  // line 47 — later, so it wins
.button-link:hover { text-decoration: underline; }
```

So the button this plugin ships renders with **no padding** and **underlines on hover**. That is what @teekennedy saw, and their nine declarations of Custom CSS are one-for-one answers to it.

## The fix

Four declarations as an inline `style` on the emitted anchor. An inline style beats a class rule that carries no `!important`, in every state including `:hover`.

**It survives sanitising**, which is why this is possible at all: the disclaimer goes through markdown-it and then DOMPurify, and `style` is in DOMPurify 2.5.9's default attribute allow-list (`src/attrs.js`, the `html` set - jellyfin-web pins that version). Nothing rests on it staying there: if a future Jellyfin narrows the list, the attribute is dropped and the button falls back to today's appearance rather than to a broken one.

## What this deliberately does not do

**Make the button full width.** `.loginDisclaimerContainer` is `display: flex` and `.loginDisclaimer` is a flex item, so the region shrinks to its content and `width: 100%` resolves against a width that came from the content. Widening it means restyling Jellyfin's own containers, which sit outside this plugin's fence, and the promise this plugin makes is that it manages its own region and leaves the rest of the page alone.

The wiki carries that two-line snippet for admins who want it, updated alongside #1373.

## Two tests needed correcting, and one of them was not mine

`BuildBlock_HostilePayload_LeavesNoUnescapedMarkupFromInput` strips the anchor open tag by pattern before asserting that no `<` from the input survives. The new attribute sits between `class` and `href`, so the pattern stopped matching, the tag it was meant to remove stayed in, and its own `<` tripped the assertion.

**The security property was never affected** - the test's picture of the template was out of date. The pattern now names the style attribute rather than skipping unknown attributes, because a pattern that skipped them would also strip an attribute an injection had introduced, which is the one thing that test exists to see.

My own new test asserted over the whole anchor tag and failed on the provider name reaching the `href`, where a word like `expression` is ordinary encoded text. It now extracts the attribute's value and compares it to the constant.

## Verified here

```
dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0
  total: 3206   failed: 0   passed: 3202   skipped: 4
```

Made to bite by shortening the style to `color:inherit`:

```
failed  BuildBlock_TheStyleAnswersEachThingTheRuntimeClassTakesAway(declaration: "padding:0.9em 1em")
failed  BuildBlock_TheStyleAnswersEachThingTheRuntimeClassTakesAway(declaration: "text-decoration:none")
failed  BuildBlock_TheStyleAnswersEachThingTheRuntimeClassTakesAway(declaration: "margin:0.25em 0")
failed  BuildBlock_CarriesTheInlineStyleThatSurvivesTheRuntimeRestyle
```

Each removed declaration reds its own case by name.
