### PR TITLE
Assert the authorize request's shape on the real identity provider

### DIFF
--- a/test/e2e/harness/harness.sh
+++ b/test/e2e/harness/harness.sh
@@ -945,6 +945,47 @@ idp_oidc_login() {
 }
 
 # --------------------------------------------------------------------------------------------------
+# Phase 3b - the shape of the authorize request the plugin issues, read off the wire (#1127)
+# --------------------------------------------------------------------------------------------------
+# The in-process pin Challenge_SendsNoNonce_AndBindsTheCodeWithPkceS256 asserts what the plugin BUILDS.
+# This asserts what the identity provider is actually SENT, on the real stack, which is the same thing
+# only until something in between changes. Same trigger as that pin: it goes red the day a `nonce`
+# appears in the authorize request without a validator on the callback, which is the CVE-2026-42206
+# shape, and the day the code binding stops being PKCE S256.
+#
+# It runs in the ordinary series rather than as a gated phase of its own. The series has a provider up
+# already, and the whole assertion is one /start, so a separate phase would pay the stack setup twice
+# for one request. Ungated also means every provider harness asserts it, not only the canonical one.
+#
+# Deliberately NOT a mismatched-nonce negative. There is nothing bound at /start for a callback to
+# mismatch - #1157 enumerated every site that could emit or read an authentication-request nonce and
+# recorded that none is sent - so such a phase would be green for a reason unrelated to what it claims.
+log "== Authorize request shape: no nonce, PKCE S256 =="
+SHAPE_JAR="$(mktemp)"
+SHAPE_HDR="$(mktemp)"
+# Sets the global `auth_url` that auth_url_param reads. At top level rather than inside $(...), so a
+# `fail` here reaches the run's FAILURES counter instead of dying with a subshell.
+auth_url="$(oid_start "$SHAPE_JAR" "$SHAPE_HDR")" || die "authorize shape: /start issued no redirect"
+
+case "$auth_url" in
+  *[?\&]nonce=*) fail "the authorize request carries a nonce, and nothing on the callback validates one" ;;
+  *)             pass "the authorize request carries no nonce" ;;
+esac
+
+SHAPE_METHOD="$(auth_url_param code_challenge_method)"
+SHAPE_CHALLENGE="$(auth_url_param code_challenge)"
+if [ "$SHAPE_METHOD" = "S256" ]; then
+  pass "the authorize request binds the code with code_challenge_method=S256"
+else
+  fail "the authorize request does not bind the code with S256 (code_challenge_method='$SHAPE_METHOD')"
+fi
+if [ -n "$SHAPE_CHALLENGE" ]; then
+  pass "the authorize request carries a code_challenge"
+else
+  fail "the authorize request carries code_challenge_method='$SHAPE_METHOD' with no code_challenge"
+fi
+
+# --------------------------------------------------------------------------------------------------
 # Phase 4 - full OIDC round-trip for alice (milestone 2)
 # --------------------------------------------------------------------------------------------------
 log "== OIDC round-trip: alice (expect success) =="


### PR DESCRIPTION
# What & why

The standing protection against the CVE-2026-42206 shape - a `nonce` arriving in the authorize request with nothing on the callback validating one - rests entirely on the in-process pin `Challenge_SendsNoNonce_AndBindsTheCodeWithPkceS256`, and that pin has never been checked against a live provider. It asserts what the plugin **builds**; this asserts what the identity provider is actually **sent**. Those are the same thing only until something in between changes.

Three assertions on the redirect `/start` issues: no `nonce` parameter, `code_challenge_method=S256`, and a non-empty `code_challenge`.

It sits in the ordinary end-to-end series rather than in a gated phase of its own. The series already has a provider up and the whole assertion is one `/start`, so a separate phase would pay the stack setup twice for one request. Ungated also means every provider harness asserts it rather than only the canonical one. The extra `/start` leaves one unredeemed authorize state behind, against a store whose cap is 100,000.

It is deliberately **not** the mismatched-nonce negative the issue asked for until today. Nothing is bound at `/start` for a callback to mismatch, so such a phase would be green for a reason unrelated to its claim. The issue's title and body are rewritten to the claim that does hold live, per the decision recorded on it.

Closes #1127. Refs #1157.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

Test-harness only; no plugin code is touched by this diff and no behaviour changes.

- [x] Fail-closed preserved: unchanged - no validation code is touched.
- [x] No secrets logged; secrets are redacted on config export. The new assertions print the code-challenge METHOD and whether a challenge exists, never the challenge value.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call - not applicable; the asserted URL is the plugin's own redirect.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit. It reuses `oid_start` and `auth_url_param` rather than parsing the URL a second way.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: no README or wiki page describes the harness phases.

## Verification

**The guard can fail.** The `nonce` arm was run both directions before it landed, because an arm that cannot fail proves nothing:

```
$ auth_url='http://kc:8080/realms/e2e/protocol/openid-connect/auth?response_type=code&state=abc&code_challenge=XYZ&code_challenge_method=S256&client_id=jellyfin-oidc&scope=openid%20profile&redirect_uri=...'
$ case "$auth_url" in *[?\&]nonce=*) echo "NONCE PRESENT" ;; *) echo "no nonce" ;; esac
no nonce
$ auth_url="$auth_url&nonce=deadbeef"
$ case "$auth_url" in *[?\&]nonce=*) echo "NONCE PRESENT (negative control works)" ;; *) echo "MISS" ;; esac
NONCE PRESENT (negative control works)

$ auth_url_param() { printf '%s' "$auth_url" | sed -n "s/.*[?&]$1=\([^&]*\).*/\1/p"; }
$ echo "method=$(auth_url_param code_challenge_method) challenge=$(auth_url_param code_challenge)"
method=S256 challenge=XYZ
```

The `code_challenge` read does not match inside `code_challenge_method`, which is what the existing helper's `[?&]` anchor and literal `=` are there for.

```
$ bash -n test/e2e/harness/harness.sh   # exit 0
```

**On the real stack:** this pull request touches `test/e2e/**`, so the E2E Login Harness runs on it against the canonical Keycloak stack. That run is the live evidence, and it also answers the third done-condition - the positive login path in the same run still passes, so these assertions cannot go green by breaking OIDC login outright.

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean - no `.js` / `.html` / `.md` / `.css` file is touched.

No C# changed, so the local .NET gate has no subject; `build` runs on this pull request.

## Notes

**No second reader.** This lands with the author's reading only, and the harness run on this pull request stands in place of one.

What it does not cover: only the canonical stack runs per pull request, so the other six provider harnesses first assert this on the next nightly, release or `providers: all` dispatch. The assertion is about the plugin's own redirect, which is provider-independent, so a per-provider difference is not expected - but it is not measured here either.
