### PR TITLE
Make the legacy-secret-migration phase able to run and to write

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -239,7 +239,7 @@ jobs:
         if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
         env:
           COMPOSE: ${{ matrix.compose }}
-        run: test/e2e/phases/legacy-secret-migration.sh
+        run: bash test/e2e/phases/legacy-secret-migration.sh
 
       - name: Dump container logs on failure
         if: failure()

--- a/test/e2e/phases/legacy-secret-migration.sh
+++ b/test/e2e/phases/legacy-secret-migration.sh
@@ -52,8 +52,38 @@ case "$(secret_element)" in
 esac
 
 log "Planting a pre-#158 plaintext secret"
-# One element, matched on its own tags, so a value containing markup could not widen the edit.
-perl -i -pe "s#<OidSecret>[^<]*</OidSecret>#<OidSecret>${PLAINTEXT}</OidSecret>#" "$CONFIG"
+# THE EDIT HAPPENS INSIDE A CONTAINER, and that is a constraint rather than a preference (#1391).
+# `plugins/configurations/` is created by the SERVER at runtime, not by the workflow, so the
+# `chmod -R 0777 test/e2e/jellyfin` in the install step never reaches it: that step runs before the
+# stack comes up and the directory does not exist yet. An in-place edit writes a new file beside the
+# target and renames it over, which needs write permission on that DIRECTORY, and the ordinary
+# workflow user has none - `perl -i` answered "Cannot make temp name: Permission denied" and the
+# step died before it asserted anything. The file itself is written by the server as root, so a
+# plain redirect over it is refused for the same reason.
+#
+# The jellyfin service already bind-mounts ./jellyfin/config at /config and runs as root, so its own
+# definition is the shortest route to a writable handle: no second mount to keep in step with the
+# compose file, and no elevation on the host. `--no-deps` starts nothing else, `--rm` leaves nothing
+# behind, and the entrypoint is replaced so no server starts in it.
+#
+# The rewrite is a SPLIT rather than a pattern substitution, because the value being planted is a
+# secret read out of the compose configuration and every substitution syntax reserves characters a
+# secret may legitimately contain - sed and awk both re-read `&` in the replacement as the match.
+# Splitting on the tags and reassembling puts the value in verbatim, whatever is in it.
+#
+# One element, the FIRST, matched on its own tags, so a value containing markup could not widen the
+# edit: `%%` cuts at the first opening tag and `#` at the first closing one.
+docker compose -f "$COMPOSE" run --rm --no-deps -T \
+  -e "PLANT=$PLAINTEXT" --entrypoint sh jellyfin -c '
+    set -eu
+    f=/config/plugins/configurations/SSO-Auth.xml
+    c=$(cat "$f")
+    case "$c" in
+      *"<OidSecret>"*"</OidSecret>"*) ;;
+      *) echo "no OidSecret element to replace in $f" >&2; exit 1 ;;
+    esac
+    printf "%s<OidSecret>%s</OidSecret>%s" "${c%%<OidSecret>*}" "$PLANT" "${c#*</OidSecret>}" > "$f"
+  ' || die "the plant could not be written - the container edit of $CONFIG failed"
 grep -qF ">${PLAINTEXT}<" "$CONFIG" || die "the plant did not take - $CONFIG still holds no plaintext secret"
 grep -q 'ssoenc:v1:' "$CONFIG" && die "an ssoenc:v1 envelope survived the plant, so the config is not in the legacy shape"
 pass "the persisted secret is now plaintext, exactly as a pre-#158 config carried it"


### PR DESCRIPTION
# What & why

The legacy-secret-migration phase had never produced a verdict in either direction. It is gated on the full matrix, which only a release, a beta release or a `providers: all` dispatch sets, and no such run had reached it since it landed. When one finally did, it failed twice, for two independent reasons, neither of which the phase is about.

**It could not start.** The step invoked its script by bare path and every tracked shell script here is mode 644, so the run answered `Permission denied` with exit 126 and the script's first line never executed. It now goes through `bash`, which is what every other site in this repository does: the sibling phase one step above it, and the harness in the compose file.

**It could not write.** The plant used `perl -i`, which writes a new file beside the target and renames it over, so it needs write permission on `test/e2e/jellyfin/config/plugins/configurations/`. That directory is created by the SERVER at runtime, after the install step's `chmod -R 0777` has already run over a tree that does not yet contain it, so the ordinary workflow user has none. The file itself is written by the server as root, so a plain redirect over it is refused for the same reason. The edit now happens inside a throwaway container built from the `jellyfin` service's own definition, which already bind-mounts the configuration and runs as root: no second mount to keep in step with the compose file, and no elevation on the host.

**The rewrite is a split, not a substitution.** The value being planted is a secret read out of the resolved compose configuration, and both `sed` and `awk` re-read `&` in a replacement as the match. A secret carrying one would have been planted as something else, pass 2's login would have failed, and the phase would have gone red while the product behaved correctly - the worst shape a regression gate can take. Splitting on the tags and reassembling puts the value in verbatim.

Closes #1391.

## Type of change

- [ ] Security hardening / vulnerability fix
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

The diff touches the release-adjacent test harness rather than the login path. No production code changes; the plugin is unchanged by this diff.

- [x] Fail-closed preserved: unchanged - no validation code is touched.
- [x] No secrets logged; secrets are redacted on config export. The planted value is a test secret from the compose file; it reaches the container through an environment value rather than a command line, and no assertion prints it.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call - not applicable, nothing is logged from an IdP here.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki page describes this phase.

## Verification

**The phase, on a real `providers: all` dispatch of this branch.** https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/32515068913 - run `success`, and the step's own transcript:

```
== Preconditions ==
PASS: the starting state is an ssoenc:v1 envelope
== Planting a pre-#158 plaintext secret ==
PASS: the persisted secret is now plaintext, exactly as a pre-#158 config carried it
== Pass 2: restart against the planted config and drive a login ==
PASS: the login succeeded with a plaintext secret on disk
== Asserting the migration ==
PASS: the persisted secret is an ssoenc:v1 envelope again
PASS: the plaintext value appears nowhere in the persisted configuration
== Pass 3: a login driven after the migration ==
PASS: the migrated secret still decrypts to the value the provider accepts

LEGACY SECRET MIGRATION PHASE PASSED
```

All seven provider jobs in that run concluded `success`.

**The split, against the case that motivated it.** A fixture whose secret carries `&`, `#` and a backslash, and a document with two `OidSecret` elements:

```
$ printf '<Plugin><OidSecret>ssoenc:v1:AAAA</OidSecret><Other>x</Other><OidSecret>second</OidSecret></Plugin>' > f.xml
$ PLANT='we&ird#se\cret' sh -c '... the container body ...'
$ cat f.xml
<Plugin><OidSecret>we&ird#se\cret</OidSecret><Other>x</Other><OidSecret>second</OidSecret></Plugin>
```

The value goes in byte for byte, and only the first element is rewritten.

```
$ bash -n test/e2e/phases/legacy-secret-migration.sh   # exit 0
$ py -3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-login.yml'))"   # parses
```

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean - no `.js` / `.html` / `.md` / `.css` file is touched.

No C# changed, so the local .NET gate has no subject; `build` runs on this pull request.

## Notes

**No second reader.** This lands with the author's reading only, and the dispatched run above stands in place of one.

What this does not do. It does not make the step run on any trigger it did not already run on: it is still release, beta release and `providers: all` only, so the next verdict comes from one of those rather than from a routine merge. The issue's note about #1390's ordering is unaffected - that phase is still ahead of this one, and now both can execute.
