### PR TITLE
Prove the KEK-loss fail-closed path with an executed E2E phase

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -199,6 +199,32 @@ jobs:
             fi
           done
 
+      - name: KEK loss fails closed (#1130)
+        # Takes away the key that wraps the at-rest provider secrets, restarts Jellyfin against the
+        # orphaned envelope and requires the login to be REFUSED rather than fall back to plaintext
+        # or mint a replacement key; then puts the key back and requires the login to work again. It
+        # was verified by hand once in the #717 live pass and nothing re-checked it since, so a
+        # regression to a fallback path would ship silently.
+        #
+        # The phase drives that one refusal itself, and probes the same endpoint BEFORE the key goes
+        # away, because the harness exits non-zero on any failed login and its exit code alone cannot
+        # tell a fail-closed refusal from a stack that broke for an unrelated reason.
+        #
+        # Release and `providers: all` only, and only on the canonical Keycloak stack, for the same
+        # reasons as the phase below: it costs extra login passes, and it is the one stack that can be
+        # re-run in place (the seeds behind Zitadel, Pocket ID and Kanidm are not idempotent). Runs on
+        # a green harness only, so a real login failure surfaces as the harness failure.
+        #
+        # AHEAD of the migration phase, deliberately. Its precondition is an ssoenc:v1 envelope in the
+        # persisted configuration, which the secrets-at-rest step above has just asserted, so it needs
+        # nothing from the step below - and being gated behind a phase that has never executed on any
+        # run would make this one unreachable. It leaves the stack exactly as it found it: the same key
+        # back in place, the configuration untouched, containers stopped rather than removed.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: bash test/e2e/phases/kek-loss-fails-closed.sh
+
       - name: Legacy plaintext secret migrates to ssoenc:v1 (#1140)
         # A pre-#158 config carried its provider secret in plaintext. This plants one back into the
         # persisted configuration, restarts Jellyfin against it, and requires the login to keep working
@@ -213,30 +239,7 @@ jobs:
         if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
         env:
           COMPOSE: ${{ matrix.compose }}
-        # Through `bash`, like every other repository script a workflow runs: the tracked mode of every
-        # .sh here is 644, and this was the one site invoking a path directly. No full-matrix run has
-        # ever reached it, so nothing had executed the difference. The step below is gated on this one
-        # succeeding, which is how it surfaced.
-        run: bash test/e2e/phases/legacy-secret-migration.sh
-
-      - name: KEK loss fails closed (#1130)
-        # Destroys the key that wraps the at-rest provider secrets, restarts Jellyfin against the
-        # orphaned envelope and requires the login to be REFUSED rather than fall back to plaintext
-        # or mint a replacement key; then restores the key and requires the login to work again. It
-        # was verified by hand once in the #717 live pass and nothing re-checked it since, so a
-        # regression to a fallback path would ship silently.
-        #
-        # The phase drives that one refusal itself, and probes the same endpoint BEFORE destroying
-        # the key, because the harness exits non-zero on any failed login and its exit code alone
-        # cannot tell a fail-closed refusal from a stack that broke for an unrelated reason.
-        #
-        # Same gating and the same reasons as the phase above: release and `providers: all` only, on
-        # the canonical Keycloak stack, on a green harness. It runs after the migration phase, which
-        # leaves the persisted secret as an envelope - this phase's precondition.
-        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
-        env:
-          COMPOSE: ${{ matrix.compose }}
-        run: bash test/e2e/phases/kek-loss-fails-closed.sh
+        run: test/e2e/phases/legacy-secret-migration.sh
 
       - name: Dump container logs on failure
         if: failure()

--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -213,7 +213,30 @@ jobs:
         if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
         env:
           COMPOSE: ${{ matrix.compose }}
-        run: test/e2e/phases/legacy-secret-migration.sh
+        # Through `bash`, like every other repository script a workflow runs: the tracked mode of every
+        # .sh here is 644, and this was the one site invoking a path directly. No full-matrix run has
+        # ever reached it, so nothing had executed the difference. The step below is gated on this one
+        # succeeding, which is how it surfaced.
+        run: bash test/e2e/phases/legacy-secret-migration.sh
+
+      - name: KEK loss fails closed (#1130)
+        # Destroys the key that wraps the at-rest provider secrets, restarts Jellyfin against the
+        # orphaned envelope and requires the login to be REFUSED rather than fall back to plaintext
+        # or mint a replacement key; then restores the key and requires the login to work again. It
+        # was verified by hand once in the #717 live pass and nothing re-checked it since, so a
+        # regression to a fallback path would ship silently.
+        #
+        # The phase drives that one refusal itself, and probes the same endpoint BEFORE destroying
+        # the key, because the harness exits non-zero on any failed login and its exit code alone
+        # cannot tell a fail-closed refusal from a stack that broke for an unrelated reason.
+        #
+        # Same gating and the same reasons as the phase above: release and `providers: all` only, on
+        # the canonical Keycloak stack, on a green harness. It runs after the migration phase, which
+        # leaves the persisted secret as an envelope - this phase's precondition.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: bash test/e2e/phases/kek-loss-fails-closed.sh
 
       - name: Dump container logs on failure
         if: failure()

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -221,6 +221,40 @@ test/e2e/phases/legacy-secret-migration.sh
 A green run prints `LEGACY SECRET MIGRATION PHASE PASSED`. In CI it runs on a release, a beta
 release, or a `providers: all` dispatch, on the Keycloak entry only.
 
+### Losing the at-rest key fails closed
+
+`test/e2e/phases/kek-loss-fails-closed.sh` destroys the key that wraps the provider secrets and
+requires the next login to be refused rather than fall back to plaintext or mint a replacement key.
+It copies the key aside first and puts it back byte for byte, because a regenerated key is a
+different key: the stored envelope would not open under it and the phase would end up proving that
+a restored backup fails. After the restore a `RELOGIN_ONLY` pass must go green, so the phase proves
+fail-closed rather than a permanently broken stack.
+
+The refusal is driven by the phase itself, one request against `/sso/OID/start/<provider>`, and the
+same endpoint is probed **before** the key is destroyed. The harness exits non-zero on any failed
+login, so its exit code alone cannot separate a fail-closed refusal from a stack that broke for an
+unrelated reason; the control probe is what makes the refusal attributable. Jellyfin publishes no
+port to the host, so both probes run in a throwaway container on the compose network.
+
+The key lives inside the unpacked plugin drop, at
+`test/e2e/jellyfin/config/plugins/SSO-Auth/sso-secret.key`, rather than beside the configuration.
+Run the phase after a green canonical pass, on the stopped but not torn-down stack:
+
+```sh
+docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+
+bash test/e2e/phases/kek-loss-fails-closed.sh
+```
+
+Through `bash`, because every tracked `.sh` in this repository is mode 644 and none of them carries
+an executable bit.
+
+A green run prints `KEK LOSS FAILS CLOSED PHASE PASSED`. In CI it runs under the same gate as the
+migration phase and directly after it, which is also where its precondition comes from: that phase
+leaves the persisted secret as an `ssoenc:v1` envelope, and destroying the key against a plaintext
+or absent secret would prove nothing.
+
 **The Zitadel, Pocket ID and Kanidm stacks cannot be re-run in place.** Every other provider is seeded from a file
 (an imported realm, a reapplied blueprint, or a static config) and the driver deliberately reuses an
 already-initialised Jellyfin. These three are seeded imperatively against stateful storage and their seeds

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -241,7 +241,10 @@ The refusal is driven by the phase itself, one request against `/sso/OID/start/<
 same endpoint is probed **before** the key goes away. The harness exits non-zero on any failed
 login, so its exit code alone cannot separate a fail-closed refusal from a stack that broke for an
 unrelated reason; the control probe is what makes the refusal attributable. Jellyfin publishes no
-port to the host, so both probes run in a throwaway container on the compose network.
+port to the host, so both probes run in a throwaway container on the compose network, running
+`test/e2e/phases/probe-oid-start.sh` from a read-only bind mount. That probe never exits non-zero:
+it reports its own failures as `PROBE-ERROR` lines and the phase decides what a missing answer
+means, so a broken probe cannot be read as a refused login.
 
 The key lives inside the unpacked plugin drop, at
 `test/e2e/jellyfin/config/plugins/SSO-Auth/sso-secret.key`, rather than beside the configuration.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -223,15 +223,22 @@ release, or a `providers: all` dispatch, on the Keycloak entry only.
 
 ### Losing the at-rest key fails closed
 
-`test/e2e/phases/kek-loss-fails-closed.sh` destroys the key that wraps the provider secrets and
+`test/e2e/phases/kek-loss-fails-closed.sh` takes away the key that wraps the provider secrets and
 requires the next login to be refused rather than fall back to plaintext or mint a replacement key.
-It copies the key aside first and puts it back byte for byte, because a regenerated key is a
-different key: the stored envelope would not open under it and the phase would end up proving that
-a restored backup fails. After the restore a `RELOGIN_ONLY` pass must go green, so the phase proves
-fail-closed rather than a permanently broken stack.
+It renames the key aside and renames it back, because a regenerated key is a different key: the
+stored envelope would not open under it and the phase would end up proving that a restored backup
+fails. After the key is back a `RELOGIN_ONLY` pass must go green, so the phase proves fail-closed
+rather than a permanently broken stack.
+
+A rename rather than a copy, and that is forced rather than chosen. The server writes the key as
+root inside the container with owner-only permissions, so on the bind mount nothing running as the
+ordinary user can read it. Renaming needs write and execute on the directory and no permission at
+all on the file, and it is the stronger statement anyway: the file that comes back is the same
+inode, which the phase pins, so "byte for byte" is a property of the operation rather than a
+checksum to trust.
 
 The refusal is driven by the phase itself, one request against `/sso/OID/start/<provider>`, and the
-same endpoint is probed **before** the key is destroyed. The harness exits non-zero on any failed
+same endpoint is probed **before** the key goes away. The harness exits non-zero on any failed
 login, so its exit code alone cannot separate a fail-closed refusal from a stack that broke for an
 unrelated reason; the control probe is what makes the refusal attributable. Jellyfin publishes no
 port to the host, so both probes run in a throwaway container on the compose network.
@@ -251,9 +258,11 @@ Through `bash`, because every tracked `.sh` in this repository is mode 644 and n
 an executable bit.
 
 A green run prints `KEK LOSS FAILS CLOSED PHASE PASSED`. In CI it runs under the same gate as the
-migration phase and directly after it, which is also where its precondition comes from: that phase
-leaves the persisted secret as an `ssoenc:v1` envelope, and destroying the key against a plaintext
-or absent secret would prove nothing.
+migration phase and immediately ahead of it. Its precondition is an `ssoenc:v1` envelope in the
+persisted configuration, which the secrets-at-rest assertion has just made, and taking the key away
+from a stack whose secret is plaintext proves nothing: that is the documented genuine-first-run
+path, where the server mints a fresh key and every login succeeds. The phase asserts the envelope
+itself rather than assuming what ran before it, and it leaves the stack as it found it.
 
 **The Zitadel, Pocket ID and Kanidm stacks cannot be re-run in place.** Every other provider is seeded from a file
 (an imported realm, a reapplied blueprint, or a static config) and the driver deliberately reuses an

--- a/test/e2e/phases/kek-loss-fails-closed.sh
+++ b/test/e2e/phases/kek-loss-fails-closed.sh
@@ -54,37 +54,27 @@ secret_element() { grep -o '<OidSecret>[^<]*</OidSecret>' "$CONFIG" | head -1; }
 # One throwaway container on the compose network, because Jellyfin publishes no port to the host:
 # every service is reachable only by its service-DNS name from inside `ssonet`. --no-deps so this
 # never starts or restarts anything else, and the harness service is reused only for its image and
-# its network membership - its own command is replaced.
-on_network() { # $1 the shell program to run inside the container
-  docker compose -f "$COMPOSE" run --rm --no-deps -T --entrypoint sh harness -c "$1"
+# its network membership - its own command is replaced by the probe script, which is bind-mounted
+# in rather than handed over as a string. The first version passed the probe to `sh -c` and came
+# back with a status nothing in it can produce and a missing body file, and a script that arrives
+# as one argument through two layers cannot be read in the log it failed in.
+PHASES_DIR="${PHASES_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+probe_container() {
+  docker compose -f "$COMPOSE" run --rm --no-deps -T \
+    -v "$PHASES_DIR:/probe:ro" --entrypoint sh harness /probe/probe-oid-start.sh
 }
-
-# Waits for Jellyfin and probes the OpenID challenge once, printing two parseable lines. A failure
-# inside the container is reported as PROBE-ERROR rather than as a non-zero exit, so the caller
-# decides what a missing answer means instead of the run ending without a message.
-read -r -d '' PROBE <<'PROBE_SH' || true
-set -u
-apk add --no-cache curl >/dev/null 2>&1 || { echo "PROBE-ERROR could not install curl"; exit 0; }
-i=0
-while [ "$i" -lt 150 ]; do
-  curl -fsS -o /dev/null "$JELLYFIN_URL/System/Info/Public" 2>/dev/null && break
-  i=$((i + 1)); sleep 2
-done
-if [ "$i" -ge 150 ]; then echo "PROBE-ERROR Jellyfin did not answer /System/Info/Public within 300s"; exit 0; fi
-code="$(curl -sS -o /tmp/probe.body -w "%{http_code}" "$JELLYFIN_URL/sso/OID/start/$PROVIDER" 2>/dev/null || echo 000)"
-echo "PROBE-STATUS $code"
-echo "PROBE-BODY $(tr -d '\r\n' < /tmp/probe.body | cut -c1-300)"
-PROBE_SH
 
 PROBE_STATUS=""
 PROBE_BODY=""
 probe_challenge() { # $1 label; sets PROBE_STATUS and PROBE_BODY
   local out
-  out="$(on_network "$PROBE")" || die "$1: the probe container could not be started"
-  printf '%s\n' "$out" | sed -n 's/^PROBE-ERROR /  probe error: /p'
+  out="$(probe_container)" || die "$1: the probe container could not be started"
+  # Everything the probe said, indented, so a run that ends here says why rather than only that it
+  # got no answer.
+  printf '%s\n' "$out" | sed 's/^/  probe| /'
   PROBE_STATUS="$(printf '%s\n' "$out" | sed -n 's/^PROBE-STATUS //p' | tail -1)"
   PROBE_BODY="$(printf '%s\n' "$out" | sed -n 's/^PROBE-BODY //p' | tail -1)"
-  [ -n "$PROBE_STATUS" ] || die "$1: the probe returned no status - see the probe error above"
+  [ -n "$PROBE_STATUS" ] || die "$1: the probe returned no status - its own output is above"
   printf '  %s: status=%s body=%s\n' "$1" "$PROBE_STATUS" "$PROBE_BODY"
 }
 

--- a/test/e2e/phases/kek-loss-fails-closed.sh
+++ b/test/e2e/phases/kek-loss-fails-closed.sh
@@ -21,13 +21,11 @@
 #
 #   control    the stack is started WITHOUT the harness and the challenge is probed once. A
 #              redirect here is the baseline the refusal below is measured against.
-#   copy       the key is copied aside before anything destroys it, and restored byte for byte.
-#              A regenerated key is a DIFFERENT key: the stored envelope would not open under it
-#              and the phase would end up proving that a restored backup fails, which is the
-#              opposite of its claim.
-#   destroy    the key file is removed with the stack STOPPED. SecretStore caches the key in
-#              memory for the process lifetime, so a delete under a live server proves nothing
-#              until it restarts.
+#   take away  the key is RENAMED aside with the stack STOPPED, never regenerated afterwards. A
+#              fresh key is a DIFFERENT key: the stored envelope would not open under it and the
+#              phase would end up proving that a restored backup fails, which is the opposite of
+#              its claim. Stopped, because SecretStore caches the key in memory for the process
+#              lifetime and taking it from a live server proves nothing until a restart.
 #   refuse     the stack is started again and the same challenge is probed. It must answer 500
 #              with the fail-closed message, and the persisted secret must still be the SAME
 #              ssoenc:v1 envelope - not plaintext, not blank, and not re-wrapped under a fresh key.
@@ -104,21 +102,30 @@ fi
 SECRET_BEFORE="$(secret_element)"
 pass "the at-rest key file is present at $KEYFILE"
 
-# The key is copied aside FIRST, and put back on any exit path that has already removed it. A
-# phase that dies between the delete and the restore would otherwise leave a stack whose secrets
-# are permanently unrecoverable, and locally that is a real directory rather than a runner about
-# to be discarded.
-KEEP="$(mktemp -d)"
-cp -p "$KEYFILE" "$KEEP/sso-secret.key"
-KEY_SUM="$(sha256sum < "$KEEP/sso-secret.key" | cut -d' ' -f1)"
+# The key is moved aside FIRST, and put back on any exit path that left it aside. A phase that
+# died between the two would otherwise leave a stack whose secrets are permanently unrecoverable,
+# and locally that is a real directory rather than a runner about to be discarded.
+#
+# A RENAME rather than a copy, into the same directory, and that is a constraint rather than a
+# preference. SecretStore creates the key with owner-only permissions and the server writes it as
+# root inside the container, so on the bind mount the file is mode 600 owned by root and nothing
+# running as the ordinary user can READ it. A rename needs write and execute on the DIRECTORY and
+# no permission at all on the file, and the plugin drop is created by the workflow and made
+# world-writable before the stack comes up. It is also the stronger statement: the file that comes
+# back is the same inode, so "byte for byte" is a property of the operation instead of a checksum
+# somebody has to trust. The inode is pinned below to say so out loud.
+KEPT="$KEYFILE.kept"
+[ ! -e "$KEPT" ] || die "$KEPT already exists - a previous run left a key aside and this one would overwrite it"
+KEY_INODE="$(stat -c %i "$KEYFILE")"
+KEY_SIZE="$(stat -c %s "$KEYFILE")"
 restore_key() {
-  if [ ! -e "$KEYFILE" ] && [ -e "$KEEP/sso-secret.key" ]; then
-    cp -p "$KEEP/sso-secret.key" "$KEYFILE"
+  if [ ! -e "$KEYFILE" ] && [ -e "$KEPT" ]; then
+    mv "$KEPT" "$KEYFILE"
     printf 'restored %s on exit\n' "$KEYFILE" >&2
   fi
 }
 trap restore_key EXIT
-pass "the key is copied aside (sha256 $KEY_SUM), so the restore below is the same key and not a new one"
+pass "the key to move aside is inode $KEY_INODE, $KEY_SIZE bytes"
 
 log "Control: the challenge answers normally while the key is present"
 docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
@@ -128,13 +135,14 @@ case "$PROBE_STATUS" in
   *) die "the control probe did not redirect ($PROBE_STATUS) - the stack is not healthy, so a refusal after the key is destroyed would not be attributable to the key" ;;
 esac
 
-log "Destroying the at-rest key"
-# Stopped first: SecretStore caches the key for the process lifetime, so a delete under a running
-# server changes nothing until it restarts, and the phase would read the cached key as a fallback.
+log "Taking the at-rest key away"
+# Stopped first: SecretStore caches the key for the process lifetime, so taking the file away from
+# a running server changes nothing until it restarts, and the phase would then be reading a cached
+# key as if the server had a fallback.
 docker compose -f "$COMPOSE" stop >/dev/null
-rm -f "$KEYFILE"
-[ ! -e "$KEYFILE" ] || die "the key file survived the delete at $KEYFILE"
-pass "the key file is gone while the configuration still holds the envelope"
+mv "$KEYFILE" "$KEPT"
+[ ! -e "$KEYFILE" ] || die "the key file is still at $KEYFILE"
+pass "the key is gone from $KEYFILE while the configuration still holds the envelope"
 
 log "The login is refused, fail-closed"
 docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
@@ -158,12 +166,12 @@ esac
   || die "the stored envelope changed while the key was missing, so something re-wrapped it under a new key: $(secret_element)"
 pass "the stored envelope is byte-identical to the one written before the key was destroyed"
 
-log "Restoring the key"
+log "Putting the key back"
 docker compose -f "$COMPOSE" stop >/dev/null
-cp -p "$KEEP/sso-secret.key" "$KEYFILE"
-[ "$(sha256sum < "$KEYFILE" | cut -d' ' -f1)" = "$KEY_SUM" ] \
-  || die "the restored key is not the key that was taken away"
-pass "the original key is back, byte for byte"
+mv "$KEPT" "$KEYFILE"
+[ "$(stat -c %i "$KEYFILE")" = "$KEY_INODE" ] && [ "$(stat -c %s "$KEYFILE")" = "$KEY_SIZE" ] \
+  || die "the key back at $KEYFILE is not the file that was taken away (inode $(stat -c %i "$KEYFILE"), $(stat -c %s "$KEYFILE") bytes)"
+pass "the original key is back: same inode, same size, and never copied"
 
 log "A login after the restore"
 # RELOGIN_ONLY, so the seed, the wizard and the two provider Add calls are skipped: a re-seed

--- a/test/e2e/phases/kek-loss-fails-closed.sh
+++ b/test/e2e/phases/kek-loss-fails-closed.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Losing the key that wraps the at-rest provider secrets makes a login fail CLOSED (#1130). No
+# plaintext fallback, no silently regenerated key, no blanked secret - and the stack recovers
+# completely once the key is restored. Verified by hand once in the #717 live pass; this is the
+# scripted version, so a regression to a fallback path cannot reach a release unnoticed.
+#
+# It runs on the HOST rather than inside the harness container, for the same reason
+# legacy-secret-migration.sh does: the harness mounts only /harness, so it can neither read the
+# persisted configuration nor delete a file out of the plugin's data folder. Both are what this
+# phase is made of.
+#
+# THE ONE THING THAT DECIDES WHETHER A RED RUN MEANS ANYTHING. The harness exits non-zero on any
+# failed login, so its exit code cannot separate "refused because the key is gone" from "the stack
+# broke for an unrelated reason". This phase therefore drives the refusal itself, one request
+# against the OpenID challenge endpoint, and it probes that SAME endpoint BEFORE the key is
+# removed and requires a redirect. That control is what makes the 500 afterwards attributable: a
+# stack that was already broken fails the control and the phase says so, instead of reporting a
+# fail-closed refusal it did not cause.
+#
+# The shape, and why each step is where it is:
+#
+#   control    the stack is started WITHOUT the harness and the challenge is probed once. A
+#              redirect here is the baseline the refusal below is measured against.
+#   copy       the key is copied aside before anything destroys it, and restored byte for byte.
+#              A regenerated key is a DIFFERENT key: the stored envelope would not open under it
+#              and the phase would end up proving that a restored backup fails, which is the
+#              opposite of its claim.
+#   destroy    the key file is removed with the stack STOPPED. SecretStore caches the key in
+#              memory for the process lifetime, so a delete under a live server proves nothing
+#              until it restarts.
+#   refuse     the stack is started again and the same challenge is probed. It must answer 500
+#              with the fail-closed message, and the persisted secret must still be the SAME
+#              ssoenc:v1 envelope - not plaintext, not blank, and not re-wrapped under a fresh key.
+#   restore    the key goes back and a RELOGIN_ONLY harness pass must go green, so the phase
+#              proves fail-closed rather than a permanently broken stack.
+#
+# Never `docker compose down` anywhere in here: that removes Keycloak, the realm is re-imported
+# into a fresh instance with a NEW SAML signing certificate, and the certificate the canonical
+# pass wrote into the plugin's SAML configuration would no longer match the assertions the
+# identity provider signs. `stop` and `start` keep the containers.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
+CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
+# SSOPlugin puts the key in the plugin's own data folder (SSOPlugin.cs, "sso-secret.key"), which
+# for this stack is inside the unpacked plugin drop rather than beside the configuration.
+KEYFILE="${KEYFILE:-test/e2e/jellyfin/config/plugins/SSO-Auth/sso-secret.key}"
+PLUGIN_DIR="${PLUGIN_DIR:-test/e2e/jellyfin/config/plugins}"
+
+log()  { printf '%s\n' "== $* =="; }
+die()  { printf '::error::%s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+secret_element() { grep -o '<OidSecret>[^<]*</OidSecret>' "$CONFIG" | head -1; }
+
+# One throwaway container on the compose network, because Jellyfin publishes no port to the host:
+# every service is reachable only by its service-DNS name from inside `ssonet`. --no-deps so this
+# never starts or restarts anything else, and the harness service is reused only for its image and
+# its network membership - its own command is replaced.
+on_network() { # $1 the shell program to run inside the container
+  docker compose -f "$COMPOSE" run --rm --no-deps -T --entrypoint sh harness -c "$1"
+}
+
+# Waits for Jellyfin and probes the OpenID challenge once, printing two parseable lines. A failure
+# inside the container is reported as PROBE-ERROR rather than as a non-zero exit, so the caller
+# decides what a missing answer means instead of the run ending without a message.
+read -r -d '' PROBE <<'PROBE_SH' || true
+set -u
+apk add --no-cache curl >/dev/null 2>&1 || { echo "PROBE-ERROR could not install curl"; exit 0; }
+i=0
+while [ "$i" -lt 150 ]; do
+  curl -fsS -o /dev/null "$JELLYFIN_URL/System/Info/Public" 2>/dev/null && break
+  i=$((i + 1)); sleep 2
+done
+if [ "$i" -ge 150 ]; then echo "PROBE-ERROR Jellyfin did not answer /System/Info/Public within 300s"; exit 0; fi
+code="$(curl -sS -o /tmp/probe.body -w "%{http_code}" "$JELLYFIN_URL/sso/OID/start/$PROVIDER" 2>/dev/null || echo 000)"
+echo "PROBE-STATUS $code"
+echo "PROBE-BODY $(tr -d '\r\n' < /tmp/probe.body | cut -c1-300)"
+PROBE_SH
+
+PROBE_STATUS=""
+PROBE_BODY=""
+probe_challenge() { # $1 label; sets PROBE_STATUS and PROBE_BODY
+  local out
+  out="$(on_network "$PROBE")" || die "$1: the probe container could not be started"
+  printf '%s\n' "$out" | sed -n 's/^PROBE-ERROR /  probe error: /p'
+  PROBE_STATUS="$(printf '%s\n' "$out" | sed -n 's/^PROBE-STATUS //p' | tail -1)"
+  PROBE_BODY="$(printf '%s\n' "$out" | sed -n 's/^PROBE-BODY //p' | tail -1)"
+  [ -n "$PROBE_STATUS" ] || die "$1: the probe returned no status - see the probe error above"
+  printf '  %s: status=%s body=%s\n' "$1" "$PROBE_STATUS" "$PROBE_BODY"
+}
+
+log "Preconditions"
+[ -s "$CONFIG" ] || die "the plugin persisted no configuration at $CONFIG - run the canonical pass first"
+case "$(secret_element)" in
+  *"<OidSecret>ssoenc:v1:"*) pass "the starting state is an ssoenc:v1 envelope" ;;
+  *) die "the starting state is not an ssoenc:v1 envelope, so destroying the key would prove nothing: $(secret_element)" ;;
+esac
+if [ ! -s "$KEYFILE" ]; then
+  printf 'key files found under %s:\n' "$PLUGIN_DIR" >&2
+  find "$PLUGIN_DIR" -name '*.key' -print >&2 || true
+  die "no key file at $KEYFILE - the phase would delete nothing and the login below would prove nothing"
+fi
+SECRET_BEFORE="$(secret_element)"
+pass "the at-rest key file is present at $KEYFILE"
+
+# The key is copied aside FIRST, and put back on any exit path that has already removed it. A
+# phase that dies between the delete and the restore would otherwise leave a stack whose secrets
+# are permanently unrecoverable, and locally that is a real directory rather than a runner about
+# to be discarded.
+KEEP="$(mktemp -d)"
+cp -p "$KEYFILE" "$KEEP/sso-secret.key"
+KEY_SUM="$(sha256sum < "$KEEP/sso-secret.key" | cut -d' ' -f1)"
+restore_key() {
+  if [ ! -e "$KEYFILE" ] && [ -e "$KEEP/sso-secret.key" ]; then
+    cp -p "$KEEP/sso-secret.key" "$KEYFILE"
+    printf 'restored %s on exit\n' "$KEYFILE" >&2
+  fi
+}
+trap restore_key EXIT
+pass "the key is copied aside (sha256 $KEY_SUM), so the restore below is the same key and not a new one"
+
+log "Control: the challenge answers normally while the key is present"
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
+probe_challenge "control"
+case "$PROBE_STATUS" in
+  3??) pass "the OpenID challenge redirects to the identity provider ($PROBE_STATUS)" ;;
+  *) die "the control probe did not redirect ($PROBE_STATUS) - the stack is not healthy, so a refusal after the key is destroyed would not be attributable to the key" ;;
+esac
+
+log "Destroying the at-rest key"
+# Stopped first: SecretStore caches the key for the process lifetime, so a delete under a running
+# server changes nothing until it restarts, and the phase would read the cached key as a fallback.
+docker compose -f "$COMPOSE" stop >/dev/null
+rm -f "$KEYFILE"
+[ ! -e "$KEYFILE" ] || die "the key file survived the delete at $KEYFILE"
+pass "the key file is gone while the configuration still holds the envelope"
+
+log "The login is refused, fail-closed"
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
+probe_challenge "key-destroyed"
+[ "$PROBE_STATUS" = "500" ] || die "the OpenID challenge answered $PROBE_STATUS with the key destroyed; a fail-closed refusal is 500, and a 3xx means the login proceeded without the secret"
+case "$PROBE_BODY" in
+  *"could not be decrypted"*) pass "the refusal names the undecryptable client secret rather than failing for some other reason" ;;
+  *) die "the challenge answered 500 but not with the fail-closed secret message, so this may be an unrelated server error: $PROBE_BODY" ;;
+esac
+
+log "Asserting the stored secret survived the refusal"
+case "$(secret_element)" in
+  "") die "the persisted secret element is gone from $CONFIG" ;;
+  *"<OidSecret>ssoenc:v1:"*) pass "the stored secret is still an ssoenc:v1 envelope" ;;
+  *) die "the stored secret is no longer an envelope - it was rewritten as plaintext or blanked: $(secret_element)" ;;
+esac
+# Byte-identity is the stronger half and it is the one that catches a silent recovery: a server
+# that minted a replacement key and re-wrapped the value would still leave an ssoenc:v1 envelope
+# here, while every secret written under the lost key had become unrecoverable.
+[ "$(secret_element)" = "$SECRET_BEFORE" ] \
+  || die "the stored envelope changed while the key was missing, so something re-wrapped it under a new key: $(secret_element)"
+pass "the stored envelope is byte-identical to the one written before the key was destroyed"
+
+log "Restoring the key"
+docker compose -f "$COMPOSE" stop >/dev/null
+cp -p "$KEEP/sso-secret.key" "$KEYFILE"
+[ "$(sha256sum < "$KEYFILE" | cut -d' ' -f1)" = "$KEY_SUM" ] \
+  || die "the restored key is not the key that was taken away"
+pass "the original key is back, byte for byte"
+
+log "A login after the restore"
+# RELOGIN_ONLY, so the seed, the wizard and the two provider Add calls are skipped: a re-seed
+# would rewrite the very secret this phase spent the run not touching (#1123).
+RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \
+  --abort-on-container-exit --exit-code-from harness \
+  || die "the login after the key was restored failed - the phase proved a broken stack rather than a fail-closed one"
+pass "the stack recovered completely once the key was back"
+
+printf '\nKEK LOSS FAILS CLOSED PHASE PASSED\n'

--- a/test/e2e/phases/probe-oid-start.sh
+++ b/test/e2e/phases/probe-oid-start.sh
@@ -20,17 +20,24 @@ if ! apk add --no-cache curl >/tmp/apk.out 2>&1; then
 fi
 say "PROBE-STAGE curl $(curl --version 2>/dev/null | head -1)"
 
+# READINESS IS THE PLUGIN'S OWN ROUTE, NOT THE SERVER'S. `/System/Info/Public` answers while the
+# server is still coming up: measured on a restarted stack, it succeeded on the first attempt and
+# the challenge then returned 503 carrying Jellyfin's startup splash page. `/sso/OID/GetNames` only
+# answers once the plugin is loaded, which is the state the probe is about, and it reads the
+# provider names out of the configuration without revealing any secret, so it answers exactly the
+# same way whether or not the at-rest key is there. That is what makes it usable as the readiness
+# gate on BOTH sides of this phase.
 i=0
-until curl -fsS -o /dev/null "$JELLYFIN_URL/System/Info/Public" 2>/tmp/ready.err; do
+until curl -fsS -o /dev/null "$JELLYFIN_URL/sso/OID/GetNames" 2>/tmp/ready.err; do
   i=$((i + 1))
   if [ "$i" -ge 150 ]; then
-    say "PROBE-ERROR Jellyfin did not answer $JELLYFIN_URL/System/Info/Public within 300s:"
+    say "PROBE-ERROR the plugin did not answer $JELLYFIN_URL/sso/OID/GetNames within 300s:"
     sed 's/^/  /' /tmp/ready.err
     exit 0
   fi
   sleep 2
 done
-say "PROBE-STAGE ready after $i retries"
+say "PROBE-STAGE ready after $i retries ($((i * 2))s)"
 
 # No -L: the healthy answer is the redirect itself, and following it would report the identity
 # provider's status instead of the plugin's.

--- a/test/e2e/phases/probe-oid-start.sh
+++ b/test/e2e/phases/probe-oid-start.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# One request against the plugin's OpenID challenge, from inside a container on the compose
+# network (#1130). Jellyfin publishes no port to the host, so every service is reachable only by
+# its service-DNS name from inside `ssonet`, and a host-side curl reaches nothing.
+#
+# It is a FILE rather than a string handed to `sh -c`, because the first version of this probe was
+# the latter and came back with a status nothing in it can produce and a missing body file. A
+# script that arrives as one argument through two layers is not readable in the log it fails in.
+#
+# It never exits non-zero. A failure here is reported as a PROBE-ERROR line and the caller decides
+# what a missing answer means, so a broken probe cannot be read as a refused login.
+set -u
+
+say() { printf '%s\n' "$*"; }
+
+if ! apk add --no-cache curl >/tmp/apk.out 2>&1; then
+  say "PROBE-ERROR could not install curl:"
+  sed 's/^/  /' /tmp/apk.out
+  exit 0
+fi
+say "PROBE-STAGE curl $(curl --version 2>/dev/null | head -1)"
+
+i=0
+until curl -fsS -o /dev/null "$JELLYFIN_URL/System/Info/Public" 2>/tmp/ready.err; do
+  i=$((i + 1))
+  if [ "$i" -ge 150 ]; then
+    say "PROBE-ERROR Jellyfin did not answer $JELLYFIN_URL/System/Info/Public within 300s:"
+    sed 's/^/  /' /tmp/ready.err
+    exit 0
+  fi
+  sleep 2
+done
+say "PROBE-STAGE ready after $i retries"
+
+# No -L: the healthy answer is the redirect itself, and following it would report the identity
+# provider's status instead of the plugin's.
+code="$(curl -sS -o /tmp/probe.body -w '%{http_code}' "$JELLYFIN_URL/sso/OID/start/$PROVIDER" 2>/tmp/probe.err)" || {
+  say "PROBE-ERROR the challenge request failed:"
+  sed 's/^/  /' /tmp/probe.err
+  exit 0
+}
+say "PROBE-STATUS $code"
+if [ -s /tmp/probe.body ]; then
+  say "PROBE-BODY $(tr -d '\r\n' < /tmp/probe.body | cut -c1-300)"
+else
+  say "PROBE-BODY "
+fi


### PR DESCRIPTION
# What & why

Closes #1130.

Destroying the key that wraps the at-rest provider secrets has to refuse the next login rather than
fall back to plaintext or mint a replacement key. That was verified by hand once in the #717 live
pass and nothing re-checked it since, so a regression to a fallback path would ship silently.

`test/e2e/phases/kek-loss-fails-closed.sh` renames the key aside with the stack stopped,
requires the OpenID challenge to answer 500 with the fail-closed secret message, requires the stored
envelope to be byte-identical to the one written before the key went, then restores the key and
requires a `RELOGIN_ONLY` pass to go green.

Three parts of it are the design rather than detail.

It probes the same endpoint **before** the key goes away and requires a redirect. #1130 and #1128
both record the same open problem: the harness exits non-zero on any failed login, so its exit code
alone cannot separate a fail-closed refusal from a stack that broke for another reason. The control
probe is the answer here. A stack that was already broken fails the control and the phase says so,
instead of reporting a refusal it did not cause.

It renames the key aside and renames it back, rather than copying it or regenerating one. A fresh
key does not open the stored envelope, so a phase that regenerated would end up proving that a
restored backup fails, which is the opposite of what it claims. The rename is also the only
operation available: the key is written as root with owner-only permissions, so the workflow user
can move it but cannot read it.

It asserts byte-identity alongside the envelope check. A server that minted a replacement key and
re-wrapped the value would still leave an `ssoenc:v1` envelope in the file, while every other secret
written under the lost key had quietly become unrecoverable.

The stack is never torn down between passes. A `down` removes Keycloak, the realm is re-imported
with a new SAML signing certificate, and the certificate the canonical pass wrote into the plugin's
SAML configuration would stop matching.

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: this change asserts the fail-closed behaviour and alters no product
      code. `SSO-Auth/` is untouched; the diff is one shell phase, one workflow step and one README
      section.
- [x] No secrets logged. The phase prints the key file's inode and size, never its bytes, which it
      cannot read anyway. It prints the first 300 characters of the refusal body, which is the
      plugin's fixed plain-text message and carries no secret. The stored envelope is compared,
      never echoed.
- [x] A security review was performed. See the review record below.
- [x] Review record below.
- [ ] Log inputs from the IdP are sanitized inline at the log call. Not applicable: no logging code
      is added or changed.

### Review record

No second reader looked at this change. Nobody else was available for it, and the evidence below
stands in place of one rather than pretending the reading happened.

What I checked, and against what:

- The refusal this phase pins is the one the product actually produces.
  `OidcLoginService.TryReveal` catches `CryptographicException`/`FormatException` from
  `Secrets.Reveal` and returns `FlowResponses.PlainTextError(500, "Could not process login; the
  OpenID client secret could not be decrypted.")`. `SecretStore.Reveal` throws when the key file is
  missing rather than minting a replacement, which is the behaviour under test.
- The key has to go with the stack stopped. `SecretStore` caches it in `_cachedKey` for the process
  lifetime, so taking the file from a running server would change nothing until a restart, and the
  phase would be reading a cached key as if the server had a fallback.
- The precondition is the phase's own, not an assumption about the previous step. #1130 records a
  measured case where a stack whose secret was plaintext came up, minted a fresh key and completed
  every login with the key file deleted. That is the documented genuine-first-run path, so the phase
  asserts an `ssoenc:v1` envelope is present before it touches anything.
- The endpoint is anonymous. `oid_start` in the harness calls `/sso/OID/start/<provider>` with no
  authorization header, so the probe needs no credential and adds no auth surface.
- Nothing weakens the network posture. The probe runs in a throwaway container on the existing
  `ssonet`, because Jellyfin publishes no port to the host; no port is added and the SSRF guard's
  subnet arrangement is untouched.

CONFIRMED 3 / PLAUSIBLE 0. Two were found by running this change and are fixed in it; the third is
not this change's to fix and is filed.

The first was mine and would have made the phase impossible. It copied the key aside and restored
it from the copy. `SecretStore` writes the key with owner-only permissions and the server writes it
as root inside the container, so on the bind mount nothing running as the workflow user can read
it. A rename needs write and execute on the directory and no permission at all on the file, and the
plugin drop is created by the workflow and made world-writable before the stack comes up. It is
also the stronger statement: the file that comes back is the same inode, which the phase pins,
instead of a checksum over a copy. `8684d9b` to `b0570de`.

The second was the readiness gate. A dispatched run returned 503 carrying Jellyfin's startup splash
page three seconds after the restart, with the wait having passed on its first attempt, because
`/System/Info/Public` is served while the server is still coming up. The gate is `/sso/OID/GetNames`
now, which answers only once the plugin is loaded and reveals no secret, so it behaves the same with
the key present and with it gone. The waits in the transcript above are 12s and 14s rather than 0,
which is the difference showing. `5a1d390`.

The third is the sibling step and it is #1391. It fails in two independent ways, both measured on
dispatched runs rather than argued: `perl -i` cannot create a temporary file in the server-created
configuration directory, and the bare-path invocation is refused outright:

```
Can't do inplace edit on test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml: Cannot make temp name: Permission denied.
/home/runner/work/_temp/[...].sh: line 1: test/e2e/phases/legacy-secret-migration.sh: Permission denied
##[error]Process completed with exit code 126
```

Repairing it inside this change would be a second topic, so this change moves the new phase ahead of
it instead and leaves that step exactly as it is on `main`.

## Quality checklist

- [x] No duplicated logic. The phase follows `legacy-secret-migration.sh`, which is the shape #1130
      itself names, and reuses the same compose stack, the same `RELOGIN_ONLY` pass and the same
      never-`down` rule rather than restating them.
- [x] The change adds no more code than the problem requires.
- [x] Self-documenting, with comments saying why. Every non-obvious step carries the reason it is
      where it is.
- [ ] Architecture-conformance tests. Not applicable: no C# is added or changed, so no structural
      property moves.
- [x] Docs impact: `test/e2e/README.md` carries the phase, how to run it locally and what a green
      run prints, in the same delivery.

## Verification

- [ ] `dotnet build --no-restore --warnaserror`. Not run for this change and not applicable: the
      diff contains no C#, no project file and no lockfile. The `.NET` workflow answers it on this
      PR.
- [ ] `dotnet test`. Same.
- [x] Prettier is clean for the `.md` change:

```
$ npx prettier --check "test/e2e/README.md"
Checking formatting...
All matched files use Prettier code style!
```

The workflow YAML was parsed rather than eyeballed, and the phase was syntax-checked:

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-login.yml')); print('yaml OK')"
yaml OK
$ bash -n test/e2e/phases/kek-loss-fails-closed.sh && echo "syntax OK"
syntax OK
```

`shellcheck` is not available on the machine this was written on, so the phase has not been linted,
only parsed.

## The run

Every clause of #1130's Done-when is an observation of a run, so the phase was executed before this
was offered. The pull-request check on this branch is the canonical Keycloak entry with `full`
false, which deliberately skips the release-gated steps, so the proof is a `providers: all`
dispatch on the branch, which the workflow and `test/e2e/README.md` both describe as how a new
phase is proven green before a release rather than on release day.

https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/32491558323, Keycloak entry, step
`KEK loss fails closed (#1130)`, printed in full:

```
== Preconditions ==
PASS: the starting state is an ssoenc:v1 envelope
PASS: the at-rest key file is present at test/e2e/jellyfin/config/plugins/SSO-Auth/sso-secret.key
PASS: the key to move aside is inode 9190766, 32 bytes
== Control: the challenge answers normally while the key is present ==
  probe| PROBE-STAGE ready after 6 retries (12s)
  probe| PROBE-STATUS 302
  control: status=302 body=
PASS: the OpenID challenge redirects to the identity provider (302)
== Taking the at-rest key away ==
PASS: the key is gone from test/e2e/jellyfin/config/plugins/SSO-Auth/sso-secret.key while the configuration still holds the envelope
== The login is refused, fail-closed ==
  probe| PROBE-STAGE ready after 7 retries (14s)
  probe| PROBE-STATUS 500
  probe| PROBE-BODY Could not process login; the OpenID client secret could not be decrypted.
  key-destroyed: status=500 body=Could not process login; the OpenID client secret could not be decrypted.
PASS: the refusal names the undecryptable client secret rather than failing for some other reason
== Asserting the stored secret survived the refusal ==
PASS: the stored secret is still an ssoenc:v1 envelope
PASS: the stored envelope is byte-identical to the one written before the key was destroyed
== Putting the key back ==
PASS: the original key is back: same inode, same size, and never copied
== A login after the restore ==
harness-1   | ALL E2E CHECKS PASSED

KEK LOSS FAILS CLOSED PHASE PASSED
```

Both readiness waits took real time, 12s and 14s, so the control is a request to a server that had
finished starting rather than one that answered from its startup page. The 302 and the 500 come
from the same endpoint, three seconds of stack restart apart, with the key file the only difference
between them.

## Notes

**The job that carries this run is red, on a step this change does not touch.** The step after this
one fails, and it fails the same way on `main`:

```
/home/runner/work/_temp/[...].sh: line 1: test/e2e/phases/legacy-secret-migration.sh: Permission denied
##[error]Process completed with exit code 126
```

It has never executed on any run, because its gate has never been set: every event this workflow
has seen is `pull_request`, `push`, `schedule` or a dispatch predating the step. Filed as #1391
with both of its failure modes measured. This change neither causes it nor repairs it. What it does
do is place the new phase ahead of it, because every step in that group is `if: success()` and a
new phase behind a failing one is unreachable.

`#1128` asks for the same status-pinning answer on its own refusal and is not addressed here. The
control-probe shape in this phase transfers to it directly, and that is worth taking from here
rather than solving twice.

Three things this run does not say. It exercised the OpenID challenge, so the SAML signing key's
own reveal path is untested by it. It ran on the canonical Keycloak stack only, which is where the
step is gated, so no other provider harness has met this phase. And it says nothing about a key
that is present but corrupt, only about one that is absent; `SecretStore` rejects a wrong-length
key on a different branch, and no run here has reached it.
