### PR TITLE
Put a proxy in front of the E2E stack and budget two clients apart

### DIFF
--- a/.github/workflows/e2e-login.yml
+++ b/.github/workflows/e2e-login.yml
@@ -241,6 +241,30 @@ jobs:
           COMPOSE: ${{ matrix.compose }}
         run: bash test/e2e/phases/legacy-secret-migration.sh
 
+      - name: Two clients behind one proxy are budgeted apart (#1125)
+        # Puts an nginx front end in front of Jellyfin, names it in the server's known proxies, and
+        # requires that exhausting one forwarded client's rate-limit budget does NOT throttle a
+        # second forwarded client arriving through the same proxy. It was verified by hand once in
+        # the #717 live pass and nothing in test/e2e put a proxy in front of Jellyfin at all, so a
+        # regression that collapsed every client behind a proxy into one bucket would ship silently
+        # and lock a whole site out on one client's noise.
+        #
+        # The audit half of #1125 is deliberately absent: the audit trail records no client address
+        # and is not going to start, so there is nothing there to assert against.
+        #
+        # The proxy sits behind a compose profile and this step is the only thing that starts it, so
+        # the per-PR harness run is unchanged. Release and `providers: all` only, and only on the
+        # canonical Keycloak stack, for the same reasons as the phases above: it costs extra login
+        # passes, and it is the one stack that can be re-run in place. Runs on a green harness only,
+        # so a real login failure surfaces as the harness failure.
+        #
+        # AHEAD of the rollover phase below, which mutates the identity provider. This one only
+        # edits Jellyfin's own persisted files and puts both back.
+        if: success() && needs.select.outputs.full == 'true' && matrix.compose == 'test/e2e/docker-compose.yml'
+        env:
+          COMPOSE: ${{ matrix.compose }}
+        run: bash test/e2e/phases/proxy-client-attribution.sh
+
       - name: SAML signing-cert rollover, the new cert validates and the old one is refused (#1128)
         # Rotates the realm's SAML signing key mid-run, imports the new certificate into the plugin,
         # and requires all three of the issue's clauses in ONE run: an assertion signed by the

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -267,6 +267,43 @@ from a stack whose secret is plaintext proves nothing: that is the documented ge
 path, where the server mints a fresh key and every login succeeds. The phase asserts the envelope
 itself rather than assuming what ran before it, and it leaves the stack as it found it.
 
+### Two clients behind one proxy are budgeted apart
+
+`test/e2e/phases/proxy-client-attribution.sh` puts an nginx front end in front of Jellyfin, names it
+in the server's known proxies, and requires that exhausting one forwarded client's rate-limit budget
+does not throttle a second forwarded client arriving through the same proxy. Until it existed
+nothing here put a proxy in front of Jellyfin at all, and a regression that collapsed every client
+behind a proxy into one bucket would have locked a whole site out on one client's noise.
+
+**What is under test is not what it looks like.** The plugin deliberately never reads
+`X-Forwarded-For`: `SsoRateLimiter` documents the connection's remote address as the only input,
+because a client-supplied header would let an attacker rotate keys to evade the limiter or pin a
+victim's address to lock them out. What the phase proves is that the plugin sits correctly on top of
+the host's forwarded-headers handling. The known-proxies setting is therefore written by the phase
+rather than assumed; without it both clients collapse to the proxy and the run would red for a
+configuration reason rather than a plugin one.
+
+**The forwarded addresses are not arbitrary.** `SsoRateLimiter.NormalizeClientKey` refuses to
+attribute a non-public source at all, and the documentation ranges somebody reaches for first
+(`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) are all blocked by `IpAddressClassifier`. A
+phase written with them would exhaust nothing, prove nothing, and look like a passing test. The two
+clients are on `11.0.9.0/24`, for the same reason the harness network itself is on `11.0.0.0/24`,
+and outside that subnet so they cannot collide with a container.
+
+**The assertion that carries the phase is the second client's first request.** If the limiter keyed
+on the proxy hop, the first client's exhaustion would be the second client's exhaustion, and that
+request would answer 429. A control request before the exhaust loop keeps the 429 attributable: a
+stack that was already refusing would produce one for free.
+
+The proxy sits behind a compose profile, so an ordinary `docker compose up` of this stack never
+starts it and the per-PR path is unchanged. The phase edits only Jellyfin's own persisted files, the
+plugin configuration and the network configuration, copies both aside first and puts them back on
+every exit path, and finishes with a `RELOGIN_ONLY` pass so it proves the stack was left working
+rather than merely left.
+
+The audit half of #1125 is deliberately absent. The audit trail records no client address and is not
+going to start, so there is nothing there to assert against.
+
 ### The SAML signing certificate is rotated mid-run
 
 `test/e2e/phases/saml-cert-rollover.sh` rotates the Keycloak realm's SAML signing key while the stack

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -87,6 +87,26 @@ services:
     networks:
       - ssonet
 
+  proxy:
+    # A reverse proxy in front of Jellyfin, for the client-attribution phase only (#1125). It sits
+    # behind a compose profile, so an ordinary run of this stack never starts it and the per-PR path
+    # is byte-identical to what it was; the phase brings it up with
+    # `docker compose --profile proxy up -d proxy`.
+    #
+    # The static address is load-bearing rather than tidiness. Jellyfin rewrites the client address
+    # from X-Forwarded-For only when the immediate peer is listed in its own "Known proxies"
+    # setting, and the phase writes THIS address into that list before restarting the server. A
+    # dynamically allocated address could not be written into a configuration file before the
+    # container exists. .200 is far above where Docker starts allocating, so it cannot collide with
+    # the services that come up first.
+    profiles: ["proxy"]
+    image: nginx:1.27-alpine
+    volumes:
+      - ./proxy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    networks:
+      ssonet:
+        ipv4_address: 11.0.0.200
+
 networks:
   ssonet:
     driver: bridge

--- a/test/e2e/phases/probe-proxy-client-budget.sh
+++ b/test/e2e/phases/probe-proxy-client-budget.sh
@@ -62,7 +62,18 @@ challenge() { # $1 forwarded client address; echoes the status
         || echo "000"
 }
 
-say "PROBE-CONTROL $(challenge "$CLIENT_A")"
+# The control's BODY is reported as well as its status. A control that does not redirect ends the
+# phase, and "it answered 400" without the body leaves the next run guessing which of the several
+# 400 arms it was: the plugin renders a distinct message for each one.
+control_code="$(curl -sS -o /tmp/control.body -w '%{http_code}' \
+    -H "X-Test-Client: $CLIENT_A" \
+    "$PROXY_URL/sso/OID/start/$PROVIDER" 2>/tmp/control.err || echo "000")"
+say "PROBE-CONTROL $control_code"
+if [ -s /tmp/control.body ]; then
+    say "PROBE-CONTROL-BODY $(tr -d '\r\n' < /tmp/control.body | cut -c1-300)"
+else
+    say "PROBE-CONTROL-BODY "
+fi
 
 # The exhaust loop reports every status it saw, not only the last one, so a run that ends without a
 # 429 says what the endpoint answered instead of only that the expected one never arrived.

--- a/test/e2e/phases/probe-proxy-client-budget.sh
+++ b/test/e2e/phases/probe-proxy-client-budget.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Drives the client-attribution phase's requests from inside the compose network (#1125). Jellyfin
+# publishes no port to the host and neither does the proxy, so every request has to originate from
+# a container on `ssonet`.
+#
+# It is a FILE rather than a string handed to `sh -c`, for the reason probe-oid-start.sh records:
+# a script that arrives as one argument through two layers cannot be read in the log it failed in.
+#
+# It never exits non-zero. Every answer is printed as a PROBE- line and the caller decides what a
+# missing one means, so a broken probe can never be read as a proven rate limit.
+#
+# What it does, in order:
+#
+#   ready     waits for the plugin's own route THROUGH THE PROXY. Waiting on Jellyfin directly
+#             would leave the proxy unproven, and a first request that fails because nginx is not
+#             up yet is indistinguishable here from one the plugin refused.
+#   control   one challenge as client A. A redirect is the baseline; without it, a 429 later says
+#             nothing, because a stack that was already refusing would produce one for free.
+#   exhaust   the same challenge as client A until it answers 429. The budget the phase wrote is
+#             small, so this is a handful of requests, and a run that never sees a 429 reports the
+#             statuses it did see.
+#   other     one challenge as client B, the assertion the phase exists for. B has spent nothing.
+#             If the limiter keyed on the proxy hop rather than on the forwarded client, A's
+#             exhaustion is B's exhaustion and this answers 429.
+set -u
+
+say() { printf '%s\n' "$*"; }
+
+PROXY_URL="${PROXY_URL:-http://proxy}"
+CLIENT_A="${CLIENT_A:-11.0.9.11}"
+CLIENT_B="${CLIENT_B:-11.0.9.22}"
+MAX_TRIES="${MAX_TRIES:-8}"
+
+if ! apk add --no-cache curl >/tmp/apk.out 2>&1; then
+    say "PROBE-ERROR could not install curl:"
+    sed 's/^/  /' /tmp/apk.out
+    exit 0
+fi
+say "PROBE-STAGE curl $(curl --version 2>/dev/null | head -1)"
+
+# Readiness is the plugin's own route, not the server's: /System/Info/Public answers while Jellyfin
+# is still coming up, and the challenge then returns a startup splash page rather than a redirect.
+# /sso/OID/GetNames only answers once the plugin is loaded, which is the state this probe is about.
+i=0
+until curl -fsS -o /dev/null -H "X-Test-Client: $CLIENT_A" "$PROXY_URL/sso/OID/GetNames" 2>/tmp/ready.err; do
+    i=$((i + 1))
+    if [ "$i" -ge 150 ]; then
+        say "PROBE-ERROR the plugin did not answer $PROXY_URL/sso/OID/GetNames through the proxy within 300s:"
+        sed 's/^/  /' /tmp/ready.err
+        exit 0
+    fi
+    sleep 2
+done
+say "PROBE-STAGE ready after $i retries ($((i * 2))s)"
+
+# No -L: the healthy answer is the redirect itself, and following it would report the identity
+# provider's status instead of the plugin's.
+challenge() { # $1 forwarded client address; echoes the status
+    curl -sS -o /dev/null -w '%{http_code}' \
+        -H "X-Test-Client: $1" \
+        "$PROXY_URL/sso/OID/start/$PROVIDER" 2>/tmp/challenge.err \
+        || echo "000"
+}
+
+say "PROBE-CONTROL $(challenge "$CLIENT_A")"
+
+# The exhaust loop reports every status it saw, not only the last one, so a run that ends without a
+# 429 says what the endpoint answered instead of only that the expected one never arrived.
+seen=""
+throttled_at=""
+n=1
+while [ "$n" -le "$MAX_TRIES" ]; do
+    code="$(challenge "$CLIENT_A")"
+    seen="$seen $code"
+    if [ "$code" = "429" ]; then
+        throttled_at="$n"
+        break
+    fi
+    n=$((n + 1))
+done
+say "PROBE-EXHAUST-STATUSES$seen"
+say "PROBE-EXHAUST-THROTTLED-AT ${throttled_at:-none}"
+
+say "PROBE-OTHER-CLIENT $(challenge "$CLIENT_B")"
+say "PROBE-CLIENTS $CLIENT_A $CLIENT_B"

--- a/test/e2e/phases/proxy-client-attribution.sh
+++ b/test/e2e/phases/proxy-client-attribution.sh
@@ -149,8 +149,14 @@ grep -q "<string>$PROXY_ADDR</string>" "$NETWORK_CONFIG" \
 pass "$PROXY_ADDR is a known proxy"
 
 log "Restarting Jellyfin against both edits, and bringing the proxy up"
+# KEYCLOAK IS STARTED TOO, AND FORGETTING IT COST A RUN. The phase before this one ends with
+# `docker compose up --abort-on-container-exit`, which stops every container when the harness exits,
+# so this phase inherits a stopped stack rather than a running one. Starting only Jellyfin left the
+# identity provider down, the challenge answered 400 with "the authorization server's discovery
+# document could not be read", and the control refused to let the run mean anything - which is what
+# the control is for. The phase beside this one starts both for the same reason.
 docker compose -f "$COMPOSE" stop jellyfin >/dev/null
-docker compose -f "$COMPOSE" start jellyfin >/dev/null
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
 docker compose -f "$COMPOSE" --profile proxy up -d proxy >/dev/null
 pass "the stack is running with a proxy in front of Jellyfin"
 
@@ -195,7 +201,7 @@ in_jellyfin "set -eu; mv -f '$CONTAINER_CONFIG.kept' '$CONTAINER_CONFIG'; mv -f 
 [ "$(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" | head -1)" = "$RATE_BEFORE" ] \
     || die "the limiter setting in $CONFIG is not what this phase found ($RATE_BEFORE), so the restore left the stack in a state the canonical pass did not create"
 docker compose -f "$COMPOSE" stop jellyfin >/dev/null
-docker compose -f "$COMPOSE" start jellyfin >/dev/null
+docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
 pass "the limiter settings and the known-proxies list are back as the canonical pass left them"
 
 log "A login after the restore"

--- a/test/e2e/phases/proxy-client-attribution.sh
+++ b/test/e2e/phases/proxy-client-attribution.sh
@@ -200,11 +200,16 @@ in_jellyfin "set -eu; mv -f '$CONTAINER_CONFIG.kept' '$CONTAINER_CONFIG'; mv -f 
     || die "a copy is still sitting beside the configuration, so the restore did not complete"
 [ "$(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" | head -1)" = "$RATE_BEFORE" ] \
     || die "the limiter setting in $CONFIG is not what this phase found ($RATE_BEFORE), so the restore left the stack in a state the canonical pass did not create"
-docker compose -f "$COMPOSE" stop jellyfin >/dev/null
-docker compose -f "$COMPOSE" start jellyfin keycloak >/dev/null
+docker compose -f "$COMPOSE" stop >/dev/null
 pass "the limiter settings and the known-proxies list are back as the canonical pass left them"
 
 log "A login after the restore"
+# STOPPED above and brought up by this `up`, rather than started separately first. `start` returns
+# when the container is running, not when the server is listening, and the harness then raced it:
+# its own readiness check passed against a server still coming up and the next request answered
+# "Failed to connect to jellyfin port 8096 after 1 ms". Letting `up` bring the stack up cold is what
+# the phase beside this one does, and the harness's wait is written for exactly that.
+#
 # RELOGIN_ONLY, so the seed, the wizard and the two provider Add calls are skipped and the
 # persisted provider configuration this phase spent the run not touching is read back (#1123).
 RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \

--- a/test/e2e/phases/proxy-client-attribution.sh
+++ b/test/e2e/phases/proxy-client-attribution.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Two clients behind ONE reverse proxy are budgeted apart by the plugin's per-client rate limiter
+# (#1125). Verified by hand once in the #717 live pass, and nothing in test/e2e put a proxy in
+# front of Jellyfin at all until this phase, so a regression that collapsed every client behind a
+# proxy into a single bucket would ship silently and lock a whole site out on one client's noise.
+#
+# WHAT IS UNDER TEST IS NOT WHAT IT LOOKS LIKE. The plugin deliberately never reads
+# X-Forwarded-For; SsoRateLimiter documents the connection's remote address as the only input,
+# because a client-supplied header would let an attacker rotate keys to evade the limiter or pin a
+# victim's address to lock them out. So the thing this phase proves is that the plugin sits
+# correctly on top of the host's forwarded-headers handling: with Jellyfin's own "Known proxies"
+# setting naming the proxy, the real client reaches the limiter, and two of them get separate
+# budgets. Without that setting both collapse to the proxy and the phase reds - which is the false
+# red worth designing out, so the setting is written by this phase rather than assumed.
+#
+# It runs on the HOST rather than inside the harness container, like the phases beside it: the
+# harness mounts only /harness, and this phase is made of edits to persisted configuration files
+# and a compose profile.
+#
+# THE ADDRESSES ARE NOT ARBITRARY. SsoRateLimiter.NormalizeClientKey refuses to attribute a
+# non-public source at all and returns null, which exempts it from throttling entirely. The
+# documentation ranges somebody would reach for first - 192.0.2.0/24, 198.51.100.0/24,
+# 203.0.113.0/24 - are all blocked by IpAddressClassifier, so a phase written with them would
+# exhaust nothing, prove nothing, and look like a passing test. The forwarded clients are
+# therefore on 11.0.9.0/24, for the same reason the harness network itself is on 11.0.0.0/24, and
+# outside that subnet so they cannot collide with a container address.
+#
+# The shape:
+#
+#   arrange   the limiter is switched on with a small budget and a window long enough that it
+#             cannot refill mid-run, and the proxy's address goes into Jellyfin's known proxies.
+#             Both files are copied aside first and restored on every exit path.
+#   restart   Jellyfin re-reads both, and the proxy comes up under its compose profile.
+#   probe     a control request, then client A until it is throttled, then ONE request as client B.
+#   assert    the control redirected, A was throttled, and B was not. That last one is the whole
+#             phase: if the limiter had keyed on the proxy hop, A's exhaustion would be B's.
+#   restore   the files go back, the proxy goes away, and a RELOGIN_ONLY pass proves the stack was
+#             left working rather than merely left.
+#
+# Never `docker compose down` here: that removes Keycloak, the realm is re-imported into a fresh
+# instance with a NEW SAML signing certificate, and the certificate the canonical pass wrote into
+# the plugin's SAML configuration would no longer match. `stop` and `start` keep the containers.
+set -euo pipefail
+
+COMPOSE="${COMPOSE:-test/e2e/docker-compose.yml}"
+CONFIG="${CONFIG:-test/e2e/jellyfin/config/plugins/configurations/SSO-Auth.xml}"
+NETWORK_CONFIG="${NETWORK_CONFIG:-test/e2e/jellyfin/config/config/network.xml}"
+JELLYFIN_DIR="${JELLYFIN_DIR:-test/e2e/jellyfin/config}"
+
+# The proxy's fixed address on the harness network, as the compose file assigns it. Written into
+# Jellyfin's known proxies below; the two must agree or the server ignores the forwarded header.
+PROXY_ADDR="${PROXY_ADDR:-11.0.0.200}"
+# Small enough that the exhaust loop is a handful of requests, and a window that outlives the run
+# so a refill cannot hand client A a fresh budget halfway through.
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-2}"
+WINDOW_SECONDS="${WINDOW_SECONDS:-600}"
+
+log() { printf '%s\n' "== $* =="; }
+die() { printf '::error::%s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+PHASES_DIR="${PHASES_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+
+log "Preconditions"
+[ -s "$CONFIG" ] || die "the plugin persisted no configuration at $CONFIG - run the canonical pass first"
+if [ ! -s "$NETWORK_CONFIG" ]; then
+    printf 'configuration files found under %s:\n' "$JELLYFIN_DIR" >&2
+    find "$JELLYFIN_DIR" -maxdepth 3 -name '*.xml' -print >&2 || true
+    die "no Jellyfin network configuration at $NETWORK_CONFIG - without it the known-proxies setting cannot be written and the phase would red for a configuration reason rather than a plugin one"
+fi
+grep -q '<KnownProxies' "$NETWORK_CONFIG" \
+    || die "no <KnownProxies> element in $NETWORK_CONFIG - this Jellyfin does not carry the setting this phase depends on, and writing one blindly would be a guess"
+pass "both configuration files are present and the known-proxies element exists"
+
+CONFIG_KEPT="$CONFIG.kept"
+NETWORK_KEPT="$NETWORK_CONFIG.kept"
+[ ! -e "$CONFIG_KEPT" ] || die "$CONFIG_KEPT already exists - a previous run left a copy aside and this one would overwrite it"
+[ ! -e "$NETWORK_KEPT" ] || die "$NETWORK_KEPT already exists - a previous run left a copy aside and this one would overwrite it"
+cp "$CONFIG" "$CONFIG_KEPT"
+cp "$NETWORK_CONFIG" "$NETWORK_KEPT"
+
+restore_config() {
+    [ -e "$CONFIG_KEPT" ] && mv -f "$CONFIG_KEPT" "$CONFIG" && printf 'restored %s on exit\n' "$CONFIG" >&2
+    [ -e "$NETWORK_KEPT" ] && mv -f "$NETWORK_KEPT" "$NETWORK_CONFIG" && printf 'restored %s on exit\n' "$NETWORK_CONFIG" >&2
+    docker compose -f "$COMPOSE" --profile proxy stop proxy >/dev/null 2>&1 || true
+    return 0
+}
+trap restore_config EXIT
+pass "both files are copied aside and restored on every exit path"
+
+log "Switching the limiter on with a small budget"
+# The limiter's settings are deliberately NOT importable through the API (ConfigImport refuses
+# them, so a foreign document cannot silently disable a DoS control), which is why this is an edit
+# to the persisted configuration and a restart rather than an HTTP call.
+sed -i \
+    -e "s|<EnableRateLimit>[^<]*</EnableRateLimit>|<EnableRateLimit>true</EnableRateLimit>|" \
+    -e "s|<RateLimitMaxAttempts>[^<]*</RateLimitMaxAttempts>|<RateLimitMaxAttempts>$MAX_ATTEMPTS</RateLimitMaxAttempts>|" \
+    -e "s|<RateLimitWindowSeconds>[^<]*</RateLimitWindowSeconds>|<RateLimitWindowSeconds>$WINDOW_SECONDS</RateLimitWindowSeconds>|" \
+    "$CONFIG"
+grep -q "<EnableRateLimit>true</EnableRateLimit>" "$CONFIG" \
+    || die "the limiter is still off in $CONFIG after the edit - the element was not where the edit expected it: $(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" || echo 'element absent')"
+grep -q "<RateLimitMaxAttempts>$MAX_ATTEMPTS</RateLimitMaxAttempts>" "$CONFIG" \
+    || die "the attempt budget was not written into $CONFIG"
+pass "the limiter is on with $MAX_ATTEMPTS attempts per ${WINDOW_SECONDS}s"
+
+log "Naming the proxy in Jellyfin's known proxies"
+# Both spellings, because an empty list serializes as a self-closing element and a populated one
+# does not, and which of the two is on disk depends on what the wizard wrote.
+if grep -q '<KnownProxies */>' "$NETWORK_CONFIG"; then
+    sed -i "s|<KnownProxies */>|<KnownProxies><string>$PROXY_ADDR</string></KnownProxies>|" "$NETWORK_CONFIG"
+else
+    sed -i "s|<KnownProxies>.*</KnownProxies>|<KnownProxies><string>$PROXY_ADDR</string></KnownProxies>|" "$NETWORK_CONFIG"
+fi
+grep -q "<string>$PROXY_ADDR</string>" "$NETWORK_CONFIG" \
+    || die "the proxy address is not in $NETWORK_CONFIG after the edit; without it Jellyfin ignores the forwarded header and both clients collapse to the proxy, which would red this phase for a configuration reason rather than a plugin one"
+pass "$PROXY_ADDR is a known proxy"
+
+log "Restarting Jellyfin against both edits, and bringing the proxy up"
+docker compose -f "$COMPOSE" stop jellyfin >/dev/null
+docker compose -f "$COMPOSE" start jellyfin >/dev/null
+docker compose -f "$COMPOSE" --profile proxy up -d proxy >/dev/null
+pass "the stack is running with a proxy in front of Jellyfin"
+
+log "Driving the two clients"
+PROBE_OUT="$(docker compose -f "$COMPOSE" run --rm --no-deps -T \
+    -v "$PHASES_DIR:/probe:ro" --entrypoint sh harness /probe/probe-proxy-client-budget.sh)" \
+    || die "the probe container could not be started"
+printf '%s\n' "$PROBE_OUT" | sed 's/^/  probe| /'
+
+field() { printf '%s\n' "$PROBE_OUT" | sed -n "s/^$1 //p" | tail -1; }
+CONTROL="$(field PROBE-CONTROL)"
+EXHAUST_STATUSES="$(field PROBE-EXHAUST-STATUSES)"
+THROTTLED_AT="$(field PROBE-EXHAUST-THROTTLED-AT)"
+OTHER="$(field PROBE-OTHER-CLIENT)"
+[ -n "$CONTROL" ] && [ -n "$OTHER" ] \
+    || die "the probe returned no statuses - its own output is above"
+
+log "Asserting"
+case "$CONTROL" in
+    3??) pass "the control request through the proxy redirects to the identity provider ($CONTROL)" ;;
+    429) die "the control request was already throttled ($CONTROL) - the budget was spent before this phase started, so nothing below would be attributable to it" ;;
+    *) die "the control request through the proxy answered $CONTROL rather than a redirect - the stack is not healthy through the proxy, so a 429 afterwards would not be attributable to the limiter" ;;
+esac
+
+[ "$THROTTLED_AT" != "none" ] \
+    || die "client A was never throttled after the exhaust loop (statuses:$EXHAUST_STATUSES). Either the limiter is not running, or the forwarded address is not being attributed at all - NormalizeClientKey returns null for a non-public source and exempts it from throttling, which looks exactly like a passing limiter from the outside"
+pass "client A is throttled after $THROTTLED_AT request(s) past the control (statuses:$EXHAUST_STATUSES)"
+
+[ "$OTHER" != "429" ] \
+    || die "client B was throttled ($OTHER) on its FIRST request, having spent nothing. The limiter is keying on the proxy hop rather than on the forwarded client, so one noisy client behind a proxy throttles every other client at the same site"
+case "$OTHER" in
+    3??) pass "client B, through the SAME proxy, is not throttled and gets its own redirect ($OTHER) - the two clients are budgeted apart" ;;
+    *) die "client B answered $OTHER: not a throttle, but not the redirect the control got either, so this run does not show two clients budgeted apart" ;;
+esac
+
+log "Putting the configuration back"
+docker compose -f "$COMPOSE" --profile proxy stop proxy >/dev/null
+mv -f "$CONFIG_KEPT" "$CONFIG"
+mv -f "$NETWORK_KEPT" "$NETWORK_CONFIG"
+docker compose -f "$COMPOSE" stop jellyfin >/dev/null
+docker compose -f "$COMPOSE" start jellyfin >/dev/null
+pass "the limiter settings and the known-proxies list are back as the canonical pass left them"
+
+log "A login after the restore"
+# RELOGIN_ONLY, so the seed, the wizard and the two provider Add calls are skipped and the
+# persisted provider configuration this phase spent the run not touching is read back (#1123).
+RELOGIN_ONLY=true docker compose -f "$COMPOSE" up \
+    --abort-on-container-exit --exit-code-from harness \
+    || die "the login after the restore failed - the phase left the stack broken rather than as it found it"
+pass "the stack still logs in with the proxy gone and the limiter off"
+
+printf '\nPROXY CLIENT ATTRIBUTION PHASE PASSED\n'

--- a/test/e2e/phases/proxy-client-attribution.sh
+++ b/test/e2e/phases/proxy-client-attribution.sh
@@ -70,18 +70,48 @@ if [ ! -s "$NETWORK_CONFIG" ]; then
 fi
 grep -q '<KnownProxies' "$NETWORK_CONFIG" \
     || die "no <KnownProxies> element in $NETWORK_CONFIG - this Jellyfin does not carry the setting this phase depends on, and writing one blindly would be a guess"
-pass "both configuration files are present and the known-proxies element exists"
+RATE_BEFORE="$(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" | head -1)"
+[ -n "$RATE_BEFORE" ] \
+    || die "no <EnableRateLimit> element in $CONFIG - the phase would have nothing to switch on and nothing to put back"
+pass "both configuration files are present, the known-proxies element exists, and the limiter reads $RATE_BEFORE"
 
 CONFIG_KEPT="$CONFIG.kept"
 NETWORK_KEPT="$NETWORK_CONFIG.kept"
 [ ! -e "$CONFIG_KEPT" ] || die "$CONFIG_KEPT already exists - a previous run left a copy aside and this one would overwrite it"
 [ ! -e "$NETWORK_KEPT" ] || die "$NETWORK_KEPT already exists - a previous run left a copy aside and this one would overwrite it"
-cp "$CONFIG" "$CONFIG_KEPT"
-cp "$NETWORK_CONFIG" "$NETWORK_KEPT"
+
+# EVERY WRITE UNDER THE BIND MOUNT HAPPENS INSIDE A CONTAINER, and that is a constraint rather than
+# a preference (#1391, measured again here). `plugins/configurations/` is created by the SERVER at
+# runtime, so the `chmod -R 0777 test/e2e/jellyfin` in the install step never reaches it: that step
+# runs before the stack comes up and the directory does not exist yet. Both files are written by the
+# server as root, and copying one aside needs write permission on the DIRECTORY, which the ordinary
+# workflow user has none of - the first run of this phase died on exactly that, at `cp`, before it
+# asserted anything.
+#
+# The jellyfin service already bind-mounts ./jellyfin/config at /config and runs as root, so its own
+# definition is the shortest route to a writable handle: no second mount to keep in step with the
+# compose file, and no elevation on the host. `--no-deps` starts nothing else, `--rm` leaves nothing
+# behind, and the entrypoint is replaced so no server starts in it. Reads stay on the host, where
+# they work.
+in_jellyfin() { # $1 the shell program to run as root against /config
+    docker compose -f "$COMPOSE" run --rm --no-deps -T \
+        -e "PROXY_ADDR=$PROXY_ADDR" \
+        -e "MAX_ATTEMPTS=$MAX_ATTEMPTS" \
+        -e "WINDOW_SECONDS=$WINDOW_SECONDS" \
+        --entrypoint sh jellyfin -c "$1"
+}
+
+CONTAINER_CONFIG="/config/plugins/configurations/SSO-Auth.xml"
+CONTAINER_NETWORK="/config/config/network.xml"
+
+in_jellyfin "set -eu; cp -p '$CONTAINER_CONFIG' '$CONTAINER_CONFIG.kept'; cp -p '$CONTAINER_NETWORK' '$CONTAINER_NETWORK.kept'" \
+    || die "the two configuration files could not be copied aside"
 
 restore_config() {
-    [ -e "$CONFIG_KEPT" ] && mv -f "$CONFIG_KEPT" "$CONFIG" && printf 'restored %s on exit\n' "$CONFIG" >&2
-    [ -e "$NETWORK_KEPT" ] && mv -f "$NETWORK_KEPT" "$NETWORK_CONFIG" && printf 'restored %s on exit\n' "$NETWORK_CONFIG" >&2
+    in_jellyfin "set -eu
+        [ -e '$CONTAINER_CONFIG.kept' ] && mv -f '$CONTAINER_CONFIG.kept' '$CONTAINER_CONFIG'
+        [ -e '$CONTAINER_NETWORK.kept' ] && mv -f '$CONTAINER_NETWORK.kept' '$CONTAINER_NETWORK'
+        exit 0" >/dev/null 2>&1 || printf 'the restore on exit did not complete - check %s and %s\n' "$CONFIG" "$NETWORK_CONFIG" >&2
     docker compose -f "$COMPOSE" --profile proxy stop proxy >/dev/null 2>&1 || true
     return 0
 }
@@ -92,11 +122,12 @@ log "Switching the limiter on with a small budget"
 # The limiter's settings are deliberately NOT importable through the API (ConfigImport refuses
 # them, so a foreign document cannot silently disable a DoS control), which is why this is an edit
 # to the persisted configuration and a restart rather than an HTTP call.
-sed -i \
-    -e "s|<EnableRateLimit>[^<]*</EnableRateLimit>|<EnableRateLimit>true</EnableRateLimit>|" \
-    -e "s|<RateLimitMaxAttempts>[^<]*</RateLimitMaxAttempts>|<RateLimitMaxAttempts>$MAX_ATTEMPTS</RateLimitMaxAttempts>|" \
-    -e "s|<RateLimitWindowSeconds>[^<]*</RateLimitWindowSeconds>|<RateLimitWindowSeconds>$WINDOW_SECONDS</RateLimitWindowSeconds>|" \
-    "$CONFIG"
+in_jellyfin "set -eu; sed -i \
+    -e \"s|<EnableRateLimit>[^<]*</EnableRateLimit>|<EnableRateLimit>true</EnableRateLimit>|\" \
+    -e \"s|<RateLimitMaxAttempts>[^<]*</RateLimitMaxAttempts>|<RateLimitMaxAttempts>\$MAX_ATTEMPTS</RateLimitMaxAttempts>|\" \
+    -e \"s|<RateLimitWindowSeconds>[^<]*</RateLimitWindowSeconds>|<RateLimitWindowSeconds>\$WINDOW_SECONDS</RateLimitWindowSeconds>|\" \
+    '$CONTAINER_CONFIG'" \
+    || die "the limiter settings could not be written into $CONFIG"
 grep -q "<EnableRateLimit>true</EnableRateLimit>" "$CONFIG" \
     || die "the limiter is still off in $CONFIG after the edit - the element was not where the edit expected it: $(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" || echo 'element absent')"
 grep -q "<RateLimitMaxAttempts>$MAX_ATTEMPTS</RateLimitMaxAttempts>" "$CONFIG" \
@@ -106,11 +137,13 @@ pass "the limiter is on with $MAX_ATTEMPTS attempts per ${WINDOW_SECONDS}s"
 log "Naming the proxy in Jellyfin's known proxies"
 # Both spellings, because an empty list serializes as a self-closing element and a populated one
 # does not, and which of the two is on disk depends on what the wizard wrote.
-if grep -q '<KnownProxies */>' "$NETWORK_CONFIG"; then
-    sed -i "s|<KnownProxies */>|<KnownProxies><string>$PROXY_ADDR</string></KnownProxies>|" "$NETWORK_CONFIG"
-else
-    sed -i "s|<KnownProxies>.*</KnownProxies>|<KnownProxies><string>$PROXY_ADDR</string></KnownProxies>|" "$NETWORK_CONFIG"
-fi
+in_jellyfin "set -eu
+    if grep -q '<KnownProxies */>' '$CONTAINER_NETWORK'; then
+        sed -i \"s|<KnownProxies */>|<KnownProxies><string>\$PROXY_ADDR</string></KnownProxies>|\" '$CONTAINER_NETWORK'
+    else
+        sed -i \"s|<KnownProxies>.*</KnownProxies>|<KnownProxies><string>\$PROXY_ADDR</string></KnownProxies>|\" '$CONTAINER_NETWORK'
+    fi" \
+    || die "the known-proxies list could not be written into $NETWORK_CONFIG"
 grep -q "<string>$PROXY_ADDR</string>" "$NETWORK_CONFIG" \
     || die "the proxy address is not in $NETWORK_CONFIG after the edit; without it Jellyfin ignores the forwarded header and both clients collapse to the proxy, which would red this phase for a configuration reason rather than a plugin one"
 pass "$PROXY_ADDR is a known proxy"
@@ -155,8 +188,12 @@ esac
 
 log "Putting the configuration back"
 docker compose -f "$COMPOSE" --profile proxy stop proxy >/dev/null
-mv -f "$CONFIG_KEPT" "$CONFIG"
-mv -f "$NETWORK_KEPT" "$NETWORK_CONFIG"
+in_jellyfin "set -eu; mv -f '$CONTAINER_CONFIG.kept' '$CONTAINER_CONFIG'; mv -f '$CONTAINER_NETWORK.kept' '$CONTAINER_NETWORK'" \
+    || die "the two configuration files could not be put back"
+[ ! -e "$CONFIG_KEPT" ] && [ ! -e "$NETWORK_KEPT" ] \
+    || die "a copy is still sitting beside the configuration, so the restore did not complete"
+[ "$(grep -o '<EnableRateLimit>[^<]*</EnableRateLimit>' "$CONFIG" | head -1)" = "$RATE_BEFORE" ] \
+    || die "the limiter setting in $CONFIG is not what this phase found ($RATE_BEFORE), so the restore left the stack in a state the canonical pass did not create"
 docker compose -f "$COMPOSE" stop jellyfin >/dev/null
 docker compose -f "$COMPOSE" start jellyfin >/dev/null
 pass "the limiter settings and the known-proxies list are back as the canonical pass left them"

--- a/test/e2e/proxy/nginx.conf
+++ b/test/e2e/proxy/nginx.conf
@@ -26,7 +26,13 @@ server {
         proxy_pass http://jellyfin:8096;
         proxy_http_version 1.1;
 
-        proxy_set_header Host $host;
+        # The CANONICAL host, not the proxy's own name. Every redirect_uri the plugin derives is built
+        # from the request host, and the one registered at the identity provider is the Jellyfin service
+        # name this stack uses everywhere else. A proxy that passed its own name through would make the
+        # plugin derive a redirect_uri nobody registered, which is a broken login rather than the
+        # attribution question this phase asks. A production proxy presents the public host for the same
+        # reason.
+        proxy_set_header Host jellyfin:8096;
         proxy_set_header X-Forwarded-For $http_x_test_client;
         proxy_set_header X-Forwarded-Proto $scheme;
 

--- a/test/e2e/proxy/nginx.conf
+++ b/test/e2e/proxy/nginx.conf
@@ -1,0 +1,38 @@
+# The reverse proxy in front of Jellyfin for the client-attribution phase (#1125).
+#
+# It exists to answer one question: with a proxy in front of the stack, does the plugin's
+# per-client rate limiter budget two different clients apart, or does it collapse them into the
+# proxy? The plugin deliberately never reads X-Forwarded-For itself, so what is really under test
+# is that Jellyfin's own forwarded-headers handling resolves the real client into the connection
+# address the limiter keys on.
+#
+# X-Forwarded-For is set from a header the caller supplies rather than from $remote_addr, and that
+# is deliberate. Every request in the phase arrives from ONE probe container, so $remote_addr is
+# the same for both simulated clients and there would be nothing to tell apart. Setting it from
+# X-Test-Client models a proxy that knows which client it is serving, which is the situation the
+# phase is about. It is `set`, not `add`, so nothing a caller sends in X-Forwarded-For itself is
+# forwarded: the proxy's own view of the client is the only value Jellyfin ever sees, exactly as a
+# correctly configured production proxy behaves.
+#
+# This file is test scaffolding on a throwaway network. It is not a template for a real
+# deployment, where the client address comes from the connection and never from a header the
+# client controls.
+
+server {
+    listen 80;
+    server_name _;
+
+    location / {
+        proxy_pass http://jellyfin:8096;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $http_x_test_client;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # The plugin's challenge answers with a redirect to the identity provider and the phase
+        # reads that status. Rewriting the Location header would hide it behind the proxy's own
+        # view of the world, so the answer is passed through untouched.
+        proxy_redirect off;
+    }
+}


### PR DESCRIPTION
# What & why

Nothing in `test/e2e` put a reverse proxy in front of Jellyfin at all, so the claim that a noisy client behind a proxy does not throttle everybody else at the same site rested on one hand pass in #717 and on nothing since. A regression that collapsed every forwarded client into the proxy would have shipped silently and locked a whole site out on one client's noise.

The phase brings up an nginx front end, names it in Jellyfin's known proxies, exhausts one forwarded client's rate-limit budget and then makes ONE request as a second forwarded client through the same proxy. That single request is the whole assertion: if the limiter keyed on the proxy hop, the first client's exhaustion would be the second client's exhaustion and it would answer 429.

**What is under test is not what it looks like.** The plugin deliberately never reads `X-Forwarded-For`, because a client-supplied header would let an attacker rotate keys to evade the limiter or pin a victim's address to lock them out. So the phase proves the plugin sits correctly on top of the host's forwarded-headers handling, and it writes the known-proxies setting itself rather than assuming it: without that setting both clients collapse to the proxy and the run would red for a configuration reason rather than a plugin one. That is the false red this issue's own analysis asked to design out up front.

**The two forwarded addresses are on `11.0.9.0/24` and that is load-bearing.** `SsoRateLimiter.NormalizeClientKey` refuses to attribute a non-public source at all, and the documentation ranges somebody reaches for first (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`) are every one of them blocked by `IpAddressClassifier`. A phase written with those would exhaust nothing, prove nothing, and look like a passing test.

The proxy sits behind a compose profile, so an ordinary run of the stack never starts it and the per-PR path is unchanged. Only Jellyfin's own persisted files are edited, both are copied aside first and restored on every exit path, and the phase ends with a `RELOGIN_ONLY` pass so it proves the stack was left working rather than merely left.

**The audit half of the issue is absent by decision**, recorded on the issue on 2026-08-21: the audit trail records no client address and is not going to start, so there is nothing there to assert against. That is a real cost and the issue states it. After a brute-force attempt an operator reading the audit trail still cannot tell which client it came from.

Closes #1125

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

No production code changes here. The whole diff is `test/e2e` plus one workflow step; no login path, no crypto, no config persistence and no release pipeline byte moves.

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

**No second reader looked at this change, and there is no review record to point at.** The runs below stand in place of one.

One thing a reader should still check rather than take on trust: `test/e2e/proxy/nginx.conf` sets `X-Forwarded-For` from a header the caller supplies. That is test scaffolding on a throwaway network and the file says so in its own comment. It is there because every request in the phase comes from one probe container, so `$remote_addr` is identical for both simulated clients and there would be nothing to tell apart. It is `set` rather than `add`, so nothing a caller puts in `X-Forwarded-For` itself is forwarded. It is not a template for a real deployment and nothing outside this phase reads it.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: `test/e2e/README.md` carries the phase, its design constraints and its bounds, in the same place the phases beside it are documented.

## Verification

This is a phase CI cannot exercise on the per-PR path by design, so it was run on the route the workflow documents for exactly this case: a manual dispatch with `providers: all`, which is how a new harness entry is proven green before a release. Five runs, and the four red ones are worth reading, because each measured something rather than being guessed at.

**Run 5, the whole provider matrix green** (`32564279343`, all seven stacks plus `select`):

```
== Driving the two clients ==
  probe| PROBE-CONTROL 302
  probe| PROBE-EXHAUST-STATUSES 302 429
  probe| PROBE-EXHAUST-THROTTLED-AT 2
  probe| PROBE-OTHER-CLIENT 302
  probe| PROBE-CLIENTS 11.0.9.11 11.0.9.22
== Asserting ==
PASS: the control request through the proxy redirects to the identity provider (302)
PASS: client A is throttled after 2 request(s) past the control (statuses:302 429)
PASS: client B, through the SAME proxy, is not throttled and gets its own redirect (302) - the two clients are budgeted apart
PASS: the limiter settings and the known-proxies list are back as the canonical pass left them
PASS: the stack still logs in with the proxy gone and the limiter off
PROXY CLIENT ATTRIBUTION PHASE PASSED
```

**The falsifier, and it is the part to read.** A phase that passes proves nothing on its own; what it has to do is fail when the property it names is absent. `probe/1125-falsifier-known-proxies` is this branch with the known-proxies write deleted and nothing else, so Jellyfin has no reason to trust the forwarded header and both clients collapse to the proxy's own address. Run `32564581781`:

```
== NOT naming the proxy in Jellyfin's known proxies (falsifier branch, never merged) ==
  probe| PROBE-EXHAUST-THROTTLED-AT 2
  probe| PROBE-OTHER-CLIENT 429
PASS: the control request through the proxy redirects to the identity provider (302)
PASS: client A is throttled after 2 request(s) past the control (statuses:302 429)
##[error]client B was throttled (429) on its FIRST request, having spent nothing. The limiter is keying
on the proxy hop rather than on the forwarded client, so one noisy client behind a proxy throttles every
other client at the same site
```

The phase reds on precisely its central assertion, for precisely the reason it names. That branch is a probe and is not proposed for merge.

**The four earlier runs, and what each one measured.** They are listed because the phase is now written around all four, and because three of them are failures of the phase rather than of the plugin.

1. `32563046036` died at the copy-aside with `Permission denied`. `plugins/configurations/` is created by the server at runtime, after the install step's `chmod` has already run, so the workflow user has no write permission there. The same wall #1391 hit; the writes now go through a container the way the phase beside this one does.
2. `32563390714` reached the assertions and the control answered 400. The phase refused to let the 429 that followed count, which is what the control is for.
3. `32563749232` measured that 400 instead of guessing at it: `Error preparing login: the authorization server's discovery document could not be read`. The phase before this one ends with `docker compose up --abort-on-container-exit`, which stops every container, so this phase inherits a stopped stack and had started only Jellyfin. The identity provider is started too now.
4. `32564019565` passed every assertion the phase exists for and then failed the login after the restore. `start` returns when the container is running, not when the server is listening, so the harness raced it. The stack is now brought up cold by the same `up` that runs the harness.

Runs 2 and 4 are also evidence in their own right: the property this phase is about held in both of them, and neither was allowed to count, because a control that had not passed or a stack that had not recovered means the run says nothing.

- [ ] `dotnet build --no-restore --warnaserror` is green - no C# changed; not re-run for this branch.
- [ ] `dotnet test` is green - no C# changed; not re-run for this branch.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change - `test/e2e/README.md` changed and was formatted with `prettier --write`; `npx prettier --check test/e2e/README.md` reports clean.

The last box is ticked in substance and left unticked in form because the repo gate runs the glob over the whole tree and this branch only ran it over the file it touched.

## Notes

The phase is gated exactly as the three beside it are: release and `providers: all` only, canonical Keycloak stack only. It is placed after the migration phase and before the SAML rollover, which is the last one because it mutates the identity provider; this one only edits Jellyfin's own files and puts both back.

Two bounds worth stating plainly. The phase does not prove anything about a proxy configuration other than the one it writes, and it says nothing about what happens when the known-proxies setting is wrong in production - that is the operator's configuration, and the phase's own refusal is what would surface it in this stack. And the budget it sets (2 attempts per 600 seconds) is chosen so the exhaust loop is short; it is not the shipped default and nothing here asserts anything about that default.
