### PR TITLE
Serve the OIDC redirect URI instead of recomputing it in the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,21 @@ suffix on the git tag and GitHub release name only (`-stable`, `-beta.<run>`,
 
 ### Changed
 
+- **The redirect URI on the settings page now comes from the server (#1303).**
+  The page used to work the value out for itself, in the browser, from the base
+  URL override and a fixed path. That made two things compose a string an
+  identity provider compares letter for letter, and when the two disagreed the
+  login did not fail on this server: it failed at the provider, with a
+  `redirect_uri` mismatch that looks like a plugin fault and that nobody here
+  ever sees. The field now shows what the server answers, so what is registered
+  at the provider and what the login sends are the same string with one author.
+  There is no local fallback, which has one visible cost: the field is filled in
+  for a provider that has been saved, and a provider still being typed shows
+  "Save this provider to see its exact redirect URI" instead of a preview. One
+  case is not covered and the field's help text names it: both sign-in routes
+  stay live, and users who still start at the older `/sso/OID/p/<name>` address
+  send the older `/sso/OID/r/<name>` form, which has to be registered as well.
+
 - **A role claim the plugin could not read now says so in the log (#1149).** A
   mistyped role-claim path and a provider that genuinely sends no roles used to
   look identical from outside: both ended with an empty role set and no entry,

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.LoginPath.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.LoginPath.cs
@@ -114,17 +114,20 @@ public partial class ArchitectureConformanceTests
     }
 
     [Fact]
-    public void OidcRedirectUriField_IsReadOnlyAndUnmarked_AndDerivesFromTheSameBaseTheLoginUses()
+    public void OidcRedirectUriField_IsReadOnly_AndIsFilledFromTheServerRatherThanComposedInThePage()
     {
-        // #724: the config page shows the exact redirect_uri the login uses so an admin registers it verbatim
-        // (a mismatch is the most common OIDC setup failure). Structural properties a JS runtime test cannot
-        // pin (no JS harness exists), locked as a source scan:
+        // #724 put the exact redirect_uri on the config page so an admin registers it verbatim (a mismatch is
+        // the most common OIDC setup failure). #1303 moved WHO computes it. The page used to compose the
+        // canonical base and the path spelling itself, which made it a second producer of bytes an identity
+        // provider compares literally - and a divergence between the two producers never fails here, it fails
+        // at the identity provider. Structural properties a JS runtime test cannot pin (no JS harness exists),
+        // locked as a source scan:
         //  - the field is READ-ONLY and carries NO sso-* marker class, so it never becomes a persisting field
         //    (it is not an OidConfig property; ProviderFormFieldIds_MatchOidConfigProperties stays green);
         //  - its value is set via .value, never innerHTML (#221);
-        //  - it derives from the Base URL Override (the same canonical base the server's OidcRedirectUriBuilder
-        //    uses) plus the fixed /sso/OID/redirect/ path - deriving from anything else would display a URI the
-        //    login does not actually send;
+        //  - the page FETCHES the value from the elevation-gated endpoint and composes no OIDC redirect path
+        //    of its own, not even as a fallback - a fallback runs exactly when nobody is watching, so the
+        //    second producer would come back at the worst moment;
         //  - the copy confirmation is announced through an aria-live region (not colour-only).
         var html = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Web", "configPage.html"));
         var js = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Web", "config.js"));
@@ -137,17 +140,15 @@ public partial class ArchitectureConformanceTests
         // The copy confirmation is a live region, not a colour-only signal.
         Assert.Matches(new Regex("id=\"OidRedirectUri-copied\"[^>]*aria-live", RegexOptions.Singleline), html);
 
-        // config.js derives from the base-URL override + the fixed server path, and writes via .value.
-        Assert.Contains("/sso/OID/redirect/", js, StringComparison.Ordinal);
-        Assert.Matches(new Regex("computeRedirectUri[\\s\\S]{0,500}BaseUrlOverride", RegexOptions.Singleline), js);
-        // It normalizes the base through the URL parser so the shown value matches the server's System.Uri
-        // canonicalization (lowercased scheme/host, default port elided) - deriving from the raw override
-        // string would display a URI the login does not send (a redirect_uri mismatch). Pinned on the exact
-        // origin+pathname derivation, which is unique to computeRedirectUri.
-        Assert.Contains("new URL(raw)", js, StringComparison.Ordinal);
-        Assert.Matches(new Regex("\\.origin\\s*\\+\\s*[A-Za-z_$][\\w$]*\\.pathname", RegexOptions.Singleline), js);
-        Assert.Matches(new Regex("#OidRedirectUri\"\\)[\\s\\S]{0,200}\\.value\\s*=", RegexOptions.Singleline), js);
+        // The page asks the server for the value and writes the answer via .value.
+        Assert.Contains("sso/OID/RedirectUri/", js, StringComparison.Ordinal);
+        Assert.Matches(new Regex("#OidRedirectUri\"\\)[\\s\\S]{0,900}\\.value\\s*=", RegexOptions.Singleline), js);
         Assert.DoesNotMatch(new Regex("OidRedirectUri[\\s\\S]{0,200}innerHTML", RegexOptions.Singleline), js);
+
+        // And composes no OIDC redirect path itself. Both live spellings are refused: either one reappearing
+        // in this file is the duplication #1303 removed, whichever variable it is concatenated onto.
+        Assert.DoesNotContain("/sso/OID/redirect/", js, StringComparison.Ordinal);
+        Assert.DoesNotContain("/sso/OID/r/", js, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Oidc.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Oidc.cs
@@ -138,21 +138,13 @@ public partial class ArchitectureConformanceTests
         Assert.Equal("options.RedirectUri = redirectUri;", assignment.Text);
     }
 
-    [Fact]
-    public void TheAdminPagesRedirectUriPreview_StillMirrorsTheServersPath()
-    {
-        // The admin config page computes the same string in JavaScript so an administrator can register it
-        // verbatim at the identity provider (#724). It is a second producer of these bytes in a language no
-        // C# rule reaches, and it hard-codes the new-path spelling. Nothing made the two move together, so a
-        // server-side path change would leave the page telling admins to register a URL the login never
-        // sends, and the failure appears at the identity provider rather than in this suite. Pinned here
-        // rather than deduplicated: the duplication itself is #1303.
-        var preview = File.ReadAllText(Path.Combine(RepoTree.Root, "SSO-Auth", "Web", "config.js"));
-        Assert.Contains(
-            $"return base + \"{OidcCallbackPathFragment}redirect/\" + providerName;",
-            preview,
-            StringComparison.Ordinal);
-    }
+    // The rule that stood here pinned the admin page's own JavaScript composition of the redirect_uri
+    // against the server's path fragment. #1303 removed the composition rather than keeping the two copies
+    // aligned, so this rule has no subject left: the page fetches the value from OID/RedirectUri and the
+    // server is the only producer of these bytes. What replaced it is
+    // OidcRedirectUriField_IsReadOnly_AndIsFilledFromTheServerRatherThanComposedInThePage in the LoginPath
+    // partial, which refuses a composition coming BACK into config.js, and the call-site walk above, which
+    // now covers the display path because it reaches the same builder over the same canonical base.
 
     [Fact]
     public void TheProvisionedUsernameAllowlist_StillMirrorsTheRecordedHostRule()

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -68,6 +68,11 @@ public partial class ArchitectureConformanceTests
         "OID/Add/{provider}", "SAML/Add/{provider}", "OID/Del/{provider}", "SAML/Del/{provider}", // elevated config CRUD
         "OID/Get", "SAML/Get", "OID/GetNames", "SAML/GetNames", "OID/States", // read-only listings
         "SAML/Test/{provider}", // LOCAL certificate parse - no outbound fetch (unlike OID/Test)
+        // Elevated read of a stored provider's redirect_uri for the admin page (#1303): pure string
+        // composition over the config already in memory, no outbound fetch and no write. Its 404 answers
+        // whether a PROVIDER exists, which the elevation-gated OID/Get already lists in full, so it is
+        // not the per-user-id enumeration surface that made the two Links routes throttled neighbours.
+        "OID/RedirectUri/{provider}",
         "Config/Export", "Config/Import", // elevated config transfer
         "SSO-Only/Status", "SSO-Only/Enable", "SSO-Only/Disable", "SSO-Only/BreakGlassAdmin", // elevated mode control
         "Config/Links/Export", // elevated read-only link snapshot (#1126), in-memory, no outbound fetch
@@ -197,6 +202,7 @@ public partial class ArchitectureConformanceTests
         "OID/logout/{provider}", "SAML/logout/{provider}", "SAML/Logout/{provider}", "OID/backchannel-logout/{provider}", // logout: resolves a stored provider
         "OID/Del/{provider}", "SAML/Del/{provider}", // removal: an already-stored name, or a no-op
         "OID/Test/{provider}", "SAML/Test/{provider}", // admin probe of a STORED provider, 404 on a miss
+        "OID/RedirectUri/{provider}", // admin read of a STORED provider's redirect_uri, 404 on a miss (#1303)
         "SAML/metadata/{provider}", // SP metadata built for a stored provider
         "{mode}/Link/{provider}/{jellyfinUserId}", "{mode}/Link/{provider}/{jellyfinUserId}/{canonicalName}", // link write against a stored, enabled provider
         "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}", // pre-provision write against a stored, enabled provider (#1133)

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -39,6 +39,9 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
     private static readonly string[] ExpectedElevationActions =
     {
         "OidAdd", "OidDel", "OidProviders", "OidTest", "OidStates",
+        // The redirect_uri the admin page displays (#1303): read-only, and elevation-gated because it
+        // answers with a provider's configured base-URL override and only an administrator has a use for it.
+        "OidRedirectUri",
         "SamlAdd", "SamlDel", "SamlProviders", "SamlTest", "SamlImportMetadata",
         "ExportConfig", "ImportConfig", "Unregister", "ExportLinks", "ExportUserLinks",
         // The SSO-only login admin surface (#165): the mode toggle, the break-glass designation, and status.

--- a/SSO-Auth.Tests/Http/SSOControllerOidRedirectUriTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerOidRedirectUriTests.cs
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Http;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Common.Api;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// In-process tests of the admin redirect-URI endpoint (#1303), the one producer of the bytes an
+/// administrator registers at an identity provider. The admin config page used to compose those bytes in
+/// JavaScript, so the page and the login were two producers of a string RFC 6749 section 4.1.3 compares
+/// literally - and the two disagreeing does not fail here, it fails at the identity provider. These pin
+/// that the endpoint answers with the same canonical base the challenge uses (base-URL override,
+/// scheme/port overrides included), that it invents nothing for a provider the server does not hold, and
+/// that its answer equals the redirect_uri an actual authorization request carries.
+/// </summary>
+[Collection("SSOController")]
+public class SSOControllerOidRedirectUriTests
+{
+    [Fact]
+    public void OidRedirectUri_IsGuardedByTheElevationPolicy()
+    {
+        // The value is not a secret, but it reports a provider's configured base-URL override, so it is
+        // administrator-only like every other per-provider admin read. Pinned structurally because the
+        // harness calls the action directly and never runs MVC's authorization filter.
+        var authorize = typeof(SSOController).GetMethod(nameof(SSOController.OidRedirectUri))!
+            .GetCustomAttribute<AuthorizeAttribute>();
+
+        Assert.NotNull(authorize);
+        Assert.Equal(Policies.RequiresElevation, authorize!.Policy);
+    }
+
+    [Fact]
+    public void OidRedirectUri_UnknownProvider_ReturnsNotFound()
+    {
+        // No value is invented for a provider the server holds nothing about. The page turns this into
+        // "save the provider first" rather than displaying a string nothing would ever send.
+        var harness = new SsoControllerHarness();
+
+        Assert.IsType<NotFoundObjectResult>(harness.Controller.OidRedirectUri("does-not-exist"));
+    }
+
+    [Fact]
+    public void OidRedirectUri_UsesTheRequestHostWhenNoOverrideIsConfigured()
+    {
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true });
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc"));
+
+        Assert.Equal("https://jf.example.com/sso/OID/redirect/kc", ok.Value);
+    }
+
+    [Fact]
+    public void OidRedirectUri_HonoursTheConfiguredBaseUrlOverride()
+    {
+        // The override is the reverse-proxy case, and it is the reason the page could not be trusted to
+        // compute this: System.Uri canonicalizes it here (scheme and host lowercased, the default port
+        // elided, the trailing slash trimmed), and a browser-side re-derivation of those rules is a second
+        // definition of them that only has to disagree once.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            BaseUrlOverride = "HTTPS://Jellyfin.EXAMPLE.com:443/media/",
+        });
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc"));
+
+        Assert.Equal("https://jellyfin.example.com/media/sso/OID/redirect/kc", ok.Value);
+    }
+
+    [Fact]
+    public void OidRedirectUri_HonoursTheSchemeAndPortOverrides()
+    {
+        // The TLS-terminating-proxy shape: an http request on port 8096 answered as the https URL on the
+        // default port that the login actually builds.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig
+        {
+            Enabled = true,
+            SchemeOverride = "https",
+            PortOverride = 443,
+        });
+        harness.Controller.ControllerContext.HttpContext.Request.Scheme = "http";
+        harness.Controller.ControllerContext.HttpContext.Request.Host = new HostString("jf.example.com", 8096);
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc"));
+
+        Assert.Equal("https://jf.example.com/sso/OID/redirect/kc", ok.Value);
+    }
+
+    [Fact]
+    public void OidRedirectUri_DoesNotFollowTheStoredNewPathSpelling()
+    {
+        // NewPath is server-managed runtime state recording the spelling the LAST non-linking login arrived
+        // on, and it defaults to the legacy one. Reading it here would show a provider nobody has logged in
+        // with yet the "/r/" route its first login does not use, because every sign-in entry point the
+        // plugin renders is the "/start/" route. The display is therefore fixed on the new-path spelling,
+        // and this pins that a stored legacy value does not move it.
+        var harness = new SsoControllerHarness(c => c.OidConfigs["kc"] = new OidConfig { Enabled = true, NewPath = false });
+
+        var ok = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc"));
+
+        Assert.Equal("https://jf.example.com/sso/OID/redirect/kc", ok.Value);
+    }
+
+    [Fact]
+    public async Task OidRedirectUri_EqualsTheRedirectUriAnAuthorizationRequestCarries()
+    {
+        // The claim the endpoint exists for, measured against a real authorization request rather than
+        // against a second expectation written in this file: drive the challenge on the route the plugin's
+        // own sign-in button links, read redirect_uri back out of the authorize URL the browser is sent to,
+        // and require the endpoint's answer to equal it byte for byte.
+        const string Authority = "https://idp-redirect-uri.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = Authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+                BaseUrlOverride = "https://jellyfin.example.com/media",
+            },
+            httpResponder: Responder);
+        harness.Controller.ControllerContext.HttpContext.Request.Path = "/sso/OID/start/kc";
+
+        var redirect = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+        var sent = RedirectUriOf(redirect.Url);
+        var shown = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc")).Value;
+
+        Assert.Equal("https://jellyfin.example.com/media/sso/OID/redirect/kc", sent);
+        Assert.Equal(sent, shown);
+    }
+
+    [Fact]
+    public async Task OidRedirectUri_DoesNotCoverALoginStartedOnTheLegacyRoute()
+    {
+        // The residual, stated as a test rather than left for somebody to discover at an identity provider.
+        // Both start routes stay live, and a login that begins at the legacy "/p/" one sends the legacy
+        // "/r/" spelling. The endpoint answers for the route the plugin renders, so for that deployment the
+        // shown value is not the sent one, and the field's help text says so and names the other spelling.
+        const string Authority = "https://idp-legacy-route.example.com";
+        var harness = new SsoControllerHarness(
+            c => c.OidConfigs["kc"] = new OidConfig
+            {
+                Enabled = true,
+                OidEndpoint = Authority,
+                OidClientId = "jf",
+                OidScopes = Array.Empty<string>(),
+                DisablePushedAuthorization = true,
+            },
+            httpResponder: Responder);
+        harness.Controller.ControllerContext.HttpContext.Request.Path = "/sso/OID/p/kc";
+
+        var redirect = Assert.IsType<RedirectResult>(await harness.Controller.OidChallenge("kc"));
+        var sent = RedirectUriOf(redirect.Url);
+        var shown = Assert.IsType<OkObjectResult>(harness.Controller.OidRedirectUri("kc")).Value;
+
+        Assert.Equal("https://jf.example.com/sso/OID/r/kc", sent);
+        Assert.Equal("https://jf.example.com/sso/OID/redirect/kc", shown);
+        Assert.NotEqual(sent, shown);
+    }
+
+    // Reads redirect_uri back out of the authorize URL the challenge redirects the browser to, so the
+    // comparison is against the bytes that leave this server rather than against a rebuilt expectation.
+    private static string RedirectUriOf(string authorizeUrl)
+    {
+        foreach (var pair in new Uri(authorizeUrl).Query.TrimStart('?').Split('&'))
+        {
+            var parts = pair.Split('=', 2);
+            if (parts.Length == 2 && string.Equals(parts[0], "redirect_uri", StringComparison.Ordinal))
+            {
+                return Uri.UnescapeDataString(parts[1]);
+            }
+        }
+
+        throw new InvalidOperationException("The authorization request carries no redirect_uri: " + authorizeUrl);
+    }
+
+    // Serves only the discovery document and its JWKS; any other URL fails the request, so a regression
+    // that reaches the token endpoint during a challenge is caught rather than silently answered.
+    private static HttpResponseMessage Responder(HttpRequestMessage request)
+    {
+        var url = request.RequestUri!.AbsoluteUri;
+        var authority = url.Substring(0, url.IndexOf('/', "https://".Length));
+
+        if (url == authority + "/.well-known/openid-configuration")
+        {
+            return Json(Discovery(authority));
+        }
+
+        return url == authority + "/jwks"
+            ? Json("{\"keys\":[]}")
+            : new HttpResponseMessage(HttpStatusCode.NotFound);
+    }
+
+    private static string Discovery(string authority) =>
+        $"{{\"issuer\":\"{authority}\","
+        + $"\"authorization_endpoint\":\"{authority}/authorize\","
+        + $"\"token_endpoint\":\"{authority}/token\","
+        + $"\"jwks_uri\":\"{authority}/jwks\","
+        + $"\"userinfo_endpoint\":\"{authority}/userinfo\","
+        + "\"response_types_supported\":[\"code\"],"
+        + "\"subject_types_supported\":[\"public\"],"
+        + "\"id_token_signing_alg_values_supported\":[\"RS256\"],"
+        + "\"grant_types_supported\":[\"authorization_code\"],"
+        + "\"code_challenge_methods_supported\":[\"S256\"]}";
+
+    private static HttpResponseMessage Json(string body) =>
+        new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+}

--- a/SSO-Auth/Api/Flows/OidcLoginService.cs
+++ b/SSO-Auth/Api/Flows/OidcLoginService.cs
@@ -835,6 +835,33 @@ internal sealed class OidcLoginService
         return new OidcClient(options);
     }
 
+    /// <summary>
+    /// Composes the challenge <c>redirect_uri</c> for a stored provider so the admin page can DISPLAY the
+    /// bytes the login sends instead of computing a second copy of them in the browser (#1303). It runs the
+    /// same <see cref="OidcRedirectUriBuilder"/> over the same canonical base the challenge runs, so the
+    /// value an administrator registers at the identity provider and the value the authorization request
+    /// carries have one producer and cannot drift apart. Read-only: it touches no state and starts no flow.
+    /// </summary>
+    /// <param name="provider">The stored provider name, appended raw exactly as the login appends it.</param>
+    /// <param name="request">The admin request whose scheme/host/path-base the canonical base falls back to.</param>
+    /// <returns>The redirect_uri, or <see langword="null"/> when no such provider is configured.</returns>
+    public string? ChallengeRedirectUriDisplay(string provider, HttpRequest request)
+    {
+        var config = FindOidConfig(provider);
+        if (config is null)
+        {
+            return null;
+        }
+
+        // The new-path spelling, fixed rather than read from config.NewPath. That field is the LAST OBSERVED
+        // spelling and defaults to the legacy one, so a provider nobody has logged in with yet would be shown
+        // a route its first login does not use - the very failure this display exists to prevent. Every
+        // sign-in entry point the plugin renders is the "/start/" route (LoginButton), which produces this
+        // spelling. The legacy "/p/" start route stays live and sends the "/r/" form; a deployment whose
+        // users still arrive on it registers that form instead, and this display does not cover that case.
+        return OidcRedirectUriBuilder.ChallengeRedirectUri(RequestBaseUrl(request, config), true, provider);
+    }
+
     // Resolves the canonical base URL from the live request and the provider's overrides - the same pure
     // CanonicalBaseUrl.Resolve decision (#242) SamlLoginService.GetRequestBase feeds for SAML. Kept as a
     // thin local read so this flow tier is self-contained.

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -834,6 +834,33 @@ public class SSOController : ControllerBase
     }
 
     /// <summary>
+    /// Returns the exact OpenID <c>redirect_uri</c> a stored provider's login sends, so the admin config page
+    /// can show it for verbatim registration at the identity provider instead of composing a second copy of
+    /// it in JavaScript (#1303). The flow service composes it, over the same builder and the same canonical
+    /// base the challenge uses, so there is one producer of these bytes.
+    /// </summary>
+    /// <remarks>
+    /// Elevation-gated like the other admin endpoints: the value is not a secret, but it reveals a
+    /// provider's configured base-URL override, and only an administrator has any use for it. Read-only -
+    /// it starts no flow, writes nothing, and makes no outbound request, so it takes no rate-limit class.
+    /// An unknown provider is the same 404 the other per-provider admin reads return; the page turns that
+    /// into "save the provider first" rather than showing a value for a provider that does not exist.
+    /// </remarks>
+    /// <param name="provider">The stored OpenID provider whose redirect_uri to compose.</param>
+    /// <returns>The redirect_uri, or 404 when the provider is not configured.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpGet("OID/RedirectUri/{provider}")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public ActionResult OidRedirectUri(string provider)
+    {
+        var redirectUri = _oidc.ChallengeRedirectUriDisplay(provider, Request);
+
+        return redirectUri is null
+            ? NotFound(NoMatchingProviderMessage)
+            : Ok(redirectUri);
+    }
+
+    /// <summary>
     /// This is a debug endpoint to list all running OpenID flows. Requires administrator privileges.
     /// </summary>
     /// <returns>The list of OpenID flows in progress.</returns>

--- a/SSO-Auth/Web/config.js
+++ b/SSO-Auth/Web/config.js
@@ -903,49 +903,70 @@ const ssoConfigurationPage = {
       },
     );
   },
-  // Computes the exact redirect_uri the login uses, so the admin can register it verbatim at the IdP (#724).
-  // Mirrors the server-side build (OidcRedirectUriBuilder): the canonical base (the Base URL Override when
-  // set, else this server's address) plus the fixed /sso/OID/redirect/<provider> path. The provider name is
-  // appended raw (names are validated to exclude URI-reserved characters, #336), matching the server, which
-  // appends the route-decoded name without re-encoding so the string equals the login's byte-for-byte.
-  computeRedirectUri: (page, providerName) => {
-    const override = page.querySelector("#BaseUrlOverride").value.trim();
-    const raw = override || ApiClient.serverAddress() || "";
-    let base;
-    try {
-      // Mirror the server's CanonicalBaseUrl (System.Uri.GetLeftPart(UriPartial.Path)) so the shown value
-      // equals what the login sends: `origin` lowercases scheme + host AND elides the default port
-      // (443/80), exactly as System.Uri does, while pathname keeps any sub-path; query/fragment are
-      // dropped and the trailing slash trimmed. A raw string strip alone would show a non-canonical override
-      // (e.g. `https://X.COM:443`) that the login then normalizes away, causing a redirect_uri mismatch.
-      const u = new URL(raw);
-      base = u.origin + u.pathname.replace(/\/+$/, "");
-    } catch (e) {
-      // Not a parseable absolute URL yet (admin mid-typing, or a bare host): best-effort fall back to the
-      // raw value with only trailing slashes stripped so the field still shows something.
-      base = raw.replace(/\/+$/, "");
-    }
-    return base + "/sso/OID/redirect/" + providerName;
-  },
-  // Live-updates the read-only redirect-URI field; empty (placeholder) until a provider name is entered. Sets
-  // .value only (never innerHTML, #221). Called on name/override input, on load, on reset, and at init.
+  // Serial of the most recent redirect-URI request. A reply for an older provider name must never land in
+  // the field after a newer one has already answered it, which per-keystroke requests otherwise allow.
+  redirectUriSerial: 0,
+  // Debounce handle for the same request: the field follows the provider-name and base-URL-override inputs,
+  // and each update is now a round trip rather than a local computation.
+  redirectUriTimer: null,
+  // Live-updates the read-only redirect-URI field from the SERVER, the one producer of these bytes (#1303).
+  // The page used to compose the value itself - the canonical base and the path spelling both - so what an
+  // administrator registered at the identity provider was a second computation of what the login sends. A
+  // divergence between the two does not fail here. It fails at the identity provider, as a redirect_uri
+  // mismatch that reads as a plugin bug, and nothing in this repository ever learns about it. There is
+  // deliberately NO local fallback: one would restore that second producer at the moment it is least likely
+  // to be noticed. Sets .value only (never innerHTML, #221). Called on name/override input, on load, on
+  // reset, and at init.
   updateRedirectUri: (page) => {
     const field = page.querySelector("#OidRedirectUri");
     if (!field) {
       return;
     }
-    const name = page.querySelector("#OidProviderName").value.trim();
-    field.value = name
-      ? ssoConfigurationPage.computeRedirectUri(page, name)
-      : "";
-    field.placeholder = name
-      ? ""
-      : "Enter a provider name above to see the redirect URI";
+
     // A name/override change invalidates any previous "copied" confirmation.
     const status = page.querySelector("#OidRedirectUri-copied");
     if (status) {
       status.textContent = "";
     }
+
+    const name = page.querySelector("#OidProviderName").value.trim();
+    const serial = (ssoConfigurationPage.redirectUriSerial += 1);
+    field.value = "";
+
+    if (ssoConfigurationPage.redirectUriTimer) {
+      clearTimeout(ssoConfigurationPage.redirectUriTimer);
+      ssoConfigurationPage.redirectUriTimer = null;
+    }
+
+    if (!name) {
+      field.placeholder = "Enter a provider name above to see the redirect URI";
+      return;
+    }
+
+    field.placeholder = "Loading the redirect URI…";
+    ssoConfigurationPage.redirectUriTimer = setTimeout(() => {
+      ApiClient.getJSON(
+        ApiClient.getUrl("sso/OID/RedirectUri/" + encodeURIComponent(name)),
+      ).then(
+        (value) => {
+          if (serial !== ssoConfigurationPage.redirectUriSerial) {
+            return;
+          }
+          field.value = typeof value === "string" ? value : "";
+          field.placeholder = "";
+        },
+        // A rejection is a 404 for a provider that has not been saved yet, or a transport/authorization
+        // failure. Say what to do; never show a value the server did not produce.
+        () => {
+          if (serial !== ssoConfigurationPage.redirectUriSerial) {
+            return;
+          }
+          field.value = "";
+          field.placeholder =
+            "Save this provider to see its exact redirect URI";
+        },
+      );
+    }, 250);
   },
   copyRedirectUri: (page) => {
     const field = page.querySelector("#OidRedirectUri");

--- a/SSO-Auth/Web/configPage.html
+++ b/SSO-Auth/Web/configPage.html
@@ -571,13 +571,14 @@
                   </div>
 
                   <!--
-                    Read-only computed redirect URI (#724): shows the exact redirect_uri the login uses, so an
-                    admin can register it verbatim at the identity provider (a wrong value is the most common
-                    OIDC setup failure). NO sso-* marker class and read-only, so it is not a persisting field
+                    Read-only redirect URI (#724): shows the exact redirect_uri the login uses, so an admin can
+                    register it verbatim at the identity provider (a wrong value is the most common OIDC setup
+                    failure). NO sso-* marker class and read-only, so it is not a persisting field
                     (listArgumentsByType must not pick it up, and it stays out of the
                     ProviderFormFieldIds_MatchOidConfigProperties contract, like OidProviderName). Its value is
-                    set via .value in config.js (never innerHTML, #221). It mirrors the server-side build:
-                    Base URL Override when set, else this server's address, + /sso/OID/redirect/<name>.
+                    set via .value in config.js (never innerHTML, #221). That value is FETCHED from
+                    sso/OID/RedirectUri/<name> rather than composed here (#1303): the server builds the bytes
+                    the login sends, so this page cannot show a second, drifting computation of them.
                   -->
                   <div class="inputContainer">
                     <label
@@ -611,13 +612,19 @@
                     ></div>
                     <div class="fieldDescription" id="OidRedirectUri-help">
                       The exact redirect URI the login uses. Register it
-                      verbatim at your identity provider. It updates as you type
-                      the provider name above. Derived from the
+                      verbatim at your identity provider. The server builds it
+                      and this field shows what the server answered, so it is
+                      the same string the login sends rather than a copy of it.
+                      Save the provider first: an unsaved one has nothing for
+                      the server to answer for. It is built from the
                       <strong>Base URL Override</strong> (in the Advanced
                       section) when set, otherwise this server's address; if you
-                      sit behind a reverse proxy, set that override so this
-                      matches what the login actually sends. The legacy spelling
-                      <code>/sso/OID/r/&lt;name&gt;</code> also works.
+                      sit behind a reverse proxy, set that override and save, so
+                      this matches what the login actually sends. Users who
+                      still start at the legacy
+                      <code>/sso/OID/p/&lt;name&gt;</code> route send the legacy
+                      <code>/sso/OID/r/&lt;name&gt;</code> spelling instead;
+                      register that one too if any of them do.
                     </div>
                   </div>
 


### PR DESCRIPTION
# What & why

The admin config page worked out the OpenID `redirect_uri` for itself, in the
browser: the canonical base, through a JavaScript re-derivation of `System.Uri`'s
rules, plus a hard-coded path spelling. That made the page a second producer of a
string RFC 6749 section 4.1.3 has the authorization server compare literally.
When two producers of that string disagree, nothing fails here. It fails at the
identity provider, as a `redirect_uri` mismatch that reads as a plugin fault, and
this repository never learns about it.

The server is now the only producer. A new elevation-gated read,
`GET sso/OID/RedirectUri/{provider}`, answers with the string the challenge
builds - the same `OidcRedirectUriBuilder` over the same `RequestBaseUrl`
canonical base - and the page shows what it answered. The client-side computation
is deleted rather than kept as a fallback, because a fallback runs exactly when
nobody is watching, which is when a second producer is least likely to be caught.

Closes #1303

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [x] Review record: per lens, its verdict and its findings, with **CONFIRMED
      0 / PLAUSIBLE 0** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**This review had no second reader.** It is the author's own reading of the diff
against the failure classes this surface has, and it is recorded as that rather
than as an independent one. The evidence it rests on is below and is
reproducible; nothing here is an assurance that somebody else looked.

- **Authorization.** The endpoint carries
  `[Authorize(Policy = Policies.RequiresElevation)]`. Held by two rules rather
  than by the attribute alone: an attribute assertion, and
  `CoversExactlyTheKnownElevationSurface`, which reads the live routing table and
  fails if the guard is ever dropped. No finding.
- **Disclosure.** The response is a URL built from the provider's base-URL
  override and scheme/port overrides plus the provider name. No secret is in it,
  and the client secret is not read on this path at all. No finding.
- **Enumeration.** A 404 answers whether a provider exists. That answer is
  already public: `OID/GetNames` is anonymous by deliberate decision (#540) and
  lists the enabled provider names. This endpoint reveals strictly less than an
  endpoint that needs no credential at all. No finding.
- **Rate limiting.** Classified exempt, with the reason recorded at the list
  entry. It makes no outbound request, writes nothing, and is pure string
  composition over configuration already in memory. It does take the
  configuration read lock - so does the anonymous `OID/GetNames`, which is also
  exempt, so this is not the weakest thing an attacker would reach for. Raised
  and declined rather than left unexamined.
- **Login path.** Untouched. Both server files are additive only, which is
  checkable: `git diff --numstat origin/main...HEAD` reports `27 0` for
  `OidcLoginService.cs` and `27 0` for `SSOController.cs`.
- **Injection into the page.** The answer is written with `.value`, never
  `innerHTML` (#221), and a rule refuses the reverse.
- **Stale-reply race.** Per-keystroke requests can resolve out of order. Each
  request carries a serial and a reply for a superseded one is dropped, so a slow
  answer for an older provider name cannot land in the field after a newer one.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The rule that pinned the page's own composition against the server's path
fragment is retired, because its subject no longer exists. Two rules stand in its
place and both were falsified before this landed.

`OidcRedirectUriField_IsReadOnly_AndIsFilledFromTheServerRatherThanComposedInThePage`
refuses a redirect-path composition coming back into `config.js`, in either live
spelling. Falsified by putting one back:

```
$ sed -i 's|field.value = typeof value === "string" ? value : "";|field.value = "https://x/sso/OID/redirect/" + name;|' SSO-Auth/Web/config.js
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*OidcRedirectUriField*"
    ...OidcRedirectUriField_IsReadOnly_AndIsFilledFromTheServerRatherThanComposedInThePage [FAIL]
   SSO-Auth.Tests  Total: 1, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0
```

`EveryOidcRedirectUriCallSite_FeedsTheOneBuilderACanonicalBase` (#1162) now
covers the display path too, because it reaches the same builder over the same
base. Falsified by taking that base away:

```
$ sed -i 's|ChallengeRedirectUri(RequestBaseUrl(request, config), true, provider)|ChallengeRedirectUri(request.Scheme + "://" + request.Host.Value, true, provider)|' SSO-Auth/Api/Flows/OidcLoginService.cs
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*EveryOidcRedirectUriCallSite*"
    Every OidcRedirectUriBuilder call must name one of its two methods and take
    RequestBaseUrl(...) as its base ...: OidcLoginService.cs:862
   SSO-Auth.Tests  Total: 1, Errors: 0, Failed: 1, Skipped: 0, Not Run: 0
```

Both files were restored afterwards; the tree that ships is the one the runs
below were made against. Two further rules refused the new route until it was
deliberately classified, once for rate limiting and once for provider-name
validation, and both answers carry their reason at the list entry.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0  --warnaserror --nologo -v q
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 warnings, 0 errors, build succeeded, for both target frameworks

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3254, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3255, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

The four skips are the pre-existing `SsoHttpTests` cases that bind a listener off
loopback. Each is skipped with its reason printed: doing so raises the Windows
firewall consent dialog, which needs an administrator (#1227). They were not run
and this does not claim they were.

Prettier: the two changed web assets and `CHANGELOG.md` pass. The check has to be
run against the bytes git stores rather than this Windows working tree, where
every tracked text file is CRLF and prettier rejects all of them, including files
this branch does not touch:

```
$ tr -d '\r' < CHANGELOG.md > /tmp/CL-lf.md && npx prettier --check /tmp/CL-lf.md
Checking formatting...
All matched files use Prettier code style!
```

## Notes

Two costs, both visible to an administrator and both written into the field's
help text and the changelog rather than left to be discovered:

- A provider that has not been saved yet shows no preview. The endpoint answers
  only for a provider the server holds, and the page says "Save this provider to
  see its exact redirect URI". This is the direct price of having no second
  producer: a preview for an unsaved provider would have to be composed from
  something the server cannot see.
- Both sign-in routes stay live. A deployment whose users still start at the
  legacy `/sso/OID/p/<name>` route sends the `/sso/OID/r/<name>` form, which this
  display does not cover.
  `OidRedirectUri_DoesNotCoverALoginStartedOnTheLegacyRoute` measures that
  difference rather than describing it, so the residual is a test rather than a
  sentence.

The display is fixed on the new-path spelling instead of following the
server-managed `NewPath` field. That field records the spelling the last
non-linking login arrived on and defaults to the legacy one, so reading it would
show a provider nobody has logged in with yet a route its first login does not
use - every sign-in entry point the plugin renders is the `/start/` route.
`OidRedirectUri_DoesNotFollowTheStoredNewPathSpelling` holds that.

The SAML side of the page still composes its ACS and metadata URLs in the browser
the same way this one used to. That is out of scope here and is not silently
covered by this change.

No README or wiki text describes how the redirect URI is produced, so nothing
there goes stale; the wording that does describe it is the field's own help text,
and it is updated in this branch.
