### PR TITLE
Rotate the SAML signing key mid-run and prove both sides of it

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -241,6 +241,28 @@ jobs:
           COMPOSE: ${{ matrix.compose }}
         run: bash test/e2e/phases/legacy-secret-migration.sh
 
+      - name: SAML signing-cert rollover, the new cert validates and the old one is refused (#1128)
+        # Rotates the realm's SAML signing key mid-run, imports the new certificate into the plugin,
+        # and requires all three of the issue's clauses in ONE run: an assertion signed by the
+        # rotated-in key mints a usable session, an assertion signed by the retired key is refused
+        # with a pinned 400, and the plugin's stored SamlCertificate observably changes. The
+        # wrong-certificate rejection is unit covered and a live rotation was demonstrated by hand
+        # once in the #717 pass, but nothing has driven rotate-then-relogin end to end since.
+        #
+        # LAST of the phases, deliberately. It is the only one that mutates the IDENTITY PROVIDER
+        # rather than Jellyfin, and although it removes the key provider it added, a phase after it
+        # would be reading a realm this one has written to. Nothing here depends on the two phases
+        # above: the order is about what this one leaves behind, not about what it needs.
+        #
+        # Release and `providers: all` only, and only on the canonical Keycloak stack, for the same
+        # reasons as the two phases above, plus one of its own: it is the only entry in the matrix
+        # whose identity provider exposes an admin API this phase can rotate a signing key through.
+        # Runs on a green harness only, so a real login failure surfaces as the harness failure.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: bash test/e2e/phases/saml-cert-rollover.sh
+
       - name: Dump container logs on failure
         if: failure()
         env:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -267,6 +267,56 @@ from a stack whose secret is plaintext proves nothing: that is the documented ge
 path, where the server mints a fresh key and every login succeeds. The phase asserts the envelope
 itself rather than assuming what ran before it, and it leaves the stack as it found it.
 
+### The SAML signing certificate is rotated mid-run
+
+`test/e2e/phases/saml-cert-rollover.sh` rotates the Keycloak realm's SAML signing key while the stack
+is up, imports the new certificate into the plugin, and requires three things in one run: an
+assertion signed by the rotated-in key mints a usable Jellyfin session, an assertion signed by the
+retired key is refused with a pinned 400, and the plugin's stored `SamlCertificate` observably
+changes across the rotation. The wrong-certificate rejection is unit covered and a live rotation was
+demonstrated by hand once in the #717 pass, but nothing had driven rotate-then-relogin end to end.
+
+**The old-certificate assertion is a fresh one, not a replay,** and the difference is the whole
+value of the phase. A replayed assertion is refused by the one-time cache whatever certificate the
+plugin holds, so a 400 would have proved the replay guard rather than the rotation. Every assertion
+here comes from its own `/start` and is never presented twice, so the only thing wrong with the
+refused one is the key that signed it. The plugin answers both cases with the same uniform body,
+which is exactly why the two must not be confused at the door.
+
+**The falsifier is the part to read.** A refusal sitting between two successes could be the clock
+rather than the certificate: assertions carry a `NotOnOrAfter` and rotating takes time. So a second
+pre-rotation assertion is captured in the same breath as the first, held through the rotation, and
+posted after the original certificate has been imported back. It is strictly older at that moment
+than the refused one was at its refusal, and it is accepted. If age explained the refusal, it would
+be refused too.
+
+The rotation adds an `rsa-generated` key provider at a higher priority rather than disabling the old
+one, so the retired key stays in the realm and merely stops being used, and deleting the added
+component at the end restores the realm exactly. Disabling would also remove the key from the JWKS
+the OpenID half of this stack reads, which is a second change the phase is not about.
+
+Like the two phases above it, the work happens in a throwaway container on the compose network
+(`test/e2e/phases/probe-saml-rollover.sh`), because neither Jellyfin nor Keycloak publishes a port to
+the host, and the probe never exits non-zero: it reports `PROBE-PASS` / `PROBE-FAIL` / `PROBE-ERROR`
+lines and the host half decides what each one means. A transcript with no final `PROBE-DONE` line is
+a failure here rather than a clean pass, because a probe killed half way leaves exactly the same
+absence of failures as one that passed. The host half is what reads the persisted configuration off
+the bind mount, so the claim that the stored certificate changed rests on the file on disk and not
+only on what the plugin says about itself.
+
+Run it after a green canonical pass, on the stopped but not torn-down stack:
+
+```sh
+docker compose -f test/e2e/docker-compose.yml up \
+  --abort-on-container-exit --exit-code-from harness
+
+bash test/e2e/phases/saml-cert-rollover.sh
+```
+
+A green run prints `SAML SIGNING-CERT ROLLOVER PHASE PASSED`. In CI it runs under the same gate as
+the two phases above and last of the three, because it is the only one that writes to the identity
+provider rather than to Jellyfin.
+
 **The Zitadel, Pocket ID and Kanidm stacks cannot be re-run in place.** Every other provider is seeded from a file
 (an imported realm, a reapplied blueprint, or a static config) and the driver deliberately reuses an
 already-initialised Jellyfin. These three are seeded imperatively against stateful storage and their seeds

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -295,6 +295,14 @@ one, so the retired key stays in the realm and merely stops being used, and dele
 component at the end restores the realm exactly. Disabling would also remove the key from the JWKS
 the OpenID half of this stack reads, which is a second change the phase is not about.
 
+It authenticates as `realmadmin`, a user of the e2e realm seeded with the realm-management
+`realm-admin` role, and not as the server's bootstrap administrator. That is forced rather than
+chosen: the master realm keeps Keycloak's default `sslRequired: external`, which refuses a plaintext
+request from any address Keycloak does not treat as private, and this compose network sits on
+`11.0.0.0/24` precisely because the plugin's SSRF guard has to treat it as public. The e2e realm sets
+`sslRequired: none`, so a realm-admin token minted there is the route to the admin API that this
+stack's plaintext http leaves open.
+
 Like the two phases above it, the work happens in a throwaway container on the compose network
 (`test/e2e/phases/probe-saml-rollover.sh`), because neither Jellyfin nor Keycloak publishes a port to
 the host, and the probe never exits non-zero: it reports `PROBE-PASS` / `PROBE-FAIL` / `PROBE-ERROR`

--- a/test/e2e/keycloak/e2e-realm.json
+++ b/test/e2e/keycloak/e2e-realm.json
@@ -94,6 +94,25 @@
   ],
   "users": [
     {
+      "username": "realmadmin",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "realmadmin@example.com",
+      "firstName": "Realm",
+      "lastName": "Admin",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "realmadmin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [],
+      "clientRoles": {
+        "realm-management": ["realm-admin"]
+      }
+    },
+    {
       "username": "alice",
       "enabled": true,
       "emailVerified": true,

--- a/test/e2e/phases/probe-saml-rollover.sh
+++ b/test/e2e/phases/probe-saml-rollover.sh
@@ -1,0 +1,456 @@
+#!/bin/sh
+# The identity provider's SAML signing key is rotated mid-run, the new certificate is imported into
+# the plugin, and three questions are answered in one pass (#1128): does an assertion signed by the
+# rotated-in key still log a user in, is an assertion signed by the retired key refused, and did the
+# plugin's stored certificate actually change.
+#
+# It runs INSIDE a container on the compose network, because everything it touches is only reachable
+# from there. Jellyfin publishes no port to the host and neither does Keycloak, so a host-side curl
+# reaches neither the plugin's ACS nor the identity provider's admin API. The host half of this phase
+# (saml-cert-rollover.sh) starts the stack, runs this file, and reads the persisted configuration off
+# the bind mount, which is the one thing a container on the network cannot see.
+#
+# WHY THE OLD-CERTIFICATE ASSERTION IS A FRESH ONE RATHER THAN A REPLAY. The issue asks for a replay
+# of the pre-rotation assertion. A replay is refused by the one-time cache whatever certificate the
+# plugin holds, so a 400 would have proved the replay guard and said nothing about the rotation. Each
+# assertion here comes from its own /start, so it is unused, and its ONLY defect is the key that
+# signed it. The plugin answers both cases with one body ("SAML response validation failed", the
+# uniform SAML rejection), which is exactly why the two must not be confused at the door.
+#
+# THE FALSIFIER IS THE PART TO READ. A refusal between two successes could be the clock rather than
+# the certificate: every assertion carries a NotOnOrAfter, Keycloak's default window is short, and
+# the rotation takes time. So a SECOND pre-rotation assertion is captured in the same breath as the
+# first, held through the whole rotation, and posted AFTER the original certificate has been put
+# back. It is strictly OLDER at that moment than the refused one was at its refusal, so if age
+# explained the refusal, this one would be refused too. It is accepted. That is what makes the
+# refusal attributable to the certificate rather than to the time it took to rotate.
+#
+# It never exits non-zero. Every finding is a PROBE-PASS / PROBE-FAIL / PROBE-ERROR line and the host
+# decides what a missing answer means, so a broken probe cannot be read as a refused login. The last
+# line of a complete run is PROBE-DONE; a run that dies half way prints no such line and the host
+# reds on its absence rather than on the assertions it never reached.
+set -u
+
+JELLYFIN="${JELLYFIN_URL:-http://jellyfin:8096}"
+KEYCLOAK="${KEYCLOAK_URL:-http://keycloak:8080}"
+REALM="${REALM:-e2e}"
+PROVIDER="${PROVIDER:-keycloak}"
+ADMIN_USER="${JF_ADMIN_USER:-e2eadmin}"
+ADMIN_PASS="${JF_ADMIN_PASS:-e2e-admin-pw}"
+# The identity provider's bootstrap administrator. These are the credentials the canonical compose
+# file states for its own test Keycloak (KC_BOOTSTRAP_ADMIN_USERNAME / _PASSWORD); nothing secret is
+# introduced by naming them, and the host passes them in so this file carries no default the host
+# cannot see.
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+# carol is the SAML user the canonical round-trip drives, and she carries the jellyfin-access role
+# the stored provider configuration gates on.
+SAML_USER="${SAML_USER:-carol}"
+SAML_PASS="${SAML_PASS:-carol}"
+SAML_ENDPOINT="${SAML_ENDPOINT:-$KEYCLOAK/realms/$REALM/protocol/saml}"
+SAML_CLIENT_ID="${SAML_CLIENT_ID:-jellyfin-saml}"
+SAML_BASE_URL_OVERRIDE="${SAML_BASE_URL_OVERRIDE:-}"
+# Always Secure, so curl stores it but will not send it back over this stack's plaintext http; the
+# same explicit replay the harness performs (#415).
+SAML_BINDING_COOKIE_NAME="__Host-sso_saml_state_binding"
+EMBY_AUTH='MediaBrowser Client="e2e-rollover", Device="rollover", DeviceId="e2e-rollover-device", Version="1.0.0"'
+# The component this phase creates, named so a leftover is recognisable rather than mysterious.
+ROLLOVER_COMPONENT_NAME="e2e-rollover-rsa"
+
+stage() { printf 'PROBE-STAGE %s\n' "$*"; }
+ok()    { printf 'PROBE-PASS %s\n' "$*"; }
+bad()   { printf 'PROBE-FAIL %s\n' "$*"; }
+oops()  { printf 'PROBE-ERROR %s\n' "$*"; }
+
+# --------------------------------------------------------------------------------------------------
+# Tools and readiness
+# --------------------------------------------------------------------------------------------------
+if ! apk add --no-cache curl jq >/tmp/apk.out 2>&1; then
+  oops "could not install curl/jq:"
+  sed 's/^/  /' /tmp/apk.out
+  exit 0
+fi
+
+# READINESS IS THE PLUGIN'S OWN ROUTE, NOT THE SERVER'S, for the reason probe-oid-start.sh measured:
+# /System/Info/Public answers while Jellyfin is still coming up and the route under test then returns
+# a startup page. SAML/GetNames answers only once the plugin is loaded, and it is the SAML twin of
+# the gate that phase settled on.
+i=0
+until curl -fsS -o /dev/null "$JELLYFIN/sso/SAML/GetNames" 2>/tmp/ready.err; do
+  i=$((i + 1))
+  if [ "$i" -ge 150 ]; then
+    oops "the plugin did not answer $JELLYFIN/sso/SAML/GetNames within 300s:"
+    sed 's/^/  /' /tmp/ready.err
+    exit 0
+  fi
+  sleep 2
+done
+stage "the plugin answers SAML/GetNames after $i retries ($((i * 2))s)"
+
+i=0
+until curl -fsS -o /dev/null "$KEYCLOAK/realms/$REALM/protocol/saml/descriptor" 2>/tmp/kcready.err; do
+  i=$((i + 1))
+  if [ "$i" -ge 90 ]; then
+    oops "the identity provider did not serve its SAML descriptor within 180s:"
+    sed 's/^/  /' /tmp/kcready.err
+    exit 0
+  fi
+  sleep 2
+done
+stage "the identity provider serves its SAML descriptor after $i retries ($((i * 2))s)"
+
+# --------------------------------------------------------------------------------------------------
+# Credentials
+# --------------------------------------------------------------------------------------------------
+JF_TOKEN="$(curl -sS -X POST "$JELLYFIN/Users/AuthenticateByName" \
+  -H 'Content-Type: application/json' -H "Authorization: $EMBY_AUTH" \
+  -d "{\"Username\":\"$ADMIN_USER\",\"Pw\":\"$ADMIN_PASS\"}" 2>/dev/null | jq -r '.AccessToken // empty')"
+if [ -z "$JF_TOKEN" ]; then
+  oops "could not authenticate as the Jellyfin administrator, so the re-import could not be performed"
+  exit 0
+fi
+stage "Jellyfin administrator token acquired"
+
+KC_TOKEN="$(curl -sS -X POST "$KEYCLOAK/realms/master/protocol/openid-connect/token" \
+  -d 'client_id=admin-cli' -d 'grant_type=password' \
+  --data-urlencode "username=$KC_ADMIN_USER" --data-urlencode "password=$KC_ADMIN_PASS" 2>/dev/null \
+  | jq -r '.access_token // empty')"
+if [ -z "$KC_TOKEN" ]; then
+  oops "could not authenticate against the identity provider's admin API, so no key could be rotated"
+  exit 0
+fi
+stage "identity-provider admin token acquired"
+
+kc() { curl -sS -H "Authorization: Bearer $KC_TOKEN" "$@"; }
+
+REALM_ID="$(kc "$KEYCLOAK/admin/realms/$REALM" 2>/dev/null | jq -r '.id // empty')"
+if [ -z "$REALM_ID" ]; then
+  oops "could not read the realm id, which the new key provider has to be parented to"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Helpers: the plugin's stored certificate, and the identity provider's signing keys
+# --------------------------------------------------------------------------------------------------
+# The plugin's OWN view of what it stores. SAML/Test parses the configured certificate and reports
+# its SHA-256 thumbprint, so this reads the value in use rather than a file somebody hopes it read.
+stored_thumbprint() {
+  curl -sS -H "Authorization: MediaBrowser Token=\"$JF_TOKEN\"" "$JELLYFIN/sso/SAML/Test/$PROVIDER" 2>/dev/null \
+    | jq -r '.Details[]? | select(startswith("SHA-256 thumbprint: "))' \
+    | sed 's/^SHA-256 thumbprint: //' | tr -d ' \r'
+}
+
+# The SHA-256 over the DER bytes, which is what a certificate thumbprint is, so the plugin's report
+# and the identity provider's key listing can be compared without either having to trust the other's
+# spelling of the same certificate.
+thumb_of() { printf '%s' "$1" | base64 -d 2>/dev/null | sha256sum | cut -d' ' -f1 | tr 'a-f' 'A-F'; }
+
+# The realm's active RS256 signing key, and the one belonging to a named provider component. The
+# certificate is read from the admin key listing rather than from the SAML descriptor: while two
+# signing keys are active the descriptor carries both, and "the first X509Certificate element" is
+# then whichever one the serialiser happened to put first.
+active_sig_cert() {
+  kc "$KEYCLOAK/admin/realms/$REALM/keys" 2>/dev/null \
+    | jq -r '[.keys[] | select(.use=="SIG" and .algorithm=="RS256" and .status=="ACTIVE")]
+             | sort_by(.providerPriority // 0) | reverse | .[0].certificate // empty'
+}
+cert_of_component() {
+  kc "$KEYCLOAK/admin/realms/$REALM/keys" 2>/dev/null \
+    | jq -r --arg id "$1" '.keys[] | select(.providerId==$id and .use=="SIG" and .algorithm=="RS256") | .certificate' \
+    | head -1
+}
+
+# SAML/Add replaces the stored provider wholesale, so changing one field means re-stating the rest.
+# The body below is the canonical harness's SAML configuration with the certificate swapped; a field
+# this phase got wrong would fail the login it drives rather than persist unnoticed.
+import_certificate() { # $1 certificate
+  curl -sS -o /tmp/samladd.out -w '%{http_code}' -X POST "$JELLYFIN/sso/SAML/Add/$PROVIDER" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: MediaBrowser Token=\"$JF_TOKEN\"" \
+    -d "{\"SamlEndpoint\":\"$SAML_ENDPOINT\",\"SamlClientId\":\"$SAML_CLIENT_ID\",\"BaseUrlOverride\":\"$SAML_BASE_URL_OVERRIDE\",\"SamlCertificate\":\"$1\",\"Enabled\":true,\"EnableAuthorization\":true,\"Roles\":[\"jellyfin-access\"]}" \
+    2>/dev/null
+}
+
+# --------------------------------------------------------------------------------------------------
+# Helpers: one SAML browser leg, captured rather than posted
+# --------------------------------------------------------------------------------------------------
+# capture <label> : drives /start and the identity provider's credential form, and files away the
+# assertion, the ACS URL, the RelayState and the browser-binding cookie WITHOUT posting anything.
+# Holding an assertion instead of posting it is the whole mechanism of this phase: it is what lets an
+# assertion signed before the rotation be presented after it.
+capture() {
+  label="$1"
+  jar="/tmp/$label.jar"; hdr="/tmp/$label.hdr"
+  : > "$jar"
+  start_out="$(curl -sS -D "$hdr" -o /dev/null -c "$jar" -b "$jar" -w '%{http_code} %{redirect_url}' \
+    "$JELLYFIN/sso/SAML/start/$PROVIDER" 2>/dev/null)" || { oops "$label: SAML/start could not be reached"; return 1; }
+  auth_url="${start_out#* }"
+  if [ -z "$auth_url" ]; then
+    oops "$label: SAML/start returned no redirect (HTTP ${start_out%% *})"
+    return 1
+  fi
+  grep -i '^set-cookie:' "$hdr" 2>/dev/null | grep -o "$SAML_BINDING_COOKIE_NAME=[^;]*" \
+    | head -1 | cut -d= -f2- > "/tmp/$label.bind"
+
+  login_page="$(curl -sSL -c "$jar" -b "$jar" "$auth_url" 2>/dev/null)" \
+    || { oops "$label: the identity provider's login page could not be fetched"; return 1; }
+  form_action="$(printf '%s' "$login_page" | grep -oE 'action="[^"]*"' | head -1 \
+    | sed -e 's/^action="//' -e 's/"$//' -e 's/&amp;/\&/g')"
+  if [ -z "$form_action" ]; then
+    oops "$label: no credential form on the identity provider's page"
+    return 1
+  fi
+  post_page="$(curl -sSL -c "$jar" -b "$jar" \
+    --data-urlencode "username=$SAML_USER" --data-urlencode "password=$SAML_PASS" \
+    --data-urlencode 'credentialId=' "$form_action" 2>/dev/null)" \
+    || { oops "$label: the credential POST failed"; return 1; }
+
+  printf '%s' "$post_page" | grep -oE 'form[^>]*action="[^"]*"' | head -1 \
+    | sed -E 's/.*action="//; s/".*//; s/&amp;/\&/g' > "/tmp/$label.acs"
+  printf '%s' "$post_page" | grep -oE 'name="SAMLResponse"[^>]*value="[^"]*"' | head -1 \
+    | sed -E 's/.*value="//; s/".*//' > "/tmp/$label.resp"
+  printf '%s' "$post_page" | grep -oE 'name="RelayState"[^>]*value="[^"]*"' | head -1 \
+    | sed -E 's/.*value="//; s/".*//' > "/tmp/$label.relay"
+  if [ ! -s "/tmp/$label.resp" ] || [ ! -s "/tmp/$label.acs" ]; then
+    oops "$label: the identity provider returned no SAML POST-binding form; first 400 chars: $(printf '%s' "$post_page" | head -c 400)"
+    return 1
+  fi
+  # An epoch stamp per assertion, so the transcript can say how old each one was when it was posted
+  # and the falsifier's claim to be the older of the two is readable rather than asserted.
+  date +%s > "/tmp/$label.at"
+  stage "$label: assertion captured ($(wc -c < "/tmp/$label.resp") base64 chars), held unposted"
+  return 0
+}
+
+# present <label> : posts a captured assertion to the plugin's ACS. Sets ACS_STATUS, ACS_BODY,
+# ACS_TOKEN (the login-outcome token a successful callback hands the browser) and ACS_AGE. No -f: a
+# refusal is an expected outcome here and has to come back with its status rather than as an error.
+ACS_STATUS=""; ACS_BODY=""; ACS_TOKEN=""; ACS_AGE=""
+present() {
+  label="$1"
+  acs="$(cat "/tmp/$label.acs")"; resp="$(cat "/tmp/$label.resp")"
+  relay="$(cat "/tmp/$label.relay" 2>/dev/null || true)"
+  ACS_AGE="$(( $(date +%s) - $(cat "/tmp/$label.at") ))"
+  if [ -n "$relay" ]; then
+    ACS_STATUS="$(curl -sS -o /tmp/acs.out -w '%{http_code}' -X POST "$acs" \
+      --data-urlencode "SAMLResponse=$resp" --data-urlencode "RelayState=$relay" 2>/dev/null)" || ACS_STATUS=""
+  else
+    ACS_STATUS="$(curl -sS -o /tmp/acs.out -w '%{http_code}' -X POST "$acs" \
+      --data-urlencode "SAMLResponse=$resp" 2>/dev/null)" || ACS_STATUS=""
+  fi
+  if [ -z "$ACS_STATUS" ]; then
+    oops "$label: the ACS could not be reached at all"
+    return 1
+  fi
+  ACS_BODY="$(tr -d '\r\n' < /tmp/acs.out | cut -c1-200)"
+  ACS_TOKEN="$(grep -oE 'var data = "[^"]*"' /tmp/acs.out 2>/dev/null | head -1 \
+    | sed -e 's/^var data = "//' -e 's/"$//')"
+  if [ -n "$ACS_TOKEN" ]; then tokseen=yes; else tokseen=no; fi
+  stage "$label: ACS answered $ACS_STATUS after ${ACS_AGE}s, login-outcome token: $tokseen"
+  return 0
+}
+
+# redeem <label> : exchanges a login-outcome token for a Jellyfin session at the same-origin mint leg
+# and uses that session against /Users/Me. Minting is what "a usable session token" means; a callback
+# that returned a token minting nothing would otherwise read as a successful login.
+redeem() {
+  label="$1"
+  bind="$(cat "/tmp/$label.bind" 2>/dev/null || true)"
+  if [ -z "$bind" ]; then
+    bad "$label: /start set no SAML browser-binding cookie, so the mint leg cannot be exercised"
+    return 1
+  fi
+  auth="$(curl -sS -H "Cookie: $SAML_BINDING_COOKIE_NAME=$bind" \
+    -X POST "$JELLYFIN/sso/SAML/Auth/$PROVIDER" -H 'Content-Type: application/json' \
+    -d "{\"deviceId\":\"e2e-rollover-device\",\"appName\":\"Jellyfin Web\",\"appVersion\":\"10.8.0\",\"deviceName\":\"rollover\",\"data\":\"$ACS_TOKEN\"}" 2>/dev/null)"
+  tok="$(printf '%s' "$auth" | jq -r '.AccessToken // empty' 2>/dev/null)"
+  if [ -z "$tok" ]; then
+    bad "$label: the login-outcome token minted no Jellyfin session: $(printf '%s' "$auth" | head -c 200)"
+    return 1
+  fi
+  me="$(curl -sS -H "Authorization: MediaBrowser Token=\"$tok\"" "$JELLYFIN/Users/Me" 2>/dev/null | jq -r '.Name // empty')"
+  if [ -z "$me" ]; then
+    bad "$label: the minted session token is not usable against /Users/Me"
+    return 1
+  fi
+  stage "$label: minted a session usable as '$me'"
+  return 0
+}
+
+# --------------------------------------------------------------------------------------------------
+# Cleanup: the realm and the plugin go back to what they were, on every exit path
+# --------------------------------------------------------------------------------------------------
+NEW_COMPONENT_ID=""
+ORIGINAL_CERT=""
+cleanup() {
+  if [ -n "$NEW_COMPONENT_ID" ]; then
+    st="$(kc -o /dev/null -w '%{http_code}' -X DELETE \
+      "$KEYCLOAK/admin/realms/$REALM/components/$NEW_COMPONENT_ID" 2>/dev/null || true)"
+    stage "cleanup: removed the rotated-in key provider (HTTP $st)"
+  fi
+  if [ -n "$ORIGINAL_CERT" ]; then
+    st="$(import_certificate "$ORIGINAL_CERT")"
+    stage "cleanup: put the original certificate back into the plugin (HTTP $st)"
+  fi
+}
+trap cleanup EXIT
+
+# --------------------------------------------------------------------------------------------------
+# The starting state
+# --------------------------------------------------------------------------------------------------
+ORIGINAL_CERT="$(active_sig_cert)"
+if [ -z "$ORIGINAL_CERT" ]; then
+  oops "the identity provider reports no active RS256 signing key, so there is nothing to rotate away from"
+  exit 0
+fi
+IDP_FP_BEFORE="$(thumb_of "$ORIGINAL_CERT")"
+STORED_FP_BEFORE="$(stored_thumbprint)"
+printf 'PROBE-CERT-BEFORE %s\n' "$STORED_FP_BEFORE"
+if [ -z "$STORED_FP_BEFORE" ]; then
+  oops "SAML/Test reported no thumbprint for the stored certificate, so no change to it could be observed"
+  exit 0
+fi
+if [ "$STORED_FP_BEFORE" = "$IDP_FP_BEFORE" ]; then
+  ok "the plugin stores the identity provider's current signing certificate ($STORED_FP_BEFORE)"
+else
+  bad "the stored certificate ($STORED_FP_BEFORE) is not the identity provider's active signing certificate ($IDP_FP_BEFORE), so this phase would be measuring something else"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------------------------------
+# Control: the captured-assertion route works before anything is rotated
+# --------------------------------------------------------------------------------------------------
+stage "control: a captured assertion is accepted while nothing has changed"
+capture control || { oops "the control assertion could not be captured, so nothing below would be attributable"; exit 0; }
+present control || exit 0
+if [ "$ACS_STATUS" = "200" ] && [ -n "$ACS_TOKEN" ]; then
+  ok "the control assertion was accepted and minted a login-outcome token (HTTP 200)"
+else
+  bad "the control assertion was not accepted (HTTP $ACS_STATUS, body '$ACS_BODY'); the stack is not in a state where a later refusal would mean anything"
+  exit 0
+fi
+
+# The two assertions that outlive the rotation. Captured back to back so they are the same vintage:
+# one is refused after the rotation, the other accepted after the restore, and their ages at those
+# two moments are what rules the clock out.
+capture stale || { oops "the pre-rotation assertion could not be captured"; exit 0; }
+capture falsifier || { oops "the falsifier assertion could not be captured"; exit 0; }
+
+# --------------------------------------------------------------------------------------------------
+# Rotate
+# --------------------------------------------------------------------------------------------------
+stage "rotating the realm's SAML signing key"
+# A key provider at a HIGHER priority, which Keycloak then signs with, rather than disabling the old
+# one. Disabling would take the retired key out of the descriptor AND out of the JWKS the OpenID side
+# of this stack reads, which is a second change this phase is not about; adding one leaves the old
+# key present and merely unused, and removing the new component at the end restores the realm exactly.
+CREATE_STATUS="$(kc -o /tmp/comp.out -D /tmp/comp.hdr -w '%{http_code}' -X POST \
+  "$KEYCLOAK/admin/realms/$REALM/components" -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$ROLLOVER_COMPONENT_NAME\",\"parentId\":\"$REALM_ID\",\"providerId\":\"rsa-generated\",\"providerType\":\"org.keycloak.keys.KeyProvider\",\"config\":{\"priority\":[\"200\"],\"enabled\":[\"true\"],\"active\":[\"true\"],\"algorithm\":[\"RS256\"],\"keySize\":[\"2048\"]}}" 2>/dev/null)"
+if [ "$CREATE_STATUS" != "201" ]; then
+  oops "the identity provider refused the new key provider (HTTP $CREATE_STATUS): $(head -c 300 /tmp/comp.out 2>/dev/null)"
+  exit 0
+fi
+NEW_COMPONENT_ID="$(grep -i '^location:' /tmp/comp.hdr | tr -d ' \r\n' | sed 's#.*/##')"
+if [ -z "$NEW_COMPONENT_ID" ]; then
+  oops "the new key provider was created but its id could not be read from the Location header, so it cannot be removed again"
+  exit 0
+fi
+stage "the rotated-in key provider is $NEW_COMPONENT_ID"
+
+ROTATED_CERT="$(cert_of_component "$NEW_COMPONENT_ID")"
+if [ -z "$ROTATED_CERT" ]; then
+  oops "the rotated-in key provider published no RS256 signing certificate"
+  exit 0
+fi
+IDP_FP_AFTER="$(thumb_of "$ROTATED_CERT")"
+if [ "$IDP_FP_AFTER" = "$IDP_FP_BEFORE" ]; then
+  oops "the rotated-in certificate is the same as the old one, so nothing was rotated"
+  exit 0
+fi
+NOW_ACTIVE="$(thumb_of "$(active_sig_cert)")"
+if [ "$NOW_ACTIVE" = "$IDP_FP_AFTER" ]; then
+  ok "the identity provider now signs with the rotated-in key ($IDP_FP_AFTER)"
+else
+  bad "the identity provider still signs with $NOW_ACTIVE after the rotation, so the login below would not be signed by the new key"
+  exit 0
+fi
+
+IMPORT_STATUS="$(import_certificate "$ROTATED_CERT")"
+if [ "$IMPORT_STATUS" != "200" ] && [ "$IMPORT_STATUS" != "204" ]; then
+  oops "SAML/Add refused the rotated-in certificate (HTTP $IMPORT_STATUS): $(head -c 300 /tmp/samladd.out 2>/dev/null)"
+  exit 0
+fi
+STORED_FP_AFTER="$(stored_thumbprint)"
+printf 'PROBE-CERT-ROTATED %s\n' "$STORED_FP_AFTER"
+if [ "$STORED_FP_AFTER" = "$IDP_FP_AFTER" ] && [ "$STORED_FP_AFTER" != "$STORED_FP_BEFORE" ]; then
+  ok "the plugin's stored certificate changed across the rotation, from $STORED_FP_BEFORE to $STORED_FP_AFTER"
+else
+  bad "the plugin's stored certificate did not become the rotated-in one (stored $STORED_FP_AFTER, expected $IDP_FP_AFTER)"
+  exit 0
+fi
+
+# --------------------------------------------------------------------------------------------------
+# The two claims
+# --------------------------------------------------------------------------------------------------
+stage "the pre-rotation assertion is presented, unused, against the rotated-in certificate"
+present stale || exit 0
+if [ "$ACS_STATUS" = "400" ]; then
+  ok "the assertion signed by the retired key was refused with HTTP 400 at ${ACS_AGE}s old"
+else
+  bad "the assertion signed by the retired key was answered HTTP $ACS_STATUS, not the 400 a failed signature check produces (body '$ACS_BODY')"
+fi
+case "$ACS_BODY" in
+  *"SAML response validation failed"*)
+    ok "the refusal carries the uniform SAML rejection body rather than a server error" ;;
+  *)
+    bad "the refusal body is not the uniform SAML rejection: '$ACS_BODY'" ;;
+esac
+if [ -n "$ACS_TOKEN" ]; then
+  bad "the refused assertion still handed out a login-outcome token"
+else
+  ok "the refused assertion handed out no login-outcome token"
+fi
+STALE_AGE="$ACS_AGE"
+
+stage "a fresh login under the rotated-in certificate"
+if capture fresh && present fresh; then
+  if [ "$ACS_STATUS" = "200" ] && [ -n "$ACS_TOKEN" ]; then
+    ok "an assertion signed by the rotated-in key was accepted (HTTP 200)"
+    if redeem fresh; then
+      ok "the rotated-in key mints a usable Jellyfin session"
+    fi
+  else
+    bad "the login under the rotated-in certificate was answered HTTP $ACS_STATUS (body '$ACS_BODY')"
+  fi
+else
+  bad "the login under the rotated-in certificate could not be driven at all"
+fi
+
+# --------------------------------------------------------------------------------------------------
+# The falsifier: put the original certificate back and present the older sibling of the refused one
+# --------------------------------------------------------------------------------------------------
+stage "restoring the original certificate and presenting the older pre-rotation assertion"
+RESTORE_STATUS="$(import_certificate "$ORIGINAL_CERT")"
+if [ "$RESTORE_STATUS" != "200" ] && [ "$RESTORE_STATUS" != "204" ]; then
+  oops "the original certificate could not be put back (HTTP $RESTORE_STATUS)"
+  exit 0
+fi
+STORED_FP_RESTORED="$(stored_thumbprint)"
+printf 'PROBE-CERT-RESTORED %s\n' "$STORED_FP_RESTORED"
+if [ "$STORED_FP_RESTORED" = "$STORED_FP_BEFORE" ]; then
+  ok "the plugin stores the original certificate again"
+else
+  bad "the restore left the plugin holding $STORED_FP_RESTORED rather than the original $STORED_FP_BEFORE"
+  exit 0
+fi
+
+present falsifier || exit 0
+if [ "$ACS_STATUS" = "200" ] && [ -n "$ACS_TOKEN" ]; then
+  ok "the same-vintage assertion was accepted at ${ACS_AGE}s old, older than the refused one was at ${STALE_AGE}s, so the refusal above was the certificate and not the clock"
+else
+  bad "the falsifier assertion was answered HTTP $ACS_STATUS at ${ACS_AGE}s old (body '$ACS_BODY'); the refusal above cannot be attributed to the certificate, because an assertion of the same vintage is refused even with the original certificate in place"
+fi
+
+printf 'PROBE-DONE\n'
+exit 0

--- a/test/e2e/phases/probe-saml-rollover.sh
+++ b/test/e2e/phases/probe-saml-rollover.sh
@@ -37,12 +37,17 @@ REALM="${REALM:-e2e}"
 PROVIDER="${PROVIDER:-keycloak}"
 ADMIN_USER="${JF_ADMIN_USER:-e2eadmin}"
 ADMIN_PASS="${JF_ADMIN_PASS:-e2e-admin-pw}"
-# The identity provider's bootstrap administrator. These are the credentials the canonical compose
-# file states for its own test Keycloak (KC_BOOTSTRAP_ADMIN_USERNAME / _PASSWORD); nothing secret is
-# introduced by naming them, and the host passes them in so this file carries no default the host
-# cannot see.
-KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
-KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+# The administrator this phase rotates a key as. It is a user of the E2E REALM carrying the
+# realm-management `realm-admin` role, seeded in e2e-realm.json, rather than the server's bootstrap
+# administrator in the master realm, and that is forced rather than chosen. The master realm keeps
+# Keycloak's default `sslRequired: external`, which refuses a plaintext request from any address
+# Keycloak does not consider private, and the compose network is deliberately on 11.0.0.0/24 - a
+# range chosen precisely because the plugin's SSRF guard treats it as public. So the master realm
+# answers the token request with "HTTPS required" from this network, measured on the run linked in
+# the commit that changed this. The e2e realm sets `sslRequired: none`, and a realm-admin token
+# minted there administers that realm.
+KC_ADMIN_USER="${KC_ADMIN_USER:-realmadmin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-realmadmin}"
 # carol is the SAML user the canonical round-trip drives, and she carries the jellyfin-access role
 # the stored provider configuration gates on.
 SAML_USER="${SAML_USER:-carol}"
@@ -99,21 +104,6 @@ until curl -fsS -o /dev/null "$KEYCLOAK/realms/$REALM/protocol/saml/descriptor" 
 done
 stage "the identity provider serves its SAML descriptor after $i retries ($((i * 2))s)"
 
-# The e2e realm answering does not mean the MASTER realm does, and the admin token below is minted
-# there. The stack was started seconds ago by the host half, so this is gated separately rather than
-# read off the gate above.
-i=0
-until curl -fsS -o /dev/null "$KEYCLOAK/realms/master/.well-known/openid-configuration" 2>/tmp/kcmaster.err; do
-  i=$((i + 1))
-  if [ "$i" -ge 90 ]; then
-    oops "the identity provider's master realm did not answer within 180s:"
-    sed 's/^/  /' /tmp/kcmaster.err
-    exit 0
-  fi
-  sleep 2
-done
-stage "the identity provider's master realm answers after $i retries ($((i * 2))s)"
-
 # --------------------------------------------------------------------------------------------------
 # Credentials
 # --------------------------------------------------------------------------------------------------
@@ -134,7 +124,7 @@ stage "Jellyfin administrator token acquired"
 # and knowing why.
 kc_token_request() {
   curl -sS -o /tmp/kctoken.out -w '%{http_code}' -X POST \
-    "$KEYCLOAK/realms/master/protocol/openid-connect/token" \
+    "$KEYCLOAK/realms/$REALM/protocol/openid-connect/token" \
     --data-urlencode 'client_id=admin-cli' --data-urlencode 'grant_type=password' \
     --data-urlencode "username=$KC_ADMIN_USER" --data-urlencode "password=$KC_ADMIN_PASS" \
     2>/tmp/kctoken.err
@@ -157,11 +147,15 @@ stage "identity-provider admin token acquired after $i retries (HTTP $KC_TOKEN_S
 
 kc() { curl -sS -H "Authorization: Bearer $KC_TOKEN" "$@"; }
 
-REALM_ID="$(kc "$KEYCLOAK/admin/realms/$REALM" 2>/dev/null | jq -r '.id // empty')"
+# The first call against the admin API, so its status and body are reported rather than reduced to a
+# missing id: this is where a token that was minted but does not administer anything shows up.
+REALM_STATUS="$(kc -o /tmp/realm.out -w '%{http_code}' "$KEYCLOAK/admin/realms/$REALM" 2>/dev/null || true)"
+REALM_ID="$(jq -r '.id // empty' /tmp/realm.out 2>/dev/null || true)"
 if [ -z "$REALM_ID" ]; then
-  oops "could not read the realm id, which the new key provider has to be parented to"
+  oops "the admin API did not return the realm id, which the new key provider has to be parented to (HTTP $REALM_STATUS): $(head -c 300 /tmp/realm.out 2>/dev/null)"
   exit 0
 fi
+stage "the admin API answers for realm '$REALM'"
 
 # --------------------------------------------------------------------------------------------------
 # Helpers: the plugin's stored certificate, and the identity provider's signing keys
@@ -332,6 +326,10 @@ trap cleanup EXIT
 # --------------------------------------------------------------------------------------------------
 # The starting state
 # --------------------------------------------------------------------------------------------------
+# The signing-key inventory, by algorithm, status and priority and nothing else: no key material and
+# no certificate. It is what a reading of the two thumbprints below needs when they disagree.
+stage "signing keys before the rotation: $(kc "$KEYCLOAK/admin/realms/$REALM/keys" 2>/dev/null | jq -r '[.keys[]? | select(.use=="SIG") | "\(.algorithm)/\(.status)/priority=\(.providerPriority // 0)"] | join(" ")')"
+
 ORIGINAL_CERT="$(active_sig_cert)"
 if [ -z "$ORIGINAL_CERT" ]; then
   oops "the identity provider reports no active RS256 signing key, so there is nothing to rotate away from"

--- a/test/e2e/phases/probe-saml-rollover.sh
+++ b/test/e2e/phases/probe-saml-rollover.sh
@@ -99,6 +99,21 @@ until curl -fsS -o /dev/null "$KEYCLOAK/realms/$REALM/protocol/saml/descriptor" 
 done
 stage "the identity provider serves its SAML descriptor after $i retries ($((i * 2))s)"
 
+# The e2e realm answering does not mean the MASTER realm does, and the admin token below is minted
+# there. The stack was started seconds ago by the host half, so this is gated separately rather than
+# read off the gate above.
+i=0
+until curl -fsS -o /dev/null "$KEYCLOAK/realms/master/.well-known/openid-configuration" 2>/tmp/kcmaster.err; do
+  i=$((i + 1))
+  if [ "$i" -ge 90 ]; then
+    oops "the identity provider's master realm did not answer within 180s:"
+    sed 's/^/  /' /tmp/kcmaster.err
+    exit 0
+  fi
+  sleep 2
+done
+stage "the identity provider's master realm answers after $i retries ($((i * 2))s)"
+
 # --------------------------------------------------------------------------------------------------
 # Credentials
 # --------------------------------------------------------------------------------------------------
@@ -111,15 +126,34 @@ if [ -z "$JF_TOKEN" ]; then
 fi
 stage "Jellyfin administrator token acquired"
 
-KC_TOKEN="$(curl -sS -X POST "$KEYCLOAK/realms/master/protocol/openid-connect/token" \
-  -d 'client_id=admin-cli' -d 'grant_type=password' \
-  --data-urlencode "username=$KC_ADMIN_USER" --data-urlencode "password=$KC_ADMIN_PASS" 2>/dev/null \
-  | jq -r '.access_token // empty')"
+# The direct grant Keycloak's own kcadm uses, retried because the admin endpoints can lag the realm
+# endpoints on a just-restarted server, and REPORTED rather than reduced to "no token": the first
+# version of this file swallowed the status and the body, and a run that ended here said only that
+# something had refused it. The body of a refusal from a test identity provider carries no secret -
+# it is an OAuth error code and its description - and it is the difference between one more dispatch
+# and knowing why.
+kc_token_request() {
+  curl -sS -o /tmp/kctoken.out -w '%{http_code}' -X POST \
+    "$KEYCLOAK/realms/master/protocol/openid-connect/token" \
+    --data-urlencode 'client_id=admin-cli' --data-urlencode 'grant_type=password' \
+    --data-urlencode "username=$KC_ADMIN_USER" --data-urlencode "password=$KC_ADMIN_PASS" \
+    2>/tmp/kctoken.err
+}
+KC_TOKEN=""
+KC_TOKEN_STATUS=""
+i=0
+while [ "$i" -lt 10 ]; do
+  KC_TOKEN_STATUS="$(kc_token_request || true)"
+  KC_TOKEN="$(jq -r '.access_token // empty' /tmp/kctoken.out 2>/dev/null || true)"
+  [ -n "$KC_TOKEN" ] && break
+  i=$((i + 1))
+  sleep 3
+done
 if [ -z "$KC_TOKEN" ]; then
-  oops "could not authenticate against the identity provider's admin API, so no key could be rotated"
+  oops "the identity provider refused an admin token for '$KC_ADMIN_USER' after $i attempts (last HTTP $KC_TOKEN_STATUS): $(head -c 400 /tmp/kctoken.out 2>/dev/null) $(head -c 200 /tmp/kctoken.err 2>/dev/null)"
   exit 0
 fi
-stage "identity-provider admin token acquired"
+stage "identity-provider admin token acquired after $i retries (HTTP $KC_TOKEN_STATUS)"
 
 kc() { curl -sS -H "Authorization: Bearer $KC_TOKEN" "$@"; }
 

--- a/test/e2e/phases/saml-cert-rollover.sh
+++ b/test/e2e/phases/saml-cert-rollover.sh
@@ -27,11 +27,15 @@ set -euo pipefail
 
 COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
 CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
-# The test Keycloak's bootstrap administrator, as the canonical compose file declares it. Passed in
-# rather than defaulted inside the probe, so the credentials this phase uses are readable in the file
-# that runs it.
-KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
-KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+# The realm administrator the rotation is performed as: a user of the e2e realm seeded in
+# `test/e2e/keycloak/e2e-realm.json` with the realm-management `realm-admin` role, NOT the server's
+# bootstrap administrator in the master realm. The master realm keeps Keycloak's default
+# `sslRequired: external` and refuses a plaintext request from any address it does not consider
+# private, which this compose network deliberately is not; the e2e realm sets `sslRequired: none`.
+# Passed in rather than only defaulted inside the probe, so the credentials this phase uses are
+# readable in the file that runs it.
+KC_ADMIN_USER="${KC_ADMIN_USER:-realmadmin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-realmadmin}"
 
 log()  { printf '%s\n' "== $* =="; }
 die()  { printf '::error::%s\n' "$*" >&2; exit 1; }

--- a/test/e2e/phases/saml-cert-rollover.sh
+++ b/test/e2e/phases/saml-cert-rollover.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# The identity provider's SAML signing key is rotated while the stack is up, the new certificate is
+# imported into the plugin, and one run answers all three of #1128's clauses: an assertion signed by
+# the rotated-in key mints a usable Jellyfin session, an assertion signed by the retired key is
+# refused with a pinned status, and the plugin's stored SamlCertificate observably changes across the
+# rotation. A live rotation was demonstrated by hand once in the #717 pass and nothing has re-checked
+# it since, so a regression to accepting a retired certificate would ship silently.
+#
+# The work happens in probe-saml-rollover.sh, inside a container on the compose network, because
+# neither Jellyfin nor Keycloak publishes a port to the host: the ACS, the plugin's admin API and the
+# identity provider's admin API are all only reachable from `ssonet`. What this file adds is the one
+# thing that container cannot do. It reads the persisted configuration off the bind mount, so the
+# claim that the STORED certificate changed rests on the file on disk as well as on what the plugin
+# says about itself, and a phase that changed only the plugin's opinion of its configuration could
+# not pass.
+#
+# WHY THE PROBE IS NOT ALLOWED TO FAIL THE STEP. The probe never exits non-zero. It reports
+# PROBE-PASS / PROBE-FAIL / PROBE-ERROR lines and this file decides what each one means, so a probe
+# that broke on its way to the assertion cannot be read as a login that was refused. The absence of
+# the final PROBE-DONE line is itself a failure here: a probe killed half way would otherwise leave a
+# transcript with no FAIL lines in it, which reads exactly like a clean pass.
+#
+# It leaves the stack as it found it. The rotated-in key provider is deleted, the original
+# certificate is imported back, and both are asserted rather than assumed: the certificate on disk
+# after the run has to be the one that was there before it.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
+CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
+# The test Keycloak's bootstrap administrator, as the canonical compose file declares it. Passed in
+# rather than defaulted inside the probe, so the credentials this phase uses are readable in the file
+# that runs it.
+KC_ADMIN_USER="${KC_ADMIN_USER:-admin}"
+KC_ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+
+log()  { printf '%s\n' "== $* =="; }
+die()  { printf '::error::%s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+# The stored identity-provider signing certificate as the persisted configuration holds it, reduced
+# to the SHA-256 over its DER bytes - the same number SAML/Test reports, so the file and the plugin's
+# own account of itself are directly comparable.
+stored_cert_b64() {
+  grep -o '<SamlCertificate>[^<]*</SamlCertificate>' "$CONFIG" | head -1 \
+    | sed -e 's#<SamlCertificate>##' -e 's#</SamlCertificate>##'
+}
+fingerprint_of() {
+  printf '%s' "$1" | base64 -d 2>/dev/null | sha256sum | cut -d' ' -f1 | tr 'a-f' 'A-F'
+}
+
+log "Preconditions"
+[ -s "$CONFIG" ] || die "the plugin persisted no configuration at $CONFIG - run the canonical pass first"
+CERT_BEFORE="$(stored_cert_b64)"
+[ -n "$CERT_BEFORE" ] || die "no SamlCertificate in $CONFIG - the canonical SAML pass has not configured a provider, so there is nothing to rotate"
+FP_BEFORE="$(fingerprint_of "$CERT_BEFORE")"
+[ -n "$FP_BEFORE" ] || die "the stored SamlCertificate is not decodable Base64, so no rotation could be observed against it"
+pass "the persisted configuration holds a SAML certificate with thumbprint $FP_BEFORE"
+
+log "Starting the stack"
+# The canonical run ends with --abort-on-container-exit, which stops every container, so the servers
+# have to be brought back up. `start`, never `up`: `up` would run the harness again, and `down` would
+# take Keycloak's realm with it - the realm is re-imported into a fresh instance with a NEW signing
+# certificate, which is the very thing this phase rotates on purpose and would then be unable to
+# distinguish from its own work.
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
+
+log "Rotating the identity provider's SAML signing key"
+# One throwaway container on the compose network, built from the harness service so it inherits that
+# service's environment and its network membership, with its command replaced by the probe. The probe
+# is bind-mounted in as a FILE rather than handed over as a string: probe-oid-start.sh records what
+# passing a script through two layers of `sh -c` cost the last time somebody tried it.
+PHASES_DIR="${PHASES_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+OUT="$(docker compose -f "$COMPOSE" run --rm --no-deps -T \
+  -e "KC_ADMIN_USER=$KC_ADMIN_USER" -e "KC_ADMIN_PASS=$KC_ADMIN_PASS" \
+  -v "$PHASES_DIR:/probe:ro" --entrypoint sh harness /probe/probe-saml-rollover.sh)" \
+  || die "the probe container could not be started"
+
+# Everything the probe said, indented, so a run that ends here says why rather than only that it got
+# no answer.
+printf '%s\n' "$OUT" | sed 's/^/  probe| /'
+
+log "Reading the probe's verdict"
+if ! printf '%s\n' "$OUT" | grep -q '^PROBE-DONE$'; then
+  die "the probe did not run to completion - its transcript is above, and a transcript without PROBE-DONE has assertions it never reached"
+fi
+if printf '%s\n' "$OUT" | grep -q '^PROBE-ERROR '; then
+  die "the probe could not judge the rotation: $(printf '%s\n' "$OUT" | grep '^PROBE-ERROR ' | head -1)"
+fi
+if printf '%s\n' "$OUT" | grep -q '^PROBE-FAIL '; then
+  printf '%s\n' "$OUT" | grep '^PROBE-FAIL ' | sed 's/^/::error::/'
+  die "the rotation phase failed - every PROBE-FAIL line is above"
+fi
+pass "every assertion the probe made was met, and it ran to completion"
+
+log "The stored certificate changed across the rotation"
+# Read off the probe's own three readings of the plugin's stored certificate. The point of asserting
+# these HERE, against the fingerprint taken from the file before anything ran, is that a phase which
+# skipped the re-import would still have driven a login and could still have printed passes.
+probe_fp() { printf '%s\n' "$OUT" | sed -n "s/^PROBE-CERT-$1 //p" | tail -1; }
+FP_PROBE_BEFORE="$(probe_fp BEFORE)"
+FP_PROBE_ROTATED="$(probe_fp ROTATED)"
+FP_PROBE_RESTORED="$(probe_fp RESTORED)"
+[ -n "$FP_PROBE_BEFORE" ] && [ -n "$FP_PROBE_ROTATED" ] && [ -n "$FP_PROBE_RESTORED" ] \
+  || die "the probe did not report all three certificate readings (before='$FP_PROBE_BEFORE' rotated='$FP_PROBE_ROTATED' restored='$FP_PROBE_RESTORED')"
+
+[ "$FP_PROBE_BEFORE" = "$FP_BEFORE" ] \
+  || die "the plugin reported $FP_PROBE_BEFORE as its stored certificate while the file on disk holds $FP_BEFORE, so the two are not describing the same configuration"
+pass "the plugin's view of its stored certificate matches the file on disk ($FP_BEFORE)"
+
+[ "$FP_PROBE_ROTATED" != "$FP_BEFORE" ] \
+  || die "the stored certificate did not change across the rotation, so the re-import was skipped and the phase proved nothing"
+pass "the stored certificate became $FP_PROBE_ROTATED across the rotation"
+
+[ "$FP_PROBE_RESTORED" = "$FP_BEFORE" ] \
+  || die "the plugin was left holding $FP_PROBE_RESTORED rather than the original $FP_BEFORE"
+
+log "The stack is as it was found"
+CERT_AFTER="$(stored_cert_b64)"
+[ -n "$CERT_AFTER" ] || die "the persisted configuration holds no SamlCertificate after the phase"
+FP_AFTER="$(fingerprint_of "$CERT_AFTER")"
+[ "$FP_AFTER" = "$FP_BEFORE" ] \
+  || die "the certificate on disk after the phase is $FP_AFTER, not the $FP_BEFORE it started with"
+pass "the persisted certificate is the one the phase found, and the rotated-in key provider was removed"
+
+printf '\nSAML SIGNING-CERT ROLLOVER PHASE PASSED\n'


### PR DESCRIPTION
# What & why

Closes #1128.

Rotating the identity provider's SAML signing key mid-run, re-importing the descriptor into the plugin, and then logging in again is the one thing nothing in this repository has ever driven end to end. The wrong-certificate rejection is unit covered (`SamlPost_SignedByAnotherCertificate_Returns400`) and a live rotation was demonstrated by hand once in the #717 pass, so a regression to accepting a retired certificate would ship with nothing red.

This adds `test/e2e/phases/saml-cert-rollover.sh` and its in-container probe, and answers all three clauses of the issue in ONE run:

- an assertion signed by the rotated-in key is accepted and mints a Jellyfin session that works against `/Users/Me`;
- an assertion signed by the retired key is refused, status-pinned to 400 with the uniform SAML rejection body and no login-outcome token;
- the plugin's stored `SamlCertificate` observably changes across the rotation, read both from `SAML/Test` and from the persisted `SSO-Auth.xml` on the bind mount.

## The old-certificate assertion is a fresh one, not a replay

The issue asks for a replay of the pre-rotation assertion. A replay is refused by the one-time cache whatever certificate the plugin holds, and both refusals carry the same body (`PublicReason.SamlResponseInvalid` maps to one 400 for malformed, invalid, unsolicited and replayed alike), so a replayed assertion would have come back 400 with the certificate check never reached. Every assertion here comes from its own `/start` and is presented exactly once, so the only thing wrong with the refused one is the key that signed it.

## The falsifier

A refusal sitting between two successes could be the clock rather than the certificate: assertions carry a `NotOnOrAfter` and rotating takes time. So a second pre-rotation assertion is captured in the same breath as the first, held through the whole rotation, and presented after the original certificate has been imported back. It is strictly older at that moment than the refused one was at its refusal, and it is accepted. If age explained the refusal, it would be refused too.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

Test harness and CI only. No file under `SSO-Auth/` is touched.

## Security checklist

Fill in for any change touching the login path, crypto (SAML/OIDC), config
persistence, or the release pipeline.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The two unticked boxes are unticked because no lens was run and no second reader looked at this. The change adds no product code: `git diff --name-only origin/main...HEAD` returns one workflow file, one README and two shell scripts, none of them shipped in the plugin. The three ticked boxes are statements about product behaviour this change observes rather than alters, and the evidence for the first of them is the run below: the phase requires the retired certificate to be refused, and it is.

The rotation is performed as `realmadmin`, a new user of the e2e realm seeded with the realm-management `realm-admin` role, in the same shape and with the same password-equals-username convention as the four test users already in that file. It is a throwaway realm on a throwaway stack; no credential of any consequence is introduced. Nothing is printed either: the transcript carries certificate thumbprints, HTTP statuses, a key inventory by algorithm and status, and assertion ages, never an assertion, a token or a key.

It is a realm-scoped admin rather than the server's bootstrap administrator because the master realm is unreachable from this network, which the run below measured rather than assumed: the master realm keeps Keycloak's default `sslRequired: external` and answers 403 to every plaintext request from an address Keycloak does not treat as private, and this compose network sits on `11.0.0.0/24` precisely because the plugin's SSRF guard has to treat it as public. The e2e realm sets `sslRequired: none`, which is what lets the rest of this harness run over http at all.

    probe| PROBE-ERROR the identity provider's master realm did not answer within 180s:
    probe|   curl: (22) The requested URL returned error: 403

    https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/32549820630

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The browser-leg helpers are deliberately a second copy of the shape `harness.sh` uses rather than a shared file: the harness mounts only `/harness` and this probe mounts only `/probe`, so a shared file would need a third mount kept in step with the compose file, and the probe needs to HOLD an assertion where the harness posts it immediately. The documentation half is in this change, as a new section of `test/e2e/README.md`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

The first two are this pull request's own `build` and test jobs rather than a local run: no C# changed, so a local gate would have re-measured `origin/main`. Prettier was run over the changed README locally and reports `All matched files use Prettier code style!`.

## The run

Executed on the branch with `providers: all`, which is the gate the step carries, so this is the phase running rather than the phase being read. Keycloak entry green, and the six other provider entries green beside it:

https://github.com/Flowfin/jellyfin-plugin-sso/actions/runs/32550178592

```
== Preconditions ==
PASS: the persisted configuration holds a SAML certificate with thumbprint A86CBC92F65AD16EB779E16889DBC2F3BBC7C49D5CB66E544B3BA18335DE7ACC
== Rotating the identity provider's SAML signing key ==
  probe| PROBE-STAGE identity-provider admin token acquired after 0 retries (HTTP 200)
  probe| PROBE-STAGE signing keys before the rotation: RS256/ACTIVE/priority=100 HS512/ACTIVE/priority=100
  probe| PROBE-PASS the plugin stores the identity provider's current signing certificate (A86CBC9...)
  probe| PROBE-STAGE control: ACS answered 200 after 0s, login-outcome token: yes
  probe| PROBE-PASS the control assertion was accepted and minted a login-outcome token (HTTP 200)
  probe| PROBE-STAGE stale: assertion captured (8485 base64 chars), held unposted
  probe| PROBE-STAGE falsifier: assertion captured (8485 base64 chars), held unposted
  probe| PROBE-PASS the identity provider now signs with the rotated-in key (9D881B6...)
  probe| PROBE-PASS the plugin's stored certificate changed across the rotation, from A86CBC9... to 9D881B6...
  probe| PROBE-STAGE stale: ACS answered 400 after 0s, login-outcome token: no
  probe| PROBE-PASS the assertion signed by the retired key was refused with HTTP 400 at 0s old
  probe| PROBE-PASS the refusal carries the uniform SAML rejection body rather than a server error
  probe| PROBE-PASS the refused assertion handed out no login-outcome token
  probe| PROBE-STAGE fresh: ACS answered 200 after 0s, login-outcome token: yes
  probe| PROBE-STAGE fresh: minted a session usable as 'carol'
  probe| PROBE-PASS the rotated-in key mints a usable Jellyfin session
  probe| PROBE-CERT-RESTORED A86CBC92F65AD16EB779E16889DBC2F3BBC7C49D5CB66E544B3BA18335DE7ACC
  probe| PROBE-STAGE falsifier: ACS answered 200 after 1s, login-outcome token: yes
  probe| PROBE-PASS the same-vintage assertion was accepted at 1s old, older than the refused one was at 0s
  probe| PROBE-DONE
  probe| PROBE-STAGE cleanup: removed the rotated-in key provider (HTTP 204)
== Reading the probe's verdict ==
PASS: every assertion the probe made was met, and it ran to completion
== The stored certificate changed across the rotation ==
PASS: the plugin's view of its stored certificate matches the file on disk (A86CBC9...)
PASS: the stored certificate became 9D881B6... across the rotation
== The stack is as it was found ==
PASS: the persisted certificate is the one the phase found, and the rotated-in key provider was removed
```

**Read the two ages honestly.** The whole sequence ran inside about two seconds, so the falsifier is older than the refused assertion by one second rather than by a comfortable margin. What rules the clock out on this run is therefore not that margin but the scale: both assertions were seconds old against an acceptance window of Keycloak's assertion lifespan plus the five minutes of skew `SamlAssertionTime.ClockSkew` allows, so expiry was never in the running. The falsifier still discharges the hypothesis in the direction it was built for, and it is the leg that would catch a future rotation slow enough for the question to become real.

## Notes

The step runs on a release, a beta release, or a `providers: all` dispatch, on the canonical Keycloak entry only, which is the gate its two neighbouring phases carry. It is the only entry in the matrix whose identity provider exposes an admin API a signing key can be rotated through, and it is placed LAST of the three because it is the only phase that writes to the identity provider rather than to Jellyfin.

It is invoked through `bash`, not by bare path: every tracked shell script here is mode 644, which is what #1391 measured when the neighbouring phase answered exit 126 on its first real run.

The rotation adds an `rsa-generated` key provider at a higher priority rather than disabling the old one. Disabling would also take the retired key out of the JWKS the OpenID half of this stack reads, which is a second change this phase is not about. The added component is deleted and the original certificate imported back on every exit path, and the certificate on disk after the phase is asserted to be the one it started with.
