### PR TITLE
Point the README at the client compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Sign in to Jellyfin with your existing identity provider - Keycloak, Authelia, a
 - **Role-based access control** - map identity-provider groups/roles to login, administrator, library folders, Live TV, generic permissions, and a per-group parental-rating ceiling.
 - **Hardened, fail-closed login path** - identities bound to the stable `sub` / `NameID`, fail-closed SAML and `id_token` validation, and SSRF-guarded avatar fetches.
 - **Optional SSO-only login** - disable password login for every account except a designated break-glass admin, behind a fail-closed last-admin guard.
-- **Avatar sync, Quick Connect, and self-service account linking.**
+- **Avatar sync, Quick Connect, and self-service account linking.** Which client reaches SSO by which mechanism, and what has actually been exercised: [Client Compatibility](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Client-Compatibility).
 - **Tested** - a growing xUnit suite over the security-critical paths, with CI (build, format, CodeQL) on every change.
 
 How this plugin compares to Jellyfin's built-in auth, the official LDAP plugin, and the archived 9p4 plugin: see the [Comparison](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Comparison) wiki page.
@@ -79,7 +79,7 @@ The self-hostable providers run in an automated end-to-end login test in CI ([`e
 2. Go to **Dashboard → Plugins → Catalog**, find **Community SSO for Jellyfin**, and install it.
 3. **Restart Jellyfin.**
 
-This project publishes only to the **beta channel** for now - a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, client (Quick Connect) support, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) wiki page.
+This project publishes only to the **beta channel** for now - a stable channel opens with the first stable release. The plugin GUID is unchanged from the original `9p4` plugin, so it installs over an existing one in place and keeps your configuration. Build-from-source, the release channels, and migrating from the old `9p4` manifest are covered on the [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) wiki page; which clients can complete an SSO sign-in, and by which mechanism, is on [Client Compatibility](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Client-Compatibility).
 
 ## Configuration
 
@@ -89,7 +89,7 @@ Configure your providers on the plugin's settings page (**Dashboard → Plugins 
 
 Full documentation lives in the **[Wiki](https://github.com/Flowfin/jellyfin-plugin-sso/wiki)**:
 
-- [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow) · [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Troubleshooting)
+- [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation) · [Provider Setup](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Provider-Setup) · [Login Flow](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Login-Flow) · [Client Compatibility](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Client-Compatibility) · [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) · [Troubleshooting](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Troubleshooting)
 - Project policies: [Governance](GOVERNANCE.md) · [Support & security updates](SECURITY.md#supported-versions--security-updates) · [Remediation & secrets policy](docs/SECURITY-REMEDIATION-POLICY.md)
 
 The plugin's own served pages are translatable from JSON catalogs, no C# involved. [Translating the UI](CONTRIBUTING.md#translating-the-ui) lists the supported languages, the catalog format, and how to add one.


### PR DESCRIPTION
# What & why

`README.md` told readers that the Installation wiki page covers "client (Quick Connect) support". It does not. That page mentions a client exactly once and it is the OpenID client library being shipped, not a Jellyfin client. A pointer that promises a specific page answers a question is worse than no pointer at all, so it now names the page that does.

The page it names is new: **Client Compatibility**, pushed to the wiki as `e60c572c4f9486dd915a8797373b2295fdf8258e`. It carries the per-client matrix #1115 asks for - mechanism (direct browser redirect / Quick Connect / none) and status - with clients that offer neither marked "use the Web UI".

This diff is the README half only. It adds the link in three places:

- the **Documentation** list, beside the other wiki pages;
- the **Quick Connect** feature bullet, which claimed the capability with no detail behind it;
- the **installing** paragraph, replacing the Installation promise. Build-from-source, the channels and the 9p4 migration stay pointed at Installation, because that page does carry them.

Refs #1115. It does not close it: two of the three link sites the issue names are wiki pages outside the approval that unblocked this work, and the reason is written on the issue.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. Three link targets in `README.md`; no code, no workflow, no configuration.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change **is** the docs update.

## Verification

```
$ git diff --name-only origin/main...HEAD
README.md

$ git grep -c -i 'client compatibility' HEAD -- README.md
3
```

No C# changed, so the local .NET gate has no subject. `prettier` runs on this pull request and is the check that matters for a Markdown diff; the local run is not usable as evidence here, because it reports the unmodified `README.md` on `origin/main` as unformatted too, which is a line-ending artefact of this machine rather than a property of the file.

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - deferred to the `prettier` check on this pull request, for the reason above.

## Notes

**No second reader.** This lands with the author's reading only.

The wiki page it points at is already live, so the link resolves the moment this merges rather than after it. The two remaining link sites - the wiki sidebar and `Login-Flow.md` § "Non-web clients and Quick Connect" - are not touched here and are not touched on the wiki either: the approval that unblocked this work names five pages and says a sixth is a sixth ask. That is written on #1115, which stays open for it.
