### PR TITLE
Watch the dependency graph, do not only record it

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,37 @@
 <Project>
 
   <PropertyGroup>
+      <!-- The graph is watched, not only recorded. NuGet checks the restored graph
+           against the advisory database and NU1901 to NU1904 are raised to errors, so a
+           known-vulnerable package fails the restore. Left as warnings they would be
+           true and green, printed into a log nobody reads.
+  
+           This board committed a lockfile and ran no audit, which is the worse half of
+           the pair: the graph was held still and nothing looked at it. Eleven boards of
+           this fleet were in that state on 2026-08-18, and the twelfth is why it
+           matters. jellyfin-plugin-watchlist was told by Scorecard about one high
+           advisory; switching this on found a second one rated critical that Scorecard
+           had never reported.
+  
+           Mode all rather than direct: both of those arrived under the Jellyfin
+           packages and neither was referenced by a project file, so a direct-only audit
+           would have found neither.
+  
+           Nothing is pinned here. Measured with the audit forced on from the command
+           line, this board reports no advisory today; the entry is the detector, not a
+           repair.
+  
+           Note for whoever edits this comment: an XML comment may not contain two
+           hyphens in a row. A draft elsewhere in this fleet spelled out a command line
+           flag, left the file malformed, and the build failed on a property defined
+           twenty lines below. -->
+      <NuGetAudit>true</NuGetAudit>
+      <NuGetAuditMode>all</NuGetAuditMode>
+      <NuGetAuditLevel>low</NuGetAuditLevel>
+      <WarningsAsErrors>$(WarningsAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <!-- CI's dotnet.yml already builds with the warnaserror flag; setting the project property too
          makes a plain local `dotnet build` (no flag) match CI instead of silently passing on
          warnings a contributor's machine would otherwise hide until the PR build. -->


### PR DESCRIPTION
Closes #1378.

## What changed

`NuGetAudit` on in `Directory.Build.props`, mode `all`, level low, with NU1901
to NU1904 raised to errors.

## What failure it prevents

A committed lockfile without an audit holds the dependency graph still and stops
looking at it. `jellyfin-plugin-watchlist` was in that state: Scorecard reported
one high advisory, and switching the audit on found a second rated **critical**
that Scorecard had never reported. Both transitive, neither referenced by a
project file, and the board had been shipping the second one.

Eleven boards of this fleet were in the same state.

## The means

Mode `all` rather than `direct`, because both of those findings arrived under
the Jellyfin packages and a direct-only audit would have found neither.

Errors rather than warnings, because a warning about a known-vulnerable package
is a true statement printed into a log nobody reads.

## Evidence

Measured before the change, with the audit forced on from the command line
against this board's tree: no advisory. The apparatus was checked against
`jellyfin-plugin-watchlist` at the commit before its repair, where it reports
the two known ones, so a zero here is a reading and not a silence.

`dotnet restore` passes with the entry in place. That is the gate this change
installs, and it was run before the pull request was opened.

## What this does not do

It repairs nothing and pins nothing. There is no vulnerable package on this
board today; if one appears, the restore now fails and names it instead of
waiting for somebody to read a Scorecard alert.

It does not add a dependency update tool. Watching without updating tells you
about a problem you then have to fix by hand, which is the state this leaves the
board in deliberately: the alternative, pinning without watching, is what this
change exists to end.

## Who read this

The same hand wrote the change and this text, and there is no second reader on
this board.
