### PR TITLE
Restore an account-link backup against the target server's ids

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Controller.cs
@@ -296,7 +296,7 @@ public partial class ArchitectureConformanceTests
         // this expected count in the same PR that adds or removes a rate-limited endpoint (as the provider-form
         // roster rules do), so a change to the limiter surface is a conscious update here rather than a silent
         // drift the offender scan cannot see.
-        const int expectedTypedCallSites = 16;
+        const int expectedTypedCallSites = 17;
         var typedCall = new Regex("RateLimitCheck\\(\\s*SsoRateLimitClass\\.");
         var typedCallSites = ControllerSourceFiles()
             .Sum(path => typedCall.Matches(File.ReadAllText(path)).Count);

--- a/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.RateLimit.cs
@@ -53,6 +53,10 @@ public partial class ArchitectureConformanceTests
         // The per-subject link export (#1091): elevation-gated and read-only, but it answers per user id,
         // so an unthrottled one is a user-table enumeration an administrator can drive in a loop.
         "Links/Export/{jellyfinUserId}",
+        // The link-backup restore (#1129): the same config-XML persist under the global lock as the two
+        // link writes above, in bulk, and its refusal names usernames this instance does not hold, which
+        // an unthrottled caller could drive in a loop as a user-table oracle.
+        "Config/Links/Import",
         // The pre-provision link write (#1133): a config-XML persist under the global lock, and its 404 is
         // an existence answer about a user id, so it is throttled for both reasons the two neighbours are.
         "Links/Preprovision/{mode}/{provider}/{jellyfinUserId}",

--- a/SSO-Auth.Tests/Config/LinkImportTests.cs
+++ b/SSO-Auth.Tests/Config/LinkImportTests.cs
@@ -1,0 +1,384 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests the restore half of the portable account-link snapshot (#1129). The document exists to survive a
+/// user-database rebuild, so the property that decides whether it means anything is the round trip: links
+/// exported against one server's ids come back bound to the ids the target holds today.
+///
+/// The rest is fail-closed, and every refusal is tested twice - that it refuses, and that the stored link
+/// table is byte-identical afterwards. A half-applied restore is the worst outcome this code can produce,
+/// because it looks restored and silently is not, so a refusal that wrote three of five links would be a
+/// worse failure than one that wrote none.
+/// </summary>
+public class LinkImportTests
+{
+    // The SOURCE server's ids, as the export was taken against them.
+    private static readonly Guid SourceAlice = Guid.Parse("a11ce000-0000-0000-0000-000000000001");
+    private static readonly Guid SourceBob = Guid.Parse("b0b00000-0000-0000-0000-000000000002");
+
+    // The TARGET server's ids for the same two usernames. Deliberately different from the source's: a
+    // rebuilt user database issues new ids, and an import that quietly reused the document's ids would
+    // pass a test whose two sides shared them.
+    private static readonly Guid TargetAlice = Guid.Parse("7a19e700-0000-0000-0000-00000000000a");
+    private static readonly Guid TargetBob = Guid.Parse("7a19e700-0000-0000-0000-00000000000b");
+    private static readonly Guid TargetMallory = Guid.Parse("7a19e700-0000-0000-0000-00000000000c");
+
+    [Fact]
+    public void ExportOnOneServer_ImportsOntoAnother_ReboundToTheTargetsOwnIds()
+    {
+        var document = LinkExport.Build(SourceConfiguration(), SourceDirectory);
+        var target = TargetConfiguration();
+
+        var restored = LinkImport.Apply(target, document, TargetDirectory);
+
+        Assert.Equal(TargetAlice, target.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+        Assert.Equal(TargetBob, target.OidConfigs["idp"].CanonicalLinks["sub-bob"]);
+        Assert.Equal(TargetAlice, target.SamlConfigs["adfs"].CanonicalLinks["nameid-alice"]);
+
+        // The source ids are what the rebuild destroyed. Any of them surviving into the target means the
+        // import copied the document's own bookkeeping instead of resolving the username.
+        Assert.DoesNotContain(SourceAlice, target.OidConfigs["idp"].CanonicalLinks.Values);
+        Assert.DoesNotContain(SourceBob, target.OidConfigs["idp"].CanonicalLinks.Values);
+        Assert.DoesNotContain(SourceAlice, target.SamlConfigs["adfs"].CanonicalLinks.Values);
+
+        Assert.Equal(
+            new[] { "OpenID/idp:2", "SAML/adfs:1" },
+            restored.Select(count => $"{count.Protocol}/{count.Provider}:{count.Links}").ToArray());
+    }
+
+    [Fact]
+    public void TheIssuerBinding_IsRestoredWithTheLinkItBinds()
+    {
+        // Without this the restored link arrives unbound, and the first login after a migration stamps
+        // whatever issuer answered (trust on first use) - which is precisely the repoint #186 exists to
+        // refuse. A restore that silently relaxes a binding is a downgrade dressed as a recovery.
+        var document = LinkExport.Build(SourceConfiguration(), SourceDirectory);
+        var target = TargetConfiguration();
+
+        LinkImport.Apply(target, document, TargetDirectory);
+
+        Assert.Equal("https://idp.example.test", target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"]);
+    }
+
+    [Fact]
+    public void ALinkWithNoBinding_RestoresWithoutInventingOne()
+    {
+        var document = LinkExport.Build(SourceConfiguration(), SourceDirectory);
+        var target = TargetConfiguration();
+
+        LinkImport.Apply(target, document, TargetDirectory);
+
+        Assert.False(target.OidConfigs["idp"].CanonicalLinkIssuers.ContainsKey("sub-bob"));
+    }
+
+    [Fact]
+    public void AnIssuerOnASamlEntry_IsNotWrittenAnywhere()
+    {
+        // SAML has no issuer binding at all. A hand-edited document carrying one on a SAML entry must not
+        // conjure a map for a protocol that does not use it.
+        var target = TargetConfiguration();
+
+        LinkImport.Apply(target, Document(Entry("SAML", "adfs", "nameid-alice", "alice", "https://forged.example.test")), TargetDirectory);
+
+        Assert.Equal(TargetAlice, target.SamlConfigs["adfs"].CanonicalLinks["nameid-alice"]);
+        Assert.IsNotType<OidConfig>(target.SamlConfigs["adfs"]);
+    }
+
+    [Fact]
+    public void AnUnknownFormatVersion_IsRefusedAndNothingIsWritten()
+    {
+        var target = TargetConfiguration();
+        var document = Document(Entry("OpenID", "idp", "sub-alice", "alice"));
+        document.FormatVersion = LinkExport.FormatVersion + 1;
+
+        var refusal = Assert.Throws<ArgumentException>(() => LinkImport.Apply(target, document, TargetDirectory));
+
+        Assert.Contains("Unsupported link export format version", refusal.Message, StringComparison.Ordinal);
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void AProviderThisInstanceDoesNotHold_RefusesTheWholeDocument()
+    {
+        var target = TargetConfiguration();
+
+        var refusal = Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "some-other-idp", "sub-alice", "alice")), TargetDirectory));
+
+        Assert.Contains("no provider of that name is configured", refusal.Message, StringComparison.Ordinal);
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void AProviderNamedUnderTheWrongProtocol_IsNotFoundOnTheOtherMap()
+    {
+        // The two protocols keep separate provider namespaces, so "adfs" existing as a SAML provider must
+        // not make an OpenID entry naming it restorable. Matching across the maps would restore a link onto
+        // a provider no login of that protocol ever reads.
+        var target = TargetConfiguration();
+
+        Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "adfs", "sub-alice", "alice")), TargetDirectory));
+
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void AUsernameThisInstanceDoesNotHold_RefusesTheWholeDocument()
+    {
+        // The import never creates an account. A backup file that could bring principals into existence is
+        // a much larger primitive than one restoring links between things that both sides already hold.
+        var target = TargetConfiguration();
+
+        var refusal = Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "nobody")), TargetDirectory));
+
+        Assert.Contains("no Jellyfin account is named 'nobody'", refusal.Message, StringComparison.Ordinal);
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void AnIdentityAlreadyLinkedToADifferentAccount_IsRefusedRatherThanRepointed()
+    {
+        // THE RULE THIS WHOLE ENDPOINT LIVES OR DIES BY. Without it a crafted backup file remaps an
+        // identity-provider subject onto any account on the server, an administrator's included, and the
+        // remap arrives through a route whose whole framing is "restore what was there".
+        var target = TargetConfiguration();
+        target.OidConfigs["idp"].CanonicalLinks["sub-alice"] = TargetMallory;
+
+        var refusal = Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "alice")), TargetDirectory));
+
+        Assert.Contains("already links that identity to a different account", refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(TargetMallory, target.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+    }
+
+    [Fact]
+    public void AlinkThisInstanceBindsToADifferentIssuer_IsRefusedRatherThanRebound()
+    {
+        // The same rule one level down (#186). Overwriting a stored binding would rewrite a security
+        // decision as a side effect of a restore. Its immediate consequence is only fail-closed, since the
+        // rebound link's next login is refused for a mismatch, but the shape is the repoint above.
+        var target = TargetConfiguration();
+        target.OidConfigs["idp"].CanonicalLinks["sub-alice"] = TargetAlice;
+        target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"] = "https://idp.example.test";
+
+        var refusal = Assert.Throws<ArgumentException>(() => LinkImport.Apply(
+            target,
+            Document(Entry("OpenID", "idp", "sub-alice", "alice", "https://forged.example.test")),
+            TargetDirectory));
+
+        Assert.Contains("binds that link to a different issuer", refusal.Message, StringComparison.Ordinal);
+        Assert.Equal("https://idp.example.test", target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"]);
+    }
+
+    [Fact]
+    public void AnEntryWithNoIssuer_RestoresAgainstABoundLinkWithoutRelaxingIt()
+    {
+        // A backup taken before the binding existed carries no issuer. Restoring it must not clear the
+        // binding the target already holds, which would silently drop the link back to trust on first use.
+        var target = TargetConfiguration();
+        target.OidConfigs["idp"].CanonicalLinks["sub-alice"] = TargetAlice;
+        target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"] = "https://idp.example.test";
+
+        LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "alice")), TargetDirectory);
+
+        Assert.Equal("https://idp.example.test", target.OidConfigs["idp"].CanonicalLinkIssuers["sub-alice"]);
+    }
+
+    [Fact]
+    public void ReimportingAMappingThisInstanceAlreadyHolds_IsNotARepointAndSucceeds()
+    {
+        // A migration is retried. An import that refused every link it had already restored would make the
+        // second attempt after a partial failure impossible, and the rule above is about repointing rather
+        // than about writing the same thing twice.
+        var target = TargetConfiguration();
+        target.OidConfigs["idp"].CanonicalLinks["sub-alice"] = TargetAlice;
+
+        var restored = LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "alice")), TargetDirectory);
+
+        Assert.Equal(TargetAlice, target.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+        Assert.Equal(1, restored.Single().Links);
+    }
+
+    [Fact]
+    public void ADocumentMappingOneIdentityToTwoAccounts_IsRefused()
+    {
+        // Which entry wins would otherwise be decided by the document's own order, silently, in exactly the
+        // case where getting it wrong hands somebody else's identity to an account.
+        var target = TargetConfiguration();
+
+        var refusal = Assert.Throws<ArgumentException>(() => LinkImport.Apply(
+            target,
+            Document(Entry("OpenID", "idp", "sub-alice", "alice"), Entry("OpenID", "idp", "sub-alice", "bob")),
+            TargetDirectory));
+
+        Assert.Contains("maps this identity to two different accounts", refusal.Message, StringComparison.Ordinal);
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void OneBadEntryLateInTheDocument_LeavesEveryEarlierLinkUnwritten()
+    {
+        // The atomicity clause, and the one worth deleting the guard to check: move the write above the
+        // validation and this is the test that reds. Two good entries precede the bad one, so a validator
+        // that wrote as it went would leave them behind.
+        var target = TargetConfiguration();
+
+        Assert.Throws<ArgumentException>(() => LinkImport.Apply(
+            target,
+            Document(
+                Entry("OpenID", "idp", "sub-alice", "alice"),
+                Entry("SAML", "adfs", "nameid-alice", "alice"),
+                Entry("OpenID", "idp", "sub-bob", "nobody")),
+            TargetDirectory));
+
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void ARefusal_NamesTheEntryAndNeverTheCanonicalSubject()
+    {
+        // The subject is the one field in the document that identifies a real person at the identity
+        // provider, and the audit trail already carries no raw subject value (T-I1). The index into the
+        // document the operator is holding is what they need to find the entry.
+        var target = TargetConfiguration();
+
+        var refusal = Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "idp", "sub-alice", "nobody")), TargetDirectory));
+
+        Assert.Contains("entry #0 (OpenID/idp)", refusal.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("sub-alice", refusal.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnEntryWithNoCanonicalName_IsRefused()
+    {
+        var target = TargetConfiguration();
+
+        Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "idp", "   ", "alice")), TargetDirectory));
+
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void AProviderStoredWithNoConfigObject_IsTreatedAsAbsentRatherThanDereferenced()
+    {
+        // A null-bodied add (#350) can leave a provider whose config object is null. The write side fails
+        // closed on it the way every read of these maps does, rather than throwing a NullReference out of a
+        // config mutation.
+        var target = TargetConfiguration();
+        target.OidConfigs["broken"] = null!;
+
+        var refusal = Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "broken", "sub-alice", "alice")), TargetDirectory));
+
+        Assert.Contains("no provider of that name is configured", refusal.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnEmptyDocument_RestoresNothingAndReportsZero()
+    {
+        // Applied rather than refused: it contradicts nothing and leaves nothing half-done. The count is
+        // what tells an operator who applied the wrong file that nothing came back.
+        var target = TargetConfiguration();
+
+        var restored = LinkImport.Apply(target, Document(), TargetDirectory);
+
+        Assert.Empty(restored);
+        AssertNoLinksWereWritten(target);
+    }
+
+    [Fact]
+    public void TheProtocolNameIsMatchedLoosely_AndTheProviderNameExactly()
+    {
+        // The protocol is a two-value vocabulary the plugin writes itself, so a lower-case spelling costs
+        // nothing to accept. The provider name is a key the rest of the plugin looks up ordinally, so
+        // accepting a different casing here would restore links onto a provider no login resolves.
+        var target = TargetConfiguration();
+
+        LinkImport.Apply(target, Document(Entry("openid", "idp", "sub-alice", "alice")), TargetDirectory);
+        Assert.Equal(TargetAlice, target.OidConfigs["idp"].CanonicalLinks["sub-alice"]);
+
+        Assert.Throws<ArgumentException>(() =>
+            LinkImport.Apply(target, Document(Entry("OpenID", "IDP", "sub-bob", "bob")), TargetDirectory));
+    }
+
+    // --- helpers ---
+
+    private static void AssertNoLinksWereWritten(PluginConfiguration target)
+    {
+        Assert.Empty(target.OidConfigs["idp"].CanonicalLinks);
+        Assert.Empty(target.OidConfigs["idp"].CanonicalLinkIssuers);
+        Assert.Empty(target.SamlConfigs["adfs"].CanonicalLinks);
+    }
+
+    private static PluginConfiguration SourceConfiguration()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["idp"] = new OidConfig
+        {
+            Enabled = true,
+            OidEndpoint = "https://idp.example.test",
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["sub-alice"] = SourceAlice, ["sub-bob"] = SourceBob },
+            CanonicalLinkIssuers = new SerializableDictionary<string, string> { ["sub-alice"] = "https://idp.example.test" },
+        };
+        configuration.SamlConfigs["adfs"] = new SamlConfig
+        {
+            Enabled = true,
+            CanonicalLinks = new SerializableDictionary<string, Guid> { ["nameid-alice"] = SourceAlice },
+        };
+        return configuration;
+    }
+
+    // The rebuilt server: the same two providers, the same two usernames, and no links at all.
+    private static PluginConfiguration TargetConfiguration()
+    {
+        var configuration = new PluginConfiguration();
+        configuration.OidConfigs["idp"] = new OidConfig { Enabled = true, OidEndpoint = "https://idp.example.test" };
+        configuration.SamlConfigs["adfs"] = new SamlConfig { Enabled = true };
+        return configuration;
+    }
+
+    private static LinkExportDocument Document(params LinkExportEntry[] entries)
+    {
+        var document = new LinkExportDocument { FormatVersion = LinkExport.FormatVersion };
+        foreach (var entry in entries)
+        {
+            document.Links.Add(entry);
+        }
+
+        return document;
+    }
+
+    private static LinkExportEntry Entry(string protocol, string provider, string canonicalName, string username, string? issuer = null) =>
+        new LinkExportEntry
+        {
+            Protocol = protocol,
+            Provider = provider,
+            CanonicalName = canonicalName,
+            Username = username,
+            Issuer = issuer,
+        };
+
+    private static string? SourceDirectory(Guid userId) =>
+        userId == SourceAlice ? "alice" : userId == SourceBob ? "bob" : null;
+
+    private static Guid? TargetDirectory(string username) => username switch
+    {
+        "alice" => TargetAlice,
+        "bob" => TargetBob,
+        "mallory" => TargetMallory,
+        _ => null,
+    };
+}

--- a/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
+++ b/SSO-Auth.Tests/Http/SSOControllerAuthorizationTests.cs
@@ -52,6 +52,9 @@ public sealed class SSOControllerAuthorizationTests : IClassFixture<SsoAuthoriza
         // The linked-account roster (#1119): read-only, and elevation-gated because it names every linked
         // account on the server.
         "LinkedAccountRoster",
+        // The link-backup restore (#1129): it rebinds identity-provider subjects onto accounts other than
+        // the caller's, in bulk, with no identity-provider response behind any of them.
+        "ImportLinks",
         // The pre-provision link write (#1133): it grants an identity-provider subject the ability to sign
         // in as an account other than the caller's, with no identity-provider response behind it.
         "PreprovisionCanonicalLink",

--- a/SSO-Auth/Api/Audit/SsoAudit.cs
+++ b/SSO-Auth/Api/Audit/SsoAudit.cs
@@ -238,6 +238,37 @@ internal static class SsoAudit
             samlProviders);
 
     /// <summary>
+    /// Records an administrator restoring an account-link backup (#1129). Every restored link is a grant
+    /// of future login capability made on an administrator credential alone and with no identity-provider
+    /// round trip, in bulk, so it is warned rather than informed for the same reason the single
+    /// pre-provision write below is: it is the line an operator looks for when an account turns out to
+    /// sign in as somebody it should not.
+    /// </summary>
+    /// <remarks>
+    /// The canonical subjects are deliberately not fields here, exactly as they are not on the single
+    /// write below (T-I1). The per-provider counts are what tell an operator whether the restore matched
+    /// the backup they applied, and a subject is the one value in that document that identifies a real
+    /// person at the identity provider.
+    /// </remarks>
+    /// <param name="logger">The logger.</param>
+    /// <param name="actor">The elevated administrator who applied the backup.</param>
+    /// <param name="totalLinks">How many links the import restored in total.</param>
+    /// <param name="perProvider">A rendered "Protocol 'provider': n" list, one entry per provider that got links back.</param>
+    internal static void LinksImported(ILogger logger, string actor, int totalLinks, string perProvider)
+    {
+        if (!logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "[SSO Audit] Account-link backup restored by {Actor}: {TotalLinks} link(s) rebound to this instance's accounts, with no identity-provider response redeemed. Per provider: {PerProvider}.",
+            actor?.ReplaceLineEndings(string.Empty),
+            totalLinks,
+            perProvider?.ReplaceLineEndings(string.Empty));
+    }
+
+    /// <summary>
     /// Records an administrator pre-provisioning a canonical link with no identity-provider round trip
     /// (#1133). A grant of future login capability made on an administrator credential alone, so it is
     /// warned rather than informed: it is the line an operator looks for when an account turns out to sign

--- a/SSO-Auth/Api/Http/SSOController.cs
+++ b/SSO-Auth/Api/Http/SSOController.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -1521,6 +1522,89 @@ public class SSOController : ControllerBase
                 }
             }
         }
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Restores an account-link backup (<c>Config/Links/Export</c>) onto this instance (#1129), rebinding
+    /// every link to the user id this server holds for that username today. Requires administrator
+    /// privileges. The counterpart to the export, and the half that completes a server migration: a
+    /// rebuilt user database issues new ids, so the stored links point at ids that no longer resolve and
+    /// only a username-keyed document can be restored against it.
+    /// </summary>
+    /// <remarks>
+    /// Fail-closed and atomic. The whole document is validated before a single link is written, and the
+    /// mutation runs inside <c>MutateConfiguration</c>, which persists nothing when the lambda throws, so
+    /// a rebuilt server either gets its complete link table back or is left exactly as it was. A
+    /// half-applied link table is the worst outcome available here, because it looks restored and is not.
+    /// <para>
+    /// The refusal that matters is the repoint: a canonical name this instance already links to a
+    /// DIFFERENT account is rejected rather than overwritten, so a crafted backup file cannot remap an
+    /// identity-provider subject onto an administrator's account. The import also never creates a Jellyfin
+    /// account, never creates a provider and never invents a user id, so it cannot bring a new principal
+    /// into existence - it only rebinds what both sides already hold.
+    /// </para>
+    /// </remarks>
+    /// <param name="document">The link export document to restore.</param>
+    /// <returns>No content on success, or 400 when the document is missing, unsupported, or carries an entry this instance cannot restore.</returns>
+    [Authorize(Policy = Policies.RequiresElevation)]
+    [HttpPost("Config/Links/Import")]
+    [RequestSizeLimit(ConfigImportMaxBytes)]
+    [Consumes(MediaTypeNames.Application.Json)]
+    public async Task<ActionResult> ImportLinks([FromBody] LinkExportDocument document)
+    {
+        // Throttle after the elevation guard, before any work (#382, #516): the [Authorize] filter refuses
+        // a non-elevated caller before the body runs, so an unauthorized request never reaches the limiter
+        // and there is no rate-limit oracle. Past it, this shares the "link" bucket with the single link
+        // writes, because it is the same config-XML persist under the global lock - in bulk - and because
+        // its refusal names usernames this instance does not hold, which an unthrottled caller could drive
+        // in a loop as a user-table oracle.
+        if (RateLimitCheck(SsoRateLimitClass.Link) is { } throttled)
+        {
+            return throttled;
+        }
+
+        if (document is null)
+        {
+            return BadRequest("The link import document is missing or is not valid JSON.");
+        }
+
+        // Every username the document names is resolved BEFORE the lock is taken, and the importer then
+        // reads this snapshot rather than the user manager. A document can carry thousands of entries, and
+        // resolving each one inside MutateConfiguration would hold the global configuration lock across
+        // that many user-manager calls - blocking every login for the duration. Same discipline as
+        // ExportUserLinks, which resolves its one username outside the lock for the same reason. A name
+        // resolved a moment before the lock is the same answer a name resolved inside it would have given,
+        // except in a race with an account being renamed or deleted, where the import's own refusal rules
+        // are what decide the outcome either way.
+        var directory = document.Links
+            .Where(entry => !string.IsNullOrWhiteSpace(entry?.Username))
+            .Select(entry => entry.Username!)
+            .Distinct(StringComparer.Ordinal)
+            .ToDictionary(username => username, username => _userManager.GetUserByName(username)?.Id, StringComparer.Ordinal);
+
+        IReadOnlyList<LinkImportCount> restored;
+        try
+        {
+            // Validate-then-write lives in the Config helper; the mutation persists only if it returns
+            // without throwing, so a rejected document leaves the stored link table untouched.
+            restored = SSOPlugin.Instance.MutateConfiguration(
+                configuration => LinkImport.Apply(configuration, document, username => directory.GetValueOrDefault(username)));
+        }
+        catch (ArgumentException ex)
+        {
+            // The importer throws ArgumentException for an unsupported version and for every unrestorable
+            // entry. Strip line endings from the echoed message so a username inside it cannot split a log
+            // line (cs/log-forging is sanitized inline at the emission point, never behind a helper).
+            return BadRequest(ex.Message?.ReplaceLineEndings(string.Empty));
+        }
+
+        SsoAudit.LinksImported(
+            _logger,
+            await ResolveActorAsync().ConfigureAwait(false),
+            restored.Sum(count => count.Links),
+            string.Join(", ", restored.Select(count => $"{count.Protocol} '{count.Provider}': {count.Links.ToString(CultureInfo.InvariantCulture)}")));
 
         return NoContent();
     }

--- a/SSO-Auth/Config/LinkImport.cs
+++ b/SSO-Auth/Config/LinkImport.cs
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// How many links one provider got back from an import (#1129), for the audit line. The protocol is part
+/// of the identity because the two protocols keep separate provider namespaces.
+/// </summary>
+/// <param name="Protocol">The protocol the provider speaks.</param>
+/// <param name="Provider">The provider the links were written on.</param>
+/// <param name="Links">How many links were written.</param>
+internal readonly record struct LinkImportCount(string Protocol, string Provider, int Links);
+
+/// <summary>
+/// Restores the portable account-link snapshot (<see cref="LinkExportDocument"/>) onto this instance
+/// (#1129), rebinding every link to the user id this server holds TODAY. The export keys on the username
+/// because a rebuilt user database issues new ids; this is the half that resolves those usernames back to
+/// ids, and it is the half with the security weight, because writing a link is granting future login
+/// capability to an identity-provider subject.
+/// </summary>
+/// <remarks>
+/// Two properties make it safe to hand an administrator a file and let them apply it.
+/// <list type="bullet">
+/// <item>Validate first, mutate second. Every entry is checked before a single link is written, and the
+/// first failure rejects the WHOLE document. Called inside <c>MutateConfiguration</c>, which persists only
+/// when the mutation returns without throwing, so a rebuilt server either gets its complete link table
+/// back or is left exactly as it was. A half-applied link table is the worst outcome available here: it
+/// looks restored and silently is not.</item>
+/// <item>No silent repoint. A canonical name this instance already links to a DIFFERENT account is
+/// refused rather than overwritten, because otherwise a crafted backup file is a primitive for remapping
+/// an identity-provider subject onto an administrator's account. An administrator unlinks first and then
+/// re-imports, which is one deliberate act rather than a side effect of a restore.</item>
+/// </list>
+/// The import never creates a Jellyfin account, never creates a provider, and never invents a user id. It
+/// only rebinds what both sides already hold, which is what keeps a backup file from being a way to bring
+/// new principals into existence.
+/// </remarks>
+internal static class LinkImport
+{
+    // How many offending entries a refusal names before it stops. A document can carry thousands of
+    // links, and a message enumerating every bad one is unreadable in a dashboard toast and pointless in
+    // a log line; the count that follows says how many more there were.
+    private const int MaxReportedEntries = 10;
+
+    /// <summary>
+    /// Validates and applies the link document onto <paramref name="live"/>. Throws before any mutation
+    /// when the document is unsupported or any entry is unrestorable, so the caller's
+    /// <c>MutateConfiguration</c> persists nothing.
+    /// </summary>
+    /// <param name="live">The live configuration to restore into (mutated in place).</param>
+    /// <param name="document">The link document to restore.</param>
+    /// <param name="resolveUserId">
+    /// Resolves a Jellyfin username to the id this instance holds for it, or null when no such account
+    /// exists. The controller supplies one backed by <c>IUserManager</c>.
+    /// </param>
+    /// <returns>How many links each provider got back, for the audit line. Empty when the document carried none.</returns>
+    /// <exception cref="ArgumentException">The document version is unsupported, or an entry names a protocol, provider, canonical name or username this instance cannot restore, or the document contradicts itself or the stored link table.</exception>
+    internal static IReadOnlyList<LinkImportCount> Apply(
+        PluginConfiguration live,
+        LinkExportDocument document,
+        Func<string, Guid?> resolveUserId)
+    {
+        ArgumentNullException.ThrowIfNull(live);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(resolveUserId);
+
+        if (document.FormatVersion != LinkExport.FormatVersion)
+        {
+            throw new ArgumentException(
+                $"Unsupported link export format version {document.FormatVersion.ToString(CultureInfo.InvariantCulture)}; this plugin imports version {LinkExport.FormatVersion.ToString(CultureInfo.InvariantCulture)}.");
+        }
+
+        // An empty document is applied rather than refused, and it restores nothing. The rejection rules
+        // below are about entries that cannot be restored; a document with no entries contradicts nothing
+        // and leaves nothing half-done, and the count the caller audits says plainly that zero links came
+        // back - which an operator who applied the wrong file reads immediately.
+        var resolved = Resolve(live, document, resolveUserId);
+        return Write(resolved);
+    }
+
+    private static List<ResolvedLink> Resolve(
+        PluginConfiguration live,
+        LinkExportDocument document,
+        Func<string, Guid?> resolveUserId)
+    {
+        var refusals = new List<string>();
+        var resolved = new List<ResolvedLink>();
+
+        // What this document itself has already claimed, so two entries mapping ONE identity to two
+        // different accounts are caught. Without it the document's own order would decide which of the
+        // two won, silently, and a restore would be non-deterministic in exactly the case that matters.
+        var claimed = new Dictionary<(string Protocol, string Provider, string CanonicalName), Guid>();
+
+        for (var index = 0; index < document.Links.Count; index++)
+        {
+            var entry = document.Links[index];
+            if (entry is null)
+            {
+                refusals.Add(Describe(index, null, null, "the entry is empty"));
+                continue;
+            }
+
+            if (!TryResolveProvider(live, entry.Protocol, entry.Provider, out var protocol, out var config))
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "no provider of that name is configured for that protocol on this instance"));
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.CanonicalName))
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "the entry carries no canonical name, so it names no identity to restore"));
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Username))
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "the entry carries no username, so nothing can be resolved for it"));
+                continue;
+            }
+
+            // The import never creates an account. A username this server does not hold is refused rather
+            // than provisioned, because a backup file that could bring principals into existence is a
+            // different and much larger primitive than one that restores links between things that exist.
+            if (resolveUserId(entry.Username) is not { } userId)
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, $"no Jellyfin account is named '{entry.Username}' on this instance"));
+                continue;
+            }
+
+            var key = (protocol, entry.Provider!, entry.CanonicalName!);
+            if (claimed.TryGetValue(key, out var alreadyClaimed) && alreadyClaimed != userId)
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "the document maps this identity to two different accounts"));
+                continue;
+            }
+
+            // The rule that makes a hostile backup file useless as a takeover primitive: an identity this
+            // instance already links to somebody ELSE is refused, and the stored link stays as it is. A
+            // restore onto a server that still holds the same mapping is not a repoint and stays a
+            // success, so re-running an import after a partial migration is safe.
+            if (config.CanonicalLinks.TryGetValue(entry.CanonicalName!, out var held) && held != userId)
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "this instance already links that identity to a different account; unlink it first"));
+                continue;
+            }
+
+            // The same rule one level down, for the issuer binding (#186). A document naming a DIFFERENT
+            // issuer for a link this instance already holds is a contradiction between the backup and the
+            // server, and quietly overwriting the stored binding would rewrite a security decision as a
+            // side effect of a restore. Its immediate consequence is only fail-closed - that link's next
+            // login is refused for a mismatch - but a restore that silently changes what a link is bound
+            // to is the same shape as the repoint above, and it is refused for the same reason. An entry
+            // carrying no issuer overwrites nothing, so a document from before the binding existed
+            // restores against a bound link without relaxing it.
+            if (!string.IsNullOrWhiteSpace(entry.Issuer)
+                && config is OidConfig existing
+                && existing.CanonicalLinkIssuers.TryGetValue(entry.CanonicalName!, out var boundTo)
+                && !string.Equals(boundTo, entry.Issuer, StringComparison.Ordinal))
+            {
+                refusals.Add(Describe(index, entry.Protocol, entry.Provider, "this instance already binds that link to a different issuer; unlink it first"));
+                continue;
+            }
+
+            claimed[key] = userId;
+            resolved.Add(new ResolvedLink(protocol, entry.Provider!, config, entry.CanonicalName!, userId, entry.Issuer));
+        }
+
+        if (refusals.Count > 0)
+        {
+            throw new ArgumentException(
+                "The link import was rejected and nothing was restored. "
+                + string.Join("; ", refusals.Take(MaxReportedEntries))
+                + (refusals.Count > MaxReportedEntries
+                    ? $"; and {(refusals.Count - MaxReportedEntries).ToString(CultureInfo.InvariantCulture)} more entr(y/ies)."
+                    : "."));
+        }
+
+        return resolved;
+    }
+
+    private static List<LinkImportCount> Write(List<ResolvedLink> resolved)
+    {
+        foreach (var link in resolved)
+        {
+            link.Config.CanonicalLinks[link.CanonicalName] = link.UserId;
+
+            // The issuer binding travels with the link (#186). Restoring the link without it would leave
+            // the restored account on trust-on-first-use, so the first login after a migration would
+            // stamp whatever issuer answered - which is precisely the repoint the binding exists to
+            // refuse. SAML carries no binding, so an issuer on a SAML entry is dropped rather than
+            // written into a map that protocol does not have.
+            if (link.Config is OidConfig oid && !string.IsNullOrWhiteSpace(link.Issuer))
+            {
+                oid.CanonicalLinkIssuers[link.CanonicalName] = link.Issuer!;
+            }
+        }
+
+        return resolved
+            .GroupBy(link => (link.Protocol, link.Provider))
+            .Select(group => new LinkImportCount(group.Key.Protocol, group.Key.Provider, group.Count()))
+            .OrderBy(count => count.Protocol, StringComparer.Ordinal)
+            .ThenBy(count => count.Provider, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // The protocol name is matched case-insensitively while the provider name is matched exactly, and the
+    // difference is deliberate. The protocol is a two-value vocabulary this plugin writes itself, so
+    // accepting "openid" costs nothing and refuses nothing real; the provider name is a key in a map the
+    // rest of the plugin looks up ordinally, so matching it loosely here would restore links onto a
+    // provider no login would ever resolve.
+    private static bool TryResolveProvider(
+        PluginConfiguration live,
+        string? protocol,
+        string? provider,
+        out string resolvedProtocol,
+        out ProviderConfigBase config)
+    {
+        resolvedProtocol = string.Empty;
+        config = null!;
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return false;
+        }
+
+        if (string.Equals(protocol, LinkExport.OpenIdProtocol, StringComparison.OrdinalIgnoreCase))
+        {
+            resolvedProtocol = LinkExport.OpenIdProtocol;
+            return TryGetConfig(live.OidConfigs, provider, out config);
+        }
+
+        if (string.Equals(protocol, LinkExport.SamlProtocol, StringComparison.OrdinalIgnoreCase))
+        {
+            resolvedProtocol = LinkExport.SamlProtocol;
+            return TryGetConfig(live.SamlConfigs, provider, out config);
+        }
+
+        return false;
+    }
+
+    // A provider stored with a null config object is reachable through a null-bodied add (#350). It is
+    // treated as absent here, exactly as every read of these maps treats it, rather than dereferenced.
+    private static bool TryGetConfig<TConfig>(
+        SerializableDictionary<string, TConfig> configs,
+        string provider,
+        out ProviderConfigBase config)
+        where TConfig : ProviderConfigBase
+    {
+        config = null!;
+        if (configs is null || !configs.TryGetValue(provider, out var stored) || stored is null)
+        {
+            return false;
+        }
+
+        config = stored;
+        return true;
+    }
+
+    // A refusal names WHICH entry and WHY, and never the canonical name. The subject is the one field in
+    // the document that identifies a real person at the identity provider, and the audit trail already
+    // carries no raw subject value (T-I1); echoing it into an HTTP error body and from there into
+    // whatever logs that body would widen where it travels for no gain an operator could use. The index
+    // into the document they are holding is what lets them find the entry.
+    private static string Describe(int index, string? protocol, string? provider, string reason) =>
+        $"entry #{index.ToString(CultureInfo.InvariantCulture)} ({protocol ?? "no protocol"}/{provider ?? "no provider"}): {reason}";
+
+    // One validated entry: the map it belongs in, and everything needed to write it. Nothing is written
+    // while this list is being built, which is the whole of the fail-closed property - the first refusal
+    // throws out of Apply with the live configuration untouched.
+    private readonly record struct ResolvedLink(
+        string Protocol,
+        string Provider,
+        ProviderConfigBase Config,
+        string CanonicalName,
+        Guid UserId,
+        string? Issuer);
+}


### PR DESCRIPTION
# What & why

The portable link snapshot has had nowhere to go since it landed. It keys on the username precisely because a rebuilt user database issues new ids, and without an importer that resolves those usernames back to ids the document is a file nobody can apply. The half that actually completes a server migration was missing.

`POST sso/Config/Links/Import` takes the document `Config/Links/Export` produces and rebinds every link to the id this instance holds for that username today. It is elevation-gated, size-capped and throttled like the single link writes, and it is audited with a per-provider count, because every restored link is a grant of future login capability made on an administrator credential alone with no identity-provider response behind it.

Two properties make it safe to hand somebody a file and let them apply it.

**Validate first, write second.** Every entry is checked before a single link is written and the first failure rejects the whole document, inside `MutateConfiguration`, which persists nothing when the lambda throws. A rebuilt server therefore gets its complete link table back or is left exactly as it was. A half-applied restore is the worst outcome this code can produce, because it looks restored and silently is not.

**No silent repoint.** A canonical name this instance already links to a different account is refused rather than overwritten, so a crafted backup file cannot remap an identity-provider subject onto an administrator's account through a route whose whole framing is "restore what was there". Re-importing a mapping the instance already holds is not a repoint and stays a success, so a retried migration works.

The import never creates an account, never creates a provider and never invents a user id. That is what keeps a backup file from being a way to bring new principals into existence, and it is why an unresolvable username is a refusal rather than a provisioning step.

Closes #1129

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [x] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader looked at this change, and the review record box above is unticked because there is no record to point at.** The review was mine and mine alone, so what follows is the evidence in place of one, and it should be read as a self-review rather than as an independent pass.

Two findings came out of it and both are fixed in this branch rather than filed:

1. **Every username was being resolved inside the configuration lock.** `LinkImport.Apply` runs inside `MutateConfiguration`, which holds the one global lock every login also takes, and the first version called `_userManager.GetUserByName` per entry in there. A document is capped at 1 MB but that is still thousands of entries, and the lock would have been held across all of them, blocking every login for the duration. The names are now resolved into a snapshot before the lock is taken, which is the discipline `ExportUserLinks` already states for its one username.
2. **A restore could silently rebind a link's stored issuer.** The no-repoint rule covered the link but not the `#186` issuer binding hanging off it, so a document naming a different issuer for a link this instance already binds would have overwritten a security decision as a side effect of a restore. Its immediate consequence is only fail-closed - the rebound link's next login is refused for a mismatch - but the shape is the repoint the rule exists against, so it is refused now. An entry carrying no issuer still overwrites nothing, so a backup taken before the binding existed restores against a bound link without relaxing it.

Three things I looked at and deliberately left as they are:

- **A document may carry an issuer for a link this instance does not yet hold.** That is the ordinary restore, and the value written is what the backup recorded. A wrong value fails that link's next login closed; it opens nothing, because reaching the account still requires controlling that subject at the provider the instance is configured against.
- **The refusal body names usernames.** The caller is already elevated and can list the user table through the server's own API, so this is not an enumeration channel it does not already have, and the name is the actionable half of the message. Canonical subjects are never named.
- **A disabled provider still accepts a restore.** The single link write requires `Enabled` because it is a new grant; a restore is prior state and the documented migration order has an administrator re-entering secrets after the config import, so refusing here would break the sequence the feature exists for. Nothing is reachable either way until the provider is on.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: filed as a `documentation` issue, linked in Notes.

The new route is classified in all three of the conformance rosters it has to be in rather than being allowed to drift: `MustThrottleRoutes`, the elevation surface in `SSOControllerAuthorizationTests`, and the typed-call-site sentinel, which moves from 16 to 17.

## Verification

Both target frameworks, `--warnaserror` on the test project so the analyzers are the gate:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
Build succeeded.  0 Warning(s)  0 Error(s)
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
Build succeeded.  0 Warning(s)  0 Error(s)

$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
SSO-Auth.Tests  Total: 3273, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
SSO-Auth.Tests  Total: 3274, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0
```

**The 4 skips are pre-existing and none of them is in this change.** One of them declines to bind a listener off loopback because doing so raises the Windows firewall consent dialog, which needs an administrator (#1227); it runs with `SSO_TESTS_ALLOW_LAN_BIND=1` and was not run here.

**The two guards that carry this change were proven by deleting them and watching the suite go red**, rather than by asserting that they are there:

```
# 1. delete the no-repoint refusal
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*LinkImport*"
Total: 17, Failed: 1
  AnIdentityAlreadyLinkedToADifferentAccount_IsRefusedRatherThanRepointed
      Expected: typeof(System.ArgumentException)

# 2. move the write into the validation loop, so it writes as it goes
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe -method "*LinkImport*"
Total: 17, Failed: 2
  ADocumentMappingOneIdentityToTwoAccounts_IsRefused
  OneBadEntryLateInTheDocument_LeavesEveryEarlierLinkUnwritten
```

The second one is the atomicity clause and it is the reason the test puts two good entries ahead of the bad one: a validator that wrote as it went would leave them behind, and a test with the bad entry first would pass anyway.

19 tests cover the round trip (export against one server's ids, import against another's, with deliberately different GUIDs on the two sides so an importer that reused the document's own ids could not pass), the issuer binding travelling with the link it binds, and every rejection rule twice - that it refuses, and that the stored link table is untouched afterwards.

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - none in this change.

## Notes

Docs impact: the new route belongs on the account-management API page that landed in #1400, and the admin-UI half is the sibling #1131, which is blocked on this. Filed as #1401 on the current milestone.

Deliberately out of scope, and each one is a decision rather than an oversight. There is no admin-UI button for this (that is #1131). The route takes the whole document rather than a per-provider selection, because a partial restore is the half-applied state this design refuses. And an operator who genuinely wants to move a subject to another account unlinks first, which is one deliberate act rather than a side effect of a restore.
