### PR TITLE
Record the EU Digital Identity Wallet as a watched direction [#762]

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,6 +163,25 @@ and the only option on every current release line - lives on
 [Native OIDC Coexistence](https://github.com/Flowfin/jellyfin-plugin-sso/wiki/Native-OIDC-Coexistence), together with the link-model
 migration honesty.
 
+## Future directions
+
+The EU Digital Identity Wallet, defined by eIDAS 2.0 (Regulation (EU) 2024/1183)
+and presented to a relying party over OpenID4VP and OpenID4VCI, is recorded here
+as a possible future identity-provider direction. It is not planned, it is not
+implemented, and nothing in the plugin speaks either protocol.
+
+A deployment that wants wallet login before any of that can put a verifier
+speaking OpenID4VP in front of this plugin and let the plugin consume it as an
+ordinary OpenID Connect provider, which needs no plugin change. No recipe for
+that arrangement is published here yet.
+
+Whether a verifier is ever built into the plugin depends on conditions outside
+the project: a relying-party registration route a self-hoster can actually use,
+a maintained .NET verifier library, and wallet verification arriving in the
+identity providers people already run. Issue
+[#762](https://github.com/Flowfin/jellyfin-plugin-sso/issues/762) carries the
+reading behind this entry.
+
 ## Following along
 
 - The [SSO Roadmap board](https://github.com/users/iderex/projects/1) is the live


### PR DESCRIPTION
# What & why

The roadmap named no position on eIDAS 2.0 or the EU Digital Identity Wallet. A
reader deciding whether to depend on this plugin inside the EU could not tell
whether the direction had been considered and set aside or had never been looked
at, and those two states read identically from outside.

This adds one `## Future directions` section to `docs/ROADMAP.md`. It says the
wallet protocols (OpenID4VP, OpenID4VCI) are neither implemented nor planned,
names Regulation (EU) 2024/1183, describes the arrangement that does work today
(an OpenID4VP verifier in front of the plugin, consumed as an ordinary OpenID
Connect provider) while stating that no recipe for it is published here, and
names the conditions outside this project that would have to change before a
verifier is built in.

Closes #762

## Type of change

- [ ] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [x] Refactor / code quality / docs

## Security checklist

Not applicable. This change touches no login path, no crypto, no config
persistence and no release pipeline. Evidence, at the head commit:

```
$ git diff --name-only origin/main...HEAD
docs/ROADMAP.md
```

- [ ] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [ ] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      __ / PLAUSIBLE __** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [ ] Log inputs from the IdP are sanitized inline at the log call.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The architecture line is ticked on the ground that no compiled file changed, so
no structural property moved. The wiki `Roadmap` page is a stub pointing at this
file, per the decision recorded on #1089, so one copy stays one copy and no wiki
edit is owed.

## Verification

- [ ] `dotnet build --no-restore --warnaserror` is green.
- [ ] `dotnet test` is green.
- [x] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

I did not run the build or the test suite, and I am not claiming them green.
No compiled file is in the diff, so neither would have judged this change.
Prettier was run and is the check that does judge it:

```
$ npx prettier --check "docs/ROADMAP.md"
Checking formatting...
All matched files use Prettier code style!
```

The second acceptance criterion on the issue asks that nothing be implemented.
That is verified by the diff quoted above rather than asserted.

The claim in the new text that nothing in the plugin speaks either protocol was
read at the branch point rather than recalled:

```
$ grep -ril 'eidas\|eudi\|openid4vp\|openid4vc' .
(no matches)
```

## Notes

The issue's acceptance criterion names the Roadmap wiki page. That page is now a
stub that points at `docs/ROADMAP.md`, which #1089 made a tracked file for
exactly this reason, so the entry lands in the file and the wiki keeps one home.

No second reader looked at this change. The evidence above stands in place of
one: the three commands are the whole of what can be checked on a documentation
change, and the judgement left over is whether the wording is honest and
non-committal, which is a reading rather than a run.
