### PR TITLE
Take provider secrets from references rather than from the document [#1096]

### DIFF
--- a/SSO-Auth.Tests/ArchitectureConformanceTests.Json.cs
+++ b/SSO-Auth.Tests/ArchitectureConformanceTests.Json.cs
@@ -92,6 +92,14 @@ public partial class ArchitectureConformanceTests
         // member named twice on this surface decides a client id, an endpoint or a secret, so it is refused
         // rather than resolved by whichever of the two parsers happens to read it.
         ["SSO-Auth/Config/DeclarativeProviderConfig.cs"] = "SSO-Auth/Config/DeclarativeProviderConfig.cs",
+
+        // The same document, re-read as a node tree to resolve the secret references in it (#1096). The gate
+        // is the loader rather than this file, and the ordering is what makes that true: the pass runs
+        // between the screen and the deserializer, over bytes the screen has already cleared, so a document
+        // naming a member twice never reaches it. It is named here rather than folded into the entry above
+        // because what this read decides is the narrower and sharper half - which environment variable or
+        // which file supplies a client secret or a signing key.
+        ["SSO-Auth/Config/DeclarativeSecretReference.cs"] = "SSO-Auth/Config/DeclarativeProviderConfig.cs",
     };
 
     // Sites over bytes the plugin itself shipped or produced, each with the reason it is not provider

--- a/SSO-Auth.Tests/Config/DeclarativeSecretReferenceTests.cs
+++ b/SSO-Auth.Tests/Config/DeclarativeSecretReferenceTests.cs
@@ -1,0 +1,506 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Xml.Serialization;
+using Jellyfin.Plugin.SSO_Auth.Api;
+using Jellyfin.Plugin.SSO_Auth.Api.Secrets;
+using Jellyfin.Plugin.SSO_Auth.Config;
+using MediaBrowser.Model.Plugins;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Jellyfin.Plugin.SSO_Auth.Tests;
+
+/// <summary>
+/// Tests for the secret-reference form of the declarative provider document (#1096): a secret is named by
+/// the environment variable or the file that holds it, never written into the document, and every way of
+/// failing to resolve one refuses the whole load.
+/// </summary>
+/// <remarks>
+/// The tests are driven through <see cref="DeclarativeProviderConfig.Apply(ProviderConfigStore, string, System.Func{string, bool}, System.Func{string, string}, ILogger, System.Func{string, string}, System.Func{string, string}, System.Func{string, string})"/>
+/// rather than against the resolver alone, because what has to hold is a property of the LOAD: a document
+/// this pass refuses must leave the stored configuration byte-identical, and a resolver returning false
+/// proves that only if the loader acts on it. The environment and the filesystem are supplied as delegates,
+/// so no test reads a real variable or a real file and one test cannot leak a secret into another.
+/// </remarks>
+public class DeclarativeSecretReferenceTests
+{
+    private const string Endpoint = "https://idp.example.invalid/.well-known/openid-configuration";
+    private const string ClientId = "the-client";
+    private const string Secret = "correct-horse-battery-staple";
+
+    private static (ProviderConfigStore Store, PluginConfiguration Live, List<BasePluginConfiguration> Persisted) CreateStore()
+    {
+        var live = new PluginConfiguration();
+        var persisted = new List<BasePluginConfiguration>();
+        return (new ProviderConfigStore(() => live, persisted.Add, new CapturingLogger()), live, persisted);
+    }
+
+    private static string Xml(PluginConfiguration configuration)
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        new XmlSerializer(typeof(PluginConfiguration)).Serialize(writer, configuration);
+        return writer.ToString();
+    }
+
+    private static DeclarativeLoadOutcome Load(
+        ProviderConfigStore store,
+        string text,
+        CapturingLogger? logger = null,
+        IReadOnlyDictionary<string, string>? environment = null,
+        IReadOnlyDictionary<string, string>? files = null,
+        Func<string?, string?>? reveal = null) =>
+        DeclarativeProviderConfig.Apply(
+            store,
+            "/run/secrets/sso.json",
+            _ => true,
+            _ => text,
+            logger,
+            name => environment is not null && environment.TryGetValue(name, out var value) ? value : null,
+            path => files is not null && files.TryGetValue(path, out var content) ? content : null,
+            reveal);
+
+    // The document as an operator writes it: a provider object with whatever members the test is about.
+    private static string Document(string map, string provider, string members) => $$"""
+        {
+          "FormatVersion": 1,
+          "Configuration": {
+            "{{map}}": {
+              "{{provider}}": { {{members}} }
+            }
+          }
+        }
+        """;
+
+    private static string OidDocument(string members) =>
+        Document("OidConfigs", "kc", $"""
+            "OidEndpoint": "{Endpoint}", "OidClientId": "{ClientId}", {members}
+            """);
+
+    private static void AssertRejected(
+        DeclarativeLoadOutcome outcome,
+        List<BasePluginConfiguration> persisted,
+        PluginConfiguration live,
+        string before,
+        CapturingLogger logger,
+        string namesThis)
+    {
+        Assert.Equal(DeclarativeLoadOutcome.Rejected, outcome);
+        Assert.Empty(persisted);
+        Assert.Equal(before, Xml(live));
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Level == LogLevel.Error && entry.Message.Contains(namesThis, StringComparison.Ordinal));
+        AssertNoEntryCarriesTheSecret(logger);
+    }
+
+    // Every rejection path is checked for this, not just the ones about logging: the reason a reference form
+    // exists at all is that the secret should not be in reach of a place people read, and a log is such a
+    // place. A message naming a variable or a path is the whole of what a rejection may say.
+    private static void AssertNoEntryCarriesTheSecret(CapturingLogger logger)
+    {
+        Assert.DoesNotContain(
+            logger.Records,
+            record => record.Message.Contains(Secret, StringComparison.Ordinal)
+                || record.Exception?.ToString().Contains(Secret, StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void EnvironmentReference_SuppliesTheSecret_AndTheDocumentNeverCarriesIt()
+    {
+        // The first form. What is in the document is the NAME of a variable, and what reaches the provider is
+        // what that variable held, so the file an operator commits carries neither.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\""),
+            logger,
+            environment: new Dictionary<string, string> { ["SSO_KC_SECRET"] = Secret });
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, outcome);
+        Assert.Single(persisted);
+        Assert.Equal(Secret, live.OidConfigs["kc"].OidSecret);
+        AssertNoEntryCarriesTheSecret(logger);
+    }
+
+    [Fact]
+    public void FileReference_SuppliesTheSecret_AndItsTrailingNewlineIsNotPartOfIt()
+    {
+        // The second form, and the trailing newline is the point rather than a detail: a container secret is
+        // written by something that ends the line, and a client secret carrying one fails at the token
+        // endpoint with an error nobody traces back to the file.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretFile\": \"/run/secrets/kc\""),
+            logger,
+            files: new Dictionary<string, string> { ["/run/secrets/kc"] = Secret + "\n" });
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, outcome);
+        Assert.Single(persisted);
+        Assert.Equal(Secret, live.OidConfigs["kc"].OidSecret);
+        AssertNoEntryCarriesTheSecret(logger);
+    }
+
+    [Fact]
+    public void InlineSecret_IsRejected_AndTheMessageNamesBothReferenceForms()
+    {
+        // The refusal the whole feature rests on. A secret written into the document is a secret in whatever
+        // holds the document - a repository, a backup, an image layer - and none of those is reachable by the
+        // plugin's at-rest encryption, so accepting it with a warning would be accepting it.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kc"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId };
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument($"\"OidSecret\": \"{Secret}\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "OidSecretEnv");
+        Assert.Contains(
+            logger.Entries,
+            entry => entry.Message.Contains("OidSecretFile", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void InlineSecretSpelledInAnotherCase_IsRejectedToo()
+    {
+        // The deserializer that reads this document matches property names case-insensitively, so a member
+        // spelled 'oidsecret' fills the same field. A refusal that compared names exactly would be a refusal
+        // with a documented way round it.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument($"\"oidsecret\": \"{Secret}\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "OidSecretEnv");
+    }
+
+    [Fact]
+    public void SecretMemberSpelledTwiceInDifferentCases_IsRejected_RatherThanLettingTheParserChoose()
+    {
+        // Two members that differ only in case are not a repeat the document-level screen can see, and both
+        // are candidates for one field. Which of them the deserializer takes would decide the secret, so the
+        // document is refused rather than one of them being picked here.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretEnv\": \"FIRST\", \"oidsecretenv\": \"SECOND\""),
+            logger,
+            environment: new Dictionary<string, string> { ["FIRST"] = Secret, ["SECOND"] = "other" });
+
+        AssertRejected(outcome, persisted, live, before, logger, "case");
+    }
+
+    [Fact]
+    public void BothReferenceFormsOnOneField_IsRejected()
+    {
+        // Mutually exclusive per field. Picking one silently would make the document's meaning depend on this
+        // code's preference rather than on what the operator wrote.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\", \"OidSecretFile\": \"/run/secrets/kc\""),
+            logger,
+            environment: new Dictionary<string, string> { ["SSO_KC_SECRET"] = Secret },
+            files: new Dictionary<string, string> { ["/run/secrets/kc"] = "other" });
+
+        AssertRejected(outcome, persisted, live, before, logger, "undecided");
+    }
+
+    [Fact]
+    public void UnsetEnvironmentVariable_RejectsTheLoad_AndNamesTheVariable()
+    {
+        // Fail-closed, and the alternative is what makes it matter: resolving to blank would be KEPT rather
+        // than applied, so the server would run on its previous secret and the log would say nothing at all.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kc"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, OidSecret = "the-old-one" };
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "SSO_KC_SECRET");
+        Assert.Equal("the-old-one", live.OidConfigs["kc"].OidSecret);
+    }
+
+    [Fact]
+    public void EnvironmentVariableHoldingOnlyWhitespace_RejectsTheLoad()
+    {
+        // A variable declared and left empty is the ordinary compose mistake, and it arrives as a value
+        // rather than as an absence. It is the same refusal, because it supplies the same nothing.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\""),
+            logger,
+            environment: new Dictionary<string, string> { ["SSO_KC_SECRET"] = "   " });
+
+        AssertRejected(outcome, persisted, live, before, logger, "SSO_KC_SECRET");
+    }
+
+    [Fact]
+    public void UnreadableFile_RejectsTheLoad_AndNamesThePath()
+    {
+        // A mount that did not arrive, or arrived without the permission to read it, is the failure this form
+        // meets most often, and the path is the one thing a diagnosis needs.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument("\"OidSecretFile\": \"/run/secrets/kc\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "/run/secrets/kc");
+    }
+
+    [Fact]
+    public void EmptyFile_RejectsTheLoad()
+    {
+        // A file that exists and holds nothing is the shape a half-finished mount produces, and it is not a
+        // secret. Reading it as one would set an empty client secret on the next apply.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"OidSecretFile\": \"/run/secrets/kc\""),
+            logger,
+            files: new Dictionary<string, string> { ["/run/secrets/kc"] = "\n  \n" });
+
+        AssertRejected(outcome, persisted, live, before, logger, "/run/secrets/kc");
+    }
+
+    [Fact]
+    public void ReferenceNamingNothing_RejectsTheLoad()
+    {
+        // A reference member present but blank says a secret is being supplied and supplies none. Treating it
+        // as absent would be the fail-open reading of exactly the member that exists to close it.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument("\"OidSecretEnv\": \"\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "OidSecretEnv");
+    }
+
+    [Fact]
+    public void ReferenceForTheOtherProtocolsSecret_RejectsTheLoad()
+    {
+        // An unknown member elsewhere in this document is a silent no-op, which the loader discloses. This one
+        // may not be: the operator who wrote it believes a secret has been supplied, and the provider would
+        // come up on whatever was stored before - working, and not from the file being read.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(
+            store,
+            OidDocument("\"SamlSigningKeyPfxEnv\": \"SSO_KC_KEY\""),
+            logger,
+            environment: new Dictionary<string, string> { ["SSO_KC_KEY"] = Secret });
+
+        AssertRejected(outcome, persisted, live, before, logger, "SamlSigningKeyPfxEnv");
+    }
+
+    [Fact]
+    public void TheOtherProtocolsSecretWrittenOutInFull_RejectsTheLoad_EvenThoughItWouldDoNothing()
+    {
+        // A member the deserializer would drop, carrying a real secret. The value never reaches a provider,
+        // so nothing here is about what the server would do with it - it is about the document, which is the
+        // artefact this whole form exists to keep secrets out of. Ignoring it quietly would leave the secret
+        // in the file and the operator with no sign that anything was wrong.
+        var (store, live, persisted) = CreateStore();
+        var before = Xml(live);
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument($"\"SamlSigningKeyPfx\": \"{Secret}\""), logger);
+
+        AssertRejected(outcome, persisted, live, before, logger, "SamlSigningKeyPfx");
+    }
+
+    [Fact]
+    public void SamlSigningKeys_TakeReferencesToo_IncludingTheRolloverKey()
+    {
+        // Both SAML keys are private keys and both are withheld at the JSON boundary, so both are secrets a
+        // document may not carry. The rollover key is named explicitly because it is the one that gets
+        // forgotten: it exists only during an overlap window, which is exactly when a document is edited.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+
+        // Real keys, because the validator this load runs through refuses a SAML signing key that is not a
+        // loadable PKCS#12 blob - so a placeholder would prove the refusal rather than the reference form.
+        var primary = SamlSigningKeyFactory.CreatePfxBase64();
+        var rollover = SamlSigningKeyFactory.CreatePfxBase64();
+
+        var document = Document("SamlConfigs", "adfs", """
+            "SamlEndpoint": "https://idp.example.invalid/sso", "SamlClientId": "sp",
+            "SamlSigningKeyPfxEnv": "SSO_PRIMARY", "SamlRolloverSigningKeyPfxFile": "/run/secrets/rollover"
+            """);
+
+        var outcome = Load(
+            store,
+            document,
+            logger,
+            environment: new Dictionary<string, string> { ["SSO_PRIMARY"] = primary },
+            files: new Dictionary<string, string> { ["/run/secrets/rollover"] = rollover + "\n" });
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, outcome);
+        Assert.Single(persisted);
+        Assert.Equal(primary, live.SamlConfigs["adfs"].SamlSigningKeyPfx);
+        Assert.Equal(rollover, live.SamlConfigs["adfs"].SamlRolloverSigningKeyPfx);
+        Assert.DoesNotContain(logger.Records, record => record.Message.Contains(primary, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ADocumentWithNoSecretAtAll_StillLoads()
+    {
+        // The reference form is not a requirement to name a secret. A document that names none leaves the
+        // stored one alone, which is the blank-means-keep rule the merge already carries, and this pins that
+        // the new pass did not turn an absence into a refusal.
+        var (store, live, persisted) = CreateStore();
+        live.OidConfigs["kc"] = new OidConfig { OidEndpoint = Endpoint, OidClientId = ClientId, OidSecret = "the-stored-one" };
+        var logger = new CapturingLogger();
+
+        var outcome = Load(store, OidDocument("\"Enabled\": true"), logger);
+
+        Assert.Equal(DeclarativeLoadOutcome.Applied, outcome);
+        Assert.Equal("the-stored-one", live.OidConfigs["kc"].OidSecret);
+    }
+
+    [Fact]
+    public void AResolvedSecretIsEncryptedAtRest_AndTheExportStillCarriesNothing()
+    {
+        // The three places a resolved secret must not appear, asserted on the same value in one test because
+        // they are one claim: the reference form is worth nothing if the secret it delivers then leaks out of
+        // the config XML, out of the admin export, or out of the log.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+        var keyPath = SuiteTempFiles.Path("sso-declref");
+
+        try
+        {
+            Assert.Equal(
+                DeclarativeLoadOutcome.Applied,
+                Load(
+                    store,
+                    OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\""),
+                    logger,
+                    environment: new Dictionary<string, string> { ["SSO_KC_SECRET"] = Secret }));
+
+            // What the plugin's persistence boundary does on the way to disk, reached the same way it is
+            // reached in production rather than asserted about.
+            var secrets = new SecretStore(keyPath);
+            ConfigSecretProtection.ProtectAll(Assert.IsType<PluginConfiguration>(Assert.Single(persisted)), secrets);
+
+            var xml = Xml(live);
+            Assert.DoesNotContain(Secret, xml, StringComparison.Ordinal);
+            Assert.True(SecretEnvelope.IsProtected(live.OidConfigs["kc"].OidSecret));
+            Assert.Equal(Secret, secrets.Reveal(live.OidConfigs["kc"].OidSecret));
+
+            var exported = JsonSerializer.Serialize(ConfigExport.Build(live));
+            Assert.DoesNotContain(Secret, exported, StringComparison.Ordinal);
+
+            AssertNoEntryCarriesTheSecret(logger);
+        }
+        finally
+        {
+            if (File.Exists(keyPath))
+            {
+                File.Delete(keyPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void ReapplyingADocumentWhoseReferenceHasNotMoved_PersistsNothingTheSecondTime()
+    {
+        // The restart-loop pin, re-run over a reference. What is stored is an envelope and what the reference
+        // resolves to is the plaintext inside it, so without the comparison against the revealed value the two
+        // never look equal and every boot rewrites config.xml with a freshly nonced envelope.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+        var keyPath = SuiteTempFiles.Path("sso-declref-loop");
+        var environment = new Dictionary<string, string> { ["SSO_KC_SECRET"] = Secret };
+        var document = OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\"");
+
+        try
+        {
+            var secrets = new SecretStore(keyPath);
+
+            Assert.Equal(DeclarativeLoadOutcome.Applied, Load(store, document, logger, environment, reveal: secrets.Reveal));
+            ConfigSecretProtection.ProtectAll(live, secrets);
+            var afterFirst = Xml(live);
+            Assert.Single(persisted);
+
+            Assert.Equal(
+                DeclarativeLoadOutcome.AlreadyCurrent,
+                Load(store, document, logger, environment, reveal: secrets.Reveal));
+
+            Assert.Single(persisted);
+            Assert.Equal(afterFirst, Xml(live));
+        }
+        finally
+        {
+            if (File.Exists(keyPath))
+            {
+                File.Delete(keyPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void AReferenceThatNowResolvesToADifferentSecret_IsAppliedRatherThanKept()
+    {
+        // The other half of the comparison above, and the one that would fail silently if it were wrong: a
+        // rotated secret must still reach the provider. A comparison that answered "already stored" too
+        // eagerly would leave the server authenticating with the retired value.
+        var (store, live, persisted) = CreateStore();
+        var logger = new CapturingLogger();
+        var keyPath = SuiteTempFiles.Path("sso-declref-rotate");
+        var document = OidDocument("\"OidSecretEnv\": \"SSO_KC_SECRET\"");
+
+        try
+        {
+            var secrets = new SecretStore(keyPath);
+
+            Assert.Equal(
+                DeclarativeLoadOutcome.Applied,
+                Load(store, document, logger, new Dictionary<string, string> { ["SSO_KC_SECRET"] = Secret }, reveal: secrets.Reveal));
+            ConfigSecretProtection.ProtectAll(live, secrets);
+
+            Assert.Equal(
+                DeclarativeLoadOutcome.Applied,
+                Load(store, document, logger, new Dictionary<string, string> { ["SSO_KC_SECRET"] = "the-rotated-one" }, reveal: secrets.Reveal));
+
+            Assert.Equal(2, persisted.Count);
+            Assert.Equal("the-rotated-one", live.OidConfigs["kc"].OidSecret);
+        }
+        finally
+        {
+            if (File.Exists(keyPath))
+            {
+                File.Delete(keyPath);
+            }
+        }
+    }
+}

--- a/SSO-Auth/Config/DeclarativeProviderConfig.cs
+++ b/SSO-Auth/Config/DeclarativeProviderConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text.Json;
 using Jellyfin.Plugin.SSO_Auth.Api;
 using Jellyfin.Plugin.SSO_Auth.Api.Audit;
@@ -34,7 +35,8 @@ internal enum DeclarativeLoadOutcome
 /// <summary>
 /// Applies a provider configuration document mounted into the container over the stored configuration at
 /// startup (#1095), so a deployment can describe its identity providers in a file it owns rather than by
-/// clicking through the settings page. The foundation of #828; the secret-reference form (#1096), the
+/// clicking through the settings page. The foundation of #828; the secrets it carries are references rather
+/// than values and are resolved by <see cref="DeclarativeSecretReference"/> (#1096), while the
 /// environment-variable source (#1097), the read-only admin surface (#1104) and the documentation (#1116)
 /// are siblings and are deliberately not here.
 /// </summary>
@@ -54,8 +56,22 @@ internal enum DeclarativeLoadOutcome
 /// stored one of that name, a provider the document does not name is left exactly as it is, and the
 /// server-managed link maps and issuer bindings survive the apply because
 /// <see cref="ServerManagedFields"/> re-injects them. A blank secret in the document keeps the stored
-/// secret, so a document that carries none does not blank one out. A secret written into the document IS
-/// applied, which is what #1096 replaces with a reference form.
+/// secret, so a document that carries none does not blank one out.
+/// </para>
+/// <para>
+/// A secret is never written into the document. <see cref="DeclarativeSecretReference"/> resolves the
+/// <c>Env</c> and <c>File</c> reference forms into it just before it is deserialized (#1096), and refuses a
+/// document that spells a secret out, so the file this loader reads can live wherever the deployment keeps
+/// the rest of its configuration without carrying a client secret or a signing key there. A reference that
+/// cannot be resolved rejects the whole document exactly like any other fault; nothing falls back to a blank
+/// secret, because a blank one is KEPT rather than applied and would leave the server running on its
+/// previous secret with nothing said about it.
+/// </para>
+/// <para>
+/// A resolved secret the store already holds is put back to blank before the merge, so the encrypted value
+/// at rest survives untouched. Without that the restart-loop promise below would not survive the first
+/// reference: what is stored is an envelope and what a reference resolves to is the plaintext inside it, so
+/// the two never compare equal and every boot would rewrite <c>config.xml</c>.
 /// </para>
 /// <para>
 /// The link maps survive with ONE exception, inherited whole from the import path rather than invented
@@ -101,8 +117,16 @@ internal static class DeclarativeProviderConfig
     /// </summary>
     /// <param name="store">The configuration store to apply the document through.</param>
     /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <param name="revealStoredSecret">
+    /// Recovers the plaintext of a secret as the store holds it, so a reference resolving to what is already
+    /// stored leaves the at-rest envelope alone (#1096). Null skips that comparison, which costs a rewrite
+    /// rather than correctness.
+    /// </param>
     /// <returns>What the load did.</returns>
-    internal static DeclarativeLoadOutcome ApplyFromEnvironment(ProviderConfigStore store, ILogger? logger)
+    internal static DeclarativeLoadOutcome ApplyFromEnvironment(
+        ProviderConfigStore store,
+        ILogger? logger,
+        Func<string?, string?>? revealStoredSecret = null)
     {
         try
         {
@@ -111,7 +135,10 @@ internal static class DeclarativeProviderConfig
                 Environment.GetEnvironmentVariable(SourcePathVariable),
                 File.Exists,
                 path => File.ReadAllText(path),
-                logger);
+                logger,
+                Environment.GetEnvironmentVariable,
+                ReadReferenceFile,
+                revealStoredSecret);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         catch (Exception ex)
@@ -142,13 +169,22 @@ internal static class DeclarativeProviderConfig
     /// <param name="exists">Answers whether the path names a readable document.</param>
     /// <param name="read">Reads the document's text.</param>
     /// <param name="logger">The logger a rejection is reported on.</param>
+    /// <param name="readEnvironmentVariable">Reads a variable a secret reference names; the process environment by default.</param>
+    /// <param name="readReferenceFile">Reads a file a secret reference names, null when it cannot be read; the filesystem by default.</param>
+    /// <param name="revealStoredSecret">
+    /// Recovers the plaintext of a secret as the store holds it (#1096). Null skips the comparison that keeps
+    /// an unchanged secret's at-rest envelope, which costs a rewrite rather than correctness.
+    /// </param>
     /// <returns>What the load did.</returns>
     internal static DeclarativeLoadOutcome Apply(
         ProviderConfigStore store,
         string? sourcePath,
         Func<string, bool> exists,
         Func<string, string> read,
-        ILogger? logger)
+        ILogger? logger,
+        Func<string, string?>? readEnvironmentVariable = null,
+        Func<string, string?>? readReferenceFile = null,
+        Func<string?, string?>? revealStoredSecret = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(exists);
@@ -202,10 +238,23 @@ internal static class DeclarativeProviderConfig
             return Reject(logger, sourcePath, reason);
         }
 
+        // The secrets arrive as references and are resolved into the document HERE, after the repeated-member
+        // screen and before the deserializer, so the pass that decides a secret reads the same bytes the
+        // screen just cleared and hands the deserializer a document with no reference left in it (#1096).
+        if (!DeclarativeSecretReference.TryResolve(
+            text,
+            readEnvironmentVariable ?? Environment.GetEnvironmentVariable,
+            readReferenceFile ?? ReadReferenceFile,
+            out var resolvedText,
+            out var secretRejection))
+        {
+            return Reject(logger, sourcePath, secretRejection ?? "a secret reference could not be resolved");
+        }
+
         ConfigExportDocument? document;
         try
         {
-            document = JsonSerializer.Deserialize<ConfigExportDocument>(text, ReadOptions);
+            document = JsonSerializer.Deserialize<ConfigExportDocument>(resolvedText, ReadOptions);
         }
         catch (JsonException ex)
         {
@@ -224,6 +273,8 @@ internal static class DeclarativeProviderConfig
         string? rejection = null;
         var changed = store.Read(live =>
         {
+            KeepWhatIsAlreadyStored(document.Configuration, live, revealStoredSecret);
+
             var candidate = live.DetachedCopy();
             try
             {
@@ -280,6 +331,119 @@ internal static class DeclarativeProviderConfig
 
         AuditInsecureOptions(logger, document.Configuration);
         return DeclarativeLoadOutcome.Applied;
+    }
+
+    // The filesystem behind a secret reference. A path that cannot be read is null rather than an exception,
+    // because every way of failing to read one is the same answer to the only question the resolver asks -
+    // "does this reference produce a secret" - and the resolver turns that answer into a refusal naming the
+    // path. The document's own read keeps its typed catches: there the reason reaches the operator.
+    private static string? ReadReferenceFile(string path)
+    {
+        try
+        {
+            return File.ReadAllText(path);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
+        }
+    }
+
+    // A resolved secret that is ALREADY the stored one is put back to blank, so the merge keeps the encrypted
+    // value at rest instead of writing the plaintext over it. Without this the loader's restart-loop promise
+    // dies at the first reference: what is stored is an ssoenc: envelope, what a reference resolves to is the
+    // plaintext inside it, the two never compare equal, and every boot rewrites config.xml with a freshly
+    // nonced envelope. Blank means keep, which is the rule ServerManagedFields already carries for every
+    // other write path, so this reaches the outcome through that rule rather than beside it.
+    private static void KeepWhatIsAlreadyStored(PluginConfiguration? incoming, PluginConfiguration live, Func<string?, string?>? reveal)
+    {
+        if (incoming is null || reveal is null)
+        {
+            return;
+        }
+
+        if (incoming.OidConfigs is { } oidConfigs && live.OidConfigs is { } storedOid)
+        {
+            foreach (var kvp in oidConfigs)
+            {
+                if (kvp.Value is null
+                    || string.IsNullOrWhiteSpace(kvp.Value.OidSecret)
+                    || !storedOid.TryGetValue(kvp.Key, out var stored)
+                    || stored is null)
+                {
+                    continue;
+                }
+
+                // Only while the provider's identity is unchanged. On a repoint ServerManagedFields drops the
+                // stored secret ON PURPOSE (#186), so blanking here would hand that provider no secret at all
+                // - the one case where "already stored" is true and keeping it is still wrong.
+                if (!string.Equals(kvp.Value.OidEndpoint, stored.OidEndpoint, StringComparison.Ordinal)
+                    || !string.Equals(kvp.Value.OidClientId, stored.OidClientId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (IsAlreadyStored(reveal, stored.OidSecret, kvp.Value.OidSecret))
+                {
+                    kvp.Value.OidSecret = null;
+                }
+            }
+        }
+
+        if (incoming.SamlConfigs is { } samlConfigs && live.SamlConfigs is { } storedSaml)
+        {
+            foreach (var kvp in samlConfigs)
+            {
+                if (kvp.Value is null || !storedSaml.TryGetValue(kvp.Key, out var stored) || stored is null)
+                {
+                    continue;
+                }
+
+                // No identity guard on this arm, because ServerManagedFields has none either: a SAML signing
+                // key is never transmitted, so blank-means-keep holds for it whatever else the document moved.
+                if (IsAlreadyStored(reveal, stored.SamlSigningKeyPfx, kvp.Value.SamlSigningKeyPfx))
+                {
+                    kvp.Value.SamlSigningKeyPfx = null;
+                }
+
+                if (IsAlreadyStored(reveal, stored.SamlRolloverSigningKeyPfx, kvp.Value.SamlRolloverSigningKeyPfx))
+                {
+                    kvp.Value.SamlRolloverSigningKeyPfx = null;
+                }
+            }
+        }
+    }
+
+    private static bool IsAlreadyStored(Func<string?, string?> reveal, string? stored, string? resolved)
+    {
+        if (string.IsNullOrWhiteSpace(resolved) || string.IsNullOrEmpty(stored))
+        {
+            return false;
+        }
+
+        try
+        {
+            return string.Equals(reveal(stored), resolved, StringComparison.Ordinal);
+        }
+        catch (CryptographicException)
+        {
+            // A stored envelope this instance can no longer read - the key file is gone. Answering "not the
+            // same" hands that case to the merge and the persist boundary, which already fail closed on
+            // exactly that pairing, rather than deciding it here on a comparison that could not be made.
+            return false;
+        }
     }
 
     // A mounted file that turns off a default-on protection has to leave the same [SSO Audit] trace a form

--- a/SSO-Auth/Config/DeclarativeSecretReference.cs
+++ b/SSO-Auth/Config/DeclarativeSecretReference.cs
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: The jellyfin-plugin-sso authors
+// SPDX-License-Identifier: GPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Jellyfin.Plugin.SSO_Auth.Config;
+
+/// <summary>
+/// Turns the secret REFERENCES in a declarative provider document into the secrets themselves, immediately
+/// before the document is deserialized (#1096), and refuses a document that writes a secret out in full.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The document the loader applies (#1095) is a file on a mounted volume, and the deployment shape it exists
+/// for keeps that file in version control. A client secret or a SAML signing key written into it is therefore
+/// a secret in a repository, in a backup and in every image layer that copied it, and the plugin's own
+/// at-rest encryption cannot reach any of those. So an inline secret is REFUSED here rather than accepted
+/// with a warning: a warning at boot is read by nobody, and the value is already committed by the time it
+/// would be printed.
+/// </para>
+/// <para>
+/// Two reference forms, one per deployment habit, each spelled as the field name it fills plus a suffix, so a
+/// reader of the document can see which secret is being named:
+/// </para>
+/// <list type="bullet">
+/// <item><c>&lt;field&gt;Env</c> names an environment variable, which is how a compose file or a Kubernetes
+/// <c>env</c> block hands a value to a container.</item>
+/// <item><c>&lt;field&gt;File</c> names a path to read, which is the docker-secret and projected-volume
+/// habit, and the reason a container secret usually arrives as a file rather than as a variable.</item>
+/// </list>
+/// <para>
+/// The three fields are the three the JSON boundary already treats as write-only through
+/// <see cref="WriteOnlySecretConverter"/>: <c>OidSecret</c> on an OpenID provider, and
+/// <c>SamlSigningKeyPfx</c> plus <c>SamlRolloverSigningKeyPfx</c> on a SAML one. That is not a coincidence
+/// to be kept in step by hand - those are exactly the values an export refuses to emit, so they are exactly
+/// the values a document has no legitimate way to carry in full.
+/// </para>
+/// <para>
+/// FAIL-CLOSED IN ONE DIRECTION. Every failure this pass can meet - an inline secret, both forms on one
+/// field, a reference to a variable that is not set, a file that cannot be read or that is empty - rejects
+/// the document, which the loader turns into a rejection of the whole load. None of them resolves to a blank
+/// secret. That difference matters more than it looks: a blank secret is KEPT rather than applied by
+/// <see cref="ServerManagedFields"/>, so the server would carry on with its previous secret and the operator
+/// would be told nothing, at boot, on the surface they are least likely to be watching.
+/// </para>
+/// <para>
+/// A refusal names the REFERENCE - the variable name, the path, the field - and never what it resolved to,
+/// so a rejection is diagnosable from a log without the log becoming the leak this exists to prevent.
+/// </para>
+/// <para>
+/// Every member lookup here is case-insensitive, because the deserializer that reads the document afterwards
+/// is. Two members differing only in case would leave that deserializer choosing which one fills the field,
+/// and on these fields the choice is a secret, so the document is refused rather than one of them being
+/// picked - the same posture the loader already takes on a member repeated exactly.
+/// </para>
+/// <para>
+/// A file's content is trimmed. A secret file written by a shell redirect, by a projected volume or by a text
+/// editor ends in a newline, and a client secret carrying a trailing newline fails at the token endpoint with
+/// an error nobody traces back to the file. The cost is stated rather than hidden: a secret whose real value
+/// begins or ends with whitespace cannot be delivered by the file form and has to use the variable form.
+/// </para>
+/// </remarks>
+internal static class DeclarativeSecretReference
+{
+    /// <summary>The suffix naming the environment variable that holds a secret field's value.</summary>
+    internal const string EnvironmentSuffix = "Env";
+
+    /// <summary>The suffix naming the path of the file that holds a secret field's value.</summary>
+    internal const string FileSuffix = "File";
+
+    private const string ConfigurationMember = "Configuration";
+
+    private static readonly string[] OidSecretFields = { "OidSecret" };
+    private static readonly string[] SamlSecretFields = { "SamlSigningKeyPfx", "SamlRolloverSigningKeyPfx" };
+
+    /// <summary>
+    /// Resolves every secret reference in <paramref name="documentText"/> into the document, or refuses it.
+    /// </summary>
+    /// <param name="documentText">The declarative document as read from its source.</param>
+    /// <param name="readEnvironmentVariable">Reads a named environment variable; null or blank means unset.</param>
+    /// <param name="readReferenceFile">Reads a referenced file; null means it could not be read at all.</param>
+    /// <param name="resolvedText">
+    /// The document with each reference replaced by the secret it named and the reference members removed;
+    /// the input unchanged when the document carries no reference.
+    /// </param>
+    /// <param name="rejection">Why the document was refused, naming the reference and never its value.</param>
+    /// <returns>True when the document may go on to the deserializer.</returns>
+    internal static bool TryResolve(
+        string documentText,
+        Func<string, string?> readEnvironmentVariable,
+        Func<string, string?> readReferenceFile,
+        out string resolvedText,
+        out string? rejection)
+    {
+        ArgumentNullException.ThrowIfNull(readEnvironmentVariable);
+        ArgumentNullException.ThrowIfNull(readReferenceFile);
+
+        resolvedText = documentText;
+        rejection = null;
+
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(documentText);
+        }
+        catch (JsonException)
+        {
+            // Syntax is the deserializer's refusal to make, and it makes it two steps later with a better
+            // message. This pass decides secrets, and a document it cannot parse carries none it can see.
+            return true;
+        }
+
+        if (root is not JsonObject document)
+        {
+            return true;
+        }
+
+        if (!TryMember(document, ConfigurationMember, out var configurationKey, out rejection))
+        {
+            return false;
+        }
+
+        if (configurationKey is null || document[configurationKey] is not JsonObject configuration)
+        {
+            return true;
+        }
+
+        var rewritten = false;
+        if (!TryResolveMap(configuration, "OidConfigs", OidSecretFields, readEnvironmentVariable, readReferenceFile, ref rewritten, out rejection)
+            || !TryResolveMap(configuration, "SamlConfigs", SamlSecretFields, readEnvironmentVariable, readReferenceFile, ref rewritten, out rejection))
+        {
+            return false;
+        }
+
+        if (rewritten)
+        {
+            resolvedText = document.ToJsonString();
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveMap(
+        JsonObject configuration,
+        string mapMember,
+        string[] secretFields,
+        Func<string, string?> readEnvironmentVariable,
+        Func<string, string?> readReferenceFile,
+        ref bool rewritten,
+        out string? rejection)
+    {
+        if (!TryMember(configuration, mapMember, out var mapKey, out rejection))
+        {
+            return false;
+        }
+
+        if (mapKey is null || configuration[mapKey] is not JsonObject providers)
+        {
+            return true;
+        }
+
+        foreach (var provider in providers)
+        {
+            if (provider.Value is not JsonObject fields)
+            {
+                continue;
+            }
+
+            if (!TryResolveProvider(fields, provider.Key, secretFields, readEnvironmentVariable, readReferenceFile, ref rewritten, out rejection))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryResolveProvider(
+        JsonObject fields,
+        string providerName,
+        string[] secretFields,
+        Func<string, string?> readEnvironmentVariable,
+        Func<string, string?> readReferenceFile,
+        ref bool rewritten,
+        out string? rejection)
+    {
+        if (!TryRefuseForeignReferences(fields, providerName, secretFields, out rejection))
+        {
+            return false;
+        }
+
+        foreach (var secretField in secretFields)
+        {
+            if (!TryMember(fields, secretField, out var secretKey, out rejection)
+                || !TryMember(fields, secretField + EnvironmentSuffix, out var environmentKey, out rejection)
+                || !TryMember(fields, secretField + FileSuffix, out var fileKey, out rejection))
+            {
+                return false;
+            }
+
+            if (secretKey is not null && !IsBlank(fields[secretKey]))
+            {
+                rejection = $"provider '{providerName}' writes '{secretField}' out in full; name it with '{secretField}{EnvironmentSuffix}' or '{secretField}{FileSuffix}' instead, so the secret stays out of the document";
+                return false;
+            }
+
+            if (environmentKey is null && fileKey is null)
+            {
+                continue;
+            }
+
+            if (environmentKey is not null && fileKey is not null)
+            {
+                rejection = $"provider '{providerName}' names both '{secretField}{EnvironmentSuffix}' and '{secretField}{FileSuffix}', so which one supplies '{secretField}' is undecided";
+                return false;
+            }
+
+            var referenceMember = environmentKey ?? fileKey!;
+            var referenceText = Text(fields[referenceMember]);
+            if (referenceText is null)
+            {
+                rejection = $"provider '{providerName}' names '{referenceMember}' without saying what it points at";
+                return false;
+            }
+
+            string? resolved;
+            if (environmentKey is not null)
+            {
+                resolved = Text(readEnvironmentVariable(referenceText));
+                if (resolved is null)
+                {
+                    rejection = $"provider '{providerName}' points '{secretField}' at the environment variable '{referenceText}', which is not set";
+                    return false;
+                }
+            }
+            else
+            {
+                resolved = ReadFile(readReferenceFile, providerName, secretField, referenceText, out rejection);
+                if (resolved is null)
+                {
+                    return false;
+                }
+            }
+
+            fields.Remove(referenceMember);
+            fields[secretKey ?? secretField] = JsonValue.Create(resolved);
+            rewritten = true;
+        }
+
+        return true;
+    }
+
+    // A secret member belonging to the OTHER protocol - the field itself or either of its reference forms -
+    // is refused rather than ignored. Every other misspelling in this document is a silent no-op, which the
+    // loader discloses; these are not allowed to be, because the operator who wrote one believes a secret has
+    // been supplied, and the provider would come up on whatever was stored before: working, and not from the
+    // file they are reading. The bare field is in the list for the second reason too - a secret written into
+    // the document under a name that happens to do nothing is still a secret in the document.
+    private static bool TryRefuseForeignReferences(JsonObject fields, string providerName, string[] secretFields, out string? rejection)
+    {
+        rejection = null;
+        foreach (var foreign in ForeignSecretMembers(secretFields))
+        {
+            if (!TryMember(fields, foreign, out var key, out rejection))
+            {
+                return false;
+            }
+
+            if (key is not null)
+            {
+                rejection = $"provider '{providerName}' names '{foreign}', which is not a secret of this provider's protocol";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static IEnumerable<string> ForeignSecretMembers(string[] own)
+    {
+        foreach (var field in OidSecretFields)
+        {
+            foreach (var member in ForeignMembersOf(field, own))
+            {
+                yield return member;
+            }
+        }
+
+        foreach (var field in SamlSecretFields)
+        {
+            foreach (var member in ForeignMembersOf(field, own))
+            {
+                yield return member;
+            }
+        }
+    }
+
+    private static IEnumerable<string> ForeignMembersOf(string field, string[] own)
+    {
+        if (Array.IndexOf(own, field) >= 0)
+        {
+            yield break;
+        }
+
+        yield return field;
+        yield return field + EnvironmentSuffix;
+        yield return field + FileSuffix;
+    }
+
+    private static string? ReadFile(
+        Func<string, string?> readReferenceFile,
+        string providerName,
+        string secretField,
+        string path,
+        out string? rejection)
+    {
+        rejection = null;
+        var content = readReferenceFile(path);
+        if (content is null)
+        {
+            rejection = $"provider '{providerName}' points '{secretField}' at the file '{path}', which could not be read";
+            return null;
+        }
+
+        var trimmed = content.Trim();
+        if (trimmed.Length == 0)
+        {
+            rejection = $"provider '{providerName}' points '{secretField}' at the file '{path}', which holds nothing";
+            return null;
+        }
+
+        return trimmed;
+    }
+
+    // A blank string and a non-string both come back as null, so a caller never has to ask which of the two
+    // it met: neither can name a variable, a path or a secret.
+    private static string? Text(JsonNode? node)
+        => node is JsonValue value && value.TryGetValue<string>(out var text) ? Text(text) : null;
+
+    private static string? Text(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    // Only an absent member, a JSON null, or a string of whitespace count as "carries no secret". A member
+    // holding a number or an object is NOT blank: it says something, this pass cannot say it is not a secret,
+    // and treating it as absent would let a document past the inline refusal.
+    private static bool IsBlank(JsonNode? node)
+        => node is null || (node is JsonValue value && value.TryGetValue<string>(out var text) && string.IsNullOrWhiteSpace(text));
+
+    // Case-insensitive, and it reports the KEY rather than the value so the caller can rewrite or remove the
+    // member it found. Two members differing only in case leave the deserializer picking one, and on these
+    // fields that pick is a secret, so the document is refused instead.
+    private static bool TryMember(JsonObject owner, string name, out string? key, out string? rejection)
+    {
+        key = null;
+        rejection = null;
+        foreach (var property in owner)
+        {
+            if (!string.Equals(property.Key, name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (key is not null)
+            {
+                rejection = $"the member '{name}' appears more than once differing only in case, so which of them decides the field is the parser's choice rather than the document's";
+                return false;
+            }
+
+            key = property.Key;
+        }
+
+        return true;
+    }
+}

--- a/SSO-Auth/SSOPlugin.cs
+++ b/SSO-Auth/SSOPlugin.cs
@@ -71,7 +71,13 @@ public class SSOPlugin : BasePlugin<PluginConfiguration>, IHasWebPages
         // persists through ConfigStore, and it returns an outcome rather than throwing - a file the operator
         // got wrong must not take the plugin, and with it every SSO login on the server, offline. With no
         // source path configured it reads nothing, writes nothing and logs nothing.
-        DeclarativeProviderConfig.ApplyFromEnvironment(ConfigStore, logger);
+        // The reveal delegate lets the loader tell a resolved secret that is ALREADY the stored one from a
+        // genuine rotation (#1096), so an unchanged mount leaves the at-rest envelope alone instead of
+        // rewriting it on every boot. A delegate rather than the store itself, because the loader has no
+        // business with the data-encryption key beyond that one comparison - and Secrets stays lazy: nothing
+        // touches the key file unless a document actually carries a reference over a provider that has a
+        // stored secret.
+        DeclarativeProviderConfig.ApplyFromEnvironment(ConfigStore, logger, stored => Secrets.Reveal(stored));
     }
 
     /// <summary>


### PR DESCRIPTION
# What & why

The declarative provider document (#1095) is a file a deployment keeps beside
the rest of its configuration, which is to say in a repository, in a backup and
in every image layer that copied it. A client secret or a SAML signing key
written into that file is a secret in all three, and the plugin's at-rest
encryption reaches none of them.

So a secret is named rather than written. Two forms, one per deployment habit:

- `<field>Env` names the environment variable holding the value, which is how a
  compose file or a Kubernetes `env` block hands one to a container.
- `<field>File` names a path to read it from, which is the docker-secret and
  projected-volume habit.

They cover the three fields the JSON boundary already withholds through
`WriteOnlySecretConverter` - `OidSecret`, `SamlSigningKeyPfx` and
`SamlRolloverSigningKeyPfx` - and a document that spells any of them out is
refused with a message naming both forms.

Resolution happens in a new `DeclarativeSecretReference`, between the
repeated-member screen and the deserializer, so it reads bytes the screen has
already cleared and hands the deserializer a document with no reference left in
it.

Closes #1096

## Type of change

- [x] Security hardening / vulnerability fix
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / code quality / docs

## Security checklist

- [x] Fail-closed preserved: a missing signature, time-bound, or audience is
      rejected, never default-accepted.
- [x] No secrets logged; secrets are redacted on config export.
- [ ] A security review was performed for changes to SAML/OIDC validation,
      config persistence, or the release pipeline.
- [ ] Review record: per lens, its verdict and its findings, with **CONFIRMED
      \_\_ / PLAUSIBLE \_\_** counts as raised (a finding is CONFIRMED only if a
      reproduction was produced). Every finding of either kind carries a
      disposition - FIX, a reasoned DECLINE, or DEFER as its own issue.
- [x] Log inputs from the IdP are sanitized inline at the log call.

The two unticked boxes are unticked because the thing they describe did not
happen. No adversarial review gate was run over this diff and no second reader
looked at it, so there is no review record and no lens verdict to report. What
stands in place of one is the falsification table below: every guard in the
change was deleted and the suite watched to go red for it.

Fail-closed here means one thing, and it is worth stating because the failure
would otherwise be quiet. Every way of failing to resolve a reference - an inline
secret, both forms on one field, a variable that is not set or holds only
whitespace, a file that cannot be read or that holds nothing, a reference naming
nothing - rejects the WHOLE document and leaves the stored configuration
byte-identical. None of them resolves to a blank secret. A blank secret is kept
rather than applied by `ServerManagedFields`, so the fail-open reading would
leave the server running on its previous secret, at boot, with nothing said about
it.

No secret reaches a log. Every rejection message names the reference - the
variable name, the path, the field - and never what it resolved to, and each
rejection test asserts that no captured record, message or exception carries the
value.

## Quality checklist

- [x] No duplicated logic; new logic lives in a small, single-purpose,
      testable unit.
- [x] The change adds no more code than the problem requires.
- [x] The code is self-documenting (readable without comments; comments explain
      why, not what) and matches the target architecture (#318).
- [x] Architecture-conformance tests pass, and any new structural property this
      change establishes is locked in as a rule in `ArchitectureConformanceTests`.
- [x] Docs impact considered: this change needs no README/wiki update, OR the
      update is included here, OR it is filed as a `documentation` issue on the
      current-release milestone (link it in Notes).

The new parse site is declared in `UntrustedJson_IsParsedOnlyThroughTheScreenedSeam`
as a gated read whose gate is the loader, which is what makes the ordering above
an asserted property rather than a described one. The suite failed on that rule
before the entry was added, which is the rule doing its job.

Three decisions a reviewer should weigh rather than skim.

**Every member lookup is case-insensitive**, because the deserializer that reads
the document afterwards is (`PropertyNameCaseInsensitive`). A member spelled
`oidsecret` fills the same field, so a refusal comparing names exactly would be a
refusal with a documented way round it. Two members differing only in case are
not a repeat the document-level screen can see, and both are candidates for one
field, so the document is refused rather than one of them being picked.

**A resolved secret the store already holds is put back to blank before the
merge.** Without that the loader's restart-loop promise dies at the first
reference: what is stored is an `ssoenc:` envelope, what a reference resolves to
is the plaintext inside it, the two never compare equal, and every boot rewrites
`config.xml` with a freshly nonced envelope. The comparison is skipped where an
OpenID provider's endpoint or client id moved, because there `ServerManagedFields`
drops the stored secret on purpose (#186) and keeping it would leave that
provider with none. It needs the plaintext of a stored secret, so `SSOPlugin`
hands the loader a reveal delegate rather than the secret store itself; the store
stays lazy and nothing touches the key file unless a document actually carries a
reference over a provider that has a stored secret.

**A file's content is trimmed.** A secret file written by a shell redirect, a
projected volume or a text editor ends in a newline, and a client secret carrying
one fails at the token endpoint with an error nobody traces back to the file. The
cost is stated rather than hidden: a secret whose real value begins or ends with
whitespace cannot be delivered by the file form and has to use the variable form.

## Verification

- [x] `dotnet build --no-restore --warnaserror` is green.
- [x] `dotnet test` is green.
- [ ] Prettier is clean for any `.js` / `.html` / `.md` / `.css` change.

Prettier is unticked because the diff carries no file of those types. Both target
frameworks, analyzer gate on, full suite:

```
$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net9.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net9.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3303, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,419s

$ dotnet build SSO-Auth.Tests/SSO-Auth.Tests.csproj -f net10.0 --warnaserror --nologo -v q
    0 Warnung(en)
    0 Fehler
$ ./SSO-Auth.Tests/bin/Debug/net10.0/SSO-Auth.Tests.exe
   SSO-Auth.Tests  Total: 3304, Errors: 0, Failed: 0, Skipped: 4, Not Run: 0, Time: 32,056s
```

The four skips are the pre-existing ones that bind a listener off loopback and
would raise a Windows firewall consent dialog needing an administrator (#1227).
They were not run and nothing here claims they were.

### Every guard proven by deleting it

Each mutation was applied to the working tree, built, run against the new tests,
and reverted before the next. The counts are what the runner printed.

| Guard removed                        | Mutation                                    | Tests that went red |
| ------------------------------------ | ------------------------------------------- | ------------------- |
| The inline-secret refusal            | condition replaced by one that never fires  | 2                   |
| Fail-closed on an unset variable     | unresolved reference falls back to a value  | 2                   |
| Case-insensitive member lookup       | `OrdinalIgnoreCase` replaced by `Ordinal`   | 2                   |
| The already-stored comparison        | the call removed                            | 1                   |
| The foreign-secret refusal           | the refusal made unreachable                | 1                   |
| Fail-closed on an unreadable file    | unreadable file falls back to a value       | 1                   |

The tree at the head commit carries none of those mutations; the suite output
quoted above is the unmutated run.

## Notes

The operator-facing documentation for the reference forms is #1116, the sibling
that documents what this family of issues settled. It is blocked until they have,
and #1095 landed on the same boundary: nothing operator-facing was written for
the loader's own `JELLYFIN_SSO_CONFIG_FILE` either. What this change documents is
the contract, in the type that implements it, where a reviewer reads it.

A bound worth naming. The refusal covers the three secret fields and their
reference forms, on both protocols. A secret written into the document under any
other member name is still an unknown member the deserializer drops, which the
loader already discloses as a silent no-op. This change narrows that hole to
exactly the names that look like secrets; it does not close the general case, and
no reading of the tree could.

No second reader looked at this change, and the falsification table is what
stands in place of one.
