### PR TITLE
Create the channel branch when the manifest publish finds it missing

### DIFF
--- a/.github/actions/generate-manifest/action.yml
+++ b/.github/actions/generate-manifest/action.yml
@@ -345,6 +345,60 @@ runs:
           | [.]
         ' "$work/plugin.json" > "$work/manifest.json"
 
+        # Base64 the manifest into a file and read it with jq --rawfile: the encoded blob outgrows the
+        # OS per-argument limit (MAX_ARG_STRLEN, ~128 KB) as the version list grows, which made jq abort
+        # with "Argument list too long" (E2BIG) once the manifest crossed it (#978). A file input is not
+        # subject to that limit; base64 -w0 emits no trailing newline, so $c is exactly the encoded blob.
+        # Both the bootstrap below and the ordinary commit send it, so it is encoded once, here.
+        base64 -w0 < "$work/manifest.json" > "$work/manifest.b64"
+
+        # DOES THE CHANNEL BRANCH EXIST? The contents endpoint at the end of this step writes into a
+        # branch that is already there and answers "Branch <name> not found (HTTP 404)" when it is not,
+        # so a channel branch that has gone missing stops the publish HERE - after the release for this
+        # run was created and sealed, which is the one thing a re-run cannot redo. Nothing else in the
+        # tree could put the branch back either: regenerate-manifest.yml, the by-hand recovery path,
+        # calls this same action and fails at the same line (#1386). So the branch is bootstrapped.
+        #
+        # matching-refs, not git/ref/heads/<branch>: it answers 200 with an array, so "the branch is
+        # absent" is an empty array while a network error, a revoked token or a permission the job does
+        # not hold all FAIL the call and red the run under set -e/pipefail. The single-ref endpoint
+        # answers 404 for absent and for several kinds of cannot-read alike, and this code CREATES
+        # something on that answer, so the two must not collapse into one exit code.
+        # The endpoint matches by PREFIX (heads/manifest-beta would also return heads/manifest-beta-old),
+        # so the ref is compared exactly rather than counted.
+        branch_exists="$(gh api "repos/${REPO}/git/matching-refs/heads/${BRANCH}" \
+          | jq -r --arg r "refs/heads/${BRANCH}" 'any(.[]; .ref == $r)')"
+
+        if [ "$branch_exists" != "true" ]; then
+          # A channel branch is a publishing surface, not a copy of the source: Jellyfin fetches exactly
+          # one file from it. So it is created with a history of its own (no parents) holding only the
+          # manifest, rather than branched off main, which would serve the whole checkout from a URL
+          # nobody reads it from and would make every later manifest commit a commit on top of main.
+          #
+          # This cannot open a channel that a leg was not already about to write: it runs inside the
+          # manifest step, which is reached only after that leg's own gates - including the explicit
+          # refusal in regenerate-manifest.yml that keeps the retired stable channel empty (#954).
+          #
+          # Serialization is what makes the create safe rather than racy: every writer of a channel
+          # joins the publish-manifest-<channel> concurrency group with cancel-in-progress false, so two
+          # runs cannot bootstrap the same branch at once. Should one ever get there anyway, the ref
+          # POST answers 422 and this run goes red with the release sealed but unpublished, which is the
+          # same failure as today rather than a new one, and never a manifest written to a guessed ref.
+          blob_sha="$(jq -nc --rawfile c "$work/manifest.b64" '{content:$c, encoding:"base64"}' \
+            | gh api -X POST "repos/${REPO}/git/blobs" --input - --jq '.sha')"
+          tree_sha="$(jq -nc --arg p "$MANIFEST_FILE" --arg s "$blob_sha" \
+            '{tree:[{path:$p, mode:"100644", type:"blob", sha:$s}]}' \
+            | gh api -X POST "repos/${REPO}/git/trees" --input - --jq '.sha')"
+          commit_sha="$(jq -nc --arg t "$tree_sha" \
+            --arg m "Create ${BRANCH} and publish the Jellyfin plugin repository." \
+            '{message:$m, tree:$t, parents:[]}' \
+            | gh api -X POST "repos/${REPO}/git/commits" --input - --jq '.sha')"
+          jq -nc --arg r "refs/heads/${BRANCH}" --arg s "$commit_sha" '{ref:$r, sha:$s}' \
+            | gh api -X POST "repos/${REPO}/git/refs" --input - >/dev/null
+          echo "created ${BRANCH} and committed $final_total versions to ${BRANCH}/${MANIFEST_FILE}"
+          exit 0
+        fi
+
         # Commit only when something changed, so an unchanged regeneration does not add an
         # empty commit to the manifest branch on every publish.
         current_sha="$(gh api "repos/${REPO}/contents/${MANIFEST_FILE}?ref=${BRANCH}" --jq '.sha' 2>/dev/null || true)"
@@ -356,11 +410,6 @@ runs:
           fi
         fi
 
-        # Base64 the manifest into a file and read it with jq --rawfile: the encoded blob outgrows the
-        # OS per-argument limit (MAX_ARG_STRLEN, ~128 KB) as the version list grows, which made jq abort
-        # with "Argument list too long" (E2BIG) once the manifest crossed it (#978). A file input is not
-        # subject to that limit; base64 -w0 emits no trailing newline, so $c is exactly the encoded blob.
-        base64 -w0 < "$work/manifest.json" > "$work/manifest.b64"
         payload="$(jq -nc --arg m "Regenerate Jellyfin plugin repository." --arg b "$BRANCH" \
           --rawfile c "$work/manifest.b64" --arg s "${current_sha:-}" \
           '{message:$m, branch:$b, content:$c} + (if $s == "" then {} else {sha:$s} end)')"


### PR DESCRIPTION
# What & why

`manifest-beta` and `manifest-release` do not exist in this repository, and the manifest step cannot put either back. The contents endpoint it writes through refuses a branch that is not there, so a publish gets as far as creating and sealing its release and then stops:

```
$ gh api repos/Flowfin/jellyfin-plugin-sso/git/refs/heads --jq '.[].ref'
refs/heads/main
$ gh run view 32332996501 --log-failed | tail -3
manifest entries per targetAbi:
  10.11.0.0: 15 (newest 4.3.0.40)
  12.0.0.0: 15 (newest 5.0.0.53)
gh: Branch manifest-beta not found (HTTP 404)
```

The URL `README.md:76` gives under Installing is served from that branch:

```
$ curl -s -o /dev/null -w '%{http_code}\n' "https://raw.githubusercontent.com/Flowfin/jellyfin-plugin-sso/manifest-beta/manifest.json"
404
```

`regenerate-manifest.yml` is the by-hand repair route and calls this same composite action (`regenerate-manifest.yml:99`), so it fails at the same line. Nothing in the tree could recreate the branch.

This adds the bootstrap: the step asks whether the channel branch exists, and where it does not, creates a blob, a tree holding `manifest.json` alone, a commit with no parents, and the ref. A channel branch is a publishing surface Jellyfin reads one file from, so it gets a history of its own rather than being cut from `main`.

The existence question goes through `git/matching-refs`, which answers 200 with an array. Absent is an empty array; a network error or a permission the job does not hold fails the call and reds the run. The single-ref endpoint answers 404 for both, and this code creates something on that answer, so the two must not become one exit code. The endpoint matches by prefix, so the ref is compared exactly.

Where the branch exists, the unchanged-check and the ordinary commit run exactly as before. The base64 encoding moved above both paths because both send it.

Means: the change stays in the composite action's bash, the language the step is already written in, so it needs no new runtime and the surrounding fail-closed style (`set -euo pipefail`, jq payloads through `--input -` for the `MAX_ARG_STRLEN` reason recorded at #978) carries straight through.

Closes #1386.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a ref lookup that cannot be answered reds the run rather than creating a branch, and the bootstrap runs only inside a leg already past its own gates, including the refusal in `regenerate-manifest.yml` that keeps the retired stable channel empty (#954).
- [x] No secrets logged; secrets are redacted on config export. Nothing here reads or writes a secret; the only new output names the branch and the version count.
- [ ] A security review was performed for changes to SAML/OIDC validation, config persistence, or the release pipeline. **No second reader looked at this change.** The falsification below is the evidence offered in place of one, and this box stays unticked rather than being answered from it.
- [ ] Review record: no lens ran, so there is no per-lens verdict and no CONFIRMED / PLAUSIBLE count to report.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP input reaches this file.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`. No structural property changes; the diff is one YAML file and no C# type.
- [x] Docs impact considered: no README or wiki change is owed. The README already documents the URL this restores.

## Verification

The diff is one composite-action file and no compiled source, so the .NET gates are unmoved by it and run on this pull request as the record. What was verified here is the shell.

The bash under test was extracted from the committed file rather than retyped, and driven with `gh` replaced by a recording stand-in, so no network call was made and no repository was touched:

```
$ sed -n '348,$p' .github/actions/generate-manifest/action.yml | sed 's/^        //' > block.check
$ cmp -s block.check block.sh && echo identical
identical
$ bash run.sh | tail -1
passed=19 failed=0
```

The four cases: an absent branch creates blob, tree, commit and ref and makes no contents PUT, with the commit carrying `parents == []`, the tree exactly one entry at `manifest.json` mode `100644`, the ref `refs/heads/manifest-beta`, and the blob byte-equal to this run's manifest; a present branch creates no ref and commits through contents to the right branch; a prefix neighbour (`refs/heads/manifest-beta-old`) is not taken for the branch; an unanswerable ref lookup fails the run and writes nothing.

Both guards were then deleted and the suite watched go red.

Replacing the exact ref comparison with a bare count:

```
$ sed -i "s|'any(.\[\]; .ref == \$r)'|'length > 0'|" block.sh && bash run.sh | tail -1
passed=18 failed=1
   FAIL  a prefix neighbour is not taken for the branch
```

Tolerating a ref lookup that could not be answered (appending `|| echo false`):

```
$ bash run.sh | tail -1
passed=17 failed=2
   FAIL  run fails closed
   FAIL  creates no ref
```

Restored, the suite is green again at 19/19.

- [ ] `dotnet build --no-restore --warnaserror` is green. Not run locally; no compiled source changed, and the `build` check on this pull request is the record.
- [ ] `dotnet test` is green. Same.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. None changed.

## Notes

What this does **not** do is put the branch back by itself. It makes the next publish, or a dispatched `regenerate-manifest`, able to. Until one of those runs, the README URL keeps returning 404, so the last Done-when clause on #1386 is not met by this merge and the issue's close should be read against a run rather than against this diff.

The bootstrap path has never executed. It cannot be executed anywhere but a run holding write access to this repository, so the stand-in above is what stands behind it, and the first real exercise will be the run that uses it. `verify-manifest` runs immediately after and already handles a first revision ("no previous revision of this manifest to compare against"), so that run checks its own result.

What removed the branch is not readable from here: the last green freshness run was `2026-08-18T12:36:51Z`, the first publish reporting it missing was `2026-08-19T04:43:46Z`, and the repository event feed reaches back only to `2026-08-18T15:00:43Z` with no branch deletion in the part of that span it covers.
