### PR TITLE
Link an account to an identity before its first login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
   reported as an orphan rather than dropped, which is the one place that state is
   visible at all. The roster is assembled from the link maps alone, so no
   provider secret, signing key or certificate can appear in it.
+- **An account can be linked to an identity before its first login (#1133).** A
+  new administrator-only endpoint writes the link from an identity-provider
+  subject to an existing Jellyfin account directly, so an account created by an
+  invite or provisioning tool signs in through SSO the first time rather than
+  starting as a password account somebody links by hand afterwards. The existing
+  link write is unchanged and still requires the person being linked to complete
+  a login at the identity provider; this one takes an administrator credential
+  instead, and differs in one behaviour because of it: a subject already linked
+  to a different account is refused and the existing link is left exactly as it
+  was, where the older write would have moved it. Sending the same mapping twice
+  succeeds, so a tool that retries a request whose answer it never saw does not
+  have to tell the two cases apart. A link is refused for a provider that does
+  not exist or is turned off, for an account id that no account holds, and for a
+  blank subject. Every link made this way is recorded as an audit event naming
+  the administrator, the provider and the account, and never the subject itself.
 
 ### Changed
 

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
@@ -296,7 +296,7 @@ public partial class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 15;
+        const int expectedTypedCallSites = 16;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -53,6 +53,9 @@ public partial class ArchitectureConformanceTests
         // The per-subject link export (#1091): elevation-gated and read-only, but it answers per user id,
         // so an unthrottled one is a user-table enumeration an administrator can drive in a loop.
         "Links/Export/{jellyfinUserId}",
+        // The pre-provision link write (#1133): a config-XML persist under the global lock, and its 404 is
+        // an existence answer about a user id, so it is throttled for both reasons the two neighbours are.
+        "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}",
     };
 
     // Routes deliberately NOT rate-limited, each with the reason it is safe: an elevation-gated admin
@@ -196,6 +199,7 @@ public partial class ArchitectureConformanceTests
         "OID/Test/{provider}", "SAML/Test/{provider}", // admin probe of a STORED provider, 404 on a miss
         "SAML/metadata/{provider}", // SP metadata built for a stored provider
         "{mode}/Link/{provider}/{jellyfinUserId}", "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}", // link write against a stored, enabled provider
+        "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}", // pre-provision write against a stored, enabled provider (#1133)
 
         // Not an SSO provider name at all: Unregister's body parameter happens to be called `provider` and
         // carries a JELLYFIN AuthenticationProviderId, written to the user record so the account falls back

--- a/SSO-Auth.Tests/Audit/SsoAuditTests.cs
+++ b/SSO-Auth.Tests/Audit/SsoAuditTests.cs
@@ -185,6 +185,40 @@ public class SsoAuditTests
     }
 
     [Fact]
+    public void LinkPreprovisioned_LogsWarning_WithTheActorProviderAndTarget_ButNoSubject()
+    {
+        // The audit line for a grant made on an administrator credential alone (#1133). The canonical
+        // subject is withheld deliberately: it identifies a real person at the identity provider, and the
+        // provider plus the target account are what an operator needs to find the grant.
+        var logger = new CapturingLogger();
+        var target = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+
+        SsoAudit.LinkPreprovisioned(logger, "admin", "OpenID", "idp", target);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("admin", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("idp", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(target.ToString(), entry.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void LinkPreprovisioned_StripsLineEndings_SoAnActorOrProviderCannotForgeALogLine()
+    {
+        // Log forging (cs/log-forging): the actor is a username and the provider is a stored name, and a
+        // line ending in either would let a second, fabricated audit line be written by the first.
+        var logger = new CapturingLogger();
+
+        SsoAudit.LinkPreprovisioned(logger, "admin\r\n[SSO Audit] forged", "OpenID", "idp\nforged", Guid.Empty);
+
+        var entry = Assert.Single(logger.Entries);
+        Assert.DoesNotContain("\n", entry.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", entry.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void LogoutRequested_LogsInformation_WithProviderAndCountOnly()
     {
         var logger = new CapturingLogger();

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -49,6 +49,9 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The linked-account roster (#1119): read-only, and elevation-gated because it names every linked
         // account on the server.
         "LinkedAccountRoster",
+        // The pre-provision link write (#1133): it grants an identity-provider subject the ability to sign
+        // in as an account other than the caller's, with no identity-provider response behind it.
+        "PreprovisionCanonicalLink",
     };
 
     // The endpoints guarded by a bare [Authorize] (any authenticated caller, no elevation) - the canonical

--- a/SSO-Auth.Tests/Http/SSOControllerPreprovisionLinkTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerPreprovisionLinkTests.cs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the pre-provision link write (#1133) via <see cref="SsoControllerHarness"/>. The
+/// endpoint grants an identity-provider subject the ability to sign in as a named Jellyfin account on an
+/// administrator credential alone, with no identity-provider response redeemed behind it, so the tests are
+/// built around the refusals rather than around the happy path: what it must NOT write is the whole reason
+/// this is a separate entry point from the self-service link write next to it.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerPreprovisionLinkTests
+{
+    private static readonly Guid Alice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid Bob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+
+    [Fact]
+    public async Task AFreshMapping_IsWritten()
+    {
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        Assert.IsType<NoContentResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice"));
+
+        Assert.Equal(Alice, harness.Configuration.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+    }
+
+    [Fact]
+    public async Task TheSameMappingPostedTwice_IsIdempotent()
+    {
+        // A provisioning tool that retried a request whose response it never saw must not be told its own
+        // earlier success is a conflict, or it reports a failure for an account that IS linked.
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice");
+
+        Assert.IsType<NoContentResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice"));
+        Assert.Equal(Alice, harness.Configuration.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+    }
+
+    [Fact]
+    public async Task TheSameSubjectPointedAtASecondAccount_IsRefused_AndTheFirstLinkSurvives()
+    {
+        // The load-bearing refusal. Without it this endpoint moves an identity-provider subject off the
+        // account holding it and onto one the caller names, which is how a crafted provisioning call takes
+        // over another person's identity. Delete the refuseRebind arm in CanonicalLinkService and this is
+        // the test that goes red.
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+        Account(harness, Bob, "bob");
+        await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice");
+
+        var result = await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Bob, "sub-alice");
+
+        Assert.IsType<ConflictObjectResult>(result);
+        Assert.Equal(Alice, harness.Configuration.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+    }
+
+    [Fact]
+    public async Task AConflict_WritesNoAuditLine()
+    {
+        // The audit line says a grant was made. A refused write made none, and a line claiming otherwise
+        // sends an operator hunting for a link that does not exist.
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+        Account(harness, Bob, "bob");
+        await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice");
+
+        await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Bob, "sub-alice");
+
+        // Counted rather than asserted absent, because the first write legitimately logged one: what must
+        // not happen is a SECOND line for the write that was refused.
+        Assert.Single(harness.ControllerLog.Entries.FindAll(entry => entry.Message.Contains("pre-provisioned", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task AnUnknownProvider_IsRefused()
+    {
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        Assert.IsType<BadRequestObjectResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "nosuch", Alice, "sub-alice"));
+    }
+
+    [Fact]
+    public async Task ADisabledProvider_IsRefused()
+    {
+        // A link written on a disabled provider survives the disable and mints a login the moment the
+        // provider is turned back on, which is the mid-flight-disable window the service write guard closes
+        // (#380). The pre-provision path must not open it again.
+        var harness = Harness(configure: configuration => configuration.OidConfigs["idp"].Enabled = false);
+        Account(harness, Alice, "alice");
+
+        Assert.IsType<BadRequestObjectResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice"));
+        Assert.False(harness.Configuration.OidConfigs["idp"].CanonicalLinks.ContainsKey("sub-alice"));
+    }
+
+    [Fact]
+    public async Task AnUnknownUserId_IsNotFound_AndWritesNothing()
+    {
+        // The endpoint links an account a provisioning tool has already created. A link against a GUID no
+        // account holds is unreachable bookkeeping no login can redeem, and it is invisible on every
+        // per-user listing.
+        var harness = Harness();
+
+        Assert.IsType<NotFoundObjectResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice"));
+        Assert.False(harness.Configuration.OidConfigs["idp"].CanonicalLinks.ContainsKey("sub-alice"));
+    }
+
+    [Fact]
+    public async Task AnEmptyCanonicalName_IsRefused()
+    {
+        // Fail closed (#95): a blank key persists a dead link no login can ever redeem.
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        Assert.IsType<BadRequestObjectResult>(await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "   "));
+        Assert.Empty(harness.Configuration.OidConfigs["idp"].CanonicalLinks);
+    }
+
+    [Fact]
+    public async Task TheSamlArm_WritesToTheSamlProvider()
+    {
+        // The mode token is parsed at the boundary and threaded inward; with the SAML arm broken the write
+        // lands on the OpenID map or nowhere, and both are silent at the HTTP boundary.
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        Assert.IsType<NoContentResult>(await harness.Controller.PreprovisionCanonicalLink("saml", "sp", Alice, "nameid-alice"));
+
+        Assert.Equal(Alice, harness.Configuration.SamlConfigs["sp"].CanonicalLinks["nameid-alice"]);
+        Assert.Empty(harness.Configuration.OidConfigs["idp"].CanonicalLinks);
+    }
+
+    [Fact]
+    public async Task ASuccessfulWrite_IsAudited_WithoutTheCanonicalSubject()
+    {
+        // The grant is made on an administrator credential with nothing from the identity provider behind
+        // it, so it must leave a trail. The subject is withheld from that trail on purpose: it is the one
+        // member of the request that identifies a real person at the identity provider (T-I1).
+        var harness = Harness();
+        Account(harness, Alice, "alice");
+
+        await harness.Controller.PreprovisionCanonicalLink("oid", "idp", Alice, "sub-alice");
+
+        var entry = Assert.Single(harness.ControllerLog.Entries, e => e.Message.Contains("pre-provisioned", StringComparison.Ordinal));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Contains("[SSO Audit]", entry.Message, StringComparison.Ordinal);
+        Assert.Contains("OpenID", entry.Message, StringComparison.Ordinal);
+        Assert.Contains(Alice.ToString(), entry.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sub-alice", entry.Message, StringComparison.Ordinal);
+    }
+
+    // --- helpers ---
+
+    private static SsoControllerHarness Harness(Action<PluginConfiguration>? configure = null)
+    {
+        return new SsoControllerHarness(configuration =>
+        {
+            configuration.OidConfigs["idp"] = new OidConfig { Enabled = true };
+            configuration.SamlConfigs["sp"] = new SamlConfig { Enabled = true };
+            configure?.Invoke(configuration);
+        });
+    }
+
+    private static void Account(SsoControllerHarness harness, Guid id, string name)
+    {
+        harness.UserManager.GetUserById(id).Returns(TestUsers.Named(name, id));
+    }
+}

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 
@@ -235,6 +236,38 @@ internal static class SsoAudit
             "[SSO Audit] Configuration imported by an administrator: {OidProviders} OpenID and {SamlProviders} SAML provider(s) merged. Server-managed secrets and links were preserved; redacted secrets must be re-entered on this instance.",
             oidProviders,
             samlProviders);
+
+    /// <summary>
+    /// Records an administrator pre-provisioning a canonical link with no identity-provider round trip
+    /// (#1133). A grant of future login capability made on an administrator credential alone, so it is
+    /// warned rather than informed: it is the line an operator looks for when an account turns out to sign
+    /// in as somebody it should not.
+    /// </summary>
+    /// <remarks>
+    /// The canonical subject is deliberately NOT a field here. The audit trail already carries no raw
+    /// subject value (T-I1), the provider and the target account are what identify the grant for an
+    /// operator, and the subject would be the one member of the request that is an identifier for a real
+    /// person at the identity provider.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="actor">The elevated administrator who made the link.</param>
+    /// <param name="protocol">The protocol (OpenID or SAML).</param>
+    /// <param name="provider">The provider the link was written on.</param>
+    /// <param name="jellyfinUserId">The Jellyfin account the identity was linked to.</param>
+    internal static void LinkPreprovisioned(ILogger logger, string actor, string protocol, string provider, Guid jellyfinUserId)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Canonical link pre-provisioned by {Actor}: {Protocol} '{Provider}' -> Jellyfin user {UserId}, with no identity-provider response redeemed.",
+            actor?.ReplaceLineEndings(string.Empty),
+            protocol,
+            provider?.ReplaceLineEndings(string.Empty),
+            jellyfinUserId);
+    }
 
     /// <summary>Records SSO-only login being turned on (#165), with the guaranteed break-glass survivor.</summary>
     /// <param name="logger">The logger.</param>

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -1661,6 +1661,66 @@ public class SSOController : ControllerBase
         || _canonicalLinks.LinksByUser(ProviderMode.Saml, jellyfinUserId).Any(entry => entry.Value.Any());
 
     /// <summary>
+    /// Pre-provisions a canonical link from an identity-provider subject to an existing Jellyfin account
+    /// (#1133), with no identity-provider response in the request, so an invite-born account created by a
+    /// provisioning tool is already SSO-linked before its first login. Requires administrator privileges.
+    /// </summary>
+    /// <remarks>
+    /// The self-service link write (<c>{mode}/Link/{provider}/{jellyfinUserId}</c>) redeems a live
+    /// authorize state or a signed assertion, so it structurally requires the linked human to complete a
+    /// flow at the identity provider; a tool holding only an administrator credential cannot drive it. This
+    /// route is that write without the round trip, and it differs in exactly one behaviour: a subject
+    /// already linked to a DIFFERENT account is refused with 409 and the stored link is left as it was.
+    /// Repeating the same mapping succeeds, so a retry after a lost response is safe.
+    /// <para>
+    /// The link is written unstamped by the OpenID issuer binding (#186), like every other administrator
+    /// link: no id_token was redeemed here, so there is no issuer to bind to, and the binding is taken on
+    /// the identity's first real login instead.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The mode of the function; SAML or OID.</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="jellyfinUserId">The existing Jellyfin account the identity is linked to.</param>
+    /// <param name="canonicalName">The provider-side identity key: the OpenID stable subject claim, or the SAML NameID.</param>
+    /// <returns>No content on success, 400 on an empty key or an unknown provider, 404 when no such Jellyfin account exists, 409 when the identity is already linked elsewhere.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("Links/Preprovision/{mode}/{provider}/{jellyfinUserId}")]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public async Task<ActionResult> PreprovisionCanonicalLink([FromRoute] string mode, [FromRoute] string provider, [FromRoute] Guid jellyfinUserId, [FromBody] string canonicalName)
+    {
+        // Throttle after the elevation guard, before any work (#382, #516): the [Authorize] filter refuses a
+        // non-elevated caller before the body runs, so an unauthorized request never reaches the limiter and
+        // there is no rate-limit oracle. Past it, this shares the "link" bucket with the self-service link
+        // and unlink writes, because it drives the same config-XML persist under the global lock.
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
+        {
+            return throttled;
+        }
+
+        // A user id nobody holds is a 404 rather than a link written against a GUID that resolves to no
+        // account: the endpoint exists to link an account a provisioning tool has ALREADY created, and a
+        // link to a non-existent account is unreachable bookkeeping that no login can ever redeem.
+        if (_userManager.GetUserById(jellyfinUserId) is null)
+        {
+            return NotFound("No Jellyfin account exists with that user id.");
+        }
+
+        var parsed = ParseMode(mode);
+        var result = _canonicalLinks.TryPreprovisionLink(parsed, provider, canonicalName, jellyfinUserId);
+        if (result == CanonicalLinkWriteResult.Created)
+        {
+            SsoAudit.LinkPreprovisioned(
+                _logger,
+                await ResolveActorAsync().ConfigureAwait(false),
+                parsed == ProviderMode.Oid ? OpenIdProtocol : SamlProtocol,
+                provider,
+                jellyfinUserId);
+        }
+
+        return FlowResponses.MapCanonicalLinkWrite(result);
+    }
+
+    /// <summary>
     /// Turns SSO-only login on (#165), designating <paramref name="breakGlassAdminUsername"/> as the account
     /// whose native password login is never disabled. Requires administrator privileges. Fail-closed: the
     /// last-admin guard runs first, and unless the designated account is an existing, enabled administrator

--- a/SSO-Auth/Api/Linking/CanonicalLinkService.cs
+++ b/SSO-Auth/Api/Linking/CanonicalLinkService.cs
@@ -37,6 +37,9 @@ internal enum CanonicalLinkWriteResult
 
     /// <summary>No provider of that mode/name exists; nothing was written.</summary>
     UnknownProvider,
+
+    /// <summary>The key is already held by a DIFFERENT Jellyfin user; nothing was written (#1133).</summary>
+    ConflictingUser,
 }
 
 /// <summary>
@@ -1115,6 +1118,47 @@ internal sealed class CanonicalLinkService
     /// <param name="issuer">The OpenID id_token issuer to issuer-bind the new link to (#186); null for SAML or an unauthenticated admin link, which leaves the link un-stamped (trust-on-first-use applies on its first login).</param>
     /// <returns>The write outcome.</returns>
     internal CanonicalLinkWriteResult TryCreateLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId, string? issuer = null)
+        => WriteLink(mode, provider, providerUserId, jellyfinUserId, issuer, refuseRebind: false);
+
+    /// <summary>
+    /// Creates a canonical link for a provisioning tool that holds no identity-provider response (#1133),
+    /// under the config lock. Same write as <see cref="TryCreateLink"/> with one difference, and the
+    /// difference is the whole point of the entry point: a key already held by a different Jellyfin user is
+    /// refused rather than repointed.
+    /// </summary>
+    /// <remarks>
+    /// The rebind refusal cannot be an extra check at the HTTP boundary. A read of the link map followed by
+    /// a write is two transactions, and a login completing between them would be silently overwritten by
+    /// the caller that read first. So the check lives inside the same <c>Mutate</c> as the write, which is
+    /// what makes "nothing was written" true of the conflict rather than merely likely.
+    /// <para>
+    /// <see cref="TryCreateLink"/> keeps its repoint on purpose and is not narrowed here. Its callers reach
+    /// it only after the human whose identity is being linked has completed a live flow at the identity
+    /// provider, so the subject presented there is one the caller demonstrably controls. This entry point
+    /// has no such proof behind it - an administrator credential is all it asks for - which is exactly why
+    /// the two differ.
+    /// </para>
+    /// </remarks>
+    /// <param name="mode">The protocol the operation applies to, parsed once at the controller boundary (#369).</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="providerUserId">The provider-side identity key (OpenID sub / SAML NameID).</param>
+    /// <param name="jellyfinUserId">The Jellyfin user to link the identity to.</param>
+    /// <returns>The write outcome, including <see cref="CanonicalLinkWriteResult.ConflictingUser"/>.</returns>
+    internal CanonicalLinkWriteResult TryPreprovisionLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId)
+        => WriteLink(mode, provider, providerUserId, jellyfinUserId, issuer: null, refuseRebind: true);
+
+    /// <summary>
+    /// The one canonical-link write, shared by the two entry points above so the fail-closed empty-key
+    /// guard, the provider lookup and the issuer stamp cannot drift between them.
+    /// </summary>
+    /// <param name="mode">The protocol the operation applies to.</param>
+    /// <param name="provider">The provider the link belongs to.</param>
+    /// <param name="providerUserId">The provider-side identity key.</param>
+    /// <param name="jellyfinUserId">The Jellyfin user to link the identity to.</param>
+    /// <param name="issuer">The OpenID id_token issuer to bind the new link to (#186), or null.</param>
+    /// <param name="refuseRebind">Whether a key already held by another Jellyfin user is refused instead of repointed.</param>
+    /// <returns>The write outcome.</returns>
+    private CanonicalLinkWriteResult WriteLink(ProviderMode mode, string provider, string providerUserId, Guid jellyfinUserId, string? issuer, bool refuseRebind)
     {
         // Fail closed (#95), linking-side choke point: an SSO identity that did not resolve must not
         // create a link - an empty or whitespace key would persist a dead link no login can ever redeem.
@@ -1136,6 +1180,16 @@ internal sealed class CanonicalLinkService
             if (!TryGetLinks(configuration, mode, provider, requireEnabled: true, out var links))
             {
                 return CanonicalLinkWriteResult.UnknownProvider;
+            }
+
+            // The rebind refusal (#1133). Re-pointing an identity-provider subject at a second account is
+            // how a crafted provisioning call would move somebody else's identity onto an account it
+            // controls, so the pre-provision entry point refuses it and leaves the existing link intact.
+            // Repeating the SAME mapping is not a rebind and stays a success, so a tool that retries a
+            // request whose response it never saw does not have to distinguish the two.
+            if (refuseRebind && links.TryGetValue(providerUserId, out var held) && held != jellyfinUserId)
+            {
+                return CanonicalLinkWriteResult.ConflictingUser;
             }
 
             links[providerUserId] = jellyfinUserId;

--- a/SSO-Auth/Api/Shared/FlowResponses.cs
+++ b/SSO-Auth/Api/Shared/FlowResponses.cs
@@ -81,6 +81,12 @@ internal static class FlowResponses
     /// response. The empty-key and unknown-provider refusals keep distinct bodies (the service checks the
     /// empty key first), and an unhandled result throws rather than silently returning a wrong status.
     /// </summary>
+    /// <remarks>
+    /// The conflict arm is reachable only from the pre-provision write (#1133); the flows redeem an
+    /// identity-provider response first and repoint rather than refuse. It is mapped here anyway rather
+    /// than at that one caller, because a refusal that leaves the stored link untouched has one correct
+    /// status whichever entry point produced it, and a second mapper is how the two would come to disagree.
+    /// </remarks>
     /// <param name="result">The closed write-result variant from <c>CanonicalLinkService.TryCreateLink</c>.</param>
     /// <returns>The mapped <see cref="ActionResult"/>.</returns>
     internal static ActionResult MapCanonicalLinkWrite(CanonicalLinkWriteResult result) => result switch
@@ -88,6 +94,7 @@ internal static class FlowResponses
         CanonicalLinkWriteResult.Created => new NoContentResult(),
         CanonicalLinkWriteResult.EmptyKey => new BadRequestObjectResult("The SSO login did not resolve an identity."),
         CanonicalLinkWriteResult.UnknownProvider => new BadRequestObjectResult(LoginStatusMapper.NoMatchingProviderMessage),
+        CanonicalLinkWriteResult.ConflictingUser => new ConflictObjectResult("That identity is already linked to a different Jellyfin account. Remove the existing link first."),
         _ => throw new InvalidOperationException($"Unhandled canonical-link write result: {result}"),
     };
 }


### PR DESCRIPTION
# What & why

Closes #1133.

The link write on the controller (`POST {mode}/Link/{provider}/{jellyfinUserId}`)
redeems a live authorize state or a signed assertion, so it structurally requires
the person being linked to complete a flow at the identity provider. A
provisioning tool holding only an administrator credential cannot drive it, which
is why invite-born accounts arrive as password accounts somebody links by hand
afterwards.

This adds `POST Links/Preprovision/{mode}/{provider}/{jellyfinUserId}`,
elevation-gated, taking the canonical subject as the body. It is the same persist
under the same config lock, and it differs in exactly one behaviour: a subject
already linked to a **different** Jellyfin account is refused with 409 and the
stored link is left as it was.

That refusal is why this is a second entry point rather than a flag on the first.
Reaching this endpoint proves an administrator credential and nothing about the
subject, so repointing an identity here would move another person's identity onto
an account the caller names. `TryCreateLink` keeps its repoint, because its
callers only reach it after the human whose identity is being linked has
completed a flow at the provider; both entry points share one private write so
the empty-key guard, the provider lookup and the issuer stamp cannot drift apart.

The issue predicted this would be a thin exposure of `TryCreateLink` and nothing
more. That turned out to be not quite right, and it is worth stating rather than
quietly working around: `TryCreateLink` assigns `links[providerUserId] =
jellyfinUserId` unconditionally, so exposing it unchanged would have answered
201/204 to exactly the rebind the issue asks to be a 409. The conflict arm is the
one behaviour this adds beyond the exposure.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader ran on this change, and the two boxes above are left unticked
for that reason rather than as an oversight.** What stands in its place is the
executed evidence below. It is not equivalent and is not offered as equivalent:
nobody but the author has read this diff.

The guard this change exists for was falsified rather than asserted. Deleting the
rebind arm from `CanonicalLinkService.WriteLink` and re-running:

```
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*Preprovision*"
  TheSameSubjectPointedAtASecondAccount_IsRefused_AndTheFirstLinkSurvives [FAIL]
    Expected: typeof(Microsoft.AspNetCore.Mvc.ConflictObjectResult)
    Actual:   typeof(Microsoft.AspNetCore.Mvc.NoContentResult)
  AConflict_WritesNoAuditLine [FAIL]
    Assert.DoesNotContain() Failure: Filter matched in collection
   SSO-Auth.Tests  Total: 12, Errors: 0, Failed: 2, Skipped: 0
```

Both go red for the reason the guard names - the link is repointed and a second
grant is logged - and both go green once the arm is restored.

Fail-safes, each with its own test:

- The rebind check lives **inside** the same `Mutate` as the write, not at the
  HTTP boundary. A read-then-write is two transactions, and a login completing
  between them would be silently overwritten, so "nothing was written" is true of
  the conflict rather than merely likely.
- Repeating the same mapping stays a success, so a tool retrying a request whose
  answer it never saw is not told its own earlier success is a conflict.
- An account id no account holds is 404 before any write.
- A blank subject, and an absent or disabled provider, are refused by the shared
  write, so the mid-flight-disable window #380 closed is not reopened here.
- Audited at Warning with the actor, the protocol, the provider and the target
  account, and never the subject, which is the one member of the request that
  identifies a real person at the provider (T-I1). A refused write logs nothing.
  Actor and provider are line-ending-stripped inline at the log call.
- Throttled on the existing `link` bucket, after the elevation guard, so an
  unauthorized caller never reaches the limiter and there is no rate-limit oracle.

The link is written unstamped by the OpenID issuer binding (#186), like every
other administrator link: no id_token was redeemed, so there is no issuer to bind
to, and the binding is taken on the identity's first real login.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable
      unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: the integration document for this surface is
      already filed as #1141, which names this endpoint as a prerequisite.

Three existing conformance lists were extended rather than bypassed, which is
what they are there for: `MustThrottleRoutes`, `ProviderNameExemptRoutes` and the
elevation surface in `SSOControllerAuthorizationTests`. The typed-call-site
sentinel in `RateLimitEndpointClass_UsesTypedConstants_NotLiterals` moves 15 to
16, as its own comment asks for in the same change that adds a limited endpoint.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3243, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3244, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The four skips are the same four this suite skips on Windows without an
administrator: binding a listener off loopback raises the firewall consent dialog
(#1227). They are disclosed here rather than counted as passes.

`npx prettier --check CHANGELOG.md` is clean. The same command over the whole
`**/*.{js,html,md,css,scss}` glob reports 20 files locally, none of them touched
by this change; that is a local Prettier 3.9.6 against whatever the workflow's
action pins, not a state this branch introduced.

## Notes

The endpoint deliberately does not create the Jellyfin account. A user id
`IUserManager` does not know is a 404, per the issue's own out-of-scope list, and
listing links across all users stays where it already landed (#1119).
