### PR TITLE
Trigger the wiki lint from the wiki, and name the revision it read

### DIFF
--- a/.github/workflows/wiki-lint.yml
+++ b/.github/workflows/wiki-lint.yml
@@ -5,9 +5,17 @@ name: Wiki Lint
 # clones the live wiki and fails on broken internal anchors, file:line citations
 # (the rule is to cite modules/types, not paths that move), and dead source links.
 #
-# Triggers: a weekly sweep, a manual run, and every push to main (so a merge that
-# moves a file the wiki links to is caught right away). Deliberately NOT on
-# pull_request: a pre-existing wiki typo must not red-X every unrelated code PR.
+# Triggers: every wiki page create or update (gollum), a weekly sweep, a manual
+# run, and every push to main (so a merge that moves a file the wiki links to is
+# caught right away). Deliberately NOT on pull_request: a pre-existing wiki typo
+# must not red-X every unrelated code PR.
+#
+# The gollum trigger is what attaches the guard to the thing it guards (#1383).
+# Without it the wiki was checked when THIS repository moved, by hand, or on
+# Monday, so a page pushed on a day with no code activity waited for the cron and
+# its coverage was a side effect of unrelated work. A wiki has no Actions of its
+# own and no pull request to hang a check on; gollum is the only event either
+# repository raises when a wiki page changes.
 #
 # The push trigger carries no paths filter, and it must not grow one. The dead
 # source link check resolves wiki links against the set of TRACKED paths, so the
@@ -16,6 +24,7 @@ name: Wiki Lint
 # enumeration of source locations therefore skips the very pushes that break the
 # lint, and leaves the failure to land on the next unrelated merge (#1151).
 on:
+  gollum:
   schedule:
     - cron: "0 5 * * 1" # Mondays 05:00 UTC
   workflow_dispatch:
@@ -25,8 +34,12 @@ on:
 permissions:
   contents: read
 
+# The event name is part of the group so a wiki edit and a code merge do not
+# cancel each other: gollum runs on the default branch, so on github.ref alone
+# both land in one group. Within one event cancelling is still right, because a
+# superseded run lints a wiki revision that no longer exists.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -41,5 +54,20 @@ jobs:
       - name: Clone the wiki
         # The wiki is public; a read-only anonymous clone needs no credentials.
         run: git clone --depth 1 "https://github.com/${GITHUB_REPOSITORY}.wiki.git" "${RUNNER_TEMP}/wiki"
+      - name: Report the wiki revision this run read
+        # A green run otherwise says only that the wiki was clean at some moment,
+        # with no way to tell from the outside which revision that was (#1383).
+        # Read from the clone above rather than from the event payload, so it is
+        # the revision actually linted on every trigger and not only on gollum.
+        run: |
+          wiki_sha="$(git -C "${RUNNER_TEMP}/wiki" rev-parse HEAD)"
+          echo "Wiki revision linted: ${wiki_sha}"
+          {
+            echo "### Wiki Lint"
+            echo
+            echo "Wiki revision read: \`${wiki_sha}\`"
+            echo
+            echo "Code revision read: \`${GITHUB_SHA}\` (trigger: \`${GITHUB_EVENT_NAME}\`)"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Lint the wiki against the code tree
         run: python3 scripts/wiki-lint.py "${RUNNER_TEMP}/wiki" "${GITHUB_WORKSPACE}"


### PR DESCRIPTION
# What & why

`.github/workflows/wiki-lint.yml` clones the live wiki and refuses broken internal anchors, `file:line` citations and dead source links. Nothing about the wiki started it. Its triggers were a Monday cron, a manual run, and a push to `main`, so a wiki page was guarded by activity in a different repository, and on a day with no code push it waited for the cron.

This adds the `gollum` trigger, which is the only event either repository raises when a wiki page is created or updated. A wiki has no Actions of its own and no pull request to hang a check on, so the alternatives the issue examined (a workflow inside the wiki, a `repository_dispatch` from it) have nowhere to run. The existing triggers are all kept: `gollum` is added beside them, not in place of any.

It also makes a green run say which wiki revision it read. Previously a pass meant the wiki was clean at some moment, with no way to tell from the outside which revision that was. A new step reads `HEAD` out of the clone and prints it to the log and the job summary. It reads the clone rather than the event payload on purpose, so the reported revision is the one actually linted on every trigger and not only on `gollum`.

The concurrency group grows `github.event_name`. `gollum` runs on the default branch, so with `github.ref` alone a wiki edit and a code merge landed in one group with `cancel-in-progress: true` and cancelled each other.

Neither refusal the issue records is disturbed: no `pull_request` trigger, and no `paths` filter on the `push` trigger.

Closes #1383.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This touches no login path, no crypto, no config persistence and no release pipeline. The workflow keeps `permissions: contents: read`, adds no credential, and the added step runs `git rev-parse` over a checkout the job already made.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: the workflow's own comment block is the doc for
      what it covers, and it is updated in this diff. No README or wiki page
      describes these triggers.

## Verification

The diff is one workflow file and no C# changed, so the local .NET gate has no subject here. What was run:

```
$ git diff --name-only origin/main...HEAD
.github/workflows/wiki-lint.yml

$ py -3 -c "import yaml;d=yaml.safe_load(open('.github/workflows/wiki-lint.yml'));print(list(d[True]))"
['gollum', 'schedule', 'workflow_dispatch', 'push']

$ git show HEAD:.github/workflows/wiki-lint.yml | grep -c $'\r'
0
```

The `on:` map parses with all four triggers, and the stored blob carries no carriage return. `build`, `prettier`, `dependency-review` and DCO run on this pull request and are the evidence for the rest.

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change. No such
      file is touched; `.yml` is outside the Prettier glob
      (`--check **/*.{js,html,md,css,scss}`).

## Notes

**No second reader.** This lands with the author's reading only, and the evidence above stands in place of one.

The issue's first done-condition asks for a real wiki push and the run it caused. That evidence cannot be produced from a branch: a `gollum` workflow runs from the default branch, so the trigger does not exist until this merges. The wiki pushes for the five approved pages follow it, and the run each one causes goes on #1383 before it closes.

What this does not do: it does not make the wiki lint a required check on anything, and a wiki page is still public from the moment it is pushed until the run finishes. The gap this closes is the one between the push and the first run that sees it, not the one between the push and the world.
