### PR TITLE
Declare the committed culture set the catalogs are checked against

### DIFF
--- a/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
+++ b/SSO-Auth.Tests/Localization/LocalizationCatalogTests.cs
@@ -17,13 +17,21 @@ namespace Jellyfin.Plugin.SSO_Auth.Tests;
 /// fallback chain terminates on, so every embedded catalog must be a flat string→string map with no blank
 /// values, and every non-English catalog must carry EXACTLY the English key set - a missing key would blank
 /// (it falls back, but a translator's catalog claiming completeness must be complete), an orphan key is dead
-/// data. This is the standing drift guard for when the full language set lands (a later sub-unit).
+/// data. Which cultures ship is declared by <c>CommittedCultures</c> rather than read off the catalogs, so
+/// a catalog cannot be lost, or arrive unread, without a check saying so (#1154).
 /// </summary>
 public class LocalizationCatalogTests
 {
     private const string ResourcePrefix = "Jellyfin.Plugin.SSO_Auth.Localization.";
     private const string ResourceSuffix = ".json";
     private const string EnglishResource = ResourcePrefix + "en" + ResourceSuffix;
+
+    // THE COMMITTED CULTURE SET, stated here and NOT derived from the catalogs on disk. The catalogs are
+    // what these checks are about, so an expectation read out of them would be deleted along with the file
+    // it was meant to protect, and the suite would stay green through the loss. A culture belongs on this
+    // list once a person has read its catalog (#1154), so the list grows by a change that adds a name here
+    // beside the file, never by a file arriving on its own.
+    private static readonly string[] CommittedCultures = ["en"];
 
     // Any type in the plugin assembly anchors GetManifestResourceStream to the resource-bearing assembly.
     private static readonly Assembly PluginAssembly = typeof(SsoLocalizer).Assembly;
@@ -32,6 +40,9 @@ public class LocalizationCatalogTests
         PluginAssembly.GetManifestResourceNames()
             .Where(name => name.StartsWith(ResourcePrefix, System.StringComparison.Ordinal)
                 && name.EndsWith(ResourceSuffix, System.StringComparison.Ordinal));
+
+    // The placeholder form i18n.js substitutes in format(): /\{(\w+)\}/g.
+    private static readonly Regex PlaceholderPattern = new(@"\{(?<name>\w+)\}", RegexOptions.Compiled);
 
     // `data-i18n="key"` and the allowlisted attribute form `data-i18n-title="key"`.
     private static readonly Regex MarkupKeyPattern = new(@"data-i18n(?:-[a-z-]+)?=""(?<key>[^""]+)""", RegexOptions.Compiled);
@@ -379,4 +390,81 @@ public class LocalizationCatalogTests
             Assert.True(orphan.Count == 0, $"{resource}: orphan keys not in English: {string.Join(", ", orphan)}");
         }
     }
+
+    [Fact]
+    public void EveryCommittedCulture_ShipsACatalog()
+    {
+        var shipped = CatalogResources().ToHashSet(System.StringComparer.Ordinal);
+
+        var absent = CommittedCultures
+            .Select(culture => ResourcePrefix + culture + ResourceSuffix)
+            .Where(resource => !shipped.Contains(resource))
+            .ToList();
+
+        Assert.True(absent.Count == 0, "committed cultures shipping no catalog: " + string.Join(", ", absent));
+    }
+
+    [Fact]
+    public void EveryShippedCatalog_IsACommittedCulture()
+    {
+        var committed = CommittedCultures
+            .Select(culture => ResourcePrefix + culture + ResourceSuffix)
+            .ToHashSet(System.StringComparer.Ordinal);
+
+        var undeclared = CatalogResources()
+            .Where(resource => !committed.Contains(resource))
+            .ToList();
+
+        Assert.True(undeclared.Count == 0, "catalogs no one is recorded as having read: " + string.Join(", ", undeclared));
+    }
+
+    [Fact]
+    public void TheLocalizer_LoadsExactlyTheCommittedCultures()
+    {
+        // The two checks above read the embedded RESOURCE. SsoLocalizer skips a catalog that is not a flat
+        // string→string map, so a file can be shipped, pass both of them, and still not exist at runtime -
+        // its keys silently fall through the chain to English. This is the same set seen from the side the
+        // served surfaces actually use.
+        Assert.Equal(
+            CommittedCultures.OrderBy(culture => culture, System.StringComparer.Ordinal).ToList(),
+            SsoLocalizer.AvailableCultures.OrderBy(culture => culture, System.StringComparer.Ordinal).ToList());
+    }
+
+    [Fact]
+    public void EveryNonEnglishCatalog_CarriesTheEnglishPlaceholdersPerKey()
+    {
+        // i18n.js substitutes `{name}` from a params object and leaves an unknown name verbatim, so a
+        // translation that drops a placeholder loses the value it was carrying and one that renames it
+        // prints the brace form at the user. Neither is a missing key, so the key-set guard cannot see it.
+        var english = ReadCatalog(EnglishResource);
+        var faults = new List<string>();
+
+        foreach (var resource in CatalogResources().Where(name => name != EnglishResource))
+        {
+            foreach (var entry in ReadCatalog(resource))
+            {
+                if (!english.TryGetValue(entry.Key, out var englishValue))
+                {
+                    // An orphan key is the key-set guard's finding; reporting it twice hides this one.
+                    continue;
+                }
+
+                var expected = Placeholders(englishValue);
+                var actual = Placeholders(entry.Value);
+                if (!expected.SetEquals(actual))
+                {
+                    faults.Add(
+                        $"{resource}: key '{entry.Key}' carries [{string.Join(",", actual.Order(System.StringComparer.Ordinal))}]"
+                        + $", English carries [{string.Join(",", expected.Order(System.StringComparer.Ordinal))}]");
+                }
+            }
+        }
+
+        Assert.True(faults.Count == 0, "placeholder drift: " + string.Join(" | ", faults));
+    }
+
+    private static HashSet<string> Placeholders(string value) =>
+        PlaceholderPattern.Matches(value)
+            .Select(match => match.Groups["name"].Value)
+            .ToHashSet(System.StringComparer.Ordinal);
 }


### PR DESCRIPTION
# What & why

`LocalizationCatalogTests` derived its expectation from the catalogs it was checking. `CatalogResources()` reads the embedded set, and every guard iterated that, so deleting a catalog deleted the expectation with it and the suite stayed green through the loss. With `en.json` the only file shipped, `EveryNonEnglishCatalog_HasExactlyTheEnglishKeySet` also iterated an empty set and passed on nothing.

```
$ git ls-tree -r origin/main --name-only -- SSO-Auth/Localization
SSO-Auth/Localization/en.json
```

`CommittedCultures` now states the set in code, independently of the files, and the checks compare the two directions:

- `EveryCommittedCulture_ShipsACatalog` fails when a declared culture ships nothing.
- `EveryShippedCatalog_IsACommittedCulture` fails when a catalog arrives that nobody is recorded as having read.
- `TheLocalizer_LoadsExactlyTheCommittedCultures` compares the same list against `SsoLocalizer.AvailableCultures`. This is not the first two repeated: a file that is present but is not a flat string to string map is skipped at load, so it passes both resource checks and still does not exist at runtime, its keys falling through the chain to English.
- `EveryNonEnglishCatalog_CarriesTheEnglishPlaceholdersPerKey` pins each catalog's placeholder set per key against English. `i18n.js` substitutes `{name}` from a params object and leaves an unknown name verbatim (`format()`, `/\{(\w+)\}/g`), so a translation that drops a placeholder loses the value it carried and one that renames it prints the brace form at the user. Neither is a missing key, so the key-set guard cannot see either.

The list holds `"en"` alone, which is what has been read. It grows by a change that adds a name beside the file, never by a file arriving on its own.

The English baseline is 71 keys today, not the 68 the issue body quotes:

```
$ node -e "const fs=require('fs');console.log(Object.keys(JSON.parse(fs.readFileSync('SSO-Auth/Localization/en.json','utf8'))).length)"
71
```

Means: the guard is xUnit v3 in `SSO-Auth.Tests`, beside the checks it extends, reading the same embedded resources through the same helpers. It needs no new dependency and no second apparatus, and `--warnaserror` on the test project is the analyzer gate it already passes under.

Refs #1154.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Not a login-path, crypto, config-persistence or release-pipeline change. Catalogs are data and stay data: nothing here alters how they are loaded, and the fail-closed load in `SsoLocalizer` is untouched.

- [x] Fail-closed preserved.
- [x] No secrets logged; secrets are redacted on config export. No secret is read here.
- [ ] A security review was performed. **No second reader looked at this change.** The falsification below is what is offered in its place, and this box stays unticked rather than being answered from it.
- [ ] Review record: no lens ran, so there is no per-lens verdict and no CONFIRMED / PLAUSIBLE count.
- [x] Log inputs from the IdP are sanitized inline at the log call. No IdP input reaches this file.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose, testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting and matches the target architecture.
- [x] Architecture-conformance tests pass, and any new structural property this change establishes is locked in as a rule in `ArchitectureConformanceTests`. The full suite ran; no structural property changes.
- [x] Docs impact considered: no README or wiki change is owed by this diff. What the promised language set should now say is content rather than a guard, and is left on the issue.

## Verification

Both target frameworks, warnings as errors, full suite:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3247, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3248, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

Each guard was then broken and the suite watched go red, one break at a time, restored between.

A declared culture that ships no catalog (`CommittedCultures = ["en", "xx"]`):

```
   EveryCommittedCulture_ShipsACatalog [FAIL]
   TheLocalizer_LoadsExactlyTheCommittedCultures [FAIL]
   Total: 15, Failed: 2
```

A catalog nobody declared (`cp en.json zz.json`):

```
   TheLocalizer_LoadsExactlyTheCommittedCultures [FAIL]
   EveryShippedCatalog_IsACommittedCulture [FAIL]
   Total: 15, Failed: 2
```

A complete, declared catalog with one placeholder renamed, `{mode}` to `{Mode}`, in `link.no_providers`. Exactly one check fires, and it is the one the key-set guard cannot stand in for:

```
   EveryNonEnglishCatalog_CarriesTheEnglishPlaceholdersPerKey [FAIL]
     placeholder drift: …zz.json: key 'link.no_providers' carries [Mode], English carries [mode]
   Total: 15, Failed: 1
```

A declared catalog the localizer skips, one value made a nested object. Four checks fire; the runtime one is the only one that says the plugin dropped the culture rather than that the file reads badly:

```
   TheLocalizer_LoadsExactlyTheCommittedCultures [FAIL]
   EveryNonEnglishCatalog_HasExactlyTheEnglishKeySet [FAIL]
   EveryNonEnglishCatalog_CarriesTheEnglishPlaceholdersPerKey [FAIL]
   EveryCatalog_HasNoBlankValues [FAIL]
   Total: 15, Failed: 4
```

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. None changed.

## Notes

**This does not close #1154 and must not be read as closing it.** That issue asks for two things, and only one is here. `EveryNonEnglishCatalog_HasExactlyTheEnglishKeySet` still iterates an empty set on `main` after this merge, because the committed set is `en` alone. The falsification above shows the guard working over a non-empty set, but it did so against a catalog made for the test and removed again, which is not the same as the suite covering a shipped one. The clause asking that it pass over a non-empty set is met by the first catalog somebody reads, not by this diff.

The other half of #1154, what the promised language set should now say, is content and is left on the issue.
