### PR TITLE
Load provider configuration from a mounted declarative file, fail-closed

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Json.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Json.cs
@@ -82,6 +82,16 @@ public partial class ArchitectureConformanceTests
         // already-validated token, so the screen runs in the reading file on the string, ahead of
         // Newtonsoft, over exactly the scopes the walk descends through.
         ["SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs"] = "SSO-Auth/Api/Oidc/OidcAuthorizeStateBuilder.cs",
+
+        // The declarative provider document read off a mounted path at startup (#1095). The gate is in the
+        // reading file, like the two claim reads above and for the same reason: the bytes arrive as a file
+        // rather than as a response, so there is no transport for a handler to sit in front of, and the
+        // screen runs on the text before the deserializer is consulted. Every object scope is screened
+        // rather than a named subset - this caller hands the whole document to a deserializer whose indexed
+        // member set it does not control, which is the discovery posture rather than the claim-walk one. A
+        // member named twice on this surface decides a client id, an endpoint or a secret, so it is refused
+        // rather than resolved by whichever of the two parsers happens to read it.
+        ["SSO-Auth/Config/DeclarativeProviderConfig.cs"] = "SSO-Auth/Config/DeclarativeProviderConfig.cs",
     };
 
     // Sites over bytes the plugin itself shipped or produced, each with the reason it is not provider

--- a/SSO-Auth.Tests/Config/DeclarativeProviderConfigTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeProviderConfigTests.cs
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for <see cref="DeclarativeProviderConfig"/> - the startup loader that applies a mounted provider
+/// document over the stored configuration (#1095). The merge rules themselves belong to
+/// <see cref="ConfigImport"/> and are pinned by <see cref="ConfigExportImportTests"/>; what is pinned here
+/// is what the loader adds on top of them and what a deployment depends on: the silent no-op when no source
+/// is configured, that every rejection leaves the stored configuration byte-identical, that the precedence
+/// is a merge rather than a replace, and that re-applying an unchanged document writes nothing so a restart
+/// loop cannot churn <c>config.xml</c>. The store is driven directly with local delegates, so no plugin
+/// instance and no filesystem are involved.
+/// </summary>
+public class DeclarativeProviderConfigTests
+{
+    private static readonly Guid Linked = Guid.Parse("55555555-5555-5555-5555-555555555555");
+
+    private const string Endpoint = "https://idp.example.invalid/.well-known/openid-configuration";
+    private const string ClientId = "the-client";
+
+    private static (ProviderConfigStore Store, PluginConfiguration Live, List<BasePluginConfiguration> Persisted) CreateStore()
+    {
+        var live = new PluginConfiguration();
+        var persisted = new List<BasePluginConfiguration>();
+        return (new ProviderConfigStore(() => live, persisted.Add, new CapturingLogger()), live, persisted);
+    }
+
+    // The document a deployment mounts: the same shape the admin export produces, serialized the same way.
+    private static string Document(PluginConfiguration configuration, int? formatVersion = null) =>
+        JsonSerializer.Serialize(new ConfigExportDocument
+        {
+            FormatVersion = formatVersion ?? ConfigExport.FormatVersion,
+            Configuration = configuration,
+        });
+
+    private static string Xml(PluginConfiguration configuration)
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        new XmlSerializer(typeof(PluginConfiguration)).Serialize(writer, configuration);
+        return writer.ToString();
+    }
+
+    private static DeclarativeLoadOutcome Load(ProviderConfigStore store, string text, CapturingLogger? logger = null) =>
+        DeclarativeProviderConfig.Apply(store, "/run/secrets/sso.json", _ => true, _ => text, logger);
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoSourcePath_ReadsNothing_WritesNothing_AndSaysSo(string? sourcePath)
+    {
+        // The no-op is the pin the whole feature rests on: an installation that never sets the variable must
+        // behave exactly as one built before this existed. Reading the file or persisting the configuration
+        // would both be visible here, and the delegates fail the test loudly rather than being ignored.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+
+        var outcome = DeclarativeProviderConfig.Apply(
+            store,
+            sourcePath,
+            _ => throw new Xunit.Sdk.XunitException("An unconfigured source must not be probed on disk."),
+            _ => throw new Xunit.Sdk.XunitException("An unconfigured source must not be read."),
+            new CapturingLogger());
+
+        Assert.Equal(DeclarativeLoadOutcome.NotConfigured, outcome);
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+    }
+
+    [Fact]
+    public void MissingFile_IsRejected_AndTheStoredConfigurationIsUntouched()
+    {
+        // A path that names nothing is a misconfiguration, not a licence to carry on quietly: the operator
+        // asked for a file to decide the providers and the server is about to run on something else.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kept"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = DeclarativeProviderConfig.Apply(
+            store,
+            "/run/secrets/absent.json",
+            _ => false,
+            _ => throw new Xunit.Sdk.XunitException("A file that does not exist must not be read."),
+            logger);
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, outcome);
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public void UnparseableDocument_IsRejected_AndTheStoredConfigurationIsByteIdentical()
+    {
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kept"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, "{ this is not json", logger));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.Contains(logger.Entries, entry => entry.Level == LogLevel.Error);
+    }
+
+    [Fact]
+    public void DocumentNamingAMemberTwice_IsRejected_RatherThanLettingTheParserChoose()
+    {
+        // A repeated member makes the document say two things, and which of them wins is the deserializer's
+        // decision rather than the operator's. On this surface that decision is a client id, an endpoint or
+        // a secret, so the document is refused before it is deserialized at all.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        const string Twice = """
+            {
+              "FormatVersion": 1,
+              "Configuration": {
+                "OidConfigs": {
+                  "kc": { "OidClientId": "first", "OidClientId": "second" }
+                }
+              }
+            }
+            """;
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, Twice, logger));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Error && entry.Message.Contains("twice", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnsupportedFormatVersion_IsRejected_AndTheStoredConfigurationIsByteIdentical()
+    {
+        // A shape this plugin does not understand is refused whole rather than half-applied, which is
+        // ConfigImport's rule reached through the loader: the version gate has to fire before the merge, not
+        // after part of it.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kept"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+        var before = Xml(live);
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["arriving"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = "other" };
+
+        Assert.Equal(
+            DeclarativeLoadOutcome.Rejected,
+            Load(store, Document(incoming, ConfigExport.FormatVersion + 1)));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.False(live.OidConfigs.ContainsKey("arriving"));
+    }
+
+    [Fact]
+    public void OneInvalidProvider_RejectsTheWholeDocument_IncludingItsValidProviders()
+    {
+        // Fail-closed as a UNIT. A document that is right about one provider and wrong about another applies
+        // neither, because a partly-applied provider set is a server whose login behaviour matches no
+        // document anybody holds. The invalid entry is the zero-hour guest duration ProviderConfigValidator
+        // already refuses (ProviderConfigValidatorTests).
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["good"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+        incoming.OidConfigs["bad"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = "second",
+            GuestAccessDurationRoleMappings = new List<GuestAccessDurationRoleMap>
+            {
+                new GuestAccessDurationRoleMap { DurationHours = 0, Roles = new[] { "guest" } },
+            },
+        };
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, Document(incoming)));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.False(live.OidConfigs.ContainsKey("good"));
+        Assert.False(live.OidConfigs.ContainsKey("bad"));
+    }
+
+    [Fact]
+    public void DocumentAssertingSsoOnlyLogin_IsRejected_BecauseNoSafeAdminCanBeProven()
+    {
+        // The loader runs while the plugin is being constructed, where there is no user manager to resolve a
+        // break-glass admin with, so the SSO-only guard cannot be satisfied and refuses. That is deliberate
+        // rather than incidental: turning off password login for a whole server is an elevated, audited act
+        // on the SSO-Only endpoints, and a file dropped into a mount is not that.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+
+        var incoming = new PluginConfiguration { DisablePasswordLogin = true, BreakGlassAdminUsername = "rescue" };
+        incoming.OidConfigs["arriving"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, Load(store, Document(incoming)));
+
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.False(live.DisablePasswordLogin);
+    }
+
+    [Fact]
+    public void ProviderArrivingWithASecurityCheckDisabled_IsAudited_LikeASaveAndAnImport()
+    {
+        // A mounted file that turns off a default-on protection has to leave the same [SSO Audit] trace the
+        // form save and the config import leave (#140/#672). Without this the quietest way to disable a
+        // protection on this server would be the one route that wrote nothing about it, and the file applies
+        // at boot, when nobody is looking at the surface it came from.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["lax"] = new OidConfig
+        {
+            OidEndpoint = Endpoint,
+            OidClientId = ClientId,
+            DoNotValidateEndpoints = true,
+        };
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, Document(incoming), logger));
+
+        Assert.Single(persisted);
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Message.Contains("[SSO Audit]", StringComparison.Ordinal)
+                && entry.Message.Contains(nameof(OidConfig.DoNotValidateEndpoints), StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Precedence_TheDocumentWinsForWhatItNames_LeavesWhatItDoesNot_AndKeepsTheServerManagedLinks()
+    {
+        // The whole precedence rule in one assertion set, because the three halves are only meaningful
+        // together: a named provider is taken from the document, an unnamed one is not touched, and the link
+        // map the server owns survives - it is in no document, so a replace instead of a merge would silently
+        // unlink every account on that provider.
+        var (store, live, persisted) = CreateStore();
+        var managed = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, Enabled = false };
+        managed.CanonicalLinks["subject-1"] = Linked;
+        live.OidConfigs["managed"] = managed;
+        live.OidConfigs["local-only"] = new OidConfig { OidEndpoint = "https://other.example.invalid/.well-known/openid-configuration", OidClientId = "local" };
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["managed"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, Enabled = true };
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, Document(incoming)));
+
+        Assert.Same(live, Assert.Single(persisted));
+        Assert.True(live.OidConfigs["managed"].Enabled);
+        Assert.Equal(Linked, live.OidConfigs["managed"].CanonicalLinks["subject-1"]);
+        Assert.Equal("local", live.OidConfigs["local-only"].OidClientId);
+    }
+
+    [Fact]
+    public void ReapplyingTheSameDocument_PersistsNothingTheSecondTime()
+    {
+        // The restart-loop pin. A container that boots with an unchanged mount must not rewrite config.xml
+        // every time, so the second load has to reach AlreadyCurrent without the persist delegate firing.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["managed"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, Enabled = false };
+
+        var incoming = new PluginConfiguration();
+        incoming.OidConfigs["managed"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, Enabled = true };
+        var document = Document(incoming);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document));
+        var afterFirst = Xml(live);
+        Assert.Single(persisted);
+
+        Assert.Equal(DeclarativeLoadOutcome.AlreadyCurrent, Load(store, document));
+
+        Assert.Single(persisted);
+        Assert.Equal(afterFirst, Xml(live));
+    }
+}

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -1,0 +1,337 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.IO;
+using System.Text.Json;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Audit;
+using Jellyfin.Plugin.SSO_Auth.Api.Oidc;
+using Jellyfin.Plugin.SSO_Auth.Api.Saml;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// What one declarative load did, so the caller and the tests observe an outcome instead of inferring it
+/// from a log line (#1095).
+/// </summary>
+internal enum DeclarativeLoadOutcome
+{
+    /// <summary>No source path is configured, so the plugin behaves exactly as it does without this feature.</summary>
+    NotConfigured,
+
+    /// <summary>The document was valid and changed the stored configuration, which was persisted.</summary>
+    Applied,
+
+    /// <summary>The document was valid and the stored configuration already matched it, so nothing was persisted.</summary>
+    AlreadyCurrent,
+
+    /// <summary>The source or the document could not be used, and the stored configuration was left untouched.</summary>
+    Rejected,
+}
+
+/// <summary>
+/// Applies a provider configuration document mounted into the container over the stored configuration at
+/// startup (#1095), so a deployment can describe its identity providers in a file it owns rather than by
+/// clicking through the settings page. The foundation of #828; the secret-reference form (#1096), the
+/// environment-variable source (#1097), the read-only admin surface (#1104) and the documentation (#1116)
+/// are siblings and are deliberately not here.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ONE setting names the source: the <see cref="SourcePathVariable"/> environment variable, holding the path
+/// of the document. An environment variable rather than a field in the plugin configuration, because the
+/// source that MANAGES the stored configuration cannot itself be stored there - a fresh install has no
+/// configuration yet, and the deployment shape this exists for points a mount at a path from its own
+/// environment. When the variable is absent or blank nothing is read, nothing is written and nothing is
+/// logged, so an installation that never sets it is byte-identical to one built before this existed.
+/// </para>
+/// <para>
+/// The document is the same shape <c>GET /sso/Config/Export</c> produces and <c>POST /sso/Config/Import</c>
+/// accepts, and it is applied through the same <see cref="ConfigImport"/>. That is the whole of the
+/// precedence rule, and it is a MERGE rather than a replace: a provider the document names wins over the
+/// stored one of that name, a provider the document does not name is left exactly as it is, and the
+/// server-managed link maps and issuer bindings survive the apply because
+/// <see cref="ServerManagedFields"/> re-injects them. A blank secret in the document keeps the stored
+/// secret, so a document that carries none does not blank one out. A secret written into the document IS
+/// applied, which is what #1096 replaces with a reference form.
+/// </para>
+/// <para>
+/// The link maps survive with ONE exception, inherited whole from the import path rather than invented
+/// here: <see cref="ServerManagedFields"/>'s repoint belt (#186) treats a changed discovery endpoint or
+/// client id on an EXISTING OpenID provider as a repoint to a possibly different identity provider, and
+/// clears that provider's links, issuer bindings and stored secret. So editing an endpoint in the mounted
+/// file unlinks every account on that provider, exactly as editing it on the settings page does. It is the
+/// behaviour that stops a foreign identity provider inheriting the old one's account mappings, and it is
+/// stated here because a file edit is a quieter act than a form save.
+/// </para>
+/// <para>
+/// Fail-closed in one direction only: a document that cannot be read, cannot be parsed, carries a version
+/// this plugin does not import, or carries a provider <see cref="ProviderConfigValidator"/> refuses is
+/// rejected AS A UNIT, logged at Error, and leaves the stored configuration byte-identical. It is never
+/// half-applied, because the document is applied to a detached copy first and only reaches the live
+/// configuration once that copy has taken it whole. Nothing here throws: this runs while the plugin is
+/// being constructed, and a throw would take the plugin - and with it every SSO login on the server -
+/// offline over a configuration file. A rejected document is a loud log line and a server that keeps
+/// running on what it already had.
+/// </para>
+/// <para>
+/// Applying the identical document twice persists nothing the second time. The comparison is made against
+/// the detached copy before the live configuration is touched, so a restart loop against an unchanged mount
+/// cannot rewrite <c>config.xml</c> on every boot.
+/// </para>
+/// </remarks>
+internal static class DeclarativeProviderConfig
+{
+    /// <summary>
+    /// The one setting that names the declarative document. Reserved by this loader: the naming scheme for
+    /// expressing the document's own FIELDS in the environment is #1097's, and must not reuse this name.
+    /// </summary>
+    internal const string SourcePathVariable = "JELLYFIN_SSO_CONFIG_FILE";
+
+    // The document is hand-written as often as it is exported, so a property spelled in another case is
+    // matched rather than silently dropped. Unknown properties are still ignored, which is the default and
+    // is disclosed rather than claimed away: a misspelled field name is a no-op here, and refusing one is
+    // the sibling rule #1097 states for its own source.
+    private static readonly JsonSerializerOptions ReadOptions = new() { PropertyNameCaseInsensitive = true };
+
+    /// <summary>
+    /// Reads the document named by <see cref="SourcePathVariable"/> and applies it to <paramref name="store"/>.
+    /// </summary>
+    /// <param name="store">The configuration store to apply the document through.</param>
+    /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <returns>What the load did.</returns>
+    internal static DeclarativeLoadOutcome ApplyFromEnvironment(ProviderConfigStore store, ILogger? logger)
+    {
+        try
+        {
+            return Apply(
+                store,
+                Environment.GetEnvironmentVariable(SourcePathVariable),
+                File.Exists,
+                path => File.ReadAllText(path),
+                logger);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            // The one place a broad catch is the correct instrument. This is called from the plugin's
+            // constructor, so anything that escapes fails the plugin load and takes every SSO login on the
+            // server offline - over a configuration file. The typed catches inside Apply name the failures
+            // that were reasoned about; this names the ones that were not, and refuses to let a
+            // configuration source decide whether the plugin exists.
+            if (logger?.IsEnabled(LogLevel.Error) == true)
+            {
+                logger.LogError(
+                    ex,
+                    "The declarative SSO configuration could not be applied and nothing was changed. The plugin is running on its stored configuration.");
+            }
+
+            return DeclarativeLoadOutcome.Rejected;
+        }
+    }
+
+    /// <summary>
+    /// Applies the document at <paramref name="sourcePath"/>, reading the filesystem through the supplied
+    /// delegates so the outcome can be driven without one.
+    /// </summary>
+    /// <param name="store">The configuration store to apply the document through.</param>
+    /// <param name="sourcePath">The document's path, or null/blank when no source is configured.</param>
+    /// <param name="exists">Answers whether the path names a readable document.</param>
+    /// <param name="read">Reads the document's text.</param>
+    /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <returns>What the load did.</returns>
+    internal static DeclarativeLoadOutcome Apply(
+        ProviderConfigStore store,
+        string? sourcePath,
+        Func<string, bool> exists,
+        Func<string, string> read,
+        ILogger? logger)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(exists);
+        ArgumentNullException.ThrowIfNull(read);
+
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            return DeclarativeLoadOutcome.NotConfigured;
+        }
+
+        if (!exists(sourcePath))
+        {
+            return Reject(logger, sourcePath, "the path names no readable file");
+        }
+
+        string text;
+        try
+        {
+            text = read(sourcePath);
+        }
+        catch (IOException ex)
+        {
+            return Reject(logger, sourcePath, ex.Message);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Reject(logger, sourcePath, ex.Message);
+        }
+        catch (ArgumentException ex)
+        {
+            // A path the platform will not accept at all, which is what a typo in a mount produces. It
+            // arrives as an argument fault rather than an I/O one, and it is a rejection like any other.
+            return Reject(logger, sourcePath, ex.Message);
+        }
+        catch (NotSupportedException ex)
+        {
+            return Reject(logger, sourcePath, ex.Message);
+        }
+
+        // Screened before it is deserialized, over EVERY object scope. A member named twice makes the
+        // document say two things and lets the deserializer pick one silently, which on this surface decides
+        // a client id, an endpoint or a secret - and the whole document is handed to a deserializer whose
+        // indexed member set this caller does not narrow, so there is no smaller set of scopes to name. It
+        // is refused rather than resolved, which is the same posture the discovery read takes.
+        var screened = StrictJson.Inspect(text, out var repeatedMember);
+        if (screened != StrictJson.Verdict.Clean)
+        {
+            var reason = screened == StrictJson.Verdict.Repeated
+                ? $"the document names the member '{repeatedMember}' twice in one object, so it says two things at once"
+                : "the document could not be read to the end";
+            return Reject(logger, sourcePath, reason);
+        }
+
+        ConfigExportDocument? document;
+        try
+        {
+            document = JsonSerializer.Deserialize<ConfigExportDocument>(text, ReadOptions);
+        }
+        catch (JsonException ex)
+        {
+            return Reject(logger, sourcePath, ex.Message);
+        }
+
+        if (document is null)
+        {
+            return Reject(logger, sourcePath, "the file holds no document");
+        }
+
+        // Applied to a DETACHED COPY of the live configuration first. That is what makes the whole document
+        // validate before anything is mutated, and it is also the comparison that keeps a restart loop from
+        // rewriting config.xml: the copy either refuses the document or shows exactly what the live
+        // configuration would become, and both answers are reached without touching it.
+        string? rejection = null;
+        var changed = store.Read(live =>
+        {
+            var candidate = live.DetachedCopy();
+            try
+            {
+                // No break-glass resolver: this runs during plugin construction, where no user manager
+                // exists, so a document asserting SSO-only login cannot prove a surviving admin password
+                // path and the whole document is refused. That mode is turned on through the elevated,
+                // audited SSO-Only endpoints, never by a file.
+                ConfigImport.Apply(candidate, document);
+            }
+            catch (ArgumentException ex)
+            {
+                rejection = ex.Message;
+                return false;
+            }
+
+            return !string.Equals(candidate.ToPersistedForm(), live.ToPersistedForm(), StringComparison.Ordinal);
+        });
+
+        if (rejection is not null)
+        {
+            return Reject(logger, sourcePath, rejection);
+        }
+
+        if (!changed)
+        {
+            if (logger?.IsEnabled(LogLevel.Debug) == true)
+            {
+                logger.LogDebug(
+                    "The declarative SSO configuration at {SourcePath} already matches the stored configuration; nothing was written.",
+                    sourcePath.ReplaceLineEndings(string.Empty));
+            }
+
+            return DeclarativeLoadOutcome.AlreadyCurrent;
+        }
+
+        try
+        {
+            store.Mutate(live => ConfigImport.Apply(live, document));
+        }
+        catch (ArgumentException ex)
+        {
+            // The live configuration moved between the copy and this apply (a login writing a canonical
+            // link is the ordinary way). ConfigImport validates before it mutates, so the refusal happened
+            // before anything was written and the store persisted nothing.
+            return Reject(logger, sourcePath, ex.Message);
+        }
+
+        if (logger?.IsEnabled(LogLevel.Information) == true)
+        {
+            logger.LogInformation(
+                "Applied the declarative SSO configuration at {SourcePath} over the stored configuration.",
+                sourcePath.ReplaceLineEndings(string.Empty));
+        }
+
+        AuditInsecureOptions(logger, document.Configuration);
+        return DeclarativeLoadOutcome.Applied;
+    }
+
+    // A mounted file that turns off a default-on protection has to leave the same [SSO Audit] trace a form
+    // save and a config import already leave (#140/#672). Without this the quietest way to disable audience
+    // validation on this server would be the one route that wrote nothing about it, and the declarative
+    // source is the route an operator is least likely to be watching at the moment it applies.
+    private static void AuditInsecureOptions(ILogger? logger, PluginConfiguration? applied)
+    {
+        if (logger is null || applied is null)
+        {
+            return;
+        }
+
+        if (applied.OidConfigs is { } oidConfigs)
+        {
+            foreach (var kvp in oidConfigs)
+            {
+                var insecure = kvp.Value is null ? null : OidcInsecureToggles.Enabled(kvp.Value);
+                if (insecure?.Count > 0)
+                {
+                    SsoAudit.InsecureOptionsEnabled(logger, "OpenID", kvp.Key, insecure);
+                }
+            }
+        }
+
+        if (applied.SamlConfigs is { } samlConfigs)
+        {
+            foreach (var kvp in samlConfigs)
+            {
+                var insecure = kvp.Value is null ? null : SamlInsecureToggles.Enabled(kvp.Value);
+                if (insecure?.Count > 0)
+                {
+                    SsoAudit.InsecureOptionsEnabled(logger, "SAML", kvp.Key, insecure);
+                }
+            }
+        }
+    }
+
+    // A rejection is Error rather than Warning: the operator asked for this file to decide the providers,
+    // and the server is now running on something else. The reason is echoed with its line endings stripped
+    // at the emission point, because it can quote a provider name that came out of the file
+    // (cs/log-forging is sanitized inline, never behind a helper).
+    private static DeclarativeLoadOutcome Reject(ILogger? logger, string sourcePath, string reason)
+    {
+        if (logger?.IsEnabled(LogLevel.Error) == true)
+        {
+            logger.LogError(
+                "The declarative SSO configuration at {SourcePath} was rejected and nothing was changed: {Reason}",
+                sourcePath.ReplaceLineEndings(string.Empty),
+                reason.ReplaceLineEndings(string.Empty));
+        }
+
+        return DeclarativeLoadOutcome.Rejected;
+    }
+}

--- a/SSO-Auth/Config/PluginConfiguration.cs
+++ b/SSO-Auth/Config/PluginConfiguration.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Jellyfin.Plugin.SSO_Auth.Config;
@@ -148,6 +151,43 @@ public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfigur
         // this to null (it is JSON-ignored), so a later write under the config lock must land in a stored map.
         get => _logoutSessions ??= new SerializableDictionary<string, LogoutSession>();
         set => _logoutSessions = value;
+    }
+
+    /// <summary>
+    /// Renders this configuration in the exact form the host persists it in, so one configuration can be
+    /// compared against another (#1095). Every persisted field counts, secrets and server-managed maps
+    /// included, which is what a JSON rendering cannot offer: that boundary withholds the secrets and drops
+    /// the link maps by design, so two configurations differing only in a secret compare as equal there.
+    /// It lives on this type rather than beside its caller because the XML stack is confined to the
+    /// persistence model and the SAML module, and this is the persistence model.
+    /// </summary>
+    /// <returns>The persisted XML form of this configuration.</returns>
+    internal string ToPersistedForm()
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        new XmlSerializer(typeof(PluginConfiguration)).Serialize(writer, this);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// Makes a detached copy of this configuration through the persisted form, so a caller can try a change
+    /// on it and decide whether to keep it while the live object never holds a half-applied state (#1095).
+    /// </summary>
+    /// <returns>An independent configuration carrying the same persisted fields.</returns>
+    internal PluginConfiguration DetachedCopy()
+    {
+        // These bytes are this object's own output rather than anything that arrived from outside, and the
+        // reader is still hardened the way every other XML read in this plugin is: no DTD, no resolver. A
+        // parse that is safe only because of where its input came from is one refactor away from not being.
+        var settings = new XmlReaderSettings
+        {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+        };
+
+        using var text = new StringReader(ToPersistedForm());
+        using var reader = XmlReader.Create(text, settings);
+        return (PluginConfiguration)new XmlSerializer(typeof(PluginConfiguration)).Deserialize(reader)!;
     }
 }
 

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -65,6 +65,13 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // created lazily on the first encrypt (a save) - never at load - so startup does no key I/O.
         _secrets = new Lazy<SecretStore>(() => new SecretStore(Path.Combine(DataFolderPath, "sso-secret.key")));
         Instance = this;
+
+        // #1095: a deployment that mounts a provider document gets it applied over the stored configuration
+        // here, before anything can serve a login against the old one. Last in the constructor because it
+        // persists through ConfigStore, and it returns an outcome rather than throwing - a file the operator
+        // got wrong must not take the plugin, and with it every SSO login on the server, offline. With no
+        // source path configured it reads nothing, writes nothing and logs nothing.
+        DeclarativeProviderConfig.ApplyFromEnvironment(ConfigStore, logger);
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

A deployment that builds its Jellyfin from a compose file had no way to describe its
identity providers in a file it owns. Every provider had to be typed into the settings
page by hand, on every rebuild. This is the foundation of #828.

One environment variable, `JELLYFIN_SSO_CONFIG_FILE`, names a document. It is the same
shape `GET /sso/Config/Export` produces and `POST /sso/Config/Import` accepts, and it is
applied through the same `ConfigImport`, so the precedence rule is the merge that already
exists rather than a second one to keep in step with it.

The four Done-when clauses, and where each is pinned:

| Clause                                                            | Pinned by                                                                                      |
| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| One documented setting; absent means behave exactly as today       | `NoSourcePath_ReadsNothing_WritesNothing_AndSaysSo` (the read and exists delegates fail the test if called) |
| Validated as a unit; a rejection leaves the stored config byte-identical | `MissingFile_…`, `UnparseableDocument_…`, `UnsupportedFormatVersion_…`, `OneInvalidProvider_RejectsTheWholeDocument_…` |
| Precedence stated in the XML doc and asserted                      | `Precedence_TheDocumentWinsForWhatItNames_LeavesWhatItDoesNot_AndKeepsTheServerManagedLinks`    |
| Re-applying the same document twice is a no-op                     | `ReapplyingTheSameDocument_PersistsNothingTheSecondTime`                                       |

## The two decisions in here

**An environment variable, not a configuration field.** The source that manages the stored
configuration cannot itself be stored there: a fresh install has no configuration yet, and
the deployment shape this exists for points a mount at a path out of its own environment.
The name is reserved for the path only; #1097 owns the scheme for expressing the document's
fields in the environment and must not reuse it.

**A detached copy, then the live object.** The document is applied to a copy of the live
configuration first. That is what makes the whole document validate before anything is
mutated, and it is the same comparison that answers whether a persist is needed at all, so
a restart loop against an unchanged mount cannot rewrite `config.xml` on every boot. The
copy and the comparison run through the persisted XML form, which counts every persisted
field: a JSON rendering withholds the secrets and drops the link maps, so two configurations
differing only in a secret would compare as equal there and a rotated secret would silently
never apply.

## What reading the change back found

Three defects, all fixed in this branch rather than filed.

**A provider arriving with a default-on protection disabled left no `[SSO Audit]` trace,**
while the identical document through the import route leaves one (#140/#672). That would
have made the declarative source the quietest way to disable a check on a server, and it
applies at boot, when nobody is watching the surface it came from. Now audited on the same
line the form save and the import use, and pinned by
`ProviderArrivingWithASecurityCheckDisabled_IsAudited_LikeASaveAndAnImport`.

**A path the platform refuses outright raises an argument fault rather than an I/O one.** It
would have escaped the typed catches and failed the plugin load, taking every SSO login on
the server offline over a configuration file. Caught now, with a broad guard at the
construction boundary for the failures nobody reasoned about; the suppression carries its
reason at the catch.

**The class documentation claimed the link maps always survive.** They do not. The repoint
belt (#186) clears a provider's links, issuer bindings and stored secret when its discovery
endpoint or client id changes, exactly as a settings-page edit does. The claim now states
the exception, because a file edit is a quieter act than a form save.

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [x] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The two review boxes stay unticked. **No second reader looked at this change**, and the
three findings above came from reading it back rather than from an independent lens, so
they are not a review record and are not presented as one. The evidence stands in place of
one and is below.

On the ticked boxes. Fail-closed: every refusal path leaves the stored configuration
byte-identical, asserted by comparing the persisted XML before and after in five tests. No
secret is logged: the only operator-authored strings that reach a log line are the source
path and a refusal reason, both with line endings stripped inline at the emission point,
and no configuration value is echoed. This change touches config persistence, which is
exactly why the missing review is disclosed rather than assumed away.

What the change does NOT do, stated because a reader will ask:

- It does not accept a secret by reference. A secret written into the document is applied
  in plaintext, which is the export document's existing semantics; #1096 is the sibling
  that replaces it with a reference form.
- It does not refuse an unknown property. A misspelled field name is a silent no-op here.
  #1097 states that rule for its own source; this loader does not yet carry it, and this
  sentence is the disclosure rather than a claim that it does.
- It does not turn SSO-only login on, and cannot: the guard refuses at construction time,
  pinned by `DocumentAssertingSsoOnlyLogin_IsRejected_BecauseNoSafeAdminCanBeProven`.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The merge itself is `ConfigImport`, unchanged and uncopied. The two conformance rules this
change met rather than worked around are worth naming:

`SamlDocumentParsing_HappensOnlyInsideTheSamlModule` refused the first draft, which held an
`XmlSerializer` round trip in the loader. The round trip moved onto `PluginConfiguration`
instead, which is the persistence model the rule already allowlists by exact path, and no
allowlist was widened.

`UntrustedJson_IsParsedOnlyThroughTheScreenedSeam` refused it too. A document read off a
mount is untrusted input, so it now passes `StrictJson.Inspect` over every object scope
before the deserializer sees it, and the site is declared in `GatedJsonReads` with the gate
in the reading file. Pinned by `DocumentNamingAMemberTwice_IsRejected_RatherThanLettingTheParserChoose`.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Both target frameworks, zero warnings, full suite:

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror
    0 Warnung(en) / 0 Fehler
    ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
    Total: 3285, Errors: 0, Failed: 0, Skipped: 4

    dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror
    0 Warnung(en) / 0 Fehler
    ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
    Total: 3286, Errors: 0, Failed: 0, Skipped: 4

Prettier is vacuously clean: the diff carries no `.js`, `.html`, `.md`, `.css` or `.scss`
file.

### Every guard was deleted and watched go red

A guard nobody falsified is a guard nobody has evidence for. Each of the three was broken
in the working tree, rebuilt, and the naming test observed failing, then restored.

| Guard removed                                                       | Test that went red                                              | Observed                        |
| -------------------------------------------------------------------- | ----------------------------------------------------------------- | --------------------------------- |
| The idempotence branch, inverted to `if (changed)`                   | `ReapplyingTheSameDocument_PersistsNothingTheSecondTime`         | Expected `Applied`, actual `AlreadyCurrent` |
| An approving break-glass resolver handed to both apply sites          | `DocumentAssertingSsoOnlyLogin_IsRejected_BecauseNoSafeAdminCanBeProven` | Expected `Rejected`, actual `Applied` |
| The `AuditInsecureOptions` call                                       | `ProviderArrivingWithASecurityCheckDisabled_IsAudited_LikeASaveAndAnImport` | Failed                          |

The second one is worth its own sentence, because the first attempt at it passed. Patching
only the copy's apply site left the live apply site refusing, so the test stayed green for
a reason it does not name, and the guard looked proven when it was not. Both sites had to
be patched before the test moved. That is the falsification catching a wrong proof rather
than confirming a right one.

## Notes

**What is not verified, and cannot be from here.** The loader runs from the plugin
constructor and, when a document changes something, persists through `ConfigStore` at that
moment. Whether `BasePlugin.UpdateConfiguration` behaves well that early in the host's
startup is not measured in this branch, because measuring it means driving a real Jellyfin
server. What limits the exposure is that the persist only happens when a mounted document
is present AND changes something: with no source configured, or with an unchanged one, the
constructor path does no I/O and no write at all. The broad catch at that boundary means
the worst observed outcome is a logged error and a plugin running on its stored
configuration.

**Size.** 689 added lines, of which 295 are tests and most of the rest is documentation on
one new type. Above the 400-line habit; it is one type, one wiring line and one table
entry, and splitting it would produce halves that only mean anything together.

**Documentation.** #1116 already owns the config-as-code page (file schema, env scheme,
precedence table, secret references) and is open on `Future / Post-1.0`, so no new
documentation issue is filed. The precedence rule, the repoint exception and the reserved
variable name are written in the loader's own XML documentation in the meantime.

**Siblings this deliberately does not touch:** #1096 (secrets as references), #1097
(environment as a content source), #1098 and #1102 and #1104 (the admin surface against a
declarative source). Each is a separate issue and none is started here.

Closes #1095
