### PR TITLE
Drop the coverage collector's injected type from the structural rules

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Shared.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Shared.cs
@@ -84,6 +84,36 @@ public partial class ArchitectureConformanceTests
         t.Name.Contains('<', StringComparison.Ordinal)
         || t.GetCustomAttribute<CompilerGeneratedAttribute>() is not null;
 
+    // The root namespace the code-coverage collector owns. Nothing in this repository may declare a type
+    // under it, so a type found there in the plugin assembly was put there by the measurement tool.
+    private const string CoverageCollectorRoot = "Microsoft.CodeCoverage";
+
+    // A type the coverage collector injected into the plugin assembly rather than one the plugin declares
+    // (#1376). Where the collector instruments statically - which is what it does on the CI runner, and what
+    // `EnableStaticManagedInstrumentation` forces locally - it rewrites SSO-Auth.dll and adds its own tracker,
+    // so reflection over the assembly returns a type no source file in this repository declares:
+    //
+    //     Microsoft.CodeCoverage.Instrumentation.Static.Tracker.StaticManagedTrackerTemplate_<guid>
+    //
+    // The structural rules below ask about THIS PLUGIN's types, so dropping it corrects what they mean instead
+    // of opening a hole in them: it sits beside IsCompilerGenerated for the same reason, a type nobody wrote.
+    // Keyed on the namespace, because the two alternatives were measured and are worse. The leaf name carries
+    // a per-run GUID (two runs of the same command produced ...Template_35ca082e-ddba-41f3-92d4-d3c73a3f411c
+    // and ...Template_d5693c66-87a6-4fe4-a052-30edbfe89233), so the full name cannot be pinned; and the only
+    // attributes the injected type carries are ExcludeFromCodeCoverage and SecuritySafeCritical, both of which
+    // a real plugin type may legitimately carry, so keying on a marker attribute would silently exempt plugin
+    // code from every rule here. Matching the collector's root rather than the tracker's exact namespace also
+    // survives a collector version that moves the injected type, and a namespace it moves OUT of Microsoft's
+    // root fails loudly rather than passing.
+    private static bool IsCoverageInstrumentation(Type t) => IsCoverageCollectorNamespace(t.Namespace);
+
+    // Whether a namespace belongs to the coverage collector, written exactly as the root-namespace rule writes
+    // its own containment test so the two cannot drift: the root itself, or a "root."-prefixed descendant. A
+    // sibling that merely starts with the same letters (Microsoft.CodeCoverageOfMine) is NOT the collector's.
+    private static bool IsCoverageCollectorNamespace(string? ns) =>
+        ns is not null
+        && (ns == CoverageCollectorRoot || ns.StartsWith(CoverageCollectorRoot + ".", StringComparison.Ordinal));
+
     // Every source file that declares a controller type, discovered from reflection so the controller
     // source scans follow the planned #318 controller split automatically (#388): reflection names the
     // controller TYPES (deriving from ControllerBase); the files are those declaring them - a partial-class

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.cs
@@ -77,10 +77,13 @@ public partial class ArchitectureConformanceTests
         typeof(ReplayCache), typeof(SamlRequestCache), typeof(OidcStateStore), typeof(SamlOutcomeStore),
     };
 
-    // Every production type, compiler-generated ones excluded - the base sequence for structural rules
-    // that must cover interfaces/enums/structs/delegates too (e.g. the namespace boundary).
+    // Every production type - the base sequence for structural rules that must cover
+    // interfaces/enums/structs/delegates too (e.g. the namespace boundary). Two kinds of type are not the
+    // plugin's, and both are dropped HERE rather than at each rule, so every rule below judges the same set:
+    // the ones the compiler emits, and the one the code-coverage collector injects when it instruments this
+    // assembly statically (#1376).
     private static IEnumerable<Type> AllPluginTypes =>
-        typeof(SSOPlugin).Assembly.GetTypes().Where(t => !IsCompilerGenerated(t));
+        typeof(SSOPlugin).Assembly.GetTypes().Where(t => !IsCompilerGenerated(t) && !IsCoverageInstrumentation(t));
 
     // The class subset, for rules that only make sense on classes (helper shape, controller base type).
     private static IEnumerable<Type> PluginClasses => AllPluginTypes.Where(t => t.IsClass);
@@ -159,5 +162,31 @@ public partial class ArchitectureConformanceTests
             .ToList();
 
         Assert.True(outside.Count == 0, "All plugin types must live under the " + Root + " root namespace: " + string.Join(", ", outside));
+    }
+
+    [Theory]
+    // What the collector owns, and is therefore dropped before the rules above see it (#1376): the namespace
+    // the injected tracker was measured in, the collector's root itself, and another descendant of that root,
+    // which is where a later collector version moving the tracker would put it.
+    [InlineData("Microsoft.CodeCoverage.Instrumentation.Static.Tracker", true)]
+    [InlineData("Microsoft.CodeCoverage", true)]
+    [InlineData("Microsoft.CodeCoverage.Somewhere.Else", true)]
+    // What it does not own, so the rule above still bites for the reason it names. The plugin's own root and
+    // its descendants are never dropped (a rule that dropped them would report nothing forever); the
+    // "…SSO_AuthEvil" sibling the rule exists to catch stays in scope; a namespace that merely opens with the
+    // collector's letters is somebody else's; and an ordinary foreign namespace is still an offender.
+    [InlineData(Root, false)]
+    [InlineData(Root + ".Api.Oidc", false)]
+    [InlineData(Root + "Evil", false)]
+    [InlineData("Microsoft.CodeCoverageOfMine", false)]
+    [InlineData("Microsoft.AspNetCore.Mvc", false)]
+    [InlineData(null, false)]
+    public void CoverageCollectorTypes_AreTheOnlyOnesTheStructuralRulesDrop(string? ns, bool dropped)
+    {
+        // The exclusion the base type sequence applies is a correction to what the rules MEAN - a type the
+        // measurement tool wrote is not one of the plugin's - so it has to be exactly as wide as the tool and
+        // no wider. Widen it and the rules stop reporting real strays; the rows below are the ones that would
+        // go red for it.
+        Assert.Equal(dropped, IsCoverageCollectorNamespace(ns));
     }
 }


### PR DESCRIPTION
# What & why

Closes #1376.

`Coverage (net10.0)` has reported `failed: 1` on every build. The step's written
exemption ignores a test failure under instrumentation on the reasoning that
such a failure is a timing heisenbug. This one is not. The same test fails on
every run, for a reason that has nothing to do with timing.

Where the code-coverage collector instruments statically, which is what it does
on the runner, it rewrites `SSO-Auth.dll` and injects its own tracker into it.
Reflection over the assembly then returns a type no source file in this
repository declares, and `EverythingLivesUnderThePluginRootNamespace` reports
it, correctly by its own words, as living outside the plugin's root namespace.

The base type sequence every structural rule reads now drops that type, beside
the compiler-generated ones it already dropped, so one place decides what counts
as one of this plugin's types.

## Reproduction

This machine's collector picks dynamic instrumentation and injects nothing, so
the other mode is forced. Two steps, at the head of this branch:

```
cat static.runsettings
<Configuration><CodeCoverage>
  <EnableStaticManagedInstrumentation>True</EnableStaticManagedInstrumentation>
  <EnableDynamicManagedInstrumentation>False</EnableDynamicManagedInstrumentation>
</CodeCoverage></Configuration>

dotnet test --project SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 \
  --no-build --coverage --coverage-settings static.runsettings \
  --coverage-output-format cobertura --coverage-output out.cobertura.xml
```

| state | total | failed | skipped |
| --- | --- | --- | --- |
| `main` at `85e9d0e` | 3223 | 1 | 4 |
| this branch | 3232 | 0 | 4 |

The nine new rows account for the whole difference in the total. The failure on
the left is the one the exemption absorbs:

```
All plugin types must live under the Jellyfin.Plugin.SSO_Auth root namespace:
Microsoft.CodeCoverage.Instrumentation.Static.Tracker.
StaticManagedTrackerTemplate_35ca082e-ddba-41f3-92d4-d3c73a3f411c
```

So `Coverage (net10.0)` and `Test` now report the same failure count, which is
the measure the issue asks for, and a `failed: 1` there means what the exemption
was written to mean.

## Why the namespace, and not the other two candidates

The issue left this open and said it needed the injected type's full name. Both
alternatives were measured off the run above and are worse.

The **full name** cannot be pinned: the leaf carries a per-run GUID. Two runs of
the same command produced
`StaticManagedTrackerTemplate_35ca082e-ddba-41f3-92d4-d3c73a3f411c` and
`StaticManagedTrackerTemplate_d5693c66-87a6-4fe4-a052-30edbfe89233`.

A **marker attribute** cannot carry it either. Read off the injected type under
the same run, its only attributes are `ExcludeFromCodeCoverage` and
`SecuritySafeCritical`, both of which a real plugin type may legitimately carry,
so keying on one would silently exempt plugin code from every rule in the file.

## Proof that the exclusion bites, and stays narrow

An exclusion has to be exactly as wide as the tool it names and no wider, so the
new theory pins it row by row: three namespaces it drops, six it must not, among
them the plugin's own root, the `SSO_AuthEvil` sibling the rule exists to catch,
and `Microsoft.CodeCoverageOfMine`, which only opens with the same letters.

Widening the constant from `Microsoft.CodeCoverage` to `Microsoft` turns two of
the nine rows red, so the rows are load-bearing rather than decoration:

```
SSO-Auth.Tests.exe -method "*CoverageCollectorTypes*"
  Total: 9, Failed: 2      constant widened to "Microsoft"
  Total: 9, Failed: 0      as it stands
```

What that theory does not prove is the rule end to end: it judges the predicate,
not a stray type reaching the rule through the live assembly, because a type
outside the plugin's root namespace cannot be added to the plugin assembly from
the test project. The end-to-end evidence is the table above, where the rule
does report the injected type when the exclusion is absent.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not applicable. The change is confined to the test project's architecture
conformance rules. It touches no login path, no crypto, no config persistence
and no release pipeline, adds no production code, and changes nothing that ships
in the plugin.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The means is C# in the suite that already holds every structural rule: no new
tool, no new dependency, no parallel apparatus, and the exclusion sits in the
one function that already answers "is this one of ours".

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror   0 warnings, 0 errors
dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror   0 warnings, 0 errors
SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe    total 3231  failed 0  skipped 4
SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe   total 3232  failed 0  skipped 4
```

The format gate covers `.js`, `.html`, `.md`, `.css` and `.scss`; this change
edits two `.cs` files and nothing else, so it puts nothing in front of it.

## Notes

Four tests skip on Windows, the same four as before this change. One of them
binds a listener off loopback, which raises a firewall consent dialog that needs
an administrator (#1227). It was not run here, and no attempt was made to work
around it.

No second reader looked at this. The evidence above stands in place of one: the
before and after are two runs of one command, quoted with the command, and the
guard is shown red under a one-word widening.

The exclusion is matched against the collector's root rather than the injected
tracker's exact namespace, so a collector version that moves the type keeps
working. A version that moves it out of that root fails loudly instead of
passing, which is the direction to fail in.


## What the checks report on this head

The measure #1376 asks for is that the two steps agree on their failure count.
Read off the `build` job for `813b987`, both are zero and the offset of exactly
one is gone:

```
Test run summary: Passed!   failed: 0   succeeded: 6463     dotnet test, net9.0 + net10.0
Test run summary: Passed!   failed: 0   succeeded: 3232     Coverage (net10.0)
Coverage gate: PASS
```

Two checks went red on this head for a reason outside the change. `Analyze
(csharp)` and `submit-nuget` both ended on the same server-side response while
uploading their results:

```
##[error]No server is currently available to service your request.
```

`Analyze (csharp)` is a required context, so I re-ran it rather than merging
around it, and it is green on the same commit. `submit-nuget`, which submits the
dependency snapshot and is not required, was re-run for the same reason.
