### PR TITLE
Publish the Roadmap and record what ecosystem outreach was decided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -469,4 +469,5 @@ AGENTS.md
 docs/*
 !docs/README.md
 !docs/SECURITY-REMEDIATION-POLICY.md
+!docs/ROADMAP.md
 StrykerOutput/

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,171 @@
+# Roadmap
+
+This page defines how the plugin's readiness is communicated and where it stands
+today. It is the single place that explains the maturity labels you see in the
+README and in the plugin's configuration page.
+
+## Where it stands
+
+**Current stage: Beta** - the third rung of the ladder.
+
+```
+○ In-Development  →  ○ Alpha  →  ● Beta  →  ○ Release Candidate  →  ○ Full Release
+                                 ▲ you are here
+```
+
+Beta means feature-complete and interface-stable: work is limited to bug fixes
+and hardening, and no new breaking change lands without a documented migration
+path. Wider testing on real but non-critical instances is encouraged; as with
+any auth change, keep a config backup.
+
+## The maturity ladder
+
+The project moves through five stages. Each has a plain definition, who it is
+for, and the explicit gates that must be met before it advances. The gates are
+deliberately conservative: this is a login path, so readiness is proven, not
+assumed.
+
+### 1. In-Development
+
+The core is being (re)built and hardened. Features are incomplete, interfaces
+and configuration can change without notice, and known security gaps are still
+being closed.
+
+- **For whom:** developers, on throwaway instances only.
+- **Gates to Alpha:**
+  - the automated test net is established and green in CI;
+  - security parity with the reference implementation is substantially reached
+    (the P2 milestone), with no known exploitable finding left open;
+  - a from-source install works end to end for both OpenID Connect and SAML.
+
+### 2. Alpha
+
+OpenID Connect and SAML sign-in work for the common providers, but the feature
+surface is not yet complete and breaking changes are still possible.
+
+- **For whom:** early adopters willing to test on non-critical instances and
+  report back; still never on production.
+- **Gates to Beta:**
+  - feature parity with the reference implementation reached (the P4 milestone);
+  - the CI and supply-chain hardening in place (the P5 / P5b milestones);
+  - user-facing documentation complete for every shipped feature;
+  - no open High or Critical security finding.
+
+### 3. Beta - _current_
+
+Feature-complete and interface-stable. Work is limited to bug fixes and
+hardening; no new breaking change lands without a documented migration path.
+
+- **For whom:** wider testing on real but non-critical instances is encouraged.
+- **Gates to Release Candidate:**
+  - a full end-to-end functional pass is green against a live Jellyfin server;
+  - the test-coverage goal is met;
+  - zero open security findings;
+  - delivery metrics are tracked (the P6 milestone);
+  - **user-facing polish** meets its definition of done - accurate catalog
+    listing, README provider matrix / comparison / visual quick-start, wiki
+    navigation, social-preview image, support on-ramps, consistent
+    status/version references - tracked item by item in
+    [#822](https://github.com/Flowfin/jellyfin-plugin-sso/issues/822).
+- **How promotion is decided:** the gates above are tracked with linked
+  evidence in the **P8 promotion epic**
+  ([#716](https://github.com/Flowfin/jellyfin-plugin-sso/issues/716)) - each gate
+  has a defined evidence artifact (a recorded live E2E run, a CI coverage report
+  meeting the numeric goal, an empty open-security list, a refreshed
+  `METRICS.md`, and the checked-off polish list in #822). The Beta→RC maturity
+  flip in the README status line and the plugin config page happens **only when
+  all boxes are checked with their evidence** - the promotion is an auditable
+  record, never a judgement call.
+
+### 4. Release Candidate
+
+_This is the deliberate name for the stage between Beta and Full Release - a
+frozen, production-ready candidate awaiting confirmation in the field, rather
+than a "release beta"._
+
+The build is frozen and treated as production-ready. Only a release-blocking
+defect can pull a change in; everything else waits for the next cycle.
+
+- **For whom:** cautious production trials on instances with a rollback plan.
+- **Gates to Full Release:**
+  - a candidate build survives a defined soak period with no release-blocking
+    defect reported.
+
+### 5. Full Release
+
+Production-ready. Safe for real Jellyfin instances with real accounts, with the
+stability and upgrade guarantees expected of a stable line.
+
+- **For whom:** everyone.
+
+## How the engineering work maps to the ladder
+
+The work that carries the plugin up the ladder is tracked as phase milestones on
+the [SSO Roadmap board](https://github.com/users/iderex/projects/1):
+
+| Phase                        | Focus                                                   | Ladder stage it unlocks  |
+| ---------------------------- | ------------------------------------------------------- | ------------------------ |
+| **P2 - Security parity**     | Port the reference implementation's hardening           | In-Development → Alpha   |
+| **P3 - Code quality**        | Thin the controller into tested, single-purpose helpers | (throughout)             |
+| **P4 - Feature parity**      | Close the remaining feature gaps                        | Alpha → Beta             |
+| **P5 - CI & supply chain**   | Reproducible builds, provenance, dependency hygiene     | Alpha → Beta             |
+| **P5b - Review-gap program** | Independent second-perspective review on every change   | Alpha → Beta             |
+| **P6 - Delivery metrics**    | Track delivery and stability                            | Beta → Release Candidate |
+
+## Principles
+
+- **Security before features.** This is a login path; the default posture is
+  fail-closed, and security work outranks feature work.
+- **Documentation describes what is implemented today**, never a planned feature.
+  If a page disagrees with the code, the code wins - please open an issue.
+- **Every change is issue-driven, reviewed, and documented** before it merges.
+
+## Distribution
+
+This is an **independent plugin repository**, installed by adding its own manifest under
+**Plugins → Repositories** (see [Installation](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Installation)). Jellyfin's built-in official
+catalog (`jellyfin/jellyfin-meta-plugins`) lists only plugins that live in the
+[`jellyfin`](https://github.com/jellyfin) GitHub org, and there is currently no official SSO
+plugin there - the LDAP plugin is the only official auth plugin. Official-catalog inclusion
+would require adoption into the `jellyfin` org through that project's governance. **Decision
+(2026-07): the project stays independent for now**, with that path understood and kept open.
+
+### Ecosystem outreach
+
+Where people looking for this plugin actually land, what was decided for each of
+those places, and what has happened so far. A surface counts as posted only when
+something was posted; a text that exists but has not been sent reads as drafted,
+because those are different states and the difference is the whole point of
+recording them.
+
+| Surface                             | Decision                                                                                               | Status                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `awesome-jellyfin` list ([#1086])   | Repoint the existing entry rather than add a second one beside it, as a pull request against that list | drafted, awaiting maintainer                                                                                        |
+| Upstream Jellyfin threads ([#1087]) | One factual note that a maintained continuation exists, and not on the open native-OIDC pull request   | drafted, awaiting maintainer                                                                                        |
+| Archived `9p4` repository ([#1088]) | Nothing is lodged there                                                                                | not actionable - the repository is archived, so it is read-only for issues, pull requests, comments and discussions |
+
+Nothing in the table has been posted. How this plugin sits beside Jellyfin's
+built-in auth, the official LDAP plugin and the archived `9p4` plugin is the
+[Comparison](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Comparison) wiki
+page, which is the positioning any of these surfaces would point at.
+
+[#1086]: https://github.com/Flowfin/jellyfin-plugin-sso/issues/1086
+[#1087]: https://github.com/Flowfin/jellyfin-plugin-sso/issues/1087
+[#1088]: https://github.com/Flowfin/jellyfin-plugin-sso/issues/1088
+
+## Upstream watch
+
+Jellyfin upstream is building **native OIDC** into the server
+([jellyfin/jellyfin#17271](https://github.com/jellyfin/jellyfin/pull/17271), landing 13.0
+at the earliest - 12.0 is in feature freeze). The plugin's documented stance -
+complementary, strictly broader (SAML, folder/Live-TV RBAC, linking, avatars, SSO-only),
+and the only option on every current release line - lives on
+[Native OIDC Coexistence](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Native-OIDC-Coexistence), together with the link-model
+migration honesty.
+
+## Following along
+
+- The [SSO Roadmap board](https://github.com/users/iderex/projects/1) is the live
+  source of truth for what is done and what is next.
+- The [Home](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Home) page lists what the plugin does today.
+- The [Security Model](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Security-Model) page explains how the login path fails closed.


### PR DESCRIPTION
# What & why

`docs/ROADMAP.md` is the page that says where the plugin stands on its own maturity ladder, and it was the one page nobody outside could read: `docs/*` is ignored with two exceptions by name, so the file appeared in no diff, no pull request and no check. This un-ignores it beside `docs/README.md` and `docs/SECURITY-REMEDIATION-POLICY.md`, and adds the ecosystem-outreach record #1089 asks for.

The new "Ecosystem outreach" subsection gives each of the three surfaces its decision and its status in the fixed vocabulary the issue asks for: `awesome-jellyfin` (#1086) and the upstream Jellyfin threads (#1087) are `drafted, awaiting my go`, and the archived `9p4` repository (#1088) is `not actionable`, with the reason. Nothing is described as posted, because nothing has been posted, and the table says so in a sentence of its own rather than leaving a reader to infer it from the status column. The `Comparison` wiki page is cross-linked as the positioning any of those surfaces would point at.

The file was not publishable as it stood, so three defects are repaired first. Eighteen em dashes are swept to the hyphen the README and the changelog already use. Two links pointed at an issue tracker under a former owner, which would have made the page's first outbound links wrong on the day it went public. Four links were wiki-relative, which resolve inside a wiki and resolve nowhere in a repository file; they are now the absolute wiki URLs the README already uses for the same pages.

The ladder diagram's glyphs and the arrows in the phase table are deliberate and are left alone. Only the dashes were in scope.

Closes #1089

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This change touches no login path, no crypto, no config persistence and no release pipeline. The only non-documentation byte is one `.gitignore` line un-ignoring an existing file.

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

**No second reader looked at this change.** There is no review record above and none was produced, so the evidence below stands in place of one.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change IS the documentation update.

## Verification

Run on the head commit of this branch:

```
$ npx prettier --check "docs/ROADMAP.md"
Checking formatting...
All matched files use Prettier code style!

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Build succeeded.
    0 Warning(s)
    0 Error(s)

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
SSO-Auth.Tests  Total: 3247, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0

$ git grep -nIP '(*UTF)[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200E}\x{200F}\x{061C}\x{200B}-\x{200D}\x{2060}]' -- . ; echo "rc=$?"
rc=1
```

The last one is the `unicode-guard` scan run locally, where `rc=1` is the clean exit. The ladder and phase-table glyphs the file keeps are ordinary printable non-ASCII and are outside that pattern.

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

## Notes

The wiki `Roadmap` stub stays a stub; this does not touch the wiki.

The three statuses were read out of the closing comments on #1086, #1087 and #1088 rather than from memory:

```
$ for n in 1086 1087 1088; do gh issue view $n --json number,state,stateReason --jq '[.number,.state,.stateReason]|@tsv'; done
1086    CLOSED  COMPLETED
1087    CLOSED  COMPLETED
1088    CLOSED  COMPLETED
```

With this landed, every acceptance criterion on the parent #741 has a closed sub-issue behind it.
